### PR TITLE
Fix potential NPE

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
@@ -134,7 +134,7 @@ public class NamingProxy {
 
             List<String> list = getServerListFromEndpoint();
 
-            if (list.isEmpty()) {
+            if (CollectionUtils.isEmpty(list)) {
                 throw new Exception("Can not acquire vipserver list");
             }
 


### PR DESCRIPTION

## What is the purpose of the change
There is a try catch block in`getServerListFromEndpoint` method,  it'll return null if any exception happens , which will raise a unexpected NPE

## Brief changelog

Using `CollectionUtils.isEmpty` to check if server list is null or empty

