### PR TITLE
[ISSUE #10197]搭建配置|插件列表框架

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/button/SwitchInterface.java
+++ b/console/src/main/java/com/alibaba/nacos/console/button/SwitchInterface.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.button;
+
+import com.alibaba.nacos.console.model.button.SwitchResult;
+
+/**
+ * interface function to change property.
+ *
+ * @author 985492783@qq.com
+ * @date 2023/3/28 10:24
+ */
+@FunctionalInterface
+public interface SwitchInterface {
+    
+    /**
+     * the change property method.
+     */
+    SwitchResult changeProperty(Object value);
+    
+}

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v2/PropertyControllerV2.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v2/PropertyControllerV2.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.controller.v2;
+
+import com.alibaba.nacos.api.annotation.NacosApi;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.console.model.button.AbstractPropertyNode;
+import com.alibaba.nacos.console.service.PropertyService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * console property controller.
+ * @author 985492783@qq.com
+ * @date 2023/3/27 16:32
+ */
+@NacosApi
+@RestController
+@RequestMapping("/v2/console/property")
+public class PropertyControllerV2 {
+    
+    private final PropertyService propertyService;
+    
+    public PropertyControllerV2(PropertyService propertyService) {
+        this.propertyService = propertyService;
+    }
+    
+    @GetMapping("/list")
+    public Result<Map<String, List<AbstractPropertyNode<?>>>> getPropertyList() {
+        return Result.success(propertyService.getPropertyMap());
+    }
+   
+}

--- a/console/src/main/java/com/alibaba/nacos/console/model/button/AbstractPropertyNode.java
+++ b/console/src/main/java/com/alibaba/nacos/console/model/button/AbstractPropertyNode.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.model.button;
+
+import com.alibaba.nacos.console.button.SwitchInterface;
+
+/**
+ * property node.
+ * @author 985492783@qq.com
+ * @date 2023/3/28 10:30
+ */
+public abstract class AbstractPropertyNode<V> {
+    
+    private final String property;
+    
+    private final V value;
+    
+    private final boolean isSwitch;
+    
+    private final String description;
+    
+    public AbstractPropertyNode(String property, V value, boolean isSwitch, String description) {
+        this.property = property;
+        this.value = value;
+        this.description = description;
+        this.isSwitch = isSwitch;
+    }
+    
+    /**
+     * create SwitchPropertyNode.
+     */
+    public static <V> AbstractPropertyNode<V> valueOf(String property, V value, String description, SwitchInterface switchInterface) {
+        return new SwitchPropertyNode<>(property, value, description, switchInterface);
+    }
+    
+    /**
+     * create NonSwitchPropertyNode.
+     */
+    public static <V> AbstractPropertyNode<V> valueOf(String property, V value, String description) {
+        return new NonSwitchPropertyNode<>(property, value, description);
+    }
+    
+    public String getProperty() {
+        return property;
+    }
+    
+    public V getValue() {
+        return value;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public boolean isSwitch() {
+        return isSwitch;
+    }
+    
+    public abstract SwitchResult changeProperty(Object value);
+    
+    /**
+     * switch property.
+     */
+    public static class SwitchPropertyNode<V> extends AbstractPropertyNode<V> {
+        
+        private final SwitchInterface switchInterface;
+    
+        private SwitchPropertyNode(String property, V value, String description, SwitchInterface switchInterface) {
+            super(property, value, true, description);
+            this.switchInterface = switchInterface;
+        }
+        
+        @Override
+        public SwitchResult changeProperty(Object value) {
+            return switchInterface.changeProperty(value);
+        }
+        
+    }
+    
+    /**
+     * just-for-show property.
+     */
+    public static class NonSwitchPropertyNode<V> extends AbstractPropertyNode<V> {
+        
+        private NonSwitchPropertyNode(String property, V value, String description) {
+            super(property, value, false, description);
+        }
+    
+        @Override
+        public SwitchResult changeProperty(Object value) {
+            return SwitchResult.nonSwitchFail();
+        }
+        
+    }
+}

--- a/console/src/main/java/com/alibaba/nacos/console/model/button/SwitchResult.java
+++ b/console/src/main/java/com/alibaba/nacos/console/model/button/SwitchResult.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.model.button;
+
+/**
+ * 开关返回结果.
+ * @author 985492783@qq.com
+ * @date 2023/3/28 10:27
+ */
+public class SwitchResult {
+    
+    private final Integer code;
+    
+    private final String message;
+    
+    public SwitchResult(Integer code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+    
+    public static SwitchResult nonSwitchFail() {
+        return new SwitchResult(400, "配置不能改变");
+    }
+    
+    public static SwitchResult nonSameClassFail() {
+        return new SwitchResult(401, "参数类型与所需类型不符");
+    }
+}

--- a/console/src/main/java/com/alibaba/nacos/console/service/PropertyService.java
+++ b/console/src/main/java/com/alibaba/nacos/console/service/PropertyService.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.service;
+
+import com.alibaba.nacos.config.server.constant.Constants;
+import com.alibaba.nacos.config.server.constant.PropertiesConstant;
+import com.alibaba.nacos.config.server.service.datasource.DataSourceService;
+import com.alibaba.nacos.config.server.service.datasource.DynamicDataSource;
+import com.alibaba.nacos.console.model.button.AbstractPropertyNode;
+import com.alibaba.nacos.console.model.button.SwitchResult;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static com.alibaba.nacos.core.listener.StartingApplicationListener.MODE_PROPERTY_KEY_STAND_MODE;
+
+/**
+ * property service.
+ * @author 985492783@qq.com
+ * @date 2023/3/27 15:17
+ */
+@Service("propertyService")
+public class PropertyService {
+    
+    private final Map<String, PropertyNodeMap> propertyMap = new LinkedHashMap<>(16);
+    
+    @PostConstruct
+    public void init() {
+        initBase();
+        initDatabase();
+    }
+    
+    private void initBase() {
+        PropertyNodeMap dataMap = propertyMap.computeIfAbsent("Basic",
+                (k) -> new PropertyNodeMap());
+        
+        AbstractPropertyNode<String> mode = AbstractPropertyNode.valueOf(MODE_PROPERTY_KEY_STAND_MODE,
+                System.getProperty(MODE_PROPERTY_KEY_STAND_MODE), "启动模式");
+        
+        dataMap.put(mode);
+    }
+    
+    /**
+     * init module Database-config.
+     */
+    private void initDatabase() {
+        PropertyNodeMap dataMap = propertyMap.computeIfAbsent("Database",
+                (k) -> new PropertyNodeMap());
+        DataSourceService dataSource = DynamicDataSource.getInstance().getDataSource();
+        AbstractPropertyNode<String> dataPlatform = AbstractPropertyNode.valueOf(PropertiesConstant.DATASOURCE_PLATFORM_PROPERTY,
+                dataSource.getDataSourceType(), "数据源");
+        AbstractPropertyNode<Boolean> dataLogEnabled = AbstractPropertyNode.valueOf(Constants.NACOS_PLUGIN_DATASOURCE_LOG,
+                EnvUtil.getProperty(Constants.NACOS_PLUGIN_DATASOURCE_LOG, Boolean.class, false), "");
+        
+        dataMap.put(dataPlatform);
+        dataMap.put(dataLogEnabled);
+    }
+    
+    public SwitchResult changeProperty(String type, String property, Object value) {
+        return propertyMap.get(type).get(property).changeProperty(value);
+    }
+    
+    public Map<String, List<AbstractPropertyNode<?>>> getPropertyMap() {
+        Map<String, List<AbstractPropertyNode<?>>> map = new LinkedHashMap<>();
+        propertyMap.forEach((k, v) -> {
+            map.put(k, new LinkedList<>(v.values()));
+        });
+        return map;
+    }
+    
+    public static class PropertyNodeMap extends LinkedHashMap<String, AbstractPropertyNode<?>> {
+        
+        public void put(AbstractPropertyNode<?> node) {
+            this.put(node.getProperty(), node);
+        }
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/listener/StartingApplicationListener.java
+++ b/core/src/main/java/com/alibaba/nacos/core/listener/StartingApplicationListener.java
@@ -56,7 +56,7 @@ public class StartingApplicationListener implements NacosApplicationListener {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(StartingApplicationListener.class);
     
-    private static final String MODE_PROPERTY_KEY_STAND_MODE = "nacos.mode";
+    public static final String MODE_PROPERTY_KEY_STAND_MODE = "nacos.mode";
     
     private static final String MODE_PROPERTY_KEY_FUNCTION_MODE = "nacos.function.mode";
     


### PR DESCRIPTION
linked #10197 build frame

考虑到未来使用开关，预留SwitchInterface接口实现让用户动态使用开关  
>SwitchInterface 预留的开关方法，用户产生开关动作后调用该方法  
>
>PropertyControllerV2 controller可以以Open-API形式先提供给用户  
>
>AbstractPropertyNode 抽象配置节点，四个属性，property=server.port, value=8848,isSwitch=false,description="端口号"，有两个子类，一个是开关类switchPropertyNode,另一个是非开关类NonSwitchPropertyNode  
>
>SwitchResult 开关返回结果，非开关类直接返回失败  
>
>PropertyService 初始化获取所有配置，并提供接口  

### 拓展方法
在propertyService中新增配置(是否是开关)节点，并放入对应的类型中，开关需要提供对应的switchInterface接口。工作量很大，需要分批次以及社区的需求进行增加。


期望效果
<table>
	<tr>
		<th>type</th>
		<th>property</th>
                <th>value</th>
		<th>switch</th>
		<th>description</th>
	</tr>
	<tr>
		<td rowspan="2">Basic</td>
		<td>server.port</td>
<td>8848</td>
		<td>false</td>
		<td>端口号</td>
	</tr>
	<tr>
		<td>mode</td>
		<td>stand alone</td>
<td>false</td>
		<td>启动模式</td>
	</tr>
	<tr>
		<td rowspan="2">Database</td>
		<td>data.platform</td>
<td>mysql</td>
		<td>false</td>
		<td>数据源</td>
	</tr>
	<tr>
		<td>xx.log.enable</td>
<td>false</td>
		<td>按钮开关</td>
		<td>xx日志</td>
	</tr>
</table>

```java
    /**
     * switch property.
     */
    public static class SwitchPropertyNode<V> extends AbstractPropertyNode<V> {
        
        private final SwitchInterface switchInterface;
    
        private SwitchPropertyNode(String property, V value, String description, SwitchInterface switchInterface) {
            super(property, value, true, description);
            this.switchInterface = switchInterface;
        }
        
        @Override
        public SwitchResult changeProperty(Object value) {
            return switchInterface.changeProperty(value);
        }
        
    }
```