### PR TITLE
hotfix #672

### DIFF
--- a/distribution/bin/startup.cmd
+++ b/distribution/bin/startup.cmd
@@ -25,7 +25,7 @@ set CUSTOM_SEARCH_LOCATIONS=%DEFAULT_SEARCH_LOCATIONS%,file:%BASE_DIR%conf/
 
 
 
-if not ""%2"" == "cluster" (
+if not "%2" == "cluster" (
     set "JAVA_OPT=%JAVA_OPT% -Xms512m -Xmx512m -Xmn256m"
     set "JAVA_OPT=%JAVA_OPT% -Dnacos.standalone=true"
  ) else (


### PR DESCRIPTION
There is a Bug in Nacos Server Folder ，Bin directory ，startup.cmd File,
if not ""%2"" == "cluster" (
)
if you run startup.cmd -m cluster can’t startup with cluster mode，
if not "%2" == "cluster" (
)
run startup.cmd -m cluster Ok，you can running in cluster mode