### PR TITLE
运行startup.cmd发生的Error：Unable access jarfile

### DIFF
--- a/distribution/bin/startup.cmd
+++ b/distribution/bin/startup.cmd
@@ -26,7 +26,7 @@ set CUSTOM_SEARCH_LOCATIONS=%DEFAULT_SEARCH_LOCATIONS%,file:%BASE_DIR%/conf/
 
 set MODE="standalone"
 set FUNCTION_MODE="all"
-set SERVER="nacos-server"
+set SERVER=nacos-server
 set MODE_INDEX=-1
 set FUNCTION_MODE_INDEX=-1
 set SERVER_INDEX=-1


### PR DESCRIPTION
当我更新到nacos 1.1.3之后，在windows平台中运行startup.cmd时，nacos并未正常启动，它抛出了一个Error：Unable access jarfile的异常，我查看了startup.cmd脚本，发现在29行处 set SERVER时带上双引号，而在JAVA_OPT赋值时最终赋值成%BASE_DIR%\target"nacos-server".jar。

我修改了/distribution/bin/startup.cmd脚本