### PR TITLE
[ISSUE #8072] Reduce memory cost in DistroProtocol initialization to avoid OutOfMemoryError

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/JacksonUtils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/JacksonUtils.java
@@ -71,7 +71,7 @@ public final class JacksonUtils {
      */
     public static byte[] toJsonBytes(Object obj) {
         try {
-            return ByteUtils.toBytes(mapper.writeValueAsString(obj));
+            return mapper.writeValueAsBytes(obj);
         } catch (JsonProcessingException e) {
             throw new NacosSerializationException(obj.getClass(), e);
         }
@@ -88,7 +88,7 @@ public final class JacksonUtils {
      */
     public static <T> T toObj(byte[] json, Class<T> cls) {
         try {
-            return toObj(StringUtils.newStringForUtf8(json), cls);
+            return mapper.readValue(json, cls);
         } catch (Exception e) {
             throw new NacosDeserializationException(cls, e);
         }
@@ -105,7 +105,7 @@ public final class JacksonUtils {
      */
     public static <T> T toObj(byte[] json, Type cls) {
         try {
-            return toObj(StringUtils.newStringForUtf8(json), cls);
+            return mapper.readValue(json, mapper.constructType(cls));
         } catch (Exception e) {
             throw new NacosDeserializationException(e);
         }
@@ -139,7 +139,7 @@ public final class JacksonUtils {
      */
     public static <T> T toObj(byte[] json, TypeReference<T> typeReference) {
         try {
-            return toObj(StringUtils.newStringForUtf8(json), typeReference);
+            return mapper.readValue(json, typeReference);
         } catch (Exception e) {
             throw new NacosDeserializationException(e);
         }

--- a/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
@@ -1,0 +1,62 @@
+package com.alibaba.nacos.common.utils;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.common.model.RestResult;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JacksonUtils tests
+ *
+ * @author liqipeng
+ * @date 2022/4/2 00:38
+ */
+public class JacksonUtilsTest {
+    
+    @Test
+    public void testToJsonBytes() {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put("string", "你好，中国！");
+        map.put("integer", 999);
+        RestResult<Map<String, Object>> restResult = new RestResult();
+        restResult.setData(map);
+    
+        byte[] bytes = JacksonUtils.toJsonBytes(restResult);
+        String jsonFromBytes = ByteUtils.toString(bytes);
+        String expectedJson = "{\"code\":0,\"data\":{\"string\":\"你好，中国！\",\"integer\":999}}";
+        Assert.assertEquals(expectedJson, jsonFromBytes);
+    
+        // old `toJsonBytes` method implementation:
+        //     public static byte[] toJsonBytes(Object obj) {
+        //        try {
+        //            return ByteUtils.toBytes(mapper.writeValueAsString(obj));
+        //        } catch (JsonProcessingException e) {
+        //            throw new NacosSerializationException(obj.getClass(), e);
+        //        }
+        //    }
+        
+        // here is a verification to compare with the old implementation
+        byte[] bytesFromOldImplementation = ByteUtils.toBytes(JacksonUtils.toJson(restResult));
+        Assert.assertEquals(expectedJson, new String(bytesFromOldImplementation, Charset.forName(Constants.ENCODE)));
+    }
+    
+    @Test
+    public void testToObjFromBytes() {
+        String json = "{\"code\":0,\"data\":{\"string\":\"你好，中国！\",\"integer\":999}}";
+        
+        RestResult<Map<String, Object>> restResult = JacksonUtils.toObj(json, RestResult.class);
+        Assert.assertEquals(0, restResult.getCode());
+        Assert.assertEquals("你好，中国！", restResult.getData().get("string"));
+        Assert.assertEquals(999, restResult.getData().get("integer"));
+    
+        restResult = JacksonUtils.toObj(json, new TypeReference<RestResult<Map<String, Object>>>() {});
+        Assert.assertEquals(0, restResult.getCode());
+        Assert.assertEquals("你好，中国！", restResult.getData().get("string"));
+        Assert.assertEquals(999, restResult.getData().get("integer"));
+    }
+}


### PR DESCRIPTION
Change implementation of JacksonUtils methods about byte operation to reduce memory cost, especially when DistroProtocol fetching full data from peer node in the initialization phase. (#8072)

## What is the purpose of the change

详见：https://github.com/alibaba/nacos/issues/8072

## Brief changelog

Reduce memory cost in DistroProtocol initialization to avoid OOM

## Verifying this change

Unit tests for changes have been added.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

