### PR TITLE
Change the length of the id column of the his_config_info table to 20

### DIFF
--- a/distribution/conf/nacos-mysql.sql
+++ b/distribution/conf/nacos-mysql.sql
@@ -142,7 +142,7 @@ CREATE TABLE `group_capacity` (
 /*   表名称 = his_config_info   */
 /******************************************/
 CREATE TABLE `his_config_info` (
-  `id` bigint(64) unsigned NOT NULL,
+  `id` bigint(20) unsigned NOT NULL,
   `nid` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `data_id` varchar(255) NOT NULL,
   `group_id` varchar(128) NOT NULL,


### PR DESCRIPTION
## What is the purpose of the change

The `id` column of the `his_config_info` table with length of 64 makes no sense.

## Brief changelog

Nothing

## Verifying this change

Unnecessary