### PR TITLE
V2.x fix(#6273): server/leave, add end conditions for cluster notifications.

### DIFF
--- a/core/src/test/java/com/alibaba/nacos/core/controller/NacosClusterControllerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/controller/NacosClusterControllerTest.java
@@ -115,7 +115,7 @@ public class NacosClusterControllerTest {
     
     @Test
     public void testLeave() throws Exception {
-        RestResult<String> result = nacosClusterController.leave(Collections.singletonList("1.1.1.1"));
+        RestResult<String> result = nacosClusterController.leave(Collections.singletonList("1.1.1.1"), true);
         Assert.assertEquals("ok", result.getData());
     }
 }


### PR DESCRIPTION
V2.x fix(#6273): server/leave, add end conditions for cluster notifications.

relate #8099 