### PR TITLE
fix(#11638): fix 服务启动时nacos没启动报nacos连接不上错误，启动nacos后无法自动重连nacos，必须重启服务才行

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/redo/RedoScheduledTask.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/redo/RedoScheduledTask.java
@@ -43,10 +43,7 @@ public class RedoScheduledTask extends AbstractExecuteTask {
     
     @Override
     public void run() {
-        if (!redoService.isConnected()) {
-            LogUtils.NAMING_LOGGER.warn("Grpc Connection is disconnect, skip current redo task");
-            return;
-        }
+        // 注册失败时的自动补偿
         try {
             redoForInstances();
             redoForSubscribes();


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

服务启动时nacos没启动报nacos连接不上错误，启动nacos后无法自动重连nacos，必须重启服务才行

## Brief changelog

服务启动时nacos没启动报nacos连接不上错误，启动nacos后无法自动重连nacos，必须重启服务才行

## Verifying this change

issue11638
