### PR TITLE
Reactor code in datasource-plugin

### DIFF
--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/ruleactivator/DiskUtils.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/ruleactivator/DiskUtils.java
@@ -64,9 +64,9 @@ public final class DiskUtils {
     
     private static final String NO_SPACE_EN = "No space left on device";
     
-    private static final String DISK_QUATA_CN = "超出磁盘限额";
+    private static final String DISK_QUOTA_CN = "超出磁盘限额";
     
-    private static final String DISK_QUATA_EN = "Disk quota exceeded";
+    private static final String DISK_QUOTA_EN = "Disk quota exceeded";
     
     private static final Charset CHARSET = StandardCharsets.UTF_8;
     
@@ -237,8 +237,8 @@ public final class DiskUtils {
         } catch (IOException ioe) {
             if (ioe.getMessage() != null) {
                 String errMsg = ioe.getMessage();
-                if (NO_SPACE_CN.equals(errMsg) || NO_SPACE_EN.equals(errMsg) || errMsg.contains(DISK_QUATA_CN) || errMsg
-                        .contains(DISK_QUATA_EN)) {
+                if (NO_SPACE_CN.equals(errMsg) || NO_SPACE_EN.equals(errMsg) || errMsg.contains(DISK_QUOTA_CN) || errMsg
+                        .contains(DISK_QUOTA_EN)) {
                     LOGGER.warn("磁盘满，自杀退出");
                     System.exit(0);
                 }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoAggrMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoAggrMapperByMySql.java
@@ -35,8 +35,8 @@ public class ConfigInfoAggrMapperByMySql extends AbstractMapper implements Confi
     
     @Override
     public MapperResult findConfigInfoAggrByPageFetchRows(MapperContext context) {
-        Integer startRow =  context.getStartRow();
-        Integer pageSize =  context.getPageSize();
+        int startRow =  context.getStartRow();
+        int pageSize =  context.getPageSize();
         String dataId = (String) context.getWhereParameter(FieldConstant.DATA_ID);
         String groupId = (String) context.getWhereParameter(FieldConstant.GROUP_ID);
         String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
@@ -52,7 +52,7 @@ public abstract class AbstractMapper implements Mapper {
         appendWhereClause(where, sql);
         return sql.toString();
     }
-
+    
     @Override
     public String insert(List<String> columns) {
         StringBuilder sql = new StringBuilder();

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
@@ -25,7 +25,7 @@ import java.util.List;
  **/
 
 public abstract class AbstractMapper implements Mapper {
-    
+
     @Override
     public String select(List<String> columns, List<String> where) {
         StringBuilder sql = new StringBuilder();
@@ -42,28 +42,22 @@ public abstract class AbstractMapper implements Mapper {
         sql.append("FROM ");
         sql.append(getTableName());
         sql.append(" ");
-        
+
         if (where.size() == 0) {
             return sql.toString();
         }
-        
-        sql.append("WHERE ");
-        for (int i = 0; i < where.size(); i++) {
-            sql.append(where.get(i)).append(" = ").append("?");
-            if (i != where.size() - 1) {
-                sql.append(" AND ");
-            }
-        }
+
+        appendWhereClause(where, sql);
         return sql.toString();
     }
-    
+
     @Override
     public String insert(List<String> columns) {
         StringBuilder sql = new StringBuilder();
         String method = "INSERT INTO ";
         sql.append(method);
         sql.append(getTableName());
-        
+
         int size = columns.size();
         sql.append("(");
         for (int i = 0; i < size; i++) {
@@ -73,7 +67,7 @@ public abstract class AbstractMapper implements Mapper {
             }
         }
         sql.append(") ");
-        
+
         sql.append("VALUES");
         sql.append("(");
         for (int i = 0; i < size; i++) {
@@ -85,36 +79,30 @@ public abstract class AbstractMapper implements Mapper {
         sql.append(")");
         return sql.toString();
     }
-    
+
     @Override
     public String update(List<String> columns, List<String> where) {
         StringBuilder sql = new StringBuilder();
         String method = "UPDATE ";
         sql.append(method);
         sql.append(getTableName()).append(" ").append("SET ");
-        
+
         for (int i = 0; i < columns.size(); i++) {
             sql.append(columns.get(i)).append(" = ").append("?");
             if (i != columns.size() - 1) {
                 sql.append(",");
             }
         }
-        
+
         if (where.size() == 0) {
             return sql.toString();
         }
-        
-        sql.append(" WHERE ");
-        
-        for (int i = 0; i < where.size(); i++) {
-            sql.append(where.get(i)).append(" = ").append("?");
-            if (i != where.size() - 1) {
-                sql.append(" AND ");
-            }
-        }
+
+        appendWhereClause(where, sql);
+
         return sql.toString();
     }
-    
+
     @Override
     public String delete(List<String> params) {
         StringBuilder sql = new StringBuilder();
@@ -126,10 +114,10 @@ public abstract class AbstractMapper implements Mapper {
                 sql.append("AND ");
             }
         }
-        
+
         return sql.toString();
     }
-    
+
     @Override
     public String count(List<String> where) {
         StringBuilder sql = new StringBuilder();
@@ -138,11 +126,22 @@ public abstract class AbstractMapper implements Mapper {
         sql.append("COUNT(*) FROM ");
         sql.append(getTableName());
         sql.append(" ");
-        
+
         if (null == where || where.size() == 0) {
             return sql.toString();
         }
-        
+
+        appendWhereClause(where, sql);
+
+        return sql.toString();
+    }
+
+    @Override
+    public String[] getPrimaryKeyGeneratedKeys() {
+        return new String[]{"id"};
+    }
+
+    private void appendWhereClause(List<String> where, StringBuilder sql) {
         sql.append("WHERE ");
         for (int i = 0; i < where.size(); i++) {
             sql.append(where.get(i)).append(" = ").append("?");
@@ -150,11 +149,5 @@ public abstract class AbstractMapper implements Mapper {
                 sql.append(" AND ");
             }
         }
-        return sql.toString();
-    }
-    
-    @Override
-    public String[] getPrimaryKeyGeneratedKeys() {
-        return new String[]{"id"};
     }
 }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.plugin.datasource.mapper;
 
+import com.alibaba.nacos.common.utils.CollectionUtils;
+
 import java.util.List;
 
 /**
@@ -43,7 +45,7 @@ public abstract class AbstractMapper implements Mapper {
         sql.append(getTableName());
         sql.append(" ");
 
-        if (where.size() == 0) {
+        if (CollectionUtils.isEmpty(where)) {
             return sql.toString();
         }
 
@@ -94,7 +96,7 @@ public abstract class AbstractMapper implements Mapper {
             }
         }
 
-        if (where.size() == 0) {
+        if (CollectionUtils.isEmpty(where)) {
             return sql.toString();
         }
 

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
@@ -52,7 +52,7 @@ public abstract class AbstractMapper implements Mapper {
         appendWhereClause(where, sql);
         return sql.toString();
     }
-    
+
     @Override
     public String insert(List<String> columns) {
         StringBuilder sql = new StringBuilder();
@@ -137,7 +137,7 @@ public abstract class AbstractMapper implements Mapper {
 
         return sql.toString();
     }
-
+    
     @Override
     public String[] getPrimaryKeyGeneratedKeys() {
         return new String[]{"id"};

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
@@ -27,7 +27,7 @@ import java.util.List;
  **/
 
 public abstract class AbstractMapper implements Mapper {
-
+    
     @Override
     public String select(List<String> columns, List<String> where) {
         StringBuilder sql = new StringBuilder();
@@ -44,22 +44,22 @@ public abstract class AbstractMapper implements Mapper {
         sql.append("FROM ");
         sql.append(getTableName());
         sql.append(" ");
-
+        
         if (CollectionUtils.isEmpty(where)) {
             return sql.toString();
         }
-
+        
         appendWhereClause(where, sql);
         return sql.toString();
     }
-
+    
     @Override
     public String insert(List<String> columns) {
         StringBuilder sql = new StringBuilder();
         String method = "INSERT INTO ";
         sql.append(method);
         sql.append(getTableName());
-
+        
         int size = columns.size();
         sql.append("(");
         for (int i = 0; i < size; i++) {
@@ -69,7 +69,7 @@ public abstract class AbstractMapper implements Mapper {
             }
         }
         sql.append(") ");
-
+        
         sql.append("VALUES");
         sql.append("(");
         for (int i = 0; i < size; i++) {
@@ -81,30 +81,30 @@ public abstract class AbstractMapper implements Mapper {
         sql.append(")");
         return sql.toString();
     }
-
+    
     @Override
     public String update(List<String> columns, List<String> where) {
         StringBuilder sql = new StringBuilder();
         String method = "UPDATE ";
         sql.append(method);
         sql.append(getTableName()).append(" ").append("SET ");
-
+        
         for (int i = 0; i < columns.size(); i++) {
             sql.append(columns.get(i)).append(" = ").append("?");
             if (i != columns.size() - 1) {
                 sql.append(",");
             }
         }
-
+        
         if (CollectionUtils.isEmpty(where)) {
             return sql.toString();
         }
-
+        
         appendWhereClause(where, sql);
-
+        
         return sql.toString();
     }
-
+    
     @Override
     public String delete(List<String> params) {
         StringBuilder sql = new StringBuilder();
@@ -116,10 +116,10 @@ public abstract class AbstractMapper implements Mapper {
                 sql.append("AND ");
             }
         }
-
+        
         return sql.toString();
     }
-
+    
     @Override
     public String count(List<String> where) {
         StringBuilder sql = new StringBuilder();
@@ -128,21 +128,21 @@ public abstract class AbstractMapper implements Mapper {
         sql.append("COUNT(*) FROM ");
         sql.append(getTableName());
         sql.append(" ");
-
+        
         if (null == where || where.size() == 0) {
             return sql.toString();
         }
-
+        
         appendWhereClause(where, sql);
-
+        
         return sql.toString();
     }
-
+    
     @Override
     public String[] getPrimaryKeyGeneratedKeys() {
-        return new String[]{"id"};
+        return new String[] {"id"};
     }
-
+    
     private void appendWhereClause(List<String> where, StringBuilder sql) {
         sql.append(" WHERE ");
         for (int i = 0; i < where.size(); i++) {

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
@@ -137,7 +137,7 @@ public abstract class AbstractMapper implements Mapper {
 
         return sql.toString();
     }
-    
+
     @Override
     public String[] getPrimaryKeyGeneratedKeys() {
         return new String[]{"id"};

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
@@ -100,6 +100,7 @@ public abstract class AbstractMapper implements Mapper {
             return sql.toString();
         }
         
+        sql.append(" ");
         appendWhereClause(where, sql);
         
         return sql.toString();
@@ -144,7 +145,7 @@ public abstract class AbstractMapper implements Mapper {
     }
     
     private void appendWhereClause(List<String> where, StringBuilder sql) {
-        sql.append(" WHERE ");
+        sql.append("WHERE ");
         for (int i = 0; i < where.size(); i++) {
             sql.append(where.get(i)).append(" = ").append("?");
             if (i != where.size() - 1) {

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
@@ -142,7 +142,7 @@ public abstract class AbstractMapper implements Mapper {
     }
 
     private void appendWhereClause(List<String> where, StringBuilder sql) {
-        sql.append("WHERE ");
+        sql.append(" WHERE ");
         for (int i = 0; i < where.size(); i++) {
             sql.append(where.get(i)).append(" = ").append("?");
             if (i != where.size() - 1) {

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
@@ -24,50 +24,50 @@ import org.junit.Test;
 import java.util.Arrays;
 
 public class AbstractMapperTest {
-
+    
     private AbstractMapper abstractMapper;
-
+    
     @Before
     public void setUp() throws Exception {
         abstractMapper = new TenantInfoMapperByMySql();
     }
-
+    
     @Test
     public void testSelect() {
         String sql = abstractMapper.select(Arrays.asList("id", "name"), Arrays.asList("id"));
         Assert.assertEquals(sql, "SELECT id,name FROM tenant_info  WHERE id = ?");
     }
-
+    
     @Test
     public void testInsert() {
         String sql = abstractMapper.insert(Arrays.asList("id", "name"));
         Assert.assertEquals(sql, "INSERT INTO tenant_info(id, name) VALUES(?,?)");
     }
-
+    
     @Test
     public void testUpdate() {
         String sql = abstractMapper.update(Arrays.asList("id", "name"), Arrays.asList("id"));
         Assert.assertEquals(sql, "UPDATE tenant_info SET id = ?,name = ? WHERE id = ?");
     }
-
+    
     @Test
     public void testDelete() {
         String sql = abstractMapper.delete(Arrays.asList("id"));
         Assert.assertEquals(sql, "DELETE FROM tenant_info WHERE id = ? ");
     }
-
+    
     @Test
     public void testCount() {
         String sql = abstractMapper.count(Arrays.asList("id"));
         Assert.assertEquals(sql, "SELECT COUNT(*) FROM tenant_info  WHERE id = ?");
     }
-
+    
     @Test
     public void testGetPrimaryKeyGeneratedKeys() {
         String[] keys = abstractMapper.getPrimaryKeyGeneratedKeys();
         Assert.assertEquals(keys[0], "id");
     }
-
+    
     @Test
     public void testSelectAll() {
         String sql = abstractMapper.select(Arrays.asList("id", "name"), null);

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
@@ -71,13 +71,13 @@ public class AbstractMapperTest {
 
     @Test
     public void testSelectAll() {
-        String sql = abstractMapper.select(Arrays.asList("id", "name"), Collections.emptyList());
+        String sql = abstractMapper.select(Arrays.asList("id", "name"), null);
         Assert.assertEquals(sql, "SELECT id,name FROM tenant_info ");
     }
 
     @Test
     public void testCountAll() {
-        String sql = abstractMapper.count(Collections.emptyList());
+        String sql = abstractMapper.count(null);
         Assert.assertEquals(sql, "SELECT COUNT(*) FROM tenant_info ");
     }
 }

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
@@ -22,7 +22,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 public class AbstractMapperTest {
 

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
@@ -22,49 +22,62 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 public class AbstractMapperTest {
-    
+
     private AbstractMapper abstractMapper;
-    
+
     @Before
     public void setUp() throws Exception {
         abstractMapper = new TenantInfoMapperByMySql();
     }
-    
+
     @Test
     public void testSelect() {
         String sql = abstractMapper.select(Arrays.asList("id", "name"), Arrays.asList("id"));
-        Assert.assertEquals(sql, "SELECT id,name FROM tenant_info WHERE id = ?");
+        Assert.assertEquals(sql, "SELECT id,name FROM tenant_info  WHERE id = ?");
     }
-    
+
     @Test
     public void testInsert() {
         String sql = abstractMapper.insert(Arrays.asList("id", "name"));
         Assert.assertEquals(sql, "INSERT INTO tenant_info(id, name) VALUES(?,?)");
     }
-    
+
     @Test
     public void testUpdate() {
         String sql = abstractMapper.update(Arrays.asList("id", "name"), Arrays.asList("id"));
         Assert.assertEquals(sql, "UPDATE tenant_info SET id = ?,name = ? WHERE id = ?");
     }
-    
+
     @Test
     public void testDelete() {
         String sql = abstractMapper.delete(Arrays.asList("id"));
         Assert.assertEquals(sql, "DELETE FROM tenant_info WHERE id = ? ");
     }
-    
+
     @Test
     public void testCount() {
         String sql = abstractMapper.count(Arrays.asList("id"));
-        Assert.assertEquals(sql, "SELECT COUNT(*) FROM tenant_info WHERE id = ?");
+        Assert.assertEquals(sql, "SELECT COUNT(*) FROM tenant_info  WHERE id = ?");
     }
-    
+
     @Test
     public void testGetPrimaryKeyGeneratedKeys() {
         String[] keys = abstractMapper.getPrimaryKeyGeneratedKeys();
         Assert.assertEquals(keys[0], "id");
+    }
+
+    @Test
+    public void testSelectAll() {
+        String sql = abstractMapper.select(Arrays.asList("id", "name"), Collections.emptyList());
+        Assert.assertEquals(sql, "SELECT id,name FROM tenant_info ");
+    }
+
+    @Test
+    public void testCountAll() {
+        String sql = abstractMapper.count(Collections.emptyList());
+        Assert.assertEquals(sql, "SELECT COUNT(*) FROM tenant_info ");
     }
 }

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
@@ -35,7 +35,7 @@ public class AbstractMapperTest {
     @Test
     public void testSelect() {
         String sql = abstractMapper.select(Arrays.asList("id", "name"), Arrays.asList("id"));
-        Assert.assertEquals(sql, "SELECT id,name FROM tenant_info  WHERE id = ?");
+        Assert.assertEquals(sql, "SELECT id,name FROM tenant_info WHERE id = ?");
     }
     
     @Test
@@ -59,7 +59,7 @@ public class AbstractMapperTest {
     @Test
     public void testCount() {
         String sql = abstractMapper.count(Arrays.asList("id"));
-        Assert.assertEquals(sql, "SELECT COUNT(*) FROM tenant_info  WHERE id = ?");
+        Assert.assertEquals(sql, "SELECT COUNT(*) FROM tenant_info WHERE id = ?");
     }
     
     @Test

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
@@ -73,7 +73,7 @@ public class AbstractMapperTest {
         String sql = abstractMapper.select(Arrays.asList("id", "name"), null);
         Assert.assertEquals(sql, "SELECT id,name FROM tenant_info ");
     }
-
+    
     @Test
     public void testCountAll() {
         String sql = abstractMapper.count(null);


### PR DESCRIPTION
## What is the purpose of the change

Reactor code in datasource-plugin

## Brief changelog

1. Extract common method to append where clause in `AbstractMapper`, in order to reduce duplicated code.
2. Remove unnecessary boxing in `ConfigInfoAggrMapperByMySql`.
3. Fix word spelling in `DiskUtils`.
4. Complete AbstractMapper Test Case.

