### PR TITLE
feat(#11393): support register or deregister persistent instance by grpc

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/ability/constant/AbilityKey.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ability/constant/AbilityKey.java
@@ -18,8 +18,8 @@ package com.alibaba.nacos.api.ability.constant;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -49,8 +49,14 @@ public enum AbilityKey {
     /**
      * For Test temporarily.
      */
-    CLUSTER_CLIENT_TEST_1("test_1", "just for junit test", AbilityMode.CLUSTER_CLIENT);
-    
+    CLUSTER_CLIENT_TEST_1("test_1", "just for junit test", AbilityMode.CLUSTER_CLIENT),
+
+    /**
+     * Support register or deregister persistent instance by grpc.
+     */
+    SUPPORT_PERSISTENT_INSTANCE_BY_GRPC("supportPersistentInstanceByGrpc",
+            "support persistent instance by grpc", AbilityMode.SERVER);
+
     /**
      * the name of a certain ability.
      */

--- a/api/src/main/java/com/alibaba/nacos/api/ability/register/impl/ServerAbilities.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ability/register/impl/ServerAbilities.java
@@ -45,6 +45,7 @@ public class ServerAbilities extends AbstractAbilityRegistry {
          *
          */
         // put ability here, which you want current server supports
+        supportedAbilities.put(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC, true);
     }
     
     /**.

--- a/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/PersistentInstanceRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/remote/request/PersistentInstanceRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.remote.request;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+
+/**
+ * Nacos persistent instances request.
+ *
+ * @author blake.qiu
+ */
+public class PersistentInstanceRequest extends AbstractNamingRequest {
+
+    private String type;
+
+    private Instance instance;
+
+    public PersistentInstanceRequest() {
+    }
+
+    public PersistentInstanceRequest(String namespace, String serviceName, String groupName, String type, Instance instance) {
+        super(namespace, serviceName, groupName);
+        this.type = type;
+        this.instance = instance;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Instance getInstance() {
+        return instance;
+    }
+
+    public void setInstance(Instance instance) {
+        this.instance = instance;
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
@@ -138,6 +138,10 @@ public class NamingUtils {
      * @throws NacosException if check failed, throw exception
      */
     public static void checkInstanceIsLegal(Instance instance) throws NacosException {
+        if (null == instance) {
+            throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.INSTANCE_ERROR,
+                    "Instance can not be null.");
+        }
         if (instance.getInstanceHeartBeatTimeOut() < instance.getInstanceHeartBeatInterval()
                 || instance.getIpDeleteTimeout() < instance.getInstanceHeartBeatInterval()) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.INSTANCE_ERROR,

--- a/api/src/test/java/com/alibaba/nacos/api/ability/register/impl/ServerAbilitiesTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ability/register/impl/ServerAbilitiesTest.java
@@ -16,15 +16,21 @@
 
 package com.alibaba.nacos.api.ability.register.impl;
 
+import com.alibaba.nacos.api.ability.constant.AbilityKey;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ServerAbilitiesTest {
-    
+
     @Test
     public void testGetStaticAbilities() {
-        // TODO add the server abilities.
-        assertTrue(ServerAbilities.getStaticAbilities().isEmpty());
+        assertFalse(ServerAbilities.getStaticAbilities().isEmpty());
+    }
+
+    @Test
+    public void testSupportPersistentInstanceByGrpcAbilities() {
+        assertTrue(ServerAbilities.getStaticAbilities().get(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC));
     }
 }

--- a/api/src/test/java/com/alibaba/nacos/api/naming/remote/request/PersistentInstanceRequestTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/naming/remote/request/PersistentInstanceRequestTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.naming.remote.request;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.remote.NamingRemoteConstants;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PersistentInstanceRequestTest extends BasedNamingRequestTest {
+    
+    @Test
+    public void testSerialize() throws JsonProcessingException {
+        PersistentInstanceRequest request = new PersistentInstanceRequest(NAMESPACE, SERVICE, GROUP,
+                NamingRemoteConstants.REGISTER_INSTANCE, new Instance());
+        String json = mapper.writeValueAsString(request);
+        checkSerializeBasedInfo(json);
+        assertTrue(json.contains("\"type\":\"" + NamingRemoteConstants.REGISTER_INSTANCE + "\""));
+        assertTrue(json.contains("\"instance\":{"));
+    }
+    
+    @Test
+    public void testDeserialize() throws JsonProcessingException {
+        String json = "{\"headers\":{},\"namespace\":\"namespace\",\"serviceName\":\"service\",\"groupName\":\"group\","
+                + "\"type\":\"deregisterInstance\",\"instance\":{\"port\":0,\"weight\":1.0,\"healthy\":true,"
+                + "\"enabled\":true,\"ephemeral\":true,\"metadata\":{},\"instanceIdGenerator\":\"simple\","
+                + "\"instanceHeartBeatInterval\":5000,\"instanceHeartBeatTimeOut\":15000,\"ipDeleteTimeout\":30000},"
+                + "\"module\":\"naming\"}";
+        PersistentInstanceRequest actual = mapper.readValue(json, PersistentInstanceRequest.class);
+        checkNamingRequestBasedInfo(actual);
+        assertEquals(NamingRemoteConstants.DE_REGISTER_INSTANCE, actual.getType());
+        assertEquals(new Instance(), actual.getInstance());
+    }
+}

--- a/api/src/test/java/com/alibaba/nacos/api/naming/utils/NamingUtilsTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/naming/utils/NamingUtilsTest.java
@@ -231,6 +231,19 @@ public class NamingUtilsTest {
             Assert.assertEquals(e.getErrCode(), NacosException.INVALID_PARAM);
         }
     }
+
+    @Test
+    public void testCheckInstanceIsNull() throws NacosException {
+        Instance instance = new Instance();
+        instance.setIp("127.0.0.1");
+        instance.setPort(9089);
+        NamingUtils.checkInstanceIsLegal(instance);
+        try {
+            NamingUtils.checkInstanceIsLegal(null);
+        } catch (NacosException e) {
+            Assert.assertEquals(e.getErrCode(), NacosException.INVALID_PARAM);
+        }
+    }
     
     @Test
     public void testIsNumber() {

--- a/api/src/test/java/com/alibaba/nacos/api/utils/AbilityKeyTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/utils/AbilityKeyTest.java
@@ -44,16 +44,20 @@ public class AbilityKeyTest {
         
         enumMap.put(AbilityKey.SERVER_TEST_1, true);
         enumMap.put(AbilityKey.SERVER_TEST_2, false);
+        enumMap.put(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC, false);
         stringBooleanMap = AbilityKey.mapStr(enumMap);
-        assertEquals(2, stringBooleanMap.size());
+        assertEquals(3, stringBooleanMap.size());
         Assert.assertTrue(stringBooleanMap.get(AbilityKey.SERVER_TEST_1.getName()));
         Assert.assertFalse(stringBooleanMap.get(AbilityKey.SERVER_TEST_2.getName()));
+        Assert.assertFalse(stringBooleanMap.get(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC.getName()));
         
         enumMap.put(AbilityKey.SERVER_TEST_2, true);
+        enumMap.put(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC, true);
         stringBooleanMap = AbilityKey.mapStr(enumMap);
-        assertEquals(2, stringBooleanMap.size());
+        assertEquals(3, stringBooleanMap.size());
         Assert.assertTrue(stringBooleanMap.get(AbilityKey.SERVER_TEST_1.getName()));
         Assert.assertTrue(stringBooleanMap.get(AbilityKey.SERVER_TEST_2.getName()));
+        Assert.assertTrue(stringBooleanMap.get(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC.getName()));
     }
     
     @Test
@@ -71,23 +75,27 @@ public class AbilityKeyTest {
         
         mapStr.put(AbilityKey.SERVER_TEST_2.getName(), false);
         mapStr.put(AbilityKey.SERVER_TEST_1.getName(), true);
+        mapStr.put(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC.getName(), true);
         enumMap = AbilityKey.mapEnum(AbilityMode.SERVER, mapStr);
         Assert.assertFalse(enumMap.get(AbilityKey.SERVER_TEST_2));
         Assert.assertTrue(enumMap.get(AbilityKey.SERVER_TEST_1));
+        Assert.assertTrue(enumMap.get(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC));
     
         mapStr.clear();
         mapStr.put(AbilityKey.SERVER_TEST_2.getName(), true);
         mapStr.put(AbilityKey.SERVER_TEST_1.getName(), true);
+        mapStr.put(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC.getName(), true);
         enumMap = AbilityKey.mapEnum(AbilityMode.SERVER, mapStr);
         Assert.assertTrue(enumMap.get(AbilityKey.SERVER_TEST_2));
         Assert.assertTrue(enumMap.get(AbilityKey.SERVER_TEST_1));
+        Assert.assertTrue(enumMap.get(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC));
         
     }
     
     @Test
     public void testGetAllValues() {
         Collection<AbilityKey> actual = AbilityKey.getAllValues(AbilityMode.SERVER);
-        assertEquals(2, actual.size());
+        assertEquals(3, actual.size());
         actual = AbilityKey.getAllValues(AbilityMode.SDK_CLIENT);
         assertEquals(1, actual.size());
         actual = AbilityKey.getAllValues(AbilityMode.CLUSTER_CLIENT);
@@ -97,7 +105,7 @@ public class AbilityKeyTest {
     @Test
     public void testGetAllNames() {
         Collection<String> actual = AbilityKey.getAllNames(AbilityMode.SERVER);
-        assertEquals(2, actual.size());
+        assertEquals(3, actual.size());
         actual = AbilityKey.getAllNames(AbilityMode.SDK_CLIENT);
         assertEquals(1, actual.size());
         actual = AbilityKey.getAllNames(AbilityMode.CLUSTER_CLIENT);

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -194,6 +194,7 @@ public class NacosNamingService implements NamingService {
     
     @Override
     public void deregisterInstance(String serviceName, String groupName, Instance instance) throws NacosException {
+        NamingUtils.checkInstanceIsLegal(instance);
         checkAndStripGroupNamePrefix(instance, groupName);
         clientProxy.deregisterService(serviceName, groupName, instance);
     }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/NamingClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/NamingClientProxy.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.client.naming.remote;
 
+import com.alibaba.nacos.api.ability.constant.AbilityKey;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
@@ -187,4 +188,12 @@ public interface NamingClientProxy extends Closeable {
      * @return true if server is healthy
      */
     boolean serverHealthy();
+
+    /**
+     * Judge nacos server whether support the ability.
+     *
+     * @param abilityKey ability key
+     * @return true if supported
+     */
+    boolean isAbilitySupportedByServer(AbilityKey abilityKey);
 }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/NamingClientProxyDelegate.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/NamingClientProxyDelegate.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.client.naming.remote;
 
+import com.alibaba.nacos.api.ability.constant.AbilityKey;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
@@ -192,9 +193,17 @@ public class NamingClientProxyDelegate implements NamingClientProxy {
     public boolean serverHealthy() {
         return grpcClientProxy.serverHealthy() || httpClientProxy.serverHealthy();
     }
-    
+
+    @Override
+    public boolean isAbilitySupportedByServer(AbilityKey abilityKey) {
+        return grpcClientProxy.isAbilitySupportedByServer(abilityKey);
+    }
+
     private NamingClientProxy getExecuteClientProxy(Instance instance) {
-        return instance.isEphemeral() ? grpcClientProxy : httpClientProxy;
+        if (instance.isEphemeral() || isAbilitySupportedByServer(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC)) {
+            return grpcClientProxy;
+        }
+        return httpClientProxy;
     }
     
     @Override

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.client.naming.remote.gprc;
 
+import com.alibaba.nacos.api.ability.constant.AbilityKey;
+import com.alibaba.nacos.api.ability.constant.AbilityStatus;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.CommonParams;
@@ -27,6 +29,7 @@ import com.alibaba.nacos.api.naming.remote.NamingRemoteConstants;
 import com.alibaba.nacos.api.naming.remote.request.AbstractNamingRequest;
 import com.alibaba.nacos.api.naming.remote.request.BatchInstanceRequest;
 import com.alibaba.nacos.api.naming.remote.request.InstanceRequest;
+import com.alibaba.nacos.api.naming.remote.request.PersistentInstanceRequest;
 import com.alibaba.nacos.api.naming.remote.request.ServiceListRequest;
 import com.alibaba.nacos.api.naming.remote.request.ServiceQueryRequest;
 import com.alibaba.nacos.api.naming.remote.request.SubscribeServiceRequest;
@@ -128,6 +131,14 @@ public class NamingGrpcClientProxy extends AbstractNamingClientProxy {
     public void registerService(String serviceName, String groupName, Instance instance) throws NacosException {
         NAMING_LOGGER.info("[REGISTER-SERVICE] {} registering service {} with instance {}", namespaceId, serviceName,
                 instance);
+        if (instance.isEphemeral()) {
+            registerServiceForEphemeral(serviceName, groupName, instance);
+        } else {
+            doRegisterServiceForPersistent(serviceName, groupName, instance);
+        }
+    }
+
+    private void registerServiceForEphemeral(String serviceName, String groupName, Instance instance) throws NacosException {
         redoService.cacheInstanceForRedo(serviceName, groupName, instance);
         doRegisterService(serviceName, groupName, instance);
     }
@@ -220,11 +231,33 @@ public class NamingGrpcClientProxy extends AbstractNamingClientProxy {
         requestToServer(request, Response.class);
         redoService.instanceRegistered(serviceName, groupName);
     }
-    
+
+    /**
+     * Execute register operation for persistent instance.
+     *
+     * @param serviceName name of service
+     * @param groupName   group of service
+     * @param instance    instance to register
+     * @throws NacosException nacos exception
+     */
+    public void doRegisterServiceForPersistent(String serviceName, String groupName, Instance instance) throws NacosException {
+        PersistentInstanceRequest request = new PersistentInstanceRequest(namespaceId, serviceName, groupName,
+                NamingRemoteConstants.REGISTER_INSTANCE, instance);
+        requestToServer(request, Response.class);
+    }
+
     @Override
     public void deregisterService(String serviceName, String groupName, Instance instance) throws NacosException {
         NAMING_LOGGER.info("[DEREGISTER-SERVICE] {} deregistering service {} with instance: {}", namespaceId,
                 serviceName, instance);
+        if (instance.isEphemeral()) {
+            deregisterServiceForEphemeral(serviceName, groupName, instance);
+        } else {
+            doDeregisterServiceForPersistent(serviceName, groupName, instance);
+        }
+    }
+
+    private void deregisterServiceForEphemeral(String serviceName, String groupName, Instance instance) throws NacosException {
         String key = NamingUtils.getGroupedName(serviceName, groupName);
         InstanceRedoData instanceRedoData = redoService.getRegisteredInstancesByKey(key);
         if (instanceRedoData instanceof BatchInstanceRedoData) {
@@ -253,7 +286,21 @@ public class NamingGrpcClientProxy extends AbstractNamingClientProxy {
         requestToServer(request, Response.class);
         redoService.instanceDeregistered(serviceName, groupName);
     }
-    
+
+    /**
+     * Execute deregister operation for persistent instance.
+     *
+     * @param serviceName service name
+     * @param groupName   group name
+     * @param instance    instance
+     * @throws NacosException nacos exception
+     */
+    public void doDeregisterServiceForPersistent(String serviceName, String groupName, Instance instance) throws NacosException {
+        PersistentInstanceRequest request = new PersistentInstanceRequest(namespaceId, serviceName, groupName,
+                NamingRemoteConstants.DE_REGISTER_INSTANCE, instance);
+        requestToServer(request, Response.class);
+    }
+
     @Override
     public void updateInstance(String serviceName, String groupName, Instance instance) throws NacosException {
     
@@ -365,7 +412,12 @@ public class NamingGrpcClientProxy extends AbstractNamingClientProxy {
     public boolean serverHealthy() {
         return rpcClient.isRunning();
     }
-    
+
+    @Override
+    public boolean isAbilitySupportedByServer(AbilityKey abilityKey) {
+        return rpcClient.getConnectionAbility(abilityKey) == AbilityStatus.SUPPORTED;
+    }
+
     private <T extends Response> T requestToServer(AbstractNamingRequest request, Class<T> responseClass)
             throws NacosException {
         Response response = null;

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
@@ -65,6 +65,7 @@ import com.alibaba.nacos.common.utils.JacksonUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -164,41 +165,58 @@ public class NamingGrpcClientProxy extends AbstractNamingClientProxy {
      *
      * @param serviceName service name
      * @param groupName   group name
-     * @param instances   instance list
-     * @return instance list that need to be deregistered.
+     * @param deRegisterInstances   deregister instance list
+     * @return instance list that need to be retained.
      */
-    private List<Instance> getRetainInstance(String serviceName, String groupName, List<Instance> instances)
+    private List<Instance> getRetainInstance(String serviceName, String groupName, List<Instance> deRegisterInstances)
             throws NacosException {
-        if (CollectionUtils.isEmpty(instances)) {
+        if (CollectionUtils.isEmpty(deRegisterInstances)) {
             throw new NacosException(NacosException.INVALID_PARAM,
                     String.format("[Batch deRegistration] need deRegister instance is empty, instances: %s,",
-                            instances));
+                            deRegisterInstances));
         }
         String combinedServiceName = NamingUtils.getGroupedName(serviceName, groupName);
         InstanceRedoData instanceRedoData = redoService.getRegisteredInstancesByKey(combinedServiceName);
         if (!(instanceRedoData instanceof BatchInstanceRedoData)) {
             throw new NacosException(NacosException.INVALID_PARAM, String.format(
                     "[Batch deRegistration] batch deRegister is not BatchInstanceRedoData type , instances: %s,",
-                    instances));
+                    deRegisterInstances));
         }
         
         BatchInstanceRedoData batchInstanceRedoData = (BatchInstanceRedoData) instanceRedoData;
-        List<Instance> allInstance = batchInstanceRedoData.getInstances();
-        if (CollectionUtils.isEmpty(allInstance)) {
+        List<Instance> allRedoInstances = batchInstanceRedoData.getInstances();
+        if (CollectionUtils.isEmpty(allRedoInstances)) {
             throw new NacosException(NacosException.INVALID_PARAM, String.format(
                     "[Batch deRegistration] not found all registerInstance , serviceName：%s , groupName: %s",
                     serviceName, groupName));
         }
         
-        Map<Instance, Instance> instanceMap = instances.stream()
+        Map<Instance, Instance> deRegisterInstanceMap = deRegisterInstances.stream()
                 .collect(Collectors.toMap(Function.identity(), Function.identity()));
         List<Instance> retainInstances = new ArrayList<>();
-        for (Instance instance : allInstance) {
-            if (!instanceMap.containsKey(instance)) {
-                retainInstances.add(instance);
+        for (Instance redoInstance : allRedoInstances) {
+            boolean needRetained = true;
+            Iterator<Map.Entry<Instance, Instance>> it = deRegisterInstanceMap.entrySet().iterator();
+            while (it.hasNext()) {
+                Instance deRegisterInstance = it.next().getKey();
+                // only compare Ip & Port because redoInstance's instanceId or serviceName might be null but deRegisterInstance's might not be null.
+                if (compareIpAndPort(deRegisterInstance, redoInstance)) {
+                    needRetained = false;
+                    // clear current entry to speed up next redoInstance comparing.
+                    it.remove();
+                    break;
+                }
+            }
+            if (needRetained) {
+                retainInstances.add(redoInstance);
             }
         }
         return retainInstances;
+    }
+    
+    private boolean compareIpAndPort(Instance deRegisterInstance, Instance redoInstance) {
+        return ((deRegisterInstance.getIp().equals(redoInstance.getIp()))
+                && (deRegisterInstance.getPort() == redoInstance.getPort()));
     }
     
     /**

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.client.naming.remote.http;
 
 import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.SystemPropertyKeyConst;
+import com.alibaba.nacos.api.ability.constant.AbilityKey;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.CommonParams;
 import com.alibaba.nacos.api.naming.pojo.Instance;
@@ -268,7 +269,6 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
     
     @Override
     public boolean serverHealthy() {
-        
         try {
             String result = reqApi(UtilAndComs.nacosUrlBase + "/operator/metrics", new HashMap<>(8), HttpMethod.GET);
             JsonNode json = JacksonUtils.toObj(result);
@@ -278,7 +278,13 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
             return false;
         }
     }
-    
+
+    @Override
+    public boolean isAbilitySupportedByServer(AbilityKey abilityKey) {
+        // Http agent does not support ability check, return true directly.
+        return false;
+    }
+
     @Override
     public ListView<String> getServiceList(int pageNo, int pageSize, String groupName, AbstractSelector selector)
             throws NacosException {

--- a/client/src/test/java/com/alibaba/nacos/client/logging/logback/LogbackNacosLoggingTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/logging/logback/LogbackNacosLoggingTest.java
@@ -18,9 +18,12 @@
 
 package com.alibaba.nacos.client.logging.logback;
 
+import ch.qos.logback.classic.LoggerContext;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.CoreMatchers.isA;
 
@@ -31,9 +34,12 @@ public class LogbackNacosLoggingTest {
     
     @Test
     public void testLoadConfiguration() {
-        exceptionRule.expectCause(isA(ClassCastException.class));
-        exceptionRule.expectMessage("Could not initialize Logback Nacos logging from classpath:nacos-logback.xml");
-        LogbackNacosLogging logbackNacosLogging = new LogbackNacosLogging();
-        logbackNacosLogging.loadConfiguration();
+        ILoggerFactory loggerFactory;
+        if ((loggerFactory = LoggerFactory.getILoggerFactory()) != null && loggerFactory instanceof LoggerContext) {
+            exceptionRule.expectCause(isA(ClassCastException.class));
+            exceptionRule.expectMessage("Could not initialize Logback Nacos logging from classpath:nacos-logback.xml");
+            LogbackNacosLogging logbackNacosLogging = new LogbackNacosLogging();
+            logbackNacosLogging.loadConfiguration();
+        }
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/AbstractNamingClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/AbstractNamingClientProxyTest.java
@@ -18,6 +18,7 @@
 
 package com.alibaba.nacos.client.naming.remote;
 
+import com.alibaba.nacos.api.ability.constant.AbilityKey;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.pojo.Instance;
@@ -177,7 +178,12 @@ public class AbstractNamingClientProxyTest {
         public boolean serverHealthy() {
             return false;
         }
-        
+
+        @Override
+        public boolean isAbilitySupportedByServer(AbilityKey abilityKey) {
+            return false;
+        }
+
         @Override
         public void shutdown() throws NacosException {
         

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
@@ -391,36 +391,6 @@ public class NamingGrpcClientProxyTest {
             return false;
         }));
     }
-
-    @Test
-    public void testBatchDeregisterServiceWithOtherPortInstance() throws NacosException {
-        try {
-            List<Instance> instanceList = new ArrayList<>();
-            instance.setHealthy(true);
-            instanceList.add(instance);
-            instanceList.add(new Instance());
-            client.batchRegisterService(SERVICE_NAME, GROUP_NAME, instanceList);
-        } catch (Exception ignored) {
-        }
-        response = new BatchInstanceResponse();
-        when(this.rpcClient.request(any())).thenReturn(response);
-        Instance otherPortInstance = new Instance();
-        otherPortInstance.setServiceName(SERVICE_NAME);
-        otherPortInstance.setIp("1.1.1.1");
-        otherPortInstance.setPort(2222);
-        List<Instance> instanceList = new ArrayList<>();
-        instanceList.add(otherPortInstance);
-        client.batchDeregisterService(SERVICE_NAME, GROUP_NAME, instanceList);
-        verify(this.rpcClient, times(2)).request(argThat(request -> {
-            if (request instanceof BatchInstanceRequest) {
-                BatchInstanceRequest request1 = (BatchInstanceRequest) request;
-                request1.setRequestId("1");
-                return request1.getInstances().size() == 2 && request1.getType()
-                        .equals(NamingRemoteConstants.BATCH_REGISTER_INSTANCE);
-            }
-            return false;
-        }));
-    }
     
     @Test
     public void testUpdateInstance() throws Exception {

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxyTest.java
@@ -18,6 +18,7 @@
 
 package com.alibaba.nacos.client.naming.remote.http;
 
+import com.alibaba.nacos.api.ability.constant.AbilityKey;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ListView;
@@ -333,7 +334,14 @@ public class NamingHttpClientProxyTest {
                 eq(HttpMethod.GET), any());
         Assert.assertTrue(serverHealthy);
     }
-    
+
+    @Test
+    public void testIsAbilitySupportedByServer() {
+        // always return false
+        Assert.assertFalse(clientProxy.isAbilitySupportedByServer(AbilityKey.SUPPORT_PERSISTENT_INSTANCE_BY_GRPC));
+        Assert.assertFalse(clientProxy.isAbilitySupportedByServer(AbilityKey.SERVER_TEST_1));
+    }
+
     @Test
     public void testGetServiceList() throws Exception {
         //given

--- a/naming/src/main/java/com/alibaba/nacos/naming/remote/rpc/handler/PersistentInstanceRequestHandler.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/remote/rpc/handler/PersistentInstanceRequestHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.remote.rpc.handler;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.remote.NamingRemoteConstants;
+import com.alibaba.nacos.api.naming.remote.request.PersistentInstanceRequest;
+import com.alibaba.nacos.api.naming.remote.response.InstanceResponse;
+import com.alibaba.nacos.api.remote.request.RequestMeta;
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.common.notify.NotifyCenter;
+import com.alibaba.nacos.common.trace.DeregisterInstanceReason;
+import com.alibaba.nacos.common.trace.event.naming.DeregisterInstanceTraceEvent;
+import com.alibaba.nacos.common.trace.event.naming.RegisterInstanceTraceEvent;
+import com.alibaba.nacos.core.control.TpsControl;
+import com.alibaba.nacos.core.paramcheck.ExtractorManager;
+import com.alibaba.nacos.core.paramcheck.impl.InstanceRequestParamExtractor;
+import com.alibaba.nacos.core.remote.RequestHandler;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.core.v2.service.impl.PersistentClientOperationServiceImpl;
+import com.alibaba.nacos.naming.utils.InstanceUtil;
+import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import org.springframework.stereotype.Component;
+
+/**
+ * Persistent instance request handler.
+ *
+ * @author blake.qiu
+ */
+@Component
+public class PersistentInstanceRequestHandler extends RequestHandler<PersistentInstanceRequest, InstanceResponse> {
+
+    private final PersistentClientOperationServiceImpl clientOperationService;
+
+    public PersistentInstanceRequestHandler(PersistentClientOperationServiceImpl clientOperationService) {
+        this.clientOperationService = clientOperationService;
+    }
+
+    @Override
+    @TpsControl(pointName = "RemoteNamingInstanceRegisterDeregister", name = "RemoteNamingInstanceRegisterDeregister")
+    @Secured(action = ActionTypes.WRITE)
+    @ExtractorManager.Extractor(rpcExtractor = InstanceRequestParamExtractor.class)
+    public InstanceResponse handle(PersistentInstanceRequest request, RequestMeta meta) throws NacosException {
+        Service service = Service
+                .newService(request.getNamespace(), request.getGroupName(), request.getServiceName(), true);
+        InstanceUtil.setInstanceIdIfEmpty(request.getInstance(), service.getGroupedServiceName());
+        switch (request.getType()) {
+            case NamingRemoteConstants.REGISTER_INSTANCE:
+                return registerInstance(service, request, meta);
+            case NamingRemoteConstants.DE_REGISTER_INSTANCE:
+                return deregisterInstance(service, request, meta);
+            default:
+                throw new NacosException(NacosException.INVALID_PARAM,
+                        String.format("Unsupported request type %s", request.getType()));
+        }
+    }
+
+    private InstanceResponse registerInstance(Service service, PersistentInstanceRequest request, RequestMeta meta) {
+        clientOperationService.registerInstance(service, request.getInstance(), meta.getConnectionId());
+        NotifyCenter.publishEvent(new RegisterInstanceTraceEvent(System.currentTimeMillis(),
+                meta.getClientIp(), true, service.getNamespace(), service.getGroup(), service.getName(),
+                request.getInstance().getIp(), request.getInstance().getPort()));
+        return new InstanceResponse(NamingRemoteConstants.REGISTER_INSTANCE);
+    }
+
+    private InstanceResponse deregisterInstance(Service service, PersistentInstanceRequest request, RequestMeta meta) {
+        clientOperationService.deregisterInstance(service, request.getInstance(), meta.getConnectionId());
+        NotifyCenter.publishEvent(new DeregisterInstanceTraceEvent(System.currentTimeMillis(),
+                meta.getClientIp(), true, DeregisterInstanceReason.REQUEST, service.getNamespace(),
+                service.getGroup(), service.getName(), request.getInstance().getIp(), request.getInstance().getPort()));
+        return new InstanceResponse(NamingRemoteConstants.DE_REGISTER_INSTANCE);
+    }
+
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/remote/rpc/handler/PersistentInstanceRequestHandlerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/remote/rpc/handler/PersistentInstanceRequestHandlerTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 1999-2021 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.alibaba.nacos.naming.remote.rpc.handler;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.remote.NamingRemoteConstants;
+import com.alibaba.nacos.api.naming.remote.request.PersistentInstanceRequest;
+import com.alibaba.nacos.api.remote.request.RequestMeta;
+import com.alibaba.nacos.naming.core.v2.service.impl.PersistentClientOperationServiceImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * {@link PersistentInstanceRequestHandler} unit tests.
+ *
+ * @author blake.qiu
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PersistentInstanceRequestHandlerTest {
+
+    @InjectMocks
+    private PersistentInstanceRequestHandler persistentInstanceRequestHandler;
+
+    @Mock
+    private PersistentClientOperationServiceImpl clientOperationService;
+
+    @Test
+    public void testHandle() throws NacosException {
+        PersistentInstanceRequest instanceRequest = new PersistentInstanceRequest();
+        instanceRequest.setType(NamingRemoteConstants.REGISTER_INSTANCE);
+        instanceRequest.setServiceName("service1");
+        instanceRequest.setGroupName("group1");
+        Instance instance = new Instance();
+        instanceRequest.setInstance(instance);
+        RequestMeta requestMeta = new RequestMeta();
+        persistentInstanceRequestHandler.handle(instanceRequest, requestMeta);
+        Mockito.verify(clientOperationService).registerInstance(Mockito.any(), Mockito.any(), Mockito.anyString());
+
+        instanceRequest.setType(NamingRemoteConstants.DE_REGISTER_INSTANCE);
+        persistentInstanceRequestHandler.handle(instanceRequest, requestMeta);
+        Mockito.verify(clientOperationService).deregisterInstance(Mockito.any(), Mockito.any(), Mockito.anyString());
+
+        instanceRequest.setType("xxx");
+        try {
+            persistentInstanceRequestHandler.handle(instanceRequest, requestMeta);
+        } catch (Exception e) {
+            Assert.assertEquals(((NacosException) e).getErrCode(), NacosException.INVALID_PARAM);
+        }
+    }
+}

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/constants/PersistenceConstant.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/constants/PersistenceConstant.java
@@ -52,7 +52,4 @@ public class PersistenceConstant {
     
     public static final String CONFIG_MODEL_RAFT_GROUP = "nacos_config";
     
-    public static final String OFFSET = "OFFSET";
-    
-    public static final String LIMIT = "LIMIT";
 }

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/repository/embedded/EmbeddedPaginationHelperImpl.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/repository/embedded/EmbeddedPaginationHelperImpl.java
@@ -16,14 +16,12 @@
 
 package com.alibaba.nacos.persistence.repository.embedded;
 
-import com.alibaba.nacos.persistence.constants.PersistenceConstant;
 import com.alibaba.nacos.persistence.model.Page;
 import com.alibaba.nacos.persistence.repository.PaginationHelper;
 import com.alibaba.nacos.persistence.repository.embedded.operate.DatabaseOperate;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 import org.springframework.jdbc.core.RowMapper;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -87,17 +85,7 @@ public class EmbeddedPaginationHelperImpl<E> implements PaginationHelper {
             return page;
         }
         
-        // fill the sql Page args
-        String fetchSql = sqlFetchRows;
-        if (!fetchSql.contains(PersistenceConstant.OFFSET)) {
-            fetchSql += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
-            Object[] newArgs = Arrays.copyOf(args, args.length + 2);
-            newArgs[args.length] = (pageNo - 1) * pageSize;
-            newArgs[args.length + 1] = pageSize;
-            args = newArgs;
-        }
-        
-        List<E> result = databaseOperate.queryMany(fetchSql, args, rowMapper);
+        List<E> result = databaseOperate.queryMany(sqlFetchRows, args, rowMapper);
         for (E item : result) {
             page.getPageItems().add(item);
         }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthPageConstant.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthPageConstant.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.constant;
+
+/**
+ * Auth plugin page constant.
+ *
+ * @author huangKeming
+ **/
+
+public class AuthPageConstant {
+    
+    public static final String OFFSET = "OFFSET";
+    
+    public static final String OFFSET_ROWS = "OFFSET ? ROWS";
+    
+    public static final String FETCH_NEXT = "FETCH NEXT ? ROWS ONLY";
+    
+    public static final String LIMIT = "LIMIT";
+    
+    public static final String LIMIT_SIZE = "LIMIT ?,?";
+    
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/model/OffsetFetchResult.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/model/OffsetFetchResult.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.model;
+
+/**
+ * Paginated query statements and query parameters encapsulate the results.
+ *
+ * @author huangKeMing
+ */
+public class OffsetFetchResult {
+    
+    String fetchSql;
+    
+    Object[] newArgs;
+    
+    public OffsetFetchResult() {
+    }
+    
+    public OffsetFetchResult(String fetchSql, Object[] newArgs) {
+        this.fetchSql = fetchSql;
+        this.newArgs = newArgs;
+    }
+    
+    public String getFetchSql() {
+        return fetchSql;
+    }
+    
+    public void setFetchSql(String fetchSql) {
+        this.fetchSql = fetchSql;
+    }
+    
+    public Object[] getNewArgs() {
+        return newArgs;
+    }
+    
+    public void setNewArgs(Object[] newArgs) {
+        this.newArgs = newArgs;
+    }
+    
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/AuthPaginationHelper.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/AuthPaginationHelper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.persistence;
+
+import com.alibaba.nacos.persistence.model.Page;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+import org.springframework.jdbc.core.RowMapper;
+
+
+/**
+ * Auth plugin Pagination Helper.
+ *
+ * @param <E> Generic class
+ * @author huangKeMing
+ */
+@SuppressWarnings("PMD.AbstractMethodOrInterfaceMethodMustUseJavadocRule")
+public interface AuthPaginationHelper<E> {
+    
+    Page<E> fetchPage(final String sqlCountRows, final String sqlFetchRows, final Object[] args, final int pageNo,
+            final int pageSize, final RowMapper<E> rowMapper);
+    
+    Page<E> fetchPage(final String sqlCountRows, final String sqlFetchRows, final Object[] args, final int pageNo,
+            final int pageSize, final Long lastMaxId, final RowMapper<E> rowMapper);
+    
+    Page<E> fetchPageLimit(final String sqlCountRows, final String sqlFetchRows, final Object[] args, final int pageNo,
+            final int pageSize, final RowMapper<E> rowMapper);
+    
+    Page<E> fetchPageLimit(final String sqlCountRows, final Object[] args1, final String sqlFetchRows,
+            final Object[] args2, final int pageNo, final int pageSize, final RowMapper<E> rowMapper);
+    
+    Page<E> fetchPageLimit(final String sqlFetchRows, final Object[] args, final int pageNo, final int pageSize,
+            final RowMapper<E> rowMapper);
+    
+    Page<E> fetchPageLimit(final MapperResult countMapperResult, final MapperResult mapperResult, final int pageNo,
+            final int pageSize, final RowMapper<E> rowMapper);
+    
+    void updateLimit(final String sql, final Object[] args);
+    
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/EmbeddedPermissionPersistServiceImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/EmbeddedPermissionPersistServiceImpl.java
@@ -19,10 +19,9 @@ package com.alibaba.nacos.plugin.auth.impl.persistence;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.persistence.configuration.condition.ConditionOnEmbeddedStorage;
 import com.alibaba.nacos.persistence.model.Page;
-import com.alibaba.nacos.persistence.repository.PaginationHelper;
-import com.alibaba.nacos.persistence.repository.embedded.EmbeddedPaginationHelperImpl;
 import com.alibaba.nacos.persistence.repository.embedded.EmbeddedStorageContextHolder;
 import com.alibaba.nacos.persistence.repository.embedded.operate.DatabaseOperate;
+import com.alibaba.nacos.plugin.auth.impl.persistence.embedded.AuthEmbeddedPaginationHelperImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -51,7 +50,7 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
     
     @Override
     public Page<PermissionInfo> getPermissions(String role, int pageNo, int pageSize) {
-        PaginationHelper<PermissionInfo> helper = createPaginationHelper();
+        AuthPaginationHelper<PermissionInfo> helper = createPaginationHelper();
         
         String sqlCountRows = "SELECT count(*) FROM permissions WHERE ";
         
@@ -65,9 +64,8 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
             where = " 1=1 ";
         }
         
-        Page<PermissionInfo> pageInfo = helper
-                .fetchPage(sqlCountRows + where, sqlFetchRows + where, params.toArray(), pageNo, pageSize,
-                        PERMISSION_ROW_MAPPER);
+        Page<PermissionInfo> pageInfo = helper.fetchPage(sqlCountRows + where, sqlFetchRows + where, params.toArray(),
+                pageNo, pageSize, PERMISSION_ROW_MAPPER);
         
         if (pageInfo == null) {
             pageInfo = new Page<>();
@@ -107,7 +105,7 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
     
     @Override
     public Page<PermissionInfo> findPermissionsLike4Page(String role, int pageNo, int pageSize) {
-        PaginationHelper<PermissionInfo> helper = createPaginationHelper();
+        AuthPaginationHelper<PermissionInfo> helper = createPaginationHelper();
         
         String sqlCountRows = "SELECT count(*) FROM permissions ";
         
@@ -121,9 +119,8 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
             params.add(generateLikeArgument(role));
         }
         
-        Page<PermissionInfo> pageInfo = helper
-                .fetchPage(sqlCountRows + where, sqlFetchRows + where, params.toArray(), pageNo, pageSize,
-                        PERMISSION_ROW_MAPPER);
+        Page<PermissionInfo> pageInfo = helper.fetchPage(sqlCountRows + where, sqlFetchRows + where, params.toArray(),
+                pageNo, pageSize, PERMISSION_ROW_MAPPER);
         
         if (pageInfo == null) {
             pageInfo = new Page<>();
@@ -149,7 +146,7 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
     }
     
     @Override
-    public <E> PaginationHelper<E> createPaginationHelper() {
-        return new EmbeddedPaginationHelperImpl<>(databaseOperate);
+    public <E> AuthPaginationHelper<E> createPaginationHelper() {
+        return new AuthEmbeddedPaginationHelperImpl<>(databaseOperate);
     }
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/EmbeddedRolePersistServiceImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/EmbeddedRolePersistServiceImpl.java
@@ -20,10 +20,9 @@ import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.persistence.configuration.condition.ConditionOnEmbeddedStorage;
 import com.alibaba.nacos.persistence.model.Page;
-import com.alibaba.nacos.persistence.repository.PaginationHelper;
-import com.alibaba.nacos.persistence.repository.embedded.EmbeddedPaginationHelperImpl;
 import com.alibaba.nacos.persistence.repository.embedded.EmbeddedStorageContextHolder;
 import com.alibaba.nacos.persistence.repository.embedded.operate.DatabaseOperate;
+import com.alibaba.nacos.plugin.auth.impl.persistence.embedded.AuthEmbeddedPaginationHelperImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -51,8 +50,8 @@ public class EmbeddedRolePersistServiceImpl implements RolePersistService {
     
     @Override
     public Page<RoleInfo> getRoles(int pageNo, int pageSize) {
-        
-        PaginationHelper<RoleInfo> helper = createPaginationHelper();
+    
+        AuthPaginationHelper<RoleInfo> helper = createPaginationHelper();
         
         String sqlCountRows = "SELECT count(*) FROM (SELECT DISTINCT role FROM roles) roles WHERE ";
         
@@ -60,9 +59,8 @@ public class EmbeddedRolePersistServiceImpl implements RolePersistService {
         
         String where = " 1=1 ";
         
-        Page<RoleInfo> pageInfo = helper
-                .fetchPage(sqlCountRows + where, sqlFetchRows + where, new ArrayList<String>().toArray(), pageNo,
-                        pageSize, ROLE_INFO_ROW_MAPPER);
+        Page<RoleInfo> pageInfo = helper.fetchPage(sqlCountRows + where, sqlFetchRows + where,
+                new ArrayList<String>().toArray(), pageNo, pageSize, ROLE_INFO_ROW_MAPPER);
         if (pageInfo == null) {
             pageInfo = new Page<>();
             pageInfo.setTotalCount(0);
@@ -74,8 +72,8 @@ public class EmbeddedRolePersistServiceImpl implements RolePersistService {
     
     @Override
     public Page<RoleInfo> getRolesByUserNameAndRoleName(String username, String role, int pageNo, int pageSize) {
-        
-        PaginationHelper<RoleInfo> helper = createPaginationHelper();
+    
+        AuthPaginationHelper<RoleInfo> helper = createPaginationHelper();
         
         String sqlCountRows = "SELECT count(*) FROM roles ";
         
@@ -188,14 +186,14 @@ public class EmbeddedRolePersistServiceImpl implements RolePersistService {
         }
         String sqlCountRows = "SELECT count(*) FROM roles";
         String sqlFetchRows = "SELECT role, username FROM roles";
-        
-        PaginationHelper<RoleInfo> helper = createPaginationHelper();
+    
+        AuthPaginationHelper<RoleInfo> helper = createPaginationHelper();
         return helper.fetchPage(sqlCountRows + where, sqlFetchRows + where, params.toArray(), pageNo, pageSize,
                 ROLE_INFO_ROW_MAPPER);
     }
     
     @Override
-    public <E> PaginationHelper<E> createPaginationHelper() {
-        return new EmbeddedPaginationHelperImpl<>(databaseOperate);
+    public <E> AuthPaginationHelper<E> createPaginationHelper() {
+        return new AuthEmbeddedPaginationHelperImpl<>(databaseOperate);
     }
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/EmbeddedUserPersistServiceImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/EmbeddedUserPersistServiceImpl.java
@@ -19,10 +19,9 @@ package com.alibaba.nacos.plugin.auth.impl.persistence;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.persistence.configuration.condition.ConditionOnEmbeddedStorage;
 import com.alibaba.nacos.persistence.model.Page;
-import com.alibaba.nacos.persistence.repository.PaginationHelper;
-import com.alibaba.nacos.persistence.repository.embedded.EmbeddedPaginationHelperImpl;
 import com.alibaba.nacos.persistence.repository.embedded.EmbeddedStorageContextHolder;
 import com.alibaba.nacos.persistence.repository.embedded.operate.DatabaseOperate;
+import com.alibaba.nacos.plugin.auth.impl.persistence.embedded.AuthEmbeddedPaginationHelperImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
@@ -107,8 +106,8 @@ public class EmbeddedUserPersistServiceImpl implements UserPersistService {
     
     @Override
     public Page<User> getUsers(int pageNo, int pageSize, String username) {
-        
-        PaginationHelper<User> helper = createPaginationHelper();
+    
+        AuthPaginationHelper<User> helper = createPaginationHelper();
         
         String sqlCountRows = "SELECT count(*) FROM users ";
         
@@ -149,8 +148,8 @@ public class EmbeddedUserPersistServiceImpl implements UserPersistService {
             where.append(SQL_DERBY_ESCAPE_BACK_SLASH_FOR_LIKE);
             params.add(generateLikeArgument(username));
         }
-        
-        PaginationHelper<User> helper = createPaginationHelper();
+    
+        AuthPaginationHelper<User> helper = createPaginationHelper();
         return helper.fetchPage(sqlCountRows + where, sqlFetchRows + where, params.toArray(), pageNo, pageSize,
                 USER_ROW_MAPPER);
     }
@@ -171,7 +170,7 @@ public class EmbeddedUserPersistServiceImpl implements UserPersistService {
     }
     
     @Override
-    public <E> PaginationHelper<E> createPaginationHelper() {
-        return new EmbeddedPaginationHelperImpl<>(databaseOperate);
+    public <E> AuthPaginationHelper<E> createPaginationHelper() {
+        return new AuthEmbeddedPaginationHelperImpl<>(databaseOperate);
     }
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/PermissionPersistService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/PermissionPersistService.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.plugin.auth.impl.persistence;
 
 import com.alibaba.nacos.persistence.model.Page;
-import com.alibaba.nacos.persistence.repository.PaginationHelper;
 
 /**
  * Permission CRUD service.
@@ -64,7 +63,7 @@ public interface PermissionPersistService {
      * create Pagination utils.
      *
      * @param <E> Generic object
-     * @return {@link PaginationHelper}
+     * @return {@link AuthPaginationHelper}
      */
-    <E> PaginationHelper<E> createPaginationHelper();
+    <E> AuthPaginationHelper<E> createPaginationHelper();
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/RolePersistService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/RolePersistService.java
@@ -16,10 +16,9 @@
 
 package com.alibaba.nacos.plugin.auth.impl.persistence;
 
-import java.util.List;
-
 import com.alibaba.nacos.persistence.model.Page;
-import com.alibaba.nacos.persistence.repository.PaginationHelper;
+
+import java.util.List;
 
 /**
  * Role CRUD service.
@@ -102,7 +101,7 @@ public interface RolePersistService {
      * create Pagination utils.
      *
      * @param <E> Generic object
-     * @return {@link PaginationHelper}
+     * @return {@link AuthPaginationHelper}
      */
-    <E> PaginationHelper<E> createPaginationHelper();
+    <E> AuthPaginationHelper<E> createPaginationHelper();
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/UserPersistService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/UserPersistService.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.plugin.auth.impl.persistence;
 
 import com.alibaba.nacos.persistence.model.Page;
-import com.alibaba.nacos.persistence.repository.PaginationHelper;
 
 import java.util.List;
 
@@ -86,7 +85,7 @@ public interface UserPersistService {
      * create Pagination utils.
      *
      * @param <E> Generic object
-     * @return {@link PaginationHelper}
+     * @return {@link AuthPaginationHelper}
      */
-    <E> PaginationHelper<E> createPaginationHelper();
+    <E> AuthPaginationHelper<E> createPaginationHelper();
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/embedded/AuthEmbeddedPaginationHelperImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/embedded/AuthEmbeddedPaginationHelperImpl.java
@@ -14,41 +14,44 @@
  * limitations under the License.
  */
 
-package com.alibaba.nacos.persistence.repository.extrnal;
+package com.alibaba.nacos.plugin.auth.impl.persistence.embedded;
 
+import com.alibaba.nacos.plugin.auth.impl.persistence.handler.PageHandlerAdapterFactory;
+import com.alibaba.nacos.plugin.auth.impl.model.OffsetFetchResult;
 import com.alibaba.nacos.persistence.model.Page;
-import com.alibaba.nacos.persistence.repository.PaginationHelper;
 import com.alibaba.nacos.persistence.repository.embedded.EmbeddedStorageContextHolder;
+import com.alibaba.nacos.persistence.repository.embedded.operate.DatabaseOperate;
+import com.alibaba.nacos.plugin.auth.impl.persistence.AuthPaginationHelper;
+import com.alibaba.nacos.plugin.auth.impl.persistence.handler.support.DerbyPageHandlerAdapter;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
 import java.util.List;
 
 /**
- * External Storage Pagination utils.
+ * Auth plugin Pagination Utils For Apache Derby.
  *
- * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
+ * @param <E> Generic class
+ * @author huangKeMing
  */
-
-public class ExternalStoragePaginationHelperImpl<E> implements PaginationHelper {
+public class AuthEmbeddedPaginationHelperImpl<E> implements AuthPaginationHelper<E> {
     
-    private final JdbcTemplate jdbcTemplate;
+    private final DatabaseOperate databaseOperate;
     
-    public ExternalStoragePaginationHelperImpl(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
+    public AuthEmbeddedPaginationHelperImpl(DatabaseOperate databaseOperate) {
+        this.databaseOperate = databaseOperate;
     }
     
     /**
      * Take paging.
      *
-     * @param sqlCountRows query total SQL
-     * @param sqlFetchRows query data sql
-     * @param args         query parameters
+     * @param sqlCountRows Query total SQL
+     * @param sqlFetchRows Query data sql
+     * @param args         query args
      * @param pageNo       page number
      * @param pageSize     page size
-     * @param rowMapper    {@link RowMapper}
-     * @return Paginated data {@code <E>}
+     * @param rowMapper    Entity mapping
+     * @return Paging data
      */
     @Override
     public Page<E> fetchPage(final String sqlCountRows, final String sqlFetchRows, final Object[] args,
@@ -63,13 +66,13 @@ public class ExternalStoragePaginationHelperImpl<E> implements PaginationHelper 
             throw new IllegalArgumentException("pageNo and pageSize must be greater than zero");
         }
         
-        // Query the total number of current records.
-        Integer rowCountInt = jdbcTemplate.queryForObject(sqlCountRows, args, Integer.class);
+        // Query the total number of current records
+        Integer rowCountInt = databaseOperate.queryOne(sqlCountRows, args, Integer.class);
         if (rowCountInt == null) {
             throw new IllegalArgumentException("fetchPageLimit error");
         }
         
-        // Compute pages count
+        // Count pages
         int pageCount = rowCountInt / pageSize;
         if (rowCountInt > pageSize * pageCount) {
             pageCount++;
@@ -85,7 +88,13 @@ public class ExternalStoragePaginationHelperImpl<E> implements PaginationHelper 
             return page;
         }
         
-        List<E> result = jdbcTemplate.query(sqlFetchRows, args, rowMapper);
+        // fill the sql Page args
+        String fetchSql = sqlFetchRows;
+        OffsetFetchResult offsetFetchResult = addOffsetAndFetchNext(fetchSql, args, pageNo, pageSize);
+        fetchSql = offsetFetchResult.getFetchSql();
+        args = offsetFetchResult.getNewArgs();
+        
+        List<E> result = databaseOperate.queryMany(fetchSql, args, rowMapper);
         for (E item : result) {
             page.getPageItems().add(item);
         }
@@ -93,18 +102,18 @@ public class ExternalStoragePaginationHelperImpl<E> implements PaginationHelper 
     }
     
     @Override
-    public Page<E> fetchPageLimit(final String sqlCountRows, final String sqlFetchRows, final Object[] args,
-            final int pageNo, final int pageSize, final RowMapper rowMapper) {
+    public Page<E> fetchPageLimit(final String sqlCountRows, final String sqlFetchRows, Object[] args, final int pageNo,
+            final int pageSize, final RowMapper rowMapper) {
         if (pageNo <= 0 || pageSize <= 0) {
             throw new IllegalArgumentException("pageNo and pageSize must be greater than zero");
         }
         // Query the total number of current records
-        Integer rowCountInt = jdbcTemplate.queryForObject(sqlCountRows, Integer.class);
+        Integer rowCountInt = databaseOperate.queryOne(sqlCountRows, Integer.class);
         if (rowCountInt == null) {
             throw new IllegalArgumentException("fetchPageLimit error");
         }
         
-        // Compute pages count
+        // Count pages
         int pageCount = rowCountInt / pageSize;
         if (rowCountInt > pageSize * pageCount) {
             pageCount++;
@@ -120,7 +129,76 @@ public class ExternalStoragePaginationHelperImpl<E> implements PaginationHelper 
             return page;
         }
         
-        List<E> result = jdbcTemplate.query(sqlFetchRows, args, rowMapper);
+        // fill the sql Page args
+        String fetchSql = sqlFetchRows;
+        OffsetFetchResult offsetFetchResult = addOffsetAndFetchNext(fetchSql, args, pageNo, pageSize);
+        fetchSql = offsetFetchResult.getFetchSql();
+        args = offsetFetchResult.getNewArgs();
+        
+        List<E> result = databaseOperate.queryMany(fetchSql, args, rowMapper);
+        for (E item : result) {
+            page.getPageItems().add(item);
+        }
+        return page;
+    }
+    
+    @Override
+    public Page<E> fetchPageLimit(final String sqlCountRows, final Object[] args1, final String sqlFetchRows,
+            Object[] args2, final int pageNo, final int pageSize, final RowMapper rowMapper) {
+        if (pageNo <= 0 || pageSize <= 0) {
+            throw new IllegalArgumentException("pageNo and pageSize must be greater than zero");
+        }
+        // Query the total number of current records
+        Integer rowCountInt = databaseOperate.queryOne(sqlCountRows, args1, Integer.class);
+        if (rowCountInt == null) {
+            throw new IllegalArgumentException("fetchPageLimit error");
+        }
+        
+        // Count pages
+        int pageCount = rowCountInt / pageSize;
+        if (rowCountInt > pageSize * pageCount) {
+            pageCount++;
+        }
+        
+        // Create Page object
+        final Page<E> page = new Page<>();
+        page.setPageNumber(pageNo);
+        page.setPagesAvailable(pageCount);
+        page.setTotalCount(rowCountInt);
+        
+        if (pageNo > pageCount) {
+            return page;
+        }
+        
+        // fill the sql Page args
+        String fetchSql = sqlFetchRows;
+        OffsetFetchResult offsetFetchResult = addOffsetAndFetchNext(fetchSql, args2, pageNo, pageSize);
+        fetchSql = offsetFetchResult.getFetchSql();
+        args2 = offsetFetchResult.getNewArgs();
+        
+        List<E> result = databaseOperate.queryMany(fetchSql, args2, rowMapper);
+        for (E item : result) {
+            page.getPageItems().add(item);
+        }
+        return page;
+    }
+    
+    @Override
+    public Page<E> fetchPageLimit(final String sqlFetchRows, Object[] args, final int pageNo, final int pageSize,
+            final RowMapper rowMapper) {
+        if (pageNo <= 0 || pageSize <= 0) {
+            throw new IllegalArgumentException("pageNo and pageSize must be greater than zero");
+        }
+        // Create Page object
+        final Page<E> page = new Page<>();
+        
+        // fill the sql Page args
+        String fetchSql = sqlFetchRows;
+        OffsetFetchResult offsetFetchResult = addOffsetAndFetchNext(fetchSql, args, pageNo, pageSize);
+        fetchSql = offsetFetchResult.getFetchSql();
+        args = offsetFetchResult.getNewArgs();
+        
+        List<E> result = databaseOperate.queryMany(fetchSql, args, rowMapper);
         for (E item : result) {
             page.getPageItems().add(item);
         }
@@ -135,78 +213,18 @@ public class ExternalStoragePaginationHelperImpl<E> implements PaginationHelper 
     }
     
     @Override
-    public Page<E> fetchPageLimit(final String sqlCountRows, final Object[] args1, final String sqlFetchRows,
-            final Object[] args2, final int pageNo, final int pageSize, final RowMapper rowMapper) {
-        if (pageNo <= 0 || pageSize <= 0) {
-            throw new IllegalArgumentException("pageNo and pageSize must be greater than zero");
-        }
-        // Query the total number of current records
-        Integer rowCountInt = jdbcTemplate.queryForObject(sqlCountRows, args1, Integer.class);
-        if (rowCountInt == null) {
-            throw new IllegalArgumentException("fetchPageLimit error");
-        }
-        
-        // Compute pages count
-        int pageCount = rowCountInt / pageSize;
-        if (rowCountInt > pageSize * pageCount) {
-            pageCount++;
-        }
-        
-        // Create Page object
-        final Page<E> page = new Page<>();
-        page.setPageNumber(pageNo);
-        page.setPagesAvailable(pageCount);
-        page.setTotalCount(rowCountInt);
-        
-        if (pageNo > pageCount) {
-            return page;
-        }
-        List<E> result = jdbcTemplate.query(sqlFetchRows, args2, rowMapper);
-        for (E item : result) {
-            page.getPageItems().add(item);
-        }
-        return page;
-    }
-    
-    @Override
-    public Page<E> fetchPageLimit(final String sqlFetchRows, final Object[] args, final int pageNo, final int pageSize,
-            final RowMapper rowMapper) {
-        if (pageNo <= 0 || pageSize <= 0) {
-            throw new IllegalArgumentException("pageNo and pageSize must be greater than zero");
-        }
-        // Create Page object
-        final Page<E> page = new Page<>();
-        List<E> result = jdbcTemplate.query(sqlFetchRows, args, rowMapper);
-        for (E item : result) {
-            page.getPageItems().add(item);
-        }
-        return page;
-    }
-    
-    @Override
     public void updateLimit(final String sql, final Object[] args) {
+        EmbeddedStorageContextHolder.addSqlContext(sql, args);
         try {
-            jdbcTemplate.update(sql, args);
+            databaseOperate.update(EmbeddedStorageContextHolder.getCurrentSqlContext());
         } finally {
             EmbeddedStorageContextHolder.cleanAllContext();
         }
     }
     
-    /**
-     * Update limit with response.
-     *
-     * @param sql  sql
-     * @param args args
-     * @return update row count
-     */
-    public int updateLimitWithResponse(final String sql, final Object[] args) {
-        String sqlUpdate = sql;
-        
-        try {
-            return jdbcTemplate.update(sqlUpdate, args);
-        } finally {
-            EmbeddedStorageContextHolder.cleanAllContext();
-        }
+    private OffsetFetchResult addOffsetAndFetchNext(String fetchSql, Object[] arg, int pageNo, int pageSize) {
+        return PageHandlerAdapterFactory.getInstance().getHandlerAdapterMap()
+                .get(DerbyPageHandlerAdapter.class.getName()).addOffsetAndFetchNext(fetchSql, arg, pageNo, pageSize);
     }
     
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/PageHandlerAdapter.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/PageHandlerAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.persistence.handler;
+
+import com.alibaba.nacos.plugin.auth.impl.model.OffsetFetchResult;
+
+/**
+ * Auth plugin page handler adapter.
+ *
+ * @author huangKeMing
+ */
+public interface PageHandlerAdapter {
+    
+    /**
+     * Determine whether the current data source supports paging.
+     *
+     * @param dataSourceType data source type
+     * @return true if the current data source supports paging
+     */
+    boolean supports(String dataSourceType);
+    
+    /**
+     * Add offset and fetch next.
+     *
+     * @param fetchSql fetch sql.
+     * @param arg      arguments.
+     * @param pageNo   page number.
+     * @param pageSize page size.
+     * @return
+     */
+    OffsetFetchResult addOffsetAndFetchNext(String fetchSql, Object[] arg, int pageNo, int pageSize);
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/PageHandlerAdapterFactory.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/PageHandlerAdapterFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.persistence.handler;
+
+import com.alibaba.nacos.plugin.auth.impl.persistence.handler.support.DerbyPageHandlerAdapter;
+import com.alibaba.nacos.plugin.auth.impl.persistence.handler.support.MysqlPageHandlerAdapter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * pagination factory.
+ *
+ * @author huangKeMing
+ */
+public class PageHandlerAdapterFactory {
+    
+    private static PageHandlerAdapterFactory instance;
+    
+    private List<PageHandlerAdapter> handlerAdapters;
+    
+    private Map<String, PageHandlerAdapter> handlerAdapterMap;
+    
+    public List<PageHandlerAdapter> getHandlerAdapters() {
+        return handlerAdapters;
+    }
+    
+    public Map<String, PageHandlerAdapter> getHandlerAdapterMap() {
+        return handlerAdapterMap;
+    }
+    
+    private PageHandlerAdapterFactory() {
+        handlerAdapters = new ArrayList<>(2);
+        handlerAdapterMap = new HashMap<>(2);
+        initHandlerAdapters();
+    }
+    
+    public static PageHandlerAdapterFactory getInstance() {
+        if (instance == null) {
+            synchronized (PageHandlerAdapterFactory.class) {
+                if (instance == null) {
+                    instance = new PageHandlerAdapterFactory();
+                }
+            }
+        }
+        return instance;
+    }
+    
+    /**
+     * init handler adapters.
+     */
+    private void initHandlerAdapters() {
+        // MysqlPageHandlerAdapter
+        addHandlerAdapter(new MysqlPageHandlerAdapter());
+        // DerbyPageHandlerAdapter
+        addHandlerAdapter(new DerbyPageHandlerAdapter());
+        // DefaultPageHandlerAdapter
+        addHandlerAdapter(new DerbyPageHandlerAdapter());
+    }
+    
+    private void addHandlerAdapter(PageHandlerAdapter handlerAdapter) {
+        handlerAdapters.add(handlerAdapter);
+        handlerAdapterMap.put(handlerAdapter.getClass().getName(), handlerAdapter);
+    }
+    
+}
+

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/support/DefaultPageHandlerAdapter.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/support/DefaultPageHandlerAdapter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.persistence.handler.support;
+
+import com.alibaba.nacos.plugin.auth.impl.model.OffsetFetchResult;
+import com.alibaba.nacos.plugin.auth.impl.persistence.handler.PageHandlerAdapter;
+
+/**
+ * Default page handler adapter.
+ *
+ * @author huangKeMing
+ */
+public class DefaultPageHandlerAdapter implements PageHandlerAdapter {
+    
+    @Override
+    public boolean supports(String dataSourceType) {
+        return false;
+    }
+    
+    @Override
+    public OffsetFetchResult addOffsetAndFetchNext(String fetchSql, Object[] arg, int pageNo, int pageSize) {
+        return new OffsetFetchResult(fetchSql, arg);
+    }
+    
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/support/DerbyPageHandlerAdapter.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/support/DerbyPageHandlerAdapter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.persistence.handler.support;
+
+import com.alibaba.nacos.persistence.constants.PersistenceConstant;
+import com.alibaba.nacos.plugin.auth.impl.constant.AuthPageConstant;
+import com.alibaba.nacos.plugin.auth.impl.model.OffsetFetchResult;
+import com.alibaba.nacos.plugin.auth.impl.persistence.handler.PageHandlerAdapter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * derby page handler adapter.
+ *
+ * @author huangKeMing
+ */
+public class DerbyPageHandlerAdapter implements PageHandlerAdapter {
+    
+    @Override
+    public boolean supports(String dataSourceType) {
+        return PersistenceConstant.DERBY.equals(dataSourceType);
+    }
+    
+    @Override
+    public OffsetFetchResult addOffsetAndFetchNext(String fetchSql, Object[] arg, int pageNo, int pageSize) {
+        if (!fetchSql.contains(AuthPageConstant.OFFSET)) {
+            fetchSql += " " + AuthPageConstant.OFFSET_ROWS + " " + AuthPageConstant.FETCH_NEXT;
+            
+            List<Object> newArgsList = new ArrayList<>(Arrays.asList(arg));
+            newArgsList.add((pageNo - 1) * pageSize);
+            newArgsList.add(pageSize);
+            
+            Object[] newArgs = newArgsList.toArray(new Object[newArgsList.size()]);
+            
+            return new OffsetFetchResult(fetchSql, newArgs);
+        }
+        
+        return new OffsetFetchResult(fetchSql, arg);
+    }
+    
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/support/MysqlPageHandlerAdapter.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/handler/support/MysqlPageHandlerAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.persistence.handler.support;
+
+import com.alibaba.nacos.persistence.constants.PersistenceConstant;
+import com.alibaba.nacos.plugin.auth.impl.constant.AuthPageConstant;
+import com.alibaba.nacos.plugin.auth.impl.model.OffsetFetchResult;
+import com.alibaba.nacos.plugin.auth.impl.persistence.handler.PageHandlerAdapter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * mysql page handler adapter.
+ *
+ * @author huangKeMing
+ */
+public class MysqlPageHandlerAdapter implements PageHandlerAdapter {
+    
+    @Override
+    public boolean supports(String dataSourceType) {
+        return PersistenceConstant.MYSQL.equals(dataSourceType);
+    }
+    
+    @Override
+    public OffsetFetchResult addOffsetAndFetchNext(String fetchSql, Object[] arg, int pageNo, int pageSize) {
+        if (!fetchSql.contains(AuthPageConstant.LIMIT)) {
+            fetchSql += " " + AuthPageConstant.LIMIT_SIZE;
+            List<Object> newArgsList = new ArrayList<>(Arrays.asList(arg));
+            newArgsList.add((pageNo - 1) * pageSize);
+            newArgsList.add(pageSize);
+            
+            Object[] newArgs = newArgsList.toArray(new Object[newArgsList.size()]);
+            return new OffsetFetchResult(fetchSql, newArgs);
+        }
+        
+        return new OffsetFetchResult(fetchSql, arg);
+    }
+    
+}


### PR DESCRIPTION
## What is the purpose of the change

Support register or deregister persistent instance by grpc.

## Brief changelog

1. Add PersistentInstanceRequest in 2.3.0 server and client.

2. Add ability tag like supportPersistentInstanceByGrpc in AbilityTables of 2.3.0 server and client.

3. when using 2.3.0 client and later version, it can judge whether use grpc request to register persistent instance, if server supported, use grpc request, otherwise use old way to adapt it.
