### PR TITLE
fix startup error for 'class not found' in debian10

### DIFF
--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -137,6 +137,6 @@ if [ ! -f "${BASE_DIR}/logs/start.out" ]; then
   touch "${BASE_DIR}/logs/start.out"
 fi
 # start
-echo "$JAVA ${JAVA_OPT}" > ${BASE_DIR}/logs/start.out 2>&1 &
-nohup "$JAVA" ${JAVA_OPT} nacos.nacos >> ${BASE_DIR}/logs/start.out 2>&1 &
+echo "${JAVA} ${JAVA_OPT}" > ${BASE_DIR}/logs/start.out 2>&1 &
+nohup ${JAVA} ${JAVA_OPT} nacos.nacos >> ${BASE_DIR}/logs/start.out 2>&1 &
 echo "nacos is starting，you can check the ${BASE_DIR}/logs/start.out"


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

修复bug https://github.com/alibaba/nacos/issues/6737

当我在debian10操作系统上运行startup.sh命令，会报错,如下所示：

![image](https://user-images.githubusercontent.com/36350800/130644579-de12cdd5-eaf1-41eb-afe2-4e4fbbfd4903.png)

修改了一下startup.sh就OK了，能够顺利启动了。

猜测是debian10解析脚本的时候被nohup后面的""这个双引号给干扰了，没有解析好。当去掉双引号之后，就能够解析正确了。

但是我在mac系统上使用原始的脚本却能够顺利启动，真是奇怪啊。

## Brief changelog

fix startup error for 'class not found' in debian10

## Verifying this change

