### PR TITLE
移除nacos/console包下NacosAuthConfig类上冗余注解@Configuration

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/security/nacos/NacosAuthConfig.java
+++ b/console/src/main/java/com/alibaba/nacos/console/security/nacos/NacosAuthConfig.java
@@ -43,7 +43,6 @@ import org.springframework.web.cors.CorsUtils;
  *
  * @author Nacos
  */
-@Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class NacosAuthConfig extends WebSecurityConfigurerAdapter {
 


### PR DESCRIPTION

![1234](https://user-images.githubusercontent.com/32069447/85300193-d3f1db80-b4d8-11ea-9101-e4b1b69fd01d.png)
NacosAuthConfig类上的@EnableGlobalMethodSecurity注解已经包含了@Configuration，冗余又写了一次@Configuration
