### PR TITLE
[1.x] Patch v1.x set default connection lease request timeout

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/http/AbstractApacheHttpClientFactory.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/AbstractApacheHttpClientFactory.java
@@ -18,6 +18,8 @@ package com.alibaba.nacos.common.http;
 
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
+
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.protocol.RequestContent;
 
@@ -31,15 +33,16 @@ public abstract class AbstractApacheHttpClientFactory extends AbstractHttpClient
     @Override
     public final NacosRestTemplate createNacosRestTemplate() {
         final HttpClientConfig originalRequestConfig = buildHttpClientConfig();
+        final RequestConfig defaultConfig = getRequestConfig();
         return new NacosRestTemplate(assignLogger(), new DefaultHttpClientRequest(
                 HttpClients.custom()
                         .addInterceptorLast(new RequestContent(true))
-                        .setDefaultRequestConfig(getRequestConfig())
+                        .setDefaultRequestConfig(defaultConfig)
                         .setUserAgent(originalRequestConfig.getUserAgent())
                         .setMaxConnTotal(originalRequestConfig.getMaxConnTotal())
                         .setMaxConnPerRoute(originalRequestConfig.getMaxConnPerRoute())
                         .setConnectionTimeToLive(originalRequestConfig.getConnTimeToLive(),
-                                originalRequestConfig.getConnTimeToLiveTimeUnit()).build()));
+                                originalRequestConfig.getConnTimeToLiveTimeUnit()).build(), defaultConfig));
     }
     
 }

--- a/common/src/main/java/com/alibaba/nacos/common/http/AbstractHttpClientFactory.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/AbstractHttpClientFactory.java
@@ -16,6 +16,33 @@
 
 package com.alibaba.nacos.common.http;
 
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.nio.conn.NHttpClientConnectionManager;
+import org.apache.http.nio.conn.NoopIOSessionStrategy;
+import org.apache.http.nio.conn.SchemeIOSessionStrategy;
+import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
+import org.apache.http.nio.reactor.IOReactorException;
+import org.apache.http.nio.reactor.IOReactorExceptionHandler;
+import org.apache.http.protocol.RequestContent;
+import org.apache.http.ssl.SSLContexts;
+import org.slf4j.Logger;
+
 import com.alibaba.nacos.common.http.client.NacosAsyncRestTemplate;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.http.client.request.DefaultAsyncHttpClientRequest;
@@ -25,18 +52,6 @@ import com.alibaba.nacos.common.tls.TlsFileWatcher;
 import com.alibaba.nacos.common.tls.TlsHelper;
 import com.alibaba.nacos.common.tls.TlsSystemConfig;
 import com.alibaba.nacos.common.utils.BiConsumer;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.impl.nio.client.HttpAsyncClients;
