### PR TITLE
[1.x] log what causes I/O reactor status to STOPPED

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/http/AbstractHttpClientFactory.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/AbstractHttpClientFactory.java
@@ -26,9 +26,21 @@ import com.alibaba.nacos.common.tls.TlsHelper;
 import com.alibaba.nacos.common.tls.TlsSystemConfig;
 import com.alibaba.nacos.common.utils.BiConsumer;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
 import org.apache.http.protocol.RequestContent;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.nio.conn.NHttpClientConnectionManager;
+import org.apache.http.nio.conn.NoopIOSessionStrategy;
+import org.apache.http.nio.conn.SchemeIOSessionStrategy;
+import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
+import org.apache.http.nio.reactor.IOReactorException;
+import org.apache.http.nio.reactor.IOReactorExceptionHandler;
 import org.slf4j.Logger;
 
 import javax.net.ssl.HostnameVerifier;
@@ -70,6 +82,7 @@ public abstract class AbstractHttpClientFactory implements HttpClientFactory {
     @Override
     public NacosAsyncRestTemplate createNacosAsyncRestTemplate() {
         final HttpClientConfig originalRequestConfig = buildHttpClientConfig();
+        final DefaultConnectingIOReactor ioreactor = getIoReactor();
         return new NacosAsyncRestTemplate(assignLogger(), new DefaultAsyncHttpClientRequest(
                 HttpAsyncClients.custom()
                         .addInterceptorLast(new RequestContent(true))
@@ -77,9 +90,72 @@ public abstract class AbstractHttpClientFactory implements HttpClientFactory {
                         .setDefaultRequestConfig(getRequestConfig())
                         .setMaxConnTotal(originalRequestConfig.getMaxConnTotal())
                         .setMaxConnPerRoute(originalRequestConfig.getMaxConnPerRoute())
-                        .setUserAgent(originalRequestConfig.getUserAgent()).build()));
+                        .setUserAgent(originalRequestConfig.getUserAgent())
+                        .setConnectionManager(getConnectionManager(originalRequestConfig, ioreactor))
+                        .build(), ioreactor));
     }
     
