### PR TITLE
fix(#11306): change the length of the field named resource from 255 to 128.

### DIFF
--- a/distribution/conf/mysql-schema.sql
+++ b/distribution/conf/mysql-schema.sql
@@ -203,7 +203,7 @@ CREATE TABLE `roles` (
 
 CREATE TABLE `permissions` (
     `role` varchar(50) NOT NULL COMMENT 'role',
-    `resource` varchar(255) NOT NULL COMMENT 'resource',
+    `resource` varchar(128) NOT NULL COMMENT 'resource',
     `action` varchar(8) NOT NULL COMMENT 'action',
     UNIQUE INDEX `uk_role_permission` (`role`,`resource`,`action`) USING BTREE
 );


### PR DESCRIPTION
## What is the purpose of the change

fix(#11306 ): change the length of the field named resource from 255 to 128.

## Brief changelog

fix(#11306 ): change the length of the field named resource from 255 to 128.

## Verifying this change

fix(#11306 ): change the length of the field named resource from 255 to 128.

