### PR TITLE
[ISSUE #8696]: Fix both GrpcSdkServer and GrpcClusterServer are always started in standalone mode or cluster mode. 

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcClusterServer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcClusterServer.java
@@ -18,7 +18,6 @@ package com.alibaba.nacos.core.remote.grpc;
 
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.core.utils.GlobalExecutor;
-import org.springframework.stereotype.Service;
 
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -28,7 +27,6 @@ import java.util.concurrent.ThreadPoolExecutor;
  * @author liuzunfei
  * @version $Id: BaseGrpcServer.java, v 0.1 2020年07月13日 3:42 PM liuzunfei Exp $
  */
-@Service
 public class GrpcClusterServer extends BaseGrpcServer {
     
     @Override

--- a/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcSdkServer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcSdkServer.java
@@ -18,7 +18,6 @@ package com.alibaba.nacos.core.remote.grpc;
 
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.core.utils.GlobalExecutor;
-import org.springframework.stereotype.Service;
 
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -28,7 +27,6 @@ import java.util.concurrent.ThreadPoolExecutor;
  * @author liuzunfei
  * @version $Id: BaseGrpcServer.java, v 0.1 2020年07月13日 3:42 PM liuzunfei Exp $
  */
-@Service
 public class GrpcSdkServer extends BaseGrpcServer {
     
     @Override

--- a/naming/src/main/java/com/alibaba/nacos/naming/remote/rpc/server/GrpcServerConfig.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/remote/rpc/server/GrpcServerConfig.java
@@ -1,0 +1,23 @@
+package com.alibaba.nacos.naming.remote.rpc.server;
+
+import com.alibaba.nacos.core.remote.grpc.BaseGrpcServer;
+import com.alibaba.nacos.core.remote.grpc.GrpcClusterServer;
+import com.alibaba.nacos.core.remote.grpc.GrpcSdkServer;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Config for GrpcServer
+ *
+ * @author Jiangnan Jia
+ **/
+@Configuration
+public class GrpcServerConfig {
+
+    @Bean
+    public BaseGrpcServer grpcServer() {
+        return EnvUtil.getStandaloneMode() ? new GrpcSdkServer() : new GrpcClusterServer();
+    }
+
+}


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change
Fix #8696 .   Both GrpcSdkServer and GrpcClusterServer are always started in standalone mode or cluster mode.

## Brief changelog
1、remove @Service on class 
      com.alibaba.nacos.core.remote.grpc.GrpcSdkServer
      com.alibaba.nacos.core.remote.grpc.GrpcClusterServer
2、 add a configuration class 'com.alibaba.nacos.naming.remote.rpc.server.GrpcServerConfig'
--------中文分割线--------
1、移除 com.alibaba.nacos.core.remote.grpc.GrpcSdkServer 和 com.alibaba.nacos.core.remote.grpc.GrpcClusterServer两个类上的 @Service 注解
2、添加一 个spring 的配置类com.alibaba.nacos.naming.remote.rpc.server.GrpcServerConfig，根据启动模式初始化Bean

## Verifying this change
1、if nacos-server was started as standalone mode, grpcClusterServer wouldn't started
2、if nacos-server was started as cluster mode, grpcSdkServer wouldn't started
--------中文分割线--------
1、如果单机模式启动，grpcClusterServer不会被初始化
2、如果集群模式启动，grpcSdkServer不会被初始化
