### PR TITLE
feat(#10727): when the doPushWithCallback push task fails, it no longer retries forever, but only the default number of retries

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/push/v2/task/PushDelayTask.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/push/v2/task/PushDelayTask.java
@@ -36,6 +36,8 @@ public class PushDelayTask extends AbstractDelayTask {
     
     private Set<String> targetClients;
     
+    private int retriedCount = 0;
+    
     public PushDelayTask(Service service, long delay) {
         this.service = service;
         pushToAll = true;
@@ -49,6 +51,25 @@ public class PushDelayTask extends AbstractDelayTask {
         this.pushToAll = false;
         this.targetClients = new HashSet<>(1);
         this.targetClients.add(targetClient);
+        setTaskInterval(delay);
+        setLastProcessTime(System.currentTimeMillis());
+    }
+    
+    public PushDelayTask(Service service, long delay, int retriedCount) {
+        this.service = service;
+        pushToAll = true;
+        targetClients = null;
+        this.retriedCount = retriedCount;
+        setTaskInterval(delay);
+        setLastProcessTime(System.currentTimeMillis());
+    }
+    
+    public PushDelayTask(Service service, long delay, String targetClient, int retriedCount) {
+        this.service = service;
+        this.pushToAll = false;
+        this.targetClients = new HashSet<>(1);
+        this.targetClients.add(targetClient);
+        this.retriedCount = retriedCount;
         setTaskInterval(delay);
         setLastProcessTime(System.currentTimeMillis());
     }
@@ -79,5 +100,9 @@ public class PushDelayTask extends AbstractDelayTask {
     
     public Set<String> getTargetClients() {
         return targetClients;
+    }
+    
+    public int getRetriedCount() {
+        return retriedCount;
     }
 }

--- a/naming/src/main/resources/application.properties
+++ b/naming/src/main/resources/application.properties
@@ -34,3 +34,5 @@ server.tomcat.accesslog.enabled=true
 server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D
 # default current work dir
 server.tomcat.basedir=file:.
+# push retry times
+push.retry.times=3

--- a/sys/src/main/java/com/alibaba/nacos/sys/env/EnvUtil.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/env/EnvUtil.java
@@ -40,11 +40,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.HashMap;
 
 /**
  * Its own configuration information manipulation tool class.
@@ -103,11 +103,17 @@ public class EnvUtil {
     private static final String NACOS_TEMP_DIR_1 = "data";
     
     private static final String NACOS_TEMP_DIR_2 = "tmp";
-
+    
     private static final String NACOS_CUSTOM_ENVIRONMENT_ENABLED = "nacos.custom.environment.enabled";
-
+    
     private static final String NACOS_CUSTOM_CONFIG_NAME = "customFirstNacosConfig";
-
+    
+    private static final int DEFAULT_PUSH_RETRY_TIME = 3;
+    
+    private static final String PUSH_RETRY_TIME = "push.retry.times";
+    
+    private static Integer pushRetryTimes;
+    
     @JustForTest
     private static String confPath = "";
     
@@ -115,7 +121,7 @@ public class EnvUtil {
     private static String nacosHomePath = null;
     
     private static ConfigurableEnvironment environment;
-
+    
     /**
      * customEnvironment.
      */
@@ -226,6 +232,21 @@ public class EnvUtil {
     
     public static void setContextPath(String contextPath) {
         EnvUtil.contextPath = contextPath;
+    }
+    
+    public static int getPushRetryTimes() {
+        if (null == pushRetryTimes) {
+            try {
+                pushRetryTimes = getProperty(PUSH_RETRY_TIME, Integer.class, DEFAULT_PUSH_RETRY_TIME);
+            } catch (Exception e) {
+                pushRetryTimes = DEFAULT_PUSH_RETRY_TIME;
+            }
+        }
+        return pushRetryTimes;
+    }
+    
+    public static void setPushRetryTimes(int pushRetryTimes) {
+        EnvUtil.pushRetryTimes = pushRetryTimes;
     }
     
     @JustForTest


### PR DESCRIPTION
## What is the purpose of the change

feat(#10727) When the doPushWithCallback push task fails, it no longer retries forever, but only the default number of retries.

## Brief changelog

DoPushWithCallback will retry after failing to push the same task. If the task fails every retry, it will retry forever. This will waste resources on invalid tasks that are bound to fail, and at the same time, when a large number of invalid tasks appear, it will cause the server to OOM.

After doPushWithCallback fails to push the same task, it will only perform the default number of retries. After the default number of times is exceeded, even if the task still fails to be pushed, it will not be added to the task queue.

## Verifying this change
After doPushWithCallback fails to push the same task, it will only perform the default number of retries. After the default number of times is exceeded, even if the task still fails to be pushed, it will not be added to the task queue.

Users can customize the number of retries. If not configured, the default value will be used. The default value is 3.
