### PR TITLE
:recycle: Refactoring pom. com.alibaba.nacos to ${project.groupId} Un…

### DIFF
--- a/address/pom.xml
+++ b/address/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>nacos-naming</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.alibaba.nacos</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nacos-cmdb</artifactId>
                 </exclusion>
             </exclusions>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba.nacos</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>nacos-api</artifactId>
         </dependency>
 

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -173,7 +173,7 @@
             <id>springboot</id>
             <dependencies>
                 <dependency>
-                    <groupId>com.alibaba.nacos</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nacos-core</artifactId>
                 </dependency>
             </dependencies>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -30,7 +30,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.alibaba.nacos</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>nacos-console</artifactId>
         </dependency>
     </dependencies>
@@ -39,7 +39,7 @@
             <id>release-config</id>
             <dependencies>
                 <dependency>
-                    <groupId>com.alibaba.nacos</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nacos-config</artifactId>
                 </dependency>
             </dependencies>
@@ -72,7 +72,7 @@
             <id>release-naming</id>
             <dependencies>
                 <dependency>
-                    <groupId>com.alibaba.nacos</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nacos-naming</artifactId>
                 </dependency>
             </dependencies>
@@ -131,7 +131,7 @@
             <id>release-client</id>
             <dependencies>
                 <dependency>
-                    <groupId>com.alibaba.nacos</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nacos-client</artifactId>
                 </dependency>
             </dependencies>
@@ -164,7 +164,7 @@
             <id>release-core</id>
             <dependencies>
                 <dependency>
-                    <groupId>com.alibaba.nacos</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nacos-core</artifactId>
                 </dependency>
             </dependencies>
@@ -197,7 +197,7 @@
             <id>release-nacos</id>
             <dependencies>
                 <dependency>
-                    <groupId>com.alibaba.nacos</groupId>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>nacos-console</artifactId>
                 </dependency>
             </dependencies>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>nacos-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.alibaba.nacos</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>nacos-client</artifactId>
         </dependency>
         <!-- log -->

--- a/naming/pom.xml
+++ b/naming/pom.xml
@@ -147,7 +147,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba.nacos</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>nacos-cmdb</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
…iform variable

Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

There are currently two ways to write pom dependencies

```
        <dependency>
            <groupId>${project.groupId}</groupId>
            <artifactId>nacos-api</artifactId>
        </dependency>
```

or

```
        <dependency>
            <groupId>com.alibaba.nacos</groupId>
            <artifactId>nacos-api</artifactId>
        </dependency>
```
I think the standards are very bad and cannot be refactored very quickly.

So we have to unify the standards

## Brief changelog

Reference to other modules must be used ${project.groupId}

## Verifying this change

exec  travis script 

