### PR TITLE
[ISSUE #5765] fix localhost not match ip

### DIFF
--- a/address/src/main/java/com/alibaba/nacos/address/component/AddressServerGeneratorManager.java
+++ b/address/src/main/java/com/alibaba/nacos/address/component/AddressServerGeneratorManager.java
@@ -18,7 +18,7 @@ package com.alibaba.nacos.address.component;
 
 import com.alibaba.nacos.address.constant.AddressServerConstants;
 import com.alibaba.nacos.api.common.Constants;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.naming.core.Instance;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
@@ -86,8 +86,8 @@ public class AddressServerGeneratorManager {
     }
     
     private String[] generateIpAndPort(String ip) {
-        String[] result = IPUtil.splitIPPortStr(ip);
-        if (result.length != IPUtil.SPLIT_IP_PORT_RESULT_LENGTH) {
+        String[] result = InternetAddressUtil.splitIPPortStr(ip);
+        if (result.length != InternetAddressUtil.SPLIT_IP_PORT_RESULT_LENGTH) {
             return new String[] {result[0], String.valueOf(AddressServerConstants.DEFAULT_SERVER_PORT)};
         }
         return result;

--- a/address/src/main/java/com/alibaba/nacos/address/controller/AddressServerClusterController.java
+++ b/address/src/main/java/com/alibaba/nacos/address/controller/AddressServerClusterController.java
@@ -22,7 +22,7 @@ import com.alibaba.nacos.address.constant.AddressServerConstants;
 import com.alibaba.nacos.address.misc.Loggers;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.naming.pojo.healthcheck.AbstractHealthChecker;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.naming.core.Cluster;
 import com.alibaba.nacos.naming.core.Instance;
 import com.alibaba.nacos.naming.core.Service;
@@ -87,8 +87,8 @@ public class AddressServerClusterController {
             clusterObj.setHealthChecker(new AbstractHealthChecker.None());
             serviceManager.createServiceIfAbsent(Constants.DEFAULT_NAMESPACE_ID, serviceName, false, clusterObj);
             String[] ipArray = addressServerManager.splitIps(ips);
-            String checkResult = IPUtil.checkIPs(ipArray);
-            if (IPUtil.checkOK(checkResult)) {
+            String checkResult = InternetAddressUtil.checkIPs(ipArray);
+            if (InternetAddressUtil.checkOK(checkResult)) {
                 List<Instance> instanceList = addressServerGeneratorManager
                         .generateInstancesByIps(serviceName, rawProductName, clusterName, ipArray);
                 for (Instance instance : instanceList) {
@@ -141,8 +141,8 @@ public class AddressServerClusterController {
             }
             // delete specified ip list
             String[] ipArray = addressServerManager.splitIps(ips);
-            String checkResult = IPUtil.checkIPs(ipArray);
-            if (IPUtil.checkOK(checkResult)) {
+            String checkResult = InternetAddressUtil.checkIPs(ipArray);
+            if (InternetAddressUtil.checkOK(checkResult)) {
                 List<Instance> instanceList = addressServerGeneratorManager
                         .generateInstancesByIps(serviceName, rawProductName, clusterName, ipArray);
                 serviceManager.removeInstance(Constants.DEFAULT_NAMESPACE_ID, serviceName, false,

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListManager.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListManager.java
@@ -31,7 +31,7 @@ import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.IoUtils;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.utils.ThreadUtils;
 import org.slf4j.Logger;
@@ -89,9 +89,9 @@ public class ServerListManager implements Closeable {
         this.isStarted = true;
         List<String> serverAddrs = new ArrayList<String>();
         for (String serverAddr : fixed) {
-            String[] serverAddrArr = IPUtil.splitIPPortStr(serverAddr);
+            String[] serverAddrArr = InternetAddressUtil.splitIPPortStr(serverAddr);
             if (serverAddrArr.length == 1) {
-                serverAddrs.add(serverAddrArr[0] + IPUtil.IP_PORT_SPLITER + ParamUtil.getDefaultServerPort());
+                serverAddrs.add(serverAddrArr[0] + InternetAddressUtil.IP_PORT_SPLITER + ParamUtil.getDefaultServerPort());
             } else {
                 serverAddrs.add(serverAddr);
             }
@@ -159,9 +159,9 @@ public class ServerListManager implements Closeable {
                 if (serverAddr.startsWith(HTTPS) || serverAddr.startsWith(HTTP)) {
                     serverAddrs.add(serverAddr);
                 } else {
-                    String[] serverAddrArr = IPUtil.splitIPPortStr(serverAddr);
+                    String[] serverAddrArr = InternetAddressUtil.splitIPPortStr(serverAddr);
                     if (serverAddrArr.length == 1) {
-                        serverAddrs.add(HTTP + serverAddrArr[0] + IPUtil.IP_PORT_SPLITER + ParamUtil
+                        serverAddrs.add(HTTP + serverAddrArr[0] + InternetAddressUtil.IP_PORT_SPLITER + ParamUtil
                                 .getDefaultServerPort());
                     } else {
                         serverAddrs.add(HTTP + serverAddr);
@@ -358,10 +358,10 @@ public class ServerListManager implements Closeable {
                 List<String> result = new ArrayList<String>(lines.size());
                 for (String serverAddr : lines) {
                     if (StringUtils.isNotBlank(serverAddr)) {
-                        String[] ipPort = IPUtil.splitIPPortStr(serverAddr.trim());
+                        String[] ipPort = InternetAddressUtil.splitIPPortStr(serverAddr.trim());
                         String ip = ipPort[0].trim();
                         if (ipPort.length == 1) {
-                            result.add(ip + IPUtil.IP_PORT_SPLITER + ParamUtil.getDefaultServerPort());
+                            result.add(ip + InternetAddressUtil.IP_PORT_SPLITER + ParamUtil.getDefaultServerPort());
                         } else {
                             result.add(serverAddr);
                         }

--- a/client/src/main/java/com/alibaba/nacos/client/config/utils/ParamUtils.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/utils/ParamUtils.java
@@ -17,7 +17,7 @@
 package com.alibaba.nacos.client.config.utils;
 
 import com.alibaba.nacos.api.exception.NacosException;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 import java.util.List;
@@ -190,7 +190,7 @@ public class ParamUtils {
         }
         String[] ipsArr = betaIps.split(",");
         for (String ip : ipsArr) {
-            if (!IPUtil.isIP(ip)) {
+            if (!InternetAddressUtil.isIP(ip)) {
                 throw new NacosException(NacosException.CLIENT_INVALID_PARAM, "betaIps invalid");
             }
         }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -47,7 +47,7 @@ import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.ConvertUtils;
 import com.alibaba.nacos.common.utils.HttpMethod;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -429,8 +429,8 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         if (curServer.startsWith(UtilAndComs.HTTPS) || curServer.startsWith(UtilAndComs.HTTP)) {
             url = curServer + api;
         } else {
-            if (!IPUtil.containsPort(curServer)) {
-                curServer = curServer + IPUtil.IP_PORT_SPLITER + serverPort;
+            if (!InternetAddressUtil.containsPort(curServer)) {
+                curServer = curServer + InternetAddressUtil.IP_PORT_SPLITER + serverPort;
             }
             url = NamingHttpClientManager.getInstance().getPrefix() + curServer + api;
         }

--- a/common/src/main/java/com/alibaba/nacos/common/tls/SelfHostnameVerifier.java
+++ b/common/src/main/java/com/alibaba/nacos/common/tls/SelfHostnameVerifier.java
@@ -16,7 +16,7 @@
 
 package com.alibaba.nacos.common.tls;
 
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +38,7 @@ public final class SelfHostnameVerifier implements HostnameVerifier {
     
     private static ConcurrentHashMap<String, Boolean> hosts = new ConcurrentHashMap<String, Boolean>();
     
-    private static final String[] LOCALHOST_HOSTNAME = new String[] {"localhost", IPUtil.localHostIP()};
+    private static final String[] LOCALHOST_HOSTNAME = new String[] {"localhost", InternetAddressUtil.localHostIP()};
     
     public SelfHostnameVerifier(HostnameVerifier hv) {
         this.hv = hv;
@@ -64,7 +64,7 @@ public final class SelfHostnameVerifier implements HostnameVerifier {
         if (cacheHostVerify != null) {
             return cacheHostVerify;
         }
-        boolean isIp = IPUtil.isIP(host);
+        boolean isIp = InternetAddressUtil.isIP(host);
         hosts.putIfAbsent(host, isIp);
         return isIp;
     }

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
@@ -137,7 +137,7 @@ public class InternetAddressUtil {
                 throw new IllegalArgumentException("The IP address(\"" + str
                         + "\") is incorrect. If it is an IPv6 address, please use [] to enclose the IP part!");
             }
-            if (!isIPv4(serverAddrArr[0]) && !DOMAIN_PATTERN.matcher(serverAddrArr[0]).matches()) {
+            if (!isIPv4(serverAddrArr[0]) && !isDomain(serverAddrArr[0])) {
                 throw new IllegalArgumentException("The IPv4 or Domain address(\"" + serverAddrArr[0] + "\") is incorrect.");
             }
         }

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
@@ -110,6 +110,7 @@ public class InternetAddressUtil {
     
     /**
      * Split IP and port strings, support IPv4 and IPv6, IP in IPv6 must be enclosed with [].
+     * Illegal IP will get abnormal results.
      *
      * @param str ip and port string
      * @return java.lang.String[]
@@ -128,18 +129,8 @@ public class InternetAddressUtil {
                 serverAddrArr[0] = str.substring(0, (str.indexOf(IPV6_END_MARK) + 1));
                 serverAddrArr[1] = str.substring((str.indexOf(IPV6_END_MARK) + 2));
             }
-            if (!isIPv6(serverAddrArr[0])) {
-                throw new IllegalArgumentException("The IPv6 address(\"" + serverAddrArr[0] + "\") is incorrect.");
-            }
         } else {
             serverAddrArr = str.split(":");
-            if (serverAddrArr.length > SPLIT_IP_PORT_RESULT_LENGTH) {
-                throw new IllegalArgumentException("The IP address(\"" + str
-                        + "\") is incorrect. If it is an IPv6 address, please use [] to enclose the IP part!");
-            }
-            if (!isIPv4(serverAddrArr[0]) && !isDomain(serverAddrArr[0])) {
-                throw new IllegalArgumentException("The IPv4 or Domain address(\"" + serverAddrArr[0] + "\") is incorrect.");
-            }
         }
         return serverAddrArr;
     }

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  * @author Nacos
  */
 @SuppressWarnings({"checkstyle:AbbreviationAsWordInName", "PMD.ClassNamingShouldBeCamelRule"})
-public class IPUtil {
+public class InternetAddressUtil {
     
     public static final boolean PREFER_IPV6_ADDRESSES = Boolean.parseBoolean(System.getProperty("java.net.preferIPv6Addresses"));
     
@@ -180,7 +180,7 @@ public class IPUtil {
         // illegal response
         StringBuilder illegalResponse = new StringBuilder();
         for (String ip : ips) {
-            if (IPUtil.isIP(ip)) {
+            if (InternetAddressUtil.isIP(ip)) {
                 continue;
             }
             illegalResponse.append(ip + ",");

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
@@ -219,7 +219,7 @@ public class InternetAddressUtil {
     }
     
     /**
-     * juege str is right domain.（Check only rule）
+     * judge str is right domain.（Check only rule）
      *
      * @param str nacosIP
      * @return nacosIP is domain

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.common.utils;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,6 +41,8 @@ public class InternetAddressUtil {
     public static final int SPLIT_IP_PORT_RESULT_LENGTH = 2;
     
     public static final String PERCENT_SIGN_IN_IPV6 = "%";
+    
+    public static final String LOCAL_HOST = "localhost";
     
     private static final String LOCAL_HOST_IP_V4 = "127.0.0.1";
     
@@ -213,6 +216,22 @@ public class InternetAddressUtil {
             return "";
         }
         return str.replaceAll("[\\[\\]]", "");
+    }
+    
+    /**
+     * juege str is right domain.（Check only rule）
+     *
+     * @param str nacosIP
+     * @return nacosIP is domain
+     */
+    public static boolean isDomain(String str) {
+        if (StringUtils.isBlank(str)) {
+            return false;
+        }
+        if (Objects.equals(str, LOCAL_HOST)) {
+            return true;
+        }
+        return DOMAIN_PATTERN.matcher(str).matches();
     }
     
 }

--- a/common/src/test/java/com/alibaba/nacos/common/utils/InternetAddressUtilTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/InternetAddressUtilTest.java
@@ -25,62 +25,62 @@ import org.junit.Test;
  * @date 2020/9/3 10:31
  */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
-public class IPUtilTest {
+public class InternetAddressUtilTest {
     
     @Test
     public void testIsIPv4() {
-        Assert.assertTrue(IPUtil.isIPv4("127.0.0.1"));
-        Assert.assertFalse(IPUtil.isIPv4("[::1]"));
-        Assert.assertFalse(IPUtil.isIPv4("asdfasf"));
-        Assert.assertFalse(IPUtil.isIPv4("ffgertert"));
-        Assert.assertFalse(IPUtil.isIPv4("127.100.19"));
+        Assert.assertTrue(InternetAddressUtil.isIPv4("127.0.0.1"));
+        Assert.assertFalse(InternetAddressUtil.isIPv4("[::1]"));
+        Assert.assertFalse(InternetAddressUtil.isIPv4("asdfasf"));
+        Assert.assertFalse(InternetAddressUtil.isIPv4("ffgertert"));
+        Assert.assertFalse(InternetAddressUtil.isIPv4("127.100.19"));
     }
     
     @Test
     public void testIsIPv6() {
-        Assert.assertTrue(IPUtil.isIPv6("[::1]"));
-        Assert.assertFalse(IPUtil.isIPv6("127.0.0.1"));
-        Assert.assertFalse(IPUtil.isIPv6("er34234"));
+        Assert.assertTrue(InternetAddressUtil.isIPv6("[::1]"));
+        Assert.assertFalse(InternetAddressUtil.isIPv6("127.0.0.1"));
+        Assert.assertFalse(InternetAddressUtil.isIPv6("er34234"));
     }
     
     @Test
     public void testIsIP() {
-        Assert.assertTrue(IPUtil.isIP("[::1]"));
-        Assert.assertTrue(IPUtil.isIP("127.0.0.1"));
-        Assert.assertFalse(IPUtil.isIP("er34234"));
-        Assert.assertFalse(IPUtil.isIP("127.100.19"));
+        Assert.assertTrue(InternetAddressUtil.isIP("[::1]"));
+        Assert.assertTrue(InternetAddressUtil.isIP("127.0.0.1"));
+        Assert.assertFalse(InternetAddressUtil.isIP("er34234"));
+        Assert.assertFalse(InternetAddressUtil.isIP("127.100.19"));
     }
     
     @Test
     public void testGetIPFromString() {
-        Assert.assertEquals("[::1]", IPUtil.getIPFromString("http://[::1]:666/xzdsfasdf/awerwef" + "?eewer=2&xxx=3"));
-        Assert.assertEquals("[::1]", IPUtil.getIPFromString(
+        Assert.assertEquals("[::1]", InternetAddressUtil.getIPFromString("http://[::1]:666/xzdsfasdf/awerwef" + "?eewer=2&xxx=3"));
+        Assert.assertEquals("[::1]", InternetAddressUtil.getIPFromString(
                 "jdbc:mysql://[::1]:3306/nacos_config_test?characterEncoding=utf8&connectTimeout=1000"
                         + "&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC"));
         Assert.assertEquals("127.0.0.1",
-                IPUtil.getIPFromString("http://127.0.0.1:666/xzdsfasdf/awerwef" + "?eewer=2&xxx=3"));
-        Assert.assertEquals("127.0.0.1", IPUtil.getIPFromString(
+                InternetAddressUtil.getIPFromString("http://127.0.0.1:666/xzdsfasdf/awerwef" + "?eewer=2&xxx=3"));
+        Assert.assertEquals("127.0.0.1", InternetAddressUtil.getIPFromString(
                 "jdbc:mysql://127.0.0.1:3306/nacos_config_test?characterEncoding=utf8&connectTimeout=1000"
                         + "&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC"));
     
         Assert.assertEquals("",
-                IPUtil.getIPFromString("http://[dddd]:666/xzdsfasdf/awerwef" + "?eewer=2&xxx=3"));
-        Assert.assertEquals("", IPUtil.getIPFromString(
+                InternetAddressUtil.getIPFromString("http://[dddd]:666/xzdsfasdf/awerwef" + "?eewer=2&xxx=3"));
+        Assert.assertEquals("", InternetAddressUtil.getIPFromString(
                 "jdbc:mysql://[127.0.0.1]:3306/nacos_config_test?characterEncoding=utf8&connectTimeout=1000"
                         + "&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC"));
-        Assert.assertEquals("", IPUtil.getIPFromString(
+        Assert.assertEquals("", InternetAddressUtil.getIPFromString(
                 "jdbc:mysql://666.288.333.444:3306/nacos_config_test?characterEncoding=utf8&connectTimeout=1000"
                         + "&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC"));
-        Assert.assertEquals("", IPUtil.getIPFromString(
+        Assert.assertEquals("", InternetAddressUtil.getIPFromString(
                 "jdbc:mysql://292.168.1.1:3306/nacos_config_test?characterEncoding=utf8&connectTimeout=1000"
                         + "&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC"));
-        Assert.assertEquals("", IPUtil.getIPFromString(
+        Assert.assertEquals("", InternetAddressUtil.getIPFromString(
                 "jdbc:mysql://29.168.1.288:3306/nacos_config_test?characterEncoding=utf8&connectTimeout=1000"
                         + "&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC"));
-        Assert.assertEquals("", IPUtil.getIPFromString(
+        Assert.assertEquals("", InternetAddressUtil.getIPFromString(
                 "jdbc:mysql://29.168.288.28:3306/nacos_config_test?characterEncoding=utf8&connectTimeout=1000"
                         + "&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC"));
-        Assert.assertEquals("", IPUtil.getIPFromString(
+        Assert.assertEquals("", InternetAddressUtil.getIPFromString(
                 "jdbc:mysql://29.288.28.28:3306/nacos_config_test?characterEncoding=utf8&connectTimeout=1000"
                         + "&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC"));
     }
@@ -109,10 +109,10 @@ public class IPUtilTest {
     @Test
     public void testCheckIPs() {
         String[] ips = {"127.0.0.1"};
-        Assert.assertEquals("ok", IPUtil.checkIPs(ips));
+        Assert.assertEquals("ok", InternetAddressUtil.checkIPs(ips));
         
         String[] illegalIps = {"127.100.19", "127.0.0.1"};
-        Assert.assertEquals("illegal ip: 127.100.19", IPUtil.checkIPs(illegalIps));
+        Assert.assertEquals("illegal ip: 127.100.19", InternetAddressUtil.checkIPs(illegalIps));
     }
     
     /**
@@ -124,7 +124,7 @@ public class IPUtilTest {
      */
     public static void checkSplitIPPortStr(String addr, boolean isEx, String... equalsStrs) {
         try {
-            String[] array = IPUtil.splitIPPortStr(addr);
+            String[] array = InternetAddressUtil.splitIPPortStr(addr);
             Assert.assertTrue(array.length == equalsStrs.length);
             if (array.length > 1) {
                 Assert.assertTrue(array[0].equals(equalsStrs[0]));

--- a/common/src/test/java/com/alibaba/nacos/common/utils/InternetAddressUtilTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/InternetAddressUtilTest.java
@@ -115,6 +115,11 @@ public class InternetAddressUtilTest {
         Assert.assertEquals("illegal ip: 127.100.19", InternetAddressUtil.checkIPs(illegalIps));
     }
     
+    @Test
+    public void testIsDomain() {
+        Assert.assertTrue(InternetAddressUtil.isDomain("localhost"));
+    }
+    
     /**
      * checkSplitIpPortStr.
      * 2020/9/4 14:12

--- a/common/src/test/java/com/alibaba/nacos/common/utils/InternetAddressUtilTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/InternetAddressUtilTest.java
@@ -100,6 +100,7 @@ public class InternetAddressUtilTest {
         checkSplitIPPortStr("[2001:db8:0000:0:1::1]:88", false, "[2001:db8:0000:0:1::1]", "88");
         checkSplitIPPortStr("[2001:DB8:0:0:1::1]:88", false, "[2001:DB8:0:0:1::1]", "88");
         checkSplitIPPortStr("[fe80::3ce6:7132:808e:707a%19]:88", false, "[fe80::3ce6:7132:808e:707a%19]", "88");
+        checkSplitIPPortStr("localhost:8848", false, "localhost", "8848");
     
         checkSplitIPPortStr("::1:88", true);
         checkSplitIPPortStr("[::1:88", true);

--- a/common/src/test/java/com/alibaba/nacos/common/utils/InternetAddressUtilTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/InternetAddressUtilTest.java
@@ -99,12 +99,17 @@ public class InternetAddressUtilTest {
         checkSplitIPPortStr("[2001:db8:0:0:1::1]:88", false, "[2001:db8:0:0:1::1]", "88");
         checkSplitIPPortStr("[2001:db8:0000:0:1::1]:88", false, "[2001:db8:0000:0:1::1]", "88");
         checkSplitIPPortStr("[2001:DB8:0:0:1::1]:88", false, "[2001:DB8:0:0:1::1]", "88");
-        checkSplitIPPortStr("[fe80::3ce6:7132:808e:707a%19]:88", false, "[fe80::3ce6:7132:808e:707a%19]", "88");
         checkSplitIPPortStr("localhost:8848", false, "localhost", "8848");
+        checkSplitIPPortStr("[dead::beef]:88", false, "[dead::beef]", "88");
     
-        checkSplitIPPortStr("::1:88", true);
-        checkSplitIPPortStr("[::1:88", true);
-        checkSplitIPPortStr("[127.0.0.1]:88", true);
+        // illegal ip will get abnormal results
+        checkSplitIPPortStr("::1:88", false, "", "", "1", "88");
+        checkSplitIPPortStr("[::1:88", false, "[", "", "1", "88");
+        checkSplitIPPortStr("[127.0.0.1]:88", false, "[127.0.0.1]", "88");
+        checkSplitIPPortStr("[dead:beef]:88", false, "[dead:beef]", "88");
+        checkSplitIPPortStr("[fe80::3ce6:7132:808e:707a%19]:88", false, "[fe80::3ce6:7132:808e:707a%19]", "88");
+        checkSplitIPPortStr("[fe80::3]e6]:88", false, "[fe80::3]", "6]:88");
+        checkSplitIPPortStr("", true);
     }
     
     @Test
@@ -132,11 +137,8 @@ public class InternetAddressUtilTest {
         try {
             String[] array = InternetAddressUtil.splitIPPortStr(addr);
             Assert.assertTrue(array.length == equalsStrs.length);
-            if (array.length > 1) {
-                Assert.assertTrue(array[0].equals(equalsStrs[0]));
-                Assert.assertTrue(array[1].equals(equalsStrs[1]));
-            } else {
-                Assert.assertTrue(array[0].equals(equalsStrs[0]));
+            for (int i = 0; i < array.length; i++) {
+                Assert.assertEquals(array[i], equalsStrs[i]);
             }
         } catch (Exception ex) {
             if (!isEx) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourceServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/datasource/ExternalDataSourceServiceImpl.java
@@ -17,7 +17,7 @@
 package com.alibaba.nacos.config.server.service.datasource;
 
 import com.alibaba.nacos.common.utils.ConvertUtils;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.monitor.MetricsMonitor;
 import com.alibaba.nacos.config.server.utils.ConfigExecutor;
@@ -183,10 +183,10 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
             if (!isHealthList.get(i)) {
                 if (i == masterIndex) {
                     // The master is unhealthy.
-                    return "DOWN:" + IPUtil.getIPFromString(dataSourceList.get(i).getJdbcUrl());
+                    return "DOWN:" + InternetAddressUtil.getIPFromString(dataSourceList.get(i).getJdbcUrl());
                 } else {
                     // The slave  is unhealthy.
-                    return "WARN:" + IPUtil.getIPFromString(dataSourceList.get(i).getJdbcUrl());
+                    return "WARN:" + InternetAddressUtil.getIPFromString(dataSourceList.get(i).getJdbcUrl());
                 }
             }
         }
@@ -248,10 +248,10 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
                 } catch (DataAccessException e) {
                     if (i == masterIndex) {
                         FATAL_LOG.error("[db-error] master db {} down.",
-                                IPUtil.getIPFromString(dataSourceList.get(i).getJdbcUrl()));
+                                InternetAddressUtil.getIPFromString(dataSourceList.get(i).getJdbcUrl()));
                     } else {
                         FATAL_LOG.error("[db-error] slave db {} down.",
-                                IPUtil.getIPFromString(dataSourceList.get(i).getJdbcUrl()));
+                                InternetAddressUtil.getIPFromString(dataSourceList.get(i).getJdbcUrl()));
                     }
                     isHealthList.set(i, Boolean.FALSE);
                     

--- a/config/src/main/java/com/alibaba/nacos/config/server/utils/SystemConfig.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/utils/SystemConfig.java
@@ -16,7 +16,7 @@
 
 package com.alibaba.nacos.config.server.utils;
 
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +41,7 @@ public class SystemConfig {
         if (StringUtils.isNotEmpty(address)) {
             return address;
         } else {
-            address = IPUtil.localHostIP();
+            address = InternetAddressUtil.localHostIP();
         }
         try {
             Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces();

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/MemberUtil.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/MemberUtil.java
@@ -17,7 +17,7 @@
 package com.alibaba.nacos.core.cluster;
 
 import com.alibaba.nacos.common.utils.ExceptionUtil;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.Objects;
 import com.alibaba.nacos.core.utils.Loggers;
 import com.alibaba.nacos.sys.env.EnvUtil;
@@ -73,7 +73,7 @@ public class MemberUtil {
         
         String address = member;
         int port = defaultPort;
-        String[] info = IPUtil.splitIPPortStr(address);
+        String[] info = InternetAddressUtil.splitIPPortStr(address);
         if (info.length > 1) {
             address = info[0];
             port = Integer.parseInt(info[1]);

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
@@ -19,7 +19,7 @@ package com.alibaba.nacos.core.distributed.raft;
 import com.alibaba.nacos.common.JustForTest;
 import com.alibaba.nacos.common.model.RestResult;
 import com.alibaba.nacos.common.utils.ConvertUtils;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.LoggerUtils;
 import com.alibaba.nacos.common.utils.ThreadUtils;
 import com.alibaba.nacos.consistency.RequestProcessor;
@@ -165,7 +165,7 @@ public class JRaftServer {
         RaftExecutor.init(config);
         
         final String self = config.getSelfMember();
-        String[] info = IPUtil.splitIPPortStr(self);
+        String[] info = InternetAddressUtil.splitIPPortStr(self);
         selfIp = info[0];
         selfPort = Integer.parseInt(info[1]);
         localPeerId = PeerId.parsePeer(self);

--- a/naming/src/main/java/com/alibaba/nacos/naming/cluster/ServerListManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/cluster/ServerListManager.java
@@ -17,7 +17,7 @@
 package com.alibaba.nacos.naming.cluster;
 
 import com.alibaba.nacos.common.notify.NotifyCenter;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.core.cluster.Member;
 import com.alibaba.nacos.core.cluster.MemberChangeListener;
@@ -126,7 +126,7 @@ public class ServerListManager extends MemberChangeListener {
                 continue;
             }
     
-            String[] info = IPUtil.splitIPPortStr(params[1]);
+            String[] info = InternetAddressUtil.splitIPPortStr(params[1]);
             Member server = Optional.ofNullable(memberManager.find(params[1]))
                     .orElse(Member.builder().ip(info[0]).state(NodeState.UP)
                             .port(Integer.parseInt(info[1])).build());
@@ -224,7 +224,7 @@ public class ServerListManager extends MemberChangeListener {
                 }
                 
                 if (allServers.size() > 0 && !EnvUtil.getLocalAddress()
-                        .contains(IPUtil.localHostIP())) {
+                        .contains(InternetAddressUtil.localHostIP())) {
                     for (Member server : allServers) {
                         if (Objects.equals(server.getAddress(), EnvUtil.getLocalAddress())) {
                             continue;

--- a/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/raft/RaftCore.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/raft/RaftCore.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.nacos.naming.consistency.persistent.raft;
 
-import com.alibaba.nacos.common.utils.IPUtil;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.common.http.Callback;
@@ -25,6 +24,7 @@ import com.alibaba.nacos.common.model.RestResult;
 import com.alibaba.nacos.common.notify.EventPublisher;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.ConcurrentHashSet;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.consistency.DataOperation;
 import com.alibaba.nacos.naming.consistency.Datum;
@@ -1008,8 +1008,8 @@ public class RaftCore implements Closeable {
      * @return api url
      */
     public static String buildUrl(String ip, String api) {
-        if (!IPUtil.containsPort(ip)) {
-            ip = ip + IPUtil.IP_PORT_SPLITER + EnvUtil.getPort();
+        if (!InternetAddressUtil.containsPort(ip)) {
+            ip = ip + InternetAddressUtil.IP_PORT_SPLITER + EnvUtil.getPort();
         }
         return "http://" + ip + EnvUtil.getContextPath() + api;
     }

--- a/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/raft/RaftProxy.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/raft/RaftProxy.java
@@ -16,10 +16,10 @@
 
 package com.alibaba.nacos.naming.consistency.persistent.raft;
 
-import com.alibaba.nacos.common.utils.IPUtil;
-import com.alibaba.nacos.sys.env.EnvUtil;
 import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.naming.misc.HttpClient;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 
@@ -45,8 +45,8 @@ public class RaftProxy {
      */
     public void proxyGet(String server, String api, Map<String, String> params) throws Exception {
         // do proxy
-        if (!IPUtil.containsPort(server)) {
-            server = server + IPUtil.IP_PORT_SPLITER + EnvUtil.getPort();
+        if (!InternetAddressUtil.containsPort(server)) {
+            server = server + InternetAddressUtil.IP_PORT_SPLITER + EnvUtil.getPort();
         }
         String url = "http://" + server + EnvUtil.getContextPath() + api;
         
@@ -67,8 +67,8 @@ public class RaftProxy {
      */
     public void proxy(String server, String api, Map<String, String> params, HttpMethod method) throws Exception {
         // do proxy
-        if (!IPUtil.containsPort(server)) {
-            server = server + IPUtil.IP_PORT_SPLITER + EnvUtil.getPort();
+        if (!InternetAddressUtil.containsPort(server)) {
+            server = server + InternetAddressUtil.IP_PORT_SPLITER + EnvUtil.getPort();
         }
         String url = "http://" + server + EnvUtil.getContextPath() + api;
         RestResult<String> result;
@@ -103,8 +103,8 @@ public class RaftProxy {
     public void proxyPostLarge(String server, String api, String content, Map<String, String> headers)
             throws Exception {
         // do proxy
-        if (!IPUtil.containsPort(server)) {
-            server = server + IPUtil.IP_PORT_SPLITER + EnvUtil.getPort();
+        if (!InternetAddressUtil.containsPort(server)) {
+            server = server + InternetAddressUtil.IP_PORT_SPLITER + EnvUtil.getPort();
         }
         String url = "http://" + server + EnvUtil.getContextPath() + api;
         

--- a/naming/src/main/java/com/alibaba/nacos/naming/controllers/OperatorController.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/controllers/OperatorController.java
@@ -19,7 +19,7 @@ package com.alibaba.nacos.naming.controllers;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.auth.common.ActionTypes;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.core.cluster.Member;
 import com.alibaba.nacos.core.cluster.NodeState;
@@ -197,7 +197,7 @@ public class OperatorController {
     @GetMapping("/distro/client")
     public ObjectNode getResponsibleServer4Client(@RequestParam String ip, @RequestParam String port) {
         ObjectNode result = JacksonUtils.createEmptyJsonNode();
-        String tag = ip + IPUtil.IP_PORT_SPLITER + port;
+        String tag = ip + InternetAddressUtil.IP_PORT_SPLITER + port;
         result.put("responsibleServer", distroMapper.mapSrv(tag));
         return result;
     }

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/HealthOperatorV2Impl.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/HealthOperatorV2Impl.java
@@ -20,7 +20,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.healthcheck.HealthCheckType;
 import com.alibaba.nacos.api.naming.utils.NamingUtils;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.client.manager.ClientManager;
@@ -72,7 +72,7 @@ public class HealthOperatorV2Impl implements HealthOperator {
         if (!HealthCheckType.NONE.name().equals(clusterMetadata.getHealthyCheckType())) {
             throwHealthCheckerException(fullServiceName, clusterName);
         }
-        String clientId = IpPortBasedClient.getClientId(ip + IPUtil.IP_PORT_SPLITER + port, false);
+        String clientId = IpPortBasedClient.getClientId(ip + InternetAddressUtil.IP_PORT_SPLITER + port, false);
         Client client = clientManager.getClient(clientId);
         if (null == client) {
             return;

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/Instance.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/Instance.java
@@ -18,7 +18,7 @@ package com.alibaba.nacos.naming.core;
 
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.naming.healthcheck.HealthCheckStatus;
 import com.alibaba.nacos.naming.misc.Loggers;
@@ -26,7 +26,6 @@ import com.alibaba.nacos.naming.misc.UtilsAndCommons;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import org.apache.commons.lang3.math.NumberUtils;
 
 import java.util.Set;
@@ -119,13 +118,13 @@ public class Instance extends com.alibaba.nacos.api.naming.pojo.Instance impleme
         String provider = ipAddressAttributes[0];
         String[] providerAddr;
         try {
-            providerAddr = IPUtil.splitIPPortStr(provider);
+            providerAddr = InternetAddressUtil.splitIPPortStr(provider);
         } catch (Exception ex) {
             return null;
         }
         
         int port = 0;
-        if (providerAddr.length == IPUtil.SPLIT_IP_PORT_RESULT_LENGTH && NumberUtils.isNumber(providerAddr[1])) {
+        if (providerAddr.length == InternetAddressUtil.SPLIT_IP_PORT_RESULT_LENGTH && NumberUtils.isNumber(providerAddr[1])) {
             port = Integer.parseInt(providerAddr[1]);
         }
         
@@ -358,7 +357,7 @@ public class Instance extends com.alibaba.nacos.api.naming.pojo.Instance impleme
      */
     public void validate() throws NacosException {
         if (onlyContainsDigitAndDot()) {
-            if (!IPUtil.containsPort(getIp() + IPUtil.IP_PORT_SPLITER + getPort())) {
+            if (!InternetAddressUtil.containsPort(getIp() + InternetAddressUtil.IP_PORT_SPLITER + getPort())) {
                 throw new NacosException(NacosException.INVALID_PARAM,
                         "instance format invalid: Your IP address is spelled incorrectly");
             }

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/InstanceOperatorClientImpl.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/InstanceOperatorClientImpl.java
@@ -23,7 +23,7 @@ import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
 import com.alibaba.nacos.api.naming.utils.NamingUtils;
 import com.alibaba.nacos.common.utils.ConvertUtils;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.naming.core.v2.ServiceManager;
 import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
@@ -207,7 +207,7 @@ public class InstanceOperatorClientImpl implements InstanceOperator {
     public int handleBeat(String namespaceId, String serviceName, String ip, int port, String cluster,
             RsInfo clientBeat) throws NacosException {
         Service service = getService(namespaceId, serviceName, true);
-        String clientId = IpPortBasedClient.getClientId(ip + IPUtil.IP_PORT_SPLITER + port, true);
+        String clientId = IpPortBasedClient.getClientId(ip + InternetAddressUtil.IP_PORT_SPLITER + port, true);
         IpPortBasedClient client = (IpPortBasedClient) clientManager.getClient(clientId);
         if (null == client || !client.getAllPublishedService().contains(service)) {
             if (null == clientBeat) {
@@ -251,7 +251,7 @@ public class InstanceOperatorClientImpl implements InstanceOperator {
                 .containsKey(PreservedMetadataKeys.HEART_BEAT_INTERVAL)) {
             return ConvertUtils.toLong(metadata.get().getExtendData().get(PreservedMetadataKeys.HEART_BEAT_INTERVAL));
         }
-        String clientId = IpPortBasedClient.getClientId(ip + IPUtil.IP_PORT_SPLITER + port, true);
+        String clientId = IpPortBasedClient.getClientId(ip + InternetAddressUtil.IP_PORT_SPLITER + port, true);
         Client client = clientManager.getClient(clientId);
         InstancePublishInfo instance = null != client ? client.getInstancePublishInfo(service) : null;
         if (null != instance && instance.getExtendDatum().containsKey(PreservedMetadataKeys.HEART_BEAT_INTERVAL)) {

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/ServiceManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/ServiceManager.java
@@ -19,7 +19,7 @@ package com.alibaba.nacos.naming.core;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.utils.NamingUtils;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.Objects;
 import com.alibaba.nacos.core.cluster.Member;
@@ -960,8 +960,8 @@ public class ServiceManager implements RecordListener<Service> {
                 contained = false;
                 List<Instance> instances = service.allIPs();
                 for (Instance instance : instances) {
-                    if (IPUtil.containsPort(containedInstance)) {
-                        if (StringUtils.equals(instance.getIp() + IPUtil.IP_PORT_SPLITER + instance.getPort(),
+                    if (InternetAddressUtil.containsPort(containedInstance)) {
+                        if (StringUtils.equals(instance.getIp() + InternetAddressUtil.IP_PORT_SPLITER + instance.getPort(),
                                 containedInstance)) {
                             contained = true;
                             break;

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/pojo/InstancePublishInfo.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/pojo/InstancePublishInfo.java
@@ -16,7 +16,7 @@
 
 package com.alibaba.nacos.naming.core.v2.pojo;
 
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -119,6 +119,6 @@ public class InstancePublishInfo implements Serializable {
     }
     
     public static String genMetadataId(String ip, int port, String cluster) {
-        return ip + IPUtil.IP_PORT_SPLITER + port + IPUtil.IP_PORT_SPLITER + cluster;
+        return ip + InternetAddressUtil.IP_PORT_SPLITER + port + InternetAddressUtil.IP_PORT_SPLITER + cluster;
     }
 }

--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/ClientBeatCheckTask.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/ClientBeatCheckTask.java
@@ -18,7 +18,7 @@ package com.alibaba.nacos.naming.healthcheck;
 
 import com.alibaba.nacos.common.http.Callback;
 import com.alibaba.nacos.common.model.RestResult;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.naming.consistency.KeyBuilder;
 import com.alibaba.nacos.naming.core.DistroMapper;
@@ -142,7 +142,7 @@ public class ClientBeatCheckTask implements BeatCheckTask {
                     .appendParam("ephemeral", "true").appendParam("clusterName", instance.getClusterName())
                     .appendParam("serviceName", service.getName()).appendParam("namespaceId", service.getNamespaceId());
             
-            String url = "http://" + IPUtil.localHostIP() + IPUtil.IP_PORT_SPLITER + EnvUtil.getPort() + EnvUtil
+            String url = "http://" + InternetAddressUtil.localHostIP() + InternetAddressUtil.IP_PORT_SPLITER + EnvUtil.getPort() + EnvUtil
                     .getContextPath() + UtilsAndCommons.NACOS_NAMING_CONTEXT + "/instance?" + request.toUrl();
             
             // delete instance asynchronously:

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/NamingProxy.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/NamingProxy.java
@@ -19,7 +19,7 @@ package com.alibaba.nacos.naming.misc;
 import com.alibaba.nacos.common.constant.HttpHeaderConsts;
 import com.alibaba.nacos.common.http.Callback;
 import com.alibaba.nacos.common.model.RestResult;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.VersionUtils;
 import com.alibaba.nacos.sys.env.EnvUtil;
@@ -202,8 +202,8 @@ public class NamingProxy {
             
             RestResult<String> result;
             
-            if (!IPUtil.containsPort(curServer)) {
-                curServer = curServer + IPUtil.IP_PORT_SPLITER + EnvUtil.getPort();
+            if (!InternetAddressUtil.containsPort(curServer)) {
+                curServer = curServer + InternetAddressUtil.IP_PORT_SPLITER + EnvUtil.getPort();
             }
             
             result = HttpClient.httpGet("http://" + curServer + api, headers, params);
@@ -244,8 +244,8 @@ public class NamingProxy {
             
             RestResult<String> result;
             
-            if (!IPUtil.containsPort(curServer)) {
-                curServer = curServer + IPUtil.IP_PORT_SPLITER + EnvUtil.getPort();
+            if (!InternetAddressUtil.containsPort(curServer)) {
+                curServer = curServer + InternetAddressUtil.IP_PORT_SPLITER + EnvUtil.getPort();
             }
             
             if (isPost) {
@@ -294,8 +294,8 @@ public class NamingProxy {
             
             RestResult<String> result;
             
-            if (!IPUtil.containsPort(curServer)) {
-                curServer = curServer + IPUtil.IP_PORT_SPLITER + EnvUtil.getPort();
+            if (!InternetAddressUtil.containsPort(curServer)) {
+                curServer = curServer + InternetAddressUtil.IP_PORT_SPLITER + EnvUtil.getPort();
             }
             
             if (isPost) {

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/NetUtils.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/NetUtils.java
@@ -16,7 +16,7 @@
 
 package com.alibaba.nacos.naming.misc;
 
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import com.alibaba.nacos.sys.utils.InetUtils;
 
@@ -33,7 +33,7 @@ public class NetUtils {
      * @return local server address
      */
     public static String localServer() {
-        return InetUtils.getSelfIP() + IPUtil.IP_PORT_SPLITER + EnvUtil.getPort();
+        return InetUtils.getSelfIP() + InternetAddressUtil.IP_PORT_SPLITER + EnvUtil.getPort();
     }
     
 }

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/ServerStatusSynchronizer.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/ServerStatusSynchronizer.java
@@ -16,10 +16,10 @@
 
 package com.alibaba.nacos.naming.misc;
 
-import com.alibaba.nacos.common.utils.IPUtil;
-import com.alibaba.nacos.sys.env.EnvUtil;
 import com.alibaba.nacos.common.http.Callback;
 import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.springframework.util.StringUtils;
 
 import java.util.HashMap;
@@ -46,7 +46,7 @@ public class ServerStatusSynchronizer implements Synchronizer {
         String url = "http://" + serverIP + ":" + EnvUtil.getPort() + EnvUtil.getContextPath()
                 + UtilsAndCommons.NACOS_NAMING_CONTEXT + "/operator/server/status";
         
-        if (IPUtil.containsPort(serverIP)) {
+        if (InternetAddressUtil.containsPort(serverIP)) {
             url = "http://" + serverIP + EnvUtil.getContextPath() + UtilsAndCommons.NACOS_NAMING_CONTEXT
                     + "/operator/server/status";
         }

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/ServiceStatusSynchronizer.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/ServiceStatusSynchronizer.java
@@ -16,9 +16,9 @@
 
 package com.alibaba.nacos.naming.misc;
 
-import com.alibaba.nacos.common.utils.IPUtil;
 import com.alibaba.nacos.common.http.Callback;
 import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -47,7 +47,7 @@ public class ServiceStatusSynchronizer implements Synchronizer {
         String url = "http://" + serverIP + ":" + EnvUtil.getPort() + EnvUtil.getContextPath()
                 + UtilsAndCommons.NACOS_NAMING_CONTEXT + "/service/status";
         
-        if (IPUtil.containsPort(serverIP)) {
+        if (InternetAddressUtil.containsPort(serverIP)) {
             url = "http://" + serverIP + EnvUtil.getContextPath() + UtilsAndCommons.NACOS_NAMING_CONTEXT
                     + "/service/status";
         }

--- a/naming/src/main/java/com/alibaba/nacos/naming/web/DistroIpPortTagGenerator.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/web/DistroIpPortTagGenerator.java
@@ -17,7 +17,7 @@
 package com.alibaba.nacos.naming.web;
 
 import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.core.utils.ReuseHttpServletRequest;
@@ -56,6 +56,6 @@ public class DistroIpPortTagGenerator implements DistroTagGenerator {
             ip = ip.trim();
         }
         port = StringUtils.isBlank(port) ? "0" : port.trim();
-        return ip + IPUtil.IP_PORT_SPLITER + port;
+        return ip + InternetAddressUtil.IP_PORT_SPLITER + port;
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatCheckTaskV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatCheckTaskV2Test.java
@@ -17,7 +17,7 @@
 package com.alibaba.nacos.naming.healthcheck.heartbeat;
 
 import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.naming.consistency.KeyBuilder;
 import com.alibaba.nacos.naming.core.DistroMapper;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
@@ -51,7 +51,7 @@ public class ClientBeatCheckTaskV2Test {
     
     private static final int PORT = 10000;
     
-    private static final String CLIENT_ID = IP + IPUtil.IP_PORT_SPLITER + PORT + "#true";
+    private static final String CLIENT_ID = IP + InternetAddressUtil.IP_PORT_SPLITER + PORT + "#true";
     
     private static final String SERVICE_NAME = "service";
     
@@ -149,7 +149,7 @@ public class ClientBeatCheckTaskV2Test {
         InstanceMetadata metadata = new InstanceMetadata();
         metadata.getExtendData().put(PreservedMetadataKeys.HEART_BEAT_TIMEOUT, 500L);
         String address =
-                IP + IPUtil.IP_PORT_SPLITER + PORT + IPUtil.IP_PORT_SPLITER + UtilsAndCommons.DEFAULT_CLUSTER_NAME;
+                IP + InternetAddressUtil.IP_PORT_SPLITER + PORT + InternetAddressUtil.IP_PORT_SPLITER + UtilsAndCommons.DEFAULT_CLUSTER_NAME;
         when(namingMetadataManager.getInstanceMetadata(service, address)).thenReturn(Optional.of(metadata));
         when(globalConfig.isExpireInstance()).thenReturn(true);
         TimeUnit.SECONDS.sleep(1);

--- a/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import static com.alibaba.nacos.sys.env.Constants.IP_ADDRESS;
 import static com.alibaba.nacos.sys.env.Constants.NACOS_SERVER_IP;
@@ -62,11 +61,6 @@ public class InetUtils {
     
     private static final List<String> IGNORED_INTERFACES = new ArrayList<String>();
     
-    private static Pattern domainPattern = Pattern
-            .compile("[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+\\.?");
-    
-    public static final String LOCAL_HOST = "localhost";
-    
     static {
         NotifyCenter.registerToSharePublisher(IPChangeEvent.class);
         
@@ -88,7 +82,7 @@ public class InetUtils {
                     nacosIP = EnvUtil.getProperty(IP_ADDRESS);
                 }
                 if (!StringUtils.isBlank(nacosIP)) {
-                    if (!(InternetAddressUtil.isIP(nacosIP) || isDomain(nacosIP))) {
+                    if (!(InternetAddressUtil.isIP(nacosIP) || InternetAddressUtil.isDomain(nacosIP))) {
                         throw new RuntimeException("nacos address " + nacosIP + " is not ip");
                     }
                 }
@@ -221,22 +215,6 @@ public class InetUtils {
             }
         }
         return false;
-    }
-    
-    /**
-     * juege str is right domain.（Check only rule）
-     *
-     * @param str nacosIP
-     * @return nacosIP is domain
-     */
-    public static boolean isDomain(String str) {
-        if (StringUtils.isBlank(str)) {
-            return false;
-        }
-        if (Objects.equals(str, LOCAL_HOST)) {
-            return true;
-        }
-        return domainPattern.matcher(str).matches();
     }
     
     /**

--- a/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
@@ -18,7 +18,7 @@ package com.alibaba.nacos.sys.utils;
 
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.notify.SlowEvent;
-import com.alibaba.nacos.common.utils.IPUtil;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.sys.env.Constants;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -88,7 +88,7 @@ public class InetUtils {
                     nacosIP = EnvUtil.getProperty(IP_ADDRESS);
                 }
                 if (!StringUtils.isBlank(nacosIP)) {
-                    if (!(IPUtil.isIP(nacosIP) || isDomain(nacosIP))) {
+                    if (!(InternetAddressUtil.isIP(nacosIP) || isDomain(nacosIP))) {
                         throw new RuntimeException("nacos address " + nacosIP + " is not ip");
                     }
                 }
@@ -116,12 +116,12 @@ public class InetUtils {
                         tmpSelfIP = Objects.requireNonNull(findFirstNonLoopbackAddress()).getHostAddress();
                     }
                 }
-                if (IPUtil.PREFER_IPV6_ADDRESSES && !tmpSelfIP.startsWith(IPUtil.IPV6_START_MARK) && !tmpSelfIP
-                        .endsWith(IPUtil.IPV6_END_MARK)) {
-                    tmpSelfIP = IPUtil.IPV6_START_MARK + tmpSelfIP + IPUtil.IPV6_END_MARK;
-                    if (StringUtils.contains(tmpSelfIP, IPUtil.PERCENT_SIGN_IN_IPV6)) {
-                        tmpSelfIP = tmpSelfIP.substring(0, tmpSelfIP.indexOf(IPUtil.PERCENT_SIGN_IN_IPV6))
-                                + IPUtil.IPV6_END_MARK;
+                if (InternetAddressUtil.PREFER_IPV6_ADDRESSES && !tmpSelfIP.startsWith(InternetAddressUtil.IPV6_START_MARK) && !tmpSelfIP
+                        .endsWith(InternetAddressUtil.IPV6_END_MARK)) {
+                    tmpSelfIP = InternetAddressUtil.IPV6_START_MARK + tmpSelfIP + InternetAddressUtil.IPV6_END_MARK;
+                    if (StringUtils.contains(tmpSelfIP, InternetAddressUtil.PERCENT_SIGN_IN_IPV6)) {
+                        tmpSelfIP = tmpSelfIP.substring(0, tmpSelfIP.indexOf(InternetAddressUtil.PERCENT_SIGN_IN_IPV6))
+                                + InternetAddressUtil.IPV6_END_MARK;
                     }
                 }
                 if (!Objects.equals(selfIP, tmpSelfIP) && Objects.nonNull(selfIP)) {
@@ -165,7 +165,7 @@ public class InetUtils {
                     if (!ignoreInterface(ifc.getDisplayName())) {
                         for (Enumeration<InetAddress> addrs = ifc.getInetAddresses(); addrs.hasMoreElements(); ) {
                             InetAddress address = addrs.nextElement();
-                            boolean isLegalIpVersion = IPUtil.PREFER_IPV6_ADDRESSES ? address instanceof Inet6Address
+                            boolean isLegalIpVersion = InternetAddressUtil.PREFER_IPV6_ADDRESSES ? address instanceof Inet6Address
                                     : address instanceof Inet4Address;
                             if (isLegalIpVersion && !address.isLoopbackAddress() && isPreferredAddress(address)) {
                                 LOG.debug("Found non-loopback interface: " + ifc.getDisplayName());

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/InetUtilsTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/InetUtilsTest.java
@@ -17,17 +17,10 @@
 package com.alibaba.nacos.sys.utils;
 
 import com.alibaba.nacos.sys.env.EnvUtil;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
 import org.springframework.core.env.StandardEnvironment;
 
 public class InetUtilsTest {
-    
-    @Test
-    public void testIsDomain() {
-        Assert.assertTrue(InetUtils.isDomain("localhost"));
-    }
     
     @Before
     public void setUp() {


### PR DESCRIPTION
## What is the purpose of the change
For #5765 
fix ```localhost``` in cluster.conf not available

## Brief changelog

- rename IPUitl to InternetAddressUtil
- move isDomain to InternetAddressUtil
- fix localhost not match ip

## Verifying this change

[unit test case](https://github.com/alibaba/nacos/commit/ad541f664c99c8dde3ec76e7b0dc4a9e87132a68#diff-e3feb653a6109bcc8e7bbc7974c2d6fa93b17cc25783e9a26f31d86f36f2d471R103) pass
