### PR TITLE
hashMap constructor : choose more appropriate initialCapacity

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/ServiceStatusSynchronizer.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/ServiceStatusSynchronizer.java
@@ -73,7 +73,7 @@ public class ServiceStatusSynchronizer implements Synchronizer {
             return null;
         }
 
-        Map<String,String> params = new HashMap<>(10);
+        Map<String,String> params = new HashMap<>(1);
 
         params.put("key", key);
 


### PR DESCRIPTION
## What is the purpose of the change

fix issues #2690 

Brief changelog
Considering that the map has only one parameter，so:
choose more appropriate initialCapacity：Change from 10 to 1