### PR TITLE
fix #1733 again for nacos 1.x

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
@@ -81,11 +81,10 @@ public class BeatReactor implements Closeable {
         NAMING_LOGGER.info("[BEAT] adding beat: {} to beat map.", beatInfo);
         String key = buildKey(serviceName, beatInfo.getIp(), beatInfo.getPort());
         BeatInfo existBeat = null;
-        //fix #1733
-        if ((existBeat = dom2Beat.remove(key)) != null) {
+        //fix #1733 again
+        if ((existBeat = dom2Beat.put(key, beatInfo)) != null) {
             existBeat.setStopped(true);
         }
-        dom2Beat.put(key, beatInfo);
         executorService.schedule(new BeatTask(beatInfo), beatInfo.getPeriod(), TimeUnit.MILLISECONDS);
         MetricsMonitor.getDom2BeatSizeMonitor().set(dom2Beat.size());
     }


### PR DESCRIPTION
fix #1733 again for nacos 1.x to avoid creating beat task more than once by doing ConcurrentHashMap.put concurrently.
i met the issue again by using nacos sync:
1. restart N instances of one sync task at the same time, it trigged sync event more than once,
2. for each sync event, nacos sync called registerInstance concurrently,
3. ConcurrentHashMap.put was called concurrently for the same instance.
