### PR TITLE
Fix response success

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/FailoverClosureImpl.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/FailoverClosureImpl.java
@@ -57,7 +57,7 @@ public class FailoverClosureImpl implements FailoverClosure {
             return;
         }
         final Throwable throwable = this.throwable;
-        future.completeExceptionally(Objects.nonNull(throwable) ? new ConsistencyException(throwable.toString())
+        future.completeExceptionally(Objects.nonNull(throwable) ? new ConsistencyException(throwable.getMessage())
                 : new ConsistencyException("operation failure"));
     }
     


### PR DESCRIPTION
## What is the purpose of the change
Now the response `success` is false, the logic is not right.

If remote processor response `success` is false, we should judge the value before future.complete.

Now the judgement is in whenComplete, it's unuseful.


