### PR TITLE
[issue-7047] Compile Nacos2.0, protobuf dependency is missing

### DIFF
--- a/istio/src/main/proto/google/api/field_behavior.proto
+++ b/istio/src/main/proto/google/api/field_behavior.proto
@@ -1,0 +1,90 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "FieldBehaviorProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.FieldOptions {
+    // A designation of a specific field behavior (required, output only, etc.)
+    // in protobuf messages.
+    //
+    // Examples:
+    //
+    //   string name = 1 [(google.api.field_behavior) = REQUIRED];
+    //   State state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    //   google.protobuf.Duration ttl = 1
+    //     [(google.api.field_behavior) = INPUT_ONLY];
+    //   google.protobuf.Timestamp expire_time = 1
+    //     [(google.api.field_behavior) = OUTPUT_ONLY,
+    //      (google.api.field_behavior) = IMMUTABLE];
+    repeated google.api.FieldBehavior field_behavior = 1052;
+}
+
+// An indicator of the behavior of a given field (for example, that a field
+// is required in requests, or given as output but ignored as input).
+// This **does not** change the behavior in protocol buffers itself; it only
+// denotes the behavior and may affect how API tooling handles the field.
+//
+// Note: This enum **may** receive new values in the future.
+enum FieldBehavior {
+    // Conventional default for enums. Do not use this.
+    FIELD_BEHAVIOR_UNSPECIFIED = 0;
+
+    // Specifically denotes a field as optional.
+    // While all fields in protocol buffers are optional, this may be specified
+    // for emphasis if appropriate.
+    OPTIONAL = 1;
+
+    // Denotes a field as required.
+    // This indicates that the field **must** be provided as part of the request,
+    // and failure to do so will cause an error (usually `INVALID_ARGUMENT`).
+    REQUIRED = 2;
+
+    // Denotes a field as output only.
+    // This indicates that the field is provided in responses, but including the
+    // field in a request does nothing (the server *must* ignore it and
+    // *must not* throw an error as a result of the field's presence).
+    OUTPUT_ONLY = 3;
+
+    // Denotes a field as input only.
+    // This indicates that the field is provided in requests, and the
+    // corresponding field is not included in output.
+    INPUT_ONLY = 4;
+
+    // Denotes a field as immutable.
+    // This indicates that the field may be set once in a request to create a
+    // resource, but may not be changed thereafter.
+    IMMUTABLE = 5;
+
+    // Denotes that a (repeated) field is an unordered list.
+    // This indicates that the service may provide the elements of the list
+    // in any arbitrary  order, rather than the order the user originally
+    // provided. Additionally, the list's order may or may not be stable.
+    UNORDERED_LIST = 6;
+
+    // Denotes that this field returns a non-empty default value if not set.
+    // This indicates that if the user provides the empty value in a request,
+    // a non-empty value will be returned. The user will not be aware of what
+    // non-empty value to expect.
+    NON_EMPTY_DEFAULT = 7;
+}

