### PR TITLE
[ISSUE-#4181]  Normalize ContextPath value in client-side

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/http/ServerHttpAgent.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/http/ServerHttpAgent.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.client.config.impl.ServerListManager;
 import com.alibaba.nacos.client.config.impl.SpasAdapter;
 import com.alibaba.nacos.client.identify.StsConfig;
 import com.alibaba.nacos.client.security.SecurityProxy;
+import com.alibaba.nacos.client.utils.ContextPathUtil;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.client.utils.ParamUtil;
 import com.alibaba.nacos.client.utils.TemplateUtils;
@@ -247,9 +248,7 @@ public class ServerHttpAgent implements HttpAgent {
     }
     
     private String getUrl(String serverAddr, String relativePath) {
-        String contextPath = serverListMgr.getContentPath().startsWith("/") ? serverListMgr.getContentPath()
-                : "/" + serverListMgr.getContentPath();
-        return serverAddr + contextPath + relativePath;
+        return serverAddr + ContextPathUtil.normalizeContextPath(serverListMgr.getContentPath()) + relativePath;
     }
     
     private boolean isFail(HttpRestResult<String> result) {

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListManager.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListManager.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.client.config.impl;
 import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.SystemPropertyKeyConst;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.client.utils.ContextPathUtil;
 import com.alibaba.nacos.client.utils.EnvUtil;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.client.utils.ParamUtil;
@@ -109,7 +110,9 @@ public class ServerListManager implements Closeable {
         this.isFixed = false;
         this.isStarted = false;
         this.name = CUSTOM_NAME + "-" + host + "-" + port;
-        this.addressServerUrl = String.format("http://%s:%d/%s/%s", host, port, this.contentPath, this.serverListName);
+        this.addressServerUrl = String
+                .format("http://%s:%d%s/%s", host, port, ContextPathUtil.normalizeContextPath(this.contentPath),
+                        this.serverListName);
     }
     
     public ServerListManager(String endpoint) throws NacosException {
@@ -128,8 +131,8 @@ public class ServerListManager implements Closeable {
         }
         if (StringUtils.isBlank(namespace)) {
             this.name = endpoint;
-            this.addressServerUrl = String
-                    .format("http://%s:%d/%s/%s", endpoint, this.endpointPort, this.contentPath, this.serverListName);
+            this.addressServerUrl = String.format("http://%s:%d%s/%s", endpoint, this.endpointPort,
+                    ContextPathUtil.normalizeContextPath(this.contentPath), this.serverListName);
         } else {
             if (StringUtils.isBlank(endpoint)) {
                 throw new NacosException(NacosException.CLIENT_INVALID_PARAM, "endpoint is blank");
@@ -137,9 +140,8 @@ public class ServerListManager implements Closeable {
             this.name = endpoint + "-" + namespace;
             this.namespace = namespace;
             this.tenant = namespace;
-            this.addressServerUrl = String
-                    .format("http://%s:%d/%s/%s?namespace=%s", endpoint, this.endpointPort, this.contentPath,
-                            this.serverListName, namespace);
+            this.addressServerUrl = String.format("http://%s:%d%s/%s?namespace=%s", endpoint, this.endpointPort,
+                    ContextPathUtil.normalizeContextPath(this.contentPath), this.serverListName, namespace);
         }
     }
     
@@ -183,16 +185,15 @@ public class ServerListManager implements Closeable {
             this.isFixed = false;
             if (StringUtils.isBlank(namespace)) {
                 this.name = endpoint;
-                this.addressServerUrl = String
-                        .format("http://%s:%d/%s/%s", this.endpoint, this.endpointPort, this.contentPath,
-                                this.serverListName);
+                this.addressServerUrl = String.format("http://%s:%d%s/%s", this.endpoint, this.endpointPort,
+                        ContextPathUtil.normalizeContextPath(this.contentPath), this.serverListName);
             } else {
                 this.namespace = namespace;
                 this.tenant = namespace;
                 this.name = this.endpoint + "-" + namespace;
                 this.addressServerUrl = String
-                        .format("http://%s:%d/%s/%s?namespace=%s", this.endpoint, this.endpointPort, this.contentPath,
-                                this.serverListName, namespace);
+                        .format("http://%s:%d%s/%s?namespace=%s", this.endpoint, this.endpointPort,
+                                ContextPathUtil.normalizeContextPath(this.contentPath), this.serverListName, namespace);
             }
         }
     }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingMaintainService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingMaintainService.java
@@ -65,7 +65,7 @@ public class NacosNamingMaintainService implements NamingMaintainService {
         namespace = InitUtils.initNamespaceForNaming(properties);
         InitUtils.initSerialization();
         initServerAddr(properties);
-        InitUtils.initWebRootContext();
+        InitUtils.initWebRootContext(properties);
         serverProxy = new NamingProxy(namespace, endpoint, serverList, properties);
     }
     

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -86,7 +86,7 @@ public class NacosNamingService implements NamingService {
         this.namespace = InitUtils.initNamespaceForNaming(properties);
         InitUtils.initSerialization();
         initServerAddr(properties);
-        InitUtils.initWebRootContext();
+        InitUtils.initWebRootContext(properties);
         initCacheDir();
         initLogName(properties);
         

--- a/client/src/main/java/com/alibaba/nacos/client/naming/utils/InitUtils.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/utils/InitUtils.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.selector.ExpressionSelector;
 import com.alibaba.nacos.api.selector.NoneSelector;
 import com.alibaba.nacos.api.selector.SelectorType;
+import com.alibaba.nacos.client.utils.ContextPathUtil;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.client.utils.ParamUtil;
 import com.alibaba.nacos.client.utils.TemplateUtils;
@@ -100,15 +101,34 @@ public class InitUtils {
     
     /**
      * Init web root context.
+     *
+     * @param properties properties
+     * @since 1.4.1
      */
+    public static void initWebRootContext(Properties properties) {
+        final String webContext = properties.getProperty(PropertyKeyConst.CONTEXT_PATH);
+        TemplateUtils.stringNotEmptyAndThenExecute(webContext, new Runnable() {
+            @Override
+            public void run() {
+                UtilAndComs.webContext = ContextPathUtil.normalizeContextPath(webContext);
+                UtilAndComs.nacosUrlBase = UtilAndComs.webContext + "/v1/ns";
+                UtilAndComs.nacosUrlInstance = UtilAndComs.nacosUrlBase + "/instance";
+            }
+        });
+        initWebRootContext();
+    }
+    
+    /**
+     * Init web root context.
+     */
+    @Deprecated
     public static void initWebRootContext() {
         // support the web context with ali-yun if the app deploy by EDAS
         final String webContext = System.getProperty(SystemPropertyKeyConst.NAMING_WEB_CONTEXT);
         TemplateUtils.stringNotEmptyAndThenExecute(webContext, new Runnable() {
             @Override
             public void run() {
-                UtilAndComs.webContext = webContext.indexOf("/") > -1 ? webContext : "/" + webContext;
-                
+                UtilAndComs.webContext = ContextPathUtil.normalizeContextPath(webContext);
                 UtilAndComs.nacosUrlBase = UtilAndComs.webContext + "/v1/ns";
                 UtilAndComs.nacosUrlInstance = UtilAndComs.nacosUrlBase + "/instance";
             }

--- a/client/src/main/java/com/alibaba/nacos/client/security/SecurityProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/security/SecurityProxy.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.client.security;
 
 import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.client.utils.ContextPathUtil;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.http.param.Header;
@@ -88,8 +89,7 @@ public class SecurityProxy {
     public SecurityProxy(Properties properties, NacosRestTemplate nacosRestTemplate) {
         username = properties.getProperty(PropertyKeyConst.USERNAME, StringUtils.EMPTY);
         password = properties.getProperty(PropertyKeyConst.PASSWORD, StringUtils.EMPTY);
-        contextPath = properties.getProperty(PropertyKeyConst.CONTEXT_PATH, "/nacos");
-        contextPath = contextPath.startsWith("/") ? contextPath : "/" + contextPath;
+        contextPath = ContextPathUtil.normalizeContextPath(properties.getProperty(PropertyKeyConst.CONTEXT_PATH, "/nacos"));
         this.nacosRestTemplate = nacosRestTemplate;
     }
     

--- a/client/src/main/java/com/alibaba/nacos/client/utils/ContextPathUtil.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/ContextPathUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.utils;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+
+/**
+ * Context path Util.
+ *
+ * @author Wei.Wang
+ */
+public class ContextPathUtil {
+    
+    private static final String ROOT_WEB_CONTEXT_PATH = "/";
+    
+    /**
+     * normalize context path.
+     *
+     * @param contextPath origin context path
+     * @return normalized context path
+     */
+    public static String normalizeContextPath(String contextPath) {
+        if (StringUtils.isBlank(contextPath) || ROOT_WEB_CONTEXT_PATH.equals(contextPath)) {
+            return StringUtils.EMPTY;
+        }
+        return contextPath.startsWith("/") ? contextPath : "/" + contextPath;
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/utils/ContextPathUtilTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/ContextPathUtilTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * ContextPathUtil test.
+ *
+ * @author Wei.Wang
+ * @date 2020/11/26 3:13 PM
+ */
+public class ContextPathUtilTest {
+    
+    @Test
+    public void testNormalizeContextPath() {
+        assertEquals("/nacos", ContextPathUtil.normalizeContextPath("/nacos"));
+        assertEquals("/nacos", ContextPathUtil.normalizeContextPath("nacos"));
+        assertEquals("", ContextPathUtil.normalizeContextPath("/"));
+        assertEquals("", ContextPathUtil.normalizeContextPath(""));
+    }
+}

--- a/test/src/test/java/com/alibaba/nacos/test/config/ConfigAPI_CITCase.java
+++ b/test/src/test/java/com/alibaba/nacos/test/config/ConfigAPI_CITCase.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -71,6 +72,9 @@ public class ConfigAPI_CITCase {
     
     String group = "yanlin";
     
+    @Value("${server.servlet.context-path}")
+    private String contextPath;
+    
     @LocalServerPort
     private int port;
     
@@ -83,7 +87,7 @@ public class ConfigAPI_CITCase {
     public void setUp() throws Exception {
         Properties properties = new Properties();
         properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1" + ":" + port);
-        properties.put(PropertyKeyConst.CONTEXT_PATH, "/nacos");
+        properties.put(PropertyKeyConst.CONTEXT_PATH, contextPath);
         iconfig = NacosFactory.createConfigService(properties);
         agent = new MetricsHttpAgent(new ServerHttpAgent(properties));
         agent.start();
@@ -517,6 +521,7 @@ public class ConfigAPI_CITCase {
         Properties properties = new Properties();
         properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1" + ":" + port);
         properties.put(PropertyKeyConst.ENABLE_REMOTE_SYNC_CONFIG, "true");
+        properties.put(PropertyKeyConst.CONTEXT_PATH, contextPath);
         ConfigService iconfig = NacosFactory.createConfigService(properties);
         
         final AtomicInteger count = new AtomicInteger(0);

--- a/test/src/test/java/com/alibaba/nacos/test/config/ConfigAPI_With_RootContextPath_CITCase.java
+++ b/test/src/test/java/com/alibaba/nacos/test/config/ConfigAPI_With_RootContextPath_CITCase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.config;
+
+import org.springframework.test.context.TestPropertySource;
+
+
+/**
+ * Test context path is '/'.
+ *
+ * @see <a href="https://github.com/alibaba/nacos/issues/4181">#4171</a>
+ */
+@TestPropertySource( properties = {"server.servlet.context-path=/", "server.port=7007"})
+public class ConfigAPI_With_RootContextPath_CITCase extends ConfigAPI_CITCase {
+
+}

--- a/test/src/test/java/com/alibaba/nacos/test/naming/DeregisterInstance_ITCase.java
+++ b/test/src/test/java/com/alibaba/nacos/test/naming/DeregisterInstance_ITCase.java
@@ -16,20 +16,22 @@
 package com.alibaba.nacos.test.naming;
 
 import com.alibaba.nacos.Nacos;
+import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.naming.NamingFactory;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.pojo.Instance;
-import com.alibaba.nacos.sys.utils.ApplicationUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.nacos.test.naming.NamingBase.TEST_PORT;
@@ -49,15 +51,21 @@ public class DeregisterInstance_ITCase {
     private NamingService naming;
     @LocalServerPort
     private int port;
-
+    
+    @Value("${server.servlet.context-path}")
+    private String contextPath;
+    
     @Before
     public void init() throws Exception {
-
-        NamingBase.prepareServer(port);
+    
+        NamingBase.prepareServer(port, contextPath);
 
         if (naming == null) {
+            Properties properties = new Properties();
+            properties.setProperty(PropertyKeyConst.SERVER_ADDR, "127.0.0.1" + ":" + port);
+            properties.put(PropertyKeyConst.CONTEXT_PATH, contextPath);
             //TimeUnit.SECONDS.sleep(10);
-            naming = NamingFactory.createNamingService("127.0.0.1" + ":" + port);
+            naming = NamingFactory.createNamingService(properties);
         }
 
         while (true) {

--- a/test/src/test/java/com/alibaba/nacos/test/naming/DeregisterInstance_With_RootContextPath_ITCase.java
+++ b/test/src/test/java/com/alibaba/nacos/test/naming/DeregisterInstance_With_RootContextPath_ITCase.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.naming;
+
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Test context path is '/'.
+ *
+ * @see <a href="https://github.com/alibaba/nacos/issues/4181">#4171</a>
+ */
+@TestPropertySource( properties = {"server.servlet.context-path=/"})
+public class DeregisterInstance_With_RootContextPath_ITCase extends DeregisterInstance_ITCase {
+
+}

--- a/test/src/test/java/com/alibaba/nacos/test/naming/NamingBase.java
+++ b/test/src/test/java/com/alibaba/nacos/test/naming/NamingBase.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.common.constant.HttpHeaderConsts;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.test.base.HttpClient4Test;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
@@ -172,31 +173,46 @@ public class NamingBase extends HttpClient4Test {
     }
 
     public static void prepareServer(int localPort) throws Exception{
-        prepareServer(localPort, "UP");
+        prepareServer(localPort, "UP", "/nacos");
+    }
+    
+    public static void prepareServer(int localPort,String contextPath) throws Exception{
+        prepareServer(localPort, "UP", contextPath);
     }
 
-    public static void prepareServer(int localPort, String status) throws Exception {
-        String url = "http://127.0.0.1:" + localPort + "/nacos/v1/ns/operator/switches?entry=overriddenServerStatus&value=" + status;
+    public static void prepareServer(int localPort, String status,String contextPath) throws Exception {
+        String url = "http://127.0.0.1:" + localPort + normalizeContextPath(contextPath) + "/v1/ns/operator/switches?entry=overriddenServerStatus&value=" + status;
         Header header = Header.newInstance();
         header.addParam(HttpHeaderConsts.USER_AGENT_HEADER, "Nacos-Server");
         HttpRestResult<String> result = nacosRestTemplate.putForm(url, header, new HashMap<>(), String.class);
         System.out.println(result);
         Assert.assertEquals(HttpStatus.SC_OK, result.getCode());
 
-        url = "http://127.0.0.1:" + localPort + "/nacos/v1/ns/operator/switches?entry=autoChangeHealthCheckEnabled&value=" + false;
+        url = "http://127.0.0.1:" + localPort + normalizeContextPath(contextPath) + "/v1/ns/operator/switches?entry=autoChangeHealthCheckEnabled&value=" + false;
 
         result = nacosRestTemplate.putForm(url, header, new HashMap<>(), String.class);
         System.out.println(result);
         Assert.assertEquals(HttpStatus.SC_OK, result.getCode());
     }
-
+    
     public static void destoryServer(int localPort) throws Exception{
-        String url = "http://127.0.0.1:" + localPort + "/nacos/v1/ns/operator/switches?entry=autoChangeHealthCheckEnabled&value=" + true;
+        destoryServer(localPort, "/nacos");
+    }
+    
+    public static void destoryServer(int localPort, String contextPath) throws Exception{
+        String url = "http://127.0.0.1:" + localPort + normalizeContextPath(contextPath) + "/v1/ns/operator/switches?entry=autoChangeHealthCheckEnabled&value=" + true;
         Header header = Header.newInstance();
         header.addParam(HttpHeaderConsts.USER_AGENT_HEADER, "Nacos-Server");
 
         HttpRestResult<String> result = nacosRestTemplate.putForm(url, header, new HashMap<>(), String.class);
         System.out.println(result);
         Assert.assertEquals(HttpStatus.SC_OK, result.getCode());
+    }
+    
+    public static String normalizeContextPath(String contextPath) {
+        if (StringUtils.isBlank(contextPath) || "/".equals(contextPath)) {
+            return StringUtils.EMPTY;
+        }
+        return contextPath.startsWith("/") ? contextPath : "/" + contextPath;
     }
 }

--- a/test/src/test/java/com/alibaba/nacos/test/naming/RegisterInstance_ITCase.java
+++ b/test/src/test/java/com/alibaba/nacos/test/naming/RegisterInstance_ITCase.java
@@ -22,11 +22,11 @@ import com.alibaba.nacos.api.naming.NamingFactory;
 import com.alibaba.nacos.api.naming.NamingService;
 import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
 import com.alibaba.nacos.api.naming.pojo.Instance;
-import com.alibaba.nacos.sys.utils.ApplicationUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -43,23 +43,29 @@ import static com.alibaba.nacos.test.naming.NamingBase.*;
  * @date 2018/6/20
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = Nacos.class, properties = {"server.servlet.context-path=/nacos"},
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = Nacos.class, properties = {
+        "server.servlet.context-path=/nacos"}, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class RegisterInstance_ITCase {
-
+    
     private NamingService naming;
-    private NamingService naming2;
+    
+    @Value("${server.servlet.context-path}")
+    private String contextPath;
+    
     @LocalServerPort
     private int port;
 
     @Before
     public void init() throws Exception {
 
-        NamingBase.prepareServer(port);
+        NamingBase.prepareServer(port, contextPath);
 
         if (naming == null) {
             TimeUnit.SECONDS.sleep(10);
-            naming = NamingFactory.createNamingService("127.0.0.1" + ":" + port);
+            Properties properties = new Properties();
+            properties.setProperty(PropertyKeyConst.SERVER_ADDR, "127.0.0.1" + ":" + port);
+            properties.put(PropertyKeyConst.CONTEXT_PATH, contextPath);
+            naming = NamingFactory.createNamingService(properties);
         }
 
         while (true) {
@@ -77,6 +83,7 @@ public class RegisterInstance_ITCase {
         Properties properties = new Properties();
         properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1:" + port);
         properties.put(PropertyKeyConst.NAMESPACE, "t3");
+        properties.put(PropertyKeyConst.CONTEXT_PATH, contextPath);
 
         naming = NamingFactory.createNamingService(properties);
         TimeUnit.SECONDS.sleep(10);

--- a/test/src/test/java/com/alibaba/nacos/test/naming/RegisterInstance_With_RootContextPath_ITCase.java
+++ b/test/src/test/java/com/alibaba/nacos/test/naming/RegisterInstance_With_RootContextPath_ITCase.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.naming;
+
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Test context path is '/'.
+ *
+ * @see <a href="https://github.com/alibaba/nacos/issues/4181">#4171</a>
+ */
+@TestPropertySource(properties = {"server.servlet.context-path=/"})
+public class RegisterInstance_With_RootContextPath_ITCase extends RegisterInstance_ITCase {
+
+}


### PR DESCRIPTION
## What is the purpose of the change

#4181

## Brief changelog

Just use ContextPathUtil normalize ContextPath value on nacos-client

> Maybe we can unified handle the acquisition of client-side attribute values in later versions

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

