### PR TITLE
[ISSUE #9415]Nacos多数据源通用适配改造点优化建议: 修改外置存储代码判断为通用反向逻辑

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/constant/PropertiesConstant.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/constant/PropertiesConstant.java
@@ -55,7 +55,7 @@ public class PropertiesConstant {
     
     public static final String SPRING_DATASOURCE_PLATFORM = "spring.datasource.platform";
     
-    public static final String MYSQL = "mysql";
+    public static final String DERBY = "derby";
     
     public static final String EMBEDDED_STORAGE = "embeddedStorage";
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/utils/PropertyUtil.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/utils/PropertyUtil.java
@@ -280,9 +280,9 @@ public class PropertyUtil implements ApplicationContextInitializer<ConfigurableA
             setCorrectUsageDelay(getInt(PropertiesConstant.CORRECT_USAGE_DELAY, correctUsageDelay));
             setInitialExpansionPercent(getInt(PropertiesConstant.INITIAL_EXPANSION_PERCENT, initialExpansionPercent));
             // External data sources are used by default in cluster mode
-            setUseExternalDB(PropertiesConstant.MYSQL
-                    .equalsIgnoreCase(getString(PropertiesConstant.SPRING_DATASOURCE_PLATFORM, "")));
-            
+            setUseExternalDB(getProperty(PropertiesConstant.SPRING_DATASOURCE_PLATFORM) != null
+                    && !PropertiesConstant.DERBY.equalsIgnoreCase(
+                    getProperty(PropertiesConstant.SPRING_DATASOURCE_PLATFORM)));
             // must initialize after setUseExternalDB
             // This value is true in stand-alone mode and false in cluster mode
             // If this value is set to true in cluster mode, nacos's distributed storage engine is turned on

--- a/core/src/main/java/com/alibaba/nacos/core/listener/StartingApplicationListener.java
+++ b/core/src/main/java/com/alibaba/nacos/core/listener/StartingApplicationListener.java
@@ -70,11 +70,9 @@ public class StartingApplicationListener implements NacosApplicationListener {
     
     private static final String DEFAULT_FUNCTION_MODE = "All";
     
-    private static final String DEFAULT_DATABASE = "mysql";
+    private static final String DEFAULT_EMBEDDED_DATABASE = "derby";
     
     private static final String DATASOURCE_PLATFORM_PROPERTY = "spring.datasource.platform";
-    
-    private static final String DEFAULT_DATASOURCE_PLATFORM = "";
     
     private static final String DATASOURCE_MODE_EXTERNAL = "external";
     
@@ -247,7 +245,9 @@ public class StartingApplicationListener implements NacosApplicationListener {
     private void judgeStorageMode(ConfigurableEnvironment env) {
         
         // External data sources are used by default in cluster mode
-        boolean useExternalStorage = (DEFAULT_DATABASE.equalsIgnoreCase(env.getProperty(DATASOURCE_PLATFORM_PROPERTY, DEFAULT_DATASOURCE_PLATFORM)));
+        String currentDatasourcePlatform = env.getProperty(DATASOURCE_PLATFORM_PROPERTY);
+        boolean useExternalStorage =
+                currentDatasourcePlatform != null && !currentDatasourcePlatform.equals(DEFAULT_EMBEDDED_DATABASE);
         
         // must initialize after setUseExternalDB
         // This value is true in stand-alone mode and false in cluster mode


### PR DESCRIPTION
## What is the purpose of the change

For #9415 .为了以后多数据库适配扩展的过程中的出现的兼容问题，建议把某些代码，更改为通用的方式，进行适配

## Brief changelog

1、StartingApplicationListener类的方法：judgeStorageMode修改为反向判断，判断当前环境的数据库类型 不等于空 并且 不等于 derby 的时候为外置存储
2、PropertyUtil类的代码：setUseExternalDB修改为反向判断，判断当前环境的数据库类型 不等于空 并且 不等于derby 的时候为外置存储

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

