### PR TITLE
resolve issue #9318 add ldap filter config:caseSensitive

### DIFF
--- a/console/src/main/resources/application.properties
+++ b/console/src/main/resources/application.properties
@@ -137,6 +137,7 @@ nacos.core.auth.plugin.nacos.token.secret.key=SecretKey0123456789012345678901234
 #nacos.core.auth.ldap.password=admin
 #nacos.core.auth.ldap.userdn=cn={0},dc=example,dc=org
 #nacos.core.auth.ldap.filter.prefix=uid
+#nacos.core.auth.ldap.case.sensitive=true
 
 
 #*************** Istio Related Configurations ***************#

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -159,6 +159,7 @@ nacos.core.auth.plugin.nacos.token.secret.key=SecretKey0123456789012345678901234
 #nacos.core.auth.ldap.password=admin
 #nacos.core.auth.ldap.userdn=cn={0},dc=example,dc=org
 #nacos.core.auth.ldap.filter.prefix=uid
+#nacos.core.auth.ldap.case.sensitive=true
 
 
 #*************** Istio Related Configurations ***************#

--- a/distribution/conf/application.properties.example
+++ b/distribution/conf/application.properties.example
@@ -147,6 +147,7 @@ nacos.core.auth.enabled=false
 #nacos.core.auth.ldap.password=admin
 #nacos.core.auth.ldap.userdn=cn={0},dc=example,dc=org
 #nacos.core.auth.ldap.filter.prefix=uid
+#nacos.core.auth.ldap.case.sensitive=true
 
 
 ### The token expiration in seconds:

