### PR TITLE
Hotfix double register null service and beat info invalid problem

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -137,8 +137,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>7</source>
-                    <target>7</target>
+                    <source>6</source>
+                    <target>6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -357,7 +357,7 @@ public class NacosNamingService implements NamingService {
     private List<Instance> selectInstances(ServiceInfo serviceInfo, boolean healthy) {
         List<Instance> list;
         if (serviceInfo == null || CollectionUtils.isEmpty(list = serviceInfo.getHosts())) {
-            return new ArrayList<>();
+            return new ArrayList<Instance>();
         }
         
         Iterator<Instance> iterator = list.iterator();

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -192,11 +192,12 @@ public class NacosNamingService implements NamingService {
     
     @Override
     public void registerInstance(String serviceName, String groupName, Instance instance) throws NacosException {
+        String groupedServiceName = NamingUtils.getGroupedName(serviceName, groupName);
         if (instance.isEphemeral()) {
-            BeatInfo beatInfo = beatReactor.buildBeatInfo(instance);
-            beatReactor.addBeatInfo(NamingUtils.getGroupedName(serviceName, groupName), beatInfo);
+            BeatInfo beatInfo = beatReactor.buildBeatInfo(groupedServiceName, instance);
+            beatReactor.addBeatInfo(groupedServiceName, beatInfo);
         }
-        serverProxy.registerService(NamingUtils.getGroupedName(serviceName, groupName), groupName, instance);
+        serverProxy.registerService(groupedServiceName, groupName, instance);
     }
     
     @Override

--- a/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
@@ -114,8 +114,19 @@ public class BeatReactor implements Closeable {
      * @return new beat information
      */
     public BeatInfo buildBeatInfo(Instance instance) {
+        return buildBeatInfo(instance.getServiceName(), instance);
+    }
+    
+    /**
+     * Build new beat information.
+     *
+     * @param groupedServiceName service name with group name, format: ${groupName}@@${serviceName}
+     * @param instance instance
+     * @return new beat information
+     */
+    public BeatInfo buildBeatInfo(String groupedServiceName, Instance instance) {
         BeatInfo beatInfo = new BeatInfo();
-        beatInfo.setServiceName(instance.getServiceName());
+        beatInfo.setServiceName(groupedServiceName);
         beatInfo.setIp(instance.getIp());
         beatInfo.setPort(instance.getPort());
         beatInfo.setCluster(instance.getClusterName());

--- a/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
@@ -52,7 +52,7 @@ public class BeatReactor implements Closeable {
     
     private boolean lightBeatEnabled = false;
     
-    public final Map<String, BeatInfo> dom2Beat = new ConcurrentHashMap<>();
+    public final Map<String, BeatInfo> dom2Beat = new ConcurrentHashMap<String, BeatInfo>();
     
     public BeatReactor(NamingProxy serverProxy) {
         this(serverProxy, UtilAndComs.DEFAULT_CLIENT_BEAT_THREAD_COUNT);

--- a/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
@@ -480,7 +480,7 @@ public class NamingProxy implements Closeable {
         String result = reqApi(UtilAndComs.nacosUrlBase + "/service/list", params, HttpMethod.GET);
         
         JsonNode json = JacksonUtils.toObj(result);
-        ListView<String> listView = new ListView<>();
+        ListView<String> listView = new ListView<String>();
         listView.setCount(json.get("count").asInt());
         listView.setData(JacksonUtils.toObj(json.get("doms").toString(), new TypeReference<List<String>>() {
         }));

--- a/client/src/main/java/com/alibaba/nacos/client/security/SecurityProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/security/SecurityProxy.java
@@ -128,7 +128,7 @@ public class SecurityProxy {
         
         if (StringUtils.isNotBlank(username)) {
             Map<String, String> params = new HashMap<String, String>(2);
-            Map<String, String> bodyMap = new HashMap<>(2);
+            Map<String, String> bodyMap = new HashMap<String, String>(2);
             params.put("username", username);
             bodyMap.put("password", password);
             String url = "http://" + server + contextPath + LOGIN_URL;

--- a/client/src/test/java/com/alibaba/nacos/client/ConfigTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ConfigTest.java
@@ -56,7 +56,7 @@ public class ConfigTest {
         boolean result = configService.publishConfig(dataId, group, content);
         Assert.assertTrue(result);
         
-        ThreadUtils.sleep(10_000);
+        ThreadUtils.sleep(10000L);
         
         String response = configService.getConfigAndSignListener(dataId, group, 5000, new AbstractListener() {
             @Override
@@ -70,7 +70,7 @@ public class ConfigTest {
         System.out.println("input content");
         while (scanner.hasNextLine()) {
             String s = scanner.next();
-            if (Objects.equals("exit", s)) {
+            if ("exit".equals(s)) {
                 scanner.close();
                 return;
             }

--- a/client/src/test/java/com/alibaba/nacos/client/NamingTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/NamingTest.java
@@ -52,13 +52,13 @@ public class NamingTest {
         NamingService namingService = NacosFactory.createNamingService(properties);
         namingService.registerInstance("nacos.test.1", instance);
         
-        ThreadUtils.sleep(5_000L);
+        ThreadUtils.sleep(5000L);
         
         List<Instance> list = namingService.getAllInstances("nacos.test.1");
         
         System.out.println(list);
         
-        ThreadUtils.sleep(30_000L);
+        ThreadUtils.sleep(30000L);
         //        ExpressionSelector expressionSelector = new ExpressionSelector();
         //        expressionSelector.setExpression("INSTANCE.metadata.registerSource = 'dubbo'");
         //        ListView<String> serviceList = namingService.getServicesOfServer(1, 10, expressionSelector);


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

When 1.3.1-BETA SDK register instance, there will be double register a `null` service.

Reason is from #3037.

The PR change the logic of create beatinfo, which get service name from instance, if users input instance without service name. It will double register a null name service.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

