### PR TITLE
Support flexible horizontal expansion

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/cluster/ServerListManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/cluster/ServerListManager.java
@@ -46,7 +46,7 @@ import static com.alibaba.nacos.core.utils.SystemUtils.*;
  * @since 1.0.0
  */
 @Component("serverListManager")
-public class ServerListManager implements RecordListener<Servers>{
+public class ServerListManager implements RecordListener<Servers> {
 
     private static final int STABLE_PERIOD = 60 * 1000;
 

--- a/naming/src/main/java/com/alibaba/nacos/naming/cluster/servers/Servers.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/cluster/servers/Servers.java
@@ -1,0 +1,37 @@
+package com.alibaba.nacos.naming.cluster.servers;
+
+import com.alibaba.nacos.common.util.Md5Utils;
+import com.alibaba.nacos.naming.pojo.Record;
+
+import java.util.List;
+
+/**
+ * @author XCXCXCXCX
+ * @since 1.0
+ */
+public class Servers implements Record{
+
+    private List<String> clusterHosts;
+
+    public Servers(List<String> clusterHosts) {
+        this.clusterHosts = clusterHosts;
+    }
+
+    public List<String> getClusterHosts() {
+        return clusterHosts;
+    }
+
+    public void setClusterHosts(List<String> clusterHosts) {
+        this.clusterHosts = clusterHosts;
+    }
+
+    /**
+     * get the checksum of this record, usually for record comparison
+     *
+     * @return checksum of record
+     */
+    @Override
+    public String getChecksum() {
+        return Md5Utils.getMD5(clusterHosts.toString(), "UTF-8");
+    }
+}

--- a/naming/src/main/java/com/alibaba/nacos/naming/cluster/servers/Servers.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/cluster/servers/Servers.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alibaba.nacos.naming.cluster.servers;
 
 import com.alibaba.nacos.common.util.Md5Utils;
@@ -9,7 +24,7 @@ import java.util.List;
  * @author XCXCXCXCX
  * @since 1.0
  */
-public class Servers implements Record{
+public class Servers implements Record {
 
     private List<String> clusterHosts;
 

--- a/naming/src/main/java/com/alibaba/nacos/naming/cluster/servers/Servers.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/cluster/servers/Servers.java
@@ -34,4 +34,11 @@ public class Servers implements Record{
     public String getChecksum() {
         return Md5Utils.getMD5(clusterHosts.toString(), "UTF-8");
     }
+
+    @Override
+    public String toString() {
+        return "Servers{" +
+            "clusterHosts=" + clusterHosts +
+            '}';
+    }
 }

--- a/naming/src/main/java/com/alibaba/nacos/naming/consistency/KeyBuilder.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/consistency/KeyBuilder.java
@@ -32,11 +32,17 @@ public class KeyBuilder {
 
     public static final String SERVICE_META_KEY_PREFIX = "com.alibaba.nacos.naming.domains.meta.";
 
+    public static final String SERVER_LIST_KEY_PREFIX = "com.alibaba.nacos.naming.";
+
     public static final String INSTANCE_LIST_KEY_PREFIX = "com.alibaba.nacos.naming.iplist.";
 
     public static final String BRIEF_SERVICE_META_KEY_PREFIX = "meta.";
 
     public static final String BRIEF_INSTANCE_LIST_KEY_PREFIX = "iplist.";
+
+    public static final String BRIEF_SERVER_LIST_KEY_PREFIX = "serverList.";
+
+    public static final String SERVER_LIST_KEY = SERVER_LIST_KEY_PREFIX + "serverList";
 
     private static String buildEphemeralInstanceListKey(String namespaceId, String serviceName) {
         return INSTANCE_LIST_KEY_PREFIX + EPHEMERAL_KEY_PREFIX + namespaceId + NAMESPACE_KEY_CONNECTOR
@@ -73,6 +79,10 @@ public class KeyBuilder {
         return key.startsWith(SERVICE_META_KEY_PREFIX) || key.startsWith(BRIEF_SERVICE_META_KEY_PREFIX);
     }
 
+    public static boolean matchServerListKey(String key){
+        return key.equals(SERVER_LIST_KEY);
+    }
+
     public static boolean matchSwitchKey(String key) {
         return key.endsWith(UtilsAndCommons.SWITCH_DOMAIN_NAME);
     }
@@ -106,6 +116,10 @@ public class KeyBuilder {
         return BRIEF_SERVICE_META_KEY_PREFIX + key.split(SERVICE_META_KEY_PREFIX)[1];
     }
 
+    public static String briefServerListKey(String key) {
+        return BRIEF_SERVER_LIST_KEY_PREFIX + key.split(SERVER_LIST_KEY_PREFIX)[1];
+    }
+
     public static String detailInstanceListkey(String key) {
         return INSTANCE_LIST_KEY_PREFIX.substring(0, INSTANCE_LIST_KEY_PREFIX.indexOf(BRIEF_INSTANCE_LIST_KEY_PREFIX))
             + key;
@@ -113,6 +127,11 @@ public class KeyBuilder {
 
     public static String detailServiceMetaKey(String key) {
         return SERVICE_META_KEY_PREFIX.substring(0, SERVICE_META_KEY_PREFIX.indexOf(BRIEF_SERVICE_META_KEY_PREFIX))
+            + key;
+    }
+
+    public static String detailServerListKey(String key) {
+        return SERVER_LIST_KEY_PREFIX.substring(0, SERVER_LIST_KEY_PREFIX.indexOf(BRIEF_SERVER_LIST_KEY_PREFIX))
             + key;
     }
 

--- a/naming/src/main/java/com/alibaba/nacos/naming/consistency/KeyBuilder.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/consistency/KeyBuilder.java
@@ -80,7 +80,7 @@ public class KeyBuilder {
     }
 
     public static boolean matchServerListKey(String key){
-        return key.equals(SERVER_LIST_KEY);
+        return SERVER_LIST_KEY.equals(key);
     }
 
     public static boolean matchSwitchKey(String key) {

--- a/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/raft/RaftCore.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/raft/RaftCore.java
@@ -20,6 +20,7 @@ import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.TypeReference;
 import com.alibaba.nacos.naming.boot.RunningConfig;
+import com.alibaba.nacos.naming.cluster.servers.Servers;
 import com.alibaba.nacos.naming.consistency.ApplyAction;
 import com.alibaba.nacos.naming.consistency.Datum;
 import com.alibaba.nacos.naming.consistency.KeyBuilder;
@@ -508,6 +509,8 @@ public class RaftCore {
                         element.put("key", KeyBuilder.briefServiceMetaKey(datum.key));
                     } else if (KeyBuilder.matchInstanceListKey(datum.key)) {
                         element.put("key", KeyBuilder.briefInstanceListkey(datum.key));
+                    } else if (KeyBuilder.matchServerListKey(datum.key)){
+                        element.put("key", KeyBuilder.briefServerListKey(datum.key));
                     }
                     element.put("timestamp", datum.timestamp);
 
@@ -700,6 +703,15 @@ public class RaftCore {
                                         instancesDatum.value =
                                             JSON.parseObject(JSON.toJSONString(datumJson.getJSONObject("value")), Instances.class);
                                         newDatum = instancesDatum;
+                                    }
+
+                                    if (KeyBuilder.matchServerListKey(datumJson.getString("key"))) {
+                                        Datum<Servers> serversDatum = new Datum<>();
+                                        serversDatum.key = datumJson.getString("key");
+                                        serversDatum.timestamp.set(datumJson.getLongValue("timestamp"));
+                                        serversDatum.value =
+                                            JSON.parseObject(JSON.toJSONString(datumJson.getJSONObject("value")), Servers.class);
+                                        newDatum = serversDatum;
                                     }
 
                                     if (newDatum == null || newDatum.value == null) {

--- a/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/raft/RaftStore.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/raft/RaftStore.java
@@ -19,6 +19,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.TypeReference;
 import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.naming.cluster.servers.Servers;
 import com.alibaba.nacos.naming.consistency.ApplyAction;
 import com.alibaba.nacos.naming.consistency.Datum;
 import com.alibaba.nacos.naming.consistency.KeyBuilder;
@@ -131,7 +132,6 @@ public class RaftStore {
             }
 
             if (KeyBuilder.matchServiceMetaKey(file.getName())) {
-
                 Datum<Service> serviceDatum;
 
                 try {
@@ -155,6 +155,11 @@ public class RaftStore {
                 }
 
                 return serviceDatum;
+            }
+
+            if(KeyBuilder.matchServerListKey(file.getName())){
+                return JSON.parseObject(json.replace("\\", ""), new TypeReference<Datum<Servers>>() {
+                });
             }
 
             if (KeyBuilder.matchInstanceListKey(file.getName())) {

--- a/naming/src/main/java/com/alibaba/nacos/naming/controllers/OperatorController.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/controllers/OperatorController.java
@@ -41,6 +41,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
@@ -214,6 +215,19 @@ public class OperatorController {
             result.put("servers", serverListManager.getServers());
         }
 
+        return result;
+    }
+
+    /**
+     * update the static file cluster.conf
+     * @param clusterHosts
+     * @return clusterHosts in the static file cluster.conf
+     */
+    @RequestMapping(value = "/servers", method = RequestMethod.PUT)
+    public JSONObject updateServerList(@RequestParam("clusterHosts") List<String> clusterHosts) throws Exception {
+        serverListManager.updateServers(clusterHosts);
+        JSONObject result = new JSONObject();
+        result.put("servers", serverListManager.getServers());
         return result;
     }
 

--- a/naming/src/main/java/com/alibaba/nacos/naming/controllers/OperatorController.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/controllers/OperatorController.java
@@ -19,6 +19,7 @@ import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.naming.CommonParams;
+import com.alibaba.nacos.common.util.IoUtils;
 import com.alibaba.nacos.core.utils.SystemUtils;
 import com.alibaba.nacos.core.utils.WebUtils;
 import com.alibaba.nacos.naming.cluster.ServerListManager;
@@ -49,6 +50,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Operation for operators
@@ -220,13 +222,36 @@ public class OperatorController {
 
     /**
      * update the static file cluster.conf
-     * @param clusterHosts
+     * @param hosts
      * @return clusterHosts in the static file cluster.conf
      */
-    @RequestMapping(value = "/servers", method = RequestMethod.PUT)
-    public String updateServerList(@RequestParam("clusterHosts") List<String> clusterHosts) throws Exception {
+    @RequestMapping(value = "/servers/add", method = RequestMethod.POST)
+    public List<String> clusterAddNode(@RequestParam("hosts") List<String> hosts) throws Exception {
+        List<String> clusterHosts = SystemUtils.readClusterConf();
+        for (String host : hosts){
+            if(!clusterHosts.contains(host)){
+                clusterHosts.add(host);
+            }
+        }
         serverListManager.updateServers(clusterHosts);
-        return "ok";
+        return clusterHosts;
+    }
+
+    /**
+     * update the static file cluster.conf
+     * @param hosts
+     * @return clusterHosts in the static file cluster.conf
+     */
+    @RequestMapping(value = "/servers/remove", method = RequestMethod.DELETE)
+    public List<String> clusterRemoveNode(@RequestParam("hosts") List<String> hosts) throws Exception {
+        List<String> clusterHosts = SystemUtils.readClusterConf();
+        for (String host : hosts){
+            if(!clusterHosts.contains(host)){
+                clusterHosts.remove(host);
+            }
+        }
+        serverListManager.updateServers(clusterHosts);
+        return clusterHosts;
     }
 
     @RequestMapping("/server/status")

--- a/naming/src/main/java/com/alibaba/nacos/naming/controllers/OperatorController.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/controllers/OperatorController.java
@@ -224,11 +224,9 @@ public class OperatorController {
      * @return clusterHosts in the static file cluster.conf
      */
     @RequestMapping(value = "/servers", method = RequestMethod.PUT)
-    public JSONObject updateServerList(@RequestParam("clusterHosts") List<String> clusterHosts) throws Exception {
+    public String updateServerList(@RequestParam("clusterHosts") List<String> clusterHosts) throws Exception {
         serverListManager.updateServers(clusterHosts);
-        JSONObject result = new JSONObject();
-        result.put("servers", serverListManager.getServers());
-        return result;
+        return "ok";
     }
 
     @RequestMapping("/server/status")

--- a/naming/src/main/java/com/alibaba/nacos/naming/controllers/RaftController.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/controllers/RaftController.java
@@ -21,6 +21,7 @@ import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.TypeReference;
 import com.alibaba.nacos.common.util.IoUtils;
 import com.alibaba.nacos.core.utils.WebUtils;
+import com.alibaba.nacos.naming.cluster.servers.Servers;
 import com.alibaba.nacos.naming.consistency.Datum;
 import com.alibaba.nacos.naming.consistency.KeyBuilder;
 import com.alibaba.nacos.naming.consistency.RecordListener;
@@ -152,6 +153,11 @@ public class RaftController {
             return "ok";
         }
 
+        if (KeyBuilder.matchServerListKey(key)){
+            raftConsistencyService.put(key, JSON.parseObject(json.getString("value"), Servers.class));
+            return "ok";
+        }
+
         throw new NacosException(NacosException.INVALID_PARAM, "unknown type publish key: " + key);
     }
 
@@ -222,6 +228,9 @@ public class RaftController {
             });
         } else if (KeyBuilder.matchSwitchKey(datumJson.getString(key))) {
             datum = JSON.parseObject(jsonObject.getString("datum"), new TypeReference<Datum<SwitchDomain>>() {
+            });
+        } else if (KeyBuilder.matchServerListKey(datumJson.getString(key))){
+            datum = JSON.parseObject(jsonObject.getString("datum"), new TypeReference<Datum<Servers>>() {
             });
         } else if (KeyBuilder.matchServiceMetaKey(datumJson.getString(key))) {
             datum = JSON.parseObject(jsonObject.getString("datum"), new TypeReference<Datum<Service>>() {

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/OperatorControllerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/OperatorControllerTest.java
@@ -1,9 +1,0 @@
-package com.alibaba.nacos.naming.controllers;
-
-/**
- * @author XCXCXCXCX
- * @date 2019/7/26
- * @project nacos
- */
-public class OperatorControllerTest {
-}

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/OperatorControllerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/OperatorControllerTest.java
@@ -1,0 +1,9 @@
+package com.alibaba.nacos.naming.controllers;
+
+/**
+ * @author XCXCXCXCX
+ * @date 2019/7/26
+ * @project nacos
+ */
+public class OperatorControllerTest {
+}


### PR DESCRIPTION

## What is the purpose of the change
#649 support a way to easier config cluster
To support flexible horizontal expansion

## Brief changelog

1. Added synchronization record in datum{KEY=com.alibaba.nacos.naming.serverList, value=com.alibaba.nacos.naming.cluster.servers.Servers@Object}
2. Added interface com.alibaba.nacos.naming.controllers.OperatorController#updateServerList
3. Allow the interface to be used to synchronize the cluster.conf configuration of each node in the nacos cluster to achieve horizontal expansion.

## Verifying this change

Three nodes are started in the idea, which are 127.0.0.1:8848, 127.0.0.1:8849,127.0.0.1:8850.
At this point, the cluster.conf configuration is: [127.0.0.1:8848,127.0.0.1:8849,127.0.0.1:8850]
Access any node via the /nacos/v1/ns/operator/servers interface and return a value of 200[OK].
At this point, the fourth node 127.0.0.1:8851 is started, and its cluster.conf configuration is [127.0.0.1:8848,127.0.0.1:8849,127.0.0.1:8850,127.0.0.1:8851].
Break the point, access other interfaces, process the request normally, and the peers list in RaftCore has been updated to 4 nodes {127.0.0.1:8848,127.0.0.1:8849,127.0.0.1:8850,127.0.0.1:8851}.