--- a/istio/src/main/proto/google/rpc/status.proto
+++ b/istio/src/main/proto/google/rpc/status.proto
@@ -1,0 +1,47 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+import "google/protobuf/any.proto";
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";
+option java_multiple_files = true;
+option java_outer_classname = "StatusProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+// The `Status` type defines a logical error model that is suitable for
+// different programming environments, including REST APIs and RPC APIs. It is
+// used by [gRPC](https://github.com/grpc). Each `Status` message contains
+// three pieces of data: error code, error message, and error details.
+//
+// You can find out more about this error model and how to work with it in the
+// [API Design Guide](https://cloud.google.com/apis/design/errors).
+message Status {
+    // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+    int32 code = 1;
+
+    // A developer-facing error message, which should be in English. Any
+    // user-facing error message should be localized and sent in the
+    // [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+    string message = 2;
+
+    // A list of messages that carry the error details.  There is a common set of
+    // message types for APIs to use.
+    repeated google.protobuf.Any details = 3;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,28 +17,28 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
     <inceptionYear>2018</inceptionYear>
     <groupId>com.alibaba.nacos</groupId>
     <artifactId>nacos-all</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>
-    
+
     <name>Alibaba NACOS ${project.version}</name>
     <description>Top Nacos project pom.xml file</description>
     <url>http://nacos.io</url>
     <prerequisites>
         <maven>3.2.5</maven>
     </prerequisites>
-    
+
     <scm>
         <url>git@github.com:alibaba/nacos.git</url>
         <connection>scm:git@github.com:alibaba/nacos.git</connection>
         <developerConnection>scm:git@github.com:alibaba/nacos.git</developerConnection>
         <tag>nacos-all-${revision}</tag>
     </scm>
-    
+
     <mailingLists>
         <mailingList>
             <name>Development List</name>
@@ -59,7 +59,7 @@
             <post>commits-nacos@googlegroups.com</post>
         </mailingList>
     </mailingLists>
-    
+
     <developers>
         <developer>
             <id>Alibaba Nacos</id>
@@ -68,7 +68,7 @@
             <email>nacos_dev@linux.alibaba.com</email>
         </developer>
     </developers>
-    
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -76,17 +76,17 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    
+
     <organization>
         <name>Alibaba Group</name>
         <url>https://github.com/alibaba</url>
     </organization>
-    
+
     <issueManagement>
         <system>github</system>
         <url>https://github.com/alibaba/nacos/issues</url>
     </issueManagement>
-    
+
     <properties>
         <revision>2.0.1</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -101,7 +101,7 @@
         <!-- Exclude all generated code -->
         <sonar.jacoco.itReportPath>${project.basedir}/../test/target/jacoco-it.exec</sonar.jacoco.itReportPath>
         <sonar.exclusions>file:**/generated-sources/**,**/test/**</sonar.exclusions>
-        
+
         <!-- plugin version -->
         <versions-maven-plugin.version>2.2</versions-maven-plugin.version>
         <dependency-mediator-maven-plugin.version>1.0.2</dependency-mediator-maven-plugin.version>
@@ -126,7 +126,7 @@
         <!-- dependency version related to plugin -->
         <extra-enforcer-rules.version>1.0-beta-4</extra-enforcer-rules.version>
         <p3c-pmd.version>1.3.0</p3c-pmd.version>
-        
+
         <!-- dependency version -->
         <spring-boot-dependencies.version>2.1.17.RELEASE</spring-boot-dependencies.version>
         <servlet-api.version>3.0</servlet-api.version>
@@ -139,7 +139,7 @@
         <slf4j-api.version>1.7.7</slf4j-api.version>
         <logback.version>1.2.3</logback.version>
         <log4j.version>2.13.3</log4j.version>
-        
+
         <httpasyncclient.version>4.1.3</httpasyncclient.version>
         <mysql-connector-java.version>8.0.21</mysql-connector-java.version>
         <derby.version>10.14.2.0</derby.version>
@@ -157,7 +157,7 @@
         <commonOkHttp.version>0.4.1</commonOkHttp.version>
         <grpc-java.version>1.24.0</grpc-java.version>
         <proto-google-common-protos.version>1.17.0</proto-google-common-protos.version>
-        <protobuf-java.version>3.8.0</protobuf-java.version>
+        <protobuf-java.version>3.9.0</protobuf-java.version>
         <protoc-gen-grpc-java.version>1.24.0</protoc-gen-grpc-java.version>
         <hessian.version>4.0.63</hessian.version>
         <reflections.version>0.9.11</reflections.version>
@@ -463,7 +463,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>jdk8</id>
@@ -502,11 +502,11 @@
                     <value>true</value>
                 </property>
             </activation>
-            
+
             <properties>
                 <maven.javadoc.skip>false</maven.javadoc.skip>
             </properties>
-            
+
             <build>
                 <plugins>
                     <plugin>
@@ -599,7 +599,7 @@
             </plugin>
         </plugins>
     </reporting>
-    
+
     <!-- 子模块管理 -->
     <modules>
         <module>config</module>
@@ -619,10 +619,10 @@
         <module>auth</module>
         <module>sys</module>
     </modules>
-    
+
     <!-- 所有的子项目默认依赖 -->
     <dependencies>
-        
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -633,9 +633,9 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-    
+
     </dependencies>
-    
+
     <!-- 管理依赖版本号,子项目不会默认依赖 -->
     <dependencyManagement>
         <dependencies>
@@ -647,7 +647,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
             <!-- Internal libs -->
             <dependency>
                 <groupId>${project.groupId}</groupId>
@@ -709,7 +709,7 @@
                 <artifactId>nacos-address</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>nacos-istio</artifactId>
@@ -730,123 +730,123 @@
                 <artifactId>nacos-sys</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>
                 <version>${servlet-api.version}</version>
                 <scope>provided</scope>
             </dependency>
-            
+
             <!-- HikariCP -->
             <dependency>
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
                 <version>${HikariCP.version}</version>
             </dependency>
-            
+
             <!-- hessian -->
-            
+
             <dependency>
                 <groupId>com.caucho</groupId>
                 <artifactId>hessian</artifactId>
                 <version>${hessian.version}</version>
             </dependency>
-            
+
             <!-- Apache commons -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>${commons-collections.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
                 <version>${commons-logging.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>commons-dbcp</groupId>
                 <artifactId>commons-dbcp</artifactId>
                 <version>${commons-dbcp.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
                 <version>${commons-cli.version}</version>
             </dependency>
-            
+
             <!-- Logging libs -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j-api.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
-            
+
             <!-- HTTP client libs -->
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpasyncclient</artifactId>
                 <version>${httpasyncclient.version}</version>
             </dependency>
-            
+
             <!-- JDBC libs -->
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql-connector-java.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
                 <version>${derby.version}</version>
             </dependency>
-            
+
             <!-- JRaft -->
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
@@ -875,32 +875,32 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>rpc-grpc-impl</artifactId>
                 <version>${rpc-grpc-impl.version}</version>
             </dependency>
-            
+
             <!-- Third-party libs -->
             <dependency>
                 <groupId>cglib</groupId>
                 <artifactId>cglib-nodep</artifactId>
                 <version>${cglib-nodep.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>net.jcip</groupId>
                 <artifactId>jcip-annotations</artifactId>
                 <version>${jcip-annotations.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson-core.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
@@ -916,7 +916,7 @@
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${jackson-core-asl.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-api</artifactId>
@@ -934,44 +934,44 @@
                 <version>${jjwt.version}</version>
                 <scope>runtime</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>${netty-all.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>javax.annotation</groupId>
                 <artifactId>javax.annotation-api</artifactId>
                 <version>1.3.2</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.mina</groupId>
                 <artifactId>mina-core</artifactId>
                 <version>${mina-core.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.javatuples</groupId>
                 <artifactId>javatuples</artifactId>
                 <version>${javatuples.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.github.keran213539</groupId>
                 <artifactId>commonOkHttp</artifactId>
                 <version>${commonOkHttp.version}</version>
                 <scope>test</scope>
             </dependency>
-            
+
             <!-- gRPC dependency start -->
             <dependency>
                 <groupId>io.grpc</groupId>
@@ -1000,49 +1000,49 @@
                 <version>${proto-google-common-protos.version}</version>
             </dependency>
             <!-- gRPC dependency end -->
-            
+
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${protobuf-java.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
                 <version>${reflections.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-all</artifactId>
                 <version>${mockito-all.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito-core.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>${hamcrest-all.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>io.prometheus</groupId>
                 <artifactId>simpleclient</artifactId>
                 <version>${prometheus-simpleclient.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-jasper</artifactId>
                 <version>${tomcat-embed-jasper.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.google.truth</groupId>
                 <artifactId>truth</artifactId>
@@ -1050,7 +1050,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-    
+
     <distributionManagement>
         <snapshotRepository>
             <!-- 这里的ID一定要在maven setting文件中存在于server下的ID -->


### PR DESCRIPTION
**Describe the bug**

Compile Nacos2.0, protobuf dependency is missing

**Expected behavior**
A clear and concise description of what you expected to happen.

**Acutally behavior**
The nacos-isito module lacks related proto files

**How to Reproduce**
Steps to reproduce the behavior:
I am trying to make an image for nacos based on GraalVM, but first need to package nacos 2.0, the work content is as follows:
https://github.com/alibaba/nacos/issues/6869

Use the following plugin to package: 

https://www.graalvm.org/reference-manual/native-image/NativeMavenPlugin/

1. When compiling the nacos-istio module of nacos, the google/api/field_behavior.proto and "google/rpc/status.proto" files are missing. I am trying to migrate related files from googleapi.
2. After compiling and generating the class file, com.google.protobuf.AbstractMessage.InternalOneOfEnum could not find the relevant file, and the answer is [unable-to-use-oneof- symbol-internaloneofenum-missing](https://stackoverflow.com/questions/58537310/grpc-maven-unable-to-use-oneof-symbol-internaloneofenum-missing). Hope to upgrade the version of protobuf from 3.8.0 to 3.9.0. So that I can complete the compilation work


**Desktop (please complete the following information):**
 - OS: Ubantu 16.04
 - Version nacos 2.0
 - Module  nacos-isito

**Additional context**
Add any other context about the problem here.
