### PR TITLE
[v2.2.1-RC-develop] 支持自定义默认 tenant/namespaceId，避免 2.2 版本后新增 oracle 等其他数据源时使用空 ID导致的问题

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/NamespaceUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/NamespaceUtil.java
@@ -28,6 +28,8 @@ public class NamespaceUtil {
     private static final String NAMESPACE_PUBLIC_KEY = "public";
     
     private static final String NAMESPACE_NULL_KEY = "null";
+
+    public static final String NAMESPACE_PUBLIC_ID_ENV_NAME = "nacos.core.namespace.defaultid";
     
     /**
      * Treat the namespace(tenant) parameters with values of "public" and "null" as an empty string.
@@ -37,9 +39,27 @@ public class NamespaceUtil {
     public static String processNamespaceParameter(String tenant) {
         if (StringUtils.isBlank(tenant) || NAMESPACE_PUBLIC_KEY.equalsIgnoreCase(tenant) || NAMESPACE_NULL_KEY
                 .equalsIgnoreCase(tenant)) {
-            return "";
+            return getNamespaceDefaultId();
         }
         return tenant.trim();
     }
 
+    /**
+     * Set default namespace id.
+     * Invoke settings at system startup
+     *
+     * @param namespaceDefaultId
+     */
+    public static void setNamespaceDefaultId(String namespaceDefaultId){
+        System.setProperty(NAMESPACE_PUBLIC_ID_ENV_NAME, namespaceDefaultId);
+    }
+
+    /**
+     * Get default namespace id
+     *
+     * @return
+     */
+    public static String getNamespaceDefaultId(){
+        return System.getProperty(NAMESPACE_PUBLIC_ID_ENV_NAME, "");
+    }
 }

