### PR TITLE
[ISSUE #7698] refactor: remove httpasyncclient version dependency management,  avoid version conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -831,13 +831,6 @@
                 <version>${log4j.version}</version>
             </dependency>
             
-            <!-- HTTP client libs -->
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpasyncclient</artifactId>
-                <version>${httpasyncclient.version}</version>
-            </dependency>
-            
             <!-- JDBC libs -->
             <dependency>
                 <groupId>mysql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,6 @@
         <logback.version>1.2.9</logback.version>
         <log4j.version>2.17.1</log4j.version>
         
-        <httpasyncclient.version>4.1.3</httpasyncclient.version>
         <mysql-connector-java.version>8.0.28</mysql-connector-java.version>
         <derby.version>10.14.2.0</derby.version>
         <jackson-core.version>2.12.6</jackson-core.version>


### PR DESCRIPTION

 remove httpasyncclient version dependency management, avoid version conflicts

I find spring boot parent had httpasyncclient version dependency management,  conflicting with own version

Avoid this issue  https://github.com/alibaba/nacos/issues/7698 from happening again
