### PR TITLE
When read-index read timeout, go to leader to read.

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
@@ -306,10 +306,9 @@ public class JRaftServer {
                         return;
                     }
                     MetricsMonitor.raftReadIndexFailed();
-                    Loggers.RAFT.error("ReadIndex has error : {}", status.getErrorMsg());
-                    future.completeExceptionally(new ConsistencyException(
-                            "The conformance protocol is temporarily unavailable for reading, " + status
-                                    .getErrorMsg()));
+                    Loggers.RAFT.error("ReadIndex has error : {}, go to Leader read.", status.getErrorMsg());
+                    MetricsMonitor.raftReadFromLeader();
+                    readFromLeader(request, future);
                 }
             });
             return future;


### PR DESCRIPTION
## What is the purpose of the change
detail #6583 

When use raft read-index, the follower will wait self apply index reach leader's commitIndex. If follower fall behind leader much, the read-index read will timeout(default timeout is 2000ms).

If read-index read timeout, request to leader directly.
