### PR TITLE
fix(#10717): com.alibaba.nacos.common.http.client.request.JdkHttpClie…

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
@@ -96,7 +96,7 @@ public class JdkHttpClientRequest implements HttpClientRequest {
         conn.setRequestMethod(httpMethod);
         if (body != null && !"".equals(body)) {
             String contentType = headers.getValue(HttpHeaderConsts.CONTENT_TYPE);
-            String bodyStr = JacksonUtils.toJson(body);
+            String bodyStr = body instanceof String ? (String) body : JacksonUtils.toJson(body);
             if (MediaType.APPLICATION_FORM_URLENCODED.equals(contentType)) {
                 Map<String, String> map = JacksonUtils.toObj(bodyStr, HashMap.class);
                 bodyStr = HttpUtils.encodingParams(map, headers.getCharset());


### PR DESCRIPTION
## What is the purpose of the change

fix the issue  #10717 

## Brief changelog

Actually, there is a serialization issue with the com.alibaba.nacos.common.utils.JacksonUtils#toJson method. When the parameter is a JSON-formatted string, the returned result is no longer a JSON-formatted string. This causes a problem in the com.alibaba.nacos.common.http.client.request.JdkHttpClientRequest#execute method when the body is a JSON string and the Content-Type is set to application/json. It leads to incorrect parsing of the body, causing the server-side to be unable to properly interpret the body. Ideally, the adjustment should be made internally in the com.alibaba.nacos.common.utils.JacksonUtils#toJson method. However, considering that this method is public, directly modifying it may affect users who rely on this method. Therefore, the adjustment will only be made to the com.alibaba.nacos.common.http.client.request.JdkHttpClientRequest#execute method to fix this issue. If necessary, a separate pull request will be submitted later to fix the com.alibaba.nacos.common.utils.JacksonUtils#toJson method.


