### PR TITLE
Fix the thread safety problem of obtaining HttpRequestBase through BaseHttpMethod enumeration

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/http/BaseHttpClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/BaseHttpClient.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.common.http;
 
+import com.alibaba.nacos.common.constant.HttpHeaderConsts;
 import com.alibaba.nacos.common.http.handler.ResponseHandler;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
@@ -97,19 +98,11 @@ public abstract class BaseHttpClient {
     
     protected HttpRequestBase build(String url, Header header, Object body, String method) throws Exception {
         
-        BaseHttpMethod httpMethod = BaseHttpMethod.sourceOf(method);
-        httpMethod.init(url);
-        httpMethod.initHeader(header);
-        httpMethod.initEntity(body, header.getValue("Content-Type"));
-        return httpMethod.getRequestBase();
-    }
-    
-    private Header convertHeader(org.apache.http.Header[] headers) {
-        final Header nHeader = Header.newInstance();
-        for (org.apache.http.Header header : headers) {
-            nHeader.addParam(header.getName(), header.getValue());
-        }
-        return nHeader;
+        final BaseHttpMethod httpMethod = BaseHttpMethod.sourceOf(method);
+        final HttpRequestBase httpRequestBase = httpMethod.init(url);
+        HttpUtils.initRequestHeader(httpRequestBase, header);
+        HttpUtils.initRequestEntity(httpRequestBase, body, header.getValue(HttpHeaderConsts.CONTENT_TYPE));
+        return httpRequestBase;
     }
     
     public static class HttpGetWithEntity extends HttpEntityEnclosingRequestBase {

--- a/common/src/main/java/com/alibaba/nacos/common/http/BaseHttpMethod.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/BaseHttpMethod.java
@@ -16,21 +16,9 @@
 
 package com.alibaba.nacos.common.http;
 
-import com.alibaba.nacos.common.http.handler.RequestHandler;
-import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.utils.HttpMethod;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import com.alibaba.nacos.common.utils.StringUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpEntityEnclosingRequest;
-import org.apache.http.HttpRequest;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
@@ -39,9 +27,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpTrace;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicNameValuePair;
 
 /**
  * Base http method.
@@ -139,76 +124,16 @@ public enum BaseHttpMethod {
     
     private String name;
     
-    private HttpRequest requestBase;
-    
     BaseHttpMethod(String name) {
         this.name = name;
     }
     
-    public void init(String url) {
-        requestBase = createRequest(url);
+    public HttpRequestBase init(String url) {
+        return createRequest(url);
     }
     
     protected HttpRequestBase createRequest(String url) {
         throw new UnsupportedOperationException();
-    }
-    
-    /**
-     * Init http header.
-     *
-     * @param header header
-     */
-    public void initHeader(Header header) {
-        Iterator<Map.Entry<String, String>> iterator = header.iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<String, String> entry = iterator.next();
-            requestBase.setHeader(entry.getKey(), entry.getValue());
-        }
-    }
-    
-    /**
-     * Init http entity.
-     *
-     * @param body      body
-     * @param mediaType mediaType {@link ContentType}
-     * @throws Exception exception
-     */
-    public void initEntity(Object body, String mediaType) throws Exception {
-        if (body == null) {
-            return;
-        }
-        if (requestBase instanceof HttpEntityEnclosingRequest) {
-            HttpEntityEnclosingRequest request = (HttpEntityEnclosingRequest) requestBase;
-            ContentType contentType = ContentType.create(mediaType);
-            StringEntity entity = new StringEntity(RequestHandler.parse(body), contentType);
-            request.setEntity(entity);
-        }
-    }
-    
-    /**
-     * Init request from entity map.
-     *
-     * @param body    body map
-     * @param charset charset of entity
-     * @throws Exception exception
-     */
-    public void initFromEntity(Map<String, String> body, String charset) throws Exception {
-        if (body == null || body.isEmpty()) {
-            return;
-        }
-        List<NameValuePair> params = new ArrayList<NameValuePair>(body.size());
-        for (Map.Entry<String, String> entry : body.entrySet()) {
-            params.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
-        }
-        if (requestBase instanceof HttpEntityEnclosingRequest) {
-            HttpEntityEnclosingRequest request = (HttpEntityEnclosingRequest) requestBase;
-            HttpEntity entity = new UrlEncodedFormEntity(params, charset);
-            request.setEntity(entity);
-        }
-    }
-    
-    public HttpRequestBase getRequestBase() {
-        return (HttpRequestBase) requestBase;
     }
     
     /**

--- a/common/src/main/java/com/alibaba/nacos/common/http/client/request/DefaultHttpClientRequest.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/request/DefaultHttpClientRequest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.common.http.client.request;
 import com.alibaba.nacos.common.constant.HttpHeaderConsts;
 import com.alibaba.nacos.common.http.BaseHttpMethod;
 import com.alibaba.nacos.common.http.HttpClientConfig;
+import com.alibaba.nacos.common.http.HttpUtils;
 import com.alibaba.nacos.common.http.client.response.DefaultClientHttpResponse;
 import com.alibaba.nacos.common.http.client.response.HttpClientResponse;
 import com.alibaba.nacos.common.http.param.Header;
@@ -56,19 +57,18 @@ public class DefaultHttpClientRequest implements HttpClientRequest {
     }
     
     static HttpRequestBase build(URI uri, String method, RequestHttpEntity requestHttpEntity) throws Exception {
-        Header headers = requestHttpEntity.getHeaders();
-        BaseHttpMethod httpMethod = BaseHttpMethod.sourceOf(method);
-        httpMethod.init(uri.toString());
-        httpMethod.initHeader(headers);
+        final Header headers = requestHttpEntity.getHeaders();
+        final BaseHttpMethod httpMethod = BaseHttpMethod.sourceOf(method);
+        final HttpRequestBase httpRequestBase = httpMethod.init(uri.toString());
+        HttpUtils.initRequestHeader(httpRequestBase, headers);
         if (MediaType.APPLICATION_FORM_URLENCODED.equals(headers.getValue(HttpHeaderConsts.CONTENT_TYPE))
                 && requestHttpEntity.getBody() instanceof Map) {
-            httpMethod.initFromEntity((Map<String, String>) requestHttpEntity.getBody(), headers.getCharset());
+            HttpUtils.initRequestFromEntity(httpRequestBase, (Map<String, String>) requestHttpEntity.getBody(), headers.getCharset());
         } else {
-            httpMethod.initEntity(requestHttpEntity.getBody(), headers.getValue(HttpHeaderConsts.CONTENT_TYPE));
+            HttpUtils.initRequestEntity(httpRequestBase, requestHttpEntity.getBody(), headers.getValue(HttpHeaderConsts.CONTENT_TYPE));
         }
-        HttpRequestBase requestBase = httpMethod.getRequestBase();
-        replaceDefaultConfig(requestBase, requestHttpEntity.getHttpClientConfig());
-        return requestBase;
+        replaceDefaultConfig(httpRequestBase, requestHttpEntity.getHttpClientConfig());
+        return httpRequestBase;
     }
     
     /**


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Since `HttpRequestBase` is an enum member attribute of `BaseHttpMethod`, when multiple threads call the init method at the same time, there will be thread safety issues.

Thereby affecting the http client request.
fix: #3366, #3314 

## Brief changelog

Remove the `HttpRequestBase` member attribute from the `BaseHttpMethod` enum, and return the instance directly through the init method

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

