### PR TITLE
feat(#5608 and #10223): When the custom instance id is empty, the id will be automatically generated.

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/constants/Constants.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/constants/Constants.java
@@ -76,9 +76,9 @@ public final class Constants {
     public static final long ACK_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(10L);
     
     /**
-     * The custom instance id key.
+     * The instance id key.
      */
-    public static final String CUSTOM_INSTANCE_ID = "customInstanceId";
+    public static final String INSTANCE_ID = "instanceId";
     
     /**
      * The weight of instance according to instance self publish.

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationService.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationService.java
@@ -19,11 +19,12 @@ package com.alibaba.nacos.naming.core.v2.service;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.naming.constants.Constants;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.misc.UtilsAndCommons;
 import com.alibaba.nacos.naming.pojo.Subscriber;
-import com.alibaba.nacos.naming.constants.Constants;
+import com.alibaba.nacos.naming.utils.InstanceUtil;
 
 import java.util.List;
 import java.util.Map;
@@ -97,9 +98,10 @@ public interface ClientOperationService {
         if (null != instance.getMetadata() && !instance.getMetadata().isEmpty()) {
             extendDatum.putAll(instance.getMetadata());
         }
-        if (StringUtils.isNotEmpty(instance.getInstanceId())) {
-            extendDatum.put(Constants.CUSTOM_INSTANCE_ID, instance.getInstanceId());
+        if (StringUtils.isEmpty(instance.getInstanceId())) {
+            instance.setInstanceId(InstanceUtil.generateInstanceId(instance));
         }
+        extendDatum.put(Constants.INSTANCE_ID, instance.getInstanceId());
         if (Constants.DEFAULT_INSTANCE_WEIGHT != instance.getWeight()) {
             extendDatum.put(Constants.PUBLISH_INSTANCE_WEIGHT, instance.getWeight());
         }

--- a/naming/src/main/java/com/alibaba/nacos/naming/utils/InstanceUtil.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/utils/InstanceUtil.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.naming.utils;
 
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.utils.NamingUtils;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.naming.constants.Constants;
 import com.alibaba.nacos.naming.core.v2.metadata.InstanceMetadata;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
@@ -49,7 +50,7 @@ public final class InstanceUtil {
         Map<String, String> instanceMetadata = new HashMap<>(instanceInfo.getExtendDatum().size());
         for (Map.Entry<String, Object> entry : instanceInfo.getExtendDatum().entrySet()) {
             switch (entry.getKey()) {
-                case Constants.CUSTOM_INSTANCE_ID:
+                case Constants.INSTANCE_ID:
                     result.setInstanceId(entry.getValue().toString());
                     break;
                 case Constants.PUBLISH_INSTANCE_ENABLE:
@@ -100,5 +101,16 @@ public final class InstanceUtil {
         target.setServiceName(source.getServiceName());
         target.setMetadata(new HashMap<>(source.getMetadata()));
         return target;
+    }
+    
+    /**
+     * generate instance id.
+     *
+     * @param instance instance to be registered
+     * @return
+     */
+    public static String generateInstanceId(Instance instance) {
+        return instance.getIp() + InternetAddressUtil.IP_PORT_SPLITER + instance.getPort() + "_"
+                + System.currentTimeMillis();
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationServiceTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationServiceTest.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.service;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.naming.constants.Constants;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * {@link ClientOperationService} unit tests.
+ *
+ * @author blake.qiu
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ClientOperationServiceTest {
+    
+    @Test
+    public void getPublishInfoAutoGenerateInsId() {
+        ClientOperationServiceProxy clientOperationService = new ClientOperationServiceProxy(null, null);
+        Instance instance = new Instance();
+        String customInsId = "1.1.1.1_custom";
+        instance.setInstanceId(customInsId);
+        InstancePublishInfo publishInfo1 = clientOperationService.getPublishInfo(instance);
+        assert customInsId.equals(publishInfo1.getExtendDatum().get(Constants.INSTANCE_ID));
+        
+        InstancePublishInfo publishInfo2 = clientOperationService.getPublishInfo(new Instance());
+        String insId = (String) publishInfo2.getExtendDatum().get(Constants.INSTANCE_ID);
+        assert StringUtils.isNotEmpty(insId);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

feat(#5608  and #10223 ): When the custom instance id is empty, the id will be automatically generated.

## Brief changelog

When the custom instance id is empty, the id will be automatically generated.

```
    public static String generateInstanceId(Instance instance) {
        return instance.getIp() + InternetAddressUtil.IP_PORT_SPLITER + instance.getPort() + "_"
                + System.currentTimeMillis();
    }
```