### PR TITLE
[ISSUE#12022] Fix nacos datasource plugin ClassCastException bug (#12…

### DIFF
--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxy.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxy.java
@@ -25,8 +25,12 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * DataSource plugin Mapper sql proxy.
@@ -40,18 +44,21 @@ public class MapperProxy implements InvocationHandler {
     private Mapper mapper;
     
     private static final Map<String, Mapper> SINGLE_MAPPER_PROXY_MAP = new ConcurrentHashMap<>(16);
-    
+
+    /**
+     * Creates a proxy instance for the sub-interfaces of Mapper.class implemented by the given object.
+     */
     public <R> R createProxy(Mapper mapper) {
         this.mapper = mapper;
         Class<?> clazz = mapper.getClass();
-        while (clazz.getInterfaces().length == 0) {
-            if (clazz.getSuperclass().equals(Object.class)) {
-                break;
-            }
+        Set<Class<?>> interfacesSet = new HashSet<>();
+        while (!clazz.equals(Object.class)) {
+            interfacesSet.addAll(Arrays.stream(clazz.getInterfaces())
+                    .filter(Mapper.class::isAssignableFrom)
+                    .collect(Collectors.toSet()));
             clazz = clazz.getSuperclass();
         }
-        Class<?>[] interfaces = clazz.getInterfaces();
-        return (R) Proxy.newProxyInstance(MapperProxy.class.getClassLoader(), interfaces, this);
+        return (R) Proxy.newProxyInstance(MapperProxy.class.getClassLoader(), interfacesSet.toArray(new Class<?>[interfacesSet.size()]), this);
     }
     
     /**

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxy.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxy.java
@@ -43,7 +43,15 @@ public class MapperProxy implements InvocationHandler {
     
     public <R> R createProxy(Mapper mapper) {
         this.mapper = mapper;
-        return (R) Proxy.newProxyInstance(MapperProxy.class.getClassLoader(), mapper.getClass().getInterfaces(), this);
+        Class<?> clazz = mapper.getClass();
+        while (clazz.getInterfaces().length == 0) {
+            if (clazz.getSuperclass().equals(Object.class)) {
+                break;
+            }
+            clazz = clazz.getSuperclass();
+        }
+        Class<?>[] interfaces = clazz.getInterfaces();
+        return (R) Proxy.newProxyInstance(MapperProxy.class.getClassLoader(), interfaces, this);
     }
     
     /**

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
@@ -17,7 +17,10 @@
 package com.alibaba.nacos.plugin.datasource;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.*;
+import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
+import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.mapper.Mapper;
+import com.alibaba.nacos.plugin.datasource.mapper.TestMapper;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
@@ -17,8 +17,7 @@
 package com.alibaba.nacos.plugin.datasource;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
-import com.alibaba.nacos.plugin.datasource.mapper.Mapper;
+import com.alibaba.nacos.plugin.datasource.mapper.*;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -69,4 +68,13 @@ public class MapperManagerTest {
         Mapper mapper = instance.findMapper(DataSourceConstant.MYSQL, "test");
         Assert.assertNotNull(mapper);
     }
+
+    @Test
+    public void testEnableDataSourceLogJoin() {
+        MapperManager.join(new TestMapper());
+        MapperManager instance = MapperManager.instance(true);
+        ConfigInfoMapper mapper = instance.findMapper(DataSourceConstant.MYSQL, "test");
+        Assert.assertNotNull(mapper);
+    }
+
 }

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
@@ -76,7 +76,7 @@ public class MapperManagerTest {
     public void testEnableDataSourceLogJoin() {
         MapperManager.join(new TestMapper());
         MapperManager instance = MapperManager.instance(true);
-        ConfigInfoAggrMapper mapper = instance.findMapper(DataSourceConstant.MYSQL, "test");
+        ConfigInfoAggrMapper mapper = instance.findMapper(DataSourceConstant.MYSQL, "enable_data_source_log_test");
         Assert.assertNotNull(mapper);
     }
 

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
@@ -18,7 +18,7 @@ package com.alibaba.nacos.plugin.datasource;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
-import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoAggrMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.Mapper;
 import com.alibaba.nacos.plugin.datasource.mapper.TestMapper;
 import org.junit.Assert;
@@ -76,7 +76,7 @@ public class MapperManagerTest {
     public void testEnableDataSourceLogJoin() {
         MapperManager.join(new TestMapper());
         MapperManager instance = MapperManager.instance(true);
-        ConfigInfoMapper mapper = instance.findMapper(DataSourceConstant.MYSQL, "test");
+        ConfigInfoAggrMapper mapper = instance.findMapper(DataSourceConstant.MYSQL, "test");
         Assert.assertNotNull(mapper);
     }
 

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/TestInterface.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/TestInterface.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.impl;
+
+/**
+ * A custom interface. just for test
+ * @author mikolls
+ **/
+public interface TestInterface {
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/TestMapper.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/TestMapper.java
@@ -16,11 +16,9 @@
 
 package com.alibaba.nacos.plugin.datasource.mapper;
 
-import com.alibaba.nacos.plugin.datasource.impl.TestInterface;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.impl.TestInterface;
 import com.alibaba.nacos.plugin.datasource.impl.base.BaseConfigInfoMapper;
-import com.alibaba.nacos.plugin.datasource.model.MapperContext;
-import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 
 /**
  * Implement interfaces other than Mapper. just for test

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/TestMapper.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/TestMapper.java
@@ -18,13 +18,13 @@ package com.alibaba.nacos.plugin.datasource.mapper;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.impl.TestInterface;
-import com.alibaba.nacos.plugin.datasource.impl.base.BaseConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.impl.mysql.ConfigInfoAggrMapperByMySql;
 
 /**
  * Implement interfaces other than Mapper. just for test
  * @author mikolls
  **/
-public class TestMapper extends BaseConfigInfoMapper implements TestInterface {
+public class TestMapper extends ConfigInfoAggrMapperByMySql implements TestInterface {
 
     @Override
     public String getTableName() {

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/TestMapper.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/TestMapper.java
@@ -28,7 +28,7 @@ public class TestMapper extends ConfigInfoAggrMapperByMySql implements TestInter
 
     @Override
     public String getTableName() {
-        return "test";
+        return "enable_data_source_log_test";
     }
 
     @Override

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/TestMapper.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/TestMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2022 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.mapper;
+
+import com.alibaba.nacos.plugin.datasource.impl.TestInterface;
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.impl.base.BaseConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+/**
+ * Implement interfaces other than Mapper. just for test
+ * @author mikolls
+ **/
+public class TestMapper extends BaseConfigInfoMapper implements TestInterface {
+
+    @Override
+    public String getTableName() {
+        return "test";
+    }
+
+    @Override
+    public String getDataSource() {
+        return DataSourceConstant.MYSQL;
+    }
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix nacos datasource plugin ClassCastException bug [https://github.com/alibaba/nacos/issues/12022](url)

## Brief changelog

Modify the clazz.getInterfaces() method in com.alibaba.nacos.plugin.datasource.proxy.MapperProxy#createProxy so that clazz can obtain the correct Class<?>[] interface

## Verifying this change

After repair, nacos can run normally without ClassCastException and does not affect the original mysql mapper.

postgersql：
![image](https://github.com/alibaba/nacos/assets/41845795/cbcaa1ba-f609-48a0-992a-c4a31ed2004e)

mysql：
![image](https://github.com/alibaba/nacos/assets/41845795/6308d757-2b34-47a6-903c-2162ee6265d9)


