### PR TITLE
[ISSUE #10206] Optimize nacos default application.properties configuration

### DIFF
--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -120,6 +120,7 @@ management.metrics.export.influx.enabled=false
 server.tomcat.accesslog.enabled=true
 
 ### file name pattern, one file per hour
+server.tomcat.accesslog.rotate=true
 server.tomcat.accesslog.file-date-format=.yyyy-MM-dd-HH
 ### The access log pattern:
 server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %{User-Agent}i %{Request-Source}i

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -97,10 +97,12 @@ db.pool.config.minimumIdle=2
 ### If turn on data loading task:
 # nacos.cmdb.loadDataAtStart=false
 
+#***********Metrics for tomcat **************************#
+server.tomcat.mbeanregistry.enabled=true
 
 #*************** Metrics Related Configurations ***************#
 ### Metrics for prometheus
-#management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=prometheus,health
 
 ### Metrics for elastic search
 management.metrics.export.elastic.enabled=false
@@ -118,6 +120,8 @@ management.metrics.export.influx.enabled=false
 ### If turn on the access log:
 server.tomcat.accesslog.enabled=true
 
+### file name pattern, one file per hour
+server.tomcat.accesslog.file-date-format=.yyyy-MM-dd-HH
 ### The access log pattern:
 server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %{User-Agent}i %{Request-Source}i
 

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -100,9 +100,8 @@ db.pool.config.minimumIdle=2
 #***********Metrics for tomcat **************************#
 server.tomcat.mbeanregistry.enabled=true
 
-#*************** Metrics Related Configurations ***************#
-### Metrics for prometheus
-management.endpoints.web.exposure.include=prometheus,health
+#***********Expose prometheus and health **************************#
+#management.endpoints.web.exposure.include=prometheus,health
 
 ### Metrics for elastic search
 management.metrics.export.elastic.enabled=false


### PR DESCRIPTION
1. expose prometheus endpoint for metrics.
2. expose health endpoint for SLB healthcheck.
3. switch on mbean for tomcat, so we can collect tomcat metrics.
4. use one file per hour for tomcat access log