-import org.apache.http.protocol.RequestContent;
-import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.slf4j.Logger;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * AbstractHttpClientFactory Let the creator only specify the http client config.
@@ -70,14 +85,79 @@ public abstract class AbstractHttpClientFactory implements HttpClientFactory {
     @Override
     public NacosAsyncRestTemplate createNacosAsyncRestTemplate() {
         final HttpClientConfig originalRequestConfig = buildHttpClientConfig();
+        final DefaultConnectingIOReactor ioreactor = getIoReactor();
+        final RequestConfig defaultConfig = getRequestConfig();
         return new NacosAsyncRestTemplate(assignLogger(), new DefaultAsyncHttpClientRequest(
                 HttpAsyncClients.custom()
                         .addInterceptorLast(new RequestContent(true))
                         .setDefaultIOReactorConfig(getIoReactorConfig())
-                        .setDefaultRequestConfig(getRequestConfig())
+                        .setDefaultRequestConfig(defaultConfig)
                         .setMaxConnTotal(originalRequestConfig.getMaxConnTotal())
                         .setMaxConnPerRoute(originalRequestConfig.getMaxConnPerRoute())
-                        .setUserAgent(originalRequestConfig.getUserAgent()).build()));
+                        .setUserAgent(originalRequestConfig.getUserAgent())
+                        .setConnectionManager(getConnectionManager(originalRequestConfig, ioreactor))
+                        .build(), ioreactor, defaultConfig));
+    }
+    
+    private DefaultConnectingIOReactor getIoReactor() {
+        final DefaultConnectingIOReactor ioreactor;
+        try {
+            ioreactor = new DefaultConnectingIOReactor(getIoReactorConfig());
+        } catch (IOReactorException e) {
+            assignLogger().error("[NHttpClientConnectionManager] Create DefaultConnectingIOReactor failed", e);
+            throw new IllegalStateException();
+        }
+
+        // if the handle return true, then the exception thrown by IOReactor will be ignore, and will not finish the IOReactor.
+        ioreactor.setExceptionHandler(new IOReactorExceptionHandler() {
+
+            @Override
+            public boolean handle(IOException ex) {
+                assignLogger().warn("[NHttpClientConnectionManager] handle IOException, ignore it.", ex);
+                return true;
+            }
+
+            @Override
+            public boolean handle(RuntimeException ex) {
+                assignLogger().warn("[NHttpClientConnectionManager] handle RuntimeException, ignore it.", ex);
+                return true;
+            }
+        });
+
+        return ioreactor;
+    }
+    
+    /**
+     * create the {@link NHttpClientConnectionManager}, the code mainly from {@link HttpAsyncClientBuilder#build()}.
+     * we add the {@link IOReactorExceptionHandler} to handle the {@link IOException} and {@link RuntimeException}
+     * thrown by the {@link org.apache.http.impl.nio.reactor.BaseIOReactor} when process the event of Network.
+     * Using this way to avoid the {@link DefaultConnectingIOReactor} killed by unknown error of network.
+     *
+     * @param originalRequestConfig request config.
+     * @param ioreactor I/O reactor.
+     * @return {@link NHttpClientConnectionManager}.
+     */
+    private NHttpClientConnectionManager getConnectionManager(HttpClientConfig originalRequestConfig, DefaultConnectingIOReactor ioreactor) {
+        SSLContext sslcontext = SSLContexts.createDefault();
+        HostnameVerifier hostnameVerifier = new DefaultHostnameVerifier();
+        SchemeIOSessionStrategy sslStrategy = new SSLIOSessionStrategy(sslcontext, null, null, hostnameVerifier);
+
+        Registry<SchemeIOSessionStrategy> registry = RegistryBuilder.<SchemeIOSessionStrategy>create()
+                .register("http", NoopIOSessionStrategy.INSTANCE)
+                .register("https", sslStrategy)
+                .build();
+        final PoolingNHttpClientConnectionManager poolingmgr = new PoolingNHttpClientConnectionManager(ioreactor, registry);
+
+        int maxTotal = originalRequestConfig.getMaxConnTotal();
+        if (maxTotal > 0) {
+            poolingmgr.setMaxTotal(maxTotal);
+        }
+
+        int maxPerRoute = originalRequestConfig.getMaxConnPerRoute();
+        if (maxPerRoute > 0) {
+            poolingmgr.setDefaultMaxPerRoute(maxPerRoute);
+        }
+        return poolingmgr;
     }
     
     protected IOReactorConfig getIoReactorConfig() {

--- a/common/src/main/java/com/alibaba/nacos/common/http/HttpClientConfig.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/HttpClientConfig.java
@@ -154,7 +154,7 @@ public class HttpClientConfig {
         
         private TimeUnit connTimeToLiveTimeUnit = TimeUnit.MILLISECONDS;
         
-        private int connectionRequestTimeout = -1;
+        private int connectionRequestTimeout = 5000;
         
         private int maxRedirects = 50;
         

--- a/common/src/main/java/com/alibaba/nacos/common/http/client/request/DefaultAsyncHttpClientRequest.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/request/DefaultAsyncHttpClientRequest.java
@@ -22,12 +22,18 @@ import com.alibaba.nacos.common.http.client.handler.ResponseHandler;
 import com.alibaba.nacos.common.http.client.response.DefaultClientHttpResponse;
 import com.alibaba.nacos.common.model.RequestHttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.impl.nio.reactor.ExceptionEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 
 /**
  * {@link AsyncHttpClientRequest} implementation that uses apache async http client to execute streaming requests.
@@ -36,10 +42,18 @@ import java.net.URI;
  */
 public class DefaultAsyncHttpClientRequest implements AsyncHttpClientRequest {
     
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAsyncHttpClientRequest.class);
+    
     private final CloseableHttpAsyncClient asyncClient;
     
-    public DefaultAsyncHttpClientRequest(CloseableHttpAsyncClient asyncClient) {
+    private final DefaultConnectingIOReactor ioreactor;
+
+    private final RequestConfig defaultConfig;
+
+    public DefaultAsyncHttpClientRequest(CloseableHttpAsyncClient asyncClient, DefaultConnectingIOReactor ioreactor, RequestConfig defaultConfig) {
         this.asyncClient = asyncClient;
+        this.ioreactor = ioreactor;
+        this.defaultConfig = defaultConfig;
         if (!this.asyncClient.isRunning()) {
             this.asyncClient.start();
         }
@@ -48,30 +62,43 @@ public class DefaultAsyncHttpClientRequest implements AsyncHttpClientRequest {
     @Override
     public <T> void execute(URI uri, String httpMethod, RequestHttpEntity requestHttpEntity, final ResponseHandler<T> responseHandler,
             final Callback<T> callback) throws Exception {
-        HttpRequestBase httpRequestBase = DefaultHttpClientRequest.build(uri, httpMethod, requestHttpEntity);
-        asyncClient.execute(httpRequestBase, new FutureCallback<HttpResponse>() {
-            @Override
-            public void completed(HttpResponse result) {
-                DefaultClientHttpResponse response = new DefaultClientHttpResponse(result);
-                try {
-                    HttpRestResult<T> httpRestResult = responseHandler.handle(response);
-                    callback.onReceive(httpRestResult);
-                } catch (Exception e) {
-                    callback.onError(e);
+        HttpRequestBase httpRequestBase = DefaultHttpClientRequest.build(uri, httpMethod, requestHttpEntity, defaultConfig);
+        try {
+            asyncClient.execute(httpRequestBase, new FutureCallback<HttpResponse>() {
+                @Override
+                public void completed(HttpResponse result) {
+                    DefaultClientHttpResponse response = new DefaultClientHttpResponse(result);
+                    try {
+                        HttpRestResult<T> httpRestResult = responseHandler.handle(response);
+                        callback.onReceive(httpRestResult);
+                    } catch (Exception e) {
+                        callback.onError(e);
+                    }
+                }
+
+                @Override
+                public void failed(Exception ex) {
+                    callback.onError(ex);
+                }
+
+                @Override
+                public void cancelled() {
+                    callback.onCancel();
+                }
+            });
+        } catch (IllegalStateException e) {
+            final List<ExceptionEvent> events = ioreactor.getAuditLog();
+            if (events != null) {
+                for (ExceptionEvent event : events) {
+                    if (event != null) {
+                        LOGGER.error("[DefaultAsyncHttpClientRequest] IllegalStateException! I/O Reactor error time: {}",
+                                event.getTimestamp(), event.getCause());
+                    }
                 }
             }
-            
-            @Override
-            public void failed(Exception ex) {
-                callback.onError(ex);
-            }
-            
-            @Override
-            public void cancelled() {
-                callback.onCancel();
-            }
-        });
-        
+            throw e;
+        }
+    
     }
     
     @Override

--- a/common/src/main/java/com/alibaba/nacos/common/http/client/request/DefaultHttpClientRequest.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/request/DefaultHttpClientRequest.java
@@ -75,7 +75,7 @@ public class DefaultHttpClientRequest implements HttpClientRequest {
     }
     
     /**
-     * Merge the HTTP config created by default with the HTTP config specified in the request, set connection request timeout if needed.
+     * Merge the HTTP config created by default with the HTTP config specified in the request.
      *
      * @param requestBase      requestBase
      * @param httpClientConfig http config
@@ -84,13 +84,9 @@ public class DefaultHttpClientRequest implements HttpClientRequest {
         if (httpClientConfig == null) {
             return;
         }
-        RequestConfig.Builder builder = RequestConfig.copy(defaultConfig)
+        requestBase.setConfig(RequestConfig.copy(defaultConfig)
                 .setConnectTimeout(httpClientConfig.getConTimeOutMillis())
-                .setSocketTimeout(httpClientConfig.getReadTimeOutMillis());
-        if (httpClientConfig.getConnectionRequestTimeout() > 0) {
-            builder.setConnectionRequestTimeout(httpClientConfig.getConnectionRequestTimeout());
-        }
-        requestBase.setConfig(builder.build());
+                .setSocketTimeout(httpClientConfig.getReadTimeOutMillis()).build());
     }
     
     @Override

--- a/common/src/main/java/com/alibaba/nacos/common/http/client/request/DefaultHttpClientRequest.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/request/DefaultHttpClientRequest.java
@@ -45,9 +45,7 @@ public class DefaultHttpClientRequest implements HttpClientRequest {
     private final CloseableHttpClient client;
     
     private final RequestConfig defaultConfig;
-
-    private static final int DEFAULT_CONNECTION_REQUEST_TIMEOUT = 5000;
-
+    
     public DefaultHttpClientRequest(CloseableHttpClient client, RequestConfig defaultConfig) {
         this.client = client;
         this.defaultConfig = defaultConfig;
@@ -84,19 +82,15 @@ public class DefaultHttpClientRequest implements HttpClientRequest {
      */
     private static void mergeDefaultConfig(HttpRequestBase requestBase, HttpClientConfig httpClientConfig, RequestConfig defaultConfig) {
         if (httpClientConfig == null) {
-            if (defaultConfig.getConnectionRequestTimeout() <= 0) {
-                requestBase.setConfig(RequestConfig.copy(defaultConfig)
-                        .setConnectionRequestTimeout(DEFAULT_CONNECTION_REQUEST_TIMEOUT).build());
-            }
             return;
         }
-        requestBase.setConfig(RequestConfig.copy(defaultConfig)
-                .setConnectionRequestTimeout(httpClientConfig.getConnectionRequestTimeout() > 0
-                        ? httpClientConfig.getConnectionRequestTimeout()
-                        : (defaultConfig.getConnectionRequestTimeout() > 0
-                                ? defaultConfig.getConnectionRequestTimeout() : DEFAULT_CONNECTION_REQUEST_TIMEOUT))
+        RequestConfig.Builder builder = RequestConfig.copy(defaultConfig)
                 .setConnectTimeout(httpClientConfig.getConTimeOutMillis())
-                .setSocketTimeout(httpClientConfig.getReadTimeOutMillis()).build());
+                .setSocketTimeout(httpClientConfig.getReadTimeOutMillis());
+        if (httpClientConfig.getConnectionRequestTimeout() > 0) {
+            builder.setConnectionRequestTimeout(httpClientConfig.getConnectionRequestTimeout());
+        }
+        requestBase.setConfig(builder.build());
     }
     
     @Override

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/HttpClient.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/HttpClient.java
@@ -270,8 +270,8 @@ public class HttpClient {
             }
             header.addParam(HttpHeaderConsts.ACCEPT_CHARSET, encoding);
             AuthHeaderUtil.addIdentityToHeader(header);
-            HttpClientConfig httpClientConfig = HttpClientConfig.builder().setConTimeOutMillis(5000).setReadTimeOutMillis(5000)
-                    .setConnectionRequestTimeout(5000).setMaxRedirects(5).build();
+            HttpClientConfig httpClientConfig = HttpClientConfig.builder().setConTimeOutMillis(5000)
+                    .setReadTimeOutMillis(5000).build();
             return APACHE_SYNC_NACOS_REST_TEMPLATE.postForm(url, httpClientConfig, header, paramValues, String.class);
         } catch (Throwable e) {
             return RestResult.<String>builder().withCode(500).withMsg(e.toString()).build();


### PR DESCRIPTION
## What is the purpose of the change
Fixes #7375
1. set default connection lease request timeout to avoid OOM under continuously huge beat requestions. 
2. merge default connection configurations to each http client request.
3. add IOReactorExceptionHandler and log ioreactor shutdown reason.