### PR TITLE
[ISSUE#12022] Fix nacos datasource plugin ClassCastException bug (#12…

### DIFF
--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxy.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxy.java
@@ -43,7 +43,15 @@ public class MapperProxy implements InvocationHandler {
     
     public <R> R createProxy(Mapper mapper) {
         this.mapper = mapper;
-        return (R) Proxy.newProxyInstance(MapperProxy.class.getClassLoader(), mapper.getClass().getInterfaces(), this);
+        Class<?> clazz = mapper.getClass();
+        while (clazz.getInterfaces().length == 0) {
+            if (clazz.getSuperclass().equals(Object.class)) {
+                break;
+            }
+            clazz = clazz.getSuperclass();
+        }
+        Class<?>[] interfaces = clazz.getInterfaces();
+        return (R) Proxy.newProxyInstance(MapperProxy.class.getClassLoader(), interfaces, this);
     }
     
     /**


### PR DESCRIPTION
## What is the purpose of the change

Fix nacos datasource plugin ClassCastException bug [https://github.com/alibaba/nacos/issues/12022](url)

## Brief changelog

Modify the clazz.getInterfaces() method in com.alibaba.nacos.plugin.datasource.proxy.MapperProxy#createProxy so that clazz can obtain the correct Class<?>[] interface

## Verifying this change

After repair, nacos can run normally without ClassCastException and does not affect the original mysql mapper.

postgersql：
![image](https://github.com/alibaba/nacos/assets/41845795/cbcaa1ba-f609-48a0-992a-c4a31ed2004e)

mysql：
![image](https://github.com/alibaba/nacos/assets/41845795/6308d757-2b34-47a6-903c-2162ee6265d9)


