### PR TITLE
Use same request instance at stateless situation.

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/remote/request/HealthCheckRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/request/HealthCheckRequest.java
@@ -23,5 +23,9 @@ package com.alibaba.nacos.api.remote.request;
  * @version $Id: ServerCheckRequest.java, v 0.1 2020年07月22日 8:32 PM liuzunfei Exp $
  */
 public class HealthCheckRequest extends InternalRequest {
-
+    
+    public static final HealthCheckRequest INSTANCE = new HealthCheckRequest();
+    
+    private HealthCheckRequest() {
+    }
 }

--- a/api/src/main/java/com/alibaba/nacos/api/remote/request/ServerCheckRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/request/ServerCheckRequest.java
@@ -23,5 +23,9 @@ package com.alibaba.nacos.api.remote.request;
  * @version $Id: ServerCheckRequest.java, v 0.1 2020年07月22日 8:32 PM liuzunfei Exp $
  */
 public class ServerCheckRequest extends InternalRequest {
-
+    
+    public static final ServerCheckRequest INSTANCE = new ServerCheckRequest();
+    
+    private ServerCheckRequest() {
+    }
 }

--- a/api/src/main/java/com/alibaba/nacos/api/remote/request/ServerLoaderInfoRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/request/ServerLoaderInfoRequest.java
@@ -23,6 +23,8 @@ package com.alibaba.nacos.api.remote.request;
  */
 public class ServerLoaderInfoRequest extends InternalRequest {
     
-    public ServerLoaderInfoRequest() {
+    public static final ServerLoaderInfoRequest INSTANCE = new ServerLoaderInfoRequest();
+    
+    private ServerLoaderInfoRequest() {
     }
 }

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
@@ -468,7 +468,7 @@ public abstract class RpcClient implements Closeable {
     }
     
     private boolean healthCheck() {
-        HealthCheckRequest healthCheckRequest = new HealthCheckRequest();
+        HealthCheckRequest healthCheckRequest = HealthCheckRequest.INSTANCE;
         if (this.currentConnection == null) {
             return false;
         }

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClient.java
@@ -140,7 +140,7 @@ public abstract class GrpcClient extends RpcClient {
             if (requestBlockingStub == null) {
                 return null;
             }
-            ServerCheckRequest serverCheckRequest = new ServerCheckRequest();
+            ServerCheckRequest serverCheckRequest = ServerCheckRequest.INSTANCE;
             Payload grpcRequest = GrpcUtils.convert(serverCheckRequest);
             ListenableFuture<Payload> responseFuture = requestBlockingStub.request(grpcRequest);
             Payload response = responseFuture.get(3000L, TimeUnit.MILLISECONDS);

--- a/core/src/main/java/com/alibaba/nacos/core/controller/ServerLoaderController.java
+++ b/core/src/main/java/com/alibaba/nacos/core/controller/ServerLoaderController.java
@@ -267,7 +267,7 @@ public class ServerLoaderController {
         CountDownLatch countDownLatch = new CountDownLatch(memberSize);
         for (Member member : serverMemberManager.allMembersWithoutSelf()) {
             if (MemberUtil.isSupportedLongCon(member)) {
-                ServerLoaderInfoRequest serverLoaderInfoRequest = new ServerLoaderInfoRequest();
+                ServerLoaderInfoRequest serverLoaderInfoRequest = ServerLoaderInfoRequest.INSTANCE;
                 
                 try {
                     clusterRpcClientProxy.asyncRequest(member, serverLoaderInfoRequest, new RequestCallBack() {
@@ -309,7 +309,7 @@ public class ServerLoaderController {
         
         try {
             ServerLoaderInfoResponse handle = serverLoaderInfoRequestHandler
-                    .handle(new ServerLoaderInfoRequest(), new RequestMeta());
+                    .handle(ServerLoaderInfoRequest.INSTANCE, new RequestMeta());
             ServerLoaderMetrics metrics = new ServerLoaderMetrics();
             metrics.setAddress(serverMemberManager.getSelf().getAddress());
             metrics.setMetric(handle.getLoaderMetrics());


### PR DESCRIPTION
Some request is stateless, so we can reuse it to avoid create new instance.