### PR TITLE
encrypted_data_key field should be defined default null

### DIFF
--- a/distribution/conf/mysql-schema.sql
+++ b/distribution/conf/mysql-schema.sql
@@ -34,7 +34,7 @@ CREATE TABLE `config_info` (
   `effect` varchar(64) DEFAULT NULL COMMENT '配置生效的描述',
   `type` varchar(64) DEFAULT NULL COMMENT '配置的类型',
   `c_schema` text COMMENT '配置的模式',
-  `encrypted_data_key` text NOT NULL COMMENT '密钥',
+  `encrypted_data_key` text DEFAULT NULL COMMENT '密钥',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_configinfo_datagrouptenant` (`data_id`,`group_id`,`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='config_info';
@@ -72,7 +72,7 @@ CREATE TABLE `config_info_beta` (
   `src_user` text COMMENT 'source user',
   `src_ip` varchar(50) DEFAULT NULL COMMENT 'source ip',
   `tenant_id` varchar(128) DEFAULT '' COMMENT '租户字段',
-  `encrypted_data_key` text NOT NULL COMMENT '密钥',
+  `encrypted_data_key` text DEFAULT NULL COMMENT '密钥',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_configinfobeta_datagrouptenant` (`data_id`,`group_id`,`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='config_info_beta';
@@ -148,7 +148,7 @@ CREATE TABLE `his_config_info` (
   `src_ip` varchar(50) DEFAULT NULL COMMENT 'source ip',
   `op_type` char(10) DEFAULT NULL COMMENT 'operation type',
   `tenant_id` varchar(128) DEFAULT '' COMMENT '租户字段',
-  `encrypted_data_key` text NOT NULL COMMENT '密钥',
+  `encrypted_data_key` text DEFAULT NULL COMMENT '密钥',
   PRIMARY KEY (`nid`),
   KEY `idx_gmt_create` (`gmt_create`),
   KEY `idx_gmt_modified` (`gmt_modified`),


### PR DESCRIPTION
- I'm using the nacos server 2.1.0 and want to upgrade to 2.3.0,  following the mysql-schema.sql by 
`alter table config_info add `encrypted_data_key` text NOT NULL COMMENT '密钥' after c_schema; `, then I published a new config, I got the following exception, encrypted_data_key field should be defined default null to make the upgrade happy

> caused: PreparedStatementCallback; SQL [INSERT INTO his_config_info (id,data_id,group_id,tenant_id,app_name,content,md5,src_ip,src_user,gmt_modified,op_type) VALUES(?,?,?,?,?,?,?,?,?,?,?)]; Field 'encrypted_data_key' doesn't have a default value; nested exception is java.sql.SQLException: Field 'encrypted_data_key' doesn't have a default value;caused: Field 'encrypted_data_key' doesn't have a default value;

- In derby-schema.sql, encrypted_data_key has been defined DEFAULT NULL, so we don't need to change it
- I test  nacos 2.1.0 and master code against the variant encrypted_data_key.
