### PR TITLE
[bot pr#10648] Optimize Guava Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,6 @@
         <jackson.annotations.version>2.12.6</jackson.annotations.version>
         <jackson-core-asl.version>1.9.13</jackson-core-asl.version>
         <jjwt.version>0.11.2</jjwt.version>
-        <guava.version>30.1-jre</guava.version>
         <javatuples.version>1.2</javatuples.version>
         <grpc-java.version>1.50.2</grpc-java.version>
         <proto-google-common-protos.version>2.7.1</proto-google-common-protos.version>
@@ -935,12 +934,6 @@
                 <groupId>javax.annotation</groupId>
                 <artifactId>javax.annotation-api</artifactId>
                 <version>1.3.2</version>
-            </dependency>
-            
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
             </dependency>
             
             <dependency>


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

[bot pr#10648] Optimize Guava Dependency

## Brief changelog

Remove guava dependencyManagement, and imported by grpc.

## Verifying this change

According to the result of `mvn dependency:tree`, the actually version of guava is `31.1-android`,which imported by `grpc-netty-shaded`.
