### PR TITLE
fix-4787

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
@@ -148,9 +148,6 @@ public class IPUtil {
                 throw new IllegalArgumentException("The IP address(\"" + str
                         + "\") is incorrect. If it is an IPv6 address, please use [] to enclose the IP part!");
             }
-            if (!isIPv4(serverAddrArr[0])) {
-                throw new IllegalArgumentException("The IPv4 address(\"" + serverAddrArr[0] + "\") is incorrect.");
-            }
         }
         return serverAddrArr;
     }
@@ -174,9 +171,6 @@ public class IPUtil {
             Matcher m = ipv4Pattern.matcher(str);
             if (m.find()) {
                 result = m.group();
-                if (!isIPv4(result)) {
-                    result = "";
-                }
             }
         }
         return result;


### PR DESCRIPTION
fix #4787 
根据冒号拆分 "IP(域名):端口" 格式字符串时,移除 isIPv4 的判断.
因为在k8s环境下,这个时候域名可能还没注册上导致域名解析失败. 并且如果域名指向的是IPV6,也会出问题