### PR TITLE
[ISSUE #4639] Fix Unlimited log files in log4j2 scenerio of nacos-client

### DIFF
--- a/client/src/main/resources/nacos-log4j2.xml
+++ b/client/src/main/resources/nacos-log4j2.xml
@@ -18,7 +18,7 @@
 <Configuration status="WARN">
     <Appenders>
         <RollingFile name="CONFIG_LOG_FILE" fileName="${sys:JM.LOG.PATH}/nacos/config.log"
-            filePattern="${sys:JM.LOG.PATH}/nacos/config.log.%d{yyyy-MM-dd}.%i">
+            filePattern="${sys:JM.LOG.PATH}/nacos/config.log.%i">
             <PatternLayout>
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
             </PatternLayout>
@@ -32,7 +32,7 @@
         </RollingFile>
     
         <RollingFile name="REMOTE_LOG_FILE" fileName="${sys:JM.LOG.PATH}/nacos/remote.log"
-            filePattern="${sys:JM.LOG.PATH}/nacos/remote.log.%d{yyyy-MM-dd}.%i">
+            filePattern="${sys:JM.LOG.PATH}/nacos/remote.log.%i">
             <PatternLayout>
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
             </PatternLayout>
@@ -46,7 +46,7 @@
         </RollingFile>
         
         <RollingFile name="NAMING_LOG_FILE" fileName="${sys:JM.LOG.PATH}/nacos/naming.log"
-            filePattern="${sys:JM.LOG.PATH}/nacos/naming.log.%d{yyyy-MM-dd}.%i">
+            filePattern="${sys:JM.LOG.PATH}/nacos/naming.log.%i">
             <PatternLayout>
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
             </PatternLayout>


### PR DESCRIPTION
Fix Unlimited log files in log4j2 scenerio

## What is the purpose of the change

to fix this [issue#4639](https://github.com/alibaba/nacos/issues/4639)
I think these log files should not be unlimited.

## Brief changelog

change rotation strategy of log4j2 to avoid too many log files



