### PR TITLE
Fix one service init twice problem.

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/HealthCheckReactor.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/HealthCheckReactor.java
@@ -51,7 +51,8 @@ public class HealthCheckReactor {
      * @param task client beat check task
      */
     public static void scheduleCheck(ClientBeatCheckTask task) {
-        futureMap.putIfAbsent(task.taskKey(), GlobalExecutor.scheduleNamingHealth(task, 5000, 5000, TimeUnit.MILLISECONDS));
+        futureMap.computeIfAbsent(task.taskKey(),
+                k -> GlobalExecutor.scheduleNamingHealth(task, 5000, 5000, TimeUnit.MILLISECONDS));
     }
     
     /**


### PR DESCRIPTION
## What is the purpose of the change
The same service call init twice concurrently,

It's just like 
```
    public static void main(String[] args) throws IOException, InterruptedException, ClassNotFoundException, IllegalAccessException, InvocationTargetException, InstantiationException {
        ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
        Map<String, ScheduledFuture> x = new ConcurrentHashMap<>();

        x.putIfAbsent("11", scheduledExecutor.scheduleWithFixedDelay(new Runnable() {
            @Override
            public void run() {
                System.out.println("3333");
            }
        }, 1000, 1000, TimeUnit.MILLISECONDS));

        x.putIfAbsent("11", scheduledExecutor.scheduleWithFixedDelay(new Runnable() {
            @Override
            public void run() {
                System.out.println("3333");
            }
        }, 1000, 1000, TimeUnit.MILLISECONDS));

        Thread.sleep(5000);

        x.get("11").cancel(true);

        System.in.read();

    }
```

When the service be remove, just one task will be cancel, and another task always run.
