### PR TITLE
Hotfix issue 8350

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -579,7 +579,7 @@ public class ClientWorker implements Closeable {
             labels.put(RemoteConstants.LABEL_SOURCE, RemoteConstants.LABEL_SOURCE_SDK);
             labels.put(RemoteConstants.LABEL_MODULE, RemoteConstants.LABEL_MODULE_CONFIG);
             labels.put(Constants.APPNAME, AppNameUtils.getAppName());
-            labels.put(Constants.VIPSERVER_TAG, EnvUtil.getSelfVipServerTag());
+            labels.put(Constants.VIPSERVER_TAG, EnvUtil.getSelfVipserverTag());
             labels.put(Constants.AMORY_TAG, EnvUtil.getSelfAmoryTag());
             labels.put(Constants.LOCATION_TAG, EnvUtil.getSelfLocationTag());
             

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -579,8 +579,8 @@ public class ClientWorker implements Closeable {
             labels.put(RemoteConstants.LABEL_SOURCE, RemoteConstants.LABEL_SOURCE_SDK);
             labels.put(RemoteConstants.LABEL_MODULE, RemoteConstants.LABEL_MODULE_CONFIG);
             labels.put(Constants.APPNAME, AppNameUtils.getAppName());
-            labels.put(Constants.VIPSERVER_TAG, EnvUtil.getSelfVipserverTag());
-            labels.put(Constants.AMORY_TAG, EnvUtil.getSelfAmorayTag());
+            labels.put(Constants.VIPSERVER_TAG, EnvUtil.getSelfVipServerTag());
+            labels.put(Constants.AMORY_TAG, EnvUtil.getSelfAmoryTag());
             labels.put(Constants.LOCATION_TAG, EnvUtil.getSelfLocationTag());
             
             return labels;

--- a/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
@@ -53,14 +53,14 @@ public class EnvUtil {
                 }
             }
             
-            List<String> vipServerTagTmp = headers.get(Constants.VIPSERVER_TAG);
-            if (vipServerTagTmp == null) {
+            List<String> vipserverTagTmp = headers.get(Constants.VIPSERVER_TAG);
+            if (vipserverTagTmp == null) {
                 if (selfVipserverTag != null) {
                     selfVipserverTag = null;
                     LOGGER.warn("selfVipServerTag:null");
                 }
             } else {
-                String vipServerTagTmpStr = listToString(vipServerTagTmp);
+                String vipServerTagTmpStr = listToString(vipserverTagTmp);
                 if (!vipServerTagTmpStr.equals(selfVipserverTag)) {
                     selfVipserverTag = vipServerTagTmpStr;
                     LOGGER.warn("selfVipServerTag:{}", selfVipserverTag);

--- a/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
@@ -33,7 +33,7 @@ public class EnvUtil {
     
     private static String selfAmoryTag;
     
-    private static String selfVipServerTag;
+    private static String selfVipserverTag;
     
     private static String selfLocationTag;
     
@@ -55,15 +55,15 @@ public class EnvUtil {
             
             List<String> vipServerTagTmp = headers.get(Constants.VIPSERVER_TAG);
             if (vipServerTagTmp == null) {
-                if (selfVipServerTag != null) {
-                    selfVipServerTag = null;
+                if (selfVipserverTag != null) {
+                    selfVipserverTag = null;
                     LOGGER.warn("selfVipServerTag:null");
                 }
             } else {
                 String vipServerTagTmpStr = listToString(vipServerTagTmp);
-                if (!vipServerTagTmpStr.equals(selfVipServerTag)) {
-                    selfVipServerTag = vipServerTagTmpStr;
-                    LOGGER.warn("selfVipServerTag:{}", selfVipServerTag);
+                if (!vipServerTagTmpStr.equals(selfVipserverTag)) {
+                    selfVipserverTag = vipServerTagTmpStr;
+                    LOGGER.warn("selfVipServerTag:{}", selfVipserverTag);
                 }
             }
             List<String> locationTagTmp = headers.get(Constants.LOCATION_TAG);
@@ -86,8 +86,8 @@ public class EnvUtil {
         return selfAmoryTag;
     }
     
-    public static String getSelfVipServerTag() {
-        return selfVipServerTag;
+    public static String getSelfVipserverTag() {
+        return selfVipserverTag;
     }
     
     public static String getSelfLocationTag() {

--- a/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
@@ -57,13 +57,13 @@ public class EnvUtil {
             if (vipserverTagTmp == null) {
                 if (selfVipserverTag != null) {
                     selfVipserverTag = null;
-                    LOGGER.warn("selfVipServerTag:null");
+                    LOGGER.warn("selfVipserverTag:null");
                 }
             } else {
-                String vipServerTagTmpStr = listToString(vipserverTagTmp);
-                if (!vipServerTagTmpStr.equals(selfVipserverTag)) {
-                    selfVipserverTag = vipServerTagTmpStr;
-                    LOGGER.warn("selfVipServerTag:{}", selfVipserverTag);
+                String vipserverTagTmpStr = listToString(vipserverTagTmp);
+                if (!vipserverTagTmpStr.equals(selfVipserverTag)) {
+                    selfVipserverTag = vipserverTagTmpStr;
+                    LOGGER.warn("selfVipserverTag:{}", selfVipserverTag);
                 }
             }
             List<String> locationTagTmp = headers.get(Constants.LOCATION_TAG);

--- a/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
@@ -31,9 +31,9 @@ public class EnvUtil {
     
     public static final Logger LOGGER = LogUtils.logger(EnvUtil.class);
     
-    private static String selfAmorayTag;
+    private static String selfAmoryTag;
     
-    private static String selfVipserverTag;
+    private static String selfVipServerTag;
     
     private static String selfLocationTag;
     
@@ -41,29 +41,29 @@ public class EnvUtil {
         if (headers != null) {
             List<String> amoryTagTmp = headers.get(Constants.AMORY_TAG);
             if (amoryTagTmp == null) {
-                if (selfAmorayTag != null) {
-                    selfAmorayTag = null;
+                if (selfAmoryTag != null) {
+                    selfAmoryTag = null;
                     LOGGER.warn("selfAmoryTag:null");
                 }
             } else {
                 String amoryTagTmpStr = listToString(amoryTagTmp);
-                if (!amoryTagTmpStr.equals(selfAmorayTag)) {
-                    selfAmorayTag = amoryTagTmpStr;
-                    LOGGER.warn("selfAmoryTag:{}", selfAmorayTag);
+                if (!amoryTagTmpStr.equals(selfAmoryTag)) {
+                    selfAmoryTag = amoryTagTmpStr;
+                    LOGGER.warn("selfAmoryTag:{}", selfAmoryTag);
                 }
             }
             
             List<String> vipServerTagTmp = headers.get(Constants.VIPSERVER_TAG);
             if (vipServerTagTmp == null) {
-                if (selfVipserverTag != null) {
-                    selfVipserverTag = null;
+                if (selfVipServerTag != null) {
+                    selfVipServerTag = null;
                     LOGGER.warn("selfVipServerTag:null");
                 }
             } else {
                 String vipServerTagTmpStr = listToString(vipServerTagTmp);
-                if (!vipServerTagTmpStr.equals(selfVipserverTag)) {
-                    selfVipserverTag = vipServerTagTmpStr;
-                    LOGGER.warn("selfVipServerTag:{}", selfVipserverTag);
+                if (!vipServerTagTmpStr.equals(selfVipServerTag)) {
+                    selfVipServerTag = vipServerTagTmpStr;
+                    LOGGER.warn("selfVipServerTag:{}", selfVipServerTag);
                 }
             }
             List<String> locationTagTmp = headers.get(Constants.LOCATION_TAG);
@@ -82,12 +82,12 @@ public class EnvUtil {
         }
     }
     
-    public static String getSelfAmorayTag() {
-        return selfAmorayTag;
+    public static String getSelfAmoryTag() {
+        return selfAmoryTag;
     }
     
-    public static String getSelfVipserverTag() {
-        return selfVipserverTag;
+    public static String getSelfVipServerTag() {
+        return selfVipServerTag;
     }
     
     public static String getSelfLocationTag() {

--- a/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/EnvUtil.java
@@ -39,31 +39,31 @@ public class EnvUtil {
     
     public static void setSelfEnv(Map<String, List<String>> headers) {
         if (headers != null) {
-            List<String> amorayTagTmp = headers.get(Constants.AMORY_TAG);
-            if (amorayTagTmp == null) {
+            List<String> amoryTagTmp = headers.get(Constants.AMORY_TAG);
+            if (amoryTagTmp == null) {
                 if (selfAmorayTag != null) {
                     selfAmorayTag = null;
                     LOGGER.warn("selfAmoryTag:null");
                 }
             } else {
-                String amorayTagTmpStr = listToString(amorayTagTmp);
-                if (!amorayTagTmpStr.equals(selfAmorayTag)) {
-                    selfAmorayTag = amorayTagTmpStr;
+                String amoryTagTmpStr = listToString(amoryTagTmp);
+                if (!amoryTagTmpStr.equals(selfAmorayTag)) {
+                    selfAmorayTag = amoryTagTmpStr;
                     LOGGER.warn("selfAmoryTag:{}", selfAmorayTag);
                 }
             }
             
-            List<String> vipserverTagTmp = headers.get(Constants.VIPSERVER_TAG);
-            if (vipserverTagTmp == null) {
+            List<String> vipServerTagTmp = headers.get(Constants.VIPSERVER_TAG);
+            if (vipServerTagTmp == null) {
                 if (selfVipserverTag != null) {
                     selfVipserverTag = null;
-                    LOGGER.warn("selfVipserverTag:null");
+                    LOGGER.warn("selfVipServerTag:null");
                 }
             } else {
-                String vipserverTagTmpStr = listToString(vipserverTagTmp);
-                if (!vipserverTagTmpStr.equals(selfVipserverTag)) {
-                    selfVipserverTag = vipserverTagTmpStr;
-                    LOGGER.warn("selfVipserverTag:{}", selfVipserverTag);
+                String vipServerTagTmpStr = listToString(vipServerTagTmp);
+                if (!vipServerTagTmpStr.equals(selfVipserverTag)) {
+                    selfVipserverTag = vipServerTagTmpStr;
+                    LOGGER.warn("selfVipServerTag:{}", selfVipserverTag);
                 }
             }
             List<String> locationTagTmp = headers.get(Constants.LOCATION_TAG);

--- a/client/src/test/java/com/alibaba/nacos/client/utils/EnvUtilTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/EnvUtilTest.java
@@ -36,8 +36,8 @@ public class EnvUtilTest {
         headers.put(Constants.VIPSERVER_TAG, Arrays.asList("b", "2"));
         headers.put(Constants.LOCATION_TAG, Arrays.asList("c", "3"));
         EnvUtil.setSelfEnv(headers);
-        Assert.assertEquals("a,1", EnvUtil.getSelfAmorayTag());
-        Assert.assertEquals("b,2", EnvUtil.getSelfVipserverTag());
+        Assert.assertEquals("a,1", EnvUtil.getSelfAmoryTag());
+        Assert.assertEquals("b,2", EnvUtil.getSelfVipServerTag());
         Assert.assertEquals("c,3", EnvUtil.getSelfLocationTag());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/utils/EnvUtilTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/EnvUtilTest.java
@@ -37,7 +37,7 @@ public class EnvUtilTest {
         headers.put(Constants.LOCATION_TAG, Arrays.asList("c", "3"));
         EnvUtil.setSelfEnv(headers);
         Assert.assertEquals("a,1", EnvUtil.getSelfAmoryTag());
-        Assert.assertEquals("b,2", EnvUtil.getSelfVipServerTag());
+        Assert.assertEquals("b,2", EnvUtil.getSelfVipserverTag());
         Assert.assertEquals("c,3", EnvUtil.getSelfLocationTag());
     }
 }


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

fix the #8350 

## What is the purpose of the change

In the process of reading the source code, it is found that the word is misspelled in the 'envutil' tool class:
在阅读源码的过程中， 发现在 `EnvUtil` 工具类中， 发现一处单词拼写错误：

源代码：
```java
  // 变量名：amorayTagTmp  
 // 这里的 amoray, 从上下文分析。 此时应为 amory
 // 可能是大佬手速太快了 [手动狗头]
  List<String> amorayTagTmp = headers.get(Constants.AMORY_TAG);
            if (amorayTagTmp == null) {
                if (selfAmorayTag != null) {
                    selfAmorayTag = null;
                    LOGGER.warn("selfAmoryTag:null");
                }
```