### PR TITLE
[#3509] Fix address server mode cannot be obtained application.properties

### DIFF
--- a/console/src/main/resources/application.properties
+++ b/console/src/main/resources/application.properties
@@ -29,7 +29,7 @@ server.port=8848
 
 
 #*************** Config Module Related Configurations ***************#
-### If user MySQL as datasource:
+### If use MySQL as datasource:
 # spring.datasource.platform=mysql
 
 ### Count of DB:
@@ -154,6 +154,12 @@ nacos.istio.mcp.server.enabled=false
 ## for AddressServerMemberLookup
 # Maximum number of retries to query the address server upon initialization
 # nacos.core.address-server.retry=5
+## Server domain name address of [address-server] mode
+# address.server.domain=jmenv.tbsite.net
+## Server port of [address-server] mode
+# address.server.port=8080
+## Request address of [address-server] mode
+# address.server.url=/nacos/serverlist
 
 #*************** JRaft Related Configurations ***************#
 

--- a/console/src/main/resources/application.properties
+++ b/console/src/main/resources/application.properties
@@ -37,8 +37,8 @@ server.port=8848
 
 ### Connect URL of DB:
 # db.url.0=jdbc:mysql://127.0.0.1:3306/nacos?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
-# db.user=root
-# db.password=1017
+# db.user=nacos
+# db.password=nacos
 
 
 #*************** Naming Module Related Configurations ***************#

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/lookup/AddressServerMemberLookup.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/lookup/AddressServerMemberLookup.java
@@ -43,30 +43,30 @@ import java.util.Map;
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
 public class AddressServerMemberLookup extends AbstractMemberLookup {
-
+    
     private final GenericType<RestResult<String>> genericType = new GenericType<RestResult<String>>() {
     };
-
+    
     public String domainName;
-
+    
     public String addressPort;
-
+    
     public String addressUrl;
-
+    
     public String envIdUrl;
-
+    
     public String addressServerUrl;
-
+    
     private volatile boolean isAddressServerHealth = true;
-
+    
     private int addressServerFailCount = 0;
-
+    
     private int maxFailCount = 12;
-
+    
     private NSyncHttpClient syncHttpClient = HttpClientManager.getSyncHttpClient();
-
+    
     private volatile boolean shutdown = false;
-
+    
     @Override
     public void start() throws NacosException {
         if (start.compareAndSet(false, true)) {
@@ -75,7 +75,7 @@ public class AddressServerMemberLookup extends AbstractMemberLookup {
             run();
         }
     }
-
+    
     private void initAddressSys() {
         String envDomainName = System.getenv("address_server_domain");
         if (StringUtils.isBlank(envDomainName)) {
@@ -97,11 +97,11 @@ public class AddressServerMemberLookup extends AbstractMemberLookup {
         }
         addressServerUrl = "http://" + domainName + ":" + addressPort + addressUrl;
         envIdUrl = "http://" + domainName + ":" + addressPort + "/env";
-
+        
         Loggers.CORE.info("ServerListService address-server port:" + addressPort);
         Loggers.CORE.info("ADDRESS_SERVER_URL:" + addressServerUrl);
     }
-
+    
     @SuppressWarnings("PMD.UndefineMagicConstantRule")
     private void run() throws NacosException {
         // With the address server, you need to perform a synchronous member node pull at startup
@@ -122,15 +122,15 @@ public class AddressServerMemberLookup extends AbstractMemberLookup {
         if (!success) {
             throw new NacosException(NacosException.SERVER_ERROR, ex);
         }
-
+        
         GlobalExecutor.scheduleByCommon(new AddressServerSyncTask(), 5_000L);
     }
-
+    
     @Override
     public void destroy() throws NacosException {
         shutdown = true;
     }
-
+    
     @Override
     public Map<String, Object> info() {
         Map<String, Object> info = new HashMap<>(4);
@@ -140,7 +140,7 @@ public class AddressServerMemberLookup extends AbstractMemberLookup {
         info.put("addressServerFailCount", addressServerFailCount);
         return info;
     }
-
+    
     private void syncFromAddressUrl() throws Exception {
         RestResult<String> result = syncHttpClient
                 .get(addressServerUrl, Header.EMPTY, Query.EMPTY, genericType.getType());
@@ -163,9 +163,9 @@ public class AddressServerMemberLookup extends AbstractMemberLookup {
             Loggers.CLUSTER.error("[serverlist] failed to get serverlist, error code {}", result.getCode());
         }
     }
-
+    
     class AddressServerSyncTask implements Runnable {
-
+        
         @Override
         public void run() {
             if (shutdown) {

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -37,8 +37,8 @@ server.port=8848
 
 ### Connect URL of DB:
 # db.url.0=jdbc:mysql://127.0.0.1:3306/nacos?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
-# db.user=root
-# db.password=1017
+# db.user=nacos
+# db.password=nacos
 
 
 #*************** Naming Module Related Configurations ***************#

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -37,8 +37,8 @@ server.port=8848
 
 ### Connect URL of DB:
 # db.url.0=jdbc:mysql://127.0.0.1:3306/nacos?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
-# db.user=nacos
-# db.password=nacos
+# db.user=root
+# db.password=1017
 
 
 #*************** Naming Module Related Configurations ***************#
@@ -98,7 +98,7 @@ management.metrics.export.influx.enabled=false
 server.tomcat.accesslog.enabled=true
 
 ### The access log pattern:
-server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %{User-Agent}i
+server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %{User-Agent}i %{Request-Source}i
 
 ### The directory of access log:
 server.tomcat.basedir=
@@ -148,15 +148,18 @@ nacos.istio.mcp.server.enabled=false
 
 ### MemberLookup
 ### Addressing pattern category, If set, the priority is highest
-# nacos.core.member.lookup.type=[file,address-server,discovery]
+# nacos.core.member.lookup.type=[file,address-server]
 ## Set the cluster list with a configuration file or command-line argument
 # nacos.member.list=192.168.16.101:8847?raft_port=8807,192.168.16.101?raft_port=8808,192.168.16.101:8849?raft_port=8809
-## for DiscoveryMemberLookup
-# If you want to use cluster node self-discovery, turn this parameter on
-# nacos.member.discovery=false
 ## for AddressServerMemberLookup
 # Maximum number of retries to query the address server upon initialization
 # nacos.core.address-server.retry=5
+## Server domain name address of [address-server] mode
+# address.server.domain=jmenv.tbsite.net
+## Server port of [address-server] mode
+# address.server.port=8080
+## Request address of [address-server] mode
+# address.server.url=/nacos/serverlist
 
 #*************** JRaft Related Configurations ***************#
 
@@ -164,13 +167,11 @@ nacos.istio.mcp.server.enabled=false
 # nacos.core.protocol.raft.data.election_timeout_ms=5000
 ### Sets the amount of time the Raft snapshot will execute periodically, default is 30 minute
 # nacos.core.protocol.raft.data.snapshot_interval_secs=30
-### Requested retries, default value is 1
-# nacos.core.protocol.raft.data.request_failoverRetries=1
 ### raft internal worker threads
 # nacos.core.protocol.raft.data.core_thread_num=8
 ### Number of threads required for raft business request processing
 # nacos.core.protocol.raft.data.cli_service_thread_num=4
-### raft linear read strategy, defaults to index
+### raft linear read strategy. Safe linear reads are used by default, that is, the Leader tenure is confirmed by heartbeat
 # nacos.core.protocol.raft.data.read_index_type=ReadOnlySafe
 ### rpc request timeout, default 5 seconds
 # nacos.core.protocol.raft.data.rpc_request_timeout_ms=5000

--- a/distribution/conf/application.properties.example
+++ b/distribution/conf/application.properties.example
@@ -29,7 +29,7 @@ server.port=8848
 
 
 #*************** Config Module Related Configurations ***************#
-### If user MySQL as datasource:
+### If use MySQL as datasource:
 # spring.datasource.platform=mysql
 
 ### Count of DB:
@@ -37,8 +37,8 @@ server.port=8848
 
 ### Connect URL of DB:
 # db.url.0=jdbc:mysql://127.0.0.1:3306/nacos?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
-# db.user=nacos
-# db.password=nacos
+# db.user=root
+# db.password=1017
 
 
 #*************** Naming Module Related Configurations ***************#
@@ -98,7 +98,7 @@ management.metrics.export.influx.enabled=false
 server.tomcat.accesslog.enabled=true
 
 ### The access log pattern:
-server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %{User-Agent}i
+server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %{User-Agent}i %{Request-Source}i
 
 ### The directory of access log:
 server.tomcat.basedir=
@@ -148,15 +148,18 @@ nacos.istio.mcp.server.enabled=false
 
 ### MemberLookup
 ### Addressing pattern category, If set, the priority is highest
-# nacos.core.member.lookup.type=[file,address-server,discovery]
+# nacos.core.member.lookup.type=[file,address-server]
 ## Set the cluster list with a configuration file or command-line argument
 # nacos.member.list=192.168.16.101:8847?raft_port=8807,192.168.16.101?raft_port=8808,192.168.16.101:8849?raft_port=8809
-## for DiscoveryMemberLookup
-# If you want to use cluster node self-discovery, turn this parameter on
-# nacos.member.discovery=false
 ## for AddressServerMemberLookup
 # Maximum number of retries to query the address server upon initialization
 # nacos.core.address-server.retry=5
+## Server domain name address of [address-server] mode
+# address.server.domain=jmenv.tbsite.net
+## Server port of [address-server] mode
+# address.server.port=8080
+## Request address of [address-server] mode
+# address.server.url=/nacos/serverlist
 
 #*************** JRaft Related Configurations ***************#
 
@@ -164,13 +167,11 @@ nacos.istio.mcp.server.enabled=false
 # nacos.core.protocol.raft.data.election_timeout_ms=5000
 ### Sets the amount of time the Raft snapshot will execute periodically, default is 30 minute
 # nacos.core.protocol.raft.data.snapshot_interval_secs=30
-### Requested retries, default value is 1
-# nacos.core.protocol.raft.data.request_failoverRetries=1
 ### raft internal worker threads
 # nacos.core.protocol.raft.data.core_thread_num=8
 ### Number of threads required for raft business request processing
 # nacos.core.protocol.raft.data.cli_service_thread_num=4
-### raft linear read strategy, defaults to index
+### raft linear read strategy. Safe linear reads are used by default, that is, the Leader tenure is confirmed by heartbeat
 # nacos.core.protocol.raft.data.read_index_type=ReadOnlySafe
 ### rpc request timeout, default 5 seconds
 # nacos.core.protocol.raft.data.rpc_request_timeout_ms=5000

--- a/distribution/conf/application.properties.example
+++ b/distribution/conf/application.properties.example
@@ -37,8 +37,8 @@ server.port=8848
 
 ### Connect URL of DB:
 # db.url.0=jdbc:mysql://127.0.0.1:3306/nacos?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
-# db.user=root
-# db.password=1017
+# db.user=nacos
+# db.password=nacos
 
 
 #*************** Naming Module Related Configurations ***************#


### PR DESCRIPTION
#  What is the purpose of the change

see #3509 

## Brief changelog

1. Use ApplicationUtils.getProperty () get variable

2. Synchronize the parameters in properties

3. After the change, get the priority system environment variable of the variable, then start the JVM (- D) - > properties property