### PR TITLE
IPv6 and IPv4 check rules are optimized. splitIPPortStr method adds IPv4 check, and the optimized method does not affect the startup of container environment

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -30,3 +30,25 @@ under the License.
 Also, please refer to each LICENSE.<component>.txt file, which is located in
 the 'license' directory of the distribution file, for the license terms of the
 components that this product depends on.
+
+
+------
+com.alibaba.nacos.common.utils.InetAddressValidator.java in this product is
+copied from com.dynatrace.openkit.core.util.InetAddressValidator.java  of openkit-java project.
+https://github.com/Dynatrace/openkit-java
+                          openkit-java
+                    ======================
+
+     Copyright 2018-2021 Dynatrace LLC
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.

--- a/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
@@ -130,9 +130,6 @@ public class IPUtil {
                 serverAddrArr[0] = str.substring(0, (str.indexOf(IPV6_END_MARK) + 1));
                 serverAddrArr[1] = str.substring((str.indexOf(IPV6_END_MARK) + 2));
             }
-            if (!isIPv6(serverAddrArr[0])) {
-                throw new IllegalArgumentException("The IPv6 address(\"" + serverAddrArr[0] + "\") is incorrect.");
-            }
         } else {
             serverAddrArr = str.split(":");
             if (serverAddrArr.length > SPLIT_IP_PORT_RESULT_LENGTH) {
@@ -155,9 +152,6 @@ public class IPUtil {
         String result = "";
         if (StringUtils.containsIgnoreCase(str, IPV6_START_MARK) && StringUtils.containsIgnoreCase(str, IPV6_END_MARK)) {
             result = str.substring(str.indexOf(IPV6_START_MARK), (str.indexOf(IPV6_END_MARK) + 1));
-            if (!isIPv6(result)) {
-                result = "";
-            }
         } else {
             Matcher m = ipv4Pattern.matcher(str);
             if (m.find()) {

--- a/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
@@ -16,8 +16,6 @@
 
 package com.alibaba.nacos.common.utils;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -54,7 +52,6 @@ public class IPUtil {
     private static final String CHECK_OK = "ok";
     
     private static Pattern domainPattern = Pattern.compile("[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+\\.?");
-    
     
     /**
      * get localhost ip.
@@ -205,16 +202,16 @@ public class IPUtil {
     }
     
     /**
-     * remove brackets "[]"
+     * remove brackets "[]".
      *
-     * @param str
+     * @param str is ipv6 address
      * @return
      */
-    public static String removeBrackets(String str){
-        if(StringUtils.isBlank(str)){
+    public static String removeBrackets(String str) {
+        if (StringUtils.isBlank(str)) {
             return "";
         }
-        return str.replaceAll("[\\[\\]]","");
+        return str.replaceAll("[\\[\\]]", "");
     }
     
 }

--- a/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
@@ -130,6 +130,9 @@ public class IPUtil {
                 serverAddrArr[0] = str.substring(0, (str.indexOf(IPV6_END_MARK) + 1));
                 serverAddrArr[1] = str.substring((str.indexOf(IPV6_END_MARK) + 2));
             }
+            if (!isIPv6(serverAddrArr[0])) {
+                throw new IllegalArgumentException("The IPv6 address(\"" + serverAddrArr[0] + "\") is incorrect.");
+            }
         } else {
             serverAddrArr = str.split(":");
             if (serverAddrArr.length > SPLIT_IP_PORT_RESULT_LENGTH) {
@@ -152,6 +155,9 @@ public class IPUtil {
         String result = "";
         if (StringUtils.containsIgnoreCase(str, IPV6_START_MARK) && StringUtils.containsIgnoreCase(str, IPV6_END_MARK)) {
             result = str.substring(str.indexOf(IPV6_START_MARK), (str.indexOf(IPV6_END_MARK) + 1));
+            if (!isIPv6(result)) {
+                result = "";
+            }
         } else {
             Matcher m = ipv4Pattern.matcher(str);
             if (m.find()) {

--- a/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/IPUtil.java
@@ -47,13 +47,14 @@ public class IPUtil {
     
     private static final String LOCAL_HOST_IP_V6 = "[::1]";
     
-    private static Pattern ipv4Pattern = Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
-    
     private static final int IPV4_ADDRESS_LENGTH = 4;
     
     private static final int IPV6_ADDRESS_LENGTH = 16;
     
     private static final String CHECK_OK = "ok";
+    
+    private static Pattern domainPattern = Pattern.compile("[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+\\.?");
+    
     
     /**
      * get localhost ip.
@@ -73,7 +74,7 @@ public class IPUtil {
      * @return boolean
      */
     public static boolean isIPv4(String addr) {
-        return ipv4Pattern.matcher(addr).matches();
+        return InetAddressValidator.isIPv4Address(addr);
     }
     
     /**
@@ -83,11 +84,7 @@ public class IPUtil {
      * @return boolean
      */
     public static boolean isIPv6(String addr) {
-        try {
-            return InetAddress.getByName(addr).getAddress().length == IPV6_ADDRESS_LENGTH;
-        } catch (UnknownHostException e) {
-            return false;
-        }
+        return InetAddressValidator.isIPv6Address(removeBrackets(addr));
     }
     
     /**
@@ -139,6 +136,9 @@ public class IPUtil {
                 throw new IllegalArgumentException("The IP address(\"" + str
                         + "\") is incorrect. If it is an IPv6 address, please use [] to enclose the IP part!");
             }
+            if (!isIPv4(serverAddrArr[0]) && !domainPattern.matcher(serverAddrArr[0]).matches()) {
+                throw new IllegalArgumentException("The IPv4 or Domain address(\"" + serverAddrArr[0] + "\") is incorrect.");
+            }
         }
         return serverAddrArr;
     }
@@ -159,7 +159,7 @@ public class IPUtil {
                 result = "";
             }
         } else {
-            Matcher m = ipv4Pattern.matcher(str);
+            Matcher m = InetAddressValidator.getIpv4Pattern().matcher(str);
             if (m.find()) {
                 result = m.group();
             }
@@ -202,6 +202,19 @@ public class IPUtil {
      */
     public static boolean checkOK(String checkIPsResult) {
         return CHECK_OK.equals(checkIPsResult);
+    }
+    
+    /**
+     * remove brackets "[]"
+     *
+     * @param str
+     * @return
+     */
+    public static String removeBrackets(String str){
+        if(StringUtils.isBlank(str)){
+            return "";
+        }
+        return str.replaceAll("[\\[\\]]","");
     }
     
 }

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2018-2021 Dynatrace LLC
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,64 +16,47 @@
 
 package com.alibaba.nacos.common.utils;
 
+
 import java.util.regex.Pattern;
 
 /**
- * This class provides static methods to check for valid Inet addresses in IPv4, IPv6 or
- * mixed notation.
+ * @author Dynatrace LLC
  */
 public class InetAddressValidator {
-
-    private static final Pattern IPV4_PATTERN =
-        Pattern.compile(
-            "^"                                             // start of string
-          + "(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)"             // first block - a number from 0-255
-          + "(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}"     // three more blocks - numbers from 0-255 - each prepended by a point character '.'
-          + "$"                                             // end of string
-        );
-
-    private static final Pattern IPV6_STD_PATTERN =
-        Pattern.compile(
-            "^"                           // start of string
-          + "(?:[0-9a-fA-F]{1,4}:){7}"    // 7 blocks of a 1 to 4 digit hex number followed by double colon ':'
-          + "[0-9a-fA-F]{1,4}"            // one more block of a 1 to 4 digit hex number
-          + "$");                         // end of string
-
-    private static final Pattern IPV6_HEX_COMPRESSED_PATTERN =
-        Pattern.compile(
-            "^"                             // start of string
-          + "("                             // 1st group
-          + "(?:[0-9A-Fa-f]{1,4}"           // at least one block of a 1 to 4 digit hex number
-          + "(?::[0-9A-Fa-f]{1,4})*)?"      // optional further blocks, any number
-          + ")"
-          + "::"                            // in the middle of the expression the two occurences of ':' are neccessary
-          + "("                             // 2nd group
-          + "(?:[0-9A-Fa-f]{1,4}"           // at least one block of a 1 to 4 digit hex number
-          + "(?::[0-9A-Fa-f]{1,4})*)?"      // optional further blocks, any number
-          + ")"
-          + "$");                           // end of string
-
-    //this regex checks the ipv6 uncompressed part of a ipv6 mixed address
-    private static final Pattern IPV6_MIXED_COMPRESSED_REGEX =
-        Pattern.compile("^"                                               // start of string
-                      + "("                                               // 1st group
-                      + "(?:[0-9A-Fa-f]{1,4}"                             // at least one block of a 1 to 4 digit hex number
-                      + "(?::[0-9A-Fa-f]{1,4})*)?"                        // optional further blocks, any number
-                      + ")"
-                      + "::"                                              // in the middle of the expression the two occurences of ':' are neccessary
-                      + "("                                               // 2nd group
-                      + "(?:[0-9A-Fa-f]{1,4}:"                            // at least one block of a 1 to 4 digit hex number followed by a ':' character
-                      + "(?:[0-9A-Fa-f]{1,4}:)*)?"                        // optional further blocks, any number, all succeeded by ':' character
-                      + ")"
-                      + "$");                                             // end of string
-
-
-    //this regex checks the ipv6 uncompressed part of a ipv6 mixed address
-    private static final Pattern IPV6_MIXED_UNCOMPRESSED_REGEX =
-        Pattern.compile("^"  // start of string
-                      + "(?:[0-9a-fA-F]{1,4}:){6}"                             // 6 blocks of a 1 to 4 digit hex number followed by double colon ':'
-                      + "$" );                                                 // end of string
-
+    
+    private static final String PERCENT = "%";
+    
+    private static final String DOUBLE_COLON = "::";
+    
+    private static final String DOUBLE_COLON_FFFF = "::ffff:";
+    
+    private static final String FE80 = "fe80:";
+    
+    private static final int ZERO = 0;
+    
+    private static final int SEVEN = 7;
+    
+    private static final int FIVE = 5;
+    
+    private static final Pattern IPV4_PATTERN = Pattern
+            .compile("^" + "(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)" + "(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}" + "$");
+    
+    private static final Pattern IPV6_STD_PATTERN = Pattern
+            .compile("^" + "(?:[0-9a-fA-F]{1,4}:){7}" + "[0-9a-fA-F]{1,4}" + "$");
+    
+    private static final Pattern IPV6_HEX_COMPRESSED_PATTERN = Pattern
+            .compile("^" + "(" + "(?:[0-9A-Fa-f]{1,4}" + "(?::[0-9A-Fa-f]{1,4})*)?" + ")" + "::"
+                    
+                    + "(" + "(?:[0-9A-Fa-f]{1,4}" + "(?::[0-9A-Fa-f]{1,4})*)?" + ")" + "$");
+    
+    private static final Pattern IPV6_MIXED_COMPRESSED_REGEX = Pattern.compile(
+            "^" + "(" + "(?:[0-9A-Fa-f]{1,4}" + "(?::[0-9A-Fa-f]{1,4})*)?" + ")" + "::" + "(" + "(?:[0-9A-Fa-f]{1,4}:"
+                    + "(?:[0-9A-Fa-f]{1,4}:)*)?" + ")" + "$");
+    
+    
+    private static final Pattern IPV6_MIXED_UNCOMPRESSED_REGEX = Pattern
+            .compile("^" + "(?:[0-9a-fA-F]{1,4}:){6}" + "$");
+    
     /**
      * Check if <code>input</code> is a valid IPv4 address
      * <p>
@@ -88,7 +71,7 @@ public class InetAddressValidator {
     public static boolean isIPv4Address(final String input) {
         return IPV4_PATTERN.matcher(input).matches();
     }
-
+    
     /**
      * Check if the given address is a valid IPv6 address in the standard format
      * <p>
@@ -103,7 +86,7 @@ public class InetAddressValidator {
     public static boolean isIPv6StdAddress(final String input) {
         return IPV6_STD_PATTERN.matcher(input).matches();
     }
-
+    
     /**
      * Check if the given address is a valid IPv6 address in the hex-compressed notation
      * <p>
@@ -118,7 +101,7 @@ public class InetAddressValidator {
     public static boolean isIPv6HexCompressedAddress(final String input) {
         return IPV6_HEX_COMPRESSED_PATTERN.matcher(input).matches();
     }
-
+    
     /**
      * Check if <code>input</code> is a IPv6 address.
      * <p>
@@ -135,40 +118,41 @@ public class InetAddressValidator {
      */
     public static boolean isIPv6Address(final String input) {
         return isIPv6StdAddress(input) || isIPv6HexCompressedAddress(input) || isLinkLocalIPv6WithZoneIndex(input)
-            || isIPv6IPv4MappedAddress(input) || isIPv6MixedAddress(input);
+                || isIPv6IPv4MappedAddress(input) || isIPv6MixedAddress(input);
     }
-
+    
     /**
      * Check if the given address is a valid IPv6 address in the mixed-standard or mixed-compressed notation.
-     *
+     * <p>
      * IPV6 Mixed mode consists of two parts, the first 96 bits (up to 6 blocks of 4 hex digits) are IPv6
      * the IPV6 part can be either compressed or uncompressed
      * the second block is a full IPv4 address
      * e.g. '0:0:0:0:0:0:172.12.55.18'
+     *
      * @param input ip-address to check
      * @return true if <code>input</code> is in correct IPv6 (mixed-standard or mixed-compressed) notation.
      */
     public static boolean isIPv6MixedAddress(final String input) {
         int splitIndex = input.lastIndexOf(':');
-
+        
         if (splitIndex == -1) {
             return false;
         }
-
+        
         //the last part is a ipv4 address
-        boolean ipv4PartValid = isIPv4Address(input.substring(splitIndex + 1 ));
-
-        String ipV6Part = input.substring(0, splitIndex + 1 );
-        if("::".equals(ipV6Part)) {
+        boolean ipv4PartValid = isIPv4Address(input.substring(splitIndex + 1));
+        
+        String ipV6Part = input.substring(ZERO, splitIndex + 1);
+        if (DOUBLE_COLON.equals(ipV6Part)) {
             return ipv4PartValid;
         }
-
+        
         boolean ipV6UncompressedDetected = IPV6_MIXED_UNCOMPRESSED_REGEX.matcher(ipV6Part).matches();
         boolean ipV6CompressedDetected = IPV6_MIXED_COMPRESSED_REGEX.matcher(ipV6Part).matches();
-
+        
         return ipv4PartValid && (ipV6UncompressedDetected || ipV6CompressedDetected);
     }
-
+    
     /**
      * Check if <code>input</code> is an IPv4 address mapped into a IPv6 address. These are
      * starting with "::ffff:" followed by the IPv4 address in a dot-seperated notation.
@@ -180,16 +164,13 @@ public class InetAddressValidator {
      * @return true if <code>input</code> is in correct IPv6 notation containing an IPv4 address
      */
     public static boolean isIPv6IPv4MappedAddress(final String input) {
-        // InetAddress automatically convert this type of address down to an IPv4 address
-        // It always starts '::ffff:' then contains an IPv4 address
-        if (input.length() > 7 && input.substring(0, 7).equalsIgnoreCase("::ffff:")) {
-            // then remove the first seven chars and see if we have an IPv4 address
-            String lowerPart = input.substring(7);
+        if (input.length() > SEVEN && input.substring(ZERO, SEVEN).equalsIgnoreCase(DOUBLE_COLON_FFFF)) {
+            String lowerPart = input.substring(SEVEN);
             return isIPv4Address(lowerPart);
         }
         return false;
     }
-
+    
     /**
      * Check if <code>input</code> is a link local IPv6 address starting with "fe80:" and containing
      * a zone index with "%xxx". The zone index will not be checked.
@@ -198,16 +179,16 @@ public class InetAddressValidator {
      * @return true if address part of <code>input</code> is in correct IPv6 notation.
      */
     public static boolean isLinkLocalIPv6WithZoneIndex(String input) {
-        if (input.length() > 5 && input.substring(0, 5).equalsIgnoreCase("fe80:")) {
-            int lastIndex = input.lastIndexOf("%");
-            if (lastIndex > 0 && lastIndex < (input.length() - 1)) { // input may not start with the zone separator
-                String ipPart = input.substring(0, lastIndex);
+        if (input.length() > FIVE && input.substring(ZERO, FIVE).equalsIgnoreCase(FE80)) {
+            int lastIndex = input.lastIndexOf(PERCENT);
+            if (lastIndex > ZERO && lastIndex < (input.length() - 1)) {
+                String ipPart = input.substring(ZERO, lastIndex);
                 return isIPv6StdAddress(ipPart) || isIPv6HexCompressedAddress(ipPart);
             }
         }
         return false;
     }
-
+    
     /**
      * Check if <code>input</code> is a valid IPv4 or IPv6 address.
      *
@@ -218,7 +199,7 @@ public class InetAddressValidator {
         if (ipAddress == null || ipAddress.length() == 0) {
             return false;
         }
-
+        
         return isIPv4Address(ipAddress) || isIPv6Address(ipAddress);
     }
     
@@ -229,7 +210,7 @@ public class InetAddressValidator {
      * @return
      */
     public static Pattern getIpv4Pattern() {
-       return IPV4_PATTERN;
+        return IPV4_PATTERN;
     }
     
 }

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright 2018-2021 Dynatrace LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.utils;
+
+import java.util.regex.Pattern;
+
+/**
+ * This class provides static methods to check for valid Inet addresses in IPv4, IPv6 or
+ * mixed notation.
+ */
+public class InetAddressValidator {
+
+    private static final Pattern IPV4_PATTERN =
+        Pattern.compile(
+            "^"                                             // start of string
+          + "(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)"             // first block - a number from 0-255
+          + "(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}"     // three more blocks - numbers from 0-255 - each prepended by a point character '.'
+          + "$"                                             // end of string
+        );
+
+    private static final Pattern IPV6_STD_PATTERN =
+        Pattern.compile(
+            "^"                           // start of string
+          + "(?:[0-9a-fA-F]{1,4}:){7}"    // 7 blocks of a 1 to 4 digit hex number followed by double colon ':'
+          + "[0-9a-fA-F]{1,4}"            // one more block of a 1 to 4 digit hex number
+          + "$");                         // end of string
+
+    private static final Pattern IPV6_HEX_COMPRESSED_PATTERN =
+        Pattern.compile(
+            "^"                             // start of string
+          + "("                             // 1st group
+          + "(?:[0-9A-Fa-f]{1,4}"           // at least one block of a 1 to 4 digit hex number
+          + "(?::[0-9A-Fa-f]{1,4})*)?"      // optional further blocks, any number
+          + ")"
+          + "::"                            // in the middle of the expression the two occurences of ':' are neccessary
+          + "("                             // 2nd group
+          + "(?:[0-9A-Fa-f]{1,4}"           // at least one block of a 1 to 4 digit hex number
+          + "(?::[0-9A-Fa-f]{1,4})*)?"      // optional further blocks, any number
+          + ")"
+          + "$");                           // end of string
+
+    //this regex checks the ipv6 uncompressed part of a ipv6 mixed address
+    private static final Pattern IPV6_MIXED_COMPRESSED_REGEX =
+        Pattern.compile("^"                                               // start of string
+                      + "("                                               // 1st group
+                      + "(?:[0-9A-Fa-f]{1,4}"                             // at least one block of a 1 to 4 digit hex number
+                      + "(?::[0-9A-Fa-f]{1,4})*)?"                        // optional further blocks, any number
+                      + ")"
+                      + "::"                                              // in the middle of the expression the two occurences of ':' are neccessary
+                      + "("                                               // 2nd group
+                      + "(?:[0-9A-Fa-f]{1,4}:"                            // at least one block of a 1 to 4 digit hex number followed by a ':' character
+                      + "(?:[0-9A-Fa-f]{1,4}:)*)?"                        // optional further blocks, any number, all succeeded by ':' character
+                      + ")"
+                      + "$");                                             // end of string
+
+
+    //this regex checks the ipv6 uncompressed part of a ipv6 mixed address
+    private static final Pattern IPV6_MIXED_UNCOMPRESSED_REGEX =
+        Pattern.compile("^"  // start of string
+                      + "(?:[0-9a-fA-F]{1,4}:){6}"                             // 6 blocks of a 1 to 4 digit hex number followed by double colon ':'
+                      + "$" );                                                 // end of string
+
+    /**
+     * Check if <code>input</code> is a valid IPv4 address
+     * <p>
+     * <p>
+     * The format is 'xxx.xxx.xxx.xxx'. Four blocks of integer numbers ranging from 0 to 255
+     * are required. Letters are not allowed.
+     * </p>
+     *
+     * @param input ip-address to check
+     * @return true if <code>input</code> is in correct IPv4 notation.
+     */
+    public static boolean isIPv4Address(final String input) {
+        return IPV4_PATTERN.matcher(input).matches();
+    }
+
+    /**
+     * Check if the given address is a valid IPv6 address in the standard format
+     * <p>
+     * <p>
+     * The format is 'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'. Eight blocks of hexadecimal digits
+     * are required.
+     * </p>
+     *
+     * @param input ip-address to check
+     * @return true if <code>input</code> is in correct IPv6 notation.
+     */
+    public static boolean isIPv6StdAddress(final String input) {
+        return IPV6_STD_PATTERN.matcher(input).matches();
+    }
+
+    /**
+     * Check if the given address is a valid IPv6 address in the hex-compressed notation
+     * <p>
+     * <p>
+     * The format is 'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'. If all digits in a block are '0'
+     * the block can be left empty.
+     * </p>
+     *
+     * @param input ip-address to check
+     * @return true if <code>input</code> is in correct IPv6 (hex-compressed) notation.
+     */
+    public static boolean isIPv6HexCompressedAddress(final String input) {
+        return IPV6_HEX_COMPRESSED_PATTERN.matcher(input).matches();
+    }
+
+    /**
+     * Check if <code>input</code> is a IPv6 address.
+     * <p>
+     * Possible notations for valid IPv6 are:
+     * - Standard IPv6 address
+     * - Hex-compressed IPv6 address
+     * - Link-local IPv6 address
+     * - IPv4-mapped-to-IPV6 address
+     * - IPv6 mixed address
+     * </p>
+     *
+     * @param input ip-address to check
+     * @return true if <code>input</code> is in correct IPv6 notation.
+     */
+    public static boolean isIPv6Address(final String input) {
+        return isIPv6StdAddress(input) || isIPv6HexCompressedAddress(input) || isLinkLocalIPv6WithZoneIndex(input)
+            || isIPv6IPv4MappedAddress(input) || isIPv6MixedAddress(input);
+    }
+
+    /**
+     * Check if the given address is a valid IPv6 address in the mixed-standard or mixed-compressed notation.
+     *
+     * IPV6 Mixed mode consists of two parts, the first 96 bits (up to 6 blocks of 4 hex digits) are IPv6
+     * the IPV6 part can be either compressed or uncompressed
+     * the second block is a full IPv4 address
+     * e.g. '0:0:0:0:0:0:172.12.55.18'
+     * @param input ip-address to check
+     * @return true if <code>input</code> is in correct IPv6 (mixed-standard or mixed-compressed) notation.
+     */
+    public static boolean isIPv6MixedAddress(final String input) {
+        int splitIndex = input.lastIndexOf(':');
+
+        if (splitIndex == -1) {
+            return false;
+        }
+
+        //the last part is a ipv4 address
+        boolean ipv4PartValid = isIPv4Address(input.substring(splitIndex + 1 ));
+
+        String ipV6Part = input.substring(0, splitIndex + 1 );
+        if("::".equals(ipV6Part)) {
+            return ipv4PartValid;
+        }
+
+        boolean ipV6UncompressedDetected = IPV6_MIXED_UNCOMPRESSED_REGEX.matcher(ipV6Part).matches();
+        boolean ipV6CompressedDetected = IPV6_MIXED_COMPRESSED_REGEX.matcher(ipV6Part).matches();
+
+        return ipv4PartValid && (ipV6UncompressedDetected || ipV6CompressedDetected);
+    }
+
+    /**
+     * Check if <code>input</code> is an IPv4 address mapped into a IPv6 address. These are
+     * starting with "::ffff:" followed by the IPv4 address in a dot-seperated notation.
+     * <p>
+     * The format is '::ffff:d.d.d.d'
+     * </p>
+     *
+     * @param input ip-address to check
+     * @return true if <code>input</code> is in correct IPv6 notation containing an IPv4 address
+     */
+    public static boolean isIPv6IPv4MappedAddress(final String input) {
+        // InetAddress automatically convert this type of address down to an IPv4 address
+        // It always starts '::ffff:' then contains an IPv4 address
+        if (input.length() > 7 && input.substring(0, 7).equalsIgnoreCase("::ffff:")) {
+            // then remove the first seven chars and see if we have an IPv4 address
+            String lowerPart = input.substring(7);
+            return isIPv4Address(lowerPart);
+        }
+        return false;
+    }
+
+    /**
+     * Check if <code>input</code> is a link local IPv6 address starting with "fe80:" and containing
+     * a zone index with "%xxx". The zone index will not be checked.
+     *
+     * @param input ip-address to check
+     * @return true if address part of <code>input</code> is in correct IPv6 notation.
+     */
+    public static boolean isLinkLocalIPv6WithZoneIndex(String input) {
+        if (input.length() > 5 && input.substring(0, 5).equalsIgnoreCase("fe80:")) {
+            int lastIndex = input.lastIndexOf("%");
+            if (lastIndex > 0 && lastIndex < (input.length() - 1)) { // input may not start with the zone separator
+                String ipPart = input.substring(0, lastIndex);
+                return isIPv6StdAddress(ipPart) || isIPv6HexCompressedAddress(ipPart);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if <code>input</code> is a valid IPv4 or IPv6 address.
+     *
+     * @param ipAddress ip-address to check
+     * @return <code>true</code> if <code>ipAddress</code> is a valid ip-address
+     */
+    public static boolean isValidIP(String ipAddress) {
+        if (ipAddress == null || ipAddress.length() == 0) {
+            return false;
+        }
+
+        return isIPv4Address(ipAddress) || isIPv6Address(ipAddress);
+    }
+    
+    
+    /**
+     * get to ipv4 pattern
+     *
+     * @return
+     */
+    public static Pattern getIpv4Pattern() {
+       return IPV4_PATTERN;
+    }
+    
+}

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
@@ -1,12 +1,9 @@
 /**
  * Copyright 2018-2021 Dynatrace LLC
- * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +13,14 @@
 
 package com.alibaba.nacos.common.utils;
 
-
 import java.util.regex.Pattern;
 
 /**
+ * ipv4 ipv6 check util.
+ *
  * @author Dynatrace LLC
  */
+@SuppressWarnings({"checkstyle:AbbreviationAsWordInName", "PMD.ClassNamingShouldBeCamelRule"})
 public class InetAddressValidator {
     
     private static final String PERCENT = "%";
@@ -53,17 +52,13 @@ public class InetAddressValidator {
             "^" + "(" + "(?:[0-9A-Fa-f]{1,4}" + "(?::[0-9A-Fa-f]{1,4})*)?" + ")" + "::" + "(" + "(?:[0-9A-Fa-f]{1,4}:"
                     + "(?:[0-9A-Fa-f]{1,4}:)*)?" + ")" + "$");
     
-    
     private static final Pattern IPV6_MIXED_UNCOMPRESSED_REGEX = Pattern
             .compile("^" + "(?:[0-9a-fA-F]{1,4}:){6}" + "$");
     
     /**
-     * Check if <code>input</code> is a valid IPv4 address
-     * <p>
-     * <p>
+     * Check if <code>input</code> is a valid IPv4 address.
      * The format is 'xxx.xxx.xxx.xxx'. Four blocks of integer numbers ranging from 0 to 255
      * are required. Letters are not allowed.
-     * </p>
      *
      * @param input ip-address to check
      * @return true if <code>input</code> is in correct IPv4 notation.
@@ -74,11 +69,8 @@ public class InetAddressValidator {
     
     /**
      * Check if the given address is a valid IPv6 address in the standard format
-     * <p>
-     * <p>
      * The format is 'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'. Eight blocks of hexadecimal digits
      * are required.
-     * </p>
      *
      * @param input ip-address to check
      * @return true if <code>input</code> is in correct IPv6 notation.
@@ -89,11 +81,8 @@ public class InetAddressValidator {
     
     /**
      * Check if the given address is a valid IPv6 address in the hex-compressed notation
-     * <p>
-     * <p>
      * The format is 'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'. If all digits in a block are '0'
      * the block can be left empty.
-     * </p>
      *
      * @param input ip-address to check
      * @return true if <code>input</code> is in correct IPv6 (hex-compressed) notation.
@@ -104,14 +93,12 @@ public class InetAddressValidator {
     
     /**
      * Check if <code>input</code> is a IPv6 address.
-     * <p>
      * Possible notations for valid IPv6 are:
      * - Standard IPv6 address
      * - Hex-compressed IPv6 address
      * - Link-local IPv6 address
      * - IPv4-mapped-to-IPV6 address
      * - IPv6 mixed address
-     * </p>
      *
      * @param input ip-address to check
      * @return true if <code>input</code> is in correct IPv6 notation.
@@ -123,7 +110,6 @@ public class InetAddressValidator {
     
     /**
      * Check if the given address is a valid IPv6 address in the mixed-standard or mixed-compressed notation.
-     * <p>
      * IPV6 Mixed mode consists of two parts, the first 96 bits (up to 6 blocks of 4 hex digits) are IPv6
      * the IPV6 part can be either compressed or uncompressed
      * the second block is a full IPv4 address
@@ -156,9 +142,7 @@ public class InetAddressValidator {
     /**
      * Check if <code>input</code> is an IPv4 address mapped into a IPv6 address. These are
      * starting with "::ffff:" followed by the IPv4 address in a dot-seperated notation.
-     * <p>
      * The format is '::ffff:d.d.d.d'
-     * </p>
      *
      * @param input ip-address to check
      * @return true if <code>input</code> is in correct IPv6 notation containing an IPv4 address
@@ -203,9 +187,8 @@ public class InetAddressValidator {
         return isIPv4Address(ipAddress) || isIPv6Address(ipAddress);
     }
     
-    
     /**
-     * get to ipv4 pattern
+     * get to ipv4 pattern.
      *
      * @return
      */

--- a/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import static com.alibaba.nacos.sys.env.Constants.IP_ADDRESS;
 import static com.alibaba.nacos.sys.env.Constants.NACOS_SERVER_IP;
@@ -61,6 +62,9 @@ public class InetUtils {
     private static final List<String> PREFERRED_NETWORKS = new ArrayList<String>();
     
     private static final List<String> IGNORED_INTERFACES = new ArrayList<String>();
+    
+    private static Pattern domainPattern = Pattern
+            .compile("[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+\\.?");
     
     static {
         NotifyCenter.registerToSharePublisher(IPChangeEvent.class);
@@ -92,8 +96,7 @@ public class InetUtils {
                     preferHostnameOverIP = Boolean.getBoolean(SYSTEM_PREFER_HOSTNAME_OVER_IP);
                     
                     if (!preferHostnameOverIP) {
-                        preferHostnameOverIP = Boolean
-                                .parseBoolean(EnvUtil.getProperty(PREFER_HOSTNAME_OVER_IP));
+                        preferHostnameOverIP = Boolean.parseBoolean(EnvUtil.getProperty(PREFER_HOSTNAME_OVER_IP));
                     }
                     
                     if (preferHostnameOverIP) {
@@ -157,7 +160,7 @@ public class InetUtils {
                     } else {
                         continue;
                     }
-    
+                    
                     if (!ignoreInterface(ifc.getDisplayName())) {
                         for (Enumeration<InetAddress> addrs = ifc.getInetAddresses(); addrs.hasMoreElements(); ) {
                             InetAddress address = addrs.nextElement();
@@ -220,18 +223,16 @@ public class InetUtils {
     }
     
     /**
-     * juege str is right domain.
+     * juege str is right domain.（Check only rule）
      *
      * @param str nacosIP
      * @return nacosIP is domain
      */
     public static boolean isDomain(String str) {
-        InetSocketAddress address = new InetSocketAddress(str, 0);
-        boolean unResolved = address.isUnresolved();
-        if (unResolved) {
-            LOG.warn("the domain: '" + str + "' can not be resolved");
+        if (StringUtils.isBlank(str)) {
+            return false;
         }
-        return !unResolved;
+        return domainPattern.matcher(str).matches();
     }
     
     /**

--- a/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 import java.util.ArrayList;


### PR DESCRIPTION
The IPv6 judgment logic in this method will obtain IP address according to the host. In the container environment, K8S has not allocated IP to this pod, and then the judgment will report an error. After finding this problem, I gave feedback to remove the IPv4 judgment, but this problem still exists in IPv6. Suggested to remove the verification logic can be in other ways to optimize.