### PR TITLE
fix(#10831): When using the deregisterInstance method to remove one o…

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/redo/NamingGrpcRedoService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/redo/NamingGrpcRedoService.java
@@ -68,6 +68,10 @@ public class NamingGrpcRedoService implements ConnectionEventListener {
                 DEFAULT_REDO_DELAY, TimeUnit.MILLISECONDS);
     }
     
+    public ConcurrentMap<String, InstanceRedoData> getRegisteredInstances() {
+        return registeredInstances;
+    }
+    
     public boolean isConnected() {
         return connected;
     }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
@@ -222,6 +222,33 @@ public class NamingGrpcClientProxyTest {
     }
     
     @Test
+    public void testDeregisterServiceForBatchRegistered() throws NacosException {
+        try {
+            List<Instance> instanceList = new ArrayList<>();
+            instance.setHealthy(true);
+            instanceList.add(instance);
+            instanceList.add(new Instance());
+            client.batchRegisterService(SERVICE_NAME, GROUP_NAME, instanceList);
+        } catch (Exception ignored) {
+        }
+        response = new BatchInstanceResponse();
+        when(this.rpcClient.request(any())).thenReturn(response);
+        List<Instance> instanceList = new ArrayList<>();
+        instance.setHealthy(true);
+        instanceList.add(instance);
+        client.deregisterService(SERVICE_NAME, GROUP_NAME, instance);
+        verify(this.rpcClient, times(1)).request(argThat(request -> {
+            if (request instanceof BatchInstanceRequest) {
+                BatchInstanceRequest request1 = (BatchInstanceRequest) request;
+                request1.setRequestId("1");
+                return request1.getInstances().size() == 1 && request1.getType()
+                        .equals(NamingRemoteConstants.BATCH_REGISTER_INSTANCE);
+            }
+            return false;
+        }));
+    }
+    
+    @Test
     public void testBatchRegisterService() throws NacosException {
         List<Instance> instanceList = new ArrayList<>();
         instance.setHealthy(true);


### PR DESCRIPTION
## What is the purpose of the change

fix(#10831  ) When using the deregisterInstance method to remove one of multiple instances registered by batchRegisterInstance, all instances registered by batchRegisterInstance will be removed. 

## Brief changelog

fix(#10831  ) When using the deregisterInstance method to remove one of multiple instances registered by batchRegisterInstance, all instances registered by batchRegisterInstance will be removed. 

## Verifying this change

fix(#10831  ) When using the deregisterInstance method to remove one of multiple instances registered by batchRegisterInstance, all instances registered by batchRegisterInstance will be removed. 