### PR TITLE
[ISSUE #9414] Optimize fuzzy queries to make SQL more general

### DIFF
--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/ExternalRolePersistServiceImpl.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/ExternalRolePersistServiceImpl.java
@@ -168,8 +168,8 @@ public class ExternalRolePersistServiceImpl implements RolePersistService {
     
     @Override
     public List<String> findRolesLikeRoleName(String role) {
-        String sql = "SELECT role FROM roles WHERE role LIKE '%' ? '%'";
-        List<String> users = this.jt.queryForList(sql, new String[] {role}, String.class);
+        String sql = "SELECT role FROM roles WHERE role LIKE ?";
+        List<String> users = this.jt.queryForList(sql, new String[] {String.format("%%%s%%", role)}, String.class);
         return users;
     }
 

--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/ExternalUserPersistServiceImpl.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/ExternalUserPersistServiceImpl.java
@@ -162,8 +162,8 @@ public class ExternalUserPersistServiceImpl implements UserPersistService {
     
     @Override
     public List<String> findUserLikeUsername(String username) {
-        String sql = "SELECT username FROM users WHERE username LIKE '%' ? '%'";
-        List<String> users = this.jt.queryForList(sql, new String[] {username}, String.class);
+        String sql = "SELECT username FROM users WHERE username LIKE ?";
+        List<String> users = this.jt.queryForList(sql, new String[]{String.format("%%%s%%", username)}, String.class);
         return users;
     }
 


### PR DESCRIPTION
优化模糊查询，使SQL就可以通用性地适配其他可能接入的数据库，减少未来插件开发者的扩展插件的时候，还需要触碰主分支。