### PR TITLE
[ISSUE #6846] Fix the bug that the registered persistent instance will become an ephemeral instance under some operations of the console / open-api

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/HealthOperatorV2Impl.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/HealthOperatorV2Impl.java
@@ -81,7 +81,7 @@ public class HealthOperatorV2Impl implements HealthOperator {
         if (null == oldInstance) {
             return;
         }
-        Instance newInstance = InstanceUtil.parseToApiInstance(service, oldInstance);
+        Instance newInstance = InstanceUtil.parseToApiInstance(service, oldInstance, client);
         newInstance.setHealthy(healthy);
         clientOperationService.registerInstance(service, newInstance, clientId);
     }

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/ServiceStorage.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/ServiceStorage.java
@@ -106,7 +106,7 @@ public class ServiceStorage {
         for (String each : serviceIndexesManager.getAllClientsRegisteredService(service)) {
             Optional<InstancePublishInfo> instancePublishInfo = getInstanceInfo(each, service);
             if (instancePublishInfo.isPresent()) {
-                Instance instance = parseInstance(service, instancePublishInfo.get());
+                Instance instance = parseInstance(service, instancePublishInfo.get(), each);
                 result.add(instance);
                 clusters.add(instance.getClusterName());
             }
@@ -124,8 +124,8 @@ public class ServiceStorage {
         return Optional.ofNullable(client.getInstancePublishInfo(service));
     }
     
-    private Instance parseInstance(Service service, InstancePublishInfo instanceInfo) {
-        Instance result = InstanceUtil.parseToApiInstance(service, instanceInfo);
+    private Instance parseInstance(Service service, InstancePublishInfo instanceInfo, String clientId) {
+        Instance result = InstanceUtil.parseToApiInstance(service, instanceInfo, clientManager.getClient(clientId));
         Optional<InstanceMetadata> metadata = metadataManager
                 .getInstanceMetadata(service, instanceInfo.getMetadataId());
         metadata.ifPresent(instanceMetadata -> InstanceUtil.updateInstanceMetadata(result, instanceMetadata));

--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/PersistentHealthStatusSynchronizer.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/PersistentHealthStatusSynchronizer.java
@@ -41,7 +41,7 @@ public class PersistentHealthStatusSynchronizer implements HealthStatusSynchroni
     @Override
     public void instanceHealthStatusChange(boolean isHealthy, Client client, Service service,
             InstancePublishInfo instance) {
-        Instance updateInstance = InstanceUtil.parseToApiInstance(service, instance);
+        Instance updateInstance = InstanceUtil.parseToApiInstance(service, instance, client);
         updateInstance.setHealthy(isHealthy);
         persistentClientOperationService.registerInstance(service, updateInstance, client.getClientId());
     }

--- a/naming/src/main/java/com/alibaba/nacos/naming/utils/InstanceUtil.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/utils/InstanceUtil.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.naming.utils;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.utils.NamingUtils;
 import com.alibaba.nacos.naming.constants.Constants;
+import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.metadata.InstanceMetadata;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
@@ -38,9 +39,10 @@ public class InstanceUtil {
      *
      * @param service      service of instance
      * @param instanceInfo instance info
+     * @param client       client
      * @return api instance
      */
-    public static Instance parseToApiInstance(Service service, InstancePublishInfo instanceInfo) {
+    public static Instance parseToApiInstance(Service service, InstancePublishInfo instanceInfo, Client client) {
         Instance result = new Instance();
         result.setIp(instanceInfo.getIp());
         result.setPort(instanceInfo.getPort());
@@ -60,6 +62,9 @@ public class InstanceUtil {
         }
         result.setMetadata(instanceMetadata);
         result.setEphemeral(service.isEphemeral());
+        if (client != null) {
+            result.setEphemeral(client.isEphemeral());
+        }
         result.setHealthy(instanceInfo.isHealthy());
         return result;
     }

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/PersistentHealthStatusSynchronizerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/PersistentHealthStatusSynchronizerTest.java
@@ -46,7 +46,7 @@ public class PersistentHealthStatusSynchronizerTest {
                 persistentClientOperationService);
         persistentHealthStatusSynchronizer.instanceHealthStatusChange(true, client, service, instancePublishInfo);
         
-        Instance updateInstance = InstanceUtil.parseToApiInstance(service, instancePublishInfo);
+        Instance updateInstance = InstanceUtil.parseToApiInstance(service, instancePublishInfo, client);
         updateInstance.setHealthy(true);
         
         verify(client).getClientId();


### PR DESCRIPTION
## What is the purpose of the change
support issue #6846: Fix the bug that the registered persistent instance will become an ephemeral instance under some operations of the console / open-api.

## Brief changelog
support issue #6846 

## Description
- 产生此bug的原因：
1. 服务端在构造ApiInstance列表返回给客户端时，其中Instance的ephemeral属性直接使用了对应Service的ephemeral属性；
2. 而服务端在获取Service实例时，有时候会从本地内存中获取(ephemeral为fasle)，有时候会直接调用构造函数实例化一个Service对象(ephemeral为true，如下图所示)。这样会导致所有实例的ephemeral变为true，在客户端看来就全部变成了临时实例。
![image](https://user-images.githubusercontent.com/28078593/132844923-7b40225f-2024-4f30-8015-23e94fb637d1.png)

- 解决方案：
服务端在构造ApiInstance列表返回给客户端时，其中Instance的ephemeral使用Client的ephemeral属性，这样才是准确的。

## Preview
1. Register three persistent instances:
![image](https://user-images.githubusercontent.com/28078593/132842684-d6d2f3e6-5dec-48eb-9246-37ea8eb2cc6b.png)

2. modify the weight of instance(127.0.0.1:8080) , the ephemeral of instance has not changed:
![image](https://user-images.githubusercontent.com/28078593/132843007-06597c2b-d6f5-4887-a441-32fb54a1d968.png)

## Verifying this change
XXXX