### PR TITLE
[ISSUE #2755]解决修改contextPath后出现no such api异常

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
+++ b/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.core.code;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.reflections.Reflections;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,6 +36,9 @@ import java.util.concurrent.ConcurrentMap;
 @Component
 public class ControllerMethodsCache {
 
+    @Value("${server.servlet.contextPath:/nacos}")
+    private String contextPath;
+
     private ConcurrentMap<String, Method> methods = new
         ConcurrentHashMap<>();
 
@@ -43,7 +47,7 @@ public class ControllerMethodsCache {
     }
 
     public Method getMethod(String httpMethod, String path) {
-        String key = httpMethod + "-->" + path.replace("/nacos", "");
+        String key = httpMethod + "-->" + path.replace(contextPath, "");
         return methods.get(key);
     }
 


### PR DESCRIPTION
#2755

ControllerMethodsCache中    
public Method getMethod(String httpMethod, String path) {
        String key = httpMethod + "-->" + path.replace(“/nacos”, "");
        return methods.get(key);
}

这里用于过滤出api，但是replace的target是写死的“/nacos”，当修改了配置文件的contextPath后，使用自定义的根路径时，此处会无法正常过滤出api，造成后续DistroFilter无法获取到指定Method，抛出NoSuchMethodException。

此处将replace的target修改为动态获取到的contextPath,即可解决该问题。
