### PR TITLE
在容器环境中IPV6的校验逻辑会影响集群部署，建议同ipv4的校验逻辑一样暂时去掉。

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
@@ -130,9 +130,6 @@ public class IPUtil {
                 serverAddrArr[0] = str.substring(0, (str.indexOf(IPV6_END_MARK) + 1));
                 serverAddrArr[1] = str.substring((str.indexOf(IPV6_END_MARK) + 2));
             }
-            if (!isIPv6(serverAddrArr[0])) {
-                throw new IllegalArgumentException("The IPv6 address(\"" + serverAddrArr[0] + "\") is incorrect.");
-            }
         } else {
             serverAddrArr = str.split(":");
             if (serverAddrArr.length > SPLIT_IP_PORT_RESULT_LENGTH) {
@@ -155,9 +152,6 @@ public class IPUtil {
         String result = "";
         if (StringUtils.containsIgnoreCase(str, IPV6_START_MARK) && StringUtils.containsIgnoreCase(str, IPV6_END_MARK)) {
             result = str.substring(str.indexOf(IPV6_START_MARK), (str.indexOf(IPV6_END_MARK) + 1));
-            if (!isIPv6(result)) {
-                result = "";
-            }
         } else {
             Matcher m = ipv4Pattern.matcher(str);
             if (m.find()) {


### PR DESCRIPTION
服务启动的过程中会调用host解析方法，该方法中的ipv6判断逻辑会根据host获取ip地址，在容器环境中k8s 还未对该pod分配ip此时判断就会报错，之前发现这个问题后进行反馈去掉了ipv4的判断，但是ipv6仍然存在该问题，建议先去掉校验逻辑可以在想其它办法优化。