### PR TITLE
fix: mac 下 oracle 安装包安装的 java 的地址可能在 /usr/bin/java

### DIFF
--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -20,6 +20,7 @@ error_exit ()
 }
 
 [ ! -e "$JAVA_HOME/bin/java" ] && JAVA_HOME=$HOME/jdk/java
+[ ! -e "$JAVA_HOME/bin/java" ] && JAVA_HOME=/usr
 [ ! -e "$JAVA_HOME/bin/java" ] && JAVA_HOME=/usr/java
 [ ! -e "$JAVA_HOME/bin/java" ] && JAVA_HOME=/opt/taobao/java
 [ ! -e "$JAVA_HOME/bin/java" ] && error_exit "Please set the JAVA_HOME variable in your environment, We need java(x64)! jdk8 or later is better!"


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

是部分 mac 用户可以轻松的使用 startup.sh 运行 nacos

## Brief changelog

支持启动脚本在 mac 下 oracle 安装包安装的 java 的地址可能在 /usr/bin/java 的情况


#601