### PR TITLE
For #3710#, Fix special characters cannot be used in Metadata

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/utils/WebUtils.java
+++ b/core/src/main/java/com/alibaba/nacos/core/utils/WebUtils.java
@@ -91,6 +91,26 @@ public class WebUtils {
             encoding = StandardCharsets.UTF_8.name();
         }
         try {
+            value = new String(value.getBytes(StandardCharsets.UTF_8), encoding);
+        } catch (UnsupportedEncodingException ignore) {
+        }
+        return value.trim();
+    }
+    
+    /**
+     * decode target value with UrlDecode.
+     *
+     * <p>Under Content-Type:application/x-www-form-urlencoded situation.
+     *
+     * @param value    value
+     * @param encoding encode
+     * @return Decoded data
+     */
+    private static String resolveValueWithUrlDecode(String value, String encoding) {
+        if (StringUtils.isEmpty(encoding)) {
+            encoding = StandardCharsets.UTF_8.name();
+        }
+        try {
             value = HttpUtils.decode(new String(value.getBytes(StandardCharsets.UTF_8), encoding), encoding);
         } catch (UnsupportedEncodingException ignore) {
         }
@@ -114,7 +134,7 @@ public class WebUtils {
      *
      * @param request HttpServletRequest
      * @return the value of the request header "user-agent", or the value of the request header "client-version" if the
-     *         request does not have a header of "user-agent".
+     * request does not have a header of "user-agent".
      */
     public static String getUserAgent(HttpServletRequest request) {
         String userAgent = request.getHeader(HttpHeaderConsts.USER_AGENT_HEADER);
@@ -144,8 +164,8 @@ public class WebUtils {
      * Handle file upload operations.
      *
      * @param multipartFile file
-     * @param consumer post processor
-     * @param response {@link DeferredResult}
+     * @param consumer      post processor
+     * @param response      {@link DeferredResult}
      */
     public static void onFileUpload(MultipartFile multipartFile, Consumer<File> consumer,
             DeferredResult<RestResult<String>> response) {


### PR DESCRIPTION
**purpose of the change**
For #3710

**Brief changelog**
Fix special characters cannot be used in Metadata

**Verifying this change**
- nacos-client uses special characters to register nacos verified

- openAPI uses special characters to register nacos verified
> RaftController
> OperationController
> ApiController
> CatalogController
> ClusterController
> InstanceController
> ServiceController
> HealthController

- Verified in the official environment