### PR TITLE
Fix npe when connection is not established.

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
@@ -463,7 +463,6 @@ public abstract class RpcClient implements Closeable {
         rpcClientStatus.set(RpcClientStatus.SHUTDOWN);
         LOGGER.info("Shutdown  client event executor " + clientEventExecutor);
         clientEventExecutor.shutdownNow();
-        LOGGER.info("Close current connection " + currentConnection.getConnectionId());
         closeConnection(currentConnection);
     }
     
@@ -595,6 +594,7 @@ public abstract class RpcClient implements Closeable {
     
     private void closeConnection(Connection connection) {
         if (connection != null) {
+            LOGGER.info("Close current connection " + connection.getConnectionId());
             connection.close();
             eventLinkedBlockingQueue.add(new ConnectionEvent(ConnectionEvent.DISCONNECTED));
         }


### PR DESCRIPTION
```
Caused by: java.lang.NullPointerException
	at com.alibaba.nacos.common.remote.client.RpcClient.shutdown(RpcClient.java:466)
	at com.alibaba.nacos.common.remote.client.grpc.GrpcClient.shutdown(GrpcClient.java:81)
	at com.alibaba.nacos.client.naming.remote.gprc.NamingGrpcClientProxy.shutdown(NamingGrpcClientProxy.java:234)
	at com.alibaba.nacos.client.naming.remote.NamingClientProxyDelegate.shutdown(NamingClientProxyDelegate.java:180)
	at com.alibaba.nacos.client.naming.NacosNamingService.shutDown(NacosNamingService.java:456)
	at org.apache.dubbo.registry.nacos.NacosNamingServiceWrapper.shutdown(NacosNamingServiceWrapper.java:78)
	at org.apache.dubbo.registry.nacos.NacosServiceDiscovery.doDestroy(NacosServiceDiscovery.java:70)
	at org.apache.dubbo.registry.client.AbstractServiceDiscovery.destroy(AbstractServiceDiscovery.java:81)
	at org.apache.dubbo.registry.client.ServiceDiscoveryRegistry.lambda$destroy$1(ServiceDiscoveryRegistry.java:291)
	at org.apache.dubbo.common.function.ThrowableAction.execute(ThrowableAction.java:46)
	... 10 more
```

The connection is not established, and the client shutdown. 