### PR TITLE
Fix an order-dependent flaky test

### DIFF
--- a/api/src/test/java/com/alibaba/nacos/api/naming/pojo/healthcheck/HealthCheckerFactoryTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/naming/pojo/healthcheck/HealthCheckerFactoryTest.java
@@ -17,12 +17,18 @@
 package com.alibaba.nacos.api.naming.pojo.healthcheck;
 
 import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Tcp;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class HealthCheckerFactoryTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        HealthCheckerFactory.registerSubType(TestChecker.class, TestChecker.TYPE);
+    }
     
     @Test
     public void testSerialize() {
@@ -33,7 +39,6 @@ public class HealthCheckerFactoryTest {
     
     @Test
     public void testSerializeExtend() {
-        HealthCheckerFactory.registerSubType(TestChecker.class, TestChecker.TYPE);
         TestChecker testChecker = new TestChecker();
         String actual = HealthCheckerFactory.serialize(testChecker);
         assertTrue(actual.contains("\"type\":\"TEST\""));


### PR DESCRIPTION
## What is the purpose of the change

Fix an order-dependent flaky test (trivial, just one line)

[Problem]
`testSerializeExtend` add an item to a static mapper,
and `testDeserializeExtend` read that item from that static mapper.
So if `testDeserializeExtend` runs before `testSerializeExtend`,
`testDeserializeExtend` will fail.

@Ignore `testSerializeExtend` can stably reproduce this issue.

[Solution]
Add that item to the static mapper at the beginning of the
`testDeserializeExtend` to make this test independent of
`testSerializeExtend`.
(Even though using static variables in unit tests is a bad practice)

## Brief changelog

N/A

## Verifying this change

`mvn test` passes

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. (**Trivial**)
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body. (**Trivial**)
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

