### PR TITLE
[ISSUE #9418] fix config: public namespace query not working

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/remote/ConfigQueryRequestHandler.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/remote/ConfigQueryRequestHandler.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.remote.request.RequestMeta;
 import com.alibaba.nacos.api.remote.response.ResponseCode;
 import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.model.CacheItem;
@@ -85,13 +86,12 @@ public class ConfigQueryRequestHandler extends RequestHandler<ConfigQueryRequest
             throws UnsupportedEncodingException {
         String dataId = configQueryRequest.getDataId();
         String group = configQueryRequest.getGroup();
-        String tenant = configQueryRequest.getTenant();
+        String tenant = NamespaceUtil.processNamespaceParameter(configQueryRequest.getTenant());
         String clientIp = meta.getClientIp();
         String tag = configQueryRequest.getTag();
         ConfigQueryResponse response = new ConfigQueryResponse();
         
-        final String groupKey = GroupKey2
-                .getKey(configQueryRequest.getDataId(), configQueryRequest.getGroup(), configQueryRequest.getTenant());
+        final String groupKey = GroupKey2.getKey(dataId, group, tenant);
         
         String autoTag = configQueryRequest.getHeader(com.alibaba.nacos.api.common.Constants.VIPSERVER_TAG);
         


### PR DESCRIPTION
## What is the purpose of the change

gRPC获取配置处理命名空间字段的方式和HTTP的不一致 , 2.1.x 版本在显示指定`public` namespance 的情况下无法获取配置
以下是HTTP获取配置对tenant字段的处理方式 (ConfigController) :
```
    @GetMapping
    @Secured(action = ActionTypes.READ, signType = SignType.CONFIG)
    public void getConfig(HttpServletRequest request, HttpServletResponse response,
            @RequestParam("dataId") String dataId, @RequestParam("group") String group,
            @RequestParam(value = "tenant", required = false, defaultValue = StringUtils.EMPTY) String tenant,
            @RequestParam(value = "tag", required = false) String tag)
            throws IOException, ServletException, NacosException {

        // check tenant
        tenant = NamespaceUtil.processNamespaceParameter(tenant);
        // ...
    }
```
gRPC 没有使用NamespaceUtil.processNamespaceParameter进行处理

ConfigQueryRequestHandler.java
```
    private ConfigQueryResponse getContext(ConfigQueryRequest configQueryRequest, RequestMeta meta, boolean notify)
            throws UnsupportedEncodingException {
        // 这里的tenant需要使用NamespaceUtil.processNamespaceParameter(tenant)处理一下
        String tenant = configQueryRequest.getTenant();
       // ...
 }
```

Bug复现见issue: #9418

