### PR TITLE
fix: https://github.com/alibaba/nacos/issues/2527

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
@@ -332,7 +332,7 @@ public class NamingProxy {
             try {
                 body = "beat=" + URLEncoder.encode(JSON.toJSONString(beatInfo), "UTF-8");
             } catch (UnsupportedEncodingException e) {
-                throw new NacosException(NacosException.SERVER_ERROR, "encod beatInfo error", e);
+                throw new NacosException(NacosException.SERVER_ERROR, "encode beatInfo error", e);
             }
         }
         params.put(CommonParams.NAMESPACE_ID, namespaceId);

--- a/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
@@ -48,7 +48,9 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.net.URLEncoder;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -327,7 +329,11 @@ public class NamingProxy {
         Map<String, String> params = new HashMap<String, String>(8);
         String body = StringUtils.EMPTY;
         if (!lightBeatEnabled) {
-            body = "beat=" + JSON.toJSONString(beatInfo);
+            try {
+                body = "beat=" + URLEncoder.encode(JSON.toJSONString(beatInfo), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new NacosException(NacosException.SERVER_ERROR, "encod beatInfo error", e);
+            }
         }
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, beatInfo.getServiceName());


### PR DESCRIPTION
ref: https://github.com/alibaba/nacos/issues/2527

encoding the body of beat to avoid the server incorrect parse；

such as this beat：
beat={"cluster":"DEFAULT","ip":"30.5.125.57","metadata":{"dubbo.metadata-service.urls":"[ \"dubbo://30.128.116.47:20880/com.alibaba.cloud.dubbo.service.DubboMetadataService?anyhost=true&application=spring-cloud-alibaba-dubbo-server&bind.ip=30.128.116.47&bind.port=20880&deprecated=false&dubbo=2.0.2&dynamic=true&generic=false&group=spring-cloud-alibaba-dubbo-server&interface=com.alibaba.cloud.dubbo.service.DubboMetadataService&methods=getAllServiceKeys,getServiceRestMetadata,getExportedURLs,getAllExportedURLs&pid=2362&qos.enable=false&release=2.7.4.1&revision=1.0.0&side=provider&timestamp=1585139980414&version=1.0.0\" ]","dubbo.protocols.dubbo.port":"20880","preserved.register.source":"SPRING_CLOUD"},"period":5000,"port":20880,"scheduled":false,"serviceName":"DEFAULT_GROUP@@spring-cloud-alibaba-dubbo-server","stopped":false,"weight":1.0}

server will parse it to several KV：
![image](https://user-images.githubusercontent.com/3760138/77559981-cc319380-6ef7-11ea-9583-f4688f60e61b.png)

