### PR TITLE
[ISSUE #9147] Fix GroupKey running NPE and wrong use of GroupKey2 in …

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/common/GroupKey.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/common/GroupKey.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.client.config.common;
 
+import com.alibaba.nacos.common.utils.AbstractAssert;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 /**
@@ -73,6 +74,8 @@ public class GroupKey {
      * @return parsed key
      */
     public static String[] parseKey(String groupKey) {
+        AbstractAssert.notNull(groupKey, "groupKey must not be null");
+
         StringBuilder sb = new StringBuilder();
         String dataId = null;
         String group = null;

--- a/client/src/test/java/com/alibaba/nacos/client/config/common/GroupKeyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/common/GroupKeyTest.java
@@ -44,7 +44,7 @@ public class GroupKeyTest {
         Assert.assertArrayEquals(new String[] {"b", "f%oo", null}, GroupKey.parseKey("b+f%25oo"));
         Assert.assertArrayEquals(new String[] {"a", "b", "c"}, GroupKey.parseKey("a+b+c"));
     }
-    
+
     @Test
     public void testParseKeyIllegalArgumentException1() {
         thrown.expect(IllegalArgumentException.class);
@@ -67,6 +67,12 @@ public class GroupKeyTest {
     public void testParseKeyIllegalArgumentException4() {
         thrown.expect(IllegalArgumentException.class);
         GroupKey.parseKey("f++bar");
+    }
+
+    @Test
+    public void testParseKeyIllegalArgumentException5() {
+        thrown.expect(IllegalArgumentException.class);
+        GroupKey.parseKey(null);
     }
     
     @Test

--- a/config/src/main/java/com/alibaba/nacos/config/server/utils/GroupKey.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/utils/GroupKey.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.config.server.utils;
 
+import com.alibaba.nacos.common.utils.AbstractAssert;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 /**
@@ -54,6 +55,8 @@ public class GroupKey {
      * Parse the group key.
      */
     public static String[] parseKey(String groupKey) {
+        AbstractAssert.notNull(groupKey, "groupKey must not be null");
+
         StringBuilder sb = new StringBuilder();
         String dataId = null;
         String group = null;

--- a/config/src/main/java/com/alibaba/nacos/config/server/utils/GroupKey2.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/utils/GroupKey2.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.config.server.utils;
 
+import com.alibaba.nacos.common.utils.AbstractAssert;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 /**
@@ -49,6 +50,8 @@ public class GroupKey2 {
      * Parse the group key.
      */
     public static String[] parseKey(String groupKey) {
+        AbstractAssert.notNull(groupKey, "groupKey must not be null");
+
         StringBuilder sb = new StringBuilder();
         String dataId = null;
         String group = null;

--- a/config/src/main/java/com/alibaba/nacos/config/server/utils/GroupKey2.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/utils/GroupKey2.java
@@ -89,7 +89,7 @@ public class GroupKey2 {
         } else {
             tenant = sb.toString();
         }
-        if (group.length() == 0) {
+        if (StringUtils.isBlank(group)) {
             throw new IllegalArgumentException("invalid groupkey:" + groupKey);
         }
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/GroupKey2Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/GroupKey2Test.java
@@ -100,7 +100,17 @@ public class GroupKey2Test {
         // Assert result
         Assert.assertArrayEquals(new String[] {null, "/", null}, actual);
     }
-    
+
+    @Test
+    public void testParseKeyForNullIllegalArgumentException() {
+
+        // Act
+        thrown.expect(IllegalArgumentException.class);
+        GroupKey2.parseKey(null);
+
+        // Method is not expected to return due to exception thrown
+    }
+
     @Test
     public void testParseKeyForPlusIllegalArgumentException() {
         

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/GroupKeyTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/GroupKeyTest.java
@@ -35,7 +35,7 @@ public class GroupKeyTest {
     public void testParseInvalidGroupKey() {
         String key = "11111+222+333333+444";
         try {
-            GroupKey2.parseKey(key);
+            GroupKey.parseKey(key);
             Assert.fail();
         } catch (IllegalArgumentException e) {
             System.out.println(e.toString());
@@ -43,7 +43,7 @@ public class GroupKeyTest {
         
         key = "11111+";
         try {
-            GroupKey2.parseKey(key);
+            GroupKey.parseKey(key);
             Assert.fail();
         } catch (IllegalArgumentException e) {
             System.out.println(e.toString());
@@ -51,7 +51,7 @@ public class GroupKeyTest {
         
         key = "11111%29+222";
         try {
-            GroupKey2.parseKey(key);
+            GroupKey.parseKey(key);
             Assert.fail();
         } catch (IllegalArgumentException e) {
             System.out.println(e.toString());
@@ -59,14 +59,14 @@ public class GroupKeyTest {
         
         key = "11111%2b+222";
         try {
-            GroupKey2.parseKey(key);
+            GroupKey.parseKey(key);
             Assert.fail();
         } catch (IllegalArgumentException e) {
             System.out.println(e.toString());
         }
         
         key = "11111%25+222";
-        String[] pair = GroupKey2.parseKey(key);
+        String[] pair = GroupKey.parseKey(key);
         Assert.assertEquals("11111%", pair[0]);
         Assert.assertEquals("222", pair[1]);
     }
@@ -120,7 +120,17 @@ public class GroupKeyTest {
         // Assert result
         Assert.assertArrayEquals(new String[] {null, "/", null}, actual);
     }
-    
+
+    @Test
+    public void testParseKeyForNullIllegalArgumentException() {
+
+        // Act
+        thrown.expect(IllegalArgumentException.class);
+        GroupKey.parseKey(null);
+
+        // Method is not expected to return due to exception thrown
+    }
+
     @Test
     public void testParseKeyForPlusIllegalArgumentException() {
         


### PR DESCRIPTION
Resolve problem https://github.com/alibaba/nacos/issues/9147 Fix GroupKey running NPE and wrong use of GroupKey2 in GroupKeyTest.
方法入口增加非空校验；增加测试用例；修改GroupKeyTest类中对GroupKey2方法的错误调用


Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

