### PR TITLE
[ISSUE #9227] fix subscriber scopeMatches

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/notify/listener/Subscriber.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/listener/Subscriber.java
@@ -69,6 +69,6 @@ public abstract class Subscriber<T extends Event> {
      * @return Whether the event's scope matches current subscriber
      */
     public boolean scopeMatches(T event) {
-        return event.scope() == null;
+        return true;
     }
 }


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change
see #9227
修复旧版本nacos-client升级到2.1.1导致自定义订阅事件失效问题

#8433 中在 com.alibaba.nacos.common.notify.listener.Subscriber 增加了 scopeMatches方法，用于区分事件的作用域 , 区分作用域的逻辑在子类中已经进行了重写 , 所以父类默认返回true即可



