### PR TITLE
ISSUE #4839 Add the interface of loading NacosNamingService with the spec…

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/naming/NamingFactory.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/NamingFactory.java
@@ -27,7 +27,7 @@ import java.util.Properties;
  * @author nkorange
  */
 public class NamingFactory {
-    
+
     /**
      * Create a new naming service.
      *
@@ -45,7 +45,7 @@ public class NamingFactory {
             throw new NacosException(NacosException.CLIENT_INVALID_PARAM, e);
         }
     }
-    
+
     /**
      * Create a new naming service.
      *
@@ -56,6 +56,44 @@ public class NamingFactory {
     public static NamingService createNamingService(Properties properties) throws NacosException {
         try {
             Class<?> driverImplClass = Class.forName("com.alibaba.nacos.client.naming.NacosNamingService");
+            Constructor constructor = driverImplClass.getConstructor(Properties.class);
+            NamingService vendorImpl = (NamingService) constructor.newInstance(properties);
+            return vendorImpl;
+        } catch (Throwable e) {
+            throw new NacosException(NacosException.CLIENT_INVALID_PARAM, e);
+        }
+    }
+
+    /**
+     * Create a new naming service.
+     *
+     * @param serverList server list
+     * @param classLoader the classloader to load NacosNamingService
+     * @return new naming service
+     * @throws NacosException nacos exception
+     */
+    public static NamingService createNamingService(String serverList, ClassLoader classLoader) throws NacosException {
+        try {
+            Class<?> driverImplClass = Class.forName("com.alibaba.nacos.client.naming.NacosNamingService", true, classLoader);
+            Constructor constructor = driverImplClass.getConstructor(String.class);
+            NamingService vendorImpl = (NamingService) constructor.newInstance(serverList);
+            return vendorImpl;
+        } catch (Throwable e) {
+            throw new NacosException(NacosException.CLIENT_INVALID_PARAM, e);
+        }
+    }
+
+    /**
+     * Create a new naming service.
+     *
+     * @param properties  naming service properties
+     * @param classLoader the classloader to load NacosNamingService
+     * @return new naming service
+     * @throws NacosException nacos exception
+     */
+    public static NamingService createNamingService(Properties properties, ClassLoader classLoader) throws NacosException {
+        try {
+            Class<?> driverImplClass = Class.forName("com.alibaba.nacos.client.naming.NacosNamingService", true, classLoader);
             Constructor constructor = driverImplClass.getConstructor(Properties.class);
             NamingService vendorImpl = (NamingService) constructor.newInstance(properties);
             return vendorImpl;


### PR DESCRIPTION
…ified class loader

## What is the purpose of the change

When NamingService is created, NacosNamingService.class is loaded through reflection. When NacosNamingService and NamingFactory (current class) are in the same classpath, they can be successfully loaded. If NamingFactory and NacosNamingService are not in the same classpath (such as OSGI, different bundles will be different Class loader loaded), an exception will be thrown. So it should provide a method to load NacosNamingService with the specified classoader




