### PR TITLE
[ISSUE #827] Fix Nacos Naming's log settings affect the root log

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/logging/log4j2/Log4J2NacosLogging.java
+++ b/client/src/main/java/com/alibaba/nacos/client/logging/log4j2/Log4J2NacosLogging.java
@@ -83,6 +83,10 @@ public class Log4J2NacosLogging extends AbstractNacosLogging {
         final List<AbstractConfiguration> configurations = new ArrayList<AbstractConfiguration>();
 
         LoggerContext loggerContext = (LoggerContext)LogManager.getContext(false);
+        Configuration contextConfiguration = loggerContext.getConfiguration();
+        if(contextConfiguration instanceof AbstractConfiguration){
+            configurations.add((AbstractConfiguration)contextConfiguration);
+        }
         for (String location : locationList) {
             try {
                 Configuration configuration = loadConfiguration(loggerContext, location);
@@ -135,6 +139,8 @@ public class Log4J2NacosLogging extends AbstractNacosLogging {
 
         supportedConfigLocations.add("log4j2.xml");
         supportedConfigLocations.add("log4j2-test.xml");
+        supportedConfigLocations.add("log4j2.properties");
+        supportedConfigLocations.add("log4j2-test.properties");
 
         return supportedConfigLocations.toArray(new String[supportedConfigLocations.size()]);
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix #827 when using log4j2.properties or log4j2-test.properties. [Ref](https://logging.apache.org/log4j/2.x/manual/configuration.html#AutomaticConfiguration)

## Brief changelog

- Keep Log4j2 context configuration after inserting Nacos configuration. 
    - Maybe a better way to fix #827 rather than searching default configuration locations.
- Add `log4j2.properties` and `log4j2-test.properties` to `getCurrentlySupportedConfigLocations()`.
   - To complement current way to fix #827.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

