### PR TITLE
[1.x] accept node return beat response and forward beat request

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/IoUtils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/IoUtils.java
@@ -37,6 +37,7 @@ import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * IO related tool methods.
@@ -45,6 +46,21 @@ import java.util.zip.GZIPInputStream;
  */
 public class IoUtils {
     
+    /**
+     * compress bytes by GZIP.
+     *
+     * @param dataBytes byte array to be compressed
+     * @return byte array after compress
+     * @throws IOException io exception
+     */
+    public static byte[] compress(byte[] dataBytes) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        GZIPOutputStream gzip = new GZIPOutputStream(out);
+        gzip.write(dataBytes);
+        gzip.close();
+        return out.toByteArray();
+    }
+
     /**
      * Try decompress by GZIP from stream.
      *

--- a/core/src/main/java/com/alibaba/nacos/core/utils/BeatRequest.java
+++ b/core/src/main/java/com/alibaba/nacos/core/utils/BeatRequest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.utils;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.naming.CommonParams;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.Serializable;
+
+/**
+ * beat request.
+ *
+ * @author zrlw@sina.com
+ */
+public class BeatRequest implements Serializable {
+    
+    private static final long serialVersionUID = 4949100576133626692L;
+    
+    private String id;
+    
+    private String ip;
+    
+    private int port;
+    
+    private String serviceName;
+    
+    private String namespaceId;
+    
+    private String clusterName;
+    
+    private String beat;
+    
+    /**
+     * get beat request object from HttpServletRequest.
+     * @param request HttpServletRequest
+     * @return beat request
+     */
+    public static BeatRequest get(HttpServletRequest request, String groupedServiceName) {
+        BeatRequest beatRequest = new BeatRequest();
+        beatRequest.id = SimpleBeatInfo.getBeatId(request);
+        beatRequest.beat = WebUtils.optional(request, "beat", StringUtils.EMPTY);
+        beatRequest.clusterName = WebUtils.optional(request, CommonParams.CLUSTER_NAME, Constants.DEFAULT_CLUSTER_NAME);
+        beatRequest.ip = WebUtils.optional(request, "ip", StringUtils.EMPTY);
+        beatRequest.port = Integer.parseInt(WebUtils.optional(request, "port", "0"));
+        beatRequest.namespaceId = WebUtils.optional(request, CommonParams.NAMESPACE_ID, Constants.DEFAULT_NAMESPACE_ID);
+        beatRequest.serviceName = groupedServiceName;
+        return beatRequest;
+    }
+    
+    public String getId() {
+        return id;
+    }
+    
+    public String getIp() {
+        return ip;
+    }
+
+    public int getPort() {
+        return port;
+    }
+    
+    public String getServiceName() {
+        return serviceName;
+    }
+    
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+    
+    public String getClusterName() {
+        return clusterName;
+    }
+    
+    public String getBeat() {
+        return beat;
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/utils/SimpleBeatInfo.java
+++ b/core/src/main/java/com/alibaba/nacos/core/utils/SimpleBeatInfo.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.utils;
+
+import com.alibaba.nacos.api.naming.CommonParams;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * simple beat info.
+ *
+ * @author zrlw@sina.com
+ */
+public class SimpleBeatInfo {
+    
+    private int port;
+    
+    private String ip;
+    
+    @Override
+    public String toString() {
+        return "SimpleBeatInfo{" + "port=" + port + ", ip='" + ip + '}';
+    }
+    
+    public String getIp() {
+        return ip;
+    }
+    
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+    
+    public int getPort() {
+        return port;
+    }
+    
+    public void setPort(int port) {
+        this.port = port;
+    }
+    
+    public static String getBeatId(HttpServletRequest req) {
+        String beatId;
+        String beat = WebUtils.optional(req, "beat", StringUtils.EMPTY);
+        if (StringUtils.isNotBlank(beat)) {
+            SimpleBeatInfo simpleBeatInfo = JacksonUtils.toObj(beat, SimpleBeatInfo.class);
+            beatId = simpleBeatInfo.getIp() + ":"
+                    + simpleBeatInfo.getPort() + " "
+                    + WebUtils.required(req, CommonParams.SERVICE_NAME);
+        } else {
+            beatId = WebUtils.optional(req, "ip", StringUtils.EMPTY) + ":"
+                    + WebUtils.optional(req, "port", "0") + " "
+                    + WebUtils.required(req, CommonParams.SERVICE_NAME);
+        }
+        return beatId;
+    }
+}

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/HttpClientManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/HttpClientManager.java
@@ -121,7 +121,7 @@ public class HttpClientManager {
         protected HttpClientConfig buildHttpClientConfig() {
             return HttpClientConfig.builder().setConTimeOutMillis(CON_TIME_OUT_MILLIS)
                     .setReadTimeOutMillis(TIME_OUT_MILLIS).setUserAgent(UtilsAndCommons.SERVER_VERSION)
-                    .setMaxConnTotal(-1).setMaxConnPerRoute(128).setMaxRedirects(0).build();
+                    .setMaxConnTotal(128).setMaxConnPerRoute(128).setMaxRedirects(0).build();
         }
         
         @Override


### PR DESCRIPTION
## What is the purpose of the change
To reduce beat retransmission times and bandwidth consumption between nodes,  and improve horizontal expansion capability. 
see #8147
1. the node which received client beat answers directly instead of responsible node.
2. each node merge, compress and retransmit beat requests that they answered at step 1 to the responsible nodes.

