### PR TITLE
feat(#5608): When the custom instance id is empty, the id will be automatically generated.

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/naming/pojo/Instance.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/pojo/Instance.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.api.naming.pojo;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
 import com.alibaba.nacos.api.naming.utils.NamingUtils;
+import com.alibaba.nacos.api.utils.StringUtils;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -26,6 +27,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Instance.
@@ -34,6 +36,11 @@ import java.util.Objects;
  */
 @JsonInclude(Include.NON_NULL)
 public class Instance implements Serializable {
+    
+    /**
+     * Instance auto-increment index, used to generate instance ID.
+     */
+    private static final AtomicLong AUTO_INCREMENT_ID = new AtomicLong();
     
     private static final long serialVersionUID = -742906310567291979L;
     
@@ -264,4 +271,14 @@ public class Instance implements Serializable {
         return getMetadata().get(key);
     }
     
+    /**
+     * Generate and set the instance id when the instance id is empty.
+     */
+    public void setInstanceIdIfNeeded() {
+        if (StringUtils.isEmpty(this.instanceId)) {
+            long curIndex = AUTO_INCREMENT_ID.getAndIncrement();
+            this.instanceId = ip + Constants.COLON + port + Constants.NAMING_INSTANCE_ID_SPLITTER + curIndex
+                    + Constants.NAMING_INSTANCE_ID_SPLITTER + System.currentTimeMillis();
+        }
+    }
 }

--- a/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
@@ -184,4 +184,24 @@ public class NamingUtils {
     public static boolean isNumber(String str) {
         return !StringUtils.isEmpty(str) && NUMBER_PATTERN.matcher(str).matches();
     }
+    
+    /**
+     * Set instanceId if needed.
+     *
+     * @param instance Instance to be registered
+     */
+    public static void setInstanceIdIfNeeded(Instance instance) {
+        instance.setInstanceIdIfNeeded();
+    }
+    
+    /**
+     * Batch set instanceId if needed.
+     *
+     * @param instances List of instances to be registered
+     */
+    public static void batchSetInstanceIdIfNeeded(List<Instance> instances) {
+        for (Instance instance : instances) {
+            instance.setInstanceIdIfNeeded();
+        }
+    }
 }

--- a/api/src/test/java/com/alibaba/nacos/api/naming/utils/NamingUtilsTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/naming/utils/NamingUtilsTest.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class NamingUtilsTest {
@@ -239,5 +241,57 @@ public class NamingUtilsTest {
     
         String str2 = "123456";
         assertTrue(NamingUtils.isNumber(str2));
+    }
+    
+    @Test
+    public void testSetInstanceIdIfNeeded() {
+        Instance instance = new Instance();
+        NamingUtils.setInstanceIdIfNeeded(instance);
+        assertNotNull(instance.getInstanceId());
+        String customInsId = "customId_1";
+        instance.setInstanceId(customInsId);
+        assertEquals(customInsId, instance.getInstanceId());
+        
+        Instance instance1 = new Instance();
+        Instance instance2 = new Instance();
+        Instance instance3 = new Instance();
+        
+        NamingUtils.setInstanceIdIfNeeded(instance1);
+        NamingUtils.setInstanceIdIfNeeded(instance2);
+        NamingUtils.setInstanceIdIfNeeded(instance3);
+        
+        assertNotNull(instance1.getInstanceId());
+        assertNotNull(instance2.getInstanceId());
+        assertNotNull(instance3.getInstanceId());
+        
+        assertNotEquals(instance1.getInstanceId(), instance2.getInstanceId());
+        assertNotEquals(instance1.getInstanceId(), instance3.getInstanceId());
+        assertNotEquals(instance2.getInstanceId(), instance3.getInstanceId());
+    }
+    
+    @Test
+    public void testBatchSetInstanceIdIfNeeded() {
+        List<Instance> instances = new ArrayList<>();
+        Instance instance1 = new Instance();
+        String customInsId = "customId_1";
+        instance1.setInstanceId(customInsId);
+        Instance instance2 = new Instance();
+        Instance instance3 = new Instance();
+        
+        instances.add(instance1);
+        instances.add(instance2);
+        instances.add(instance3);
+        
+        NamingUtils.batchSetInstanceIdIfNeeded(instances);
+        
+        assertNotNull(instance1.getInstanceId());
+        assertNotNull(instance2.getInstanceId());
+        assertNotNull(instance3.getInstanceId());
+        
+        assertEquals(customInsId, instance1.getInstanceId());
+        
+        assertNotEquals(instance1.getInstanceId(), instance2.getInstanceId());
+        assertNotEquals(instance1.getInstanceId(), instance3.getInstanceId());
+        assertNotEquals(instance2.getInstanceId(), instance3.getInstanceId());
     }
 }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -140,6 +140,7 @@ public class NacosNamingService implements NamingService {
     @Override
     public void registerInstance(String serviceName, String groupName, Instance instance) throws NacosException {
         NamingUtils.checkInstanceIsLegal(instance);
+        NamingUtils.setInstanceIdIfNeeded(instance);
         clientProxy.registerService(serviceName, groupName, instance);
     }
     
@@ -147,6 +148,7 @@ public class NacosNamingService implements NamingService {
     public void batchRegisterInstance(String serviceName, String groupName, List<Instance> instances)
             throws NacosException {
         NamingUtils.batchCheckInstanceIsLegal(instances);
+        NamingUtils.batchSetInstanceIdIfNeeded(instances);
         clientProxy.batchRegisterService(serviceName, groupName, instances);
     }
     


### PR DESCRIPTION
## What is the purpose of the change

feat(#5608): When the custom instance id is empty, the id will be automatically generated.

When the client initiates a request to register an instance, it will determine whether the instance ID is empty. If it is empty, the instance ID will be automatically generated and set.

```
public void setInstanceIdIfNeeded() {
        if (StringUtils.isEmpty(this.instanceId)) {
            long curIndex = index.getAndIncrement();
            this.instanceId = ip + Constants.COLON + port + Constants.NAMING_INSTANCE_ID_SPLITTER + curIndex
                    + Constants.NAMING_INSTANCE_ID_SPLITTER + System.currentTimeMillis();
        }
    }
```