### PR TITLE
Add log level judgment for some log outputs with performance cost

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessor.java
@@ -75,7 +75,9 @@ public class HttpLoginProcessor implements LoginProcessor {
             HttpRestResult<String> restResult = nacosRestTemplate
                     .postForm(url, Header.EMPTY, Query.newInstance().initParams(params), bodyMap, String.class);
             if (!restResult.ok()) {
-                SECURITY_LOGGER.error("login failed: {}", JacksonUtils.toJson(restResult));
+                if (SECURITY_LOGGER.isErrorEnabled()) {
+                    SECURITY_LOGGER.error("login failed: {}", JacksonUtils.toJson(restResult));
+                }
                 return null;
             }
             JsonNode obj = JacksonUtils.toObj(restResult.getData());

--- a/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/beat/BeatReactor.java
@@ -206,12 +206,15 @@ public class BeatReactor implements Closeable {
                     }
                 }
             } catch (NacosException ex) {
-                NAMING_LOGGER.error("[CLIENT-BEAT] failed to send beat: {}, code: {}, msg: {}",
-                        JacksonUtils.toJson(beatInfo), ex.getErrCode(), ex.getErrMsg());
-    
+                if (NAMING_LOGGER.isErrorEnabled()) {
+                    NAMING_LOGGER.error("[CLIENT-BEAT] failed to send beat: {}, code: {}, msg: {}",
+                            JacksonUtils.toJson(beatInfo), ex.getErrCode(), ex.getErrMsg());
+                }
             } catch (Exception unknownEx) {
-                NAMING_LOGGER.error("[CLIENT-BEAT] failed to send beat: {}, unknown exception msg: {}",
-                        JacksonUtils.toJson(beatInfo), unknownEx.getMessage(), unknownEx);
+                if (NAMING_LOGGER.isErrorEnabled()) {
+                    NAMING_LOGGER.error("[CLIENT-BEAT] failed to send beat: {}, unknown exception msg: {}",
+                            JacksonUtils.toJson(beatInfo), unknownEx.getMessage(), unknownEx);
+                }
             } finally {
                 executorService.schedule(new BeatTask(beatInfo), nextTime, TimeUnit.MILLISECONDS);
             }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
