### PR TITLE
Modify the string splicing method of getgroupedname()

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
@@ -24,7 +24,11 @@ import com.alibaba.nacos.api.common.Constants;
 public class NamingUtils {
 
     public static String getGroupedName(String serviceName, String groupName) {
-        return groupName + Constants.SERVICE_INFO_SPLITER + serviceName;
+        StringBuilder resultGroupedName = new StringBuilder()
+            .append(groupName)
+            .append(Constants.SERVICE_INFO_SPLITER)
+            .append(serviceName);
+        return resultGroupedName.toString().intern();
     }
 
     public static String getServiceName(String serviceNameWithGroup) {


### PR DESCRIPTION
Modify the string splicing method of com.alibaba.nacos.api.naming.utils.NamingUtils.getGroupedName(String serviceName, String groupName).
Because com.alibaba.nacos.client.utils.stringutils has been marked @ deprecated, otherwise public splicing methods can be proposed