### PR TITLE
The button '新建命名空间' misses marginRight on the page '命名空间'

### DIFF
--- a/console-ui/src/pages/NameSpace/NameSpace.js
+++ b/console-ui/src/pages/NameSpace/NameSpace.js
@@ -308,7 +308,7 @@ class NameSpace extends React.Component {
               <div style={{ textAlign: 'right', marginBottom: 10 }}>
                 <Button
                   type="primary"
-                  style={{ marginRight: 0, marginTop: 10 }}
+                  style={{ marginRight: 20, marginTop: 10 }}
                   onClick={this.addNameSpace.bind(this)}
                 >
                   {namespaceAdd}


### PR DESCRIPTION
## What is the purpose of the change

The old marginTop of this button is zero, so we need to fix it.

**Before fixing, it looks like:**
![Screen Shot 2020-11-29 at 17 10 44](https://user-images.githubusercontent.com/38745805/100538191-1fb76680-3269-11eb-9d64-0a05fbe6a30d.png)


**After fixing, it looks beautiful than before:**

![Screen Shot 2020-11-29 at 17 10 30](https://user-images.githubusercontent.com/38745805/100538170-02829800-3269-11eb-86d9-b73f9009633d.png)

## Brief changelog

Update `mariginRight: 0` to `mariginRight: 20`

## Verifying this change

Open your browser and visit it.

