### PR TITLE
Only null property compatible with oracle

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/HistoryService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/HistoryService.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.config.server.service;
 
 import com.alibaba.nacos.common.utils.Pair;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.model.ConfigHistoryInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
 import com.alibaba.nacos.config.server.model.Page;
@@ -104,7 +105,7 @@ public class HistoryService {
             String namespaceId) throws AccessException {
         if (!Objects.equals(configHistoryInfo.getDataId(), dataId) || !Objects
 		.equals(configHistoryInfo.getGroup(), group)
-		|| (!Objects.isNull(configHistoryInfo.getTenant()) && !Objects.equals(configHistoryInfo.getTenant(), namespaceId))) {
+		|| (!StringUtils.isEmpty(configHistoryInfo.getTenant()) && !Objects.equals(configHistoryInfo.getTenant(), namespaceId))) {
 	    throw new AccessException("Please check dataId, group or namespaceId.");
 	}
     }

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/HistoryService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/HistoryService.java
@@ -103,9 +103,9 @@ public class HistoryService {
     private void checkHistoryInfoPermission(ConfigHistoryInfo configHistoryInfo, String dataId, String group,
             String namespaceId) throws AccessException {
         if (!Objects.equals(configHistoryInfo.getDataId(), dataId) || !Objects
-				.equals(configHistoryInfo.getGroup(), group)
-				|| (!Objects.isNull(configHistoryInfo.getTenant()) && !Objects.equals(configHistoryInfo.getTenant(), namespaceId))) {
-			throw new AccessException("Please check dataId, group or namespaceId.");
-		}
+		.equals(configHistoryInfo.getGroup(), group)
+		|| (!Objects.isNull(configHistoryInfo.getTenant()) && !Objects.equals(configHistoryInfo.getTenant(), namespaceId))) {
+	    throw new AccessException("Please check dataId, group or namespaceId.");
+	}
     }
 }

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/HistoryService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/HistoryService.java
@@ -103,9 +103,9 @@ public class HistoryService {
     private void checkHistoryInfoPermission(ConfigHistoryInfo configHistoryInfo, String dataId, String group,
             String namespaceId) throws AccessException {
         if (!Objects.equals(configHistoryInfo.getDataId(), dataId) || !Objects
-                .equals(configHistoryInfo.getGroup(), group) || !Objects
-                .equals(configHistoryInfo.getTenant(), namespaceId)) {
-            throw new AccessException("Please check dataId, group or namespaceId.");
-        }
+				.equals(configHistoryInfo.getGroup(), group)
+				|| (!Objects.isNull(configHistoryInfo.getTenant()) && !Objects.equals(configHistoryInfo.getTenant(), namespaceId))) {
+			throw new AccessException("Please check dataId, group or namespaceId.");
+		}
     }
 }


### PR DESCRIPTION
It is hoped that the official can be compatible with oracle, so as to make friendly use of oracle database plug-ins.

Because it has only a null property, there is no empty string. Errors occur when they are compared.

Thank you.

Please do not create a Pull Request without creating an issue first.
