### PR TITLE
feat(#10891): Provide a configuration item for the maximum number of p…

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigCommonConfig.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigCommonConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.configuration;
+
+import com.alibaba.nacos.core.config.AbstractDynamicConfig;
+import com.alibaba.nacos.sys.env.EnvUtil;
+
+/**
+ * Nacos config common configs.
+ *
+ * @author blake.qiu
+ */
+
+public class ConfigCommonConfig extends AbstractDynamicConfig {
+    
+    private static final String CONFIG_COMMON = "ConfigCommon";
+    
+    private static final ConfigCommonConfig INSTANCE = new ConfigCommonConfig();
+    
+    private int maxPushRetryTimes = 50;
+    
+    private ConfigCommonConfig() {
+        super(CONFIG_COMMON);
+        resetConfig();
+    }
+    
+    public static ConfigCommonConfig getInstance() {
+        return INSTANCE;
+    }
+    
+    public int getMaxPushRetryTimes() {
+        return maxPushRetryTimes;
+    }
+    
+    public void setMaxPushRetryTimes(int maxPushRetryTimes) {
+        this.maxPushRetryTimes = maxPushRetryTimes;
+    }
+    
+    @Override
+    protected void getConfigFromEnv() {
+        maxPushRetryTimes = EnvUtil.getProperty("nacos.config.push.maxRetryTime", Integer.class, 50);
+    }
+    
+    @Override
+    protected String printConfig() {
+        return "ConfigCommonConfigs{" + "maxPushRetryTimes=" + maxPushRetryTimes + '}';
+    }
+}

--- a/config/src/main/java/com/alibaba/nacos/config/server/remote/RpcConfigChangeNotifier.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/remote/RpcConfigChangeNotifier.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.notify.listener.Subscriber;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.config.server.configuration.ConfigCommonConfig;
 import com.alibaba.nacos.config.server.model.event.LocalDataChangeEvent;
 import com.alibaba.nacos.config.server.utils.ConfigExecutor;
 import com.alibaba.nacos.config.server.utils.GroupKey;
@@ -113,7 +114,8 @@ public class RpcConfigChangeNotifier extends Subscriber<LocalDataChangeEvent> {
             
             ConfigChangeNotifyRequest notifyRequest = ConfigChangeNotifyRequest.build(dataId, group, tenant);
             
-            RpcPushTask rpcPushRetryTask = new RpcPushTask(notifyRequest, 50, client, clientIp, metaInfo.getAppName());
+            RpcPushTask rpcPushRetryTask = new RpcPushTask(notifyRequest,
+                    ConfigCommonConfig.getInstance().getMaxPushRetryTimes(), client, clientIp, metaInfo.getAppName());
             push(rpcPushRetryTask);
             notifyClientCount++;
         }

--- a/config/src/test/java/com/alibaba/nacos/config/server/configuration/ConfigCommonConfigTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/configuration/ConfigCommonConfigTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.configuration;
+
+import com.alibaba.nacos.common.event.ServerConfigChangeEvent;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Constructor;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Nacos config common configs test.
+ *
+ * @author blake.qiu
+ */
+public class ConfigCommonConfigTest {
+    
+    private ConfigCommonConfig commonConfig;
+    
+    private MockEnvironment environment;
+    
+    @Before
+    public void setUp() throws Exception {
+        environment = new MockEnvironment();
+        EnvUtil.setEnvironment(environment);
+        commonConfig = ConfigCommonConfig.getInstance();
+    }
+    
+    @Test
+    public void getMaxPushRetryTimes() {
+        assertEquals(50, commonConfig.getMaxPushRetryTimes());
+    }
+    
+    @Test
+    public void setMaxPushRetryTimes() {
+        commonConfig.setMaxPushRetryTimes(100);
+        assertEquals(100, commonConfig.getMaxPushRetryTimes());
+    }
+    
+    @Test
+    public void testUpgradeFromEvent() {
+        environment.setProperty("nacos.config.push.maxRetryTime", "100");
+        commonConfig.onEvent(ServerConfigChangeEvent.newEvent());
+        assertEquals(100, commonConfig.getMaxPushRetryTimes());
+    }
+    
+    @Test
+    public void testInitConfigFormEnv() throws ReflectiveOperationException {
+        MockEnvironment environment = new MockEnvironment();
+        EnvUtil.setEnvironment(environment);
+        environment.setProperty("nacos.config.push.maxRetryTime", "6");
+        Constructor<ConfigCommonConfig> declaredConstructor = ConfigCommonConfig.class.getDeclaredConstructor();
+        declaredConstructor.setAccessible(true);
+        ConfigCommonConfig configCommonConfig = declaredConstructor.newInstance();
+        Assert.assertEquals(6, configCommonConfig.getMaxPushRetryTimes());
+    }
+}

--- a/console/src/main/resources/application.properties
+++ b/console/src/main/resources/application.properties
@@ -42,6 +42,9 @@ server.port=8848
 # db.user=nacos
 # db.password=nacos
 
+### the maximum retry times for push
+nacos.config.push.maxRetryTime=50
+
 #*************** Naming Module Related Configurations ***************#
 ### Data dispatch task execution period in milliseconds:
 

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -50,6 +50,9 @@ db.pool.config.validationTimeout=10000
 db.pool.config.maximumPoolSize=20
 db.pool.config.minimumIdle=2
 
+### the maximum retry times for push
+nacos.config.push.maxRetryTime=50
+
 #*************** Naming Module Related Configurations ***************#
 
 ### If enable data warmup. If set to false, the server would accept request without local data preparation:

--- a/distribution/conf/application.properties.example
+++ b/distribution/conf/application.properties.example
@@ -50,6 +50,9 @@ db.pool.config.validationTimeout=10000
 db.pool.config.maximumPoolSize=20
 db.pool.config.minimumIdle=2
 
+### the maximum retry times for push
+nacos.config.push.maxRetryTime=50
+
 #*************** Naming Module Related Configurations ***************#
 ### If enable data warmup. If set to false, the server would accept request without local data preparation:
 # nacos.naming.data.warmup=true


### PR DESCRIPTION
## What is the purpose of the change

feat(#10891 ): Provide a configuration item for the maximum number of push retries, instead of directly hardcoding it to 50 times in the code.

## Brief changelog

feat(#10891 ): Provide a configuration item for the maximum number of push retries, instead of directly hardcoding it to 50 times in the code.