### PR TITLE
Extract the cluster of AbstractClusterRequest as a constant

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
+++ b/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
@@ -245,6 +245,14 @@ public class Constants {
     }
     
     /**
+     * The constants in Cluster directory.
+     */
+    public static class Cluster {
+        
+        public static final String CLUSTER_MODULE = "cluster";
+    }
+    
+    /**
      * The constants in exception directory.
      */
     public static class Exception {

--- a/naming/src/main/java/com/alibaba/nacos/naming/cluster/remote/request/AbstractClusterRequest.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/cluster/remote/request/AbstractClusterRequest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.naming.cluster.remote.request;
 
+import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.remote.request.Request;
 
 /**
@@ -24,11 +25,8 @@ import com.alibaba.nacos.api.remote.request.Request;
  * @author xiweng.yy
  */
 public abstract class AbstractClusterRequest extends Request {
-    
-    private static final String CLUSTER = "cluster";
-    
     @Override
     public String getModule() {
-        return CLUSTER;
+        return Constants.Cluster.CLUSTER_MODULE;
     }
 }


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

To unify the code style.

Because I see that the implementation of the subclasses of com. alibaba. nacos. api. remote. request. Request # getModule uses the constants defined in the Constants, and only AbstractClusterRequest is a constant directly defined in the current class, which is inconsistent with the system code style.


因为我看见 com.alibaba.nacos.api.remote.request.Request#getModule 的子类的实现都是使用的 Constants 中定义的常量，而只有AbstractClusterRequest 是直接在当前类定义的一个常量，这与系统现代码风格不符

## Brief changelog
com.alibaba.nacos.naming.cluster.remote.request.AbstractClusterRequest#getModule 的返回值定义到了 

com.alibaba.nacos.api.common.Constants.Cluster#CLUSTER_MODULE

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

