### PR TITLE
update spring-boot-dependencies version to 2.7.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <p3c-pmd.version>1.3.0</p3c-pmd.version>
         
         <!-- dependency version -->
-        <spring-boot-dependencies.version>2.7.11</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.7.18</spring-boot-dependencies.version>
         <servlet-api.version>3.0</servlet-api.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <commons-io.version>2.7</commons-io.version>


### PR DESCRIPTION
## What is the purpose of the change

update spring boot version and fix CVE-2023-34034 in nacos 1.x version

