### PR TITLE
[ISSUE #6382] Fix the Algorithm HmacSHA256 not available error when login

### DIFF
--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -108,7 +108,7 @@ JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/
 if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]] ; then
   JAVA_OPT="${JAVA_OPT} -Xlog:gc*:file=${BASE_DIR}/logs/nacos_gc.log:time,tags:filecount=10,filesize=102400"
 else
-  JAVA_OPT_EXT_FIX="-Djava.ext.dirs=\"${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext\""
+  JAVA_OPT_EXT_FIX="-Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext"
   JAVA_OPT="${JAVA_OPT} -Xloggc:${BASE_DIR}/logs/nacos_gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
 fi
 


### PR DESCRIPTION
## What is the purpose of the change
#6335 Fix the problem of startup error when the `JAVA_HOME` path contains spaces under Linux/Unix/Mac system, but this leads to another problem, #6382 -- You will get the following error when logging in to the console:
```
caused: Unable to obtain JCA MAC algorithm 'HmacSHA256': Algorithm HmacSHA256 not available;caused: Algorithm HmacSHA256 not available;
```
This is due to the failure to load the lib package specified by `-Djava.ext.dirs`. Therefore, the security algorithm of JDK is not available.

## Brief changelog
Modify the `distribution/bin/startup.sh` file, change 
```
JAVA_OPT_EXT_FIX="-Djava.ext.dirs=\"${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext\""
``` 
to 
```
JAVA_OPT_EXT_FIX="-Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext"
```
Just remove the `\"` around `java.ext.dirs` value.

## Verifying this change
It can work with the `JAVA_HOME` path that contains spaces, and also can log in to the console successfully.

```
/data/java 8-openjdk-amd64/bin/java -Djava.ext.dirs=/data/java 8-openjdk-amd64/jre/lib/ext:/data/java 8-openjdk-amd64/lib/ext  -Xms512m -Xmx512m -Xmn256m -Dnacos.standalone=true -Dnacos.member.list= -Xloggc:/data/nacos/distribution/target/nacos-server-2.0.3-SNAPSHOT/nacos/logs/nacos_gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M -Dloader.path=/data/nacos/distribution/target/nacos-server-2.0.3-SNAPSHOT/nacos/plugins/health,/data/nacos/distribution/target/nacos-server-2.0.3-SNAPSHOT/nacos/plugins/cmdb -Dnacos.home=/data/nacos/distribution/target/nacos-server-2.0.3-SNAPSHOT/nacos -jar /data/nacos/distribution/target/nacos-server-2.0.3-SNAPSHOT/nacos/target/nacos-server.jar  --spring.config.additional-location=file:/data/nacos/distribution/target/nacos-server-2.0.3-SNAPSHOT/nacos/conf/ --logging.config=/data/nacos/distribution/target/nacos-server-2.0.3-SNAPSHOT/nacos/conf/nacos-logback.xml --server.max-http-header-size=524288

         ,--.
       ,--.'|
   ,--,:  : |                                           Nacos 2.0.3-SNAPSHOT
,`--.'`|  ' :                       ,---.               Running in stand alone mode, All function modules
|   :  :  | |                      '   ,'\   .--.--.    Port: 8848
:   |   \ | :  ,--.--.     ,---.  /   /   | /  /    '   Pid: 19111
|   : '  '; | /       \   /     \.   ; ,. :|  :  /`./   Console: http://172.16.4.235:8848/nacos/index.html
'   ' ;.    ;.--.  .-. | /    / ''   | |: :|  :  ;_
|   | | \   | \__\/: . ..    ' / '   | .; : \  \    `.      https://nacos.io
'   : |  ; .' ," .--.; |'   ; :__|   :    |  `----.   \
|   | '`--'  /  /  ,.  |'   | '.'|\   \  /  /  /`--'  /
'   : |     ;  :   .'   \   :    : `----'  '--'.     /
;   |.'     |  ,     .-./\   \  /            `--'---'
'---'        `--`---'     `----'

```