### PR TITLE
fix(#10427): When the execution of handleServerRequest() encounters an exception, record the log and throw an exception, then quickly response to the server errResponse

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
@@ -832,6 +832,7 @@ public abstract class RpcClient implements Closeable {
             } catch (Exception e) {
                 LoggerUtils.printIfInfoEnabled(LOGGER, "[{}] HandleServerRequest:{}, errorMessage = {}",
                         rpcClientConfig.name(), serverRequestHandler.getClass().getName(), e.getMessage());
+                throw e;
             }
             
         }

--- a/common/src/test/java/com/alibaba/nacos/common/remote/client/RpcClientTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/remote/client/RpcClientTest.java
@@ -635,4 +635,19 @@ public class RpcClientTest {
             }
         };
     }
+    
+    @Test(expected = RuntimeException.class)
+    public void testHandleServerRequestWhenExceptionThenThrowException() throws RuntimeException {
+        RpcClient rpcClient = buildTestNextRpcServerClient();
+        Request request = new Request() {
+            @Override
+            public String getModule() {
+                return null;
+            }
+        };
+        rpcClient.serverRequestHandlers.add(req -> {
+            throw new RuntimeException();
+        });
+        rpcClient.handleServerRequest(request);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

fix(#10427): When the execution of handleServerRequest() encounters an exception, record the log and throw an exception, then quickly response to the server errResponse

