### PR TITLE
[ISSUE #11231]Optimize the handleSpringBinder method in PropertiesUtil.

### DIFF
--- a/auth/src/main/java/com/alibaba/nacos/auth/config/AuthConfigs.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/config/AuthConfigs.java
@@ -107,12 +107,14 @@ public class AuthConfigs extends Subscriber<ServerConfigChangeEvent> {
         try {
             Map<String, Properties> newProperties = new HashMap<>(1);
             Properties properties = PropertiesUtil.getPropertiesWithPrefix(EnvUtil.getEnvironment(), PREFIX);
-            for (String each : properties.stringPropertyNames()) {
-                int typeIndex = each.indexOf('.');
-                String type = each.substring(0, typeIndex);
-                String subKey = each.substring(typeIndex + 1);
-                newProperties.computeIfAbsent(type, key -> new Properties())
-                        .setProperty(subKey, properties.getProperty(each));
+            if (properties != null) {
+                for (String each : properties.stringPropertyNames()) {
+                    int typeIndex = each.indexOf('.');
+                    String type = each.substring(0, typeIndex);
+                    String subKey = each.substring(typeIndex + 1);
+                    newProperties.computeIfAbsent(type, key -> new Properties())
+                            .setProperty(subKey, properties.getProperty(each));
+                }
             }
             authPluginProperties = newProperties;
         } catch (Exception e) {
@@ -177,8 +179,8 @@ public class AuthConfigs extends Subscriber<ServerConfigChangeEvent> {
             cachingEnabled = EnvUtil.getProperty(Constants.Auth.NACOS_CORE_AUTH_CACHING_ENABLED, Boolean.class, true);
             serverIdentityKey = EnvUtil.getProperty(Constants.Auth.NACOS_CORE_AUTH_SERVER_IDENTITY_KEY, "");
             serverIdentityValue = EnvUtil.getProperty(Constants.Auth.NACOS_CORE_AUTH_SERVER_IDENTITY_VALUE, "");
-            enableUserAgentAuthWhite = EnvUtil
-                    .getProperty(Constants.Auth.NACOS_CORE_AUTH_ENABLE_USER_AGENT_AUTH_WHITE, Boolean.class, false);
+            enableUserAgentAuthWhite = EnvUtil.getProperty(Constants.Auth.NACOS_CORE_AUTH_ENABLE_USER_AGENT_AUTH_WHITE,
+                    Boolean.class, false);
             nacosAuthSystemType = EnvUtil.getProperty(Constants.Auth.NACOS_CORE_AUTH_SYSTEM_TYPE, "");
             refreshPluginProperties();
             ModuleStateHolder.getInstance().getModuleState(AuthModuleStateBuilder.AUTH_MODULE)

--- a/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigs.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigs.java
@@ -54,12 +54,14 @@ public class ConfigChangeConfigs extends Subscriber<ServerConfigChangeEvent> {
         try {
             Map<String, Properties> newProperties = new HashMap<>(3);
             Properties properties = PropertiesUtil.getPropertiesWithPrefix(EnvUtil.getEnvironment(), PREFIX);
-            for (String each : properties.stringPropertyNames()) {
-                int typeIndex = each.indexOf('.');
-                String type = each.substring(0, typeIndex);
-                String subKey = each.substring(typeIndex + 1);
-                newProperties.computeIfAbsent(type, key -> new Properties())
-                        .setProperty(subKey, properties.getProperty(each));
+            if (properties != null) {
+                for (String each : properties.stringPropertyNames()) {
+                    int typeIndex = each.indexOf('.');
+                    String type = each.substring(0, typeIndex);
+                    String subKey = each.substring(typeIndex + 1);
+                    newProperties.computeIfAbsent(type, key -> new Properties())
+                            .setProperty(subKey, properties.getProperty(each));
+                }
             }
             configPluginProperties = newProperties;
         } catch (Exception e) {

--- a/core/src/main/java/com/alibaba/nacos/core/remote/tls/RpcServerTlsConfig.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/tls/RpcServerTlsConfig.java
@@ -22,8 +22,6 @@ import com.alibaba.nacos.core.utils.Loggers;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import com.alibaba.nacos.sys.utils.PropertiesUtil;
 
-import java.lang.reflect.InvocationTargetException;
-
 /**
  * Grpc config.
  *
@@ -41,11 +39,9 @@ public class RpcServerTlsConfig extends TlsConfig {
     
     public static synchronized RpcServerTlsConfig getInstance() {
         if (null == instance) {
-            try {
-                instance = PropertiesUtil
-                        .handleSpringBinder(EnvUtil.getEnvironment(), PREFIX, RpcServerTlsConfig.class);
-            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | ClassNotFoundException e) {
-                Loggers.REMOTE.warn("TLS config bind failed, use default value", e);
+            instance = PropertiesUtil.handleSpringBinder(EnvUtil.getEnvironment(), PREFIX, RpcServerTlsConfig.class);
+            if (instance == null) {
+                Loggers.REMOTE.debug("TLS configuration is empty, use default value");
                 instance = new RpcServerTlsConfig();
             }
         }

--- a/sys/src/main/java/com/alibaba/nacos/sys/utils/PropertiesUtil.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/utils/PropertiesUtil.java
@@ -16,10 +16,10 @@
 
 package com.alibaba.nacos.sys.utils;
 
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.Environment;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Properties;
 
@@ -30,13 +30,11 @@ import java.util.Properties;
  */
 public class PropertiesUtil {
     
-    public static Properties getPropertiesWithPrefix(Environment environment, String prefix)
-            throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public static Properties getPropertiesWithPrefix(Environment environment, String prefix) {
         return handleSpringBinder(environment, prefix, Properties.class);
     }
     
-    public static Map<String, Object> getPropertiesWithPrefixForMap(Environment environment, String prefix)
-            throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public static Map<String, Object> getPropertiesWithPrefixForMap(Environment environment, String prefix) {
         return handleSpringBinder(environment, prefix, Map.class);
     }
     
@@ -49,16 +47,8 @@ public class PropertiesUtil {
      * @param <T>         target class
      * @return binder object
      */
-    @SuppressWarnings("unchecked")
-    public static <T> T handleSpringBinder(Environment environment, String prefix, Class<T> targetClass)
-            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, ClassNotFoundException {
-        Class<?> binderClass = Class.forName("org.springframework.boot.context.properties.bind.Binder");
-        Method getMethod = binderClass.getDeclaredMethod("get", Environment.class);
-        Method bindMethod = binderClass.getDeclaredMethod("bind", String.class, Class.class);
-        Object binderObject = getMethod.invoke(null, environment);
+    public static <T> T handleSpringBinder(Environment environment, String prefix, Class<T> targetClass) {
         String prefixParam = prefix.endsWith(".") ? prefix.substring(0, prefix.length() - 1) : prefix;
-        Object bindResultObject = bindMethod.invoke(binderObject, prefixParam, targetClass);
-        Method resultGetMethod = bindResultObject.getClass().getDeclaredMethod("get");
-        return (T) resultGetMethod.invoke(bindResultObject);
+        return Binder.get(environment).bind(prefixParam, Bindable.of(targetClass)).orElse(null);
     }
 }

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/PropertiesUtilTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/PropertiesUtilTest.java
@@ -24,7 +24,6 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -40,8 +39,7 @@ public class PropertiesUtilTest {
     
     @Test
     @SuppressWarnings("unchecked")
-    public void testGetPropertiesWithPrefixForMap()
-            throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    public void testGetPropertiesWithPrefixForMap() {
         Map<String, Object> actual = PropertiesUtil.getPropertiesWithPrefixForMap(environment, "nacos.prefix");
         assertEquals(3, actual.size());
         for (Map.Entry<String, Object> entry : actual.entrySet()) {
@@ -64,9 +62,14 @@ public class PropertiesUtilTest {
     }
     
     @Test
-    public void testGetPropertiesWithPrefix()
-            throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    public void testGetPropertiesWithPrefix() {
         Properties actual = PropertiesUtil.getPropertiesWithPrefix(environment, "nacos.prefix");
         assertEquals(3, actual.size());
+    }
+    
+    @Test
+    public void testHandleSpringBinder() {
+        Map properties = PropertiesUtil.handleSpringBinder(environment, "nacos.prefix", Map.class);
+        assertEquals(3, properties.size());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The Nacos source code startup results in an error as follows:

```
2023-10-09 21:26:50.729  WARN 4688 --- [           main] c.a.n.c.s.c.ConfigChangeConfigs          : [ConfigChangeConfigs]Refresh config plugin properties failed 

java.lang.reflect.InvocationTargetException: null
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.alibaba.nacos.sys.utils.PropertiesUtil.handleSpringBinder(PropertiesUtil.java:62)
	at com.alibaba.nacos.sys.utils.PropertiesUtil.getPropertiesWithPrefix(PropertiesUtil.java:35)
	at com.alibaba.nacos.config.server.configuration.ConfigChangeConfigs.refreshPluginProperties(ConfigChangeConfigs.java:56)
	at com.alibaba.nacos.config.server.configuration.ConfigChangeConfigs.<init>(ConfigChangeConfigs.java:50)
	at com.alibaba.nacos.config.server.configuration.ConfigChangeConfigs$$EnhancerBySpringCGLIB$$fb3b6b82.<init>(<generated>)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:211)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:87)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateBean(AbstractAutowireCapableBeanFactory.java:1326)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1232)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208)
	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:276)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1391)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1311)
	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:887)
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:791)
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:229)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1372)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1222)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:955)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:921)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583)
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:147)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:731)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:408)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:307)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1303)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1292)
	at com.alibaba.nacos.Nacos.main(Nacos.java:48)
Caused by: java.util.NoSuchElementException: No value bound
	at org.springframework.boot.context.properties.bind.BindResult.get(BindResult.java:55)
	... 47 common frames omitted
```

Reason: The Nacos source code by default does not have configuration related to change plugins (nacos.core.config.plugin.*).

Below is the source code related to BindResult:

```java
public final class BindResult<T> {
    ...
    public T get() throws NoSuchElementException {
        if (this.value == null) {
            throw new NoSuchElementException("No value bound");
        } else {
            return this.value;
        }
    }

    public T orElse(T other) {
        return this.value != null ? this.value : other;
    }
   ...
}
```

## Brief changelog

- Change the previous approach of using reflection calls to using object-based invocations.

- Replace the previous usage of the BindResult#get() method with BindResult#orElse method, which defaults to returning null if not present. Then, perform null-check handling at the outer layer.

## Verifying this change

Enable authentication plugin

### Before the modification
#### Authentication plugin reads the content

![image-20231009214817170](https://github.com/alibaba/nacos/assets/35629966/e5550421-b5a8-4ef1-8084-a2d129713488)

### After the modification

#### Fix the error in the configuration change plugin.

#### Authentication-related property content

![image-20231009214628958](https://github.com/alibaba/nacos/assets/35629966/4dfb090c-19d2-435c-8ce8-5ae8ee78fa8b)


Consistent with the content before the change.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

