### PR TITLE
[ISSUE #7971] fix ClusterVersionJudgement#ClusterVersionJudge Task never stop

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/ClusterVersionJudgement.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/ClusterVersionJudgement.java
@@ -74,7 +74,7 @@ public class ClusterVersionJudgement {
         try {
             finish = judge();
         } finally {
-            if(!finish){
+            if (!finish) {
                 GlobalExecutor.submitClusterVersionJudge(this::runVersionListener, TimeUnit.SECONDS.toMillis(5));
             }
         }

--- a/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/ClusterVersionJudgement.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/consistency/persistent/ClusterVersionJudgement.java
@@ -70,15 +70,18 @@ public class ClusterVersionJudgement {
             notifyAllListener();
             return;
         }
+        boolean finish = false;
         try {
-            judge();
+            finish = judge();
         } finally {
-            GlobalExecutor.submitClusterVersionJudge(this::runVersionListener, TimeUnit.SECONDS.toMillis(5));
+            if(!finish){
+                GlobalExecutor.submitClusterVersionJudge(this::runVersionListener, TimeUnit.SECONDS.toMillis(5));
+            }
         }
     }
     
-    protected void judge() {
-        
+    protected boolean judge() {
+        boolean finish = false;
         Collection<Member> members = memberManager.allMembers();
         final String oldVersion = "1.4.0";
         boolean allMemberIsNewVersion = true;
@@ -91,7 +94,9 @@ public class ClusterVersionJudgement {
         // can only trigger once
         if (allMemberIsNewVersion && !this.allMemberIsNewVersion) {
             notifyAllListener();
+            finish = true;
         }
+        return finish;
     }
     
     private void notifyAllListener() {


### PR DESCRIPTION
## What is the purpose of the change
fix bug #7971 

## Brief changelog
ClusterVersionJudgement在执行runVersionListener的时候增加判断，如果所有成员已经是新版本，且通知成功，则不再执行后续的runVersionListener

## Verifying this change
已经通知过后，就不会再次提交runVersionListener任务

