### PR TITLE
refactor: isChangedServiceInfo method in ServiceInfoHolder has been r…

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
@@ -199,50 +199,38 @@ public class ServiceInfoHolder implements Closeable {
         for (Instance host : newService.getHosts()) {
             newHostMap.put(host.toInetAddr(), host);
         }
-        
-        Set<Instance> modHosts = new HashSet<>();
-        Set<Instance> newHosts = new HashSet<>();
-        Set<Instance> remvHosts = new HashSet<>();
-        
-        List<Map.Entry<String, Instance>> newServiceHosts = new ArrayList<>(
-                newHostMap.entrySet());
-        for (Map.Entry<String, Instance> entry : newServiceHosts) {
-            Instance host = entry.getValue();
-            String key = entry.getKey();
-            if (oldHostMap.containsKey(key) && !StringUtils.equals(host.toString(), oldHostMap.get(key).toString())) {
-                modHosts.add(host);
-                continue;
-            }
-            
-            if (!oldHostMap.containsKey(key)) {
-                newHosts.add(host);
-            }
-        }
-        
-        for (Map.Entry<String, Instance> entry : oldHostMap.entrySet()) {
-            Instance host = entry.getValue();
-            String key = entry.getKey();
-            if (newHostMap.containsKey(key)) {
-                continue;
-            }
 
-            //add to remove hosts
-            remvHosts.add(host);
+        List<Instance> modHosts = new ArrayList<>();
+        List<Instance> newHosts = new ArrayList<>();
+        List<Instance> remvHosts = new ArrayList<>();
+
+        Set<String> allHostMapKeys = new HashSet<>(newHostMap.keySet());
+        allHostMapKeys.addAll(oldHostMap.keySet());
+        for (String key : allHostMapKeys) {
+            Instance newHost = newHostMap.get(key);
+            Instance oldHost = oldHostMap.get(key);
+            if (newHost != null && oldHost != null && !StringUtils.equals(newHost.toString(), oldHost.toString())) {
+                modHosts.add(newHost);
+            } else if (newHost != null && oldHost == null) {
+                newHosts.add(newHost);
+            } else if (newHost == null && oldHost != null) {
+                remvHosts.add(oldHost);
+            }
         }
-        
-        if (newHosts.size() > 0) {
+
+        if (!newHosts.isEmpty()) {
             changed = true;
             NAMING_LOGGER.info("new ips({}) service: {} -> {}", newHosts.size(), newService.getKey(),
                     JacksonUtils.toJson(newHosts));
         }
-        
-        if (remvHosts.size() > 0) {
+
+        if (!remvHosts.isEmpty()) {
             changed = true;
             NAMING_LOGGER.info("removed ips({}) service: {} -> {}", remvHosts.size(), newService.getKey(),
                     JacksonUtils.toJson(remvHosts));
         }
-        
-        if (modHosts.size() > 0) {
+
+        if (!modHosts.isEmpty()) {
             changed = true;
             NAMING_LOGGER.info("modified ips({}) service: {} -> {}", modHosts.size(), newService.getKey(),
                     JacksonUtils.toJson(modHosts));

--- a/config/src/main/java/com/alibaba/nacos/config/server/aspect/CapacityManagementAspect.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/aspect/CapacityManagementAspect.java
@@ -28,7 +28,6 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -55,11 +54,14 @@ public class CapacityManagementAspect {
             "execution(* com.alibaba.nacos.config.server.controller.ConfigController.deleteConfig(..)) && args"
                     + "(request,response,dataId,group,tenant,..)";
     
-    @Autowired
-    private CapacityService capacityService;
-    
-    @Autowired
-    private ConfigInfoPersistService configInfoPersistService;
+    private final CapacityService capacityService;
+
+    private final ConfigInfoPersistService configInfoPersistService;
+
+    public CapacityManagementAspect(ConfigInfoPersistService configInfoPersistService, CapacityService capacityService) {
+        this.configInfoPersistService = configInfoPersistService;
+        this.capacityService = capacityService;
+    }
     
     /**
      * Need to judge the size of content whether to exceed the limitation.


### PR DESCRIPTION
The isChangedServiceInfo method primarily aims to compare instance information for any changes and then categorize them into three separate collections: new, deleted, and modified collections.

In the original code, adding and modifying instances were processed within one loop, while deleting instances were handled in another loop, resulting in unnecessary iterations. In the refactored code, I combined the keys of the newHostMap and oldHostMap collections and used a HashSet to remove duplicates. Then, within the loop of the allHostMapKeys collection, the following conditions were checked sequentially:

1. newInstance ！= oldInstance 
add modHosts

2. newInstance ！= null && oldInstance == null
add newHosts

3. newInstance == null && oldInstance ！= null
add remvHosts

Add them to the ArrayList, and there is no longer a need for HashSet to handle duplicate results，The improvement has enhanced the efficiency and code readability of the method, while also eliminating redundant processing.