### PR TITLE
Fix the problem of startup error when the JAVA_HOME path contains spa…

### DIFF
--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -108,7 +108,7 @@ JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/
 if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]] ; then
   JAVA_OPT="${JAVA_OPT} -Xlog:gc*:file=${BASE_DIR}/logs/nacos_gc.log:time,tags:filecount=10,filesize=102400"
 else
-  JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext"
+  JAVA_OPT_EXT_FIX="-Djava.ext.dirs=\"${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext\""
   JAVA_OPT="${JAVA_OPT} -Xloggc:${BASE_DIR}/logs/nacos_gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
 fi
 
@@ -124,7 +124,7 @@ if [ ! -d "${BASE_DIR}/logs" ]; then
   mkdir ${BASE_DIR}/logs
 fi
 
-echo "$JAVA ${JAVA_OPT}"
+echo "$JAVA $JAVA_OPT_EXT_FIX ${JAVA_OPT}"
 
 if [[ "${MODE}" == "standalone" ]]; then
     echo "nacos is starting with standalone"
@@ -137,6 +137,6 @@ if [ ! -f "${BASE_DIR}/logs/start.out" ]; then
   touch "${BASE_DIR}/logs/start.out"
 fi
 # start
-echo "$JAVA ${JAVA_OPT}" > ${BASE_DIR}/logs/start.out 2>&1 &
-nohup $JAVA ${JAVA_OPT} nacos.nacos >> ${BASE_DIR}/logs/start.out 2>&1 &
+echo "$JAVA $JAVA_OPT_EXT_FIX ${JAVA_OPT}" > ${BASE_DIR}/logs/start.out 2>&1 &
+nohup "$JAVA" "$JAVA_OPT_EXT_FIX" ${JAVA_OPT} nacos.nacos >> ${BASE_DIR}/logs/start.out 2>&1 &
 echo "nacos is starting，you can check the ${BASE_DIR}/logs/start.out"


### PR DESCRIPTION
## What is the purpose of the change

Fix the problem of startup error when the JAVA_HOME path contains spaces under Linux/Unix/Mac system

## Brief changelog

Finally, execute the command to add double quotation marks to deal with the situation that there are spaces in the full path of the JAVA command, and at the same time to configure "-Djava.ext.dirs" to independently define a variable to deal with the problem of spaces in the JAVA_HOME path
```
JAVA_OPT_EXT_FIX="-Djava.ext.dirs=\"${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext\""
.
.
.
nohup "$JAVA" "$JAVA_OPT_EXT_FIX" ${JAVA_OPT} nacos.nacos >> ${BASE_DIR}/logs/start.out 2>&1 &

```

## Verifying this change

Before repair
```
/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java  -Xms512m -Xmx512m -Xmn256m -Dnacos.standalone=true -Dnacos.member.list= -Djava.ext.dirs=/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/jre/lib/ext:/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/ext -Xloggc:/Users/ixx/Downloads/nacos/nacos/logs/nacos_gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M -Dloader.path=/Users/ixx/Downloads/nacos/nacos/plugins/health,/Users/ixx/Downloads/nacos/nacos/plugins/cmdb -Dnacos.home=/Users/ixx/Downloads/nacos/nacos -jar /Users/ixx/Downloads/nacos/nacos/target/nacos-server.jar  --spring.config.additional-location=file:/Users/ixx/Downloads/nacos/nacos/conf/ --logging.config=/Users/ixx/Downloads/nacos/nacos/conf/nacos-logback.xml --server.max-http-header-size=524288
nohup: /Library/Internet: No such file or directory
```
After repair
```
/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java -Djava.ext.dirs="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/jre/lib/ext:/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/ext"  -Xms512m -Xmx512m -Xmn256m -Dnacos.standalone=true -Dnacos.member.list= -Xloggc:/Users/ixx/Downloads/nacos/nacos/logs/nacos_gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M -Dloader.path=/Users/ixx/Downloads/nacos/nacos/plugins/health,/Users/ixx/Downloads/nacos/nacos/plugins/cmdb -Dnacos.home=/Users/ixx/Downloads/nacos/nacos -jar /Users/ixx/Downloads/nacos/nacos/target/nacos-server.jar  --spring.config.additional-location=file:/Users/ixx/Downloads/nacos/nacos/conf/ --logging.config=/Users/ixx/Downloads/nacos/nacos/conf/nacos-logback.xml --server.max-http-header-size=524288

         ,--.
       ,--.'|
   ,--,:  : |                                           Nacos 2.0.2
,`--.'`|  ' :                       ,---.               Running in stand alone mode, All function modules
|   :  :  | |                      '   ,'\   .--.--.    Port: 8848
:   |   \ | :  ,--.--.     ,---.  /   /   | /  /    '   Pid: 66084
|   : '  '; | /       \   /     \.   ; ,. :|  :  /`./   Console: http://192.168.1.8:8848/nacos/index.html
'   ' ;.    ;.--.  .-. | /    / ''   | |: :|  :  ;_
|   | | \   | \__\/: . ..    ' / '   | .; : \  \    `.      https://nacos.io
'   : |  ; .' ," .--.; |'   ; :__|   :    |  `----.   \
|   | '`--'  /  /  ,.  |'   | '.'|\   \  /  /  /`--'  /
'   : |     ;  :   .'   \   :    : `----'  '--'.     /
;   |.'     |  ,     .-./\   \  /            `--'---'
'---'        `--`---'     `----'

```
