### PR TITLE
PUT /instance should use param key "useIPPort4Check" instead of "userIPPort4Check"

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/controllers/InstanceController.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/controllers/InstanceController.java
@@ -102,7 +102,7 @@ public class InstanceController extends ApiCommands {
             mockHttpRequest.addParameter("cluster", StringUtils.EMPTY);
             mockHttpRequest.addParameter("defIPPort", cluster.getString("defaultPort"));
             mockHttpRequest.addParameter("defCkport", cluster.getString("defaultCheckPort"));
-            mockHttpRequest.addParameter("ipPort4Check", cluster.getString("userIPPort4Check"));
+            mockHttpRequest.addParameter("ipPort4Check", cluster.getString("useIPPort4Check"));
             mockHttpRequest.addParameter("clusterMetadata", cluster.getString("metadata"));
 
         }


### PR DESCRIPTION
Fix #219
PUT /instance should use param key "useIPPort4Check" instead of "userIPPort4Check"

## What is the purpose of the change

Fix the bug when call PUT /instance ， it will not become effective if chage the value of “userIPPort4Check“ in the Cluster


