### PR TITLE
[ISSUE #5095] Add unit test for TlsFileWatcher

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
+++ b/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
@@ -52,9 +52,9 @@ public final class TlsFileWatcher {
     
     private final int checkInterval = TlsSystemConfig.tlsFileCheckInterval;
     
-    private Map<String, String> fileMd5Map = new HashMap<String, String>();
+    private Map<String, String> fileMd5Map = new HashMap<>();
     
-    private ConcurrentHashMap<String, FileChangeListener> watchFilesMap = new ConcurrentHashMap<String, FileChangeListener>();
+    private ConcurrentHashMap<String, FileChangeListener> watchFilesMap = new ConcurrentHashMap<>();
     
     private final ScheduledExecutorService service = ExecutorFactory.Managed
             .newSingleScheduledExecutorService(ClassUtils.getCanonicalName(TlsFileWatcher.class),

--- a/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
+++ b/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
@@ -112,7 +112,7 @@ public final class TlsFileWatcher {
                         IoUtils.closeQuietly(in);
                     }
                     if (!newHash.equals(fileMd5Map.get(filePath))) {
-                        LOGGER.info(filePath + " file hash changed,need reload sslcontext");
+                        LOGGER.info(filePath + " file hash changed, need reload ssl context");
                         fileMd5Map.put(filePath, newHash);
                         item.getValue().onChanged(filePath);
                         LOGGER.info(filePath + " onChanged success!");

--- a/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
+++ b/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
@@ -97,28 +97,25 @@ public final class TlsFileWatcher {
      */
     public void start() {
         if (started.compareAndSet(false, true)) {
-            service.scheduleAtFixedRate(new Runnable() {
-                @Override
-                public void run() {
-                    for (Map.Entry<String, FileChangeListener> item : watchFilesMap.entrySet()) {
-                        String filePath = item.getKey();
-                        String newHash;
-                        InputStream in = null;
-                        try {
-                            in = new FileInputStream(filePath);
-                            newHash = MD5Utils.md5Hex(IoUtils.toString(in, Constants.ENCODE), Constants.ENCODE);
-                        } catch (Exception ignored) {
-                            LOGGER.warn(" service has exception when calculate the file MD5. " + ignored);
-                            continue;
-                        } finally {
-                            IoUtils.closeQuietly(in);
-                        }
-                        if (!newHash.equals(fileMd5Map.get(filePath))) {
-                            LOGGER.info(filePath + " file hash changed,need reload sslcontext");
-                            fileMd5Map.put(filePath, newHash);
-                            item.getValue().onChanged(filePath);
-                            LOGGER.info(filePath + " onChanged success!");
-                        }
+            service.scheduleAtFixedRate(() -> {
+                for (Map.Entry<String, FileChangeListener> item : watchFilesMap.entrySet()) {
+                    String filePath = item.getKey();
+                    String newHash;
+                    InputStream in = null;
+                    try {
+                        in = new FileInputStream(filePath);
+                        newHash = MD5Utils.md5Hex(IoUtils.toString(in, Constants.ENCODE), Constants.ENCODE);
+                    } catch (Exception ignored) {
+                        LOGGER.warn(" service has exception when calculate the file MD5. " + ignored);
+                        continue;
+                    } finally {
+                        IoUtils.closeQuietly(in);
+                    }
+                    if (!newHash.equals(fileMd5Map.get(filePath))) {
+                        LOGGER.info(filePath + " file hash changed,need reload sslcontext");
+                        fileMd5Map.put(filePath, newHash);
+                        item.getValue().onChanged(filePath);
+                        LOGGER.info(filePath + " onChanged success!");
                     }
                 }
             }, 1, checkInterval, TimeUnit.MINUTES);

--- a/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
+++ b/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
@@ -105,8 +105,8 @@ public final class TlsFileWatcher {
                     try {
                         in = new FileInputStream(filePath);
                         newHash = MD5Utils.md5Hex(IoUtils.toString(in, Constants.ENCODE), Constants.ENCODE);
-                    } catch (Exception ignored) {
-                        LOGGER.warn(" service has exception when calculate the file MD5. " + ignored);
+                    } catch (Exception exception) {
+                        LOGGER.warn(" service has exception when calculate the file MD5. " + exception);
                         continue;
                     } finally {
                         IoUtils.closeQuietly(in);

--- a/common/src/test/java/com/alibaba/nacos/common/tls/TlsFileWatcherTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/tls/TlsFileWatcherTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.tls;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TlsFileWatcherTest {
+    
+    static Field watchFilesMapField;
+    
+    static Field fileMd5MapField;
+    
+    static Field serviceField;
+    
+    static Field startedField;
+    
+    File tempFile;
+    
+    @Mock
+    ScheduledExecutorService executorService;
+    
+    @BeforeClass
+    public static void setUpBeforeClass() throws NoSuchFieldException, IllegalAccessException {
+        watchFilesMapField = TlsFileWatcher.getInstance().getClass().getDeclaredField("watchFilesMap");
+        watchFilesMapField.setAccessible(true);
+        Field modifiersField1 = Field.class.getDeclaredField("modifiers");
+        modifiersField1.setAccessible(true);
+        modifiersField1.setInt(watchFilesMapField, watchFilesMapField.getModifiers() & ~Modifier.FINAL);
+    
+        fileMd5MapField = TlsFileWatcher.getInstance().getClass().getDeclaredField("fileMd5Map");
+        fileMd5MapField.setAccessible(true);
+    
+        serviceField = TlsFileWatcher.getInstance().getClass().getDeclaredField("service");
+        serviceField.setAccessible(true);
+        Field modifiersField2 = Field.class.getDeclaredField("modifiers");
+        modifiersField2.setAccessible(true);
+        modifiersField2.setInt(watchFilesMapField, watchFilesMapField.getModifiers() & ~Modifier.FINAL);
+    
+        startedField = TlsFileWatcher.getInstance().getClass().getDeclaredField("started");
+        startedField.setAccessible(true);
+        Field modifiersField3 = Field.class.getDeclaredField("modifiers");
+        modifiersField3.setAccessible(true);
+        modifiersField3.setInt(watchFilesMapField, watchFilesMapField.getModifiers() & ~Modifier.FINAL);
+    }
+    
+    @Before
+    public void setUp() throws IOException, IllegalAccessException {
+        tempFile = new File("test.txt");
+        tempFile.createNewFile();
+        serviceField.set(TlsFileWatcher.getInstance(), executorService);
+        startedField.set(TlsFileWatcher.getInstance(), new AtomicBoolean(false));
+        Answer<?> answer = invocationOnMock -> {
+            Runnable runnable = (Runnable) invocationOnMock.getArguments()[0];
+            runnable.run();
+            return null;
+        };
+        doAnswer(answer).when(executorService).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
+    }
+    
+    @After
+    public void tearDown() throws IllegalAccessException {
+        ((Map<?, ?>) watchFilesMapField.get(TlsFileWatcher.getInstance())).clear();
+        ((Map<?, ?>) fileMd5MapField.get(TlsFileWatcher.getInstance())).clear();
+        tempFile.deleteOnExit();
+    }
+    
+    @Test
+    public void testAddFileChangeListener1() throws IOException, IllegalAccessException {
+        TlsFileWatcher.getInstance().addFileChangeListener(
+                filePath -> { }, 
+                "not/exist/path"
+        );
+    
+        Assert.assertTrue(((Map<?, ?>) watchFilesMapField.get(TlsFileWatcher.getInstance())).isEmpty());
+        Assert.assertTrue(((Map<?, ?>) fileMd5MapField.get(TlsFileWatcher.getInstance())).isEmpty());
+    }
+    
+    @Test
+    public void testAddFileChangeListener2() throws IOException, IllegalAccessException {
+        TlsFileWatcher.getInstance().addFileChangeListener(
+                filePath -> { }, 
+                (String) null
+        );
+        
+        Assert.assertTrue(((Map<?, ?>) watchFilesMapField.get(TlsFileWatcher.getInstance())).isEmpty());
+        Assert.assertTrue(((Map<?, ?>) fileMd5MapField.get(TlsFileWatcher.getInstance())).isEmpty());
+    }
+    
+    @Test
+    public void testAddFileChangeListener3() throws IOException, IllegalAccessException {
+        TlsFileWatcher.getInstance().addFileChangeListener(
+                filePath -> { },
+                tempFile.getPath()
+        );
+        
+        Assert.assertEquals(1, ((Map<?, ?>) watchFilesMapField.get(TlsFileWatcher.getInstance())).size());
+        Assert.assertEquals(1, ((Map<?, ?>) fileMd5MapField.get(TlsFileWatcher.getInstance())).size());
+    }
+    
+    @Test
+    public void testStartGivenTlsFileNotChangeThenNoNotify() throws IllegalAccessException, InterruptedException, IOException {
+        // given
+        AtomicBoolean notified = new AtomicBoolean(false);
+        TlsFileWatcher.getInstance().addFileChangeListener(
+                filePath -> notified.set(true),
+                tempFile.getPath()
+        );
+        
+        // when
+        TlsFileWatcher.getInstance().start();
+        
+        // then
+        Assert.assertFalse(notified.get());
+    }
+    
+    @Test
+    public void testStartGivenTlsFileChangeThenNotifyTheChangeFilePath() throws IllegalAccessException, IOException {
+        // given
+        AtomicBoolean notified = new AtomicBoolean(false);
+        AtomicReference<String> changedFilePath = new AtomicReference<>();
+        TlsFileWatcher.getInstance().addFileChangeListener(
+                filePath -> {
+                    notified.set(true);
+                    changedFilePath.set(filePath);
+                },
+                tempFile.getPath()
+        );
+        ((Map<String, String>) fileMd5MapField.get(TlsFileWatcher.getInstance())).put("test.txt", "");
+    
+        // when
+        TlsFileWatcher.getInstance().start();
+        
+        // then
+        Assert.assertTrue(notified.get());
+        Assert.assertEquals("test.txt", changedFilePath.get());
+    }
+    
+    @Test
+    public void testStartGivenTaskIsAlreadyRunThenNotRunAgain() {
+        TlsFileWatcher.getInstance().start();
+        TlsFileWatcher.getInstance().start();
+        
+        verify(executorService, times(1)).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The nacos-common in nacos 2.0 module coverage rate is too low.
For #5095

## Brief changelog

- add unit test case
- replace explicit type argument with <>
- replace anonymous Runnable with lambda
- rename parameter because of catch parameter named 'ignored' is used
- adjust log style

## Verifying this change
[before coverage](https://htmlpreview.github.io/?https://raw.githubusercontent.com/SunJiFengPlus/nacos/common-coverage/docs/com.alibaba.nacos.common.tls/.classes/TlsFileWatcher.html)
[after coverage](https://htmlpreview.github.io/?https://raw.githubusercontent.com/SunJiFengPlus/nacos/common-coverage/common-coverage/common-current/com.alibaba.nacos.common.tls/.classes/TlsFileWatcher.html)