### PR TITLE
In CacheItem, it's better to use the private and final keywords to modify the member variable rwLock.

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/model/CacheItem.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/CacheItem.java
@@ -60,7 +60,7 @@ public class CacheItem {
      */
     private volatile Map<String, ConfigCache> configCacheTags = null;
     
-    public SimpleReadWriteLock rwLock = new SimpleReadWriteLock();
+    private final SimpleReadWriteLock rwLock = new SimpleReadWriteLock();
     
     public CacheItem(String groupKey, String encryptedDataKey) {
         this.groupKey = StringPool.get(groupKey);
@@ -102,10 +102,6 @@ public class CacheItem {
     
     public SimpleReadWriteLock getRwLock() {
         return rwLock;
-    }
-    
-    public void setRwLock(SimpleReadWriteLock rwLock) {
-        this.rwLock = rwLock;
     }
     
     public String getType() {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
@@ -831,7 +831,7 @@ public class ConfigCacheService {
      */
     public static int tryReadLock(String groupKey) {
         CacheItem groupItem = CACHE.get(groupKey);
-        int result = (null == groupItem) ? 0 : (groupItem.rwLock.tryReadLock() ? 1 : -1);
+        int result = (null == groupItem) ? 0 : (groupItem.getRwLock().tryReadLock() ? 1 : -1);
         if (result < 0) {
             DEFAULT_LOG.warn("[read-lock] failed, {}, {}", result, groupKey);
         }
@@ -846,7 +846,7 @@ public class ConfigCacheService {
     public static void releaseReadLock(String groupKey) {
         CacheItem item = CACHE.get(groupKey);
         if (null != item) {
-            item.rwLock.releaseReadLock();
+            item.getRwLock().releaseReadLock();
         }
     }
     
@@ -859,7 +859,7 @@ public class ConfigCacheService {
      */
     static int tryWriteLock(String groupKey) {
         CacheItem groupItem = CACHE.get(groupKey);
-        int result = (null == groupItem) ? 0 : (groupItem.rwLock.tryWriteLock() ? 1 : -1);
+        int result = (null == groupItem) ? 0 : (groupItem.getRwLock().tryWriteLock() ? 1 : -1);
         if (result < 0) {
             DEFAULT_LOG.warn("[write-lock] failed, {}, {}", result, groupKey);
         }
@@ -869,7 +869,7 @@ public class ConfigCacheService {
     static void releaseWriteLock(String groupKey) {
         CacheItem groupItem = CACHE.get(groupKey);
         if (null != groupItem) {
-            groupItem.rwLock.releaseWriteLock();
+            groupItem.getRwLock().releaseWriteLock();
         }
     }
     


### PR DESCRIPTION
## What is the purpose of the change

(Fix #10963 ) In CacheItem, it's better to use the private and final keywords to modify the member variable rwLock.

## Brief changelog

(Fix #10963 ) In CacheItem, it's better to use the private and final keywords to modify the member variable rwLock.


