### PR TITLE
optimize dump all logic and optimize dump change interface

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/model/ConfigInfoStateWrapper.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/ConfigInfoStateWrapper.java
@@ -36,6 +36,8 @@ public class ConfigInfoStateWrapper implements Serializable {
     
     private long lastModified;
     
+    private String md5;
+    
     public long getId() {
         return id;
     }
@@ -86,11 +88,21 @@ public class ConfigInfoStateWrapper implements Serializable {
         }
         ConfigInfoStateWrapper that = (ConfigInfoStateWrapper) o;
         return id == that.id && lastModified == that.lastModified && Objects.equals(dataId, that.dataId)
-                && Objects.equals(group, that.group) && Objects.equals(tenant, that.tenant);
+                && Objects.equals(group, that.group) && Objects.equals(tenant, that.tenant) && Objects.equals(md5,
+                that.md5);
     }
     
     @Override
     public int hashCode() {
-        return Objects.hash(id, dataId, group, tenant, lastModified);
+        return Objects.hash(dataId, group, tenant);
     }
+    
+    public String getMd5() {
+        return md5;
+    }
+    
+    public void setMd5(String md5) {
+        this.md5 = md5;
+    }
+    
 }

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.alibaba.nacos.config.server.constant.Constants.ENCODE_UTF8;
+import static com.alibaba.nacos.config.server.constant.Constants.PERSIST_ENCODE;
 import static com.alibaba.nacos.config.server.utils.LogUtil.DEFAULT_LOG;
 import static com.alibaba.nacos.config.server.utils.LogUtil.DUMP_LOG;
 import static com.alibaba.nacos.config.server.utils.LogUtil.FATAL_LOG;
