### PR TITLE
fix(#11083): Standardize the naming of the ServerlistChangeEvent class.

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -729,7 +729,7 @@ public class ClientWorker implements Closeable {
                 
                 @Override
                 public Class<? extends Event> subscribeType() {
-                    return ServerlistChangeEvent.class;
+                    return ServerListChangeEvent.class;
                 }
             };
             NotifyCenter.registerSubscriber(subscriber);

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListChangeEvent.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListChangeEvent.java
@@ -23,5 +23,5 @@ import com.alibaba.nacos.common.notify.SlowEvent;
  *
  * @author zongtanghu
  */
-public class ServerlistChangeEvent extends SlowEvent {
+public class ServerListChangeEvent extends SlowEvent {
 }

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListManager.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListManager.java
@@ -408,8 +408,8 @@ public class ServerListManager implements Closeable {
         currentServerAddr = iterator.next();
         
         // Using unified event processor, NotifyCenter
-        NotifyCenter.publishEvent(new ServerlistChangeEvent());
-        LOGGER.info("[{}] [update-serverlist] serverlist updated to {}", name, serverUrls);
+        NotifyCenter.publishEvent(new ServerListChangeEvent());
+        LOGGER.info("[{}] [update-serverList] serverList updated to {}", name, serverUrls);
     }
     
     private List<String> getApacheServerList(String url, String name) {


### PR DESCRIPTION
## What is the purpose of the change
fix(#11083 ): Standardize the naming of the ServerlistChangeEvent class.


