### PR TITLE
[ISSUE #5095] Add unit test for RpcClient

### DIFF
--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ClientWorkerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ClientWorkerTest.java
@@ -140,7 +140,7 @@ public class ClientWorkerTest {
             clientWorker.removeConfig(dataId, group, tenant, tag);
             Assert.fail();
         } catch (NacosException e) {
-            Assert.assertEquals("Client not connected,current status:STARTING", e.getErrMsg());
+            Assert.assertEquals("Client not connected, current status:STARTING", e.getErrMsg());
             Assert.assertEquals(-401, e.getErrCode());
             
         }
@@ -148,7 +148,7 @@ public class ClientWorkerTest {
             clientWorker.getServerConfig(dataId, group, tenant, 100, false);
             Assert.fail();
         } catch (NacosException e) {
-            Assert.assertEquals("Client not connected,current status:STARTING", e.getErrMsg());
+            Assert.assertEquals("Client not connected, current status:STARTING", e.getErrMsg());
             Assert.assertEquals(-401, e.getErrCode());
         }
     }

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/ConnectionEventListener.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/ConnectionEventListener.java
@@ -26,10 +26,10 @@ public interface ConnectionEventListener {
     /**
      * notify when  connected to server.
      */
-    public void onConnected();
+    void onConnected();
 
     /**
      * notify when  disconnected to server.
      */
-    public void onDisConnect();
+    void onDisConnect();
 }

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
@@ -284,7 +284,7 @@ public abstract class RpcClient implements Closeable {
         // connection event consumer.
         clientEventExecutor.submit(() -> {
             while (!clientEventExecutor.isTerminated() && !clientEventExecutor.isShutdown()) {
-                ConnectionEvent take = null;
+                ConnectionEvent take;
                 try {
                     take = eventLinkedBlockingQueue.take();
                     if (take.isConnected()) {
@@ -504,7 +504,7 @@ public abstract class RpcClient implements Closeable {
             
             int reConnectTimes = 0;
             int retryTurns = 0;
-            Exception lastException = null;
+            Exception lastException;
             while (!switchSuccess && !isShutdown()) {
                 
                 //1.get a new server
@@ -630,7 +630,7 @@ public abstract class RpcClient implements Closeable {
      */
     public Response request(Request request, long timeoutMills) throws NacosException {
         int retryTimes = 0;
-        Response response = null;
+        Response response;
         Exception exceptionThrow = null;
         long start = System.currentTimeMillis();
         while (retryTimes < RETRY_TIMES && System.currentTimeMillis() < timeoutMills + start) {
@@ -902,7 +902,7 @@ public abstract class RpcClient implements Closeable {
     private ServerInfo resolveServerInfo(String serverAddress) {
         String property = System.getProperty("nacos.server.port", "8848");
         int serverPort = Integer.parseInt(property);
-        ServerInfo serverInfo = null;
+        ServerInfo serverInfo;
         if (serverAddress.contains(Constants.HTTP_PREFIX)) {
             String[] split = serverAddress.split(Constants.COLON);
             String serverIp = split[1].replaceAll("//", "");

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
@@ -115,7 +115,7 @@ public abstract class RpcClient implements Closeable {
     public RpcClient(ServerListFactory serverListFactory) {
         this.serverListFactory = serverListFactory;
         rpcClientStatus.compareAndSet(RpcClientStatus.WAIT_INIT, RpcClientStatus.INITIALIZED);
-        LoggerUtils.printIfInfoEnabled(LOGGER, "RpcClient init in constructor, ServerListFactory ={}",
+        LoggerUtils.printIfInfoEnabled(LOGGER, "RpcClient init in constructor, ServerListFactory = {}",
                 serverListFactory.getClass().getName());
     }
     
@@ -123,7 +123,7 @@ public abstract class RpcClient implements Closeable {
         this(name);
         this.serverListFactory = serverListFactory;
         rpcClientStatus.compareAndSet(RpcClientStatus.WAIT_INIT, RpcClientStatus.INITIALIZED);
-        LoggerUtils.printIfInfoEnabled(LOGGER, "RpcClient init in constructor, ServerListFactory ={}",
+        LoggerUtils.printIfInfoEnabled(LOGGER, "RpcClient init in constructor, ServerListFactory = {}",
                 serverListFactory.getClass().getName());
     }
     
@@ -138,7 +138,7 @@ public abstract class RpcClient implements Closeable {
     }
     
     /**
-     * init server list factory.only can init once.
+     * init server list factory. only can init once.
      *
      * @param serverListFactory serverListFactory
      */
@@ -149,7 +149,7 @@ public abstract class RpcClient implements Closeable {
         this.serverListFactory = serverListFactory;
         rpcClientStatus.compareAndSet(RpcClientStatus.WAIT_INIT, RpcClientStatus.INITIALIZED);
         
-        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]RpcClient init, ServerListFactory ={}", name,
+        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] RpcClient init, ServerListFactory = {}", name,
                 serverListFactory.getClass().getName());
         return this;
     }
@@ -161,7 +161,7 @@ public abstract class RpcClient implements Closeable {
      */
     public RpcClient labels(Map<String, String> labels) {
         this.labels.putAll(labels);
-        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]RpcClient init label, labels={}", name, this.labels);
+        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] RpcClient init label, labels = {}", name, this.labels);
         return this;
     }
     
@@ -173,7 +173,7 @@ public abstract class RpcClient implements Closeable {
      */
     public RpcClient keepAlive(long keepAliveTime, TimeUnit timeUnit) {
         this.keepAliveTime = keepAliveTime * timeUnit.toMillis(keepAliveTime);
-        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]RpcClient init keepalive time, keepAliveTimeMillis={}", name,
+        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] RpcClient init keepalive time, keepAliveTimeMillis = {}", name,
                 keepAliveTime);
         return this;
     }
@@ -185,12 +185,12 @@ public abstract class RpcClient implements Closeable {
         if (connectionEventListeners.isEmpty()) {
             return;
         }
-        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]Notify disconnected event to listeners", name);
+        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Notify disconnected event to listeners", name);
         for (ConnectionEventListener connectionEventListener : connectionEventListeners) {
             try {
                 connectionEventListener.onDisConnect();
             } catch (Throwable throwable) {
-                LoggerUtils.printIfErrorEnabled(LOGGER, "[{}]Notify disconnect listener error,listener ={}", name,
+                LoggerUtils.printIfErrorEnabled(LOGGER, "[{}] Notify disconnect listener error, listener = {}", name,
                         connectionEventListener.getClass().getName());
             }
         }
@@ -203,12 +203,12 @@ public abstract class RpcClient implements Closeable {
         if (connectionEventListeners.isEmpty()) {
             return;
         }
-        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]Notify connected event to listeners.", name);
+        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Notify connected event to listeners.", name);
         for (ConnectionEventListener connectionEventListener : connectionEventListeners) {
             try {
                 connectionEventListener.onConnected();
             } catch (Throwable throwable) {
-                LoggerUtils.printIfErrorEnabled(LOGGER, "[{}]Notify connect listener error,listener ={}", name,
+                LoggerUtils.printIfErrorEnabled(LOGGER, "[{}] Notify connect listener error, listener = {}", name,
                         connectionEventListener.getClass().getName());
             }
         }
@@ -242,7 +242,7 @@ public abstract class RpcClient implements Closeable {
     }
     
     /**
-     * check if current connected server is in serverlist ,if not switch server.
+     * check if current connected server is in server list, if not switch server.
      */
     public void onServerListChange() {
         if (currentConnection != null && currentConnection.serverInfo != null) {
@@ -256,7 +256,7 @@ public abstract class RpcClient implements Closeable {
             }
             if (!found) {
                 LoggerUtils.printIfInfoEnabled(LOGGER,
-                        "Current connected server {}  is not in latest server list,switch switchServerAsync",
+                        "Current connected server {} is not in latest server list, switch switchServerAsync",
                         serverInfo.getAddress());
                 switchServerAsync();
             }
@@ -293,7 +293,7 @@ public abstract class RpcClient implements Closeable {
                         notifyDisConnected();
                     }
                 } catch (Throwable e) {
-                    //Do nothing
+                    // Do nothing
                 }
             }
         });
@@ -307,7 +307,7 @@ public abstract class RpcClient implements Closeable {
                     ReconnectContext reconnectContext = reconnectionSignal
                             .poll(keepAliveTime, TimeUnit.MILLISECONDS);
                     if (reconnectContext == null) {
-                        //check alive time.
+                        // check alive time.
                         if (System.currentTimeMillis() - lastActiveTimeStamp >= keepAliveTime) {
                             boolean isHealthy = healthCheck();
                             if (!isHealthy) {
@@ -315,7 +315,7 @@ public abstract class RpcClient implements Closeable {
                                     continue;
                                 }
                                 LoggerUtils.printIfInfoEnabled(LOGGER,
-                                        "[{}]Server healthy check fail,currentConnection={}", name,
+                                        "[{}] Server healthy check fail, currentConnection = {}", name,
                                         currentConnection.getConnectionId());
                                 
                                 RpcClientStatus rpcClientStatus = RpcClient.this.rpcClientStatus.get();
@@ -342,7 +342,7 @@ public abstract class RpcClient implements Closeable {
                     }
                     
                     if (reconnectContext.serverInfo != null) {
-                        //clear recommend server if server is not in server list.
+                        // clear recommend server if server is not in server list.
                         boolean serverExist = false;
                         for (String server : getServerListFactory().getServerList()) {
                             ServerInfo serverInfo = resolveServerInfo(server);
@@ -354,7 +354,7 @@ public abstract class RpcClient implements Closeable {
                         }
                         if (!serverExist) {
                             LoggerUtils.printIfInfoEnabled(LOGGER,
-                                    "[{}] Recommend server is not in server list ,ignore recommend server {}", name,
+                                    "[{}] Recommend server is not in server list, ignore recommend server {}", name,
                                     reconnectContext.serverInfo.getAddress());
                             
                             reconnectContext.serverInfo = null;
@@ -363,12 +363,12 @@ public abstract class RpcClient implements Closeable {
                     }
                     reconnect(reconnectContext.serverInfo, reconnectContext.onRequestFail);
                 } catch (Throwable throwable) {
-                    //Do nothing
+                    // Do nothing
                 }
             }
         });
         
-        //connect to server ,try to connect to server sync once, async starting if fail.
+        // connect to server, try to connect to server sync RETRY_TIMES times, async starting if failed.
         Connection connectToServer = null;
         rpcClientStatus.set(RpcClientStatus.STARTING);
         
@@ -384,14 +384,14 @@ public abstract class RpcClient implements Closeable {
                 connectToServer = connectToServer(serverInfo);
             } catch (Throwable e) {
                 LoggerUtils.printIfWarnEnabled(LOGGER,
-                        "[{}]Fail to connect to server on start up, error message={}, start up retry times left: {}",
+                        "[{}] Fail to connect to server on start up, error message = {}, start up retry times left: {}",
                         name, e.getMessage(), startUpRetryTimes);
             }
             
         }
         
         if (connectToServer != null) {
-            LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Success to connect to server [{}] on start up,connectionId={}",
+            LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Success to connect to server [{}] on start up, connectionId = {}",
                     name, connectToServer.serverInfo.getAddress(), connectToServer.getConnectionId());
             this.currentConnection = connectToServer;
             rpcClientStatus.set(RpcClientStatus.RUNNING);
@@ -402,7 +402,7 @@ public abstract class RpcClient implements Closeable {
         
         registerServerRequestHandler(new ConnectResetRequestHandler());
         
-        //register client detection request.
+        // register client detection request.
         registerServerRequestHandler(request -> {
             if (request instanceof ClientDetectionRequest) {
                 return new ClientDetectionResponse();
@@ -435,7 +435,7 @@ public abstract class RpcClient implements Closeable {
                         }
                     }
                 } catch (Exception e) {
-                    LoggerUtils.printIfErrorEnabled(LOGGER, "[{}]Switch server error ,{}", name, e);
+                    LoggerUtils.printIfErrorEnabled(LOGGER, "[{}] Switch server error, {}", name, e);
                 }
                 return new ConnectResetResponse();
             }
@@ -445,9 +445,9 @@ public abstract class RpcClient implements Closeable {
     
     @Override
     public void shutdown() throws NacosException {
-        LOGGER.info("Shutdown rpc client ,set status to shutdown");
+        LOGGER.info("Shutdown rpc client, set status to shutdown");
         rpcClientStatus.set(RpcClientStatus.SHUTDOWN);
-        LOGGER.info("Shutdown  client event executor " + clientEventExecutor);
+        LOGGER.info("Shutdown client event executor " + clientEventExecutor);
         clientEventExecutor.shutdownNow();
         LOGGER.info("Close current connection " + currentConnection.getConnectionId());
         closeConnection(currentConnection);
@@ -460,10 +460,10 @@ public abstract class RpcClient implements Closeable {
         }
         try {
             Response response = this.currentConnection.request(healthCheckRequest, 3000L);
-            //not only check server is ok ,also check connection is register.
+            // not only check server is ok, also check connection is register.
             return response != null && response.isSuccess();
         } catch (NacosException e) {
-            //ignore
+            // ignore
         }
         return false;
     }
@@ -489,14 +489,14 @@ public abstract class RpcClient implements Closeable {
             
             AtomicReference<ServerInfo> recommendServer = new AtomicReference<>(recommendServerInfo);
             if (onRequestFail && healthCheck()) {
-                LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Server check success,currentServer is{} ", name,
+                LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Server check success, currentServer is {} ", name,
                         currentConnection.serverInfo.getAddress());
                 rpcClientStatus.set(RpcClientStatus.RUNNING);
                 return;
             }
             
-            LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] try to re connect to a new server ,server is {}", name,
-                    recommendServerInfo == null ? " not appointed,will choose a random server."
+            LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Try to reconnect to a new server, server is {}", name,
+                    recommendServerInfo == null ? " not appointed, will choose a random server."
                             : (recommendServerInfo.getAddress() + ", will try it once."));
             
             // loop until start client success.
@@ -507,21 +507,21 @@ public abstract class RpcClient implements Closeable {
             Exception lastException;
             while (!switchSuccess && !isShutdown()) {
                 
-                //1.get a new server
+                // 1.get a new server
                 ServerInfo serverInfo = null;
                 try {
                     serverInfo = recommendServer.get() == null ? nextRpcServer() : recommendServer.get();
-                    //2.create a new channel to new server
+                    // 2.create a new channel to new server
                     Connection connectionNew = connectToServer(serverInfo);
                     if (connectionNew != null) {
-                        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] success to connect a server  [{}],connectionId={}",
+                        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Success to connect a server [{}], connectionId = {}",
                                 name, serverInfo.getAddress(), connectionNew.getConnectionId());
-                        //successfully create a new connect.
+                        // successfully create a new connect.
                         if (currentConnection != null) {
                             LoggerUtils.printIfInfoEnabled(LOGGER,
-                                    "[{}] Abandon prev connection ,server is  {}, connectionId is {}", name,
+                                    "[{}] Abandon prev connection, server is {}, connectionId is {}", name,
                                     currentConnection.serverInfo.getAddress(), currentConnection.getConnectionId());
-                            //set current connection to enable connection event.
+                            // set current connection to enable connection event.
                             currentConnection.setAbandon(true);
                             closeConnection(currentConnection);
                         }
@@ -532,7 +532,7 @@ public abstract class RpcClient implements Closeable {
                         return;
                     }
                     
-                    //close connection if client is already shutdown.
+                    // close connection if client is already shutdown.
                     if (isShutdown()) {
                         closeConnection(currentConnection);
                     }
@@ -548,7 +548,7 @@ public abstract class RpcClient implements Closeable {
                 if (reConnectTimes > 0
                         && reConnectTimes % RpcClient.this.serverListFactory.getServerList().size() == 0) {
                     LoggerUtils.printIfInfoEnabled(LOGGER,
-                            "[{}] fail to connect server,after trying {} times, last try server is {},error={}", name,
+                            "[{}] Fail to connect server, after trying {} times, last try server is {}, error = {}", name,
                             reConnectTimes, serverInfo, lastException == null ? "unknown" : lastException);
                     if (Integer.MAX_VALUE == retryTurns) {
                         retryTurns = 50;
@@ -560,22 +560,22 @@ public abstract class RpcClient implements Closeable {
                 reConnectTimes++;
                 
                 try {
-                    //sleep x milliseconds to switch next server.
+                    // sleep x milliseconds to switch next server.
                     if (!isRunning()) {
-                        // first round ,try servers at a delay 100ms;second round ,200ms; max delays 5s. to be reconsidered.
+                        // first round, try servers at a delay 100ms;second round, 200ms; max delays 5s. to be reconsidered.
                         Thread.sleep(Math.min(retryTurns + 1, 50) * 100L);
                     }
                 } catch (InterruptedException e) {
-                    // Do  nothing.
+                    // Do nothing.
                 }
             }
             
             if (isShutdown()) {
-                LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Client is shutdown ,stop reconnect to server", name);
+                LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Client is shutdown, stop reconnect to server", name);
             }
             
         } catch (Exception e) {
-            LoggerUtils.printIfWarnEnabled(LOGGER, "[{}] Fail to  re connect to server ,error is {}", name, e);
+            LoggerUtils.printIfWarnEnabled(LOGGER, "[{}] Fail to reconnect to server, error is {}", name, e);
         }
     }
     
@@ -639,7 +639,7 @@ public abstract class RpcClient implements Closeable {
                 if (this.currentConnection == null || !isRunning()) {
                     waitReconnect = true;
                     throw new NacosException(NacosException.CLIENT_DISCONNECT,
-                            "Client not connected,current status:" + rpcClientStatus.get());
+                            "Client not connected, current status:" + rpcClientStatus.get());
                 }
                 response = this.currentConnection.request(request, timeoutMills);
                 if (response == null) {
@@ -651,7 +651,7 @@ public abstract class RpcClient implements Closeable {
                             waitReconnect = true;
                             if (rpcClientStatus.compareAndSet(RpcClientStatus.RUNNING, RpcClientStatus.UNHEALTHY)) {
                                 LoggerUtils.printIfErrorEnabled(LOGGER,
-                                        "Connection is unregistered, switch server,connectionId={},request={}",
+                                        "Connection is unregistered, switch server, connectionId = {}, request = {}",
                                         currentConnection.getConnectionId(), request.getClass().getSimpleName());
                                 switchServerAsync();
                             }
@@ -667,14 +667,14 @@ public abstract class RpcClient implements Closeable {
             } catch (Exception e) {
                 if (waitReconnect) {
                     try {
-                        //wait client to re connect.
+                        // wait client to reconnect.
                         Thread.sleep(Math.min(100, timeoutMills / 3));
                     } catch (Exception exception) {
-                        //Do nothing.
+                        // Do nothing.
                     }
                 }
                 
-                LoggerUtils.printIfErrorEnabled(LOGGER, "Send request fail, request={}, retryTimes={},errorMessage={}",
+                LoggerUtils.printIfErrorEnabled(LOGGER, "Send request fail, request = {}, retryTimes = {}, errorMessage = {}",
                         request, retryTimes, e.getMessage());
                 
                 exceptionThrow = e;
@@ -718,14 +718,14 @@ public abstract class RpcClient implements Closeable {
             } catch (Exception e) {
                 if (waitReconnect) {
                     try {
-                        //wait client to re connect.
+                        // wait client to reconnect.
                         Thread.sleep(Math.min(100, callback.getTimeout() / 3));
                     } catch (Exception exception) {
-                        //Do nothing.
+                        // Do nothing.
                     }
                 }
                 LoggerUtils
-                        .printIfErrorEnabled(LOGGER, "[{}]Send request fail, request={}, retryTimes={},errorMessage={}",
+                        .printIfErrorEnabled(LOGGER, "[{}] Send request fail, request = {}, retryTimes = {}, errorMessage = {}",
                                 name, request, retryTimes, e.getMessage());
                 exceptionToThrow = e;
                 
@@ -766,14 +766,14 @@ public abstract class RpcClient implements Closeable {
             } catch (Exception e) {
                 if (waitReconnect) {
                     try {
-                        //wait client to re connect.
+                        // wait client to reconnect.
                         Thread.sleep(100L);
                     } catch (Exception exception) {
-                        //Do nothing.
+                        // Do nothing.
                     }
                 }
                 LoggerUtils
-                        .printIfErrorEnabled(LOGGER, "[{}]Send request fail, request={}, retryTimes={},errorMessage={}",
+                        .printIfErrorEnabled(LOGGER, "[{}] Send request fail, request = {}, retryTimes = {}, errorMessage = {}",
                                 name, request, retryTimes, e.getMessage());
                 exceptionToThrow = e;
                 
@@ -810,7 +810,7 @@ public abstract class RpcClient implements Closeable {
      */
     protected Response handleServerRequest(final Request request) {
         
-        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]receive server push request,request={},requestId={}", name,
+        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Receive server push request, request = {}, requestId = {}", name,
                 request.getClass().getSimpleName(), request.getRequestId());
         lastActiveTimeStamp = System.currentTimeMillis();
         for (ServerRequestHandler serverRequestHandler : serverRequestHandlers) {
@@ -818,12 +818,12 @@ public abstract class RpcClient implements Closeable {
                 Response response = serverRequestHandler.requestReply(request);
                 
                 if (response != null) {
-                    LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]ack server push request,request={},requestId={}", name,
+                    LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Ack server push request, request = {}, requestId = {}", name,
                             request.getClass().getSimpleName(), request.getRequestId());
                     return response;
                 }
             } catch (Exception e) {
-                LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]handleServerRequest:{}, errorMessage={}", name,
+                LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] HandleServerRequest:{}, errorMessage = {}", name,
                         serverRequestHandler.getClass().getName(), e.getMessage());
             }
             
@@ -838,7 +838,7 @@ public abstract class RpcClient implements Closeable {
      */
     public synchronized void registerConnectionListener(ConnectionEventListener connectionEventListener) {
         
-        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]Registry connection listener to current client:{}", name,
+        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Registry connection listener to current client:{}", name,
                 connectionEventListener.getClass().getName());
         this.connectionEventListeners.add(connectionEventListener);
     }
@@ -849,7 +849,7 @@ public abstract class RpcClient implements Closeable {
      * @param serverRequestHandler serverRequestHandler
      */
     public synchronized void registerServerRequestHandler(ServerRequestHandler serverRequestHandler) {
-        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}]Register server push request handler:{}", name,
+        LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Register server push request handler:{}", name,
                 serverRequestHandler.getClass().getName());
         
         this.serverRequestHandlers.add(serverRequestHandler);
@@ -983,7 +983,7 @@ public abstract class RpcClient implements Closeable {
         
         @Override
         public String toString() {
-            return "{serverIp='" + serverIp + '\'' + ", server main port=" + serverPort + '}';
+            return "{serverIp = '" + serverIp + '\'' + ", server main port = " + serverPort + '}';
         }
     }
     

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
@@ -65,18 +65,18 @@ public abstract class RpcClient implements Closeable {
     
     private ServerListFactory serverListFactory;
     
-    protected LinkedBlockingQueue<ConnectionEvent> eventLinkedBlockingQueue = new LinkedBlockingQueue<ConnectionEvent>();
+    protected LinkedBlockingQueue<ConnectionEvent> eventLinkedBlockingQueue = new LinkedBlockingQueue<>();
     
-    protected volatile AtomicReference<RpcClientStatus> rpcClientStatus = new AtomicReference<RpcClientStatus>(
+    protected volatile AtomicReference<RpcClientStatus> rpcClientStatus = new AtomicReference<>(
             RpcClientStatus.WAIT_INIT);
     
     protected ScheduledExecutorService clientEventExecutor;
     
-    private final BlockingQueue<ReconnectContext> reconnectionSignal = new ArrayBlockingQueue<ReconnectContext>(1);
+    private final BlockingQueue<ReconnectContext> reconnectionSignal = new ArrayBlockingQueue<>(1);
     
     protected volatile Connection currentConnection;
     
-    protected Map<String, String> labels = new HashMap<String, String>();
+    protected Map<String, String> labels = new HashMap<>();
     
     private String name;
     
@@ -98,12 +98,12 @@ public abstract class RpcClient implements Closeable {
     /**
      * listener called where connection's status changed.
      */
-    protected List<ConnectionEventListener> connectionEventListeners = new ArrayList<ConnectionEventListener>();
+    protected List<ConnectionEventListener> connectionEventListeners = new ArrayList<>();
     
     /**
      * handlers to process server push request.
      */
-    protected List<ServerRequestHandler> serverRequestHandlers = new ArrayList<ServerRequestHandler>();
+    protected List<ServerRequestHandler> serverRequestHandlers = new ArrayList<>();
     
     static {
         PayloadRegistry.init();
@@ -500,7 +500,7 @@ public abstract class RpcClient implements Closeable {
         
         try {
             
-            AtomicReference<ServerInfo> recommendServer = new AtomicReference<ServerInfo>(recommendServerInfo);
+            AtomicReference<ServerInfo> recommendServer = new AtomicReference<>(recommendServerInfo);
             if (onRequestFail && healthCheck()) {
                 LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] Server check success,currentServer is{} ", name,
                         currentConnection.serverInfo.getAddress());

--- a/common/src/test/java/com/alibaba/nacos/common/remote/client/RpcClientTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/remote/client/RpcClientTest.java
@@ -1,0 +1,459 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.remote.client;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.remote.RequestCallBack;
+import com.alibaba.nacos.api.remote.request.Request;
+import com.alibaba.nacos.api.remote.response.ErrorResponse;
+import com.alibaba.nacos.common.remote.ConnectionType;
+import com.alibaba.nacos.common.remote.client.grpc.GrpcConnection;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(RpcClient.class)
+public class RpcClientTest {
+    
+    RpcClient rpcClient;
+    
+    Field keepAliveTimeField;
+    
+    Field serverListFactoryField;
+    
+    Field reconnectionSignalField;
+    
+    Field lastActiveTimeStampField;
+    
+    Field retryTimesField;
+    
+    Method resolveServerInfoMethod;
+    
+    Answer<?> runAsSync;
+    
+    Answer<?> notInvoke;
+    
+    @Mock
+    ServerListFactory serverListFactory;
+    
+    @Mock
+    ScheduledThreadPoolExecutor scheduledThreadPoolExecutor;
+    
+    @Mock
+    ConnectionEventListener connectionEventListener;
+    
+    @Mock
+    Connection connection;
+    
+    @Before
+    public void setUp() throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException {
+        rpcClient = spy(new RpcClient("testClient") {
+            @Override
+            public ConnectionType getConnectionType() {
+                return null;
+            }
+            
+            @Override
+            public int rpcPortOffset() {
+                return 0;
+            }
+            
+            @Override
+            public Connection connectToServer(ServerInfo serverInfo) {
+                return null;
+            }
+        });
+        
+        keepAliveTimeField = RpcClient.class.getDeclaredField("keepAliveTime");
+        keepAliveTimeField.setAccessible(true);
+        
+        serverListFactoryField = RpcClient.class.getDeclaredField("serverListFactory");
+        serverListFactoryField.setAccessible(true);
+        
+        reconnectionSignalField = RpcClient.class.getDeclaredField("reconnectionSignal");
+        reconnectionSignalField.setAccessible(true);
+        Field modifiersField1 = Field.class.getDeclaredField("modifiers");
+        modifiersField1.setAccessible(true);
+        modifiersField1.setInt(reconnectionSignalField, reconnectionSignalField.getModifiers() & ~Modifier.FINAL);
+        
+        lastActiveTimeStampField = RpcClient.class.getDeclaredField("lastActiveTimeStamp");
+        lastActiveTimeStampField.setAccessible(true);
+        Field modifiersField2 = Field.class.getDeclaredField("modifiers");
+        modifiersField2.setAccessible(true);
+        modifiersField2.setInt(reconnectionSignalField, reconnectionSignalField.getModifiers() & ~Modifier.FINAL);
+    
+        retryTimesField = RpcClient.class.getDeclaredField("RETRY_TIMES");
+        retryTimesField.setAccessible(true);
+        Field modifiersField3 = Field.class.getDeclaredField("modifiers");
+        modifiersField3.setAccessible(true);
+        modifiersField3.setInt(reconnectionSignalField, reconnectionSignalField.getModifiers() & ~Modifier.FINAL);
+        
+        resolveServerInfoMethod = RpcClient.class.getDeclaredMethod("resolveServerInfo", String.class);
+        resolveServerInfoMethod.setAccessible(true);
+        
+        runAsSync = invocationOnMock -> {
+            Runnable runnable = (Runnable) invocationOnMock.getArguments()[0];
+            runnable.run();
+            return null;
+        };
+        
+        notInvoke = invocationOnMock -> null;
+    }
+    
+    @After
+    public void tearDown() throws IllegalAccessException {
+        rpcClient.labels.clear();
+        rpcClient.rpcClientStatus.set(RpcClientStatus.WAIT_INIT);
+        serverListFactoryField.set(rpcClient, null);
+        ((Queue<?>) reconnectionSignalField.get(rpcClient)).clear();
+        rpcClient.currentConnection = null;
+        System.clearProperty("nacos.server.port");
+        rpcClient.eventLinkedBlockingQueue.clear();
+    }
+    
+    @Test
+    public void testInitServerListFactory() {
+        rpcClient.rpcClientStatus.set(RpcClientStatus.WAIT_INIT);
+        rpcClient.serverListFactory(serverListFactory);
+        Assert.assertEquals(RpcClientStatus.INITIALIZED, rpcClient.rpcClientStatus.get());
+        
+        rpcClient.rpcClientStatus.set(RpcClientStatus.INITIALIZED);
+        rpcClient.serverListFactory(serverListFactory);
+        Assert.assertEquals(RpcClientStatus.INITIALIZED, rpcClient.rpcClientStatus.get());
+        
+        RpcClient client1 = new RpcClient("test", serverListFactory) {
+            @Override
+            public ConnectionType getConnectionType() {
+                return null;
+            }
+            
+            @Override
+            public int rpcPortOffset() {
+                return 0;
+            }
+            
+            @Override
+            public Connection connectToServer(ServerInfo serverInfo) {
+                return null;
+            }
+        };
+        Assert.assertEquals(RpcClientStatus.INITIALIZED, client1.rpcClientStatus.get());
+        
+        RpcClient client2 = new RpcClient(serverListFactory) {
+            @Override
+            public ConnectionType getConnectionType() {
+                return null;
+            }
+            
+            @Override
+            public int rpcPortOffset() {
+                return 0;
+            }
+            
+            @Override
+            public Connection connectToServer(ServerInfo serverInfo) {
+                return null;
+            }
+        };
+        Assert.assertEquals(RpcClientStatus.INITIALIZED, client2.rpcClientStatus.get());
+    }
+    
+    @Test
+    public void testLabels() {
+        rpcClient.labels(Collections.singletonMap("labelKey1", "labelValue1"));
+        Map.Entry<String, String> element = rpcClient.getLabels().entrySet().iterator().next();
+        Assert.assertEquals("labelKey1", element.getKey());
+        Assert.assertEquals("labelValue1", element.getValue());
+        
+        // accumulate labels
+        rpcClient.labels(Collections.singletonMap("labelKey2", "labelValue2"));
+        Assert.assertEquals(2, rpcClient.getLabels().size());
+    }
+    
+    @Test
+    public void testKeepAlive() throws IllegalAccessException {
+        rpcClient.keepAlive(1, TimeUnit.SECONDS);
+        long keepAliveTime = (long) keepAliveTimeField.get(rpcClient);
+        Assert.assertEquals(1000L, keepAliveTime);
+        
+        rpcClient.keepAlive(1, TimeUnit.MINUTES);
+        keepAliveTime = (long) keepAliveTimeField.get(rpcClient);
+        Assert.assertEquals(60000L, keepAliveTime);
+    }
+    
+    @Test
+    public void testOnServerListChangeWhenCurrentConnectionIsNullThenDoNothing() throws IllegalAccessException {
+        int beforeSize = ((Queue<?>) reconnectionSignalField.get(rpcClient)).size();
+        rpcClient.serverListFactory(serverListFactory);
+        
+        rpcClient.onServerListChange();
+        
+        int afterSize = ((Queue<?>) reconnectionSignalField.get(rpcClient)).size();
+        Assert.assertEquals(beforeSize, afterSize);
+    }
+    
+    @Test
+    public void testOnServerListChangeWhenServiceInfoIsNullThenDoNothing() throws IllegalAccessException {
+        int beforeSize = ((Queue<?>) reconnectionSignalField.get(rpcClient)).size();
+        rpcClient.currentConnection = mock(Connection.class);
+        
+        rpcClient.onServerListChange();
+        
+        int afterSize = ((Queue<?>) reconnectionSignalField.get(rpcClient)).size();
+        Assert.assertEquals(beforeSize, afterSize);
+    }
+    
+    @Test
+    public void testOnServerListChangeWhenCurrentConnectionIsNotInServerListThenSwitchServerAsync()
+            throws IllegalAccessException {
+        final int beforeSize = ((Queue<?>) reconnectionSignalField.get(rpcClient)).size();
+        rpcClient.serverListFactory(serverListFactory);
+        rpcClient.currentConnection = new GrpcConnection(new RpcClient.ServerInfo("10.10.10.10", 8848), null);
+        doReturn(Collections.singletonList("")).when(serverListFactory).getServerList();
+        
+        rpcClient.onServerListChange();
+        
+        int afterSize = ((Queue<?>) reconnectionSignalField.get(rpcClient)).size();
+        Assert.assertEquals(beforeSize + 1, afterSize);
+    }
+    
+    @Test
+    public void testOnServerListChangeWhenCurrentConnectionIsInServerListThenDoNothing() throws IllegalAccessException {
+        final int beforeSize = ((Queue<?>) reconnectionSignalField.get(rpcClient)).size();
+        rpcClient.serverListFactory(serverListFactory);
+        rpcClient.currentConnection = new GrpcConnection(new RpcClient.ServerInfo("10.10.10.10", 8848), null);
+        doReturn(Collections.singletonList("http://10.10.10.10:8848")).when(serverListFactory).getServerList();
+        
+        rpcClient.onServerListChange();
+        
+        int afterSize = ((Queue<?>) reconnectionSignalField.get(rpcClient)).size();
+        Assert.assertEquals(beforeSize, afterSize);
+    }
+    
+    @Test
+    public void testResolveServerInfo1() throws InvocationTargetException, IllegalAccessException {
+        Assert.assertEquals(":8848",
+                ((RpcClient.ServerInfo) resolveServerInfoMethod.invoke(rpcClient, "")).getAddress());
+        Assert.assertEquals("10.10.10.10:8848",
+                ((RpcClient.ServerInfo) resolveServerInfoMethod.invoke(rpcClient, "10.10.10.10::8848")).getAddress());
+        Assert.assertEquals("10.10.10.10:8848",
+                ((RpcClient.ServerInfo) resolveServerInfoMethod.invoke(rpcClient, "10.10.10.10:8848")).getAddress());
+        Assert.assertEquals("10.10.10.10:8848", ((RpcClient.ServerInfo) resolveServerInfoMethod.invoke(rpcClient,
+                "http://10.10.10.10:8848")).getAddress());
+        Assert.assertEquals("10.10.10.10:8848", ((RpcClient.ServerInfo) resolveServerInfoMethod.invoke(rpcClient,
+                "http://10.10.10.10::8848")).getAddress());
+        Assert.assertEquals("10.10.10.10:8848",
+                ((RpcClient.ServerInfo) resolveServerInfoMethod.invoke(rpcClient, "http://10.10.10.10")).getAddress());
+    }
+    
+    @Test
+    public void testResolveServerInfo2() throws InvocationTargetException, IllegalAccessException {
+        System.setProperty("nacos.server.port", "4424");
+        Assert.assertEquals("10.10.10.10:4424",
+                ((RpcClient.ServerInfo) resolveServerInfoMethod.invoke(rpcClient, "http://10.10.10.10")).getAddress());
+    }
+    
+    @Test
+    public void testStartWhenClientConnectedThenNotifyListener() throws Exception {
+        // given
+        rpcClient.rpcClientStatus.set(RpcClientStatus.INITIALIZED);
+        whenNew(ScheduledThreadPoolExecutor.class).withAnyArguments().thenReturn(scheduledThreadPoolExecutor);
+        Answer<?> runAsSync = invocationOnMock -> {
+            Runnable runnable = (Runnable) invocationOnMock.getArguments()[0];
+            runnable.run();
+            return null;
+        };
+        doAnswer(runAsSync).doAnswer(notInvoke).when(scheduledThreadPoolExecutor).submit(any(Runnable.class));
+        rpcClient.eventLinkedBlockingQueue.add(rpcClient.new ConnectionEvent(RpcClient.ConnectionEvent.CONNECTED));
+        rpcClient.connectionEventListeners.add(connectionEventListener);
+        doReturn(false, true).when(scheduledThreadPoolExecutor).isTerminated();
+        doReturn(false).when(scheduledThreadPoolExecutor).isShutdown();
+        
+        // when
+        rpcClient.start();
+        
+        // then
+        verify(connectionEventListener, times(1)).onConnected();
+    }
+    
+    @Test
+    public void testStartWhenClientDisconnectedThenNotifyListener() throws Exception {
+        // given
+        rpcClient.rpcClientStatus.set(RpcClientStatus.INITIALIZED);
+        whenNew(ScheduledThreadPoolExecutor.class).withAnyArguments().thenReturn(scheduledThreadPoolExecutor);
+        doAnswer(runAsSync).doAnswer(notInvoke).when(scheduledThreadPoolExecutor).submit(any(Runnable.class));
+        rpcClient.eventLinkedBlockingQueue.add(rpcClient.new ConnectionEvent(RpcClient.ConnectionEvent.DISCONNECTED));
+        rpcClient.connectionEventListeners.add(connectionEventListener);
+        doReturn(false, true).when(scheduledThreadPoolExecutor).isTerminated();
+        doReturn(false).when(scheduledThreadPoolExecutor).isShutdown();
+        
+        // when
+        rpcClient.start();
+        
+        // then
+        verify(connectionEventListener, times(1)).onDisConnect();
+    }
+    
+    @Test
+    public void testStartWhenServerIsUnhealthyThenSwitchServer() throws Exception {
+        // given
+        whenNew(ScheduledThreadPoolExecutor.class).withAnyArguments().thenReturn(scheduledThreadPoolExecutor);
+        doAnswer(notInvoke).doAnswer(runAsSync).when(scheduledThreadPoolExecutor).submit(any(Runnable.class));
+        rpcClient.currentConnection = connection;
+        rpcClient.serverListFactory(serverListFactory);
+        doReturn("").when(serverListFactory).genNextServer();
+        doReturn(false, false, true).when(rpcClient).isShutdown();
+        BlockingQueue<?> blockingQueue = mock(ArrayBlockingQueue.class);
+        reconnectionSignalField.set(rpcClient, blockingQueue);
+        lastActiveTimeStampField.set(rpcClient, System.currentTimeMillis() - (long) keepAliveTimeField.get(rpcClient));
+        connection.serverInfo = new RpcClient.ServerInfo();
+        doReturn(connection).when(rpcClient).connectToServer(any());
+        
+        // when
+        rpcClient.start();
+        
+        // then
+        // 1 init connection event, 1 current connection close event, 1 new connection create event.
+        Assert.assertEquals(3, rpcClient.eventLinkedBlockingQueue.size());
+        verify(this.connection).setAbandon(true);
+        Assert.assertEquals(connection, rpcClient.currentConnection);
+    }
+    
+    @Test
+    public void testStartWhenRetryMannyTimesStillCanNotConnectToServerThenConnectAsync() throws Exception {
+        // given
+        whenNew(ScheduledThreadPoolExecutor.class).withAnyArguments().thenReturn(scheduledThreadPoolExecutor);
+        doAnswer(notInvoke).doAnswer(notInvoke).when(scheduledThreadPoolExecutor).submit(any(Runnable.class));
+        doReturn(null).when(rpcClient).nextRpcServer();
+        doReturn(null).when(rpcClient).connectToServer(any());
+        rpcClient.rpcClientStatus.set(RpcClientStatus.INITIALIZED);
+        
+        // when
+        rpcClient.start();
+    
+        // then
+        Assert.assertEquals(1, ((Queue<?>) reconnectionSignalField.get(rpcClient)).size());
+        verify(rpcClient, times((int) retryTimesField.get(rpcClient))).nextRpcServer();
+        verify(rpcClient, times((int) retryTimesField.get(rpcClient))).connectToServer(any());
+    }
+    
+    @Test(expected = NacosException.class)
+    public void testRequestWhenClientAlreadyShutDownThenThrowException() throws NacosException {
+        rpcClient.rpcClientStatus.set(RpcClientStatus.SHUTDOWN);
+        rpcClient.currentConnection = connection;
+        rpcClient.request(null, 10000);
+    }
+    
+    @Test(expected = NacosException.class)
+    public void testRequestWhenTimeoutThenThrowException() throws NacosException {
+        rpcClient.rpcClientStatus.set(RpcClientStatus.RUNNING);
+        rpcClient.currentConnection = connection;
+        doReturn(null).when(connection).request(any(), anyLong());
+        
+        rpcClient.request(null, 10000);
+    }
+    
+    @Test(expected = NacosException.class)
+    public void testRequestWhenResponseErrorThenThrowException() throws NacosException {
+        rpcClient.rpcClientStatus.set(RpcClientStatus.RUNNING);
+        rpcClient.currentConnection = connection;
+        doReturn(new ErrorResponse()).when(connection).request(any(), anyLong());
+    
+        rpcClient.request(null, 10000);
+    }
+    
+    @Test
+    public void testRequestWhenResponseUnregisterThenSwitchServer() throws NacosException {
+        rpcClient.rpcClientStatus.set(RpcClientStatus.RUNNING);
+        rpcClient.currentConnection = connection;
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setErrorCode(NacosException.UN_REGISTER);
+        doReturn(errorResponse).when(connection).request(any(), anyLong());
+        Exception exception = null;
+        
+        try {
+            rpcClient.request(mock(Request.class), 10000);
+        } catch (Exception e) {
+            exception = e;
+        }
+        
+        Assert.assertEquals(RpcClientStatus.UNHEALTHY, rpcClient.rpcClientStatus.get());
+        verify(rpcClient).switchServerAsync();
+        Assert.assertNotNull(exception);
+    }
+    
+    @Test(expected = NacosException.class)
+    public void testAsyncRequestWhenClientAlreadyShutDownThenThrowException() throws NacosException {
+        rpcClient.rpcClientStatus.set(RpcClientStatus.SHUTDOWN);
+        rpcClient.currentConnection = connection;
+        RequestCallBack<?> requestCallBack = mock(RequestCallBack.class);
+        doReturn(10000L).when(requestCallBack).getTimeout();
+        rpcClient.asyncRequest(null, requestCallBack);
+    }
+    
+    @Test
+    public void testAsyncRequestWhenSendRequestFailedMannyTimesThenSwitchServer() throws NacosException {
+        rpcClient.rpcClientStatus.set(RpcClientStatus.RUNNING);
+        rpcClient.currentConnection = connection;
+        doThrow(new NacosException()).when(connection).asyncRequest(any(), any());
+        RequestCallBack<?> requestCallBack = mock(RequestCallBack.class);
+        doReturn(10000L).when(requestCallBack).getTimeout();
+        Exception exception = null;
+    
+        try {
+            rpcClient.asyncRequest(null, requestCallBack);
+        } catch (NacosException e) {
+            exception = e;
+        }
+        
+        verify(connection, atLeastOnce()).asyncRequest(any(), any());
+        verify(rpcClient).switchServerAsyncOnRequestFail();
+        Assert.assertNotNull(exception);
+        Assert.assertEquals(RpcClientStatus.UNHEALTHY, rpcClient.rpcClientStatus.get());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
         <HikariCP.version>3.4.2</HikariCP.version>
         <jraft-core.version>1.3.5</jraft-core.version>
         <rpc-grpc-impl.version>1.3.5</rpc-grpc-impl.version>
+        <powermock.version>2.0.9</powermock.version>
     </properties>
     <!-- == -->
     <!-- =========================================================Build plugins================================================ -->
@@ -630,6 +631,18 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     


### PR DESCRIPTION
## What is the purpose of the change

The nacos-common in nacos 2.0 module coverage rate is too low.
For #5095

## Brief changelog

- remove unnecessary public
- add powermock
- add unit test to RpcClient
- replace explicit type argument with <>
-  replace anonymous class with lambda
- remove redundant initializer
- format comment & log and fix typo

## Verifying this change
[before coverage](https://htmlpreview.github.io/?https://raw.githubusercontent.com/SunJiFengPlus/nacos/common-coverage/docs/com.alibaba.nacos.common.remote.client/.classes/RpcClient.html)
[after coverage](https://htmlpreview.github.io/?https://raw.githubusercontent.com/SunJiFengPlus/nacos/common-coverage/common-coverage/common-current/ns-10/sources/source-2.html)