@@ -166,8 +166,10 @@ public class ServiceInfoHolder implements Closeable {
         }
         MetricsMonitor.getServiceInfoMapSizeMonitor().set(serviceInfoMap.size());
         if (changed) {
-            NAMING_LOGGER.info("current ips:({}) service: {} -> {}", serviceInfo.ipCount(), serviceInfo.getKey(),
-                    JacksonUtils.toJson(serviceInfo.getHosts()));
+            if (NAMING_LOGGER.isInfoEnabled()) {
+                NAMING_LOGGER.info("current ips:({}) service: {} -> {}", serviceInfo.ipCount(), serviceInfo.getKey(),
+                        JacksonUtils.toJson(serviceInfo.getHosts()));
+            }
             NotifyCenter.publishEvent(new InstancesChangeEvent(notifierEventScope, serviceInfo.getName(), serviceInfo.getGroupName(),
                     serviceInfo.getClusters(), serviceInfo.getHosts()));
             DiskCache.write(serviceInfo, cacheDir);
@@ -181,8 +183,10 @@ public class ServiceInfoHolder implements Closeable {
     
     private boolean isChangedServiceInfo(ServiceInfo oldService, ServiceInfo newService) {
         if (null == oldService) {
-            NAMING_LOGGER.info("init new ips({}) service: {} -> {}", newService.ipCount(), newService.getKey(),
-                    JacksonUtils.toJson(newService.getHosts()));
+            if (NAMING_LOGGER.isInfoEnabled()) {
+                NAMING_LOGGER.info("init new ips({}) service: {} -> {}", newService.ipCount(), newService.getKey(),
+                        JacksonUtils.toJson(newService.getHosts()));
+            }
             return true;
         }
         if (oldService.getLastRefTime() > newService.getLastRefTime()) {
@@ -234,20 +238,26 @@ public class ServiceInfoHolder implements Closeable {
         
         if (newHosts.size() > 0) {
             changed = true;
-            NAMING_LOGGER.info("new ips({}) service: {} -> {}", newHosts.size(), newService.getKey(),
-                    JacksonUtils.toJson(newHosts));
+            if (NAMING_LOGGER.isInfoEnabled()) {
+                NAMING_LOGGER.info("new ips({}) service: {} -> {}", newHosts.size(), newService.getKey(),
+                        JacksonUtils.toJson(newHosts));
+            }
         }
         
         if (remvHosts.size() > 0) {
             changed = true;
-            NAMING_LOGGER.info("removed ips({}) service: {} -> {}", remvHosts.size(), newService.getKey(),
-                    JacksonUtils.toJson(remvHosts));
+            if (NAMING_LOGGER.isInfoEnabled()) {
+                NAMING_LOGGER.info("removed ips({}) service: {} -> {}", remvHosts.size(), newService.getKey(),
+                        JacksonUtils.toJson(remvHosts));
+            }
         }
         
         if (modHosts.size() > 0) {
             changed = true;
-            NAMING_LOGGER.info("modified ips({}) service: {} -> {}", modHosts.size(), newService.getKey(),
-                    JacksonUtils.toJson(modHosts));
+            if (NAMING_LOGGER.isInfoEnabled()) {
+                NAMING_LOGGER.info("modified ips({}) service: {} -> {}", modHosts.size(), newService.getKey(),
+                        JacksonUtils.toJson(modHosts));
+            }
         }
         return changed;
     }

--- a/cmdb/src/main/java/com/alibaba/nacos/cmdb/memory/CmdbProvider.java
+++ b/cmdb/src/main/java/com/alibaba/nacos/cmdb/memory/CmdbProvider.java
@@ -175,7 +175,7 @@ public class CmdbProvider implements CmdbReader, CmdbWriter {
         @Override
         public void run() {
             
-            Loggers.MAIN.debug("LABEL-TASK {}", "start dump.");
+            Loggers.MAIN.debug("LABEL-TASK start dump.");
             
             if (cmdbService == null) {
                 return;
@@ -187,7 +187,7 @@ public class CmdbProvider implements CmdbReader, CmdbWriter {
                 
                 Set<String> labelNames = cmdbService.getLabelNames();
                 if (labelNames == null || labelNames.isEmpty()) {
-                    Loggers.MAIN.warn("CMDB-LABEL-TASK {}", "load label names failed!");
+                    Loggers.MAIN.warn("CMDB-LABEL-TASK load label names failed!");
                 } else {
                     for (String labelName : labelNames) {
                         // If get null label, it's still ok. We will try it later when we meet this label:
@@ -195,14 +195,14 @@ public class CmdbProvider implements CmdbReader, CmdbWriter {
                     }
                     
                     if (Loggers.MAIN.isDebugEnabled()) {
-                        Loggers.MAIN.debug("LABEL-TASK {}", "got label map:" + JacksonUtils.toJson(tmpLabelMap));
+                        Loggers.MAIN.debug("LABEL-TASK got label map:{}", JacksonUtils.toJson(tmpLabelMap));
                     }
                     
                     labelMap = tmpLabelMap;
                 }
                 
             } catch (Exception e) {
-                Loggers.MAIN.error("CMDB-LABEL-TASK {}", "dump failed!", e);
+                Loggers.MAIN.error("CMDB-LABEL-TASK dump failed!", e);
             } finally {
                 CmdbExecutor.scheduleCmdbTask(this, switches.getLabelTaskInterval(), TimeUnit.SECONDS);
             }
@@ -216,7 +216,7 @@ public class CmdbProvider implements CmdbReader, CmdbWriter {
             
             try {
                 
-                Loggers.MAIN.debug("DUMP-TASK {}", "start dump.");
+                Loggers.MAIN.debug("DUMP-TASK start dump.");
                 
                 if (cmdbService == null) {
                     return;
@@ -224,7 +224,7 @@ public class CmdbProvider implements CmdbReader, CmdbWriter {
                 // refresh entity map:
                 entityMap = cmdbService.getAllEntities();
             } catch (Exception e) {
-                Loggers.MAIN.error("DUMP-TASK {}", "dump failed!", e);
+                Loggers.MAIN.error("DUMP-TASK dump failed!", e);
             } finally {
                 CmdbExecutor.scheduleCmdbTask(this, switches.getDumpTaskInterval(), TimeUnit.SECONDS);
             }
@@ -237,7 +237,7 @@ public class CmdbProvider implements CmdbReader, CmdbWriter {
         public void run() {
             try {
                 
-                Loggers.MAIN.debug("EVENT-TASK {}", "start dump.");
+                Loggers.MAIN.debug("EVENT-TASK start dump.");
                 
                 if (cmdbService == null) {
                     return;
@@ -248,7 +248,8 @@ public class CmdbProvider implements CmdbReader, CmdbWriter {
                 eventTimestamp = current;
                 
                 if (Loggers.MAIN.isDebugEnabled()) {
-                    Loggers.MAIN.debug("EVENT-TASK {}", "got events size:" + ", events:" + JacksonUtils.toJson(events));
+                    Loggers.MAIN.debug("EVENT-TASK got events size:{}, events:{}", events.size(),
+                            JacksonUtils.toJson(events));
                 }
                 
                 if (events != null && !events.isEmpty()) {
@@ -268,7 +269,7 @@ public class CmdbProvider implements CmdbReader, CmdbWriter {
                 }
                 
             } catch (Exception e) {
-                Loggers.MAIN.error("CMDB-EVENT {}", "event task failed!", e);
+                Loggers.MAIN.error("CMDB-EVENT event task failed!", e);
             } finally {
                 CmdbExecutor.scheduleCmdbTask(this, switches.getEventTaskInterval(), TimeUnit.SECONDS);
             }


### PR DESCRIPTION
When size of ```newHosts``` is huge, it cost some performance even if the log level setted to ERROR.
```
        if (newHosts.size() > 0) {
            changed = true;
            NAMING_LOGGER.info("new ips({}) service: {} -> {}", newHosts.size(), newService.getKey(),
                    JacksonUtils.toJson(newHosts));
        }
```
It is better to add log level judgment like this :
```
        if (newHosts.size() > 0) {
            changed = true;
            if (NAMING_LOGGER.isInfoEnabled()) {
                NAMING_LOGGER.info("new ips({}) service: {} -> {}", newHosts.size(), newService.getKey(),
                        JacksonUtils.toJson(newHosts));
            }
        }
```

So I search some other places and do some changes.