### PR TITLE
optimize the HashMap’s initialCapacity

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -149,7 +149,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
             BeatInfo beatInfo = beatReactor.buildBeatInfo(groupedServiceName, instance);
             beatReactor.addBeatInfo(groupedServiceName, beatInfo);
         }
-        final Map<String, String> params = new HashMap<String, String>(16);
+        final Map<String, String> params = new HashMap<String, String>(32);
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, groupedServiceName);
         params.put(CommonParams.GROUP_NAME, groupName);
@@ -175,7 +175,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
             beatReactor.removeBeatInfo(NamingUtils.getGroupedName(serviceName, groupName), instance.getIp(),
                     instance.getPort());
         }
-        final Map<String, String> params = new HashMap<String, String>(8);
+        final Map<String, String> params = new HashMap<String, String>(16);
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, NamingUtils.getGroupedName(serviceName, groupName));
         params.put(CommonParams.CLUSTER_NAME, instance.getClusterName());
@@ -191,7 +191,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         NAMING_LOGGER
                 .info("[UPDATE-SERVICE] {} update service {} with instance: {}", namespaceId, serviceName, instance);
         
-        final Map<String, String> params = new HashMap<String, String>(8);
+        final Map<String, String> params = new HashMap<String, String>(32);
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, serviceName);
         params.put(CommonParams.GROUP_NAME, groupName);
@@ -209,7 +209,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
     @Override
     public ServiceInfo queryInstancesOfService(String serviceName, String groupName, String clusters, int udpPort,
             boolean healthyOnly) throws NacosException {
-        final Map<String, String> params = new HashMap<String, String>(8);
+        final Map<String, String> params = new HashMap<String, String>(16);
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, NamingUtils.getGroupedName(serviceName, groupName));
         params.put(CLUSTERS_PARAM, clusters);
@@ -227,7 +227,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
     public Service queryService(String serviceName, String groupName) throws NacosException {
         NAMING_LOGGER.info("[QUERY-SERVICE] {} query service : {}, {}", namespaceId, serviceName, groupName);
         
-        final Map<String, String> params = new HashMap<String, String>(3);
+        final Map<String, String> params = new HashMap<String, String>(16);
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, serviceName);
         params.put(CommonParams.GROUP_NAME, groupName);
@@ -241,7 +241,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         
         NAMING_LOGGER.info("[CREATE-SERVICE] {} creating service : {}", namespaceId, service);
         
-        final Map<String, String> params = new HashMap<String, String>(6);
+        final Map<String, String> params = new HashMap<String, String>(16);
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, service.getName());
         params.put(CommonParams.GROUP_NAME, service.getGroupName());
@@ -258,7 +258,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         NAMING_LOGGER.info("[DELETE-SERVICE] {} deleting service : {} with groupName : {}", namespaceId, serviceName,
                 groupName);
         
-        final Map<String, String> params = new HashMap<String, String>(6);
+        final Map<String, String> params = new HashMap<String, String>(16);
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, serviceName);
         params.put(CommonParams.GROUP_NAME, groupName);
@@ -271,7 +271,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
     public void updateService(Service service, AbstractSelector selector) throws NacosException {
         NAMING_LOGGER.info("[UPDATE-SERVICE] {} updating service : {}", namespaceId, service);
         
-        final Map<String, String> params = new HashMap<String, String>(6);
+        final Map<String, String> params = new HashMap<String, String>(16);
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, service.getName());
         params.put(CommonParams.GROUP_NAME, service.getGroupName());
@@ -295,7 +295,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         if (NAMING_LOGGER.isDebugEnabled()) {
             NAMING_LOGGER.debug("[BEAT] {} sending beat to server: {}", namespaceId, beatInfo.toString());
         }
-        Map<String, String> params = new HashMap<String, String>(8);
+        Map<String, String> params = new HashMap<String, String>(16);
         Map<String, String> bodyMap = new HashMap<String, String>(2);
         if (!lightBeatEnabled) {
             bodyMap.put("beat", JacksonUtils.toJson(beatInfo));
@@ -313,7 +313,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
     public boolean serverHealthy() {
         
         try {
-            String result = reqApi(UtilAndComs.nacosUrlBase + "/operator/metrics", new HashMap<String, String>(2),
+            String result = reqApi(UtilAndComs.nacosUrlBase + "/operator/metrics", new HashMap<String, String>(8),
                     HttpMethod.GET);
             JsonNode json = JacksonUtils.toObj(result);
             String serverStatus = json.get("status").asText();
@@ -327,7 +327,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
     public ListView<String> getServiceList(int pageNo, int pageSize, String groupName, AbstractSelector selector)
             throws NacosException {
         
-        Map<String, String> params = new HashMap<String, String>(4);
+        Map<String, String> params = new HashMap<String, String>(16);
         params.put("pageNo", String.valueOf(pageNo));
         params.put("pageSize", String.valueOf(pageSize));
         params.put(CommonParams.NAMESPACE_ID, namespaceId);


### PR DESCRIPTION
## What is the purpose of the change

optimize the HashMap’s initialCapacity

## Brief changelog

HashMap will automatically expand, when it‘s size greater than initialCapacity * 0.75. And the initialCapacity’s value should be 2^n.

The following code will expand：

（1）NamingHttpClientProxy#registerService method：

The size of "params" will be 13 or 16. Because the reqApi method will put 2 or 5 value into the it. So the initialCapacity should be 32.

(2)NamingHttpClientProxy#deregisterService method:

The size of "params" will be 8 or 11. So the initialCapacity should be 16.

(3)NamingHttpClientProxy#updateInstance method:

The size of "params" will be 12 or 15. So the initialCapacity should be 32.

(4)NamingHttpClientProxy#queryInstancesOfService method:

The size of "params" will be 8 or 11. So the initialCapacity should be 16.

(5)NamingHttpClientProxy#queryService method:

The size of "params" will be 5 or 8. So the initialCapacity should be 16.

(6)NamingHttpClientProxy#createService method:

The size of "params" will be 8 or 11. So the initialCapacity should be 16.

(7)NamingHttpClientProxy#deleteService method:

The size of "params" will be 5 or 8. So the initialCapacity should be 16.

(8)NamingHttpClientProxy#updateService method:

The size of "params" will be 8 or 11. So the initialCapacity should be 16.

(9)NamingHttpClientProxy#sendBeat method:

The size of "params" will be 7 or 10. So the initialCapacity should be 16.

(10)NamingHttpClientProxy#serverHealthy method:

The size of "params" will be 3 or 6. So the initialCapacity should be 8.

(11)NamingHttpClientProxy#getServiceList method:

The size of "params" will be 7 or 10. So the initialCapacity should be 16.