### PR TITLE
[ISSUE#8699] Fix the problem that the client saves local files w…

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/NacosConfigService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/NacosConfigService.java
@@ -32,6 +32,7 @@ import com.alibaba.nacos.client.config.impl.LocalEncryptedDataKeyProcessor;
 import com.alibaba.nacos.client.config.impl.ServerListManager;
 import com.alibaba.nacos.client.config.utils.ContentUtils;
 import com.alibaba.nacos.client.config.utils.ParamUtils;
+import com.alibaba.nacos.client.constant.ServerAddressConstant;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.client.utils.ParamUtil;
 import com.alibaba.nacos.client.utils.ValidatorUtils;
@@ -72,7 +73,9 @@ public class NacosConfigService implements ConfigService {
     
     public NacosConfigService(Properties properties) throws NacosException {
         ValidatorUtils.checkInitParam(properties);
-        
+
+        ServerAddressConstant.setServerAddress(properties.getProperty(PropertyKeyConst.SERVER_ADDR));
+
         initNamespace(properties);
         this.configFilterChainManager = new ConfigFilterChainManager(properties);
         ServerListManager serverListManager = new ServerListManager(properties);

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/LocalConfigInfoProcessor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/LocalConfigInfoProcessor.java
@@ -20,7 +20,9 @@ import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.client.config.utils.ConcurrentDiskUtil;
 import com.alibaba.nacos.client.config.utils.JvmUtil;
 import com.alibaba.nacos.client.config.utils.SnapShotSwitch;
+import com.alibaba.nacos.client.constant.ServerAddressConstant;
 import com.alibaba.nacos.client.utils.LogUtils;
+import com.alibaba.nacos.client.utils.MultipleServerDirMap;
 import com.alibaba.nacos.common.utils.IoUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import org.slf4j.Logger;
@@ -36,43 +38,47 @@ import java.io.InputStream;
  * @author Nacos
  */
 public class LocalConfigInfoProcessor {
-    
+
     private static final Logger LOGGER = LogUtils.logger(LocalConfigInfoProcessor.class);
-    
+
     public static final String LOCAL_FILEROOT_PATH;
-    
+
     public static final String LOCAL_SNAPSHOT_PATH;
-    
+
     private static final String SUFFIX = "_nacos";
-    
+
     private static final String ENV_CHILD = "snapshot";
-    
+
     private static final String FAILOVER_FILE_CHILD_1 = "data";
-    
+
     private static final String FAILOVER_FILE_CHILD_2 = "config-data";
-    
+
     private static final String FAILOVER_FILE_CHILD_3 = "config-data-tenant";
-    
+
     private static final String SNAPSHOT_FILE_CHILD_1 = "snapshot";
-    
+
     private static final String SNAPSHOT_FILE_CHILD_2 = "snapshot-tenant";
-    
+
     static {
-        LOCAL_FILEROOT_PATH =
+        String baseDir = MultipleServerDirMap.convertBaseDir(
                 System.getProperty("JM.LOG.PATH", System.getProperty("user.home")) + File.separator + "nacos"
-                        + File.separator + "config";
-        LOCAL_SNAPSHOT_PATH =
-                System.getProperty("JM.SNAPSHOT.PATH", System.getProperty("user.home")) + File.separator + "nacos"
-                        + File.separator + "config";
+                , ServerAddressConstant.getServerAddress());
+        LOCAL_FILEROOT_PATH = baseDir + File.separator + "config";
+        LOCAL_SNAPSHOT_PATH = baseDir + File.separator + "config";
         LOGGER.info("LOCAL_SNAPSHOT_PATH:{}", LOCAL_SNAPSHOT_PATH);
     }
-    
+
+    public static void setServerAddress(String serverAddress) {
+
+        LOGGER.info("LOCAL_SNAPSHOT_PATH map to:{}", LOCAL_SNAPSHOT_PATH);
+    }
+
     public static String getFailover(String serverName, String dataId, String group, String tenant) {
         File localPath = getFailoverFile(serverName, dataId, group, tenant);
         if (!localPath.exists() || !localPath.isFile()) {
             return null;
         }
-        
+
         try {
             return readFile(localPath);
         } catch (IOException ioe) {
@@ -80,7 +86,7 @@ public class LocalConfigInfoProcessor {
             return null;
         }
     }
-    
+
     /**
      * get snapshot file content. NULL means no local file or throw exception.
      */
@@ -92,7 +98,7 @@ public class LocalConfigInfoProcessor {
         if (!file.exists() || !file.isFile()) {
             return null;
         }
-        
+
         try {
             return readFile(file);
         } catch (IOException ioe) {
@@ -100,12 +106,12 @@ public class LocalConfigInfoProcessor {
             return null;
         }
     }
-    
+
     protected static String readFile(File file) throws IOException {
         if (!file.exists() || !file.isFile()) {
             return null;
         }
-        
+
         if (JvmUtil.isMultiInstance()) {
             return ConcurrentDiskUtil.getFileContent(file, Constants.ENCODE);
         } else {
@@ -114,7 +120,7 @@ public class LocalConfigInfoProcessor {
             }
         }
     }
-    
+
     /**
      * Save snapshot.
      *
@@ -144,7 +150,7 @@ public class LocalConfigInfoProcessor {
                         LOGGER.error("[{}] save snapshot error", envName);
                     }
                 }
-                
+
                 if (JvmUtil.isMultiInstance()) {
                     ConcurrentDiskUtil.writeFileContent(file, config, Constants.ENCODE);
                 } else {
@@ -155,7 +161,7 @@ public class LocalConfigInfoProcessor {
             }
         }
     }
-    
+
     /**
      * clear the cache files under snapshot directory.
      */
@@ -175,7 +181,7 @@ public class LocalConfigInfoProcessor {
             LOGGER.error("clean all snapshot error, " + ioe.toString(), ioe);
         }
     }
-    
+
     /**
      * Clean snapshot.
      *
@@ -191,7 +197,7 @@ public class LocalConfigInfoProcessor {
             LOGGER.warn("fail delete {}-snapshot, exception: ", envName, e);
         }
     }
-    
+
     static File getFailoverFile(String serverName, String dataId, String group, String tenant) {
         File tmp = new File(LOCAL_SNAPSHOT_PATH, serverName + SUFFIX);
         tmp = new File(tmp, FAILOVER_FILE_CHILD_1);
@@ -203,7 +209,7 @@ public class LocalConfigInfoProcessor {
         }
         return new File(new File(tmp, group), dataId);
     }
-    
+
     static File getSnapshotFile(String envName, String dataId, String group, String tenant) {
         File tmp = new File(LOCAL_SNAPSHOT_PATH, envName + SUFFIX);
         if (StringUtils.isBlank(tenant)) {
@@ -212,7 +218,7 @@ public class LocalConfigInfoProcessor {
             tmp = new File(tmp, SNAPSHOT_FILE_CHILD_2);
             tmp = new File(tmp, tenant);
         }
-        
+
         return new File(new File(tmp, group), dataId);
     }
 }

--- a/client/src/main/java/com/alibaba/nacos/client/constant/ServerAddressConstant.java
+++ b/client/src/main/java/com/alibaba/nacos/client/constant/ServerAddressConstant.java
@@ -1,0 +1,18 @@
+package com.alibaba.nacos.client.constant;
+
+/**
+ * @author HuHan
+ * @date 2022/8/1 18:22
+ */
+public class ServerAddressConstant {
+
+    private static String serverAddress;
+
+    public static String getServerAddress() {
+        return serverAddress;
+    }
+
+    public static void setServerAddress(String serverAddress) {
+        ServerAddressConstant.serverAddress = serverAddress;
+    }
+}

--- a/client/src/main/java/com/alibaba/nacos/client/naming/backups/FailoverReactor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/backups/FailoverReactor.java
@@ -253,7 +253,8 @@ public class FailoverReactor implements Closeable {
         
         @Override
         public void run() {
-            Map<String, ServiceInfo> map = serviceInfoHolder.getServiceInfoMap();
+            // Filter old dirty data
+            Map<String, ServiceInfo> map = serviceInfoHolder.readCache();
             for (Map.Entry<String, ServiceInfo> entry : map.entrySet()) {
                 ServiceInfo serviceInfo = entry.getValue();
                 if (StringUtils.equals(serviceInfo.getKey(), UtilAndComs.ALL_IPS) || StringUtils

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.ConvertUtils;
 import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.MapUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 import java.io.File;
@@ -44,29 +45,27 @@ import static com.alibaba.nacos.client.utils.LogUtils.NAMING_LOGGER;
  * @author xiweng.yy
  */
 public class ServiceInfoHolder implements Closeable {
-    
     private static final String JM_SNAPSHOT_PATH_PROPERTY = "JM.SNAPSHOT.PATH";
-    
     private static final String FILE_PATH_NACOS = "nacos";
-    
     private static final String FILE_PATH_NAMING = "naming";
-    
     private static final String USER_HOME_PROPERTY = "user.home";
-    
     private final ConcurrentMap<String, ServiceInfo> serviceInfoMap;
-    
     private final FailoverReactor failoverReactor;
-    
     private final boolean pushEmptyProtection;
-    
     private String cacheDir;
-    
+    @Deprecated
+    private String oldCacheDir;
     private String notifierEventScope;
 
     public ServiceInfoHolder(String namespace, String notifierEventScope, Properties properties) {
         initCacheDir(namespace, properties);
         if (isLoadCacheAtStart(properties)) {
-            this.serviceInfoMap = new ConcurrentHashMap<>(DiskCache.read(this.cacheDir));
+            Map<String, ServiceInfo> read = readCache();
+            // Compatible processing
+            if (MapUtil.isEmpty(read)) {
+                read = readOldCache();
+            }
+            this.serviceInfoMap = new ConcurrentHashMap<>(read);
         } else {
             this.serviceInfoMap = new ConcurrentHashMap<>(16);
         }
@@ -74,10 +73,21 @@ public class ServiceInfoHolder implements Closeable {
         this.pushEmptyProtection = isPushEmptyProtect(properties);
         this.notifierEventScope = notifierEventScope;
     }
-    
+    public Map<String, ServiceInfo> readCache() {
+        return DiskCache.read(this.cacheDir);
+    }
+
+    /**
+     * For compatibility with older versions
+     * @return
+     */
+    @Deprecated
+    private Map<String, ServiceInfo> readOldCache() {
+        return DiskCache.read(this.oldCacheDir);
+    }
     private void initCacheDir(String namespace, Properties properties) {
         String jmSnapshotPath = System.getProperty(JM_SNAPSHOT_PATH_PROPERTY);
-    
+
         String namingCacheRegistryDir = "";
         if (properties.getProperty(PropertyKeyConst.NAMING_CACHE_REGISTRY_DIR) != null) {
             namingCacheRegistryDir = File.separator + properties.getProperty(PropertyKeyConst.NAMING_CACHE_REGISTRY_DIR);
@@ -93,7 +103,6 @@ public class ServiceInfoHolder implements Closeable {
         cacheDir = MultipleServerDirMap.convertBaseDir(prefix, properties.getProperty(PropertyKeyConst.SERVER_ADDR))
                 + suffix;
     }
-    
     private boolean isLoadCacheAtStart(Properties properties) {
         boolean loadCacheAtStart = false;
         if (properties != null && StringUtils
@@ -103,7 +112,6 @@ public class ServiceInfoHolder implements Closeable {
         }
         return loadCacheAtStart;
     }
-    
     private boolean isPushEmptyProtect(Properties properties) {
         boolean pushEmptyProtection = false;
         if (properties != null && StringUtils
@@ -113,11 +121,9 @@ public class ServiceInfoHolder implements Closeable {
         }
         return pushEmptyProtection;
     }
-    
     public Map<String, ServiceInfo> getServiceInfoMap() {
         return serviceInfoMap;
     }
-    
     public ServiceInfo getServiceInfo(final String serviceName, final String groupName, final String clusters) {
         NAMING_LOGGER.debug("failover-mode: {}", failoverReactor.isFailoverSwitch());
         String groupedServiceName = NamingUtils.getGroupedName(serviceName, groupName);
@@ -127,7 +133,6 @@ public class ServiceInfoHolder implements Closeable {
         }
         return serviceInfoMap.get(key);
     }
-    
     /**
      * Process service json.
      *
@@ -139,7 +144,6 @@ public class ServiceInfoHolder implements Closeable {
         serviceInfo.setJsonFromServer(json);
         return processServiceInfo(serviceInfo);
     }
-    
     /**
      * Process service info.
      *
@@ -171,11 +175,9 @@ public class ServiceInfoHolder implements Closeable {
         }
         return serviceInfo;
     }
-    
     private boolean isEmptyOrErrorPush(ServiceInfo serviceInfo) {
         return null == serviceInfo.getHosts() || (pushEmptyProtection && !serviceInfo.validate());
     }
-    
     private boolean isChangedServiceInfo(ServiceInfo oldService, ServiceInfo newService) {
         if (null == oldService) {
             NAMING_LOGGER.info("init new ips({}) service: {} -> {}", newService.ipCount(), newService.getKey(),
@@ -196,7 +198,6 @@ public class ServiceInfoHolder implements Closeable {
         for (Instance host : newService.getHosts()) {
             newHostMap.put(host.toInetAddr(), host);
         }
-        
         Set<Instance> modHosts = new HashSet<>();
         Set<Instance> newHosts = new HashSet<>();
         Set<Instance> remvHosts = new HashSet<>();
@@ -210,12 +211,10 @@ public class ServiceInfoHolder implements Closeable {
                 modHosts.add(host);
                 continue;
             }
-            
             if (!oldHostMap.containsKey(key)) {
                 newHosts.add(host);
             }
         }
-        
         for (Map.Entry<String, Instance> entry : oldHostMap.entrySet()) {
             Instance host = entry.getValue();
             String key = entry.getKey();
@@ -226,19 +225,16 @@ public class ServiceInfoHolder implements Closeable {
             //add to remove hosts
             remvHosts.add(host);
         }
-        
         if (newHosts.size() > 0) {
             changed = true;
             NAMING_LOGGER.info("new ips({}) service: {} -> {}", newHosts.size(), newService.getKey(),
                     JacksonUtils.toJson(newHosts));
         }
-        
         if (remvHosts.size() > 0) {
             changed = true;
             NAMING_LOGGER.info("removed ips({}) service: {} -> {}", remvHosts.size(), newService.getKey(),
                     JacksonUtils.toJson(remvHosts));
         }
-        
         if (modHosts.size() > 0) {
             changed = true;
             NAMING_LOGGER.info("modified ips({}) service: {} -> {}", modHosts.size(), newService.getKey(),
@@ -246,7 +242,6 @@ public class ServiceInfoHolder implements Closeable {
         }
         return changed;
     }
-    
     @Override
     public void shutdown() throws NacosException {
         String className = this.getClass().getName();

--- a/client/src/main/java/com/alibaba/nacos/client/utils/MultipleServerDirMap.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/MultipleServerDirMap.java
@@ -1,0 +1,87 @@
+package com.alibaba.nacos.client.utils;
+
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * @author ggggg
+ */
+
+public class MultipleServerDirMap {
+
+    public static final Logger LOGGER = LogUtils.logger(EnvUtil.class);
+
+    private static final String DEFAULT_SERVER = "localhost:8888";
+
+    private static final String SERVER_DIR_MAP = "serverDirMap";
+
+    private static final String SERVER_ADDRESS_DELIMITER = ",";
+
+    public static String convertBaseDir(String prefix, String serverAddress) {
+        assert !StringUtils.isBlank(prefix) : "the prefix of the baseAddress can not be empty";
+        if (StringUtils.isBlank(serverAddress)) {
+            serverAddress = DEFAULT_SERVER;
+        }
+        File mapFile = new File(prefix + File.separator + SERVER_DIR_MAP);
+        List<String> addressList = formattedAddress(serverAddress);
+        Map<String, String> keyMap = readCacheKey(mapFile);
+        String key = null;
+        for (String add : addressList) {
+            key = keyMap.get(add);
+            if (!StringUtils.isBlank(key)) {
+                break;
+            }
+        }
+        key = initKey(addressList, keyMap, key);
+        try {
+            FileUtils.write(mapFile, JacksonUtils.toJson(keyMap), StandardCharsets.UTF_8, false);
+        } catch (IOException e) {
+            LOGGER.error("write address map key file fail", e);
+        }
+        return prefix + File.separator + key;
+
+    }
+
+    private static String initKey(List<String> addressList, Map<String, String> map,
+                                  String defaultKey) {
+        String key = defaultKey == null ? MD5Utils.encodeHexString(addressList.get(0).getBytes()) : defaultKey;
+        for (String add : addressList) {
+            map.put(add, key);
+        }
+        return key;
+    }
+
+    private static List<String> formattedAddress(String serverAddress) {
+        String[] addressStrArr = serverAddress.split(SERVER_ADDRESS_DELIMITER);
+        ArrayList<String> results = new ArrayList<>();
+        for (String address : addressStrArr) {
+            if (!StringUtils.isBlank(address)) {
+                results.add(address.replace(":", "_"));
+            }
+        }
+        Collections.sort(results);
+        return results;
+    }
+
+    private static Map<String, String> readCacheKey(File mapFile) {
+        HashMap<String, String> map = new HashMap<>();
+        if (mapFile.exists()) {
+            try {
+                String context = FileUtils.readFileToString(mapFile, StandardCharsets.UTF_8);
+                map = JacksonUtils.toObj(context, HashMap.class);
+            } catch (IOException e) {
+                LOGGER.error("read address map key file fail", e);
+            }
+        }
+        return map;
+    }
+
+}

--- a/client/src/test/java/com/alibaba/nacos/client/utils/MultipleServerDirMapTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/MultipleServerDirMapTest.java
@@ -1,0 +1,27 @@
+package com.alibaba.nacos.client.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * @author HuHan
+ * @date 2022/8/1 17:04
+ */
+public class MultipleServerDirMapTest {
+
+    @Test
+    public void testBaseDir() {
+        String basePath = System.getProperty("user.home") + File.separator + "nacos";
+        String key1 = MultipleServerDirMap.convertBaseDir(basePath, "localhost:2215,127.25.36.52:2254");
+        String key2 = MultipleServerDirMap.convertBaseDir(basePath, "127.0.0.1:2215,127.25.36.52:2254");
+        String key3 = MultipleServerDirMap.convertBaseDir(basePath, "127.25.36.52:2254");
+        String key4 = MultipleServerDirMap.convertBaseDir(basePath, "127.25.146.52:225");
+        String key5 = MultipleServerDirMap.convertBaseDir(basePath, "127.25.146.52:225,120.36.25.12:2253");
+        Assert.assertTrue(key1.equals(key2));
+        Assert.assertTrue(key3.equals(key2));
+        Assert.assertFalse(key1.equals(key4));
+        Assert.assertTrue(key4.equals(key5));
+    }
+}


### PR DESCRIPTION
…ithout partitions

客户端在保存配置和服务实例信息到本地的时候,单纯的放在
user.home/nacos文件夹下,没有考虑如果本地有两类服务.连的是不同的nacos服务端,会导致读取到脏数据的问题.

Please do not create a Pull Request without creating an issue first.

What is the purpose of the change
For https://github.com/alibaba/nacos/issues/8699 nacos-client ServiceInfoHolder cache serviceInfo bug

Brief changelog
Added some formatting class and initialization paths methods

Verifying this change
Added some formatting class and initialization paths methods

Follow this checklist to help us incorporate your contribution quickly and easily:

[√ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
[√ ] Format the pull request title like [ISSUE #123] Fix UnknownException when host config not exist. Each commit in the pull request should have a meaningful subject line and body.
[√ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
[√ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
[√ ] Run mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true to make sure basic checks pass. Run mvn clean install -DskipITs to make sure unit-test pass. Run mvn clean test-compile failsafe:integration-test to make sure integration-test pass.