### PR TITLE
Explicitly specify spring-boot-maven-plugin version same as spring-boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,15 @@
     <!-- =========================================================Build plugins================================================ -->
     <!-- == -->
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot-dependencies.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Explicitly specify ```spring-boot-maven-plugin``` version same as spring-boot by pluginManagement.