### PR TITLE
增加对状态码为404的判断

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/http/ServerHttpAgent.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/http/ServerHttpAgent.java
@@ -225,7 +225,8 @@ public class ServerHttpAgent implements HttpAgent {
     private boolean isFail(HttpRestResult<String> result) {
         return result.getCode() == HttpURLConnection.HTTP_INTERNAL_ERROR
                 || result.getCode() == HttpURLConnection.HTTP_BAD_GATEWAY
-                || result.getCode() == HttpURLConnection.HTTP_UNAVAILABLE;
+                || result.getCode() == HttpURLConnection.HTTP_UNAVAILABLE
+                || result.getCode() == HttpURLConnection.HTTP_NOT_FOUND;
     }
     
     public static String getAppname() {


### PR DESCRIPTION
## What is the purpose of the change

由于目前调用GET: /nacos/v1/cs/configs，当配置不存在时，会返回状态码为404。此处无法识别错误，导致日志看不出来

## Brief changelog

增加对404状态码的判断


