### PR TITLE
统一 taskDispatchPeriod 的默认值

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/GlobalConfig.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/GlobalConfig.java
@@ -27,8 +27,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class GlobalConfig {
 
-    @Value("${nacos.naming.distro.taskDispatchPeriod:200}")
-    private int taskDispatchPeriod = 200;
+    @Value("${nacos.naming.distro.taskDispatchPeriod:2000}")
+    private int taskDispatchPeriod = 2000;
 
     @Value("${nacos.naming.distro.batchSyncKeyCount:1000}")
     private int batchSyncKeyCount = 1000;

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/GlobalConfig.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/GlobalConfig.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
 public class GlobalConfig {
 
     @Value("${nacos.naming.distro.taskDispatchPeriod:200}")
-    private int taskDispatchPeriod = 2000;
+    private int taskDispatchPeriod = 200;
 
     @Value("${nacos.naming.distro.batchSyncKeyCount:1000}")
     private int batchSyncKeyCount = 1000;


### PR DESCRIPTION
## What is the purpose of the change

将 taskDispatchPeriod 的注解上的默认值与代码设置的默认值统一

Fixs [#2370](https://github.com/alibaba/nacos/issues/2370)

## Brief changelog

taskDispatchPeriod 的默认值设置为 200

