### PR TITLE
[1.x] Patch v1.x member manager

### DIFF
--- a/core/src/test/java/com/alibaba/nacos/core/cluster/ServerMemberManagerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/cluster/ServerMemberManagerTest.java
@@ -21,11 +21,15 @@ import com.alibaba.nacos.common.notify.EventPublisher;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.web.context.WebServerInitializedEvent;
+import org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 
 import javax.servlet.ServletContext;
@@ -50,6 +54,9 @@ public class ServerMemberManagerTest {
     
     @Mock
     private EventPublisher eventPublisher;
+    
+    @Mock
+    private WebServerInitializedEvent mockEvent;
     
     private ServerMemberManager serverMemberManager;
     
@@ -107,5 +114,15 @@ public class ServerMemberManagerTest {
         assertTrue(serverMemberManager.getMemberAddressInfos().contains("1.1.1.1:8848"));
         assertEquals("test", serverMemberManager.getServerList().get("1.1.1.1:8848").getExtendVal("naming"));
         verify(eventPublisher, never()).publish(any(MembersChangeEvent.class));
+    }
+    
+    @Test
+    public void testEnvSetPort() {
+        ServletWebServerApplicationContext context = new ServletWebServerApplicationContext();
+        context.setServerNamespace("management");
+        Mockito.when(mockEvent.getApplicationContext()).thenReturn(context);
+        serverMemberManager.onApplicationEvent(mockEvent);
+        int port = EnvUtil.getPort();
+        Assert.assertEquals(port, 8848);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
1. report metadata to other nodes concurrently to eliminate the side effect of PR #4948 - which made the initial status of all other nodes to DOWN, changing their status all back to UP took much more time if report metadata only to one of them at each report task.  And even worse than that if the number of other nodes is more than 7, some beat requests will not be transfer to the correct node till timeout.
2. eliminate concurrent issue between MemberUtil#onFail and DistroMapper#onEvent when two or more nodes is DOWN and  reporting metadata to other nodes concurrently.
3. apply PR #7236 from develop branch to ignore the WebServerInitializedEvent of management.