### PR TITLE
Fix apache http exception due to the character set of Content-Type

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/http/HttpUtils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/HttpUtils.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.common.http;
 
 import com.alibaba.nacos.common.constant.HttpHeaderConsts;
 import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.http.param.MediaType;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
@@ -81,7 +82,8 @@ public final class HttpUtils {
         }
         if (requestBase instanceof HttpEntityEnclosingRequest) {
             HttpEntityEnclosingRequest request = (HttpEntityEnclosingRequest) requestBase;
-            ContentType contentType = ContentType.create(header.getValue(HttpHeaderConsts.CONTENT_TYPE), header.getCharset());
+            MediaType mediaType = MediaType.valueOf(header.getValue(HttpHeaderConsts.CONTENT_TYPE));
+            ContentType contentType = ContentType.create(mediaType.getType(), mediaType.getCharset());
             HttpEntity entity;
             if (body instanceof byte[]) {
                 entity = new ByteArrayEntity((byte[]) body, contentType);

--- a/common/src/main/java/com/alibaba/nacos/common/http/param/MediaType.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/param/MediaType.java
@@ -16,15 +16,15 @@
 
 package com.alibaba.nacos.common.http.param;
 
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.common.utils.StringUtils;
+
 /**
  * Http Media type.
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
 public final class MediaType {
-    
-    private MediaType() {
-    }
     
     public static final String APPLICATION_ATOM_XML = "application/atom+xml";
     
@@ -46,4 +46,66 @@ public final class MediaType {
     
     public static final String TEXT_PLAIN = "text/plain;charset=UTF-8";
     
+    private MediaType(String type, String charset) {
+        this.type = type;
+        this.charset = charset;
+    }
+    
+    /**
+     * content type.
+     */
+    private final String type;
+    
+    /**
+     * content type charset.
+     */
+    private final String charset;
+    
+    /**
+     * Parse the given String contentType into a {@code MediaType} object.
+     *
+     * @param contentType mediaType
+     * @return MediaType
+     */
+    public static MediaType valueOf(String contentType) {
+        if (StringUtils.isEmpty(contentType)) {
+            throw new IllegalArgumentException("MediaType must not be empty");
+        }
+        String[] values = contentType.split(";");
+        String charset = Constants.ENCODE;
+        for (String value : values) {
+            if (value.startsWith("charset=")) {
+                charset = value.substring("charset=".length());
+            }
+        }
+        return new MediaType(values[0], charset);
+    }
+    
+    /**
+     * Use the given contentType and charset to assemble into a {@code MediaType} object.
+     *
+     * @param contentType contentType
+     * @param charset charset
+     * @return MediaType
+     */
+    public static MediaType valueOf(String contentType, String charset) {
+        if (StringUtils.isEmpty(contentType)) {
+            throw new IllegalArgumentException("MediaType must not be empty");
+        }
+        String[] values = contentType.split(";");
+        return new MediaType(values[0], StringUtils.isEmpty(charset) ? Constants.ENCODE : charset);
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public String getCharset() {
+        return charset;
+    }
+    
+    @Override
+    public String toString() {
+        return type + ";charset=" + charset;
+    }
 }

--- a/common/src/test/java/com/alibaba/nacos/common/http/param/MediaTypeTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/http/param/MediaTypeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.http.param;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * MediaTypeTest.
+ *
+ * @author mai.jh
+ */
+public class MediaTypeTest {
+    
+    @Test
+    public void testValueOf() {
+        MediaType mediaType = MediaType.valueOf(MediaType.APPLICATION_FORM_URLENCODED);
+        String type = "application/x-www-form-urlencoded";
+        String charset = "UTF-8";
+        assertEquals(type, mediaType.getType());
+        assertEquals(charset, mediaType.getCharset());
+        assertEquals(MediaType.APPLICATION_FORM_URLENCODED, mediaType.toString());
+    }
+    
+    @Test
+    public void testValueOf2() {
+        MediaType mediaType = MediaType.valueOf(MediaType.APPLICATION_FORM_URLENCODED, "ISO-8859-1");
+        String type = "application/x-www-form-urlencoded";
+        String charset = "ISO-8859-1";
+        String excepted = "application/x-www-form-urlencoded;charset=ISO-8859-1";
+        assertEquals(type, mediaType.getType());
+        assertEquals(charset, mediaType.getCharset());
+        assertEquals(excepted, mediaType.toString());
+    }
+    
+    @Test
+    public void testValueOf3() {
+        MediaType mediaType = MediaType.valueOf("application/x-www-form-urlencoded", "ISO-8859-1");
+        String type = "application/x-www-form-urlencoded";
+        String charset = "ISO-8859-1";
+        String excepted = "application/x-www-form-urlencoded;charset=ISO-8859-1";
+        assertEquals(type, mediaType.getType());
+        assertEquals(charset, mediaType.getCharset());
+        assertEquals(excepted, mediaType.toString());
+    }
+    
+}


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Because MediaType has supplemented the character set at present, this causes apache http to be abnormal when initRequestEntity.

Error message : `java.lang.IllegalArgumentException: MIME type may not contain reserved characters`

Reason: When using the `org.apache.http.entity.ContentType#create(java.lang.String, java.lang.String) `method to pass in mimeType and charset, mimeType is not allowed to have a character set.


## Brief changelog


## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

