### PR TITLE
Fix NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Nacos
-Copyright 2018-2019 The Apache Software Foundation
+Copyright 2018-2020
 
 This product includes software developed at
 The Alibaba MiddleWare Group.


### PR DESCRIPTION
Two issues about the current NOTICE file

1. The Nacos is belonging to Alibaba, not the Apache Foundation, so the copyright should be removed.
1. The year should be updated with the new year coming.

Btw, SkyWalking contributor @songzhendong is adding Nacos to the SkyWalking option list through https://github.com/apache/skywalking/pull/4967. Thank you for your previous changes and helps.