### PR TITLE
fix: 详情页返回历史版本页后参数丢失

### DIFF
--- a/console-ui/src/pages/ConfigurationManagement/HistoryDetail/HistoryDetail.js
+++ b/console-ui/src/pages/ConfigurationManagement/HistoryDetail/HistoryDetail.js
@@ -85,7 +85,7 @@ class HistoryDetail extends React.Component {
 
   goList() {
     this.props.history.push(
-      `/historyRollback?serverId=${this.serverId}&group=${this.group}&dataId=${this.dataId}&namespace=${this.tenant}`
+      `/historyRollback?serverId=${this.serverId}&historyGroup=${this.group}&historyDataId=${this.dataId}&namespace=${this.tenant}`
     );
   }
 


### PR DESCRIPTION

## What is the purpose of the change

修复 #5617  的问题

在后台管理页面,  进行以下操作：
历史版本 -> 详情 -> 点击返回按钮

返回到历史版本页面时, 查询参数丢失了。

## Brief changelog

返回按钮携带参数名称错误, 更正为 : historyGroup 和 historyDataId

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