--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthConfig.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthConfig.java
@@ -55,10 +55,10 @@ public class LdapAuthConfig {
     
     @Value(("${" + AuthConstants.NACOS_CORE_AUTH_LDAP_FILTER_PREFIX + ":uid}"))
     private String filterPrefix;
-
+    
     @Value(("${" + AuthConstants.NACOS_CORE_AUTH_CASE_SENSITIVE + ":true}"))
     private boolean caseSensitive;
-
+    
     @Bean
     @Conditional(ConditionOnLdapAuth.class)
     public LdapTemplate ldapTemplate(LdapContextSource ldapContextSource) {
@@ -74,7 +74,8 @@ public class LdapAuthConfig {
     @Conditional(ConditionOnLdapAuth.class)
     public LdapAuthenticationProvider ldapAuthenticationProvider(LdapTemplate ldapTemplate,
             NacosUserDetailsServiceImpl userDetailsService, NacosRoleServiceImpl nacosRoleService) {
-        return new LdapAuthenticationProvider(ldapTemplate, userDetailsService, nacosRoleService, filterPrefix, caseSensitive);
+        return new LdapAuthenticationProvider(ldapTemplate, userDetailsService, nacosRoleService, filterPrefix,
+                caseSensitive);
     }
     
 }

--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthConfig.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthConfig.java
@@ -55,7 +55,10 @@ public class LdapAuthConfig {
     
     @Value(("${" + AuthConstants.NACOS_CORE_AUTH_LDAP_FILTER_PREFIX + ":uid}"))
     private String filterPrefix;
-    
+
+    @Value(("${" + AuthConstants.NACOS_CORE_AUTH_CASE_SENSITIVE + ":true}"))
+    private boolean caseSensitive;
+
     @Bean
     @Conditional(ConditionOnLdapAuth.class)
     public LdapTemplate ldapTemplate(LdapContextSource ldapContextSource) {
@@ -71,7 +74,7 @@ public class LdapAuthConfig {
     @Conditional(ConditionOnLdapAuth.class)
     public LdapAuthenticationProvider ldapAuthenticationProvider(LdapTemplate ldapTemplate,
             NacosUserDetailsServiceImpl userDetailsService, NacosRoleServiceImpl nacosRoleService) {
-        return new LdapAuthenticationProvider(ldapTemplate, userDetailsService, nacosRoleService, filterPrefix);
+        return new LdapAuthenticationProvider(ldapTemplate, userDetailsService, nacosRoleService, filterPrefix, caseSensitive);
     }
     
 }

--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProvider.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProvider.java
@@ -48,13 +48,13 @@ public class LdapAuthenticationProvider implements AuthenticationProvider {
     private static final String LDAP_PREFIX = "LDAP_";
     
     private final NacosUserDetailsServiceImpl userDetailsService;
-
+    
     private final NacosRoleServiceImpl nacosRoleService;
-
+    
     private final LdapTemplate ldapTemplate;
     
     private final String filterPrefix;
-
+    
     private final boolean caseSensitive;
     
     public LdapAuthenticationProvider(LdapTemplate ldapTemplate, NacosUserDetailsServiceImpl userDetailsService,
@@ -79,8 +79,8 @@ public class LdapAuthenticationProvider implements AuthenticationProvider {
                 return null;
             }
         }
-
-        if(!caseSensitive){
+        
+        if (!caseSensitive) {
             username = StringUtils.lowerCase(username);
         }
         

--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProvider.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProvider.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.plugin.auth.impl.roles.NacosRoleServiceImpl;
 import com.alibaba.nacos.plugin.auth.impl.users.NacosUserDetails;
 import com.alibaba.nacos.plugin.auth.impl.users.NacosUserDetailsServiceImpl;
 import com.alibaba.nacos.plugin.auth.impl.utils.PasswordEncoderUtil;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -53,13 +54,16 @@ public class LdapAuthenticationProvider implements AuthenticationProvider {
     private final LdapTemplate ldapTemplate;
     
     private final String filterPrefix;
+
+    private final boolean caseSensitive;
     
     public LdapAuthenticationProvider(LdapTemplate ldapTemplate, NacosUserDetailsServiceImpl userDetailsService,
-            NacosRoleServiceImpl nacosRoleService, String filterPrefix) {
+            NacosRoleServiceImpl nacosRoleService, String filterPrefix, boolean caseSensitive) {
         this.ldapTemplate = ldapTemplate;
         this.nacosRoleService = nacosRoleService;
         this.userDetailsService = userDetailsService;
         this.filterPrefix = filterPrefix;
+        this.caseSensitive = caseSensitive;
     }
     
     @Override
@@ -74,6 +78,10 @@ public class LdapAuthenticationProvider implements AuthenticationProvider {
             } else {
                 return null;
             }
+        }
+
+        if(!caseSensitive){
+            username = StringUtils.lowerCase(username);
         }
         
         try {

--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
@@ -62,6 +62,6 @@ public class AuthConstants {
     public static final String NACOS_CORE_AUTH_LDAP_PASSWORD = "nacos.core.auth.ldap.password";
     
     public static final String NACOS_CORE_AUTH_LDAP_FILTER_PREFIX = "nacos.core.auth.ldap.filter.prefix";
-
+    
     public static final String NACOS_CORE_AUTH_CASE_SENSITIVE = "nacos.core.auth.ldap.case.sensitive";
 }

--- a/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
+++ b/plugin-default-impl/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
@@ -62,4 +62,6 @@ public class AuthConstants {
     public static final String NACOS_CORE_AUTH_LDAP_PASSWORD = "nacos.core.auth.ldap.password";
     
     public static final String NACOS_CORE_AUTH_LDAP_FILTER_PREFIX = "nacos.core.auth.ldap.filter.prefix";
+
+    public static final String NACOS_CORE_AUTH_CASE_SENSITIVE = "nacos.core.auth.ldap.case.sensitive";
 }

--- a/plugin-default-impl/src/test/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProviderTest.java
+++ b/plugin-default-impl/src/test/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProviderTest.java
@@ -58,6 +58,8 @@ public class LdapAuthenticationProviderTest {
     private final String normalUserName = "normal";
     
     private final String filterPrefix = "uid";
+
+    private final boolean caseSensitive = true;
     
     Method isAdmin;
     
@@ -87,7 +89,7 @@ public class LdapAuthenticationProviderTest {
                     }
                 });
         this.ldapAuthenticationProvider = new LdapAuthenticationProvider(ldapTemplate, userDetailsService,
-                nacosRoleService, filterPrefix);
+                nacosRoleService, filterPrefix, caseSensitive);
         isAdmin = LdapAuthenticationProvider.class.getDeclaredMethod("isAdmin", String.class);
         isAdmin.setAccessible(true);
         ldapLogin = LdapAuthenticationProvider.class.getDeclaredMethod("ldapLogin", String.class, String.class);

--- a/plugin-default-impl/src/test/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProviderTest.java
+++ b/plugin-default-impl/src/test/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProviderTest.java
@@ -58,8 +58,8 @@ public class LdapAuthenticationProviderTest {
     private final String normalUserName = "normal";
     
     private final String filterPrefix = "uid";
-
-    private final boolean caseSensitive = true;
+    
+    private final boolean caseSensitive = false;
     
     Method isAdmin;
     
@@ -75,8 +75,8 @@ public class LdapAuthenticationProviderTest {
         roleInfos.add(adminRole);
         when(nacosRoleService.getRoles(adminUserName)).thenReturn(roleInfos);
         when(nacosRoleService.getRoles(normalUserName)).thenReturn(new ArrayList<>());
-        when(ldapTemplate.authenticate("", "(" + filterPrefix + "=" + adminUserName + ")", defaultPassWord)).thenAnswer(
-                new Answer<Boolean>() {
+        when(ldapTemplate.authenticate("", "(" + filterPrefix + "=" + adminUserName + ")", defaultPassWord))
+                .thenAnswer(new Answer<Boolean>() {
                     @Override
                     public Boolean answer(InvocationOnMock invocation) throws Throwable {
                         Object[] args = invocation.getArguments();

--- a/plugin-default-impl/src/test/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProviderTest.java
+++ b/plugin-default-impl/src/test/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProviderTest.java
@@ -18,8 +18,11 @@ package com.alibaba.nacos.plugin.auth.impl;
 
 import com.alibaba.nacos.plugin.auth.impl.constant.AuthConstants;
 import com.alibaba.nacos.plugin.auth.impl.persistence.RoleInfo;
+import com.alibaba.nacos.plugin.auth.impl.persistence.User;
 import com.alibaba.nacos.plugin.auth.impl.roles.NacosRoleServiceImpl;
+import com.alibaba.nacos.plugin.auth.impl.users.NacosUserDetails;
 import com.alibaba.nacos.plugin.auth.impl.users.NacosUserDetailsServiceImpl;
+import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +32,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -51,6 +56,8 @@ public class LdapAuthenticationProviderTest {
     
     private LdapAuthenticationProvider ldapAuthenticationProvider;
     
+    private LdapAuthenticationProvider ldapAuthenticationProviderForCloseCaseSensitive;
+    
     private List<RoleInfo> roleInfos = new ArrayList<>();
     
     private final String adminUserName = "nacos";
@@ -59,7 +66,9 @@ public class LdapAuthenticationProviderTest {
     
     private final String filterPrefix = "uid";
     
-    private final boolean caseSensitive = false;
+    private final boolean caseSensitive = true;
+    
+    private static final String LDAP_PREFIX = "LDAP_";
     
     Method isAdmin;
     
@@ -90,6 +99,8 @@ public class LdapAuthenticationProviderTest {
                 });
         this.ldapAuthenticationProvider = new LdapAuthenticationProvider(ldapTemplate, userDetailsService,
                 nacosRoleService, filterPrefix, caseSensitive);
+        this.ldapAuthenticationProviderForCloseCaseSensitive = new LdapAuthenticationProvider(ldapTemplate,
+                userDetailsService, nacosRoleService, filterPrefix, !caseSensitive);
         isAdmin = LdapAuthenticationProvider.class.getDeclaredMethod("isAdmin", String.class);
         isAdmin.setAccessible(true);
         ldapLogin = LdapAuthenticationProvider.class.getDeclaredMethod("ldapLogin", String.class, String.class);
@@ -135,5 +146,59 @@ public class LdapAuthenticationProviderTest {
         } catch (InvocationTargetException e) {
             Assert.fail();
         }
+    }
+    
+    @Test
+    public void testDefaultCaseSensitive() {
+        String userName = StringUtils.upperCase(normalUserName);
+        when(ldapTemplate.authenticate("", "(" + filterPrefix + "=" + userName + ")", defaultPassWord))
+                .thenAnswer(new Answer<Boolean>() {
+                    @Override
+                    public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        String b = (String) args[1];
+                        String c = (String) args[2];
+                        if (defaultPassWord.equals(c)) {
+                            return true;
+                        }
+                        return false;
+                    }
+                });
+        User userUpperCase = new User();
+        userUpperCase.setUsername(LDAP_PREFIX + userName);
+        userUpperCase.setPassword(defaultPassWord);
+        when(userDetailsService.loadUserByUsername(LDAP_PREFIX + userName))
+                .thenReturn(new NacosUserDetails(userUpperCase));
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userName, defaultPassWord);
+        Authentication result = ldapAuthenticationProvider.authenticate(authentication);
+        NacosUserDetails nacosUserDetails = (NacosUserDetails) result.getPrincipal();
+        Assert.assertTrue(nacosUserDetails.getUsername().equals(LDAP_PREFIX + userName));
+    }
+    
+    @Test
+    public void testCloseCaseSensitive() {
+        when(ldapTemplate.authenticate("", "(" + filterPrefix + "=" + normalUserName + ")", defaultPassWord))
+                .thenAnswer(new Answer<Boolean>() {
+                    @Override
+                    public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        String b = (String) args[1];
+                        String c = (String) args[2];
+                        if (defaultPassWord.equals(c)) {
+                            return true;
+                        }
+                        return false;
+                    }
+                });
+        User user = new User();
+        user.setUsername(LDAP_PREFIX + normalUserName);
+        user.setPassword(defaultPassWord);
+        when(userDetailsService.loadUserByUsername(LDAP_PREFIX + normalUserName))
+                .thenReturn(new NacosUserDetails(user));
+        Authentication authentication = new UsernamePasswordAuthenticationToken(StringUtils.upperCase(normalUserName),
+                defaultPassWord);
+        Authentication result = ldapAuthenticationProviderForCloseCaseSensitive.authenticate(authentication);
+        NacosUserDetails nacosUserDetails = (NacosUserDetails) result.getPrincipal();
+        Assert.assertTrue(nacosUserDetails.getUsername().equals(LDAP_PREFIX + normalUserName));
     }
 }


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

解决nacos提供的默认ldap鉴权实现更好的适配ldap服务（如微软AD域控）用户名不区分大小写的情况。

## Brief changelog

XX

## Verifying this change

默认情况下是改实现是大小写敏感的，也可以通过设置nacos.core.auth.ldap.case.sensitive=false调整默认ldap鉴权插件的用户名为大小写不敏感。

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

