### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-classic to 1.4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <commons-io.version>2.7</commons-io.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <slf4j-api.version>1.7.26</slf4j-api.version>
-        <logback.version>1.2.13</logback.version>
+        <logback.version>1.4.12</logback.version>
         <log4j.version>2.17.1</log4j.version>
         
         <mysql-connector-java.version>8.0.28</mysql-connector-java.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ch.qos.logback:logback-classic 1.2.13
- [CVE-2023-6378](https://www.oscs1024.com/hd/CVE-2023-6378)


### What did I do？
Upgrade ch.qos.logback:logback-classic from 1.2.13 to 1.4.12 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS