### PR TITLE
For #3300, 优化Naocs默认设置的Hikari连接池最小空闲数

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourceProperties.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourceProperties.java
@@ -45,7 +45,7 @@ public class ExternalDataSourceProperties {
     
     public static final int DEFAULT_MAX_POOL_SIZE = 20;
     
-    public static final int DEFAULT_MINIMUM_IDLE = 50;
+    public static final int DEFAULT_MINIMUM_IDLE = 20;
     
     private Integer num;
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourcePropertiesTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourcePropertiesTest.java
@@ -97,6 +97,20 @@ public class ExternalDataSourcePropertiesTest {
         }));
         Assert.assertEquals(dataSources.size(), 2);
     }
+
+    @Test
+    public void externalDatasourceToAssertMinIdle() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("db.num", "1");
+        environment.setProperty("db.user", USERNAME);
+        environment.setProperty("db.password", PASSWORD);
+        environment.setProperty("db.url.0", JDBC_URL);
+        List<HikariDataSource> dataSources = new ExternalDataSourceProperties().build(environment, (dataSource -> {
+            dataSource.validate();
+            Assert.assertEquals(dataSource.getMinimumIdle(), ExternalDataSourceProperties.DEFAULT_MINIMUM_IDLE);
+        }));
+        Assert.assertEquals(dataSources.size(), 1);
+    }
     
     @Test(expected = IllegalArgumentException.class)
     public void externalDatasourceFailureWithLarkInfo() {


### PR DESCRIPTION
Hikari连接池的最大连接数不应该小于最小空闲数。
我将 com.alibaba.nacos.config.server.service.datasource.ExternalDataSourceProperties的”DEFAULT_MINIMUM_IDLE“设置为了20，使之与”DEFAULT_MAX_POOL_SIZE“相等，并为之添加了一个单测用例。