### PR TITLE
[1.x] Patch v1.x console exception handler

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/exception/ConsoleExceptionHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/exception/ConsoleExceptionHandler.java
@@ -18,6 +18,10 @@ package com.alibaba.nacos.console.exception;
 
 import com.alibaba.nacos.auth.exception.AccessException;
 import com.alibaba.nacos.common.utils.ExceptionUtil;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.catalina.connector.ClientAbortException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -37,18 +41,25 @@ public class ConsoleExceptionHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleExceptionHandler.class);
     
     @ExceptionHandler(AccessException.class)
-    private ResponseEntity<String> handleAccessException(AccessException e) {
+    private ResponseEntity<String> handleAccessException(HttpServletRequest req, AccessException e) {
+        LOGGER.error("CONSOLE - access denied, request: {} from {}", req.getRequestURI(), req.getRemoteHost(), e);
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getErrMsg());
     }
     
     @ExceptionHandler(IllegalArgumentException.class)
-    private ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+    private ResponseEntity<String> handleIllegalArgumentException(HttpServletRequest req, IllegalArgumentException e) {
+        LOGGER.error("CONSOLE - illegal argument, request: {} from {}", req.getRequestURI(), req.getRemoteHost(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ExceptionUtil.getAllExceptionMsg(e));
     }
     
+    @ExceptionHandler(ClientAbortException.class)
+    private void handleClientAbortException(HttpServletRequest req, ClientAbortException e) {
+        LOGGER.error("CONSOLE - client abort, request: {} from {}", req.getRequestURI(), req.getRemoteHost(), e);
+    }
+    
     @ExceptionHandler(Exception.class)
-    private ResponseEntity<String> handleException(Exception e) {
-        LOGGER.error("CONSOLE", e);
+    private ResponseEntity<String> handleException(HttpServletRequest req, Exception e) {
+        LOGGER.error("CONSOLE - unknown exception, request: {} from {}", req.getRequestURI(), req.getRemoteHost(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ExceptionUtil.getAllExceptionMsg(e));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
1. don't set response entity when ClientAbortException occurred (avoid infinite exception handler loop).
2. log request uri and address at exception handlers.