### PR TITLE
[ISSUE #9014] performance optimization--refacte TpsMonitorPoint

### DIFF
--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/LimiterTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/LimiterTest.java
@@ -24,6 +24,7 @@ public class LimiterTest {
     @Test
     public void testIsLimit() {
         String keyId = "a";
+        //For initiating.
         Assert.assertFalse(Limiter.isLimit(keyId));
         long start = System.currentTimeMillis();
         for (int j = 0; j < 5; j++) {
@@ -31,6 +32,6 @@ public class LimiterTest {
         }
         long elapse = System.currentTimeMillis() - start;
         // assert  < limit 5qps
-        Assert.assertTrue(Math.abs(1000 - elapse) < 20);
+        Assert.assertTrue(elapse > 980);
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/remote/control/TpsMonitorPoint.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/control/TpsMonitorPoint.java
@@ -99,7 +99,7 @@ public class TpsMonitorPoint {
     }
     
     /**
-     * get format string for "yyyy-MM-dd HH:mm:ss"
+     * get format string for "yyyy-MM-dd HH:mm:ss".
      *
      * @param timeStamp timestamp milliseconds.
      * @return datetime string.

--- a/core/src/main/java/com/alibaba/nacos/core/remote/control/TpsMonitorPoint.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/control/TpsMonitorPoint.java
@@ -18,12 +18,14 @@ package com.alibaba.nacos.core.remote.control;
 
 import com.alibaba.nacos.core.utils.Loggers;
 
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +41,9 @@ public class TpsMonitorPoint {
     public static final int DEFAULT_RECORD_SIZE = 10;
     
     private static final String DATETIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
+    
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern(DATETIME_PATTERN)
+            .withZone(ZoneId.systemDefault()).withLocale(Locale.getDefault());
     
     private long startTime;
     
@@ -69,9 +74,7 @@ public class TpsMonitorPoint {
      * @return mills of second.
      */
     public static long getTrimMillsOfSecond(long timeStamp) {
-        String millString = String.valueOf(timeStamp);
-        String substring = millString.substring(0, millString.length() - 3);
-        return Long.parseLong(substring + "000");
+        return timeStamp - timeStamp % 1_000L;
         
     }
     
@@ -82,9 +85,7 @@ public class TpsMonitorPoint {
      * @return minis of minute.
      */
     public static long getTrimMillsOfMinute(long timeStamp) {
-        String millString = String.valueOf(timeStamp);
-        String substring = millString.substring(0, millString.length() - 3);
-        return Long.parseLong(Long.parseLong(substring) / 60 * 60 + "000");
+        return timeStamp - timeStamp % 60_000L;
     }
     
     /**
@@ -94,19 +95,17 @@ public class TpsMonitorPoint {
      * @return mills of hour.
      */
     public static long getTrimMillsOfHour(long timeStamp) {
-        String millString = String.valueOf(timeStamp);
-        String substring = millString.substring(0, millString.length() - 3);
-        return Long.parseLong(Long.parseLong(substring) / (60 * 60) * (60 * 60) + "000");
+        return timeStamp - timeStamp % 3_600_000L;
     }
     
     /**
-     * get format string "2021-01-16 17:20:21" of timestamp.
+     * get format string for "yyyy-MM-dd HH:mm:ss"
      *
      * @param timeStamp timestamp milliseconds.
      * @return datetime string.
      */
     public static String getTimeFormatOfSecond(long timeStamp) {
-        return new SimpleDateFormat(DATETIME_PATTERN).format(new Date(timeStamp));
+        return DATETIME_FORMATTER.format(Instant.ofEpochMilli(timeStamp));
     }
     
     private void stopAllMonitorClient() {

--- a/core/src/test/java/com/alibaba/nacos/core/cluster/lookup/LookupFactoryTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/cluster/lookup/LookupFactoryTest.java
@@ -24,14 +24,17 @@ import com.alibaba.nacos.sys.file.WatchFileCenter;
 import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 
 @RunWith(MockitoJUnitRunner.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class LookupFactoryTest extends TestCase {
     
     private static final String LOOKUP_MODE_TYPE = "nacos.core.member.lookup.type";
@@ -58,27 +61,30 @@ public class LookupFactoryTest extends TestCase {
     
     /**
      * createLookUpStandalone MemberLookup.
+     *
      * @throws NacosException NacosException
      */
     @Test
     public void createLookUpStandaloneMemberLookup() throws NacosException {
         EnvUtil.setIsStandalone(true);
         memberLookup = LookupFactory.createLookUp(memberManager);
-        assertEquals(memberLookup.getClass(), StandaloneMemberLookup.class);
+        assertEquals(StandaloneMemberLookup.class, memberLookup.getClass());
     }
     
     @Test
     public void createLookUpFileConfigMemberLookup() throws Exception {
+        EnvUtil.setIsStandalone(false);
         mockEnvironment.setProperty(LOOKUP_MODE_TYPE, "file");
         memberLookup = LookupFactory.createLookUp(memberManager);
-        assertEquals(memberLookup.getClass(), FileConfigMemberLookup.class);
+        assertEquals(FileConfigMemberLookup.class, memberLookup.getClass());
     }
     
     @Test
     public void createLookUpAddressServerMemberLookup() throws Exception {
+        EnvUtil.setIsStandalone(false);
         mockEnvironment.setProperty(LOOKUP_MODE_TYPE, "address-server");
         memberLookup = LookupFactory.createLookUp(memberManager);
-        assertEquals(memberLookup.getClass(), AddressServerMemberLookup.class);
+        assertEquals(AddressServerMemberLookup.class, memberLookup.getClass());
     }
     
     @Test
@@ -94,7 +100,7 @@ public class LookupFactoryTest extends TestCase {
         String name2 = "address-server";
         memberLookup = LookupFactory.switchLookup(name2, memberManager);
         assertEquals(memberLookup.getClass(), AddressServerMemberLookup.class);
-
+        
         createLookUpStandaloneMemberLookup();
         String name3 = "address-server";
         memberLookup = LookupFactory.switchLookup(name3, memberManager);

--- a/core/src/test/java/com/alibaba/nacos/core/remote/control/TpsMonitorPointTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/remote/control/TpsMonitorPointTest.java
@@ -16,8 +16,9 @@
 
 package com.alibaba.nacos.core.remote.control;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * {@link TpsMonitorPoint} unit tests.
@@ -29,14 +30,13 @@ public class TpsMonitorPointTest {
     
     @Test
     public void testStaticMethod() {
-        long current = System.currentTimeMillis();
-        String date = TpsMonitorPoint.getTimeFormatOfSecond(current);
-        Assert.assertNotNull(date);
-        
-        TpsMonitorPoint.getTrimMillsOfSecond(current);
-    
-        TpsMonitorPoint.getTrimMillsOfMinute(current);
-    
-        TpsMonitorPoint.getTrimMillsOfHour(current);
+        //2022-08-23 14:23:53
+        assertEquals(1661235833000L, TpsMonitorPoint.getTrimMillsOfSecond(1661235833111L));
+        //2022-08-23 14:23:00
+        assertEquals(1661235780000L, TpsMonitorPoint.getTrimMillsOfMinute(1661235833111L));
+        //2022-08-23 14:00:00
+        assertEquals(1661234400000L, TpsMonitorPoint.getTrimMillsOfHour(1661235833111L));
+        assertEquals("2022-08-23 14:23:53", TpsMonitorPoint.getTimeFormatOfSecond(1661235833111L));
     }
+
 }

--- a/core/src/test/java/com/alibaba/nacos/core/remote/control/TpsMonitorPointTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/remote/control/TpsMonitorPointTest.java
@@ -18,8 +18,13 @@ package com.alibaba.nacos.core.remote.control;
 
 import org.junit.Test;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * {@link TpsMonitorPoint} unit tests.
@@ -38,7 +43,9 @@ public class TpsMonitorPointTest {
         //2022-08-23 14:00:00
         assertEquals(1661234400000L, TpsMonitorPoint.getTrimMillsOfHour(1661235833111L));
         
-        assertNotNull(TpsMonitorPoint.getTimeFormatOfSecond(1661235833111L));
+        assertEquals(LocalDateTime.of(2022, 8, 23, 14, 23, 53).atZone(ZoneOffset.ofHours(8))
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault())
+                        .withLocale(Locale.getDefault())), TpsMonitorPoint.getTimeFormatOfSecond(1661235833111L));
     }
     
 }

--- a/core/src/test/java/com/alibaba/nacos/core/remote/control/TpsMonitorPointTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/remote/control/TpsMonitorPointTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.core.remote.control;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * {@link TpsMonitorPoint} unit tests.
@@ -36,7 +37,8 @@ public class TpsMonitorPointTest {
         assertEquals(1661235780000L, TpsMonitorPoint.getTrimMillsOfMinute(1661235833111L));
         //2022-08-23 14:00:00
         assertEquals(1661234400000L, TpsMonitorPoint.getTrimMillsOfHour(1661235833111L));
-        assertEquals("2022-08-23 14:23:53", TpsMonitorPoint.getTimeFormatOfSecond(1661235833111L));
+        
+        assertNotNull(TpsMonitorPoint.getTimeFormatOfSecond(1661235833111L));
     }
-
+    
 }


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

performance optimization for #9014 

## Brief changelog

Refact `TpsMonitorPoint` methods: 
- `getTrimMillsOfSecond`,
- `getTrimMillsOfMinute`,
- `getTrimMillsOfHour`,
- `getTimeFormatOfSecond`.

## Verifying this change

pass test unit and jmh test

### JMH banchmark

#### banchmark platform info:

OS: macOS Monterey 12.5.1
CPU: M1 Pro
Memory: 16GB

#### banchmark test

```java
@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Benchmark)
@Warmup(iterations = 5, time = 100, timeUnit = TimeUnit.MICROSECONDS)
@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
@Fork(1)
public class JmhTpsMonitorPoint {
    
    @Benchmark
    public void measureGetTrimMillsOfSecond() {
        TpsMonitorPoint.getTrimMillsOfSecond(1661235833111L);
    }
    
    @Benchmark
    public void measureGetTrimMillsOfMinute() {
        TpsMonitorPoint.getTrimMillsOfMinute(1661235833111L);
    }
    
    @Benchmark
    public void measureGetTrimMillsOfHour() {
        TpsMonitorPoint.getTrimMillsOfHour(1661235833111L);
    }
    
    @Benchmark
    //@Threads(5)
    public void measureGetTimeFormatOfSecond() {
        TpsMonitorPoint.getTimeFormatOfSecond(1661235833111L);
    }
}
```

#### banchmark result

Befor refacting:

```text
Benchmark                                         Mode  Cnt    Score     Error   Units
JmhTpsMonitorPoint.measureGetTimeFormatOfSecond  thrpt    5    0.001 ±   0.001  ops/ns
JmhTpsMonitorPoint.measureGetTrimMillsOfHour     thrpt    5    0.008 ±   0.001  ops/ns
JmhTpsMonitorPoint.measureGetTrimMillsOfMinute   thrpt    5    0.007 ±   0.001  ops/ns
JmhTpsMonitorPoint.measureGetTrimMillsOfSecond   thrpt    5    0.013 ±   0.001  ops/ns
JmhTpsMonitorPoint.measureGetTimeFormatOfSecond   avgt    5  926.852 ± 178.963   ns/op
JmhTpsMonitorPoint.measureGetTrimMillsOfHour      avgt    5  129.973 ±  14.357   ns/op
JmhTpsMonitorPoint.measureGetTrimMillsOfMinute    avgt    5  137.669 ±  10.380   ns/op
JmhTpsMonitorPoint.measureGetTrimMillsOfSecond    avgt    5   77.030 ±  17.750   ns/op
```

After refacting:

```text
Benchmark                                         Mode  Cnt    Score    Error   Units
JmhTpsMonitorPoint.measureGetTimeFormatOfSecond  thrpt    5    0.004 ±  0.001  ops/ns
JmhTpsMonitorPoint.measureGetTrimMillsOfHour     thrpt    5    2.362 ±  0.044  ops/ns
JmhTpsMonitorPoint.measureGetTrimMillsOfMinute   thrpt    5    2.345 ±  0.201  ops/ns
JmhTpsMonitorPoint.measureGetTrimMillsOfSecond   thrpt    5    2.369 ±  0.058  ops/ns
JmhTpsMonitorPoint.measureGetTimeFormatOfSecond   avgt    5  241.058 ± 29.693   ns/op
JmhTpsMonitorPoint.measureGetTrimMillsOfHour      avgt    5    0.421 ±  0.002   ns/op
JmhTpsMonitorPoint.measureGetTrimMillsOfMinute    avgt    5    0.422 ±  0.005   ns/op
JmhTpsMonitorPoint.measureGetTrimMillsOfSecond    avgt    5    0.419 ±  0.004   ns/op
```

The complete banchmark result:
[Before](https://www.yunweizhan.com.cn/wp-content/uploads/2022/08/BasedTestNanos.txt)
[Optimized](https://www.yunweizhan.com.cn/wp-content/uploads/2022/08/OptimizedTestNanos.txt)

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

