### PR TITLE
get retained instances only based on ip and port checking

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
@@ -204,7 +204,8 @@ public class NamingGrpcClientProxy extends AbstractNamingClientProxy {
     }
     
     private boolean compareIpAndPort(Instance deRegisterInstance, Instance redoInstance) {
-        return ((deRegisterInstance.getIp().equals(redoInstance.getIp())) && (deRegisterInstance.getPort() == redoInstance.getPort()));
+        return ((deRegisterInstance.getIp().equals(redoInstance.getIp()))
+                && (deRegisterInstance.getPort() == redoInstance.getPort()));
     }
     
     /**

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
@@ -339,11 +339,11 @@ public class NamingGrpcClientProxyTest {
         }
         response = new BatchInstanceResponse();
         when(this.rpcClient.request(any())).thenReturn(response);
-        List<Instance> instanceList = new ArrayList<>();
         Instance otherPortInstance = new Instance();
         otherPortInstance.setServiceName(SERVICE_NAME);
         otherPortInstance.setIp("1.1.1.1");
         otherPortInstance.setPort(2222);
+        List<Instance> instanceList = new ArrayList<>();
         instanceList.add(otherPortInstance);
         client.batchDeregisterService(SERVICE_NAME, GROUP_NAME, instanceList);
         verify(this.rpcClient, times(2)).request(argThat(request -> {

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
@@ -328,6 +328,36 @@ public class NamingGrpcClientProxyTest {
     }
     
     @Test
+    public void testBatchDeregisterServiceWithOtherPortInstance() throws NacosException {
+        try {
+            List<Instance> instanceList = new ArrayList<>();
+            instance.setHealthy(true);
+            instanceList.add(instance);
+            instanceList.add(new Instance());
+            client.batchRegisterService(SERVICE_NAME, GROUP_NAME, instanceList);
+        } catch (Exception ignored) {
+        }
+        response = new BatchInstanceResponse();
+        when(this.rpcClient.request(any())).thenReturn(response);
+        List<Instance> instanceList = new ArrayList<>();
+        Instance otherPortInstance = new Instance();
+        otherPortInstance.setServiceName(SERVICE_NAME);
+        otherPortInstance.setIp("1.1.1.1");
+        otherPortInstance.setPort(2222);
+        instanceList.add(otherPortInstance);
+        client.batchDeregisterService(SERVICE_NAME, GROUP_NAME, instanceList);
+        verify(this.rpcClient, times(2)).request(argThat(request -> {
+            if (request instanceof BatchInstanceRequest) {
+                BatchInstanceRequest request1 = (BatchInstanceRequest) request;
+                request1.setRequestId("1");
+                return request1.getInstances().size() == 2 && request1.getType()
+                        .equals(NamingRemoteConstants.BATCH_REGISTER_INSTANCE);
+            }
+            return false;
+        }));
+    }
+    
+    @Test
     public void testUpdateInstance() throws Exception {
         //TODO thrown.expect(UnsupportedOperationException.class);
         client.updateInstance(SERVICE_NAME, GROUP_NAME, instance);


### PR DESCRIPTION
## What is the purpose of the change
fix #11298

## Brief changelog
* only check  ip and port of deregister instances at getRetainInstance function of NamingGrpcClientProxy.java

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

