### PR TITLE
Remove UDP Receiver

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -160,8 +160,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
     }
     
     @Override
-    public void batchDeregisterService(String serviceName, String groupName, List<Instance> instances)
-            throws NacosException {
+    public void batchDeregisterService(String serviceName, String groupName, List<Instance> instances) {
         throw new UnsupportedOperationException(
                 "Do not support persistent instances to perform batch de registration methods.");
     }
@@ -212,7 +211,6 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, NamingUtils.getGroupedName(serviceName, groupName));
         params.put(CLUSTERS_PARAM, clusters);
-        params.put(UDP_PORT_PARAM, String.valueOf(udpPort));
         params.put(CLIENT_IP_PARAM, NetUtils.localIP());
         params.put(HEALTHY_ONLY_PARAM, String.valueOf(healthyOnly));
         String result = reqApi(UtilAndComs.nacosUrlBase + "/instance/list", params, HttpMethod.GET);

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -160,7 +160,8 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
     }
     
     @Override
-    public void batchDeregisterService(String serviceName, String groupName, List<Instance> instances) {
+    public void batchDeregisterService(String serviceName, String groupName, List<Instance> instances)
+            throws NacosException {
         throw new UnsupportedOperationException(
                 "Do not support persistent instances to perform batch de registration methods.");
     }
@@ -211,6 +212,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         params.put(CommonParams.NAMESPACE_ID, namespaceId);
         params.put(CommonParams.SERVICE_NAME, NamingUtils.getGroupedName(serviceName, groupName));
         params.put(CLUSTERS_PARAM, clusters);
+        params.put(UDP_PORT_PARAM, String.valueOf(udpPort));
         params.put(CLIENT_IP_PARAM, NetUtils.localIP());
         params.put(HEALTHY_ONLY_PARAM, String.valueOf(healthyOnly));
         String result = reqApi(UtilAndComs.nacosUrlBase + "/instance/list", params, HttpMethod.GET);

--- a/naming/src/main/java/com/alibaba/nacos/naming/remote/udp/UdpConnector.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/remote/udp/UdpConnector.java
@@ -47,7 +47,6 @@ public class UdpConnector {
     
     private final DatagramSocket udpSocket;
     
-    
     public UdpConnector() throws SocketException {
         this.ackMap = new ConcurrentHashMap<>();
         this.callbackMap = new ConcurrentHashMap<>();

--- a/naming/src/main/java/com/alibaba/nacos/naming/remote/udp/UdpConnector.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/remote/udp/UdpConnector.java
@@ -47,7 +47,6 @@ public class UdpConnector {
     
     private final DatagramSocket udpSocket;
     
-    private volatile boolean running = true;
     
     public UdpConnector() throws SocketException {
         this.ackMap = new ConcurrentHashMap<>();
@@ -56,7 +55,6 @@ public class UdpConnector {
     }
     
     public void shutdown() {
-        running = false;
     }
     
     public boolean containAck(String ackId) {

--- a/naming/src/test/java/com/alibaba/nacos/naming/remote/udp/UdpConnectorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/remote/udp/UdpConnectorTest.java
@@ -39,8 +39,6 @@ import java.net.DatagramSocket;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 /**
@@ -75,10 +73,6 @@ public class UdpConnectorTest {
         ReflectionTestUtils.setField(udpConnector, "callbackMap", callbackMap);
         DatagramSocket oldSocket = (DatagramSocket) ReflectionTestUtils.getField(udpConnector, "udpSocket");
         ReflectionTestUtils.setField(udpConnector, "udpSocket", udpSocket);
-        doAnswer(invocationOnMock -> {
-            TimeUnit.SECONDS.sleep(3);
-            return null;
-        }).when(udpSocket).receive(any(DatagramPacket.class));
         oldSocket.close();
         TimeUnit.SECONDS.sleep(1);
     }


### PR DESCRIPTION
## What is the purpose of the change

Remove `UdpReceiver` for client-v2.

## Brief changelog

1. Remove `UdpConnector.UdpReceiver` task to release udp port on client.
2. Remove udp request param in instance query api.
3. Remove Unnecessary mock stub in `UdpConnectorTest`.
