### PR TITLE
[ISSUE #11502]fix proxy mapper bug

### DIFF
--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxy.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxy.java
@@ -39,7 +39,7 @@ public class MapperProxy implements InvocationHandler {
     
     private Mapper mapper;
     
-    private static final Map<String, MapperProxy> SINGLE_MAPPER_PROXY_MAP = new ConcurrentHashMap<>(16);
+    private static final Map<String, Mapper> SINGLE_MAPPER_PROXY_MAP = new ConcurrentHashMap<>(16);
     
     public <R> R createProxy(Mapper mapper) {
         this.mapper = mapper;


### PR DESCRIPTION
description: when set nacos.plugin.datasource.log.enabled=true, will create Proxy Object, but it was mistakenly changed to a different type<MapperProxy>

relate #11497 #11461 