### PR TITLE
[ISSUE#7780] Fix a-b-a problem.

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
@@ -105,7 +105,12 @@ public class ConfigCacheService {
         
         try {
             final String md5 = MD5Utils.md5Hex(content, Constants.ENCODE);
-            
+            if (lastModifiedTs < ConfigCacheService.getLastModifiedTs(groupKey)) {
+                DUMP_LOG.warn("[dump-ignore] the content is old. groupKey={}, md5={}, lastModifiedOld={}, "
+                                + "lastModifiedNew={}", groupKey, md5, ConfigCacheService.getLastModifiedTs(groupKey),
+                        lastModifiedTs);
+                return true;
+            }
             if (md5.equals(ConfigCacheService.getContentMd5(groupKey)) && DiskUtil.targetFile(dataId, group, tenant).exists()) {
                 DUMP_LOG.warn("[dump-ignore] ignore to save cache file. groupKey={}, md5={}, lastModifiedOld={}, "
                                 + "lastModifiedNew={}", groupKey, md5, ConfigCacheService.getLastModifiedTs(groupKey),
@@ -158,6 +163,12 @@ public class ConfigCacheService {
         
         try {
             final String md5 = MD5Utils.md5Hex(content, Constants.ENCODE);
+            if (lastModifiedTs < ConfigCacheService.getLastModifiedTs4Beta(groupKey)) {
+                DUMP_LOG.warn("[dump-beta-ignore] the content is old. groupKey={}, md5={}, lastModifiedOld={}, "
+                                + "lastModifiedNew={}", groupKey, md5,
+                        ConfigCacheService.getLastModifiedTs4Beta(groupKey), lastModifiedTs);
+                return true;
+            }
             if (md5.equals(ConfigCacheService.getContentBetaMd5(groupKey)) && DiskUtil.targetBetaFile(dataId, group, tenant).exists()) {
                 DUMP_LOG.warn("[dump-beta-ignore] ignore to save cache file. groupKey={}, md5={}, lastModifiedOld={}, "
                                 + "lastModifiedNew={}", groupKey, md5, ConfigCacheService.getLastModifiedTs(groupKey),
@@ -203,6 +214,12 @@ public class ConfigCacheService {
         
         try {
             final String md5 = MD5Utils.md5Hex(content, Constants.ENCODE);
+            if (lastModifiedTs < ConfigCacheService.getTagLastModifiedTs(groupKey, tag)) {
+                DUMP_LOG.warn("[dump-tag-ignore] the tag is old. groupKey={}, md5={}, lastTagModifiedOld={}, "
+                                + "lastModifiedNew={}", groupKey, md5,
+                        ConfigCacheService.getTagLastModifiedTs(groupKey, tag), lastModifiedTs);
+                return true;
+            }
             if (md5.equals(ConfigCacheService.getContentTagMd5(groupKey, tag)) && DiskUtil.targetTagFile(dataId, group, tenant, tag).exists()) {
                 DUMP_LOG.warn("[dump-tag-ignore] ignore to save cache file. groupKey={}, md5={}, lastModifiedOld={}, "
                                 + "lastModifiedNew={}", groupKey, md5, ConfigCacheService.getLastModifiedTs(groupKey),
@@ -245,6 +262,12 @@ public class ConfigCacheService {
         
         try {
             final String md5 = MD5Utils.md5Hex(content, Constants.ENCODE);
+            if (lastModifiedTs < ConfigCacheService.getLastModifiedTs(groupKey)) {
+                DUMP_LOG.warn("[dump-ignore] the content is old. groupKey={}, md5={}, lastModifiedOld={}, "
+                                + "lastModifiedNew={}", groupKey, md5, ConfigCacheService.getLastModifiedTs(groupKey),
+                        lastModifiedTs);
+                return true;
+            }
             if (!PropertyUtil.isDirectRead()) {
                 String localMd5 = DiskUtil.getLocalConfigMd5(dataId, group, tenant);
                 if (md5.equals(localMd5)) {
@@ -609,6 +632,19 @@ public class ConfigCacheService {
     public static long getLastModifiedTs(String groupKey) {
         CacheItem item = CACHE.get(groupKey);
         return (null != item) ? item.lastModifiedTs : 0L;
+    }
+    
+    public static long getLastModifiedTs4Beta(String groupKey) {
+        CacheItem item = CACHE.get(groupKey);
+        return (null != item) ? item.lastModifiedTs4Beta : 0L;
+    }
+    
+    public static long getTagLastModifiedTs(String groupKey, String tag) {
+        CacheItem item = CACHE.get(groupKey);
+        if (item == null || item.getTagLastModifiedTs() == null) {
+            return 0L;
+        }
+        return item.getTagLastModifiedTs().getOrDefault(tag, 0L);
     }
     
     public static boolean isUptodate(String groupKey, String md5) {


### PR DESCRIPTION
## What is the purpose of the change

Fix the problem mentioned in [issue #7780] (https://github.com/alibaba/nacos/issues/7780): Data inconsistency (a-b-a) caused by concurrent execution of DumpAllProcessor and DumpProcessor

修复 [ISSUE#7780](https://github.com/alibaba/nacos/issues/7780) 中提到的问题：DumpAllProcessor和DumpProcessor 并发执行导致的数据不一致

## Brief changelog

When dump is executed, add the comparison logic of the last modification time. If the target data is older than the data in the cache, directly `reture true` and no modification logic will be executed

dump执行到修改逻辑前，加上最后修改时间的对比逻辑，如果目标数据比缓存中数据老的时候，直接 `reture true`，不再执行修改


## Verifying this change

Use [ISSUE#7780](https://github.com/alibaba/nacos/issues/7780) The reproduction method in has been verified and can solve this problem

使用 [ISSUE#7780](https://github.com/alibaba/nacos/issues/7780) 中的复现方法已经验证通过，可以解决此问题

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
