### PR TITLE
[ISSUES #11624] 修改Nacos 2.3.0 反脆弱插件NacosConnectionControlManager类判断条件

### DIFF
--- a/plugin-default-impl/nacos-default-control-plugin/src/main/java/com/alibaba/nacos/plugin/control/impl/NacosConnectionControlManager.java
+++ b/plugin-default-impl/nacos-default-control-plugin/src/main/java/com/alibaba/nacos/plugin/control/impl/NacosConnectionControlManager.java
@@ -62,7 +62,7 @@ public class NacosConnectionControlManager extends ConnectionControlManager {
         Map<String, Integer> metricsTotalCount = metricsCollectorList.stream().collect(
                 Collectors.toMap(ConnectionMetricsCollector::getName, ConnectionMetricsCollector::getTotalCount));
         int totalCount = metricsTotalCount.values().stream().mapToInt(Integer::intValue).sum();
-        if (totalCount > totalCountLimit) {
+        if (totalCount >= totalCountLimit) {
             connectionCheckResponse.setSuccess(false);
             connectionCheckResponse.setCode(ConnectionCheckCode.DENY_BY_TOTAL_OVER);
         }


### PR DESCRIPTION
Fixed an issue [#11624](https://github.com/alibaba/nacos/issues/11624) where the maximum number of anti-fragile plug-ins implemented by default in Nacos is one more than the actual number of connections.