### PR TITLE
[1.x] Patch v1.x apache sync http client factory

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/HttpClientManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/HttpClientManager.java
@@ -148,9 +148,9 @@ public class HttpClientManager {
         
         @Override
         protected HttpClientConfig buildHttpClientConfig() {
-            return HttpClientConfig.builder().setConnectionTimeToLive(500, TimeUnit.MILLISECONDS)
-                    .setMaxConnTotal(Runtime.getRuntime().availableProcessors() * 2)
-                    .setMaxConnPerRoute(Runtime.getRuntime().availableProcessors()).setMaxRedirects(0).build();
+            return HttpClientConfig.builder().setConnectionTimeToLive(-1, TimeUnit.MILLISECONDS)
+                    .setMaxConnTotal(2000)
+                    .setMaxConnPerRoute(200).setMaxRedirects(0).build();
         }
         
         @Override


### PR DESCRIPTION
## What is the purpose of the change
modify connection pool parameters of ApacheSyncHttpClientFactory.
1. setConnectionTimeToLive to -1: keep connection alive as long as possible to support http1.1 keep alive mode.
2. setMaxConnPerRoute to 200: equal the default threads number of Tomcat, it might be set larger if having ample CPUs.
2. setMaxConnTotal to 2000:  it might be set larger if having more than 10 nacos nodes.
this PR is not ideal because MaxConnPerRoute and MaxConnTotal should match with running enviroment.