+    private DefaultConnectingIOReactor getIoReactor() {
+        final DefaultConnectingIOReactor ioreactor;
+        try {
+            ioreactor = new DefaultConnectingIOReactor(getIoReactorConfig());
+        } catch (IOReactorException e) {
+            assignLogger().error("[NHttpClientConnectionManager] Create DefaultConnectingIOReactor failed", e);
+            throw new IllegalStateException();
+        }
+        
+        // if the handle return true, then the exception thrown by IOReactor will be ignore, and will not finish the IOReactor.
+        ioreactor.setExceptionHandler(new IOReactorExceptionHandler() {
+            
+            @Override
+            public boolean handle(IOException ex) {
+                assignLogger().warn("[NHttpClientConnectionManager] handle IOException, ignore it.", ex);
+                return true;
+            }
+            
+            @Override
+            public boolean handle(RuntimeException ex) {
+                assignLogger().warn("[NHttpClientConnectionManager] handle RuntimeException, ignore it.", ex);
+                return true;
+            }
+        });
+        
+        return ioreactor;
+    }
+    
+    /**
+     * create the {@link NHttpClientConnectionManager}, the code mainly from {@link HttpAsyncClientBuilder#build()}.
+     * we add the {@link IOReactorExceptionHandler} to handle the {@link IOException} and {@link RuntimeException}
+     * thrown by the {@link org.apache.http.impl.nio.reactor.BaseIOReactor} when process the event of Network.
+     * Using this way to avoid the {@link DefaultConnectingIOReactor} killed by unknown error of network.
+     *
+     * @param originalRequestConfig request config.
+     * @param ioreactor I/O reactor.
+     * @return {@link NHttpClientConnectionManager}.
+     */
+    private NHttpClientConnectionManager getConnectionManager(HttpClientConfig originalRequestConfig, DefaultConnectingIOReactor ioreactor) {
+        SSLContext sslcontext = SSLContexts.createDefault();
+        HostnameVerifier hostnameVerifier = new DefaultHostnameVerifier();
+        SchemeIOSessionStrategy sslStrategy = new SSLIOSessionStrategy(sslcontext, null, null, hostnameVerifier);
+
+        Registry<SchemeIOSessionStrategy> registry = RegistryBuilder.<SchemeIOSessionStrategy>create()
+                .register("http", NoopIOSessionStrategy.INSTANCE)
+                .register("https", sslStrategy)
+                .build();
+        final PoolingNHttpClientConnectionManager poolingmgr = new PoolingNHttpClientConnectionManager(ioreactor, registry);
+
+        int maxTotal = originalRequestConfig.getMaxConnTotal();
+        if (maxTotal > 0) {
+            poolingmgr.setMaxTotal(maxTotal);
+        }
+
+        int maxPerRoute = originalRequestConfig.getMaxConnPerRoute();
+        if (maxPerRoute > 0) {
+            poolingmgr.setDefaultMaxPerRoute(maxPerRoute);
+        }
+        return poolingmgr;
+    }
+
     protected IOReactorConfig getIoReactorConfig() {
         HttpClientConfig httpClientConfig = buildHttpClientConfig();
         return IOReactorConfig.custom().setIoThreadCount(httpClientConfig.getIoThreadCount()).build();

--- a/pom.xml
+++ b/pom.xml
@@ -137,10 +137,9 @@
         <commons-dbcp.version>1.4</commons-dbcp.version>
         <commons-cli.version>1.2</commons-cli.version>
         <slf4j-api.version>1.7.7</slf4j-api.version>
-        <logback.version>1.2.3</logback.version>
-        <log4j.version>2.17.0</log4j.version>
-        <httpcore.version>4.4.1</httpcore.version>
-        <httpclient.version>4.5</httpclient.version>
+        <logback.version>1.2.9</logback.version>
+        <log4j.version>2.17.1</log4j.version>
+        
         <httpasyncclient.version>4.1.3</httpasyncclient.version>
         <mysql-connector-java.version>8.0.21</mysql-connector-java.version>
         <derby.version>10.14.2.0</derby.version>
@@ -152,14 +151,13 @@
         <jackson-core-asl.version>1.9.13</jackson-core-asl.version>
         <jjwt.version>0.11.2</jjwt.version>
         <netty-all.version>4.1.59.Final</netty-all.version>
-        <netty-common.version>4.1.59.Final</netty-common.version>
         <mina-core.version>2.0.0-RC1</mina-core.version>
         <guava.version>30.1-jre</guava.version>
         <javatuples.version>1.2</javatuples.version>
         <commonOkHttp.version>0.4.1</commonOkHttp.version>
         <grpc-java.version>1.24.0</grpc-java.version>
         <proto-google-common-protos.version>1.17.0</proto-google-common-protos.version>
-        <protobuf-java.version>3.8.0</protobuf-java.version>
+        <protobuf-java.version>3.16.1</protobuf-java.version>
         <protoc-gen-grpc-java.version>1.24.0</protoc-gen-grpc-java.version>
         <hessian.version>4.0.63</hessian.version>
         <reflections.version>0.9.11</reflections.version>
@@ -169,8 +167,8 @@
         <tomcat-embed-jasper.version>9.0.40</tomcat-embed-jasper.version>
         <truth.version>0.30</truth.version>
         <HikariCP.version>3.4.2</HikariCP.version>
-        <jraft-core.version>1.3.5</jraft-core.version>
-        <rpc-grpc-impl.version>1.3.5</rpc-grpc-impl.version>
+        <jraft-core.version>1.3.8</jraft-core.version>
+        <rpc-grpc-impl.version>1.3.8</rpc-grpc-impl.version>
     </properties>
     <!-- == -->
     <!-- =========================================================Build plugins================================================ -->
@@ -841,24 +839,6 @@
             <!-- HTTP client libs -->
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore</artifactId>
-                <version>${httpcore.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>${httpclient.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>commons-logging</artifactId>
-                        <groupId>commons-logging</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpasyncclient</artifactId>
                 <version>${httpasyncclient.version}</version>
             </dependency>
@@ -968,12 +948,6 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>${netty-all.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-common</artifactId>
-                <version>${netty-common.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## What is the purpose of the change
Fixes #7698 

1. log what causes I/O reactor status to STOPPED.
2. add IOReactorExceptionHandler.
3. modify dependency version.