@@ -72,6 +73,7 @@ public class ConfigCacheService {
      * @param group          group string value.
      * @param tenant         tenant string value.
      * @param content        content string value.
+     * @param md5            md5 of persist.
      * @param lastModifiedTs lastModifiedTs.
      * @param type           file type.
      * @return dumpChange success or not.
@@ -100,7 +102,7 @@ public class ConfigCacheService {
             boolean newLastModified = lastModifiedTs > ConfigCacheService.getLastModifiedTs(groupKey);
             
             if (md5 == null) {
-                md5 = MD5Utils.md5Hex(content, ENCODE_UTF8);
+                md5 = MD5Utils.md5Hex(content, PERSIST_ENCODE);
             }
             
             //check md5 & update local disk cache.

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpChangeConfigWorker.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpChangeConfigWorker.java
@@ -18,7 +18,7 @@ package com.alibaba.nacos.config.server.service.dump;
 
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.constant.Constants;
-import com.alibaba.nacos.config.server.model.ConfigInfo;
+import com.alibaba.nacos.config.server.model.ConfigInfoStateWrapper;
 import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
 import com.alibaba.nacos.config.server.service.ConfigCacheService;
 import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
@@ -81,9 +81,9 @@ public class DumpChangeConfigWorker implements Runnable {
             long deleteCursorId = 0L;
             
             while (true) {
-                List<ConfigInfoWrapper> configDeleted = historyConfigInfoPersistService.findDeletedConfig(startTime,
+                List<ConfigInfoStateWrapper> configDeleted = historyConfigInfoPersistService.findDeletedConfig(startTime,
                         deleteCursorId, pageSize);
-                for (ConfigInfo configInfo : configDeleted) {
+                for (ConfigInfoStateWrapper configInfo : configDeleted) {
                     if (configInfoPersistService.findConfigInfoState(configInfo.getDataId(), configInfo.getGroup(),
                             configInfo.getTenant()) == null) {
                         ConfigCacheService.remove(configInfo.getDataId(), configInfo.getGroup(),
@@ -107,9 +107,9 @@ public class DumpChangeConfigWorker implements Runnable {
             long changeCursorId = 0L;
             while (true) {
                 LogUtil.DEFAULT_LOG.info("Check changed configs from  time {},lastMaxId={}", startTime, changeCursorId);
-                List<ConfigInfoWrapper> changeConfigs = configInfoPersistService.findChangeConfig(startTime,
+                List<ConfigInfoStateWrapper> changeConfigs = configInfoPersistService.findChangeConfig(startTime,
                         changeCursorId, pageSize);
-                for (ConfigInfoWrapper cf : changeConfigs) {
+                for (ConfigInfoStateWrapper cf : changeConfigs) {
                     final String groupKey = GroupKey2.getKey(cf.getDataId(), cf.getGroup(), cf.getTenant());
                     //check md5 & localtimestamp update local disk cache.
                     boolean newLastModified = cf.getLastModified() > ConfigCacheService.getLastModifiedTs(groupKey);
@@ -151,7 +151,7 @@ public class DumpChangeConfigWorker implements Runnable {
         } finally {
             ConfigExecutor.scheduleConfigChangeTask(this, PropertyUtil.getDumpChangeWorkerInterval(),
                     TimeUnit.MILLISECONDS);
-            LogUtil.DEFAULT_LOG.info("Next dump change will scheduled after {} millseconds",
+            LogUtil.DEFAULT_LOG.info("Next dump change will scheduled after {} milliseconds",
                     PropertyUtil.getDumpChangeWorkerInterval());
             
         }

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpService.java
@@ -53,7 +53,6 @@ import com.alibaba.nacos.sys.utils.TimerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -263,7 +262,7 @@ public abstract class DumpService {
             Timestamp currentTime = new Timestamp(System.currentTimeMillis());
             
             try {
-                dumpConfigInfo(dumpAllProcessor);
+                dumpAllConfigInfoOnStartup(dumpAllProcessor);
                 
                 // update Beta cache
                 LogUtil.DEFAULT_LOG.info("start clear all config-info-beta.");
@@ -324,12 +323,12 @@ public abstract class DumpService {
         
     }
     
-    private void dumpConfigInfo(DumpAllProcessor dumpAllProcessor) throws IOException {
+    private void dumpAllConfigInfoOnStartup(DumpAllProcessor dumpAllProcessor) {
         
         try {
             LogUtil.DEFAULT_LOG.info("start clear all config-info.");
             ConfigDiskServiceFactory.getInstance().clearAll();
-            dumpAllProcessor.process(new DumpAllTask());
+            dumpAllProcessor.process(new DumpAllTask(true));
         } catch (Exception e) {
             LogUtil.FATAL_LOG.error("dump config fail" + e.getMessage());
             throw e;

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessor.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessor.java
@@ -19,17 +19,24 @@ package com.alibaba.nacos.config.server.service.dump.processor;
 import com.alibaba.nacos.common.task.NacosTask;
 import com.alibaba.nacos.common.task.NacosTaskProcessor;
 import com.alibaba.nacos.common.utils.MD5Utils;
-import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
 import com.alibaba.nacos.config.server.service.AggrWhitelist;
 import com.alibaba.nacos.config.server.service.ClientIpWhiteList;
 import com.alibaba.nacos.config.server.service.ConfigCacheService;
 import com.alibaba.nacos.config.server.service.SwitchService;
+import com.alibaba.nacos.config.server.service.dump.task.DumpAllTask;
 import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
 import com.alibaba.nacos.config.server.utils.GroupKey2;
 import com.alibaba.nacos.config.server.utils.LogUtil;
+import com.alibaba.nacos.config.server.utils.PropertyUtil;
 import com.alibaba.nacos.persistence.model.Page;
 
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static com.alibaba.nacos.config.server.constant.Constants.ENCODE_UTF8;
 import static com.alibaba.nacos.config.server.utils.LogUtil.DEFAULT_LOG;
 
 /**
@@ -46,16 +53,59 @@ public class DumpAllProcessor implements NacosTaskProcessor {
     
     @Override
     public boolean process(NacosTask task) {
+        if (!(task instanceof DumpAllTask)) {
+            DEFAULT_LOG.error("[all-dump-error] ,invalid task type,DumpAllProcessor should process DumpAllTask type.");
+            return false;
+        }
+        DumpAllTask dumpAllTask = (DumpAllTask) task;
+        
         long currentMaxId = configInfoPersistService.findConfigMaxId();
         long lastMaxId = 0;
+        ThreadPoolExecutor executorService = null;
+        if (dumpAllTask.isStartUp()) {
+            executorService = new ThreadPoolExecutor(Runtime.getRuntime().availableProcessors(),
+                    Runtime.getRuntime().availableProcessors(), 60L, TimeUnit.SECONDS,
+                    new LinkedBlockingQueue<>(PropertyUtil.getAllDumpPageSize() * 2),
+                    r -> new Thread(r, "dump all executor"), new ThreadPoolExecutor.CallerRunsPolicy());
+        } else {
+            executorService = new ThreadPoolExecutor(1, 1, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
+                    r -> new Thread(r, "dump all executor"), new ThreadPoolExecutor.CallerRunsPolicy());
+        }
+        
+        DEFAULT_LOG.info("start dump all config-info...");
+        
         while (lastMaxId < currentMaxId) {
-            Page<ConfigInfoWrapper> page = configInfoPersistService.findAllConfigInfoFragment(lastMaxId, PAGE_SIZE);
+            
+            long start = System.currentTimeMillis();
+            
+            Page<ConfigInfoWrapper> page = configInfoPersistService.findAllConfigInfoFragment(lastMaxId,
+                    PropertyUtil.getAllDumpPageSize(), dumpAllTask.isStartUp());
+            long dbTimeStamp = System.currentTimeMillis();
             if (page == null || page.getPageItems() == null || page.getPageItems().isEmpty()) {
                 break;
             }
+            
             for (ConfigInfoWrapper cf : page.getPageItems()) {
-                long id = cf.getId();
-                lastMaxId = Math.max(id, lastMaxId);
+                lastMaxId = Math.max(cf.getId(), lastMaxId);
+                //if not start up, page query will not return content, check md5 and lastModified first ,if changed ,get single content info to dump.
+                if (!dumpAllTask.isStartUp()) {
+                    final String groupKey = GroupKey2.getKey(cf.getDataId(), cf.getGroup(), cf.getTenant());
+                    boolean newLastModified = cf.getLastModified() > ConfigCacheService.getLastModifiedTs(groupKey);
+                    //check md5 & update local disk cache.
+                    String localContentMd5 = ConfigCacheService.getContentMd5(groupKey);
+                    boolean md5Update = !localContentMd5.equals(cf.getMd5());
+                    if (newLastModified || md5Update) {
+                        LogUtil.DUMP_LOG.info("[dump-all] find change config {}, {}, md5={}", groupKey,
+                                cf.getLastModified(), cf.getMd5());
+                        cf = configInfoPersistService.findConfigInfo(cf.getDataId(), cf.getGroup(), cf.getTenant());
+                    } else {
+                        continue;
+                    }
+                }
+                
+                if (cf == null) {
+                    continue;
+                }
                 if (cf.getDataId().equals(AggrWhitelist.AGGRIDS_METADATA)) {
                     AggrWhitelist.load(cf.getContent());
                 }
@@ -67,22 +117,50 @@ public class DumpAllProcessor implements NacosTaskProcessor {
                 if (cf.getDataId().equals(SwitchService.SWITCH_META_DATA_ID)) {
                     SwitchService.load(cf.getContent());
                 }
-
-                ConfigCacheService.dump(cf.getDataId(), cf.getGroup(), cf.getTenant(), cf.getContent(),
-                        cf.getLastModified(), cf.getType(), cf.getEncryptedDataKey());
                 
                 final String content = cf.getContent();
-                final String md5 = MD5Utils.md5Hex(content, Constants.ENCODE);
-                LogUtil.DUMP_LOG.info("[dump-all-ok] {}, {}, length={}, md5={}",
-                        GroupKey2.getKey(cf.getDataId(), cf.getGroup()), cf.getLastModified(), content.length(),
-                        md5);
+                final String dataId = cf.getDataId();
+                final String group = cf.getGroup();
+                final String tenant = cf.getTenant();
+                final long lastModified = cf.getLastModified();
+                final String type = cf.getType();
+                final String encryptedDataKey = cf.getEncryptedDataKey();
+                
+                executorService.execute(() -> {
+                    final String md5Utf8 = MD5Utils.md5Hex(content, ENCODE_UTF8);
+                    boolean result = ConfigCacheService.dumpWithMd5(dataId, group, tenant, content, md5Utf8,
+                            lastModified, type, encryptedDataKey);
+                    if (result) {
+                        LogUtil.DUMP_LOG.info("[dump-all-ok] {}, {}, length={},md5UTF8={}",
+                                GroupKey2.getKey(dataId, group), lastModified, content.length(), md5Utf8);
+                    } else {
+                        LogUtil.DUMP_LOG.info("[dump-all-error] {}", GroupKey2.getKey(dataId, group));
+                    }
+                    
+                });
+                
             }
-            DEFAULT_LOG.info("[all-dump] {} / {}", lastMaxId, currentMaxId);
+            
+            long diskStamp = System.currentTimeMillis();
+            DEFAULT_LOG.info("[all-dump] submit all task for {} / {}, dbTime={},diskTime={}", lastMaxId, currentMaxId,
+                    (dbTimeStamp - start), (diskStamp - dbTimeStamp));
         }
+        
+        //wait all task are finished and then shutdown executor.
+        try {
+            int unfinishedTaskCount = 0;
+            while ((unfinishedTaskCount = executorService.getQueue().size() + executorService.getActiveCount()) > 0) {
+                DEFAULT_LOG.info("[all-dump] wait {} dump tasks to be finished", unfinishedTaskCount);
+                Thread.sleep(1000L);
+            }
+            executorService.shutdown();
+            
+        } catch (Exception e) {
+            DEFAULT_LOG.error("[all-dump] wait  dump tasks to be finished error", e);
+        }
+        DEFAULT_LOG.info("success to  dump all config-info。");
         return true;
     }
-    
-    static final int PAGE_SIZE = 1000;
     
     final ConfigInfoPersistService configInfoPersistService;
 }

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/task/DumpAllTask.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/task/DumpAllTask.java
@@ -26,6 +26,19 @@ import com.alibaba.nacos.common.task.AbstractDelayTask;
  */
 public class DumpAllTask extends AbstractDelayTask {
     
+    private boolean startUp;
+    
+    public DumpAllTask() {
+    }
+    
+    public DumpAllTask(boolean startUp) {
+        this.startUp = startUp;
+    }
+    
+    public boolean isStartUp() {
+        return startUp;
+    }
+    
     @Override
     public void merge(AbstractDelayTask task) {
     }

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/ConfigInfoPersistService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/ConfigInfoPersistService.java
@@ -245,7 +245,7 @@ public interface ConfigInfoPersistService {
      * @return config max id
      */
     long findConfigMaxId();
-
+    
     /**
      * Query configuration information by primary key ID.
      *
@@ -315,11 +315,12 @@ public interface ConfigInfoPersistService {
     /**
      * Query all config info.
      *
-     * @param lastMaxId last max id
-     * @param pageSize  page size
+     * @param lastMaxId   last max id
+     * @param pageSize    page size
+     * @param needContent need content or not.
      * @return {@link Page} with {@link ConfigInfoWrapper} generation
      */
-    Page<ConfigInfoWrapper> findAllConfigInfoFragment(final long lastMaxId, final int pageSize);
+    Page<ConfigInfoWrapper> findAllConfigInfoFragment(final long lastMaxId, final int pageSize, boolean needContent);
     
     /**
      * Query config info.
@@ -334,7 +335,7 @@ public interface ConfigInfoPersistService {
      */
     Page<ConfigInfo> findConfigInfoLike4Page(final int pageNo, final int pageSize, final String dataId,
             final String group, final String tenant, final Map<String, Object> configAdvanceInfo);
-
+    
     /**
      * Query change config.order by id asc.
      *

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/ConfigInfoPersistService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/ConfigInfoPersistService.java
@@ -344,7 +344,7 @@ public interface ConfigInfoPersistService {
      * @param pageSize  pageSize
      * @return {@link ConfigInfoWrapper} list
      */
-    List<ConfigInfoWrapper> findChangeConfig(final Timestamp startTime, long lastMaxId, final int pageSize);
+    List<ConfigInfoStateWrapper> findChangeConfig(final Timestamp startTime, long lastMaxId, final int pageSize);
     
     /**
      * Query tag list.

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/ConfigRowMapperInjector.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/ConfigRowMapperInjector.java
@@ -222,7 +222,11 @@ public class ConfigRowMapperInjector {
             info.setGroup(rs.getString("group_id"));
             info.setTenant(rs.getString("tenant_id"));
             info.setLastModified(rs.getTimestamp("gmt_modified").getTime());
-            
+            try {
+                info.setMd5(rs.getString("md5"));
+            } catch (SQLException e) {
+                // ignore
+            }
             try {
                 info.setId(rs.getLong("id"));
             } catch (SQLException e) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/HistoryConfigInfoPersistService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/HistoryConfigInfoPersistService.java
@@ -18,13 +18,12 @@ package com.alibaba.nacos.config.server.service.repository;
 
 import com.alibaba.nacos.config.server.model.ConfigHistoryInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
-import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
+import com.alibaba.nacos.config.server.model.ConfigInfoStateWrapper;
 import com.alibaba.nacos.persistence.model.Page;
 import com.alibaba.nacos.persistence.repository.PaginationHelper;
 
 import java.sql.Timestamp;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Database service, providing access to his_config_info in the database.
@@ -40,14 +39,6 @@ public interface HistoryConfigInfoPersistService {
      * @return {@link PaginationHelper}
      */
     <E> PaginationHelper<E> createPaginationHelper();
-    
-    /**
-     * Convert delete config.
-     *
-     * @param list origin data
-     * @return {@link ConfigInfo} list
-     */
-    List<ConfigInfoWrapper> convertDeletedConfig(List<Map<String, Object>> list);
     
     //------------------------------------------insert---------------------------------------------//
     
@@ -81,9 +72,9 @@ public interface HistoryConfigInfoPersistService {
      * @param startTime start time
      * @param startId   last max id
      * @param size      page size
-     * @return {@link ConfigInfo} list
+     * @return {@link ConfigInfoStateWrapper} list
      */
-    List<ConfigInfoWrapper> findDeletedConfig(final Timestamp startTime, final long startId, int size);
+    List<ConfigInfoStateWrapper> findDeletedConfig(final Timestamp startTime, final long startId, int size);
     
     /**
      * List configuration history change record.

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
@@ -48,6 +48,7 @@ import com.alibaba.nacos.persistence.repository.embedded.EmbeddedStorageContextH
 import com.alibaba.nacos.persistence.repository.embedded.operate.DatabaseOperate;
 import com.alibaba.nacos.plugin.datasource.MapperManager;
 import com.alibaba.nacos.plugin.datasource.constants.CommonConstant;
+import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
@@ -793,8 +794,9 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
         MapperContext context = new MapperContext(0, pageSize);
+        context.putContextParameter(ContextConstant.NEED_CONTENT, String.valueOf(needContent));
         context.putWhereParameter(FieldConstant.ID, lastMaxId);
-        MapperResult select = configInfoMapper.findAllConfigInfoFragment(context, needContent);
+        MapperResult select = configInfoMapper.findAllConfigInfoFragment(context);
         PaginationHelper<ConfigInfoWrapper> helper = createPaginationHelper();
         return helper.fetchPageLimit(select.getSql(), select.getParamList().toArray(), 1, pageSize,
                 CONFIG_INFO_WRAPPER_ROW_MAPPER);
@@ -853,7 +855,8 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
     }
     
     @Override
-    public List<ConfigInfoStateWrapper> findChangeConfig(final Timestamp startTime, long lastMaxId, final int pageSize) {
+    public List<ConfigInfoStateWrapper> findChangeConfig(final Timestamp startTime, long lastMaxId,
+            final int pageSize) {
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
         

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
@@ -853,7 +853,7 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
     }
     
     @Override
-    public List<ConfigInfoWrapper> findChangeConfig(final Timestamp startTime, long lastMaxId, final int pageSize) {
+    public List<ConfigInfoStateWrapper> findChangeConfig(final Timestamp startTime, long lastMaxId, final int pageSize) {
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
         
@@ -864,7 +864,7 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         
         MapperResult mapperResult = configInfoMapper.findChangeConfig(context);
         return databaseOperate.queryMany(mapperResult.getSql(), mapperResult.getParamList().toArray(),
-                CONFIG_INFO_WRAPPER_ROW_MAPPER);
+                CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER);
         
     }
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
@@ -788,12 +788,13 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
     }
     
     @Override
-    public Page<ConfigInfoWrapper> findAllConfigInfoFragment(final long lastMaxId, final int pageSize) {
+    public Page<ConfigInfoWrapper> findAllConfigInfoFragment(final long lastMaxId, final int pageSize,
+            boolean needContent) {
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
         MapperContext context = new MapperContext(0, pageSize);
         context.putWhereParameter(FieldConstant.ID, lastMaxId);
-        MapperResult select = configInfoMapper.findAllConfigInfoFragment(context);
+        MapperResult select = configInfoMapper.findAllConfigInfoFragment(context, needContent);
         PaginationHelper<ConfigInfoWrapper> helper = createPaginationHelper();
         return helper.fetchPageLimit(select.getSql(), select.getParamList().toArray(), 1, pageSize,
                 CONFIG_INFO_WRAPPER_ROW_MAPPER);

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -822,12 +822,13 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
     }
     
     @Override
-    public Page<ConfigInfoWrapper> findAllConfigInfoFragment(final long lastMaxId, final int pageSize) {
+    public Page<ConfigInfoWrapper> findAllConfigInfoFragment(final long lastMaxId, final int pageSize,
+            boolean needContent) {
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
         MapperContext context = new MapperContext(0, pageSize);
         context.putWhereParameter(FieldConstant.ID, lastMaxId);
-        MapperResult select = configInfoMapper.findAllConfigInfoFragment(context);
+        MapperResult select = configInfoMapper.findAllConfigInfoFragment(context, needContent);
         PaginationHelper<ConfigInfoWrapper> helper = createPaginationHelper();
         try {
             return helper.fetchPageLimit(select.getSql(), select.getParamList().toArray(), 1, pageSize,

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -42,6 +42,7 @@ import com.alibaba.nacos.persistence.repository.PaginationHelper;
 import com.alibaba.nacos.persistence.repository.extrnal.ExternalStoragePaginationHelperImpl;
 import com.alibaba.nacos.plugin.datasource.MapperManager;
 import com.alibaba.nacos.plugin.datasource.constants.CommonConstant;
+import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
@@ -827,8 +828,9 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
         MapperContext context = new MapperContext(0, pageSize);
+        context.putContextParameter(ContextConstant.NEED_CONTENT, String.valueOf(needContent));
         context.putWhereParameter(FieldConstant.ID, lastMaxId);
-        MapperResult select = configInfoMapper.findAllConfigInfoFragment(context, needContent);
+        MapperResult select = configInfoMapper.findAllConfigInfoFragment(context);
         PaginationHelper<ConfigInfoWrapper> helper = createPaginationHelper();
         try {
             return helper.fetchPageLimit(select.getSql(), select.getParamList().toArray(), 1, pageSize,

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -897,7 +897,8 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
     }
     
     @Override
-    public List<ConfigInfoWrapper> findChangeConfig(final Timestamp startTime, long lastMaxId, final int pageSize) {
+    public List<ConfigInfoStateWrapper> findChangeConfig(final Timestamp startTime, long lastMaxId,
+            final int pageSize) {
         try {
             ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                     TableConstant.CONFIG_INFO);
@@ -909,7 +910,7 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
             
             MapperResult mapperResult = configInfoMapper.findChangeConfig(context);
             return jt.query(mapperResult.getSql(), mapperResult.getParamList().toArray(),
-                    CONFIG_INFO_WRAPPER_ROW_MAPPER);
+                    CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER);
         } catch (DataAccessException e) {
             LogUtil.FATAL_LOG.error("[db-error] " + e, e);
             throw e;

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpChangeConfigWorkerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpChangeConfigWorkerTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.config.server.service.dump;
 
 import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.config.server.model.ConfigInfoStateWrapper;
 import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
 import com.alibaba.nacos.config.server.service.ConfigCacheService;
 import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskService;
@@ -129,13 +130,13 @@ public class DumpChangeConfigWorkerTest {
         PropertyUtil.setDumpChangeOn(true);
         dumpChangeConfigWorker.setPageSize(3);
         //mock delete first page
-        List<ConfigInfoWrapper> firstPageDeleted = new ArrayList<>();
+        List<ConfigInfoStateWrapper> firstPageDeleted = new ArrayList<>();
         Timestamp startTime = dumpChangeConfigWorker.startTime;
         String dataIdPrefix = "d12345";
         
-        firstPageDeleted.add(createConfigInfoWrapper(dataIdPrefix, 1, startTime.getTime() + 1));
-        firstPageDeleted.add(createConfigInfoWrapper(dataIdPrefix, 2, startTime.getTime() + 2));
-        firstPageDeleted.add(createConfigInfoWrapper(dataIdPrefix, 3, startTime.getTime() + 3));
+        firstPageDeleted.add(createConfigInfoStateWrapper(dataIdPrefix, 1, startTime.getTime() + 1));
+        firstPageDeleted.add(createConfigInfoStateWrapper(dataIdPrefix, 2, startTime.getTime() + 2));
+        firstPageDeleted.add(createConfigInfoStateWrapper(dataIdPrefix, 3, startTime.getTime() + 3));
         //pre set cache for id1
         preSetCache(dataIdPrefix, 1, System.currentTimeMillis());
         Assert.assertEquals("encrykey" + 1,
@@ -173,8 +174,8 @@ public class DumpChangeConfigWorkerTest {
         Assert.assertEquals(startTime.getTime() - 1,
                 ConfigCacheService.getContentCache(GroupKey.getKeyTenant(dataIdPrefix + 1, "group" + 1, "tenant" + 1))
                         .getConfigCache().getLastModifiedTs());
-        List<ConfigInfoWrapper> firstChanged = new ArrayList<>();
-        firstChanged.add(createConfigInfoWrapper(dataIdPrefix, 1, startTime.getTime() + 1));
+        List<ConfigInfoStateWrapper> firstChanged = new ArrayList<>();
+        firstChanged.add(createConfigInfoStateWrapper(dataIdPrefix, 1, startTime.getTime() + 1));
         
         Mockito.when(configInfoPersistService.findChangeConfig(eq(startTime), eq(0L), eq(3))).thenReturn(firstChanged);
         
@@ -211,8 +212,8 @@ public class DumpChangeConfigWorkerTest {
         Assert.assertEquals(startTime.getTime() - 1,
                 ConfigCacheService.getContentCache(GroupKey.getKeyTenant(dataIdPrefix + 1, "group" + 1, "tenant" + 1))
                         .getConfigCache().getLastModifiedTs());
-        List<ConfigInfoWrapper> firstChanged = new ArrayList<>();
-        firstChanged.add(createConfigInfoWrapper(dataIdPrefix, 1, startTime.getTime() + 1));
+        List<ConfigInfoStateWrapper> firstChanged = new ArrayList<>();
+        firstChanged.add(createConfigInfoStateWrapper(dataIdPrefix, 1, startTime.getTime() + 1));
         
         Mockito.when(configInfoPersistService.findChangeConfig(eq(startTime), eq(0L), eq(3))).thenReturn(firstChanged);
         
@@ -250,8 +251,8 @@ public class DumpChangeConfigWorkerTest {
         Assert.assertEquals(startTime.getTime() - 1,
                 ConfigCacheService.getContentCache(GroupKey.getKeyTenant(dataIdPrefix + 1, "group" + 1, "tenant" + 1))
                         .getConfigCache().getLastModifiedTs());
-        List<ConfigInfoWrapper> firstChanged = new ArrayList<>();
-        firstChanged.add(createConfigInfoWrapper(dataIdPrefix, 1, startTime.getTime() - 2));
+        List<ConfigInfoStateWrapper> firstChanged = new ArrayList<>();
+        firstChanged.add(createConfigInfoStateWrapper(dataIdPrefix, 1, startTime.getTime() - 2));
         
         Mockito.when(configInfoPersistService.findChangeConfig(eq(startTime), eq(0L), eq(3))).thenReturn(firstChanged);
         
@@ -290,8 +291,8 @@ public class DumpChangeConfigWorkerTest {
         Assert.assertEquals(startTime.getTime() - 1,
                 ConfigCacheService.getContentCache(GroupKey.getKeyTenant(dataIdPrefix + 1, "group" + 1, "tenant" + 1))
                         .getConfigCache().getLastModifiedTs());
-        List<ConfigInfoWrapper> firstChanged = new ArrayList<>();
-        firstChanged.add(createConfigInfoWrapper(dataIdPrefix, 1, startTime.getTime() - 1));
+        List<ConfigInfoStateWrapper> firstChanged = new ArrayList<>();
+        firstChanged.add(createConfigInfoStateWrapper(dataIdPrefix, 1, startTime.getTime() - 1));
         
         Mockito.when(configInfoPersistService.findChangeConfig(eq(startTime), eq(0L), eq(3))).thenReturn(firstChanged);
         
@@ -320,12 +321,24 @@ public class DumpChangeConfigWorkerTest {
                 MD5Utils.md5Hex("content" + id, "UTF-8"), timeStamp, "json", "encrykey" + id);
     }
     
+    private ConfigInfoStateWrapper createConfigInfoStateWrapper(String dataIdPreFix, long id, long timeStamp) {
+        ConfigInfoStateWrapper configInfoWrapper = new ConfigInfoStateWrapper();
+        configInfoWrapper.setDataId(dataIdPreFix + id);
+        configInfoWrapper.setGroup("group" + id);
+        configInfoWrapper.setTenant("md5" + id);
+        configInfoWrapper.setTenant("tenant" + id);
+        configInfoWrapper.setId(id);
+        configInfoWrapper.setLastModified(timeStamp);
+        return configInfoWrapper;
+    }
+    
     private ConfigInfoWrapper createConfigInfoWrapper(String dataIdPreFix, long id, long timeStamp) {
         ConfigInfoWrapper configInfoWrapper = new ConfigInfoWrapper();
         configInfoWrapper.setDataId(dataIdPreFix + id);
         configInfoWrapper.setGroup("group" + id);
-        configInfoWrapper.setTenant("tenant" + id);
+        configInfoWrapper.setMd5("md5" + id);
         configInfoWrapper.setContent("content" + id);
+        configInfoWrapper.setTenant("tenant" + id);
         configInfoWrapper.setId(id);
         configInfoWrapper.setLastModified(timeStamp);
         return configInfoWrapper;

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessorTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessorTest.java
@@ -269,4 +269,5 @@ public class DumpAllProcessorTest extends TestCase {
                         configInfoWrapper2.getTenant());
         Assert.assertEquals(configInfoWrapperSingle2.getContent(), contentFromDisk2);
     }
+
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessorTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessorTest.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.config.server.service.repository.ConfigInfoBetaPersistS
 import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
 import com.alibaba.nacos.config.server.service.repository.ConfigInfoTagPersistService;
 import com.alibaba.nacos.config.server.utils.GroupKey2;
+import com.alibaba.nacos.config.server.utils.PropertyUtil;
 import com.alibaba.nacos.persistence.datasource.DataSourceService;
 import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
 import com.alibaba.nacos.persistence.model.Page;
@@ -42,8 +43,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.BeanUtils;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -76,6 +77,8 @@ public class DumpAllProcessorTest extends TestCase {
     
     MockedStatic<EnvUtil> envUtilMockedStatic;
     
+    private String mockMem = "tmpmocklimitfile.txt";
+    
     @Before
     public void init() throws Exception {
         dynamicDataSourceMockedStatic = Mockito.mockStatic(DynamicDataSource.class);
@@ -92,6 +95,8 @@ public class DumpAllProcessorTest extends TestCase {
                 configInfoTagPersistService, null, null);
         
         dumpAllProcessor = new DumpAllProcessor(configInfoPersistService);
+        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq("memory_limit_file_path"),
+                eq("/sys/fs/cgroup/memory/memory.limit_in_bytes"))).thenReturn(mockMem);
     }
     
     @After
@@ -118,7 +123,7 @@ public class DumpAllProcessorTest extends TestCase {
     }
     
     @Test
-    public void testDumpAll() throws IOException {
+    public void testDumpAllOnStartUp() throws Exception {
         ConfigInfoWrapper configInfoWrapper1 = createNewConfig(1);
         ConfigInfoWrapper configInfoWrapper2 = createNewConfig(2);
         long timestamp = System.currentTimeMillis();
@@ -132,12 +137,9 @@ public class DumpAllProcessorTest extends TestCase {
         page.setPageItems(list);
         
         Mockito.when(configInfoPersistService.findConfigMaxId()).thenReturn(2L);
-        Mockito.when(configInfoPersistService.findAllConfigInfoFragment(0, 1000)).thenReturn(page);
+        Mockito.when(configInfoPersistService.findAllConfigInfoFragment(0, PropertyUtil.getAllDumpPageSize(), true))
+                .thenReturn(page);
         
-        String groupKey1 = GroupKey2.getKey(configInfoWrapper1.getDataId(), configInfoWrapper1.getGroup(),
-                configInfoWrapper1.getTenant());
-        String groupKey2 = GroupKey2.getKey(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
-                configInfoWrapper2.getTenant());
         // For config 1, assign a latter time, to make sure that it would be updated.
         // For config 2, assign an earlier time, to make sure that it is not be updated.
         String md51 = MD5Utils.md5Hex(configInfoWrapper1.getContent(), "UTF-8");
@@ -152,7 +154,8 @@ public class DumpAllProcessorTest extends TestCase {
                 configInfoWrapper2.getTenant(), configInfoWrapper2.getContent(), md52, earlierTimestamp, "json",
                 encryptedDataKey);
         
-        DumpAllTask dumpAllTask = new DumpAllTask();
+        DumpAllTask dumpAllTask = new DumpAllTask(true);
+        
         boolean process = dumpAllProcessor.process(dumpAllTask);
         Assert.assertTrue(process);
         
@@ -182,5 +185,88 @@ public class DumpAllProcessorTest extends TestCase {
                 .getContent(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
                         configInfoWrapper2.getTenant());
         Assert.assertEquals(configInfoWrapper2.getContent(), contentFromDisk2);
+    }
+    
+    /**
+     * test dump all for all check task.
+     *
+     */
+    @Test
+    public void testDumpAllOnCheckAll() throws Exception {
+        ConfigInfoWrapper configInfoWrapper1 = createNewConfig(1);
+        ConfigInfoWrapper configInfoWrapper2 = createNewConfig(2);
+        long timestamp = System.currentTimeMillis();
+        configInfoWrapper1.setLastModified(timestamp);
+        configInfoWrapper2.setLastModified(timestamp);
+        Page<ConfigInfoWrapper> page = new Page<>();
+        page.setTotalCount(2);
+        page.setPagesAvailable(2);
+        page.setPageNumber(1);
+        List<ConfigInfoWrapper> list = Arrays.asList(configInfoWrapper1, configInfoWrapper2);
+        page.setPageItems(list);
+        
+        Mockito.when(configInfoPersistService.findConfigMaxId()).thenReturn(2L);
+        Mockito.when(configInfoPersistService.findAllConfigInfoFragment(0, PropertyUtil.getAllDumpPageSize(), false))
+                .thenReturn(page);
+        
+        ConfigInfoWrapper configInfoWrapperSingle1 = new ConfigInfoWrapper();
+        BeanUtils.copyProperties(configInfoWrapper1, configInfoWrapperSingle1);
+        configInfoWrapperSingle1.setContent("content123456");
+        Mockito.when(
+                configInfoPersistService.findConfigInfo(configInfoWrapper1.getDataId(), configInfoWrapper1.getGroup(),
+                        configInfoWrapper1.getTenant())).thenReturn(configInfoWrapperSingle1);
+        
+        ConfigInfoWrapper configInfoWrapperSingle2 = new ConfigInfoWrapper();
+        BeanUtils.copyProperties(configInfoWrapper2, configInfoWrapperSingle2);
+        configInfoWrapperSingle2.setContent("content123456222");
+        Mockito.when(
+                configInfoPersistService.findConfigInfo(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
+                        configInfoWrapper2.getTenant())).thenReturn(configInfoWrapperSingle2);
+        
+        // For config 1, assign a latter time, to make sure that it would not be updated.
+        // For config 2, assign an earlier time, to make sure that it would be updated.
+        String md51 = MD5Utils.md5Hex(configInfoWrapper1.getContent(), "UTF-8");
+        String md52 = MD5Utils.md5Hex(configInfoWrapper2.getContent(), "UTF-8");
+        long latterTimestamp = timestamp + 999;
+        long earlierTimestamp = timestamp - 999;
+        String encryptedDataKey = "testEncryptedDataKey";
+        ConfigCacheService.dumpWithMd5(configInfoWrapper1.getDataId(), configInfoWrapper1.getGroup(),
+                configInfoWrapper1.getTenant(), configInfoWrapper1.getContent(), md51, latterTimestamp, "json",
+                encryptedDataKey);
+        ConfigCacheService.dumpWithMd5(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
+                configInfoWrapper2.getTenant(), configInfoWrapper2.getContent(), md52, earlierTimestamp, "json",
+                encryptedDataKey);
+        
+        DumpAllTask dumpAllTask = new DumpAllTask(false);
+        boolean process = dumpAllProcessor.process(dumpAllTask);
+        
+        Assert.assertTrue(process);
+        
+        //Check cache
+        CacheItem contentCache1 = ConfigCacheService.getContentCache(
+                GroupKey2.getKey(configInfoWrapper1.getDataId(), configInfoWrapper1.getGroup(),
+                        configInfoWrapper1.getTenant()));
+        // check if config1 is not updated
+        Assert.assertEquals(md51, contentCache1.getConfigCache().getMd5Utf8());
+        Assert.assertEquals(latterTimestamp, contentCache1.getConfigCache().getLastModifiedTs());
+        //check disk
+        String contentFromDisk1 = ConfigDiskServiceFactory.getInstance()
+                .getContent(configInfoWrapper1.getDataId(), configInfoWrapper1.getGroup(),
+                        configInfoWrapper1.getTenant());
+        Assert.assertEquals(configInfoWrapper1.getContent(), contentFromDisk1);
+        
+        //Check cache
+        CacheItem contentCache2 = ConfigCacheService.getContentCache(
+                GroupKey2.getKey(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
+                        configInfoWrapper2.getTenant()));
+        // check if config2 is updated
+        Assert.assertEquals(MD5Utils.md5Hex(configInfoWrapperSingle2.getContent(), "UTF-8"),
+                contentCache2.getConfigCache().getMd5Utf8());
+        Assert.assertEquals(configInfoWrapper2.getLastModified(), contentCache2.getConfigCache().getLastModifiedTs());
+        //check disk
+        String contentFromDisk2 = ConfigDiskServiceFactory.getInstance()
+                .getContent(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
+                        configInfoWrapper2.getTenant());
+        Assert.assertEquals(configInfoWrapperSingle2.getContent(), contentFromDisk2);
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
@@ -1019,7 +1019,7 @@ public class EmbeddedConfigInfoPersistServiceImplTest {
         int pageSize = 100;
         //execute return mock obj
         Page<ConfigInfoWrapper> returnConfigPage = embeddedConfigInfoPersistService.findAllConfigInfoFragment(lastId,
-                pageSize);
+                pageSize, true);
         //expect check
         Assert.assertEquals(mockConfigs, returnConfigPage.getPageItems());
         

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
@@ -579,6 +579,14 @@ public class EmbeddedConfigInfoPersistServiceImplTest {
         return configAllInfo;
     }
     
+    private ConfigInfoStateWrapper createMockConfigInfoStateWrapper(long mockId) {
+        ConfigInfoStateWrapper configAllInfo = new ConfigInfoStateWrapper();
+        configAllInfo.setDataId("test" + mockId + ".yaml");
+        configAllInfo.setGroup("test");
+        configAllInfo.setLastModified(System.currentTimeMillis());
+        return configAllInfo;
+    }
+    
     private ConfigInfo createMockConfigInfo(long mockId) {
         ConfigInfo configInfo = new ConfigInfo();
         configInfo.setDataId("test" + mockId + ".yaml");
@@ -784,17 +792,17 @@ public class EmbeddedConfigInfoPersistServiceImplTest {
     public void testFindChangeConfig() {
         
         //mock page list
-        List<ConfigInfoWrapper> result = new ArrayList<>();
-        result.add(createMockConfigInfoWrapper(0));
-        result.add(createMockConfigInfoWrapper(1));
-        result.add(createMockConfigInfoWrapper(2));
+        List<ConfigInfoStateWrapper> result = new ArrayList<>();
+        result.add(createMockConfigInfoStateWrapper(0));
+        result.add(createMockConfigInfoStateWrapper(1));
+        result.add(createMockConfigInfoStateWrapper(2));
         Timestamp startTime = new Timestamp(System.currentTimeMillis() - 1000L);
         long lastMaxId = 10000L;
         int pageSize = 30;
         when(databaseOperate.queryMany(anyString(), eq(new Object[] {startTime, lastMaxId, pageSize}),
-                eq(CONFIG_INFO_WRAPPER_ROW_MAPPER))).thenReturn(result);
+                eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(result);
         
-        List<ConfigInfoWrapper> configInfo4List = embeddedConfigInfoPersistService.findChangeConfig(startTime,
+        List<ConfigInfoStateWrapper> configInfo4List = embeddedConfigInfoPersistService.findChangeConfig(startTime,
                 lastMaxId, pageSize);
         Assert.assertEquals(result.size(), configInfo4List.size());
     }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
@@ -642,6 +642,14 @@ public class ExternalConfigInfoPersistServiceImplTest {
         return configAllInfo;
     }
     
+    private ConfigInfoStateWrapper createMockConfigInfoStateWrapper(long mockId) {
+        ConfigInfoStateWrapper configAllInfo = new ConfigInfoStateWrapper();
+        configAllInfo.setDataId("test" + mockId + ".yaml");
+        configAllInfo.setGroup("test");
+        configAllInfo.setLastModified(System.currentTimeMillis());
+        return configAllInfo;
+    }
+    
     private ConfigInfo createMockConfigInfo(long mockId) {
         ConfigInfo configInfo = new ConfigInfo();
         configInfo.setDataId("test" + mockId + ".yaml");
@@ -900,17 +908,17 @@ public class ExternalConfigInfoPersistServiceImplTest {
     public void testFindChangeConfig() {
         
         //mock page list
-        List<ConfigInfoWrapper> result = new ArrayList<>();
-        result.add(createMockConfigInfoWrapper(0));
-        result.add(createMockConfigInfoWrapper(1));
-        result.add(createMockConfigInfoWrapper(2));
+        List<ConfigInfoStateWrapper> result = new ArrayList<>();
+        result.add(createMockConfigInfoStateWrapper(0));
+        result.add(createMockConfigInfoStateWrapper(1));
+        result.add(createMockConfigInfoStateWrapper(2));
         Timestamp startTime = new Timestamp(System.currentTimeMillis() - 1000L);
         long lastMaxId = 10000L;
         int pageSize = 30;
         when(jdbcTemplate.query(anyString(), eq(new Object[] {startTime, lastMaxId, pageSize}),
-                eq(CONFIG_INFO_WRAPPER_ROW_MAPPER))).thenReturn(result);
+                eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(result);
         
-        List<ConfigInfoWrapper> configInfo4List = externalConfigInfoPersistService.findChangeConfig(startTime,
+        List<ConfigInfoStateWrapper> configInfo4List = externalConfigInfoPersistService.findChangeConfig(startTime,
                 lastMaxId, pageSize);
         Assert.assertEquals(result.size(), configInfo4List.size());
     }
@@ -922,9 +930,9 @@ public class ExternalConfigInfoPersistServiceImplTest {
         int pageSize = 30;
         //mock page list
         when(jdbcTemplate.query(anyString(), eq(new Object[] {startTime, lastMaxId, pageSize}),
-                eq(CONFIG_INFO_WRAPPER_ROW_MAPPER))).thenThrow(new CannotAcquireLockException("mock ex"));
+                eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenThrow(new CannotAcquireLockException("mock ex"));
         try {
-            List<ConfigInfoWrapper> configInfo4List = externalConfigInfoPersistService.findChangeConfig(startTime,
+            List<ConfigInfoStateWrapper> configInfo4List = externalConfigInfoPersistService.findChangeConfig(startTime,
                     lastMaxId, pageSize);
             Assert.assertTrue(false);
         } catch (Exception e) {

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
@@ -1256,7 +1256,7 @@ public class ExternalConfigInfoPersistServiceImplTest {
         int pageSize = 100;
         //execute return mock obj
         Page<ConfigInfoWrapper> returnConfigPage = externalConfigInfoPersistService.findAllConfigInfoFragment(lastId,
-                pageSize);
+                pageSize, true);
         
         //expect check
         Assert.assertEquals(mockConfigs, returnConfigPage.getPageItems());
@@ -1264,7 +1264,7 @@ public class ExternalConfigInfoPersistServiceImplTest {
         when(jdbcTemplate.query(anyString(), eq(new Object[] {lastId}), eq(CONFIG_INFO_WRAPPER_ROW_MAPPER))).thenThrow(
                 new CannotGetJdbcConnectionException("mock fail"));
         try {
-            externalConfigInfoPersistService.findAllConfigInfoFragment(lastId, pageSize);
+            externalConfigInfoPersistService.findAllConfigInfoFragment(lastId, pageSize, true);
             Assert.assertTrue(false);
         } catch (Exception e) {
             Assert.assertEquals("mock fail", e.getMessage());

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalHistoryConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalHistoryConfigInfoPersistServiceImplTest.java
@@ -18,7 +18,7 @@ package com.alibaba.nacos.config.server.service.repository.extrnal;
 
 import com.alibaba.nacos.config.server.model.ConfigHistoryInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
-import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
+import com.alibaba.nacos.config.server.model.ConfigInfoStateWrapper;
 import com.alibaba.nacos.config.server.service.sql.ExternalStorageUtils;
 import com.alibaba.nacos.config.server.utils.TestCaseUtils;
 import com.alibaba.nacos.persistence.datasource.DataSourceService;
@@ -39,17 +39,11 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import java.math.BigInteger;
 import java.sql.Timestamp;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
+import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.HISTORY_DETAIL_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.HISTORY_LIST_ROW_MAPPER;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -150,44 +144,42 @@ public class ExternalHistoryConfigInfoPersistServiceImplTest {
     public void testFindDeletedConfig() {
         
         //mock query list return
-        Map<String, Object> mockObj1 = new HashMap<>();
-        mockObj1.put("nid", new BigInteger("1234"));
-        mockObj1.put("data_id", "data_id1");
-        mockObj1.put("group_id", "group_id1");
-        mockObj1.put("tenant_id", "tenant_id1");
-        LocalDateTime now = LocalDateTime.of(LocalDate.now(), LocalTime.now());
-        mockObj1.put("gmt_modified", now);
-        List<Map<String, Object>> list = new ArrayList<>();
+        ConfigInfoStateWrapper mockObj1 = new ConfigInfoStateWrapper();
+        mockObj1.setDataId("data_id1");
+        mockObj1.setGroup("group_id1");
+        mockObj1.setTenant("tenant_id1");
+        mockObj1.setMd5("md51");
+        mockObj1.setLastModified(System.currentTimeMillis());
+        
+        List<ConfigInfoStateWrapper> list = new ArrayList<>();
         list.add(mockObj1);
-        Map<String, Object> mockObj2 = new HashMap<>();
-        mockObj2.put("nid", new BigInteger("12345"));
-        mockObj2.put("data_id", "data_id2");
-        mockObj2.put("group_id", "group_id2");
-        mockObj2.put("tenant_id", "tenant_id2");
-        LocalDateTime now2 = LocalDateTime.of(LocalDate.now(), LocalTime.now());
-        mockObj2.put("gmt_modified", now2);
+        ConfigInfoStateWrapper mockObj2 = new ConfigInfoStateWrapper();
+        mockObj2.setDataId("data_id2");
+        mockObj2.setGroup("group_id2");
+        mockObj2.setTenant("tenant_id2");
+        mockObj2.setMd5("md52");
         list.add(mockObj2);
         int pageSize = 1233;
         long startId = 23456;
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-        Mockito.when(jdbcTemplate.queryForList(anyString(), eq(timestamp), eq(startId), eq(pageSize))).thenReturn(list);
+        Mockito.when(jdbcTemplate.query(anyString(), eq(new Object[] {timestamp, startId, pageSize}),
+                eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(list);
         //execute
-        List<ConfigInfoWrapper> deletedConfig = externalHistoryConfigInfoPersistService.findDeletedConfig(timestamp,
-                startId, pageSize);
+        List<ConfigInfoStateWrapper> deletedConfig = externalHistoryConfigInfoPersistService.findDeletedConfig(
+                timestamp, startId, pageSize);
         //expect verify
         Assert.assertEquals("data_id1", deletedConfig.get(0).getDataId());
         Assert.assertEquals("group_id1", deletedConfig.get(0).getGroup());
         Assert.assertEquals("tenant_id1", deletedConfig.get(0).getTenant());
-        Assert.assertEquals(now.toInstant(ZoneOffset.ofHours(8)).toEpochMilli(),
-                deletedConfig.get(0).getLastModified());
+        Assert.assertEquals(mockObj1.getLastModified(), deletedConfig.get(0).getLastModified());
         Assert.assertEquals("data_id2", deletedConfig.get(1).getDataId());
         Assert.assertEquals("group_id2", deletedConfig.get(1).getGroup());
         Assert.assertEquals("tenant_id2", deletedConfig.get(1).getTenant());
-        Assert.assertEquals(now2.toInstant(ZoneOffset.ofHours(8)).toEpochMilli(),
-                deletedConfig.get(1).getLastModified());
+        Assert.assertEquals(mockObj2.getLastModified(), deletedConfig.get(1).getLastModified());
         
         //mock exception
-        Mockito.when(jdbcTemplate.queryForList(anyString(), eq(timestamp), eq(startId), eq(pageSize)))
+        Mockito.when(jdbcTemplate.query(anyString(), eq(new Object[] {timestamp, startId, pageSize}),
+                        eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
                 .thenThrow(new CannotGetJdbcConnectionException("conn error"));
         
         try {

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/PropertyUtilTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/PropertyUtilTest.java
@@ -17,43 +17,109 @@
 package com.alibaba.nacos.config.server.utils;
 
 import com.alibaba.nacos.sys.env.EnvUtil;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.security.util.FieldUtils;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.File;
+import java.lang.reflect.Field;
 
 import static org.mockito.ArgumentMatchers.eq;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class PropertyUtilTest {
     
-    @Mock
-    private ConfigurableEnvironment configurableEnvironment;
+    MockedStatic<EnvUtil> envUtilMockedStatic;
     
-    @Test
-    public void testGetPropertyV1() {
-        MockedStatic<EnvUtil> envUtilMockedStatic = Mockito.mockStatic(EnvUtil.class);
+    private String mockMem = "tmpmocklimitfile.txt";
+    
+    @Before
+    public void setUp() {
+        envUtilMockedStatic = Mockito.mockStatic(EnvUtil.class);
+        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq("memory_limit_file_path"),
+                eq("/sys/fs/cgroup/memory/memory.limit_in_bytes"))).thenReturn(mockMem);
         
-        EnvUtil.setEnvironment(configurableEnvironment);
-        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq("test"))).thenReturn("test");
-        Assert.assertEquals("test", new PropertyUtil().getProperty("test"));
-        
+    }
+    
+    @After
+    public void after() {
         envUtilMockedStatic.close();
     }
     
     @Test
-    public void testGetPropertyV2() {
-        MockedStatic<EnvUtil> envUtilMockedStatic = Mockito.mockStatic(EnvUtil.class);
+    public void testGetPropertyV1() {
         
-        EnvUtil.setEnvironment(configurableEnvironment);
+        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq("test"))).thenReturn("test");
+        Assert.assertEquals("test", new PropertyUtil().getProperty("test"));
+        
+    }
+    
+    @Test
+    public void testGetPropertyV2() {
+        
         envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq("test"), eq("default"))).thenReturn("default");
         Assert.assertEquals("default", new PropertyUtil().getProperty("test", "default"));
+    }
     
-        envUtilMockedStatic.close();
+    private void clearAllDumpFiled() throws Exception {
+        Field allDumpPageSizeFiled = FieldUtils.getField(PropertyUtil.class, "allDumpPageSize");
+        allDumpPageSizeFiled.setAccessible(true);
+        allDumpPageSizeFiled.set(null, null);
+    }
+    
+    @Test
+    public void testGetAllDumpPageSize() throws Exception {
+        
+        clearAllDumpFiled();
+        File file = new File(mockMem);
+        
+        //2G pageSize between  50 to 1000
+        long gb2 = 2L * 1024L * 1024L * 1024L;
+        FileUtils.writeStringToFile(file, String.valueOf(gb2));
+        int allDumpPageSizeNormal = PropertyUtil.getAllDumpPageSize();
+        //expect  2*2*50
+        Assert.assertEquals(200, allDumpPageSizeNormal);
+        
+        clearAllDumpFiled();
+        // 12G pageSize over 1000
+        long gb12 = 12L * 1024L * 1024L * 1024L;
+        FileUtils.writeStringToFile(file, String.valueOf(gb12));
+        int allDumpPageSizeOverMax = PropertyUtil.getAllDumpPageSize();
+        Assert.assertEquals(1000, allDumpPageSizeOverMax);
+        
+        clearAllDumpFiled();
+        //100MB
+        long mb100 = 100L * 1024L * 1024L;
+        FileUtils.writeStringToFile(file, String.valueOf(mb100));
+        
+        int allDumpPageSizeUnderMin = PropertyUtil.getAllDumpPageSize();
+        Assert.assertEquals(50, allDumpPageSizeUnderMin);
+    }
+    
+    @Test
+    public void testGetAllDumpPageSizeWithJvmArgs() throws Exception {
+        
+        File file = new File(mockMem);
+        if (file.exists()) {
+            file.delete();
+        }
+        int allDumpPageSizeUnderMin = PropertyUtil.initAllDumpPageSize();
+        long maxMem = Runtime.getRuntime().maxMemory();
+        long pageSize = maxMem / 1024 / 1024 / 512 * 50;
+        if (pageSize < 50) {
+            Assert.assertEquals(50, allDumpPageSizeUnderMin);
+        } else if (pageSize > 1000) {
+            Assert.assertEquals(1000, allDumpPageSizeUnderMin);
+        } else {
+            Assert.assertEquals(pageSize, allDumpPageSizeUnderMin);
+        }
     }
     
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/PropertyUtilTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/PropertyUtilTest.java
@@ -51,6 +51,10 @@ public class PropertyUtilTest {
     @After
     public void after() {
         envUtilMockedStatic.close();
+        File file = new File(mockMem);
+        if (file.exists()) {
+            file.delete();
+        }
     }
     
     @Test

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/ContextConstant.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/ContextConstant.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.constants;
+
+/**
+ * Datasource plugin common constant.
+ *
+ * @author zunfei.lzf
+ */
+public class ContextConstant {
+    
+    public static final String NEED_CONTENT = "needContent";
+    
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.plugin.datasource.impl.derby;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
@@ -90,8 +91,9 @@ public class ConfigInfoMapperByDerby extends AbstractMapper implements ConfigInf
     }
     
     @Override
-    public MapperResult findAllConfigInfoFragment(MapperContext context, boolean needContent) {
-        
+    public MapperResult findAllConfigInfoFragment(MapperContext context) {
+        String contextParameter = context.getContextParameter(ContextConstant.NEED_CONTENT);
+        boolean needContent = contextParameter != null && Boolean.parseBoolean(contextParameter);
         return new MapperResult("SELECT id,data_id,group_id,tenant_id,app_name," + (needContent ? "content," : "")
                 + "md5,gmt_modified,type FROM config_info WHERE id > ? " + "ORDER BY id ASC OFFSET "
                 + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY",

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
@@ -77,8 +77,7 @@ public class ConfigInfoMapperByDerby extends AbstractMapper implements ConfigInf
                 + " ( SELECT id FROM config_info WHERE tenant_id LIKE ? ORDER BY id OFFSET " + context.getStartRow()
                 + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY ) "
                 + "g, config_info t  WHERE g.id = t.id ";
-        return new MapperResult(sql,
-                CollectionUtils.list(context.getWhereParameter(FieldConstant.TENANT_ID)));
+        return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.TENANT_ID)));
     }
     
     @Override
@@ -91,12 +90,11 @@ public class ConfigInfoMapperByDerby extends AbstractMapper implements ConfigInf
     }
     
     @Override
-    public MapperResult findAllConfigInfoFragment(MapperContext context) {
+    public MapperResult findAllConfigInfoFragment(MapperContext context, boolean needContent) {
         
-        return new MapperResult(
-                "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type FROM config_info WHERE id > ? "
-                        + "ORDER BY id ASC OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
-                        + context.getPageSize() + " ROWS ONLY",
+        return new MapperResult("SELECT id,data_id,group_id,tenant_id,app_name," + (needContent ? "content," : "")
+                + "md5,gmt_modified,type FROM config_info WHERE id > ? " + "ORDER BY id ASC OFFSET "
+                + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY",
                 CollectionUtils.list(context.getWhereParameter(FieldConstant.ID)));
     }
     
@@ -276,7 +274,7 @@ public class ConfigInfoMapperByDerby extends AbstractMapper implements ConfigInf
     public String getDataSource() {
         return DataSourceConstant.DERBY;
     }
-
+    
     @Override
     public MapperResult findChangeConfig(MapperContext context) {
         String sql =

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
@@ -83,9 +83,6 @@ public class ConfigInfoMapperByMySql extends AbstractMapper implements ConfigInf
     
     @Override
     public MapperResult findAllConfigInfoBaseFetchRows(MapperContext context) {
-        String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
-        final String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
-        
         String sql = "SELECT t.id,data_id,group_id,content,md5"
                 + " FROM ( SELECT id FROM config_info ORDER BY id LIMIT ?,?  ) "
                 + " g, config_info t  WHERE g.id = t.id ";

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.plugin.datasource.impl.mysql;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
@@ -90,8 +91,9 @@ public class ConfigInfoMapperByMySql extends AbstractMapper implements ConfigInf
     }
     
     @Override
-    public MapperResult findAllConfigInfoFragment(MapperContext context, boolean needContent) {
-        
+    public MapperResult findAllConfigInfoFragment(MapperContext context) {
+        String contextParameter = context.getContextParameter(ContextConstant.NEED_CONTENT);
+        boolean needContent = contextParameter != null && Boolean.parseBoolean(contextParameter);
         String sql = "SELECT id,data_id,group_id,tenant_id,app_name," + (needContent ? "content," : "")
                 + "md5,gmt_modified,type,encrypted_data_key FROM config_info WHERE id > ? ORDER BY id ASC LIMIT "
                 + context.getStartRow() + "," + context.getPageSize();

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
@@ -93,11 +93,11 @@ public class ConfigInfoMapperByMySql extends AbstractMapper implements ConfigInf
     }
     
     @Override
-    public MapperResult findAllConfigInfoFragment(MapperContext context) {
+    public MapperResult findAllConfigInfoFragment(MapperContext context, boolean needContent) {
         
-        String sql = "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type,encrypted_data_key "
-                + "FROM config_info WHERE id > ? ORDER BY id ASC LIMIT " + context.getStartRow() + ","
-                + context.getPageSize();
+        String sql = "SELECT id,data_id,group_id,tenant_id,app_name," + (needContent ? "content," : "")
+                + "md5,gmt_modified,type,encrypted_data_key FROM config_info WHERE id > ? ORDER BY id ASC LIMIT "
+                + context.getStartRow() + "," + context.getPageSize();
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.ID)));
     }
     

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
@@ -135,10 +135,11 @@ public interface ConfigInfoMapper extends Mapper {
      * id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type,encrypted_data_key FROM config_info WHERE id
      * > ? ORDER BY id ASC LIMIT startRow,pageSize
      *
-     * @param context The context of startRow, pageSize
+     * @param context     The context of startRow, pageSize
+     * @param needContent need content or not.
      * @return The sql of querying all config info.
      */
-    MapperResult findAllConfigInfoFragment(MapperContext context);
+    MapperResult findAllConfigInfoFragment(MapperContext context, boolean needContent);
     
     /**
      * Query change config. <br/>The default sql: SELECT data_id, group_id, tenant_id, app_name, content,

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
@@ -136,10 +136,9 @@ public interface ConfigInfoMapper extends Mapper {
      * > ? ORDER BY id ASC LIMIT startRow,pageSize
      *
      * @param context     The context of startRow, pageSize
-     * @param needContent need content or not.
      * @return The sql of querying all config info.
      */
-    MapperResult findAllConfigInfoFragment(MapperContext context, boolean needContent);
+    MapperResult findAllConfigInfoFragment(MapperContext context);
     
     /**
      * Query change config. <br/>The default sql: SELECT data_id, group_id, tenant_id, app_name, content,

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/model/MapperContext.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/model/MapperContext.java
@@ -86,7 +86,7 @@ public class MapperContext {
      * @param value Value to be associated with the specified key
      */
     public void putContextParameter(String key, String value) {
-        this.whereParamMap.put(key, value);
+        this.contextParamMap.put(key, value);
     }
     
     /**

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/model/MapperContext.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/model/MapperContext.java
@@ -31,6 +31,8 @@ public class MapperContext {
     
     private final Map<String, Object> updateParamMap;
     
+    private final Map<String, String> contextParamMap;
+    
     private int startRow;
     
     private int pageSize;
@@ -38,11 +40,11 @@ public class MapperContext {
     public MapperContext() {
         this.whereParamMap = new HashMap<>();
         this.updateParamMap = new HashMap<>();
+        this.contextParamMap = new HashMap<>();
     }
     
     public MapperContext(int startRow, int pageSize) {
-        this.whereParamMap = new HashMap<>();
-        this.updateParamMap = new HashMap<>();
+        this();
         this.startRow = startRow;
         this.pageSize = pageSize;
     }
@@ -64,6 +66,26 @@ public class MapperContext {
      * @param value Value to be associated with the specified key
      */
     public void putWhereParameter(String key, Object value) {
+        this.whereParamMap.put(key, value);
+    }
+    
+    /**
+     * Returns the value to which the key is mapped, it will return the context param.
+     *
+     * @param key The key whose associated value is to be returned
+     * @return The value to which the key is mapped
+     */
+    public String getContextParameter(String key) {
+        return contextParamMap.get(key);
+    }
+    
+    /**
+     * Associates the value with the key in this map, it will contain the context parameter.
+     *
+     * @param key   Key with which the value is to be associated
+     * @param value Value to be associated with the specified key
+     */
+    public void putContextParameter(String key, String value) {
         this.whereParamMap.put(key, value);
     }
     

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.datasource.impl.derby;
 
+import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
@@ -150,6 +151,7 @@ public class ConfigInfoMapperByDerbyTest {
     @Test
     public void testFindAllConfigInfoFragment() {
         //with content
+        context.putContextParameter(ContextConstant.NEED_CONTENT, "true");
         MapperResult mapperResult = configInfoMapperByDerby.findAllConfigInfoFragment(context);
         Assert.assertEquals(mapperResult.getSql(),
                 "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type FROM config_info "
@@ -157,6 +159,8 @@ public class ConfigInfoMapperByDerbyTest {
                         + " ROWS ONLY");
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(), new Object[] {id});
         //with out content
+        context.putContextParameter(ContextConstant.NEED_CONTENT, "false");
+    
         MapperResult mapperResult2 = configInfoMapperByDerby.findAllConfigInfoFragment(context);
         Assert.assertEquals(mapperResult2.getSql(),
                 "SELECT id,data_id,group_id,tenant_id,app_name,md5,gmt_modified,type FROM config_info "

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
@@ -149,12 +149,20 @@ public class ConfigInfoMapperByDerbyTest {
     
     @Test
     public void testFindAllConfigInfoFragment() {
-        MapperResult mapperResult = configInfoMapperByDerby.findAllConfigInfoFragment(context);
+        //with content
+        MapperResult mapperResult = configInfoMapperByDerby.findAllConfigInfoFragment(context, true);
         Assert.assertEquals(mapperResult.getSql(),
                 "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type FROM config_info "
                         + "WHERE id > ? ORDER BY id ASC OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize
                         + " ROWS ONLY");
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(), new Object[] {id});
+        //with out content
+        MapperResult mapperResult2 = configInfoMapperByDerby.findAllConfigInfoFragment(context, false);
+        Assert.assertEquals(mapperResult2.getSql(),
+                "SELECT id,data_id,group_id,tenant_id,app_name,md5,gmt_modified,type FROM config_info "
+                        + "WHERE id > ? ORDER BY id ASC OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize
+                        + " ROWS ONLY");
+        Assert.assertArrayEquals(mapperResult2.getParamList().toArray(), new Object[] {id});
     }
     
     @Test

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
@@ -150,14 +150,14 @@ public class ConfigInfoMapperByDerbyTest {
     @Test
     public void testFindAllConfigInfoFragment() {
         //with content
-        MapperResult mapperResult = configInfoMapperByDerby.findAllConfigInfoFragment(context, true);
+        MapperResult mapperResult = configInfoMapperByDerby.findAllConfigInfoFragment(context);
         Assert.assertEquals(mapperResult.getSql(),
                 "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type FROM config_info "
                         + "WHERE id > ? ORDER BY id ASC OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize
                         + " ROWS ONLY");
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(), new Object[] {id});
         //with out content
-        MapperResult mapperResult2 = configInfoMapperByDerby.findAllConfigInfoFragment(context, false);
+        MapperResult mapperResult2 = configInfoMapperByDerby.findAllConfigInfoFragment(context);
         Assert.assertEquals(mapperResult2.getSql(),
                 "SELECT id,data_id,group_id,tenant_id,app_name,md5,gmt_modified,type FROM config_info "
                         + "WHERE id > ? ORDER BY id ASC OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
@@ -150,14 +150,14 @@ public class ConfigInfoMapperByMySqlTest {
     @Test
     public void testFindAllConfigInfoFragment() {
         //with content
-        MapperResult mapperResult = configInfoMapperByMySql.findAllConfigInfoFragment(context, true);
+        MapperResult mapperResult = configInfoMapperByMySql.findAllConfigInfoFragment(context);
         Assert.assertEquals(
                 "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type,encrypted_data_key "
                         + "FROM config_info WHERE id > ? ORDER BY id ASC LIMIT " + startRow + "," + pageSize,
                 mapperResult.getSql());
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(), new Object[] {id});
         
-        MapperResult mapperResult2 = configInfoMapperByMySql.findAllConfigInfoFragment(context, false);
+        MapperResult mapperResult2 = configInfoMapperByMySql.findAllConfigInfoFragment(context);
         Assert.assertEquals("SELECT id,data_id,group_id,tenant_id,app_name,md5,gmt_modified,type,encrypted_data_key "
                         + "FROM config_info WHERE id > ? ORDER BY id ASC LIMIT " + startRow + "," + pageSize,
                 mapperResult2.getSql());

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
@@ -149,11 +149,19 @@ public class ConfigInfoMapperByMySqlTest {
     
     @Test
     public void testFindAllConfigInfoFragment() {
-        MapperResult mapperResult = configInfoMapperByMySql.findAllConfigInfoFragment(context);
-        Assert.assertEquals(mapperResult.getSql(),
+        //with content
+        MapperResult mapperResult = configInfoMapperByMySql.findAllConfigInfoFragment(context, true);
+        Assert.assertEquals(
                 "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type,encrypted_data_key "
-                        + "FROM config_info WHERE id > ? ORDER BY id ASC LIMIT " + startRow + "," + pageSize);
+                        + "FROM config_info WHERE id > ? ORDER BY id ASC LIMIT " + startRow + "," + pageSize,
+                mapperResult.getSql());
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(), new Object[] {id});
+        
+        MapperResult mapperResult2 = configInfoMapperByMySql.findAllConfigInfoFragment(context, false);
+        Assert.assertEquals("SELECT id,data_id,group_id,tenant_id,app_name,md5,gmt_modified,type,encrypted_data_key "
+                        + "FROM config_info WHERE id > ? ORDER BY id ASC LIMIT " + startRow + "," + pageSize,
+                mapperResult2.getSql());
+        Assert.assertArrayEquals(mapperResult2.getParamList().toArray(), new Object[] {id});
     }
     
     @Test

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.plugin.datasource.impl.mysql;
 
 import com.alibaba.nacos.common.utils.NamespaceUtil;
+import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
@@ -150,6 +151,8 @@ public class ConfigInfoMapperByMySqlTest {
     @Test
     public void testFindAllConfigInfoFragment() {
         //with content
+        context.putContextParameter(ContextConstant.NEED_CONTENT, "true");
+        
         MapperResult mapperResult = configInfoMapperByMySql.findAllConfigInfoFragment(context);
         Assert.assertEquals(
                 "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type,encrypted_data_key "
@@ -157,6 +160,7 @@ public class ConfigInfoMapperByMySqlTest {
                 mapperResult.getSql());
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(), new Object[] {id});
         
+        context.putContextParameter(ContextConstant.NEED_CONTENT, "false");
         MapperResult mapperResult2 = configInfoMapperByMySql.findAllConfigInfoFragment(context);
         Assert.assertEquals("SELECT id,data_id,group_id,tenant_id,app_name,md5,gmt_modified,type,encrypted_data_key "
                         + "FROM config_info WHERE id > ? ORDER BY id ASC LIMIT " + startRow + "," + pageSize,


### PR DESCRIPTION


1.optimize config dump all,do not select content in page query,single query config on md5 and ts updated.
2. remove convertDeleteConfig and convertConfigConfig ，use standard RowMapper instead.

