### PR TITLE
[ISSUE #6693] Fix the group name send in heartbeats must be DEFAULT_GROUP

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/controllers/InstanceController.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/controllers/InstanceController.java
@@ -393,6 +393,10 @@ public class InstanceController {
         String namespaceId = WebUtils.optional(request, CommonParams.NAMESPACE_ID, Constants.DEFAULT_NAMESPACE_ID);
         String serviceName = WebUtils.required(request, CommonParams.SERVICE_NAME);
         NamingUtils.checkServiceNameFormat(serviceName);
+        // fix https://github.com/alibaba/nacos/issues/6693
+        if (clientBeat != null) {
+            clientBeat.setServiceName(serviceName);
+        }
         Loggers.SRV_LOG.debug("[CLIENT-BEAT] full arguments: beat: {}, serviceName: {}, namespaceId: {}", clientBeat,
                 serviceName, namespaceId);
         BeatInfoInstanceBuilder builder = BeatInfoInstanceBuilder.newBuilder();

--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatProcessorV2.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatProcessorV2.java
@@ -57,7 +57,7 @@ public class ClientBeatProcessorV2 implements BeatProcessor {
         String groupName = NamingUtils.getGroupName(rsInfo.getServiceName());
         Service service = Service.newService(namespace, groupName, serviceName, rsInfo.isEphemeral());
         HealthCheckInstancePublishInfo instance = (HealthCheckInstancePublishInfo) client.getInstancePublishInfo(service);
-        if (instance.getIp().equals(ip) && instance.getPort() == port) {
+        if (instance != null && instance.getIp().equals(ip) && instance.getPort() == port) {
             if (Loggers.EVT_LOG.isDebugEnabled()) {
                 Loggers.EVT_LOG.debug("[CLIENT-BEAT] refresh beat: {}", rsInfo);
             }


### PR DESCRIPTION
## What is the purpose of the change

Fix #6693 
If `serviceName` in beat send with open api is not `group@@serviceName`, then it will always be `DEFAULT_GROUP@@serviceName`.

## Brief changelog
- `ServiceNameFilter` replace the service name with `groupName@@serviceName`, so the `serviceName` parameter in beat request is also this format;
```java
// com.alibaba.nacos.naming.controllers.InstanceController.beat
// the serviceName must be groupName@@serviceName
String serviceName = WebUtils.required(request, CommonParams.SERVICE_NAME);
NamingUtils.checkServiceNameFormat(serviceName);
```
- In addition, sending the heartbeat data of another service in the request has no practical meaning, so 
just set the serviceName of `clientBeat` to `serviceName`, even if other service name or group name may specified in `beat`.
```java
if (clientBeat != null) {
    clientBeat.setServiceName(serviceName);
}
```
- And, should consider the situation where the instance cannot be obtained:
```java
// com.alibaba.nacos.naming.healthcheck.heartbeat.ClientBeatProcessorV2.run
HealthCheckInstancePublishInfo instance = (HealthCheckInstancePublishInfo) client.getInstancePublishInfo(service);
if (instance != null && instance.getIp().equals(ip) && instance.getPort() == port) {
    ...
}
```

## Verifying this change
Heartbeat send with open api will keep your instance health, regardless of whether this instance is in DEFAULT_GROUP.