### PR TITLE
Fix PushAckRequest mismatch problem.

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/exception/NacosException.java
+++ b/api/src/main/java/com/alibaba/nacos/api/exception/NacosException.java
@@ -149,6 +149,11 @@ public class NacosException extends Exception {
     public static final int SERVER_ERROR = 500;
     
     /**
+     * client error（client异常，返回给服务端）.
+     */
+    public static final int CLIENT_ERROR = -500;
+    
+    /**
      * bad gateway（路由异常，如nginx后面的Server挂掉）.
      */
     public static final int BAD_GATEWAY = 502;

--- a/api/src/main/java/com/alibaba/nacos/api/remote/response/ErrorResponse.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/response/ErrorResponse.java
@@ -24,4 +24,10 @@ package com.alibaba.nacos.api.remote.response;
  */
 public class ErrorResponse extends Response {
     
+    public static Response build(int errorCode, String msg) {
+        ErrorResponse response = new ErrorResponse();
+        response.setErrorInfo(errorCode, msg);
+        return response;
+    }
+    
 }

--- a/api/src/main/java/com/alibaba/nacos/api/remote/response/ErrorResponse.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/response/ErrorResponse.java
@@ -24,6 +24,12 @@ package com.alibaba.nacos.api.remote.response;
  */
 public class ErrorResponse extends Response {
     
+    /**
+     *
+     * @param errorCode errorCode
+     * @param msg msg
+     * @return response
+     */
     public static Response build(int errorCode, String msg) {
         ErrorResponse response = new ErrorResponse();
         response.setErrorInfo(errorCode, msg);

--- a/api/src/main/java/com/alibaba/nacos/api/remote/response/ErrorResponse.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/response/ErrorResponse.java
@@ -25,6 +25,7 @@ package com.alibaba.nacos.api.remote.response;
 public class ErrorResponse extends Response {
     
     /**
+     * build an error response.
      *
      * @param errorCode errorCode
      * @param msg msg

--- a/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcRequestAcceptor.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcRequestAcceptor.java
@@ -79,7 +79,7 @@ public class GrpcRequestAcceptor extends RequestGrpc.RequestImplBase {
         //server is on starting.
         if (!ApplicationUtils.isStarted()) {
             Payload payloadResponse = GrpcUtils.convert(
-                    buildErrorResponse(NacosException.INVALID_SERVER_STATUS, "Server is starting,please try later."));
+                    ErrorResponse.build(NacosException.INVALID_SERVER_STATUS, "Server is starting,please try later."));
             traceIfNecessary(payloadResponse, false);
             responseObserver.onNext(payloadResponse);
             
@@ -101,7 +101,7 @@ public class GrpcRequestAcceptor extends RequestGrpc.RequestImplBase {
         if (requestHandler == null) {
             Loggers.REMOTE_DIGEST.warn(String.format("[%s] No handler for request type : %s :", "grpc", type));
             Payload payloadResponse = GrpcUtils
-                    .convert(buildErrorResponse(NacosException.NO_HANDLER, "RequestHandler Not Found"));
+                    .convert(ErrorResponse.build(NacosException.NO_HANDLER, "RequestHandler Not Found"));
             traceIfNecessary(payloadResponse, false);
             responseObserver.onNext(payloadResponse);
             responseObserver.onCompleted();
@@ -115,7 +115,7 @@ public class GrpcRequestAcceptor extends RequestGrpc.RequestImplBase {
             Loggers.REMOTE_DIGEST
                     .warn("[{}] Invalid connection Id ,connection [{}] is un registered ,", "grpc", connectionId);
             Payload payloadResponse = GrpcUtils
-                    .convert(buildErrorResponse(NacosException.UN_REGISTER, "Connection is unregistered."));
+                    .convert(ErrorResponse.build(NacosException.UN_REGISTER, "Connection is unregistered."));
             traceIfNecessary(payloadResponse, false);
             responseObserver.onNext(payloadResponse);
             responseObserver.onCompleted();
@@ -128,7 +128,7 @@ public class GrpcRequestAcceptor extends RequestGrpc.RequestImplBase {
         } catch (Exception e) {
             Loggers.REMOTE_DIGEST
                     .warn("[{}] Invalid request receive from connection [{}] ,error={}", "grpc", connectionId, e);
-            Payload payloadResponse = GrpcUtils.convert(buildErrorResponse(NacosException.BAD_GATEWAY, e.getMessage()));
+            Payload payloadResponse = GrpcUtils.convert(ErrorResponse.build(NacosException.BAD_GATEWAY, e.getMessage()));
             traceIfNecessary(payloadResponse, false);
             responseObserver.onNext(payloadResponse);
             responseObserver.onCompleted();
@@ -138,7 +138,7 @@ public class GrpcRequestAcceptor extends RequestGrpc.RequestImplBase {
         if (parseObj == null) {
             Loggers.REMOTE_DIGEST.warn("[{}] Invalid request receive  ,parse request is null", connectionId);
             Payload payloadResponse = GrpcUtils
-                    .convert(buildErrorResponse(NacosException.BAD_GATEWAY, "Invalid request"));
+                    .convert(ErrorResponse.build(NacosException.BAD_GATEWAY, "Invalid request"));
             traceIfNecessary(payloadResponse, false);
             responseObserver.onNext(payloadResponse);
             responseObserver.onCompleted();
@@ -149,7 +149,7 @@ public class GrpcRequestAcceptor extends RequestGrpc.RequestImplBase {
                     .warn("[{}] Invalid request receive  ,parsed payload is not a request,parseObj={}", connectionId,
                             parseObj);
             Payload payloadResponse = GrpcUtils
-                    .convert(buildErrorResponse(NacosException.BAD_GATEWAY, "Invalid request"));
+                    .convert(ErrorResponse.build(NacosException.BAD_GATEWAY, "Invalid request"));
             traceIfNecessary(payloadResponse, false);
             responseObserver.onNext(payloadResponse);
             responseObserver.onCompleted();
@@ -174,7 +174,7 @@ public class GrpcRequestAcceptor extends RequestGrpc.RequestImplBase {
             Loggers.REMOTE_DIGEST
                     .error("[{}] Fail to handle request from connection [{}] ,error message :{}", "grpc", connectionId,
                             e);
-            Payload payloadResponse = GrpcUtils.convert(buildErrorResponse(
+            Payload payloadResponse = GrpcUtils.convert(ErrorResponse.build(
                     (e instanceof NacosException) ? ((NacosException) e).getErrCode() : ResponseCode.FAIL.getCode(),
                     e.getMessage()));
             traceIfNecessary(payloadResponse, false);
@@ -184,9 +184,4 @@ public class GrpcRequestAcceptor extends RequestGrpc.RequestImplBase {
         
     }
     
-    private Response buildErrorResponse(int errorCode, String msg) {
-        ErrorResponse response = new ErrorResponse();
-        response.setErrorInfo(errorCode, msg);
-        return response;
-    }
 }


### PR DESCRIPTION
## What is the purpose of the change
At now, when client handle request from server error, it will send PushAckRequest to server, but server side didn't hold corresponding requestHandler, it should use bidiStream to send response directly.

