### PR TITLE
[ISSUE #8403] change judge permission method when update password

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/auth/AuthFilter.java
+++ b/core/src/main/java/com/alibaba/nacos/core/auth/AuthFilter.java
@@ -160,5 +160,9 @@ public class AuthFilter implements Filter {
                 .getParameter(com.alibaba.nacos.plugin.auth.constant.Constants.Identity.IDENTITY_ID, StringUtils.EMPTY);
         request.getSession()
                 .setAttribute(com.alibaba.nacos.plugin.auth.constant.Constants.Identity.IDENTITY_ID, identityId);
+        boolean globalAdmin = identityContext
+                .getParameter(com.alibaba.nacos.plugin.auth.constant.Constants.Identity.ADMIN_IDENTITY, false);
+        request.getSession()
+                .setAttribute(com.alibaba.nacos.plugin.auth.constant.Constants.Identity.ADMIN_IDENTITY, globalAdmin);
     }
 }

--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthPluginService.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthPluginService.java
@@ -67,10 +67,12 @@ public class NacosAuthPluginService implements AuthPluginService {
     @Override
     public boolean validateIdentity(IdentityContext identityContext, Resource resource) throws AccessException {
         checkNacosAuthManager();
-        User user = nacosAuthManager.login(identityContext);
+        NacosUser user = (NacosUser) nacosAuthManager.login(identityContext);
         identityContext.setParameter(USER_IDENTITY_PARAM_KEY, user);
         identityContext.setParameter(com.alibaba.nacos.plugin.auth.constant.Constants.Identity.IDENTITY_ID,
                 user.getUserName());
+        identityContext.setParameter(com.alibaba.nacos.plugin.auth.constant.Constants.Identity.ADMIN_IDENTITY,
+                user.isGlobalAdmin());
         return true;
     }
     

--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/UserController.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/UserController.java
@@ -22,6 +22,8 @@ import com.alibaba.nacos.auth.config.AuthConfigs;
 import com.alibaba.nacos.common.model.RestResult;
 import com.alibaba.nacos.common.model.RestResultUtils;
 import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.config.server.utils.RequestUtil;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.exception.AccessException;
 import com.alibaba.nacos.plugin.auth.impl.JwtTokenManager;
@@ -166,6 +168,15 @@ public class UserController {
     
     private boolean hasPermission(String username, HttpServletRequest request) throws HttpSessionRequiredException {
         if (!authConfigs.isAuthEnabled()) {
+            return true;
+        }
+        Object globalAdmin = request.getSession()
+                .getAttribute(com.alibaba.nacos.plugin.auth.constant.Constants.Identity.ADMIN_IDENTITY);
+        if (null != globalAdmin && (boolean) globalAdmin) {
+            return true;
+        }
+        String identityId = RequestUtil.getSrcUserName(request);
+        if (StringUtils.isNotBlank(identityId) && identityId.equals(username)) {
             return true;
         }
         NacosUser user = (NacosUser) request.getSession().getAttribute(AuthConstants.NACOS_USER_KEY);

--- a/plugin/auth/src/main/java/com/alibaba/nacos/plugin/auth/constant/Constants.java
+++ b/plugin/auth/src/main/java/com/alibaba/nacos/plugin/auth/constant/Constants.java
@@ -57,5 +57,7 @@ public class Constants {
         public static final String X_REAL_IP = "X-Real-IP";
         
         public static final String REMOTE_IP = "remote_ip";
+
+        public static final String ADMIN_IDENTITY = "global_admin";
     }
 }


### PR DESCRIPTION
**What is the purpose of the change**

[8403](https://github.com/alibaba/nacos/issues/8403)
新版本的 Authfilter 改变了设置用户信息的方式，非当前服务器 login 的用户无法从 session 获取到 nacosUser。

改成从 session 获取 IDENTITY_ID 确定 username，同时因为 admin 也能改别人的密码，添加 globalAdmin 到 session。

感觉 hasPermission 原有的逻辑可以删除，但是也不是很确定，所以做了兼容。

不确定获取 globalAdmin 信息是否有其他功能需要，没有直接放到 RequestUtil。
