### PR TITLE
fix 1.4.2 EncryptedData Long-Polling listerning bug in client(LongPollingRunnable). 

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
@@ -267,7 +267,7 @@ public class CacheData {
             tmpStaticConfigFilterChainManager.doFilter(null, cr);
             config = cr.getContent();
         } catch (NacosException e) {
-            LOGGER.error("[CacheData-getMd5String] error by encryptedDataKey={}", encryptedDataKey);
+            LOGGER.error("[CacheData-getMd5String] error by encryptedDataKey={},config={}", encryptedDataKey, config, e);
         }
         return MD5Utils.md5Hex(config, Constants.ENCODE);
     }
@@ -302,7 +302,7 @@ public class CacheData {
     private final String name;
     
     /**
-     * FIXME temporary provide for {@link #getMd5String(String, String)}
+     * FIXME temporary provide for {@link #getMd5String(String, String)}.
      */
     private static ConfigFilterChainManager tmpStaticConfigFilterChainManager;
     

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -259,10 +259,11 @@ public class ClientWorker implements Closeable {
             final String md5 = MD5Utils.md5Hex(content, Constants.ENCODE);
             cacheData.setUseLocalConfigInfo(true);
             cacheData.setLocalConfigInfoVersion(path.lastModified());
-            cacheData.setContent(content);
+            // FIXME temporary fix https://github.com/alibaba/nacos/issues/7039
             String encryptedDataKey = LocalEncryptedDataKeyProcessor
                     .getEncryptDataKeyFailover(agent.getName(), dataId, group, tenant);
             cacheData.setEncryptedDataKey(encryptedDataKey);
+            cacheData.setContent(content);
             
             LOGGER.warn(
                     "[{}] [failover-change] failover file created. dataId={}, group={}, tenant={}, md5={}, content={}",
@@ -285,10 +286,11 @@ public class ClientWorker implements Closeable {
             final String md5 = MD5Utils.md5Hex(content, Constants.ENCODE);
             cacheData.setUseLocalConfigInfo(true);
             cacheData.setLocalConfigInfoVersion(path.lastModified());
-            cacheData.setContent(content);
+            // FIXME temporary fix https://github.com/alibaba/nacos/issues/7039
             String encryptedDataKey = LocalEncryptedDataKeyProcessor
                     .getEncryptDataKeyFailover(agent.getName(), dataId, group, tenant);
             cacheData.setEncryptedDataKey(encryptedDataKey);
+            cacheData.setContent(content);
             LOGGER.warn(
                     "[{}] [failover-change] failover file changed. dataId={}, group={}, tenant={}, md5={}, content={}",
                     agent.getName(), dataId, group, tenant, md5, ContentUtils.truncateContent(content));
@@ -547,8 +549,9 @@ public class ClientWorker implements Closeable {
                     try {
                         ConfigResponse response = getServerConfig(dataId, group, tenant, 3000L);
                         CacheData cache = cacheMap.get(GroupKey.getKeyTenant(dataId, group, tenant));
-                        cache.setContent(response.getContent());
+                        // FIXME temporary fix https://github.com/alibaba/nacos/issues/7039
                         cache.setEncryptedDataKey(response.getEncryptedDataKey());
+                        cache.setContent(response.getContent());
                         if (null != response.getConfigType()) {
                             cache.setType(response.getConfigType());
                         }


### PR DESCRIPTION
fix #7039

不是好的实现方式，临时修复至配置解密可用。期待社区统一考虑配置获取和解密 Filter 等，同时也兼并考虑 2.x 版本里的这部分。
提 PR 仅是希望知道真的有这个 bug，谢谢。

---

It is not a good implementation method. It is temporarily repaired until the configuration decryption is available. The community is expected to uniformly consider the configuration, acquisition and decryption of filter, and also consider this part in version 2.x.
I just want to know that there is really a bug. Thank you.