### PR TITLE
[ISSUE #1753] Remove [nacos-console] server.contextPath

### DIFF
--- a/console/src/main/resources/application.properties
+++ b/console/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 # spring
 
-server.contextPath=/nacos
 server.servlet.contextPath=/nacos
 server.port=8848
 


### PR DESCRIPTION
Issue  #1753 

## What is the purpose of the change

In the Spring Boot 2.x, remove `server.contextPath`

## Brief changelog

nacos-console remove `server.contextPath`

## Verifying this change

nacos-console remove `server.contextPath`

