### PR TITLE
feat(#5346): reset raft cluster ops for no leader, use JRaft Api resetPeers.

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftConstants.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftConstants.java
@@ -43,5 +43,10 @@ public class JRaftConstants {
     public static final String REMOVE_PEERS = "removePeers";
     
     public static final String CHANGE_PEERS = "changePeers";
-    
+
+    /**
+     * resetPeers.
+     */
+    public static final String RESET_PEERS = "resetPeers";
+
 }

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftOps.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftOps.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 @SuppressWarnings("all")
 public enum JRaftOps {
     
-    TRANSFER_LEADER("transferLeader") {
+    TRANSFER_LEADER(JRaftConstants.TRANSFER_LEADER) {
         @Override
         public RestResult<String> execute(CliService cliService, String groupId, Node node, Map<String, String> args) {
             final Configuration conf = node.getOptions().getInitialConf();
@@ -50,7 +50,7 @@ public enum JRaftOps {
         }
     },
     
-    RESET_RAFT_CLUSTER("restRaftCluster") {
+    RESET_RAFT_CLUSTER(JRaftConstants.RESET_RAFT_CLUSTER) {
         @Override
         public RestResult<String> execute(CliService cliService, String groupId, Node node, Map<String, String> args) {
             final Configuration conf = node.getOptions().getInitialConf();
@@ -64,7 +64,7 @@ public enum JRaftOps {
         }
     },
     
-    DO_SNAPSHOT("doSnapshot") {
+    DO_SNAPSHOT(JRaftConstants.DO_SNAPSHOT) {
         @Override
         public RestResult<String> execute(CliService cliService, String groupId, Node node, Map<String, String> args) {
             final Configuration conf = node.getOptions().getInitialConf();
@@ -77,7 +77,7 @@ public enum JRaftOps {
         }
     },
     
-    REMOVE_PEER("removePeer") {
+    REMOVE_PEER(JRaftConstants.REMOVE_PEER) {
         @Override
         public RestResult<String> execute(CliService cliService, String groupId, Node node, Map<String, String> args) {
             final Configuration conf = node.getOptions().getInitialConf();
@@ -98,7 +98,7 @@ public enum JRaftOps {
         }
     },
     
-    REMOVE_PEERS("removePeers") {
+    REMOVE_PEERS(JRaftConstants.REMOVE_PEERS) {
         @Override
         public RestResult<String> execute(CliService cliService, String groupId, Node node, Map<String, String> args) {
             final Configuration conf = node.getOptions().getInitialConf();
@@ -121,7 +121,7 @@ public enum JRaftOps {
         }
     },
     
-    CHANGE_PEERS("changePeers") {
+    CHANGE_PEERS(JRaftConstants.CHANGE_PEERS) {
         @Override
         public RestResult<String> execute(CliService cliService, String groupId, Node node, Map<String, String> args) {
             final Configuration conf = node.getOptions().getInitialConf();
@@ -136,6 +136,31 @@ public enum JRaftOps {
             }
             
             Status status = cliService.changePeers(groupId, conf, newConf);
+            if (status.isOk()) {
+                return RestResultUtils.success();
+            }
+            return RestResultUtils.failed(status.getErrorMsg());
+        }
+    },
+
+    /**
+     * resetPeers.
+     * <p>
+     * Use only in very urgent situations where availability is more important!
+     * https://www.sofastack.tech/projects/sofa-jraft/jraft-user-guide/#7.3
+     * </p>
+     */
+    RESET_PEERS(JRaftConstants.RESET_PEERS) {
+        @Override
+        public RestResult<String> execute(CliService cliService, String groupId, Node node, Map<String, String> args) {
+            final Configuration newConf = new Configuration();
+            String peers = args.get(JRaftConstants.COMMAND_VALUE);
+            for (String peer : peers.split(",")) {
+                newConf.addPeer(PeerId.parsePeer(peer.trim()));
+            }
+
+            final PeerId nodePeerId = node.getNodeId().getPeerId();
+            Status status = cliService.resetPeer(groupId, nodePeerId, newConf);
             if (status.isOk()) {
                 return RestResultUtils.success();
             }


### PR DESCRIPTION
feat(#5346): reset raft cluster ops for no leader, use JRaft Api resetPeers.

Use only in very urgent situations where availability is more important!
https://www.sofastack.tech/projects/sofa-jraft/jraft-user-guide/#7.3 多数节点故障
只有在非常紧急并且可用性更为重要的情况下使用。

> 面对 k8s 云环境这种上下线/重启等成员 ip 变动大的情况，常常遇到 issue 里描述的问题；
而 Nacos 还是 AP 用法，所以 CP 不应该作为影响集群整体可用性的拦路虎；
而且 nacos-client 也会不断 beat 补全注册的数据，从而我这边增加了一个重置整个集群选举的入口 resetPeers （用于真的无法选主时的极限运维，总好过集群整体挂掉）