### PR TITLE
Replace "google.common.reflect.* TypeToken" API with jdk API

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/utils/GenericType.java
+++ b/core/src/main/java/com/alibaba/nacos/core/utils/GenericType.java
@@ -16,15 +16,40 @@
 
 package com.alibaba.nacos.core.utils;
 
-import com.google.common.reflect.TypeToken;
+import com.alibaba.nacos.common.utils.Preconditions;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 
 /**
  * Encapsulates third party tools for generics acquisition.
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-public class GenericType<T> extends TypeToken<T> {
+public class GenericType<T> {
     
     private static final long serialVersionUID = -2103808581228167629L;
     
+    private final Type runtimeType;
+    
+    final Type capture() {
+        Type superclass = getClass().getGenericSuperclass();
+        Preconditions.checkArgument(superclass instanceof ParameterizedType, "%s isn't parameterized", superclass);
+        return ((ParameterizedType) superclass).getActualTypeArguments()[0];
+    }
+    
+    protected GenericType() {
+        this.runtimeType = capture();
+        if (runtimeType instanceof TypeVariable) {
+            throw new IllegalArgumentException("runtimeType must be ParameterizedType Class");
+        }
+    }
+    
+    /**
+     * Returns the represented type.
+     */
+    public final Type getType() {
+        return runtimeType;
+    }
 }

--- a/core/src/test/java/com/alibaba/nacos/core/utils/ClassUtilsTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/utils/ClassUtilsTest.java
@@ -19,6 +19,8 @@ package com.alibaba.nacos.core.utils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.List;
 
 /**
@@ -29,10 +31,10 @@ public class ClassUtilsTest {
     
     @Test
     public void testGeneric() {
-        GenericType<List<String>> genericType = new GenericType<List<String>>() {
-        };
-        Assert.assertEquals(genericType.getType(), new GenericType<List<String>>() {
-        }.getType());
+        Type type = new GenericType<List<String>>() {
+        }.getType();
+        Assert.assertEquals("java.util.List<java.lang.String>", type.getTypeName());
+        Assert.assertTrue(type instanceof ParameterizedType);
     }
     
     @Test

--- a/core/src/test/java/com/alibaba/nacos/core/utils/ClassUtilsTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/utils/ClassUtilsTest.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.nacos.core.utils;
 
-import com.google.common.reflect.TypeToken;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,7 +31,7 @@ public class ClassUtilsTest {
     public void testGeneric() {
         GenericType<List<String>> genericType = new GenericType<List<String>>() {
         };
-        Assert.assertEquals(genericType.getType(), new TypeToken<java.util.List<java.lang.String>>() {
+        Assert.assertEquals(genericType.getType(), new GenericType<List<String>>() {
         }.getType());
     }
     


### PR DESCRIPTION
Replace "com.google.common.reflect.TypeToken" API with jdk API. for #6523 