### PR TITLE
Fix data race in xds.

### DIFF
--- a/istio/src/main/java/com/alibaba/nacos/istio/mcp/McpConnection.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/mcp/McpConnection.java
@@ -32,7 +32,7 @@ public class McpConnection extends AbstractConnection<Mcp.Resources> {
     }
 
     @Override
-    public void push(Mcp.Resources response, WatchedStatus watchedStatus) {
+    public synchronized void push(Mcp.Resources response, WatchedStatus watchedStatus) {
         if (Loggers.MAIN.isDebugEnabled()) {
             Loggers.MAIN.debug("Mcp.Resources: {}", response.toString());
         }

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/XdsConnection.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/XdsConnection.java
@@ -32,7 +32,7 @@ public class XdsConnection extends AbstractConnection<DiscoveryResponse> {
     }
 
     @Override
-    public void push(DiscoveryResponse response, WatchedStatus watchedStatus) {
+    public synchronized void push(DiscoveryResponse response, WatchedStatus watchedStatus) {
         if (Loggers.MAIN.isDebugEnabled()) {
             Loggers.MAIN.debug("discoveryResponse: {}", response.toString());
         }


### PR DESCRIPTION
The onNext operation of grpc stream oberver is not thread-safe. So we must synchronize calls on push.