### PR TITLE
[ISSUE #12060]  fix too large ttl when auth disabled

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/token/impl/JwtTokenManagerTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/token/impl/JwtTokenManagerTest.java
@@ -35,6 +35,7 @@ import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -105,12 +106,48 @@ public class JwtTokenManagerTest {
     public void testGetExpiredTimeInSeconds() throws AccessException {
         Assert.assertTrue(jwtTokenManager.getExpiredTimeInSeconds(jwtTokenManager.createToken("nacos")) > 0);
     }
+
+    @Test
+    public void testGetTokenTtlInSecondsWhenAuthDisabled() throws AccessException {
+        when(authConfigs.isAuthEnabled()).thenReturn(false);
+        // valid secret key
+        String ttl = EnvUtil.getProperty(AuthConstants.TOKEN_EXPIRE_SECONDS);
+        Assert.assertEquals(Integer.parseInt(ttl), jwtTokenManager.getTokenTtlInSeconds(jwtTokenManager.createToken("nacos")));
+        // invalid secret key
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        mockEnvironment.setProperty(AuthConstants.TOKEN_SECRET_KEY,"");
+        EnvUtil.setEnvironment(mockEnvironment);
+        jwtTokenManager = new JwtTokenManager(authConfigs);
+        Assert.assertEquals(Integer.parseInt(ttl), jwtTokenManager.getTokenTtlInSeconds(jwtTokenManager.createToken("nacos")));
+    }
     
     @Test
-    public void testCreateTokenWhenDisableAuth() {
+    public void testCreateTokenWhenDisableAuthAndSecretKeyIsBlank() {
         when(authConfigs.isAuthEnabled()).thenReturn(false);
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        mockEnvironment.setProperty(AuthConstants.TOKEN_SECRET_KEY, "");
+        mockEnvironment
+                .setProperty(AuthConstants.TOKEN_EXPIRE_SECONDS, AuthConstants.DEFAULT_TOKEN_EXPIRE_SECONDS.toString());
+
+        EnvUtil.setEnvironment(mockEnvironment);
         jwtTokenManager = new JwtTokenManager(authConfigs);
         assertEquals("AUTH_DISABLED", jwtTokenManager.createToken("nacos"));
+    }
+
+    @Test
+    public void testCreateTokenWhenDisableAuthAndSecretKeyIsNotBlank() throws AccessException {
+        when(authConfigs.isAuthEnabled()).thenReturn(false);
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        String tmpKey = "SecretKey0123567890234567890123456789012345678901234567890123456789";
+        mockEnvironment.setProperty(AuthConstants.TOKEN_SECRET_KEY,
+                Base64.getEncoder().encodeToString(tmpKey.getBytes(StandardCharsets.UTF_8)));
+        mockEnvironment
+                .setProperty(AuthConstants.TOKEN_EXPIRE_SECONDS, AuthConstants.DEFAULT_TOKEN_EXPIRE_SECONDS.toString());
+        EnvUtil.setEnvironment(mockEnvironment);
+        jwtTokenManager = new JwtTokenManager(authConfigs);
+        String token = jwtTokenManager.createToken("nacos");
+        assertNotEquals("AUTH_DISABLED", token);
+        jwtTokenManager.validateToken(token);
     }
     
     @Test

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/token/impl/JwtTokenManagerTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/token/impl/JwtTokenManagerTest.java
@@ -115,7 +115,7 @@ public class JwtTokenManagerTest {
         Assert.assertEquals(Integer.parseInt(ttl), jwtTokenManager.getTokenTtlInSeconds(jwtTokenManager.createToken("nacos")));
         // invalid secret key
         MockEnvironment mockEnvironment = new MockEnvironment();
-        mockEnvironment.setProperty(AuthConstants.TOKEN_SECRET_KEY,"");
+        mockEnvironment.setProperty(AuthConstants.TOKEN_SECRET_KEY, "");
         EnvUtil.setEnvironment(mockEnvironment);
         jwtTokenManager = new JwtTokenManager(authConfigs);
         Assert.assertEquals(Integer.parseInt(ttl), jwtTokenManager.getTokenTtlInSeconds(jwtTokenManager.createToken("nacos")));


### PR DESCRIPTION

## What is the purpose of the change

fix issue #12060

## Brief changelog

> 1. fix too large ttl when auth disabled
> 2. generate a valid token when nacos.core.auth.plugin.nacos.token.secret.key is valid even if auth disabled

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

