### PR TITLE
[ISSUE #10380] Add Fuzzy Watch Client Side Operation

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
+++ b/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
@@ -182,7 +182,11 @@ public class Constants {
     
     public static final int WRITE_REDIRECT_CODE = 307;
     
+    public static final String NAMESPACE_ID_SPLITER = ">>";
+    
     public static final String SERVICE_INFO_SPLITER = "@@";
+    
+    public static final String MATCH_PATTERN_SPLITER = "##";
     
     public static final int SERVICE_INFO_SPLIT_COUNT = 2;
     
@@ -234,6 +238,34 @@ public class Constants {
         public static final String NAMING_MODULE = "naming";
     
         public static final String CMDB_CONTEXT_TYPE = "CMDB";
+    }
+    
+    /**
+     * The constants in config directory.
+     */
+    public static class WatchMatchRule {
+        
+        public static final String MATCH_ALL = "MATCH_ALL";
+        
+        public static final String MATCH_PREFIX = "MATCH_PREFIX";
+        
+    }
+    
+    public static class WatchEventType {
+        
+        public static final String ADD_SERVICE = "ADD_SERVICE";
+        
+        public static final String DELETE_SERVICE = "DELETE_SERVICE";
+        
+        public static final String INSTANCE_CHANGED = "INSTANCE_CHANGED";
+        
+        public static final String HEART_BEAT = "HEART_BEAT";
+        
+        public static final String SERVICE_SUBSCRIBED = "SERVICE_SUBSCRIBED";
+        
+        public static final String WATCH_INITIAL_MATCH = "WATCH_INITIAL_MATCH";
+        
+        public static final String FINISH_WATCH_INIT = "FINISH_WATCH_INIT";
     }
     
     /**

--- a/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
+++ b/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
@@ -241,7 +241,7 @@ public class Constants {
     }
     
     /**
-     * The constants in config directory.
+     * The constants in Watch Pattern Match Rule directory.
      */
     public static class WatchMatchRule {
         
@@ -251,6 +251,9 @@ public class Constants {
         
     }
     
+    /**
+     * The constants in Watch Notify Event directory.
+     */
     public static class WatchEventType {
         
         public static final String ADD_SERVICE = "ADD_SERVICE";

--- a/api/src/main/java/com/alibaba/nacos/api/naming/NamingService.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/NamingService.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.api.naming;
 
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.listener.AbstractWatchEventListener;
 import com.alibaba.nacos.api.naming.listener.EventListener;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
@@ -531,6 +532,45 @@ public interface NamingService {
      */
     void unsubscribe(String serviceName, String groupName, List<String> clusters, EventListener listener)
             throws NacosException;
+    
+    /**
+     * Watch a range of services by match rule to receive notify events of matched services alteration.
+     *
+     * @param fixedGroupName fixed group name for watch
+     * @param listener event listener
+     * @throws NacosException nacos exception
+     */
+    void fuzzyWatch(String fixedGroupName, AbstractWatchEventListener listener) throws NacosException;
+    
+    /**
+     * Watch a range of services by match rule to receive notify events of matched services alteration.
+     *
+     * @param serviceNamePattern service name pattern for watch
+     * @param fixedGroupName fixed group name for watch
+     * @param listener event listener
+     * @throws NacosException nacos exception
+     */
+    void fuzzyWatch(String serviceNamePattern, String fixedGroupName,
+            AbstractWatchEventListener listener) throws NacosException;
+    
+    /**
+     * Cancel watch event listener of a pattern.
+     *
+     * @param fixedGroupName fixed group name for watch
+     * @param listener event listener
+     * @throws NacosException nacos exception
+     */
+    void cancelFuzzyWatch(String fixedGroupName, AbstractWatchEventListener listener) throws NacosException;
+    
+    /**
+     * Cancel watch event listener of a pattern.
+     *
+     * @param serviceNamePattern service name pattern for watch
+     * @param fixedGroupName fixed group name for watch
+     * @param listener event listener
+     * @throws NacosException nacos exception
+     */
+    void cancelFuzzyWatch(String serviceNamePattern, String fixedGroupName, AbstractWatchEventListener listener) throws NacosException;
     
     /**
      * Get all service names from server.

--- a/api/src/main/java/com/alibaba/nacos/api/naming/listener/AbstractWatchEventListener.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/listener/AbstractWatchEventListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.listener;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Abstract watch event listener, to support handle event by user custom executor.
+ *
+ * @author tanyongquan
+ */
+public abstract class AbstractWatchEventListener implements WatchListener {
+    
+    String uuid;
+    
+    public Executor getExecutor() {
+        return null;
+    }
+    
+    public final void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+    
+    public final String getUuid() {
+        return uuid;
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/listener/WatchListener.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/listener/WatchListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.listener;
+
+/**
+ * Watch Listener.
+ *
+ * @author tanyongquan
+ */
+public interface WatchListener {
+    
+    /**
+     * callback event.
+     *
+     * @param event event
+     */
+    void onEvent(WatchNotifyEvent event);
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/listener/WatchNotifyEvent.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/listener/WatchNotifyEvent.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.listener;
+
+import com.alibaba.nacos.api.naming.pojo.Service;
+
+/**
+ * Watch Notify Event.
+ *
+ * @author tanyongquan
+ */
+public class WatchNotifyEvent implements Event {
+    
+    private Service service;
+    
+    private String changeType;
+    
+    public WatchNotifyEvent() {
+    }
+    
+    public WatchNotifyEvent(Service service, String changeType) {
+        this.service = service;
+        this.changeType = changeType;
+    }
+    
+    public Service getService() {
+        return service;
+    }
+    
+    public void setService(Service service) {
+        this.service = service;
+    }
+    
+    public String getChangeType() {
+        return changeType;
+    }
+    
+    public void setChangeType(String changeType) {
+        this.changeType = changeType;
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/pojo/Service.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/pojo/Service.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.api.naming.pojo;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Service of Nacos.
@@ -61,6 +62,11 @@ public class Service implements Serializable {
     
     public Service(String name) {
         this.name = name;
+    }
+    
+    public Service(String name, String groupName) {
+        this.name = name;
+        this.groupName = groupName;
     }
     
     public String getName() {
@@ -111,5 +117,22 @@ public class Service implements Serializable {
     public String toString() {
         return "Service{" + "name='" + name + '\'' + ", protectThreshold=" + protectThreshold + ", appName='" + appName
                 + '\'' + ", groupName='" + groupName + '\'' + ", metadata=" + metadata + '}';
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Service service = (Service) o;
+        return name.equals(service.name) && groupName.equals(service.groupName);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, groupName);
     }
 }

--- a/api/src/main/java/com/alibaba/nacos/api/naming/remote/NamingRemoteConstants.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/remote/NamingRemoteConstants.java
@@ -30,6 +30,10 @@ public class NamingRemoteConstants {
     
     public static final String DE_REGISTER_INSTANCE = "deregisterInstance";
     
+    public static final String WATCH_SERVICE = "watchService";
+    
+    public static final String CANCEL_WATCH_SERVICE = "cancelWatchService";
+    
     public static final String QUERY_SERVICE = "queryService";
     
     public static final String SUBSCRIBE_SERVICE = "subscribeService";

--- a/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/AbstractWatchNotifyRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/AbstractWatchNotifyRequest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.remote.request;
+
+import com.alibaba.nacos.api.remote.request.ServerRequest;
+
+import static com.alibaba.nacos.api.common.Constants.Naming.NAMING_MODULE;
+
+/**
+ * Abstract watch notify request, including basic watch notify information.
+ *
+ * @author tanyongquan
+ */
+public abstract class AbstractWatchNotifyRequest extends ServerRequest {
+    private String namespace;
+    
+    private String pattern;
+    
+    private String serviceChangedType;
+    
+    public AbstractWatchNotifyRequest(){
+    }
+    
+    public AbstractWatchNotifyRequest(String namespace, String pattern, String serviceChangedType) {
+        this.namespace = namespace;
+        this.pattern = pattern;
+        this.serviceChangedType = serviceChangedType;
+    }
+    
+    public String getNamespace() {
+        return namespace;
+    }
+    
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+    
+    public String getServiceChangedType() {
+        return serviceChangedType;
+    }
+    
+    public void setServiceChangedType(String serviceChangedType) {
+        this.serviceChangedType = serviceChangedType;
+    }
+    
+    public String getPattern() {
+        return pattern;
+    }
+    
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+    
+    @Override
+    public String getModule() {
+        return NAMING_MODULE;
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/WatchNotifyChangeRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/WatchNotifyChangeRequest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.remote.request;
+
+/**
+ * Nacos watch notify service change request, use it when one of the services changes.
+ *
+ * @author tanyongquan
+ */
+public class WatchNotifyChangeRequest extends AbstractWatchNotifyRequest {
+    
+    String serviceName;
+    
+    String groupName;
+    
+    public WatchNotifyChangeRequest() {
+    }
+    
+    public WatchNotifyChangeRequest(String namespace, String serviceName,
+            String groupName, String serviceChangedType) {
+        super(namespace, "", serviceChangedType);
+        this.serviceName = serviceName;
+        this.groupName = groupName;
+    }
+    
+    public String getServiceName() {
+        return serviceName;
+    }
+    
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+    
+    public String getGroupName() {
+        return groupName;
+    }
+    
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/WatchNotifyInitRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/WatchNotifyInitRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.remote.request;
+
+import com.alibaba.nacos.api.common.Constants;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * Nacos watch initial notify request, use it when init a watch request, push service by batch.
+ *
+ * @author tanyongquan
+ */
+public class WatchNotifyInitRequest extends AbstractWatchNotifyRequest {
+    
+    private Collection<String> servicesName;
+    
+    public WatchNotifyInitRequest() {
+    }
+    
+    private WatchNotifyInitRequest(String namespace, String pattern, String serviceChangedType, Collection<String> servicesName) {
+        super(namespace, pattern, serviceChangedType);
+        this.servicesName = servicesName;
+    }
+    
+    public static WatchNotifyInitRequest buildInitRequest(String namespace, String pattern, Collection<String> servicesName) {
+        return new WatchNotifyInitRequest(namespace, pattern, Constants.WatchEventType.WATCH_INITIAL_MATCH, servicesName);
+    }
+    
+    public static WatchNotifyInitRequest buildInitFinishRequest(String namespace, String pattern) {
+        return new WatchNotifyInitRequest(namespace, pattern, Constants.WatchEventType.FINISH_WATCH_INIT, new HashSet<>(1));
+    }
+    
+    public Collection<String> getServicesName() {
+        return servicesName;
+    }
+    
+    public void setServicesName(Collection<String> servicesName) {
+        this.servicesName = servicesName;
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/WatchServiceRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/WatchServiceRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.remote.request;
+
+/**
+ * Nacos naming watch service request.
+ *
+ * @author tanyongquan
+ */
+public class WatchServiceRequest extends AbstractNamingRequest {
+    
+    private String type;
+    
+    public WatchServiceRequest() {
+    }
+    
+    public WatchServiceRequest(String namespace, String serviceNamePattern, String groupNamePattern, String type) {
+        super(namespace, serviceNamePattern, groupNamePattern);
+        this.type = type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
+    public String getType() {
+        return this.type;
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/remote/response/NotifyWatcherResponse.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/remote/response/NotifyWatcherResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.remote.response;
+
+import com.alibaba.nacos.api.remote.response.Response;
+
+/**
+ * Response for notify watcher.
+ *
+ * @author tanyongquan
+ */
+public class NotifyWatcherResponse extends Response {
+
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/remote/response/WatchServiceResponse.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/remote/response/WatchServiceResponse.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.remote.response;
+
+import com.alibaba.nacos.api.remote.response.Response;
+import com.alibaba.nacos.api.remote.response.ResponseCode;
+
+/**
+ * Nacos naming watch service response.
+ *
+ * @author tanyongquan
+ */
+public class WatchServiceResponse extends Response {
+    
+    private String type;
+    
+    public WatchServiceResponse(){
+    }
+    
+    public WatchServiceResponse(String type) {
+        this.type = type;
+    }
+    
+    public static WatchServiceResponse buildSuccessResponse(String type) {
+        return new WatchServiceResponse(type);
+    }
+    
+    /**
+     * Build fail response.
+     *
+     * @param message error message
+     * @return fail response
+     */
+    public static WatchServiceResponse buildFailResponse(String message) {
+        WatchServiceResponse result = new WatchServiceResponse();
+        result.setErrorInfo(ResponseCode.FAIL.getCode(), message);
+        return result;
+    }
+    
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
@@ -175,6 +175,103 @@ public class NamingUtils {
         }
     }
     
+    public static String getPatternWithNamespace(final String namespaceId, final String groupedPattern) {
+        if (StringUtils.isBlank(namespaceId)) {
+            throw new IllegalArgumentException("Param 'namespaceId' is illegal, namespaceId is blank");
+        }
+        if (StringUtils.isBlank(groupedPattern)) {
+            throw new IllegalArgumentException("Param 'groupedPattern' is illegal, groupedPattern is blank");
+        }
+        final String resultGroupedPattern = namespaceId + Constants.NAMESPACE_ID_SPLITER + groupedPattern;
+        return resultGroupedPattern.intern();
+    }
+    
+    public static String getNamespaceFromPattern(String completedPattern) {
+        if (StringUtils.isBlank(completedPattern)) {
+            return StringUtils.EMPTY;
+        }
+        if (!completedPattern.contains(Constants.NAMESPACE_ID_SPLITER)) {
+            return Constants.DEFAULT_NAMESPACE_ID;
+        }
+        return completedPattern.split(Constants.NAMESPACE_ID_SPLITER)[0];
+    }
+    
+    public static String getPatternRemovedNamespace(String completedPattern) {
+        if (StringUtils.isBlank(completedPattern)) {
+            return StringUtils.EMPTY;
+        }
+        if (!completedPattern.contains(Constants.NAMESPACE_ID_SPLITER)) {
+            return completedPattern;
+        }
+        return completedPattern.split(Constants.NAMESPACE_ID_SPLITER)[1];
+    }
+    
+    /**
+     * Get the Pattern subscribed to under this NamespaceId.
+     * @param namespaceId name space id
+     * @param completedPattern a set of all watch pattern(with namespace id)
+     * @return filtered pattern set
+     */
+    public static Set<String> filterPatternWithNamespace(String namespaceId, Set<String> completedPattern) {
+        Set<String> patterns = new HashSet<>();
+        for (String each : completedPattern) {
+            String eachId = getNamespaceFromPattern(each);
+            if (namespaceId.equals(eachId)) {
+                patterns.add(getPatternRemovedNamespace(each));
+            }
+        }
+        return patterns;
+    }
+    
+    /**
+     * Returns a combined string with matchPattern and matchType.
+     * @param matchPattern a match pattern. Such as a 'serviceNamePrefix'
+     * @param matchType The match type want to use
+     * @return 'matchPattern##matchType'
+     */
+    public static String getGroupedPattern(final String matchPattern, final String matchType) {
+        if (StringUtils.isBlank(matchPattern) && !matchType.equals(Constants.WatchMatchRule.MATCH_ALL)) {
+            throw new IllegalArgumentException("Param 'matchPattern' is illegal, matchPattern is blank");
+        }
+        if (StringUtils.isBlank(matchType)) {
+            throw new IllegalArgumentException("Param 'matchType' is illegal, matchType is blank");
+        } else if (matchType.equals(Constants.WatchMatchRule.MATCH_ALL)) {
+            return Constants.WatchMatchRule.MATCH_ALL;
+        }
+        final String resultGroupedName = matchPattern + Constants.MATCH_PATTERN_SPLITER + matchType;
+        return resultGroupedName.intern();
+    }
+    
+    /**
+     *  Given a Pattern, return the string to be used for the match.
+     * @param groupedPattern a grouped pattern (match string ## match type)
+     * @return the string to be used for the match.
+     */
+    public static String getMatchName(String groupedPattern) {
+        if (StringUtils.isBlank(groupedPattern)) {
+            return StringUtils.EMPTY;
+        }
+        if (!groupedPattern.contains(Constants.MATCH_PATTERN_SPLITER)) {
+            return groupedPattern;
+        }
+        return groupedPattern.split(Constants.MATCH_PATTERN_SPLITER)[0];
+    }
+    
+    /**
+     * Given a Pattern, return the matching rule type.
+     * @param groupedPattern a grouped pattern (match string ## match type)
+     * @return the matching rule type.
+     */
+    public static String getMatchRule(String groupedPattern) {
+        if (StringUtils.isBlank(groupedPattern)) {
+            return StringUtils.EMPTY;
+        }
+        if (!groupedPattern.contains(Constants.MATCH_PATTERN_SPLITER)) {
+            return Constants.WatchMatchRule.MATCH_ALL;
+        }
+        return groupedPattern.split(Constants.MATCH_PATTERN_SPLITER)[1];
+    }
+    
     /**
      * Check string is a number or not.
      *

--- a/api/src/main/resources/META-INF/services/com.alibaba.nacos.api.remote.Payload
+++ b/api/src/main/resources/META-INF/services/com.alibaba.nacos.api.remote.Payload
@@ -46,12 +46,17 @@ com.alibaba.nacos.api.config.remote.response.cluster.ConfigChangeClusterSyncResp
 com.alibaba.nacos.api.naming.remote.request.BatchInstanceRequest
 com.alibaba.nacos.api.naming.remote.request.InstanceRequest
 com.alibaba.nacos.api.naming.remote.request.NotifySubscriberRequest
+com.alibaba.nacos.api.naming.remote.request.WatchNotifyChangeRequest
+com.alibaba.nacos.api.naming.remote.request.WatchNotifyInitRequest
 com.alibaba.nacos.api.naming.remote.request.ServiceListRequest
 com.alibaba.nacos.api.naming.remote.request.ServiceQueryRequest
 com.alibaba.nacos.api.naming.remote.request.SubscribeServiceRequest
+com.alibaba.nacos.api.naming.remote.request.WatchServiceRequest
 com.alibaba.nacos.api.naming.remote.response.BatchInstanceResponse
 com.alibaba.nacos.api.naming.remote.response.InstanceResponse
 com.alibaba.nacos.api.naming.remote.response.NotifySubscriberResponse
+com.alibaba.nacos.api.naming.remote.response.NotifyWatcherResponse
 com.alibaba.nacos.api.naming.remote.response.QueryServiceResponse
 com.alibaba.nacos.api.naming.remote.response.ServiceListResponse
 com.alibaba.nacos.api.naming.remote.response.SubscribeServiceResponse
+com.alibaba.nacos.api.naming.remote.response.WatchServiceResponse

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.listener.AbstractWatchEventListener;
 import com.alibaba.nacos.api.naming.listener.EventListener;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
@@ -28,9 +29,12 @@ import com.alibaba.nacos.api.naming.utils.NamingUtils;
 import com.alibaba.nacos.api.selector.AbstractSelector;
 import com.alibaba.nacos.client.env.NacosClientProperties;
 import com.alibaba.nacos.client.naming.cache.ServiceInfoHolder;
+import com.alibaba.nacos.client.naming.cache.WatchServiceListHolder;
 import com.alibaba.nacos.client.naming.core.Balancer;
 import com.alibaba.nacos.client.naming.event.InstancesChangeEvent;
 import com.alibaba.nacos.client.naming.event.InstancesChangeNotifier;
+import com.alibaba.nacos.client.naming.event.WatchNotifyEvent;
+import com.alibaba.nacos.client.naming.event.WatchServiceChangeNotifier;
 import com.alibaba.nacos.client.naming.remote.NamingClientProxy;
 import com.alibaba.nacos.client.naming.remote.NamingClientProxyDelegate;
 import com.alibaba.nacos.client.naming.utils.CollectionUtils;
@@ -69,7 +73,11 @@ public class NacosNamingService implements NamingService {
     
     private ServiceInfoHolder serviceInfoHolder;
     
+    private WatchServiceListHolder watchServiceListHolder;
+    
     private InstancesChangeNotifier changeNotifier;
+    
+    private WatchServiceChangeNotifier watchServiceChangeNotifier;
     
     private NamingClientProxy clientProxy;
     
@@ -98,8 +106,14 @@ public class NacosNamingService implements NamingService {
         this.changeNotifier = new InstancesChangeNotifier(this.notifierEventScope);
         NotifyCenter.registerToPublisher(InstancesChangeEvent.class, 16384);
         NotifyCenter.registerSubscriber(changeNotifier);
+        this.watchServiceChangeNotifier = new WatchServiceChangeNotifier(this.notifierEventScope);
+        NotifyCenter.registerToPublisher(WatchNotifyEvent.class, 16384);
+        NotifyCenter.registerSubscriber(watchServiceChangeNotifier);
+        
         this.serviceInfoHolder = new ServiceInfoHolder(namespace, this.notifierEventScope, nacosClientProperties);
-        this.clientProxy = new NamingClientProxyDelegate(this.namespace, serviceInfoHolder, nacosClientProperties, changeNotifier);
+        this.watchServiceListHolder = new WatchServiceListHolder(this.notifierEventScope, nacosClientProperties);
+        this.clientProxy = new NamingClientProxyDelegate(this.namespace, serviceInfoHolder, watchServiceListHolder,
+                nacosClientProperties, changeNotifier);
     }
     
     private void initLogName(NacosClientProperties properties) {
@@ -427,6 +441,53 @@ public class NacosNamingService implements NamingService {
         changeNotifier.deregisterListener(groupName, serviceName, clustersString, listener);
         if (!changeNotifier.isSubscribed(groupName, serviceName, clustersString)) {
             clientProxy.unsubscribe(serviceName, groupName, clustersString);
+        }
+    }
+    
+    @Override
+    public void fuzzyWatch(String fixedGroupName, AbstractWatchEventListener listener) throws NacosException {
+        // pattern e.g. DEFAULT_GROUP@@MATCH_ALL
+        doFuzzyWatch(Constants.WatchMatchRule.MATCH_ALL, fixedGroupName, listener);
+    }
+    
+    @Override
+    public void fuzzyWatch(String serviceNamePattern, String fixedGroupName,
+            AbstractWatchEventListener listener) throws NacosException {
+        // only support prefix match right now
+        // pattern e.g. DEFAULT_GROUP@@nacos.test##MATCH_PREFIX
+        String serviceNamePrefixPattern = NamingUtils.getGroupedPattern(serviceNamePattern, Constants.WatchMatchRule.MATCH_PREFIX);
+        doFuzzyWatch(serviceNamePrefixPattern, fixedGroupName, listener);
+    }
+    
+    private void doFuzzyWatch(String serviceNamePattern, String groupNamePattern,
+            AbstractWatchEventListener listener) throws NacosException {
+        if (null == listener) {
+            return;
+        }
+        String uuid = UUID.randomUUID().toString();
+        listener.setUuid(uuid);
+        watchServiceChangeNotifier.registerWatchListener(serviceNamePattern, groupNamePattern, listener);
+        clientProxy.fuzzyWatch(serviceNamePattern, groupNamePattern, uuid);
+    }
+    
+    @Override
+    public void cancelFuzzyWatch(String fixedGroupName, AbstractWatchEventListener listener) throws NacosException {
+        doCancelFuzzyWatch(Constants.WatchMatchRule.MATCH_ALL, fixedGroupName, listener);
+    }
+    
+    @Override
+    public void cancelFuzzyWatch(String serviceNamePattern, String fixedGroupName, AbstractWatchEventListener listener) throws NacosException {
+        String serviceNamePrefixPattern =  NamingUtils.getGroupedPattern(serviceNamePattern, Constants.WatchMatchRule.MATCH_PREFIX);
+        doCancelFuzzyWatch(serviceNamePrefixPattern, fixedGroupName, listener);
+    }
+    
+    private void doCancelFuzzyWatch(String serviceNamePattern, String groupNamePattern, AbstractWatchEventListener listener) throws NacosException {
+        if (null == listener) {
+            return;
+        }
+        watchServiceChangeNotifier.deregisterWatchListener(serviceNamePattern, groupNamePattern, listener);
+        if (!watchServiceChangeNotifier.isWatched(serviceNamePattern, groupNamePattern)) {
+            clientProxy.cancelFuzzyWatch(serviceNamePattern, groupNamePattern);
         }
     }
     

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/WatchServiceListHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/WatchServiceListHolder.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.naming.cache;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.naming.pojo.Service;
+import com.alibaba.nacos.api.naming.remote.request.AbstractWatchNotifyRequest;
+import com.alibaba.nacos.api.naming.remote.request.WatchNotifyChangeRequest;
+import com.alibaba.nacos.api.naming.remote.request.WatchNotifyInitRequest;
+import com.alibaba.nacos.api.naming.utils.NamingUtils;
+import com.alibaba.nacos.client.env.NacosClientProperties;
+import com.alibaba.nacos.client.naming.event.WatchNotifyEvent;
+import com.alibaba.nacos.client.naming.utils.CollectionUtils;
+import com.alibaba.nacos.common.notify.NotifyCenter;
+import com.alibaba.nacos.common.utils.ConcurrentHashSet;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Naming client watch service list holder.
+ *
+ * @author tanyongquan
+ */
+public class WatchServiceListHolder {
+    
+    private String notifierEventScope;
+    
+    /**
+     * The contents of {@code patternMatchMap} are Map{pattern -> Set[matched services]}.
+     */
+    private Map<String, ConcurrentHashSet<Service>> patternMatchMap = new ConcurrentHashMap<>();
+    
+    public WatchServiceListHolder(String notifierEventScope, NacosClientProperties properties) {
+        this.notifierEventScope = notifierEventScope;
+    }
+    
+    /**
+     * Publish service change event notify by watch.
+     *
+     * @param request watch notify request from Nacos server
+     */
+    public void processServiceChange(AbstractWatchNotifyRequest request) {
+        if (request instanceof WatchNotifyInitRequest) {
+            WatchNotifyInitRequest watchNotifyInitRequest = (WatchNotifyInitRequest) request;
+            Set<Service> cacheService = patternMatchMap.computeIfAbsent(request.getPattern(), keyInner -> new ConcurrentHashSet<>());
+            Collection<String> servicesName = watchNotifyInitRequest.getServicesName();
+            for (String groupedName : servicesName) {
+                Service service = new Service(NamingUtils.getServiceName(groupedName), NamingUtils.getGroupName(groupedName));
+                // may have a 'change event' sent to client before 'init event'
+                if (cacheService.add(service)) {
+                    NotifyCenter.publishEvent(WatchNotifyEvent.buildNotifyPatternAllListenersEvent(notifierEventScope,
+                            service, request.getPattern(), Constants.WatchEventType.ADD_SERVICE));
+                }
+            }
+        } else if (request instanceof WatchNotifyChangeRequest) {
+            WatchNotifyChangeRequest notifyChangeRequest = (WatchNotifyChangeRequest) request;
+            Collection<String> matchedPattern = NamingUtils.getServiceMatchedPatterns(notifyChangeRequest.getServiceName(),
+                    notifyChangeRequest.getGroupName(),  patternMatchMap.keySet());
+            Service service = new Service(notifyChangeRequest.getServiceName(), notifyChangeRequest.getServiceName());
+            String serviceChangeType = request.getServiceChangedType();
+            
+            switch (serviceChangeType) {
+                case Constants.WatchEventType.ADD_SERVICE:
+                case Constants.WatchEventType.INSTANCE_CHANGED:
+                    for (String pattern : matchedPattern) {
+                        Set<Service> matchedServiceSet = patternMatchMap.get(pattern);
+                        if (matchedServiceSet != null && matchedServiceSet.add(service)) {
+                            NotifyCenter.publishEvent(
+                                    WatchNotifyEvent.buildNotifyPatternAllListenersEvent(notifierEventScope,
+                                            service, pattern, serviceChangeType));
+                        }
+                    }
+                    break;
+                case Constants.WatchEventType.DELETE_SERVICE:
+                    for (String pattern : matchedPattern) {
+                        Set<Service> matchedServiceSet = patternMatchMap.get(pattern);
+                        if (matchedServiceSet != null && matchedServiceSet.remove(service)) {
+                            NotifyCenter.publishEvent(
+                                    WatchNotifyEvent.buildNotifyPatternAllListenersEvent(notifierEventScope,
+                                            service, pattern, serviceChangeType));
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    
+    /**
+     * For a duplicate watch of a certain pattern, initiate an initialization event to the corresponding Listener.
+     *
+     * @param serviceNamePattern service name pattern.
+     * @param groupNamePattern group name pattern.
+     * @param uuid The UUID that identifies the Listener.
+     */
+    public void duplicateWatchInit(String serviceNamePattern, String groupNamePattern, String uuid) {
+        String pattern = NamingUtils.getGroupedName(serviceNamePattern, groupNamePattern);
+        Collection<Service> cacheServices = patternMatchMap.get(pattern);
+        if (cacheServices == null) {
+            return;
+        }
+        for (Service service : cacheServices) {
+            NotifyCenter.publishEvent(WatchNotifyEvent.buildNotifyPatternSpecificListenerEvent(notifierEventScope, service,
+                    pattern, uuid, Constants.WatchEventType.ADD_SERVICE));
+        }
+    }
+    
+    public boolean containsPatternMatchCache(String serviceNamePattern, String groupNamePattern) {
+        String pattern = NamingUtils.getGroupedName(serviceNamePattern, groupNamePattern);
+        return CollectionUtils.isEmpty(patternMatchMap.get(pattern));
+    }
+    
+    public void removePatternMatchCache(String serviceNamePattern, String groupNamePattern) {
+        String pattern = NamingUtils.getGroupedName(serviceNamePattern, groupNamePattern);
+        patternMatchMap.remove(pattern);
+    }
+    
+    public void addPatternMatchCache(String serviceNamePattern, String groupNamePattern) {
+        String pattern = NamingUtils.getGroupedName(serviceNamePattern, groupNamePattern);
+        patternMatchMap.computeIfAbsent(pattern, keyInner -> new ConcurrentHashSet<>());
+    }
+}

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/WatchServiceListHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/WatchServiceListHolder.java
@@ -73,7 +73,7 @@ public class WatchServiceListHolder {
             WatchNotifyChangeRequest notifyChangeRequest = (WatchNotifyChangeRequest) request;
             Collection<String> matchedPattern = NamingUtils.getServiceMatchedPatterns(notifyChangeRequest.getServiceName(),
                     notifyChangeRequest.getGroupName(),  patternMatchMap.keySet());
-            Service service = new Service(notifyChangeRequest.getServiceName(), notifyChangeRequest.getServiceName());
+            Service service = new Service(notifyChangeRequest.getServiceName(), notifyChangeRequest.getGroupName());
             String serviceChangeType = request.getServiceChangedType();
             
             switch (serviceChangeType) {

--- a/client/src/main/java/com/alibaba/nacos/client/naming/event/WatchNotifyEvent.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/event/WatchNotifyEvent.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.naming.event;
+
+import com.alibaba.nacos.api.naming.pojo.Service;
+import com.alibaba.nacos.common.notify.Event;
+
+/**
+ * Watch notify event, including service change/watch initial.
+ *
+ * @author tanyongquan
+ */
+public class WatchNotifyEvent extends Event {
+    
+    private final String eventScope;
+    
+    private final Service changedService;
+    
+    private String pattern;
+    
+    private String uuid;
+    
+    private final String serviceChangedType;
+    
+    private WatchNotifyEvent(String eventScope, Service changedService, String pattern, String uuid, String serviceChangedType) {
+        this(eventScope, changedService, pattern, serviceChangedType);
+        this.uuid = uuid;
+    }
+    
+    private WatchNotifyEvent(String eventScope, Service changedService, String pattern, String serviceChangedType) {
+        this.eventScope = eventScope;
+        this.changedService = changedService;
+        this.serviceChangedType = serviceChangedType;
+        this.pattern = pattern;
+    }
+    
+    public static WatchNotifyEvent buildNotifyPatternSpecificListenerEvent(String eventScope, Service changedService,
+            String pattern, String uuid, String serviceChangedType) {
+        return new WatchNotifyEvent(eventScope, changedService, pattern, uuid, serviceChangedType);
+    }
+    
+    public static WatchNotifyEvent buildNotifyPatternAllListenersEvent(String eventScope, Service changedService,
+            String pattern, String serviceChangedType) {
+        return new WatchNotifyEvent(eventScope, changedService, pattern, serviceChangedType);
+    }
+    
+    public Service getChangedService() {
+        return changedService;
+    }
+    
+    public String getPattern() {
+        return pattern;
+    }
+    
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+    
+    public String getUuid() {
+        return uuid;
+    }
+    
+    public String getServiceChangedType() {
+        return serviceChangedType;
+    }
+    
+    @Override
+    public String scope() {
+        return this.eventScope;
+    }
+}

--- a/client/src/main/java/com/alibaba/nacos/client/naming/event/WatchServiceChangeNotifier.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/event/WatchServiceChangeNotifier.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.naming.event;
+
+import com.alibaba.nacos.api.naming.listener.AbstractWatchEventListener;
+import com.alibaba.nacos.api.naming.utils.NamingUtils;
+import com.alibaba.nacos.common.JustForTest;
+import com.alibaba.nacos.common.notify.Event;
+import com.alibaba.nacos.common.notify.listener.Subscriber;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.ConcurrentHashSet;
+import com.alibaba.nacos.common.utils.StringUtils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A watcher to notify watch event Listener callback.
+ *
+ * @author tanyongquan
+ */
+public class WatchServiceChangeNotifier extends Subscriber<WatchNotifyEvent> {
+    
+    private final String eventScope;
+    
+    @JustForTest
+    public WatchServiceChangeNotifier() {
+        this.eventScope = UUID.randomUUID().toString();
+    }
+    
+    public WatchServiceChangeNotifier(String eventScope) {
+        this.eventScope = eventScope;
+    }
+    
+    /**
+     * pattern -> Set[Listener].
+     */
+    private final Map<String, ConcurrentHashSet<AbstractWatchEventListener>> watchListenerMap = new ConcurrentHashMap<>();
+    
+    /** register watch listener.
+     *  This listener responds to changes of the services (not the instance).
+     *
+     * @param serviceNamePattern service name pattern
+     * @param groupNamePattern group name pattern
+     * @param listener custom listener
+     */
+    public void registerWatchListener(String serviceNamePattern, String groupNamePattern, AbstractWatchEventListener listener) {
+        String key = NamingUtils.getGroupedName(serviceNamePattern, groupNamePattern);
+        Set<AbstractWatchEventListener> eventListeners = watchListenerMap.computeIfAbsent(key, keyInner -> new ConcurrentHashSet<>());
+        eventListeners.add(listener);
+    }
+    
+    /** remove watch listener.
+     *
+     * @param serviceNamePattern service name pattern
+     * @param groupNamePattern group name pattern
+     */
+    public void deregisterWatchListener(String serviceNamePattern, String groupNamePattern, AbstractWatchEventListener listener) {
+        String key = NamingUtils.getGroupedName(serviceNamePattern, groupNamePattern);
+        ConcurrentHashSet<AbstractWatchEventListener> eventListeners = watchListenerMap.get(key);
+        if (eventListeners == null) {
+            return;
+        }
+        eventListeners.remove(listener);
+        if (CollectionUtils.isEmpty(eventListeners)) {
+            watchListenerMap.remove(key);
+        }
+    }
+    
+    /**
+     * check pattern is watched.
+     *
+     * @param serviceNamePattern service name pattern
+     * @param groupNamePattern group name pattern
+     * @return is pattern watched
+     */
+    public boolean isWatched(String serviceNamePattern, String groupNamePattern) {
+        String key = NamingUtils.getGroupedName(serviceNamePattern, groupNamePattern);
+        ConcurrentHashSet<AbstractWatchEventListener> eventListeners = watchListenerMap.get(key);
+        return CollectionUtils.isNotEmpty(eventListeners);
+    }
+    
+    /**
+     * receive watch notify (watch init or service change) from nacos server, notify all listener watch this pattern.
+     * If the event contains a UUID, then the event is used to notify the specified Listener when there are
+     * multiple watches for a particular Pattern
+     *
+     * @param event watch notify event
+     */
+    @Override
+    public void onEvent(WatchNotifyEvent event) {
+        String uuid = event.getUuid();
+        Collection<AbstractWatchEventListener> listeners = watchListenerMap.get(event.getPattern());
+        final com.alibaba.nacos.api.naming.listener.WatchNotifyEvent watchNotifyEvent = transferToWatchNotifyEvent(event);
+        for (AbstractWatchEventListener each : listeners) {
+            // notify all listener watch this pattern
+            if (StringUtils.isEmpty(uuid)) {
+                if (each.getExecutor() != null) {
+                    each.getExecutor().execute(() -> each.onEvent(watchNotifyEvent));
+                } else {
+                    each.onEvent(watchNotifyEvent);
+                }
+            } else if (uuid.equals(each.getUuid())) {
+                // notify specific listener by uuid, use in duplicate watch a same pattern
+                if (each.getExecutor() != null) {
+                    each.getExecutor().execute(() -> each.onEvent(watchNotifyEvent));
+                } else {
+                    each.onEvent(watchNotifyEvent);
+                }
+                return;
+            }
+        }
+    }
+    
+    private com.alibaba.nacos.api.naming.listener.WatchNotifyEvent transferToWatchNotifyEvent(
+            WatchNotifyEvent watchNotifyEvent) {
+        return new com.alibaba.nacos.api.naming.listener.WatchNotifyEvent(watchNotifyEvent.getChangedService(),
+                watchNotifyEvent.getServiceChangedType());
+    }
+    
+    @Override
+    public Class<? extends Event> subscribeType() {
+        return WatchNotifyEvent.class;
+    }
+    
+    @Override
+    public boolean scopeMatches(WatchNotifyEvent event) {
+        return this.eventScope.equals(event.scope());
+    }
+}

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/NamingClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/NamingClientProxy.java
@@ -183,6 +183,33 @@ public interface NamingClientProxy extends Closeable {
     boolean isSubscribed(String serviceName, String groupName, String clusters) throws NacosException;
     
     /**
+     * Watch services change by pattern.
+     *
+     * @param serviceNamePattern service name pattern
+     * @param groupNamePattern group name pattern
+     * @param uuid UUID used to identify the Listener. Used for local initialization when repeating Watch
+     * @throws NacosException nacos exception
+     */
+    void fuzzyWatch(String serviceNamePattern, String groupNamePattern, String uuid) throws NacosException;
+    
+    /** Judge whether pattern has been watched.
+     *
+     * @param serviceNamePattern service name pattern
+     * @param groupNamePattern group name pattern
+     * @return {@code true} if subscribed, otherwise {@code false}
+     * @throws NacosException nacos exception
+     */
+    boolean isFuzzyWatched(String serviceNamePattern, String groupNamePattern) throws NacosException;
+    
+    /** Cancel watch pattern.
+     *
+     * @param serviceNamePattern service name pattern
+     * @param groupNamePattern group name pattern
+     * @throws NacosException nacos exception
+     */
+    void cancelFuzzyWatch(String serviceNamePattern, String groupNamePattern) throws NacosException;
+    
+    /**
      * Check Server healthy.
      *
      * @return true if server is healthy

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingPushRequestHandler.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingPushRequestHandler.java
@@ -16,11 +16,14 @@
 
 package com.alibaba.nacos.client.naming.remote.gprc;
 
+import com.alibaba.nacos.api.naming.remote.request.AbstractWatchNotifyRequest;
 import com.alibaba.nacos.api.naming.remote.request.NotifySubscriberRequest;
 import com.alibaba.nacos.api.naming.remote.response.NotifySubscriberResponse;
+import com.alibaba.nacos.api.naming.remote.response.NotifyWatcherResponse;
 import com.alibaba.nacos.api.remote.request.Request;
 import com.alibaba.nacos.api.remote.response.Response;
 import com.alibaba.nacos.client.naming.cache.ServiceInfoHolder;
+import com.alibaba.nacos.client.naming.cache.WatchServiceListHolder;
 import com.alibaba.nacos.common.remote.client.ServerRequestHandler;
 
 /**
@@ -32,8 +35,11 @@ public class NamingPushRequestHandler implements ServerRequestHandler {
     
     private final ServiceInfoHolder serviceInfoHolder;
     
-    public NamingPushRequestHandler(ServiceInfoHolder serviceInfoHolder) {
+    private final WatchServiceListHolder watchServiceListHolder;
+    
+    public NamingPushRequestHandler(ServiceInfoHolder serviceInfoHolder, WatchServiceListHolder watchServiceListHolder) {
         this.serviceInfoHolder = serviceInfoHolder;
+        this.watchServiceListHolder = watchServiceListHolder;
     }
     
     @Override
@@ -42,6 +48,10 @@ public class NamingPushRequestHandler implements ServerRequestHandler {
             NotifySubscriberRequest notifyRequest = (NotifySubscriberRequest) request;
             serviceInfoHolder.processServiceInfo(notifyRequest.getServiceInfo());
             return new NotifySubscriberResponse();
+        } else if (request instanceof AbstractWatchNotifyRequest) {
+            AbstractWatchNotifyRequest notifyRequest = (AbstractWatchNotifyRequest) request;
+            watchServiceListHolder.processServiceChange(notifyRequest);
+            return new NotifyWatcherResponse();
         }
         return null;
     }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/redo/data/WatcherRedoData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/redo/data/WatcherRedoData.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.naming.remote.gprc.redo.data;
+
+/**
+ * Redo data for Watcher.
+ *
+ * @author tanyongquan
+ */
+public class WatcherRedoData extends RedoData<String> {
+    
+    private WatcherRedoData(String serviceNamePattern, String groupNamePattern) {
+        super(serviceNamePattern, groupNamePattern);
+    }
+    
+    public static WatcherRedoData build(String serviceNamePattern, String groupNamePattern) {
+        return new WatcherRedoData(serviceNamePattern, groupNamePattern);
+    }
+}

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -342,6 +342,21 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         return true;
     }
     
+    @Override
+    public void fuzzyWatch(String serviceNamePattern, String groupNamePattern, String uuid) throws NacosException {
+        throw new UnsupportedOperationException("Do not support watch services by UDP, please use gRPC replaced.");
+    }
+    
+    @Override
+    public void cancelFuzzyWatch(String serviceNamePattern, String groupNamePattern) throws NacosException {
+        throw new UnsupportedOperationException("Do not support watch service by UDP, please use gRPC replaced.");
+    }
+    
+    @Override
+    public boolean isFuzzyWatched(String serviceNamePattern, String groupNamePattern) {
+        throw new UnsupportedOperationException("Do not support watch service by UDP, please use gRPC replaced.");
+    }
+    
     public String reqApi(String api, Map<String, String> params, String method) throws NacosException {
         return reqApi(api, params, Collections.EMPTY_MAP, method);
     }

--- a/client/src/main/resources/META-INF/native-image/com.alibaba.nacos/nacos-client/reflect-config.json
+++ b/client/src/main/resources/META-INF/native-image/com.alibaba.nacos/nacos-client/reflect-config.json
@@ -348,6 +348,18 @@
   ]
 },
 {
+  "name":"com.alibaba.nacos.api.naming.remote.request.AbstractWatchNotifyRequest",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[
+    {"name":"<init>","parameterTypes":[] },
+    {"name":"getModule","parameterTypes":[] },
+    {"name":"getServiceChangedType","parameterTypes":[] },
+    {"name":"getPattern","parameterTypes":[] }
+  ]
+},
+{
   "name":"com.alibaba.nacos.api.naming.remote.request.InstanceRequest",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/AbstractNamingClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/AbstractNamingClientProxyTest.java
@@ -174,6 +174,21 @@ public class AbstractNamingClientProxyTest {
         }
         
         @Override
+        public void fuzzyWatch(String serviceNamePattern, String groupNamePattern, String uuid) throws NacosException {
+        
+        }
+        
+        @Override
+        public void cancelFuzzyWatch(String serviceNamePattern, String groupNamePattern) throws NacosException {
+        
+        }
+        
+        @Override
+        public boolean isFuzzyWatched(String serviceNamePattern, String groupNamePattern) {
+            return false;
+        }
+        
+        @Override
         public boolean serverHealthy() {
             return false;
         }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/NamingClientProxyDelegateTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/NamingClientProxyDelegateTest.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.api.selector.ExpressionSelector;
 import com.alibaba.nacos.api.selector.NoneSelector;
 import com.alibaba.nacos.client.env.NacosClientProperties;
 import com.alibaba.nacos.client.naming.cache.ServiceInfoHolder;
+import com.alibaba.nacos.client.naming.cache.WatchServiceListHolder;
 import com.alibaba.nacos.client.naming.event.InstancesChangeNotifier;
 import com.alibaba.nacos.client.naming.remote.gprc.NamingGrpcClientProxy;
 import com.alibaba.nacos.client.naming.remote.http.NamingHttpClientProxy;
@@ -49,11 +50,13 @@ public class NamingClientProxyDelegateTest {
     public void testRegisterServiceByGrpc() throws NacosException, NoSuchFieldException, IllegalAccessException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingGrpcClientProxy mockGrpcClient = Mockito.mock(NamingGrpcClientProxy.class);
         Field grpcClientProxyField = NamingClientProxyDelegate.class.getDeclaredField("grpcClientProxy");
         grpcClientProxyField.setAccessible(true);
@@ -75,12 +78,13 @@ public class NamingClientProxyDelegateTest {
     public void testBatchRegisterServiceByGrpc() throws NacosException, NoSuchFieldException, IllegalAccessException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingGrpcClientProxy mockGrpcClient = Mockito.mock(NamingGrpcClientProxy.class);
         Field grpcClientProxyField = NamingClientProxyDelegate.class.getDeclaredField("grpcClientProxy");
         grpcClientProxyField.setAccessible(true);
@@ -103,12 +107,14 @@ public class NamingClientProxyDelegateTest {
     public void testRegisterServiceByHttp() throws NacosException, NoSuchFieldException, IllegalAccessException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingHttpClientProxy mockHttpClient = Mockito.mock(NamingHttpClientProxy.class);
         Field mockHttpClientField = NamingClientProxyDelegate.class.getDeclaredField("httpClientProxy");
         mockHttpClientField.setAccessible(true);
@@ -131,12 +137,14 @@ public class NamingClientProxyDelegateTest {
     public void testDeregisterServiceGrpc() throws NacosException, NoSuchFieldException, IllegalAccessException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingGrpcClientProxy mockGrpcClient = Mockito.mock(NamingGrpcClientProxy.class);
         Field grpcClientProxyField = NamingClientProxyDelegate.class.getDeclaredField("grpcClientProxy");
         grpcClientProxyField.setAccessible(true);
@@ -159,12 +167,14 @@ public class NamingClientProxyDelegateTest {
     public void testDeregisterServiceHttp() throws NacosException, NoSuchFieldException, IllegalAccessException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingHttpClientProxy mockHttpClient = Mockito.mock(NamingHttpClientProxy.class);
         Field mockHttpClientField = NamingClientProxyDelegate.class.getDeclaredField("httpClientProxy");
         mockHttpClientField.setAccessible(true);
@@ -187,12 +197,14 @@ public class NamingClientProxyDelegateTest {
     public void testUpdateInstance() throws NacosException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         String serviceName = "service1";
         String groupName = "group1";
         Instance instance = new Instance();
@@ -207,12 +219,14 @@ public class NamingClientProxyDelegateTest {
     public void testQueryInstancesOfService() throws NacosException, IllegalAccessException, NoSuchFieldException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingGrpcClientProxy mockGrpcClient = Mockito.mock(NamingGrpcClientProxy.class);
         Field grpcClientProxyField = NamingClientProxyDelegate.class.getDeclaredField("grpcClientProxy");
         grpcClientProxyField.setAccessible(true);
@@ -229,12 +243,14 @@ public class NamingClientProxyDelegateTest {
     public void testQueryService() throws NacosException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         Service service = delegate.queryService("a", "b");
         Assert.assertNull(service);
     }
@@ -243,12 +259,14 @@ public class NamingClientProxyDelegateTest {
     public void testCreateService() throws NacosException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         Service service = new Service();
         try {
             delegate.createService(service, new NoneSelector());
@@ -261,12 +279,14 @@ public class NamingClientProxyDelegateTest {
     public void testDeleteService() throws NacosException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         Assert.assertFalse(delegate.deleteService("service", "group1"));
     }
     
@@ -274,12 +294,14 @@ public class NamingClientProxyDelegateTest {
     public void testUpdateService() throws NacosException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         Service service = new Service();
         try {
             delegate.updateService(service, new ExpressionSelector());
@@ -292,12 +314,14 @@ public class NamingClientProxyDelegateTest {
     public void testGetServiceList() throws NacosException, NoSuchFieldException, IllegalAccessException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingGrpcClientProxy mockGrpcClient = Mockito.mock(NamingGrpcClientProxy.class);
         Field grpcClientProxyField = NamingClientProxyDelegate.class.getDeclaredField("grpcClientProxy");
         grpcClientProxyField.setAccessible(true);
@@ -316,12 +340,14 @@ public class NamingClientProxyDelegateTest {
     public void testSubscribe() throws NacosException, NoSuchFieldException, IllegalAccessException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingGrpcClientProxy mockGrpcClient = Mockito.mock(NamingGrpcClientProxy.class);
         Field grpcClientProxyField = NamingClientProxyDelegate.class.getDeclaredField("grpcClientProxy");
         grpcClientProxyField.setAccessible(true);
@@ -347,12 +373,14 @@ public class NamingClientProxyDelegateTest {
     public void testUnsubscribe() throws NacosException, IllegalAccessException, NoSuchFieldException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingGrpcClientProxy mockGrpcClient = Mockito.mock(NamingGrpcClientProxy.class);
         Field grpcClientProxyField = NamingClientProxyDelegate.class.getDeclaredField("grpcClientProxy");
         grpcClientProxyField.setAccessible(true);
@@ -370,12 +398,14 @@ public class NamingClientProxyDelegateTest {
     public void testServerHealthy() throws IllegalAccessException, NacosException, NoSuchFieldException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingGrpcClientProxy mockGrpcClient = Mockito.mock(NamingGrpcClientProxy.class);
         Field grpcClientProxyField = NamingClientProxyDelegate.class.getDeclaredField("grpcClientProxy");
         grpcClientProxyField.setAccessible(true);
@@ -389,12 +419,14 @@ public class NamingClientProxyDelegateTest {
     public void testShutdown() throws NacosException, IllegalAccessException, NoSuchFieldException {
         String ns = "ns1";
         ServiceInfoHolder holder = Mockito.mock(ServiceInfoHolder.class);
+        WatchServiceListHolder watchServiceListHolder = Mockito.mock(WatchServiceListHolder.class);
         Properties props = new Properties();
         props.setProperty("serverAddr", "localhost");
         InstancesChangeNotifier notifier = new InstancesChangeNotifier();
-    
+        
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(props);
-        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, nacosClientProperties, notifier);
+        NamingClientProxyDelegate delegate = new NamingClientProxyDelegate(ns, holder, watchServiceListHolder,
+                nacosClientProperties, notifier);
         NamingGrpcClientProxy mockGrpcClient = Mockito.mock(NamingGrpcClientProxy.class);
         Field grpcClientProxyField = NamingClientProxyDelegate.class.getDeclaredField("grpcClientProxy");
         grpcClientProxyField.setAccessible(true);

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
@@ -43,6 +43,7 @@ import com.alibaba.nacos.api.selector.AbstractSelector;
 import com.alibaba.nacos.api.selector.NoneSelector;
 import com.alibaba.nacos.client.env.NacosClientProperties;
 import com.alibaba.nacos.client.naming.cache.ServiceInfoHolder;
+import com.alibaba.nacos.client.naming.cache.WatchServiceListHolder;
 import com.alibaba.nacos.client.naming.event.ServerListChangedEvent;
 import com.alibaba.nacos.client.naming.remote.gprc.redo.NamingGrpcRedoService;
 import com.alibaba.nacos.client.security.SecurityProxy;
@@ -113,6 +114,9 @@ public class NamingGrpcClientProxyTest {
     private ServiceInfoHolder holder;
     
     @Mock
+    private WatchServiceListHolder watchServiceListHolder;
+    
+    @Mock
     private RpcClient rpcClient;
     
     private Properties prop;
@@ -138,7 +142,8 @@ public class NamingGrpcClientProxyTest {
         prop = new Properties();
         
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(prop);
-        client = new NamingGrpcClientProxy(NAMESPACE_ID, proxy, factory, nacosClientProperties, holder);
+        client = new NamingGrpcClientProxy(NAMESPACE_ID, proxy, factory, nacosClientProperties, holder,
+                watchServiceListHolder);
         
         Field uuidField = NamingGrpcClientProxy.class.getDeclaredField("uuid");
         uuidField.setAccessible(true);
@@ -501,7 +506,7 @@ public class NamingGrpcClientProxyTest {
         rpcClient.set(client, rpc);
         
         rpc.serverListFactory(factory);
-        rpc.registerServerRequestHandler(new NamingPushRequestHandler(holder));
+        rpc.registerServerRequestHandler(new NamingPushRequestHandler(holder, watchServiceListHolder));
         Field listenerField = NamingGrpcClientProxy.class.getDeclaredField("redoService");
         listenerField.setAccessible(true);
         NamingGrpcRedoService listener = (NamingGrpcRedoService) listenerField.get(client);
@@ -536,7 +541,8 @@ public class NamingGrpcClientProxyTest {
     @Test
     public void testConfigAppNameLabels() throws Exception {
         final NacosClientProperties nacosClientProperties = NacosClientProperties.PROTOTYPE.derive(prop);
-        client = new NamingGrpcClientProxy(NAMESPACE_ID, proxy, factory, nacosClientProperties, holder);
+        client = new NamingGrpcClientProxy(NAMESPACE_ID, proxy, factory, nacosClientProperties, holder,
+                watchServiceListHolder);
         Field rpcClientField = NamingGrpcClientProxy.class.getDeclaredField("rpcClient");
         rpcClientField.setAccessible(true);
         RpcClient rpcClient = (RpcClient) rpcClientField.get(client);

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingPushRequestHandlerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingPushRequestHandlerTest.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.api.naming.remote.response.NotifySubscriberResponse;
 import com.alibaba.nacos.api.remote.request.Request;
 import com.alibaba.nacos.api.remote.response.Response;
 import com.alibaba.nacos.client.naming.cache.ServiceInfoHolder;
+import com.alibaba.nacos.client.naming.cache.WatchServiceListHolder;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,7 +38,8 @@ public class NamingPushRequestHandlerTest {
     public void testRequestReply() {
         //given
         ServiceInfoHolder holder = mock(ServiceInfoHolder.class);
-        NamingPushRequestHandler handler = new NamingPushRequestHandler(holder);
+        WatchServiceListHolder watchServiceListHolder = mock(WatchServiceListHolder.class);
+        NamingPushRequestHandler handler = new NamingPushRequestHandler(holder, watchServiceListHolder);
         ServiceInfo info = new ServiceInfo("name", "cluster1");
         Request req = NotifySubscriberRequest.buildNotifySubscriberRequest(info);
         //when


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

For #10380, Support for fuzzy subscription capability for Nacos registration center.

## Brief changelog

Add nacos naming watch interface
Add naocs watch client proxy
Add fuzzy watch pattern match rule in Constants.
Add the corresponding pattern splicing and match function in NamingUtils.
Add Watch NotifyEvent and Watch Service Change Notifier.
Add fuzzy watch redo service
Add watch service request and response
Add watch nacos server notify request and response
Add request SPI and reflect config
Add Watch match cache in nacos client