### PR TITLE
在容器环境中IPV6的校验逻辑会影响集群部署，建议同ipv4的校验逻辑一样暂时去掉.

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
@@ -130,9 +130,6 @@ public class IPUtil {
                 serverAddrArr[0] = str.substring(0, (str.indexOf(IPV6_END_MARK) + 1));
                 serverAddrArr[1] = str.substring((str.indexOf(IPV6_END_MARK) + 2));
             }
-            if (!isIPv6(serverAddrArr[0])) {
-                throw new IllegalArgumentException("The IPv6 address(\"" + serverAddrArr[0] + "\") is incorrect.");
-            }
         } else {
             serverAddrArr = str.split(":");
             if (serverAddrArr.length > SPLIT_IP_PORT_RESULT_LENGTH) {
@@ -155,9 +152,6 @@ public class IPUtil {
         String result = "";
         if (StringUtils.containsIgnoreCase(str, IPV6_START_MARK) && StringUtils.containsIgnoreCase(str, IPV6_END_MARK)) {
             result = str.substring(str.indexOf(IPV6_START_MARK), (str.indexOf(IPV6_END_MARK) + 1));
-            if (!isIPv6(result)) {
-                result = "";
-            }
         } else {
             Matcher m = ipv4Pattern.matcher(str);
             if (m.find()) {

--- a/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
@@ -130,6 +130,9 @@ public class IPUtil {
                 serverAddrArr[0] = str.substring(0, (str.indexOf(IPV6_END_MARK) + 1));
                 serverAddrArr[1] = str.substring((str.indexOf(IPV6_END_MARK) + 2));
             }
+            if (!isIPv6(serverAddrArr[0])) {
+                throw new IllegalArgumentException("The IPv6 address(\"" + serverAddrArr[0] + "\") is incorrect.");
+            }
         } else {
             serverAddrArr = str.split(":");
             if (serverAddrArr.length > SPLIT_IP_PORT_RESULT_LENGTH) {
@@ -152,6 +155,9 @@ public class IPUtil {
         String result = "";
         if (StringUtils.containsIgnoreCase(str, IPV6_START_MARK) && StringUtils.containsIgnoreCase(str, IPV6_END_MARK)) {
             result = str.substring(str.indexOf(IPV6_START_MARK), (str.indexOf(IPV6_END_MARK) + 1));
+            if (!isIPv6(result)) {
+                result = "";
+            }
         } else {
             Matcher m = ipv4Pattern.matcher(str);
             if (m.find()) {


### PR DESCRIPTION
The IPv6 judgment logic in this method will obtain IP address according to the host. In the container environment, K8S has not allocated IP to this pod, and then the judgment will report an error. After finding this problem, I gave feedback to remove the IPv4 judgment, but this problem still exists in IPv6. Suggested to remove the verification logic can be in other ways to optimize.
Reset mailboxes and users