### PR TITLE
fix: [ISSUE#8699] Fix the problem that the client saves local files w…

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/NacosConfigService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/NacosConfigService.java
@@ -32,6 +32,7 @@ import com.alibaba.nacos.client.config.impl.LocalEncryptedDataKeyProcessor;
 import com.alibaba.nacos.client.config.impl.ServerListManager;
 import com.alibaba.nacos.client.config.utils.ContentUtils;
 import com.alibaba.nacos.client.config.utils.ParamUtils;
+import com.alibaba.nacos.client.constant.ServerAddressConstant;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.client.utils.ParamUtil;
 import com.alibaba.nacos.client.utils.ValidatorUtils;
@@ -72,7 +73,9 @@ public class NacosConfigService implements ConfigService {
     
     public NacosConfigService(Properties properties) throws NacosException {
         ValidatorUtils.checkInitParam(properties);
-        
+
+        ServerAddressConstant.setServerAddress(properties.getProperty(PropertyKeyConst.SERVER_ADDR));
+
         initNamespace(properties);
         this.configFilterChainManager = new ConfigFilterChainManager(properties);
         ServerListManager serverListManager = new ServerListManager(properties);

--- a/client/src/main/java/com/alibaba/nacos/client/constant/ServerAddressConstant.java
+++ b/client/src/main/java/com/alibaba/nacos/client/constant/ServerAddressConstant.java
@@ -1,0 +1,14 @@
+package com.alibaba.nacos.client.constant;
+
+/**
+ * @author HuHan
+ * @date 2022/8/1 18:22
+ */
+public class ServerAddressConstant {
+
+    public static String serverAddress;
+
+    public static void setServerAddress(String serverAddress) {
+        ServerAddressConstant.serverAddress = serverAddress;
+    }
+}

--- a/client/src/main/java/com/alibaba/nacos/client/utils/MultipleServerDirMap.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/MultipleServerDirMap.java
@@ -1,0 +1,87 @@
+package com.alibaba.nacos.client.utils;
+
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * @author ggggg
+ */
+
+public class MultipleServerDirMap {
+
+    public static final Logger LOGGER = LogUtils.logger(EnvUtil.class);
+
+    private static final String DEFAULT_SERVER = "localhost:8888";
+
+    private static final String SERVER_DIR_MAP = "serverDirMap";
+
+    private static final String SERVER_ADDRESS_DELIMITER = ",";
+
+    public static String convertBaseDir(String prefix, String serverAddress) {
+        assert !StringUtils.isBlank(prefix) : "the prefix of the baseAddress can not be empty";
+        if (StringUtils.isBlank(serverAddress)) {
+            serverAddress = DEFAULT_SERVER;
+        }
+        File mapFile = new File(prefix + File.separator + SERVER_DIR_MAP);
+        List<String> addressList = formattedAddress(serverAddress);
+        Map<String, String> keyMap = readCacheKey(mapFile);
+        String key = null;
+        for (String add : addressList) {
+            key = keyMap.get(add);
+            if (!StringUtils.isBlank(key)) {
+                break;
+            }
+        }
+        key = initKey(addressList, keyMap, key);
+        try {
+            FileUtils.write(mapFile, JacksonUtils.toJson(keyMap), StandardCharsets.UTF_8, false);
+        } catch (IOException e) {
+            LOGGER.error("write address map key file fail", e);
+        }
+        return prefix + File.separator + key;
+
+    }
+
+    private static String initKey(List<String> addressList, Map<String, String> map,
+                                  String defaultKey) {
+        String key = defaultKey == null ? MD5Utils.encodeHexString(addressList.get(0).getBytes()) : defaultKey;
+        for (String add : addressList) {
+            map.put(add, key);
+        }
+        return key;
+    }
+
+    private static List<String> formattedAddress(String serverAddress) {
+        String[] addressStrArr = serverAddress.split(SERVER_ADDRESS_DELIMITER);
+        ArrayList<String> results = new ArrayList<>();
+        for (String address : addressStrArr) {
+            if (!StringUtils.isBlank(address)) {
+                results.add(address.replace(":", "_"));
+            }
+        }
+        Collections.sort(results);
+        return results;
+    }
+
+    private static Map<String, String> readCacheKey(File mapFile) {
+        HashMap<String, String> map = new HashMap<>();
+        if (mapFile.exists()) {
+            try {
+                String context = FileUtils.readFileToString(mapFile, StandardCharsets.UTF_8);
+                map = JacksonUtils.toObj(context, HashMap.class);
+            } catch (IOException e) {
+                LOGGER.error("read address map key file fail", e);
+            }
+        }
+        return map;
+    }
+
+}

--- a/client/src/test/java/com/alibaba/nacos/client/utils/MultipleServerDirMapTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/MultipleServerDirMapTest.java
@@ -1,0 +1,27 @@
+package com.alibaba.nacos.client.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * @author HuHan
+ * @date 2022/8/1 17:04
+ */
+public class MultipleServerDirMapTest {
+
+    @Test
+    public void testBaseDir() {
+        String basePath = System.getProperty("user.home") + File.separator + "nacos";
+        String key1 = MultipleServerDirMap.convertBaseDir(basePath, "localhost:2215,127.25.36.52:2254");
+        String key2 = MultipleServerDirMap.convertBaseDir(basePath, "127.0.0.1:2215,127.25.36.52:2254");
+        String key3 = MultipleServerDirMap.convertBaseDir(basePath, "127.25.36.52:2254");
+        String key4 = MultipleServerDirMap.convertBaseDir(basePath, "127.25.146.52:225");
+        String key5 = MultipleServerDirMap.convertBaseDir(basePath, "127.25.146.52:225,120.36.25.12:2253");
+        Assert.assertTrue(key1.equals(key2));
+        Assert.assertTrue(key3.equals(key2));
+        Assert.assertFalse(key1.equals(key4));
+        Assert.assertTrue(key4.equals(key5));
+    }
+}


### PR DESCRIPTION
…ithout partitions

客户端在保存配置和服务实例信息到本地的时候,单纯的放在
user.home/nacos文件夹下,没有考虑如果本地有两类服务.连的是不同的nacos服务端,会导致读取到脏数据的问题.

Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

For #8699 nacos-client ServiceInfoHolder cache serviceInfo bug

## Brief changelog

Added some formatting class and initialization paths methods

## Verifying this change

Added some formatting class and initialization paths methods

Follow this checklist to help us incorporate your contribution quickly and easily:

* [√ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [√ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [√ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [√ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [√ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

