### PR TITLE
Fix merge mistake

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
@@ -360,8 +360,6 @@ public class ServerMemberManager implements ApplicationListener<WebServerInitial
                 tmpMap.put(address, existMember);
             }
             
-            // Ensure that the node is created only once
-            tmpMap.put(address, member);
             if (NodeState.UP.equals(member.getState())) {
                 tmpAddressInfo.add(address);
             }


### PR DESCRIPTION
It seem a mistake when merging from develop branch(#5135)。

https://github.com/alibaba/nacos/pull/5135/files#diff-df650e04d1ac3fca2d6a980d5f05ab28d926d1e6ecf0c7d2f866034b7e8bc879R364

which may cause members to lose state, such as `supportRemoteConnection`.
When the node list is changed, `ClusterRpcClientProxy#refresh` is judged as a member leave.