--- a/common/src/main/java/com/alibaba/nacos/common/utils/NamespaceUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/NamespaceUtil.java
@@ -29,7 +29,9 @@ public class NamespaceUtil {
     
     private static final String NAMESPACE_NULL_KEY = "null";
 
-    public static final String NAMESPACE_PUBLIC_ID_ENV_NAME = "nacos.core.namespace.defaultid";
+    public static final String NAMESPACE_FILL_PUBLIC_ID_ENV_NAME = "nacos.core.namespace.fill-public-id";
+
+    private static final String NAMESPACE_PUBLIC_ID_ENV_NAME = "nacos.core.namespace.public-id";
     
     /**
      * Treat the namespace(tenant) parameters with values of "public" and "null" as an empty string.

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/ClientMetricsController.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/ClientMetricsController.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.common.http.client.NacosAsyncRestTemplate;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.utils.GroupKey2;
@@ -82,6 +83,7 @@ public class ClientMetricsController {
             @RequestParam(value = "tenant", required = false) String tenant) {
         Loggers.CORE.info("Get cluster config metrics received, ip={},dataId={},group={},tenant={}", ip, dataId, group,
                 tenant);
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         Map<String, Object> responseMap = new HashMap<>(3);
         Collection<Member> members = serverMemberManager.allMembers();
         final NacosAsyncRestTemplate nacosAsyncRestTemplate = HttpClientBeanHolder
@@ -136,6 +138,7 @@ public class ClientMetricsController {
             @RequestParam(value = "dataId", required = false) String dataId,
             @RequestParam(value = "group", required = false) String group,
             @RequestParam(value = "tenant", required = false) String tenant) {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         Map<String, Object> metrics = new HashMap<>(16);
         List<Connection> connectionsByIp = connectionManager.getConnectionByIp(ip);
         for (Connection connectionByIp : connectionsByIp) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/ClientMetricsController.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/ClientMetricsController.java
@@ -80,10 +80,10 @@ public class ClientMetricsController {
     public ResponseEntity metric(@RequestParam("ip") String ip,
             @RequestParam(value = "dataId", required = false) String dataId,
             @RequestParam(value = "group", required = false) String group,
-            @RequestParam(value = "tenant", required = false) String tenant) {
+            @RequestParam(value = "tenant", required = false) String tenantParam) {
         Loggers.CORE.info("Get cluster config metrics received, ip={},dataId={},group={},tenant={}", ip, dataId, group,
-                tenant);
-        tenant = NamespaceUtil.processNamespaceParameter(tenant);
+                tenantParam);
+        String tenant = NamespaceUtil.processNamespaceParameter(tenantParam);
         Map<String, Object> responseMap = new HashMap<>(3);
         Collection<Member> members = serverMemberManager.allMembers();
         final NacosAsyncRestTemplate nacosAsyncRestTemplate = HttpClientBeanHolder

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/CommunicationController.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/CommunicationController.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.config.server.controller;
 
 import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.model.SampleResult;
@@ -74,6 +75,7 @@ public class CommunicationController {
             @RequestParam("group") String group,
             @RequestParam(value = "tenant", required = false, defaultValue = StringUtils.EMPTY) String tenant,
             @RequestParam(value = "tag", required = false) String tag) {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         dataId = dataId.trim();
         group = group.trim();
         String lastModified = request.getHeader(NotifyService.NOTIFY_HEADER_LAST_MODIFIED);
@@ -94,6 +96,7 @@ public class CommunicationController {
     @GetMapping("/configWatchers")
     public SampleResult getSubClientConfig(@RequestParam("dataId") String dataId, @RequestParam("group") String group,
             @RequestParam(value = "tenant", required = false) String tenant, ModelMap modelMap) {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         group = StringUtils.isBlank(group) ? Constants.DEFAULT_GROUP : group;
         // long polling listeners.
         SampleResult result = longPollingService.getCollectSubscribleInfo(dataId, group, tenant);

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/ConfigController.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/ConfigController.java
@@ -163,6 +163,7 @@ public class ConfigController {
         
         // check tenant
         ParamUtils.checkTenant(tenant);
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         ParamUtils.checkParam(dataId, group, "datumId", content);
         ParamUtils.checkParam(tag);
     
@@ -237,6 +238,7 @@ public class ConfigController {
             throws NacosException {
         // check tenant
         ParamUtils.checkTenant(tenant);
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         // check params
         ParamUtils.checkParam(dataId, group, "datumId", "content");
         ConfigAllInfo configAllInfo = configInfoPersistService.findConfigAllInfo(dataId, group, tenant);
@@ -269,6 +271,7 @@ public class ConfigController {
             @RequestParam(value = "tag", required = false) String tag) throws NacosException {
         // check tenant
         ParamUtils.checkTenant(tenant);
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         ParamUtils.checkParam(dataId, group, "datumId", "rm");
         ParamUtils.checkParam(tag);
     
@@ -313,6 +316,7 @@ public class ConfigController {
     public RestResult<ConfigAdvanceInfo> getConfigAdvanceInfo(@RequestParam("dataId") String dataId,
             @RequestParam("group") String group,
             @RequestParam(value = "tenant", required = false, defaultValue = StringUtils.EMPTY) String tenant) {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         ConfigAdvanceInfo configInfo = configInfoPersistService.findConfigAdvanceInfo(dataId, group, tenant);
         return RestResultUtils.success(configInfo);
     }
@@ -353,6 +357,7 @@ public class ConfigController {
     public GroupkeyListenserStatus getListeners(@RequestParam("dataId") String dataId,
             @RequestParam("group") String group, @RequestParam(value = "tenant", required = false) String tenant,
             @RequestParam(value = "sampleTime", required = false, defaultValue = "1") int sampleTime) throws Exception {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         group = StringUtils.isBlank(group) ? Constants.DEFAULT_GROUP : group;
         SampleResult collectSampleResult = configSubService.getCollectSampleResult(dataId, group, tenant, sampleTime);
         GroupkeyListenserStatus gls = new GroupkeyListenserStatus();
@@ -373,6 +378,7 @@ public class ConfigController {
             @RequestParam(value = "tenant", required = false, defaultValue = StringUtils.EMPTY) String tenant,
             @RequestParam(value = "config_tags", required = false) String configTags,
             @RequestParam("pageNo") int pageNo, @RequestParam("pageSize") int pageSize) {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         Map<String, Object> configAdvanceInfo = new HashMap<>(100);
         if (StringUtils.isNotBlank(appName)) {
             configAdvanceInfo.put("appName", appName);
@@ -400,6 +406,7 @@ public class ConfigController {
             @RequestParam(value = "tenant", required = false, defaultValue = StringUtils.EMPTY) String tenant,
             @RequestParam(value = "config_tags", required = false) String configTags,
             @RequestParam("pageNo") int pageNo, @RequestParam("pageSize") int pageSize) {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         MetricsMonitor.getFuzzySearchMonitor().incrementAndGet();
         Map<String, Object> configAdvanceInfo = new HashMap<>(50);
         if (StringUtils.isNotBlank(appName)) {
@@ -430,6 +437,7 @@ public class ConfigController {
     public RestResult<Boolean> stopBeta(@RequestParam(value = "dataId") String dataId,
             @RequestParam(value = "group") String group,
             @RequestParam(value = "tenant", required = false, defaultValue = StringUtils.EMPTY) String tenant) {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         try {
             configInfoBetaPersistService.removeConfigInfo4Beta(dataId, group, tenant);
         } catch (Throwable e) {
@@ -454,6 +462,7 @@ public class ConfigController {
     public RestResult<ConfigInfo4Beta> queryBeta(@RequestParam(value = "dataId") String dataId,
             @RequestParam(value = "group") String group,
             @RequestParam(value = "tenant", required = false, defaultValue = StringUtils.EMPTY) String tenant) {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         try {
             ConfigInfo4Beta ci = configInfoBetaPersistService.findConfigInfo4Beta(dataId, group, tenant);
             

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/HistoryController.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/HistoryController.java
@@ -72,6 +72,7 @@ public class HistoryController {
             @RequestParam(value = "appName", required = false) String appName,
             @RequestParam(value = "pageNo", required = false) Integer pageNo,
             @RequestParam(value = "pageSize", required = false) Integer pageSize, ModelMap modelMap) {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         pageNo = null == pageNo ? 1 : pageNo;
         pageSize = null == pageSize ? 100 : pageSize;
         pageSize = Math.min(500, pageSize);
@@ -95,6 +96,7 @@ public class HistoryController {
             @RequestParam("group") String group,
             @RequestParam(value = "tenant", required = false, defaultValue = StringUtils.EMPTY) String tenant,
             @RequestParam("nid") Long nid) throws AccessException {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         return historyService.getConfigHistoryInfo(dataId, group, tenant, nid);
     }
     
@@ -115,6 +117,7 @@ public class HistoryController {
             @RequestParam("group") String group,
             @RequestParam(value = "tenant", required = false, defaultValue = StringUtils.EMPTY) String tenant,
             @RequestParam("id") Long id) throws AccessException {
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         return historyService.getPreviousConfigHistoryInfo(dataId, group, tenant, id);
     }
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/ListenerController.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/ListenerController.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.config.server.controller;
 
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.model.GroupkeyListenserStatus;
@@ -61,6 +62,7 @@ public class ListenerController {
         if (collectSampleResult.getLisentersGroupkeyStatus() == null) {
             return gls;
         }
+        tenant = NamespaceUtil.processNamespaceParameter(tenant);
         Map<String, String> status = collectSampleResult.getLisentersGroupkeyStatus();
         for (Map.Entry<String, String> config : status.entrySet()) {
             if (!StringUtils.isBlank(tenant) && config.getKey().contains(tenant)) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v2/ConfigControllerV2.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v2/ConfigControllerV2.java
@@ -141,6 +141,7 @@ public class ConfigControllerV2 {
             @RequestParam(value = "tag", required = false) String tag) throws NacosException {
         // check namespaceId
         ParamUtils.checkTenantV2(namespaceId);
+        namespaceId = NamespaceUtil.processNamespaceParameter(namespaceId);
         ParamUtils.checkParam(dataId, group, "datumId", "rm");
         ParamUtils.checkParamV2(tag);
         

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v2/HistoryControllerV2.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v2/HistoryControllerV2.java
@@ -77,6 +77,7 @@ public class HistoryControllerV2 {
             @RequestParam(value = "pageNo", required = false, defaultValue = "1") Integer pageNo,
             @RequestParam(value = "pageSize", required = false, defaultValue = "100") Integer pageSize) {
         pageSize = Math.min(500, pageSize);
+        namespaceId = NamespaceUtil.processNamespaceParameter(namespaceId);
         return Result.success(historyService.listConfigHistory(dataId, group, namespaceId, pageNo, pageSize));
     }
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v2/HistoryControllerV2.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v2/HistoryControllerV2.java
@@ -96,6 +96,7 @@ public class HistoryControllerV2 {
             @RequestParam("group") String group,
             @RequestParam(value = "namespaceId", required = false, defaultValue = StringUtils.EMPTY) String namespaceId,
             @RequestParam("nid") Long nid) throws AccessException, NacosApiException {
+        namespaceId = NamespaceUtil.processNamespaceParameter(namespaceId);
         ConfigHistoryInfo configHistoryInfo;
         try {
             configHistoryInfo = historyService.getConfigHistoryInfo(dataId, group, namespaceId, nid);
@@ -121,6 +122,7 @@ public class HistoryControllerV2 {
             @RequestParam("group") String group,
             @RequestParam(value = "namespaceId", required = false, defaultValue = StringUtils.EMPTY) String namespaceId,
             @RequestParam("id") Long id) throws AccessException, NacosApiException {
+        namespaceId = NamespaceUtil.processNamespaceParameter(namespaceId);
         ConfigHistoryInfo configHistoryInfo;
         try {
             configHistoryInfo = historyService.getPreviousConfigHistoryInfo(dataId, group, namespaceId, id);

--- a/console/src/main/java/com/alibaba/nacos/console/config/ConsoleConfig.java
+++ b/console/src/main/java/com/alibaba/nacos/console/config/ConsoleConfig.java
@@ -16,8 +16,10 @@
 
 package com.alibaba.nacos.console.config;
 
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.console.filter.XssFilter;
 import com.alibaba.nacos.core.code.ControllerMethodsCache;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -55,6 +57,7 @@ public class ConsoleConfig {
         methodsCache.initClassMethod("com.alibaba.nacos.naming.controllers");
         methodsCache.initClassMethod("com.alibaba.nacos.config.server.controller");
         methodsCache.initClassMethod("com.alibaba.nacos.console.controller");
+        NamespaceUtil.setNamespaceDefaultId(EnvUtil.getProperty(NamespaceUtil.NAMESPACE_PUBLIC_ID_ENV_NAME, ""));
     }
     
     @Bean

--- a/console/src/main/java/com/alibaba/nacos/console/config/ConsoleConfig.java
+++ b/console/src/main/java/com/alibaba/nacos/console/config/ConsoleConfig.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.console.config;
 
+import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.console.filter.XssFilter;
 import com.alibaba.nacos.core.code.ControllerMethodsCache;
@@ -57,7 +58,7 @@ public class ConsoleConfig {
         methodsCache.initClassMethod("com.alibaba.nacos.naming.controllers");
         methodsCache.initClassMethod("com.alibaba.nacos.config.server.controller");
         methodsCache.initClassMethod("com.alibaba.nacos.console.controller");
-        NamespaceUtil.setNamespaceDefaultId(EnvUtil.getProperty(NamespaceUtil.NAMESPACE_PUBLIC_ID_ENV_NAME, ""));
+        NamespaceUtil.setNamespaceDefaultId("true".equals(EnvUtil.getProperty(NamespaceUtil.NAMESPACE_FILL_PUBLIC_ID_ENV_NAME, "false")) ? Constants.DEFAULT_NAMESPACE_ID : "");
     }
     
     @Bean

--- a/console/src/main/java/com/alibaba/nacos/console/service/NamespaceOperationService.java
+++ b/console/src/main/java/com/alibaba/nacos/console/service/NamespaceOperationService.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.console.service;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.model.TenantInfo;
 import com.alibaba.nacos.config.server.service.repository.CommonPersistService;
@@ -70,7 +71,7 @@ public class NamespaceOperationService {
         // TODO 获取用kp
         List<TenantInfo> tenantInfos = commonPersistService.findTenantByKp(DEFAULT_KP);
         
-        Namespace namespace0 = new Namespace("", DEFAULT_NAMESPACE, DEFAULT_QUOTA,
+        Namespace namespace0 = new Namespace(NamespaceUtil.getNamespaceDefaultId(), DEFAULT_NAMESPACE, DEFAULT_QUOTA,
                 configInfoPersistService.configInfoCount(DEFAULT_TENANT), NamespaceTypeEnum.GLOBAL.getType());
         List<Namespace> namespaceList = new ArrayList<>();
         namespaceList.add(namespace0);

--- a/console/src/main/java/com/alibaba/nacos/console/service/NamespaceOperationService.java
+++ b/console/src/main/java/com/alibaba/nacos/console/service/NamespaceOperationService.java
@@ -93,7 +93,7 @@ public class NamespaceOperationService {
      */
     public NamespaceAllInfo getNamespace(String namespaceId) throws NacosException {
         // TODO 获取用kp
-        if (StringUtils.isBlank(namespaceId)) {
+        if (StringUtils.isBlank(namespaceId) || namespaceId.equals(NamespaceUtil.getNamespaceDefaultId())) {
             return new NamespaceAllInfo(namespaceId, DEFAULT_NAMESPACE_SHOW_NAME, DEFAULT_QUOTA,
                     configInfoPersistService.configInfoCount(DEFAULT_TENANT), NamespaceTypeEnum.GLOBAL.getType(),
                     DEFAULT_NAMESPACE_DESCRIPTION);

--- a/console/src/main/resources/application.properties
+++ b/console/src/main/resources/application.properties
@@ -29,6 +29,8 @@ server.port=8848
 ### Specify local server's IP:
 # nacos.inetutils.ip-address=
 
+### The default tenant/namespace ID is empty, you can customize. Especially useful in Oracle database, oracle database fields do not distinguish between "" and null.
+# nacos.core.namespace.defaultid=
 
 #*************** Config Module Related Configurations ***************#
 ### Deprecated configuration property, it is recommended to use `spring.sql.init.platform` replaced.

--- a/console/src/main/resources/application.properties
+++ b/console/src/main/resources/application.properties
@@ -29,8 +29,8 @@ server.port=8848
 ### Specify local server's IP:
 # nacos.inetutils.ip-address=
 
-### The default tenant/namespace ID is empty, you can customize. Especially useful in Oracle database, oracle database fields do not distinguish between "" and null.
-# nacos.core.namespace.defaultid=
+### The default tenant/namespace ID is empty, you can select to fill in as "public". Especially useful in Oracle database, oracle database fields do not distinguish between "" and null.
+# nacos.core.namespace.fill-public-id=true
 
 #*************** Config Module Related Configurations ***************#
 ### Deprecated configuration property, it is recommended to use `spring.sql.init.platform` replaced.

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.plugin.datasource.impl.derby;
 
 import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
@@ -79,7 +80,7 @@ public class ConfigInfoMapperByDerby extends AbstractMapper implements ConfigInf
     
     @Override
     public String getGroupIdList(int startRow, int pageSize) {
-        return "SELECT group_id FROM config_info WHERE tenant_id ='' GROUP BY group_id OFFSET " + startRow
+        return "SELECT group_id FROM config_info WHERE tenant_id ='"+ NamespaceUtil.getNamespaceDefaultId() +"' GROUP BY group_id OFFSET " + startRow
                 + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY";
     }
     
@@ -214,7 +215,7 @@ public class ConfigInfoMapperByDerby extends AbstractMapper implements ConfigInf
     @Override
     public String findConfigInfoBaseLikeCountRows(Map<String, String> params) {
         final String sqlCountRows = "SELECT count(*) FROM config_info WHERE ";
-        String where = " 1=1 AND tenant_id='' ";
+        String where = " 1=1 AND tenant_id='"+ NamespaceUtil.getNamespaceDefaultId() +"' ";
         if (!StringUtils.isBlank(params.get(DATA_ID))) {
             where += " AND data_id LIKE ? ";
         }
@@ -230,7 +231,7 @@ public class ConfigInfoMapperByDerby extends AbstractMapper implements ConfigInf
     @Override
     public String findConfigInfoBaseLikeFetchRows(Map<String, String> params, int startRow, int pageSize) {
         final String sqlFetchRows = "SELECT id,data_id,group_id,tenant_id,content FROM config_info WHERE ";
-        String where = " 1=1 AND tenant_id='' ";
+        String where = " 1=1 AND tenant_id='"+ NamespaceUtil.getNamespaceDefaultId() +"' ";
         if (!StringUtils.isBlank(params.get(DATA_ID))) {
             where += " AND data_id LIKE ? ";
         }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/GroupCapacityMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/GroupCapacityMapperByDerby.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.datasource.impl.derby;
 
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
@@ -47,7 +48,7 @@ public class GroupCapacityMapperByDerby extends AbstractMapper implements GroupC
     @Override
     public String insertIntoSelectByWhere() {
         return "INSERT INTO group_capacity (group_id, quota,`usage`, `max_size`, max_aggr_count, max_aggr_size, gmt_create,"
-                + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE group_id=? AND tenant_id = ''";
+                + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE group_id=? AND tenant_id = '"+ NamespaceUtil.getNamespaceDefaultId() +"'";
     }
     
     @Override
@@ -77,7 +78,7 @@ public class GroupCapacityMapperByDerby extends AbstractMapper implements GroupC
     
     @Override
     public String updateUsageByWhere() {
-        return "UPDATE group_capacity SET `usage` = (SELECT count(*) FROM config_info WHERE group_id=? AND tenant_id = ''),"
+        return "UPDATE group_capacity SET `usage` = (SELECT count(*) FROM config_info WHERE group_id=? AND tenant_id = '"+ NamespaceUtil.getNamespaceDefaultId() +"'),"
                 + " gmt_modified = ? WHERE group_id= ?";
     }
     

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.plugin.datasource.impl.mysql;
 
 import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
@@ -80,7 +81,7 @@ public class ConfigInfoMapperByMySql extends AbstractMapper implements ConfigInf
     
     @Override
     public String getGroupIdList(int startRow, int pageSize) {
-        return "SELECT group_id FROM config_info WHERE tenant_id ='' GROUP BY group_id LIMIT " + startRow + ","
+        return "SELECT group_id FROM config_info WHERE tenant_id ='"+ NamespaceUtil.getNamespaceDefaultId() +"' GROUP BY group_id LIMIT " + startRow + ","
                 + pageSize;
     }
     
@@ -221,7 +222,7 @@ public class ConfigInfoMapperByMySql extends AbstractMapper implements ConfigInf
     @Override
     public String findConfigInfoBaseLikeCountRows(Map<String, String> params) {
         final String sqlCountRows = "SELECT count(*) FROM config_info WHERE ";
-        String where = " 1=1 AND tenant_id='' ";
+        String where = " 1=1 AND tenant_id='"+ NamespaceUtil.getNamespaceDefaultId() +"' ";
         
         if (!StringUtils.isBlank(params.get(DATA_ID))) {
             where += " AND data_id LIKE ? ";
@@ -238,7 +239,7 @@ public class ConfigInfoMapperByMySql extends AbstractMapper implements ConfigInf
     @Override
     public String findConfigInfoBaseLikeFetchRows(Map<String, String> params, int startRow, int pageSize) {
         final String sqlFetchRows = "SELECT id,data_id,group_id,tenant_id,content FROM config_info WHERE ";
-        String where = " 1=1 AND tenant_id='' ";
+        String where = " 1=1 AND tenant_id='"+ NamespaceUtil.getNamespaceDefaultId() +"' ";
         if (!StringUtils.isBlank(params.get(DATA_ID))) {
             where += " AND data_id LIKE ? ";
         }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/GroupCapacityMapperByMysql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/GroupCapacityMapperByMysql.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.datasource.impl.mysql;
 
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
@@ -47,7 +48,7 @@ public class GroupCapacityMapperByMysql extends AbstractMapper implements GroupC
     @Override
     public String insertIntoSelectByWhere() {
         return "INSERT INTO group_capacity (group_id, quota,`usage`, `max_size`, max_aggr_count, max_aggr_size, gmt_create,"
-                + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE group_id=? AND tenant_id = ''";
+                + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE group_id=? AND tenant_id = '"+ NamespaceUtil.getNamespaceDefaultId() +"'";
     }
     
     @Override
@@ -77,7 +78,7 @@ public class GroupCapacityMapperByMysql extends AbstractMapper implements GroupC
     
     @Override
     public String updateUsageByWhere() {
-        return "UPDATE group_capacity SET `usage` = (SELECT count(*) FROM config_info WHERE group_id=? AND tenant_id = ''),"
+        return "UPDATE group_capacity SET `usage` = (SELECT count(*) FROM config_info WHERE group_id=? AND tenant_id = '"+ NamespaceUtil.getNamespaceDefaultId() +"'),"
                 + " gmt_modified = ? WHERE group_id= ?";
     }
     

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
@@ -89,7 +89,7 @@ public interface ConfigInfoMapper extends Mapper {
     /**
      * Get group id list  by page.
      * The default sql:
-     * SELECT group_id FROM config_info WHERE tenant_id ='' GROUP BY group_id LIMIT startRow, pageSize
+     * SELECT group_id FROM config_info WHERE tenant_id ='{defaultNamespaceId}' GROUP BY group_id LIMIT startRow, pageSize
      *
      * @param startRow The start index.
      * @param pageSize The size of page.

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/GroupCapacityMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/GroupCapacityMapper.java
@@ -36,11 +36,11 @@ public interface GroupCapacityMapper extends Mapper {
     /**
      * INSERT INTO SELECT statement. Used to insert query results into a table.
      *
-     * <p>Where condition: group_id=? AND tenant_id = ''
+     * <p>Where condition: group_id=? AND tenant_id = '{defaultNamespaceId}'
      *
      * <p>Example: INSERT INTO group_capacity (group_id, quota,`usage`, `max_size`, max_aggr_count,
      * max_aggr_size,gmt_create, gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info where group_id=?
-     * AND tenant_id = '';
+     * AND tenant_id = '{defaultNamespaceId}';
      *
      * @return sql.
      */
@@ -108,7 +108,7 @@ public interface GroupCapacityMapper extends Mapper {
     /**
      * used to update usage field.
      *
-     * <p>Where condition: group_id=? AND tenant_id = ''
+     * <p>Where condition: group_id=? AND tenant_id = '{defaultNamespaceId}'
      *
      * <p>Example: UPDATE group_capacity SET `usage` = (SELECT count(*) FROM config_info WHERE group_id=? AND tenant_id
      * =


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

为空的 tenant/namespaceId 会导致 oracle 数据库无法正常开发多数据源，因为在 Oracle 数据库中 where tenant = ? （? 实际值为 ""） ，无法正常获取数据，oracle 数据库 "" 值实际上为 null。

## Brief changelog

1、现有 nacos 源码中对 NamespaceUtil.processNamespaceParameter(tenantId); 的处理，部分处理了部分没处理，本次统一集中筛选全部进行了处理，为可以统一处理默认 ID 做了基础。

2、新增可以填充默认id 为public，配置文件中使用开关方式配置 `nacos.core.namespace.fill-public-id=true`，默认不配置照旧默认id是 ""，但是用户可以按需打开，比如需要用到 Oracle 等其他数据库 "" 和 null 不分时，可以通过打开配置为 `true` 来解决问题。

本次修改向前兼容，不产生其他影响。
