### PR TITLE
[ISSUE #4925] correct the member's state when the cluster information…

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
@@ -307,6 +307,14 @@ public class ServerMemberManager implements ApplicationListener<WebServerInitial
             
             if (!serverList.containsKey(address)) {
                 hasChange = true;
+                // If the cluster information in cluster.conf or address-server has been changed,
+                // while the corresponding nacos-server has not been started yet, the member's state
+                // should be set to DOWN. If the corresponding nacos-server has been started, the
+                // member's state will be set to UP after detection in a few seconds.
+                member.setState(NodeState.DOWN);
+            } else {
+                //fix issue # 4925
+                member.setState(serverList.get(address).getState());
             }
             
             // Ensure that the node is created only once


### PR DESCRIPTION

Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

try to fix issue #4925

## Brief changelog

1. set the member's state to DOWN when the member joins the server list for the first time in case of the corresponding nacos-server has not been started.
2.  Keep the state of member consistent with the value in the server list， otherwise there will be problems like issue #4925
## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

