### PR TITLE
Service instance should display related color when healthy or unhealthy

### DIFF
--- a/console-ui/src/index.scss
+++ b/console-ui/src/index.scss
@@ -1244,7 +1244,7 @@ form.vertical-margin-lg .form-group {
 }
 
 .row-bg-green {
-  background-color: #e4fdda;
+  background-color: #e4fdda !important;
 }
 
 .row-bg-light-green {
@@ -1256,7 +1256,7 @@ form.vertical-margin-lg .form-group {
 }
 
 .row-bg-red {
-  background-color: #ffece4;
+  background-color: #ffece4 !important;
 }
 
 


### PR DESCRIPTION
- Healthy instance displays green and unhealthy instance displays red, which  is a good UI function for users, However the new UI has overridden it, resume it.
- Tested by `Chrome  114.0.5735.198 (x86_64)` and `Safari 15.2 (17612.3.6.1.6)`
