### PR TITLE
fix(#10980 ): After connectionIds.remove(connectionId) is executed, if connectionsIds is empty, clear the k-v corresponding to groupKeyContext.

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/remote/ConfigChangeListenContext.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/remote/ConfigChangeListenContext.java
@@ -143,6 +143,9 @@ public class ConfigChangeListenContext {
             Set<String> connectionIds = groupKeyContext.get(groupKey.getKey());
             if (CollectionUtils.isNotEmpty(connectionIds)) {
                 connectionIds.remove(connectionId);
+                if (connectionIds.isEmpty()) {
+                    groupKeyContext.remove(groupKey.getKey());
+                }
             } else {
                 groupKeyContext.remove(groupKey.getKey());
             }


### PR DESCRIPTION
## What is the purpose of the change

fix(#10980 ): After connectionIds.remove(connectionId) is executed, if connectionsIds is empty, clear the k-v corresponding to groupKeyContext.

## Brief changelog

fix(#10980 ): After connectionIds.remove(connectionId) is executed, if connectionsIds is empty, clear the k-v corresponding to groupKeyContext.


## Verifying this change

fix(#10980 ): After connectionIds.remove(connectionId) is executed, if connectionsIds is empty, clear the k-v corresponding to groupKeyContext.
