### PR TITLE
[ISSUE #963] to support registering instance with host name

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/Instance.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/Instance.java
@@ -297,7 +297,7 @@ public class Instance extends com.alibaba.nacos.api.naming.pojo.Instance impleme
 
     public boolean validate() {
 
-        if(getIp().contains(":")){
+        if(getIp().contains(UtilsAndCommons.IP_PORT_SPLITER)){
             Matcher matcher = IP_PATTERN.matcher(getIp() + ":" + getPort());
             if (!matcher.matches()) {
                 return false;

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/Instance.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/Instance.java
@@ -297,9 +297,11 @@ public class Instance extends com.alibaba.nacos.api.naming.pojo.Instance impleme
 
     public boolean validate() {
 
-        Matcher matcher = IP_PATTERN.matcher(getIp() + ":" + getPort());
-        if (!matcher.matches()) {
-            return false;
+        if(getIp().contains(":")){
+            Matcher matcher = IP_PATTERN.matcher(getIp() + ":" + getPort());
+            if (!matcher.matches()) {
+                return false;
+            }
         }
 
         if (getWeight() > MAX_WEIGHT_VALUE || getWeight() < MIN_WEIGHT_VALUE) {


### PR DESCRIPTION

## What is the purpose of the change

To support registering instance with host name

## Brief changelog

Only ip address contain ':' will be validated ip format.

**from** 
`public boolean validate() {

        Matcher matcher = IP_PATTERN.matcher(getIp() + ":" + getPort());
        if (!matcher.matches()) {
            return false;
        }

        if (getWeight() > MAX_WEIGHT_VALUE || getWeight() < MIN_WEIGHT_VALUE) {
            return false;
        }

        return true;
    }`
**to** 

```
public boolean validate() {

        if(getIp().contains(":")){
            Matcher matcher = IP_PATTERN.matcher(getIp() + ":" + getPort());
            if (!matcher.matches()) {
                return false;
            }
        }

        if (getWeight() > MAX_WEIGHT_VALUE || getWeight() < MIN_WEIGHT_VALUE) {
            return false;
        }

        return true;
    }
```



