### PR TITLE
For #3300, 优化Naocs默认设置的Hikari连接池最小空闲数

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourceProperties.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourceProperties.java
@@ -34,55 +34,55 @@ import com.zaxxer.hikari.HikariDataSource;
  * @author Nacos
  */
 public class ExternalDataSourceProperties {
-    
+
     private static final String JDBC_DRIVER_NAME = "com.mysql.cj.jdbc.Driver";
-    
+
     public static final long CONNECTION_TIMEOUT_MS = 3000L;
-    
+
     public static final long VALIDATION_TIMEOUT = 10L;
-    
+
     public static final String TEST_QUERY = "SELECT 1 FROM dual";
-    
+
     public static final int DEFAULT_MAX_POOL_SIZE = 20;
-    
-    public static final int DEFAULT_MINIMUM_IDLE = 50;
-    
+
+    public static final int DEFAULT_MINIMUM_IDLE = 20;
+
     private Integer num;
-    
+
     private List<String> url = new ArrayList<>();
-    
+
     private List<String> user = new ArrayList<>();
-    
+
     private List<String> password = new ArrayList<>();
-    
+
     private List<Integer> maxPoolSize = new ArrayList<>();
-    
+
     private List<Integer> minIdle = new ArrayList<>();
-    
+
     public void setNum(Integer num) {
         this.num = num;
     }
-    
+
     public void setUrl(List<String> url) {
         this.url = url;
     }
-    
+
     public void setUser(List<String> user) {
         this.user = user;
     }
-    
+
     public void setPassword(List<String> password) {
         this.password = password;
     }
-    
+
     public void setMaxPoolSize(List<Integer> maxPoolSize) {
         this.maxPoolSize = maxPoolSize;
     }
-    
+
     public void setMinIdle(List<Integer> minIdle) {
         this.minIdle = minIdle;
     }
-    
+
     /**
      * Build serveral HikariDataSource.
      *
@@ -116,9 +116,9 @@ public class ExternalDataSourceProperties {
         Preconditions.checkArgument(CollectionUtils.isNotEmpty(dataSources), "no datasource available");
         return dataSources;
     }
-    
+
     interface Callback<D> {
-        
+
         /**
          * Perform custom logic.
          *

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourcePropertiesTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourcePropertiesTest.java
@@ -24,14 +24,14 @@ import org.springframework.mock.env.MockEnvironment;
 import java.util.List;
 
 public class ExternalDataSourcePropertiesTest {
-    
+
     @SuppressWarnings("checkstyle:linelength")
     public static final String JDBC_URL = "jdbc:mysql://127.0.0.1:3306/nacos_devtest?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC";
-    
+
     public static final String PASSWORD = "nacos";
-    
+
     public static final String USERNAME = "nacos_devtest";
-    
+
     @Test
     public void externalDatasourceNormally() {
         HikariDataSource expectedDataSource = new HikariDataSource();
@@ -47,14 +47,14 @@ public class ExternalDataSourcePropertiesTest {
             Assert.assertEquals(dataSource.getJdbcUrl(), expectedDataSource.getJdbcUrl());
             Assert.assertEquals(dataSource.getUsername(), expectedDataSource.getUsername());
             Assert.assertEquals(dataSource.getPassword(), expectedDataSource.getPassword());
-            
+
         }));
         Assert.assertEquals(dataSources.size(), 1);
     }
-    
+
     @Test
     public void externalDatasourceToAssertMultiJdbcUrl() {
-        
+
         HikariDataSource expectedDataSource = new HikariDataSource();
         expectedDataSource.setJdbcUrl(JDBC_URL);
         expectedDataSource.setUsername(USERNAME);
@@ -69,14 +69,14 @@ public class ExternalDataSourcePropertiesTest {
             Assert.assertEquals(dataSource.getJdbcUrl(), expectedDataSource.getJdbcUrl());
             Assert.assertEquals(dataSource.getUsername(), expectedDataSource.getUsername());
             Assert.assertEquals(dataSource.getPassword(), expectedDataSource.getPassword());
-            
+
         }));
         Assert.assertEquals(dataSources.size(), 2);
     }
-    
+
     @Test
     public void externalDatasourceToAssertMultiPasswordAndUsername() {
-        
+
         HikariDataSource expectedDataSource = new HikariDataSource();
         expectedDataSource.setJdbcUrl(JDBC_URL);
         expectedDataSource.setUsername(USERNAME);
@@ -93,22 +93,36 @@ public class ExternalDataSourcePropertiesTest {
             Assert.assertEquals(dataSource.getJdbcUrl(), expectedDataSource.getJdbcUrl());
             Assert.assertEquals(dataSource.getUsername(), expectedDataSource.getUsername());
             Assert.assertEquals(dataSource.getPassword(), expectedDataSource.getPassword());
-            
+
         }));
         Assert.assertEquals(dataSources.size(), 2);
     }
-    
+
+    @Test
+    public void externalDatasourceToAssertMinIdle() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("db.num", "1");
+        environment.setProperty("db.user", USERNAME);
+        environment.setProperty("db.password", PASSWORD);
+        environment.setProperty("db.url.0", JDBC_URL);
+        List<HikariDataSource> dataSources = new ExternalDataSourceProperties().build(environment, (dataSource -> {
+            dataSource.validate();
+            Assert.assertEquals(dataSource.getMinimumIdle(), ExternalDataSourceProperties.DEFAULT_MINIMUM_IDLE);
+        }));
+        Assert.assertEquals(dataSources.size(), 1);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void externalDatasourceFailureWithLarkInfo() {
-        
+
         MockEnvironment environment = new MockEnvironment();
         new ExternalDataSourceProperties().build(environment, null);
-        
+
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void externalDatasourceFailureWithErrorInfo() {
-        
+
         HikariDataSource expectedDataSource = new HikariDataSource();
         expectedDataSource.setJdbcUrl(JDBC_URL);
         expectedDataSource.setUsername(USERNAME);
@@ -123,8 +137,8 @@ public class ExternalDataSourcePropertiesTest {
             Assert.assertEquals(dataSource.getJdbcUrl(), expectedDataSource.getJdbcUrl());
             Assert.assertEquals(dataSource.getUsername(), expectedDataSource.getUsername());
             Assert.assertEquals(dataSource.getPassword(), expectedDataSource.getPassword());
-            
+
         }));
     }
-    
+
 }


### PR DESCRIPTION
## 优化Naocs默认设置的Hikari连接池最小空闲数

Hikari连接池的最大连接数不应该小于最小空闲数。
我将 com.alibaba.nacos.config.server.service.datasource.ExternalDataSourceProperties的”DEFAULT_MINIMUM_IDLE“设置为了20，使之与”DEFAULT_MAX_POOL_SIZE“相等，并为之添加了一个单测用例。