### PR TITLE
#1115 import and export config file

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -83,6 +83,10 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
 
         <!-- for aop -->
         <dependency>

--- a/config/src/main/java/com/alibaba/nacos/config/server/constant/Constants.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/constant/Constants.java
@@ -119,6 +119,8 @@ public class Constants {
 
     public static final String NAMESPACE_CONTROLLER_PATH = BASE_PATH + "/namespaces";
 
+    public static final String FILE_CONTROLLER_PATH = BASE_PATH + "/file";
+
     public static final String ENCODE = "UTF-8";
 
     public static final String MAP_FILE = "map-file.js";

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/FileController.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/FileController.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.config.server.controller;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.nacos.config.server.constant.Constants;
+import com.alibaba.nacos.config.server.model.RestResult;
+import com.alibaba.nacos.config.server.model.TenantInfo;
+import com.alibaba.nacos.config.server.service.FileService;
+import com.alibaba.nacos.config.server.service.PersistService;
+import com.alibaba.nacos.config.server.utils.LogUtil;
+import com.alibaba.nacos.config.server.utils.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.List;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * export and import config file
+ * @author rushsky518
+ */
+@Controller
+@RequestMapping(Constants.FILE_CONTROLLER_PATH)
+public class FileController {
+
+    private final PersistService persistService;
+
+    private final FileService fileService;
+
+    @Autowired
+    public FileController(PersistService persistService, FileService fileService) {
+        this.persistService = persistService;
+        this.fileService = fileService;
+    }
+
+    @RequestMapping(value = "/downloadNamespace", method = RequestMethod.GET)
+    public ResponseEntity<byte[]> downloadNamespace(@RequestParam String namespaceId, @RequestParam(required = false) String group) throws UnsupportedEncodingException {
+        checkNamespaceId(namespaceId);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ZipOutputStream zos = new ZipOutputStream(bos);
+        byte[] bytes = null;
+        try {
+            fileService.download(zos, namespaceId, group);
+            bytes = bos.toByteArray();
+        } catch (IOException e) {
+            LogUtil.fatalLog.error("io exception occurs when download config file", e);
+        } finally {
+            try {
+                zos.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return new ResponseEntity<>(bytes, genHttpHeaders(namespaceId), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/downloadMultiFiles", method = RequestMethod.GET)
+    public ResponseEntity<byte[]> downloadMultiFiles(@RequestParam String param) throws IOException {
+        JSONObject json = JSON.parseObject(param);
+        String namespaceId = json.getString("namespaceId");
+        List files = json.getJSONArray("files");
+        if (StringUtils.isBlank(namespaceId)) {
+            namespaceId = "";
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ZipOutputStream zos = new ZipOutputStream(baos);
+        byte[] bytes = null;
+        try {
+            fileService.download(zos, namespaceId, files);
+            bytes = baos.toByteArray();
+        } catch (IOException e) {
+            LogUtil.fatalLog.error("io exception occurs when download config file", e);
+        } finally {
+            try {
+                zos.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return new ResponseEntity<>(bytes, genHttpHeaders(namespaceId), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/upload", method = RequestMethod.POST)
+    @ResponseBody
+    public RestResult upload(@RequestParam MultipartFile file,
+                             @RequestParam(required = false, defaultValue = "") String namespaceId,
+                             @RequestParam(required = false, defaultValue = "abort") String uploadMode) throws IOException {
+        checkNamespaceId(namespaceId);
+
+        if (0 == file.getSize()) {
+            return new RestResult(0, "empty file");
+        }
+
+        fileService.resolveZipFile(file.getInputStream(), namespaceId, uploadMode);
+
+        return new RestResult(0, "upload success");
+    }
+
+    private void checkNamespaceId(String namespaceId) {
+        if (!"".equals(namespaceId)) {
+            TenantInfo tenant = persistService.findTenantByKp("1", namespaceId);
+            if (null == tenant) {
+                throw new IllegalArgumentException("namespace does not exist");
+            }
+        }
+    }
+
+    private HttpHeaders genHttpHeaders(String namespaceId) throws UnsupportedEncodingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        String filename = (StringUtils.isBlank(namespaceId) ? "public" : namespaceId) + "_" + System.currentTimeMillis() + ".zip";
+        headers.set("Content-Disposition", "attachment; filename=" + URLEncoder.encode(filename, "UTF-8"));
+        return headers;
+    }
+}

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/FileService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/FileService.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.nacos.config.server.service;
+
+import com.alibaba.nacos.config.server.model.ConfigInfo;
+import com.alibaba.nacos.config.server.model.Page;
+import com.alibaba.nacos.config.server.utils.StringUtils;
+import com.alibaba.nacos.config.server.utils.TimeUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.*;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import static com.alibaba.nacos.config.server.service.FileService.FileType.*;
+import static com.alibaba.nacos.config.server.service.FileService.UploadPolicy.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * FileService
+ * @author rushsky518
+ */
+@Service
+public class FileService {
+    @Autowired
+    private PersistService persistService;
+
+    public void download(ZipOutputStream zos, String namespaceId, String group) throws IOException {
+        zipFilesByPage(zos, namespaceId, group);
+    }
+
+    public void download(ZipOutputStream zos, String namespaceId, List files) throws IOException {
+        if (null != files && !files.isEmpty()) {
+            StringBuilder sb = new StringBuilder(512);
+            for (int i = 0; i< files.size(); i++) {
+                Map map = (Map)files.get(i);
+                String dataId = map.get("dataId").toString();
+                String group = map.get("group").toString();
+
+                ConfigInfo configInfo = persistService.findConfigInfo(dataId, group, namespaceId);
+                if (null == configInfo) {
+                    continue;
+                }
+                zipSingleFile(zos, new ByteArrayInputStream(configInfo.getContent().getBytes(UTF_8)), configInfo.getGroup() + ZIP_SEPARATOR + configInfo.getDataId());
+                genMetaYmlContent(sb, configInfo);
+            }
+
+            if (sb.length() > 0) {
+                zipSingleFile(zos, new ByteArrayInputStream(sb.toString().getBytes(UTF_8)), META_FILENAME);
+            }
+        } else {
+            zipFilesByPage(zos, namespaceId, null);
+        }
+    }
+
+    public void resolveZipFile(InputStream is, String namespaceId, String uploadMode) throws IOException {
+        Map<String, String> metaMap = new HashMap<>(64);
+        List<ConfigInfo> cfList = new ArrayList<>(64);
+        resolveMetaAndConfig(is, namespaceId, metaMap, cfList);
+        addOrUpdateConfig(namespaceId, uploadMode, metaMap, cfList);
+    }
+
+    private void resolveMetaAndConfig(InputStream is, String namespaceId, Map<String, String> metaMap, List<ConfigInfo> cfList) throws IOException {
+        ZipInputStream zis = new ZipInputStream(is);
+        for (ZipEntry zipEntry = zis.getNextEntry(); null != zipEntry; zipEntry = zis.getNextEntry()) {
+            if (zipEntry.isDirectory()) {
+                continue;
+            }
+
+            if (zipEntry.getName().equals(META_FILENAME)) {
+                fillMetaMap(zis, metaMap);
+                continue;
+            }
+
+            String[] dirs = zipEntry.getName().split(ZIP_SEPARATOR);
+            if (dirs.length != 2) {
+                continue;
+            }
+            cfList.add(readConfigInfoFromZip(zis, namespaceId, dirs[0], dirs[1]));
+        }
+
+        zis.closeEntry();
+        zis.close();
+    }
+
+    private void addOrUpdateConfig(String namespaceId, String uploadMode,  Map<String, String> metaMap, List<ConfigInfo> cfList) {
+        UploadPolicy policy = UploadPolicy.valueOf(uploadMode.toUpperCase());
+
+        for (ConfigInfo cf: cfList) {
+            // query from db
+            ConfigInfo dbCf = persistService.findConfigInfo(cf.getDataId(), cf.getGroup(), namespaceId);
+            if (null == dbCf) {
+                String appname = metaMap.get(cf.getGroup() + cf.getDataId());
+                cf.setAppName(appname == null ? "" : appname);
+                Map<String, Object> advanceInfo = new HashMap<>(4);
+                advanceInfo.put("type", getFileType(cf.getDataId()));
+
+                persistService.addConfigInfo(null, null, cf, TimeUtils.getCurrentTime(), advanceInfo, false);
+                continue;
+            }
+
+            if (ABORT.equals(policy)) {
+                break;
+            } else if (OVERWRITE.equals(policy)) {
+                String appname = metaMap.get(cf.getGroup() + cf.getDataId());
+                cf.setAppName(appname == null ? "" : appname);
+                Timestamp time = TimeUtils.getCurrentTime();
+                Map<String, Object> advanceInfo = new HashMap<>(4);
+                advanceInfo.put("type", getFileType(cf.getDataId()));
+                persistService.updateConfigInfo(cf,null, null,time, advanceInfo, true);
+            } else if (SKIP.equals(policy)) { }
+        }
+    }
+
+    private void zipFilesByPage( ZipOutputStream zos, String namespaceId, String group) throws IOException {
+        int pageNo = 1;
+        int pageSize = 20;
+
+        Page<ConfigInfo> configInfos = persistService.findConfigInfo4Page(pageNo, pageSize, null, group, namespaceId, null);
+        if (null == configInfos) {
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder(512);
+        while(true) {
+            for (int i = 0; i < configInfos.getPageItems().size(); i++) {
+                ConfigInfo configInfo = configInfos.getPageItems().get(i);
+                zipSingleFile(zos, new ByteArrayInputStream(configInfo.getContent().getBytes(UTF_8)), configInfo.getGroup() + ZIP_SEPARATOR + configInfo.getDataId());
+                genMetaYmlContent(sb,configInfo);
+            }
+            configInfos = persistService.findConfigInfo4Page(++pageNo, pageSize, null, group, namespaceId, null);
+            if (null == configInfos) {
+                break;
+            }
+        }
+
+        if (sb.length() > 0) {
+            zipSingleFile(zos, new ByteArrayInputStream(sb.toString().getBytes(UTF_8)), META_FILENAME);
+        }
+    }
+
+    private void fillMetaMap(ZipInputStream zis, Map<String, String> metaMap) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(zis));
+        String line;
+        while ((line = br.readLine()) != null) {
+            if (StringUtils.isBlank(line)) {
+                continue;
+            }
+            // example: DEFAULT_GROUP.biz~properties.app=appname
+            String[] arr = line.split("\\.");
+            if (3 != arr.length) {
+                continue;
+            }
+
+            String group = arr[0];
+            String dataId = arr[1].replace(WAVE, DOT);
+            String appname = arr[2].split("=")[1];
+            metaMap.put(group + dataId, appname);
+        }
+    }
+
+    private ConfigInfo readConfigInfoFromZip(ZipInputStream zis, String namespaceId, String group, String dataId) throws IOException {
+        int len;
+        byte[] buffer = new byte[512];
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
+        while ((len = zis.read(buffer)) > 0) {
+            baos.write(buffer, 0, len);
+        }
+        ConfigInfo cf = new ConfigInfo(dataId, group, new String(baos.toByteArray(), UTF_8));
+        cf.setTenant(namespaceId);
+        baos.close();
+        return cf;
+    }
+
+    private String getFileType(String dataId) {
+        String type = TEXT.getValue();
+        if (dataId.contains(JSON.getValue())) {
+            type = JSON.getValue();
+        } else if (dataId.contains(XML.getValue())) {
+            type = XML.getValue();
+        } else if (dataId.contains(YML.getValue()) || dataId.contains(YAML.getValue())) {
+            type = YAML.getValue();
+        } else if (dataId.contains(HTML.getValue()) || dataId.contains(HTM.getValue())) {
+            type = HTML.getValue();
+        } else if (dataId.contains(PROPERTIES.getValue())) {
+            type = PROPERTIES.getValue();
+        }
+        return type;
+    }
+
+    private void zipSingleFile(ZipOutputStream zos, InputStream is, String fileName) throws IOException {
+        ZipEntry zipEntry = new ZipEntry(fileName);
+        zos.putNextEntry(zipEntry);
+        byte[] bytes = new byte[1024];
+        int length;
+        while ((length = is.read(bytes)) >= 0) {
+            zos.write(bytes, 0, length);
+        }
+        is.close();
+        zos.closeEntry();
+    }
+
+    private void genMetaYmlContent(StringBuilder sb, ConfigInfo ci) {
+        if (null == ci || StringUtils.isBlank(ci.getAppName())) {
+            return;
+        }
+
+        sb.append(ci.getGroup()).append(DOT)
+            .append(ci.getDataId().replace(DOT, WAVE)).append(DOT)
+            .append("app=").append(ci.getAppName())
+            .append("\n");
+    }
+
+    enum FileType {
+        /** txt */
+        TXT("txt"),
+        /** text */
+        TEXT("text"),
+        /** json */
+        JSON("json"),
+        /** xml */
+        XML("xml"),
+        /** yml */
+        YML("yml"),
+        /** yaml */
+        YAML("yaml"),
+        /** html */
+        HTML("html"),
+        /** htm */
+        HTM("htm"),
+        /** properties */
+        PROPERTIES("properties");
+
+        private String value;
+        FileType(String value) {
+            this.value = value;
+        }
+        public String getValue() {
+            return value;
+        }
+    }
+
+    enum UploadPolicy {
+        /** abort */
+        ABORT,
+        /** skip */
+        SKIP,
+        /** overwrite */
+        OVERWRITE;
+    }
+
+    private final String WAVE = "~";
+    private final String DOT = ".";
+    private final String META_FILENAME = ".meta.yml";
+    private final String ZIP_SEPARATOR = "/";
+}

--- a/console/src/main/resources/static/console-fe/src/components/SimpleDialog/exportDialog.js
+++ b/console/src/main/resources/static/console-fe/src/components/SimpleDialog/exportDialog.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Button, Dialog, Form } from '@alifd/next';
+
+const FormItem = Form.Item;
+
+class ExportDialog extends React.Component {
+  static displayName = 'FileDialog';
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      visible: false,
+      serverId: '',
+      serverName: '',
+      totalSelected: 0,
+    };
+  }
+
+  componentDidMount() {}
+
+  openDialog(payload = {}, callback = () => {}) {
+    this.callback = callback;
+    this.setState({
+      visible: true,
+      serverId: payload.id,
+      serverName: payload.name,
+      totalSelected: payload.total,
+    });
+  }
+
+  closeDialog = () => {
+    this.setState({
+      visible: false,
+    });
+  };
+
+  setPolicy = (...value) => {
+    this.setState({
+      policyLabel: value[1].label,
+      policy: value[0],
+    });
+  };
+
+  render() {
+    const { totalSelected } = this.state;
+    const footer =
+      totalSelected !== 0 ? (
+        <Button type={'primary'} onClick={() => this.callback()}>
+          导出
+        </Button>
+      ) : (
+        <Button type={'primary'} onClick={() => this.closeDialog()}>
+          确定
+        </Button>
+      );
+
+    return (
+      <div>
+        <Dialog
+          visible={this.state.visible}
+          footer={footer}
+          footerAlign="center"
+          style={{ width: 480 }}
+          onCancel={this.closeDialog}
+          onClose={this.closeDialog}
+          title={`导出配置${this.state.serverName}`}
+        >
+          {totalSelected === 0 ? (
+            '请先选择导出项'
+          ) : (
+            <Form>
+              <FormItem label="源空间:">
+                <p>
+                  <span style={{ color: '#33cde5' }}>{this.state.serverName}</span>
+                  {` | ${this.state.serverId}`}
+                </p>
+              </FormItem>
+              <FormItem label="配置数量:">{totalSelected}个条目已选中</FormItem>
+            </Form>
+          )}
+        </Dialog>
+      </div>
+    );
+  }
+}
+
+export default ExportDialog;

--- a/console/src/main/resources/static/console-fe/src/components/SimpleDialog/importDialog.js
+++ b/console/src/main/resources/static/console-fe/src/components/SimpleDialog/importDialog.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Button, Dialog, Form, Select } from '@alifd/next';
+
+const FormItem = Form.Item;
+
+class ImportDialog extends React.Component {
+  static displayName = 'FileDialog';
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      visible: false,
+      serverId: '',
+      serverName: '',
+      isUploading: true,
+      policy: '',
+      policyLabel: '',
+      allPolicy: [],
+    };
+  }
+
+  componentDidMount() {
+    this.setState({
+      policy: 'abort',
+      policyLabel: '终止导入',
+      allPolicy: [
+        { value: 'abort', label: '终止导入' },
+        { value: 'skip', label: '跳过' },
+        { value: 'overwrite', label: '覆盖' },
+      ],
+    });
+  }
+
+  openDialog(payload = {}, callback = () => {}) {
+    this.callback = callback;
+    this.setState({
+      visible: true,
+      isUploading: false,
+      serverId: payload.id,
+      serverName: payload.name,
+    });
+  }
+
+  closeDialog = () => {
+    this.setState({
+      visible: false,
+    });
+  };
+
+  setPolicy = (...value) => {
+    this.setState({
+      policyLabel: value[2].label,
+      policy: value[0],
+    });
+  };
+
+  handleFileChanged(e) {
+    const files = e.target.files;
+
+    if (!files || files.length === 0) {
+    } else {
+      let targetFile = files[0];
+
+      this.setUploadingflag(true);
+      this.callback(targetFile, this.state.policy);
+    }
+  }
+
+  setUploadingflag(flag) {
+    this.setState({ isUploading: flag });
+  }
+
+  render() {
+    const footer = (
+      <div>
+        <input
+          type="file"
+          accept=".zip"
+          style={{ display: 'none' }}
+          ref={ref => (this.uploader = ref)}
+          onChange={this.handleFileChanged.bind(this)}
+        />
+        <Button
+          type={'primary'}
+          onClick={() => this.uploader.click()}
+          disabled={this.state.isUploading}
+        >
+          选择文件
+        </Button>
+      </div>
+    );
+
+    return (
+      <div>
+        <Dialog
+          visible={this.state.visible}
+          footer={footer}
+          footerAlign="center"
+          style={{ width: 480 }}
+          onCancel={this.closeDialog}
+          onClose={this.closeDialog}
+          title={`导入配置${this.state.serverName}`}
+        >
+          <Form>
+            <FormItem label="目标空间:">
+              <p>
+                <span style={{ color: '#33cde5' }}>{this.state.serverName}</span>
+                {` | ${this.state.serverId}`}
+              </p>
+            </FormItem>
+            <FormItem label="相同配置:">
+              <Select
+                size={'medium'}
+                hasArrow
+                defaultValue={this.state.policyLabel}
+                dataSource={this.state.allPolicy}
+                onChange={this.setPolicy}
+              />
+            </FormItem>
+            文件上传后将直接导入配置，请务必谨慎操作！
+          </Form>
+        </Dialog>
+      </div>
+    );
+  }
+}
+
+export default ImportDialog;


### PR DESCRIPTION
接口
1. 根据 namespaceId 和 group 下载配置文件
实现：分页查询 config_info 表，写入 ZipOutputStream。

2. 先查询，点击选择并下载配置文件
实现：根据参数逐个查询 config_info 表，写入 ZipOutputStream。

3. 上传配置文件
实现：读取 ZipInputStream，生成 ConfigInfo 对象，从 db 中查询配置，不存在则写入，存在则终止/跳过/覆盖。

原则
考虑到导入导出是低频操作，没有考虑效率，力求代码简洁，复用原有 api。

说明
导入导出文件不落盘，是借鉴邪影的思路。前端代码是公司同事所写。