### PR TITLE
Optimizing client beat log output

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
@@ -194,7 +194,7 @@ public class BeatReactor implements Closeable {
                     }
                 }
             } catch (NacosException ex) {
-                NAMING_LOGGER.error("[CLIENT-BEAT] failed to send beat: {}, code: {}, msg: {}",
+                NAMING_LOGGER.warn("[CLIENT-BEAT] failed to send beat: {}, code: {}, msg: {}",
                         JacksonUtils.toJson(beatInfo), ex.getErrCode(), ex.getErrMsg());
     
             } catch (Exception unknownEx) {

--- a/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/net/NamingProxy.java
@@ -58,6 +58,8 @@ import org.apache.http.HttpStatus;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -616,9 +618,18 @@ public class NamingProxy implements Closeable {
                 return StringUtils.EMPTY;
             }
             throw new NacosException(restResult.getCode(), restResult.getMessage());
-        } catch (Exception e) {
-            NAMING_LOGGER.error("[NA] failed to request", e);
-            throw new NacosException(NacosException.SERVER_ERROR, e);
+        } catch (NacosException ex) {
+            NAMING_LOGGER.warn("[NA] failed to request cause of inner exception");
+            throw ex;
+        } catch (ConnectException connectException) {
+            NAMING_LOGGER.warn("[NA] failed to request cause of connection exception");
+            throw new NacosException(NacosException.SERVER_ERROR, connectException);
+        } catch (SocketTimeoutException timeoutException) {
+            NAMING_LOGGER.warn("[NA] failed to request cause of connection time out exception");
+            throw new NacosException(NacosException.SERVER_ERROR, timeoutException);
+        } catch (Exception unknownEx) {
+            NAMING_LOGGER.error("[NA] failed to request cause of unknown reason", unknownEx);
+            throw new NacosException(NacosException.SERVER_ERROR, unknownEx);
         }
     }
     


### PR DESCRIPTION

## What is the purpose of the change

Users often complain about the annoying nacos client beat error log when they look over application logs.
And also they always get a 500(HttpStatus) instead of other HttpStatus.
So this change will improve the experience of looking over application logs when the application goes wrong.

## Brief changelog

Following exceptions logs has bean optimized
- 403、404 exceptions come from nacos server and so on
- java.net.ConnectException
- java.net.SocketTimeoutException

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

