### PR TITLE
fix(#12231): When inserting and updating configurations in the database, the time-related field values need to be set using the time obtained from the database's built-in time function.

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
@@ -51,8 +51,10 @@ import com.alibaba.nacos.plugin.datasource.constants.CommonConstant;
 import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
+import com.alibaba.nacos.plugin.datasource.enums.TrustedSqlFunctionEnum;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigTagsRelationMapper;
+import com.alibaba.nacos.plugin.datasource.model.ColumnFunctionPair;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 import com.alibaba.nacos.plugin.encryption.handler.EncryptionHandler;
@@ -264,15 +266,27 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 configInfo.getEncryptedDataKey() == null ? StringUtils.EMPTY : configInfo.getEncryptedDataKey();
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
-        Timestamp time = new Timestamp(System.currentTimeMillis());
-        
         final String sql = configInfoMapper.insert(
-                Arrays.asList("id", "data_id", "group_id", "tenant_id", "app_name", "content", "md5", "src_ip",
-                        "src_user", "gmt_create", "gmt_modified", "c_desc", "c_use", "effect", "type", "c_schema",
-                        "encrypted_data_key"));
-        final Object[] args = new Object[] {id, configInfo.getDataId(), configInfo.getGroup(), tenantTmp, appNameTmp,
-                configInfo.getContent(), md5Tmp, srcIp, srcUser, time, time, desc, use, effect, type, schema,
-                encryptedDataKey};
+                Arrays.asList(
+                        ColumnFunctionPair.withColumn("id"),
+                        ColumnFunctionPair.withColumn("data_id"),
+                        ColumnFunctionPair.withColumn("group_id"),
+                        ColumnFunctionPair.withColumn("tenant_id"),
+                        ColumnFunctionPair.withColumn("app_name"),
+                        ColumnFunctionPair.withColumn("content"),
+                        ColumnFunctionPair.withColumn("md5"),
+                        ColumnFunctionPair.withColumn("src_ip"),
+                        ColumnFunctionPair.withColumn("src_user"),
+                        ColumnFunctionPair.withColumnAndFunction("gmt_create", TrustedSqlFunctionEnum.CURRENT_TIMESTAMP),
+                        ColumnFunctionPair.withColumnAndFunction("gmt_modified", TrustedSqlFunctionEnum.CURRENT_TIMESTAMP),
+                        ColumnFunctionPair.withColumn("c_desc"),
+                        ColumnFunctionPair.withColumn("c_use"),
+                        ColumnFunctionPair.withColumn("effect"),
+                        ColumnFunctionPair.withColumn("type"),
+                        ColumnFunctionPair.withColumn("c_schema"),
+                        ColumnFunctionPair.withColumn("encrypted_data_key")));
+        final Object[] args = new Object[]{id, configInfo.getDataId(), configInfo.getGroup(), tenantTmp, appNameTmp,
+                configInfo.getContent(), md5Tmp, srcIp, srcUser, desc, use, effect, type, schema, encryptedDataKey};
         EmbeddedStorageContextHolder.addSqlContext(sql, args);
         return id;
     }
@@ -282,8 +296,14 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         ConfigTagsRelationMapper configTagsRelationMapper = mapperManager.findMapper(
                 dataSourceService.getDataSourceType(), TableConstant.CONFIG_TAGS_RELATION);
         final String sql = configTagsRelationMapper.insert(
-                Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"));
-        final Object[] args = new Object[] {configId, tagName, StringUtils.EMPTY, dataId, group, tenant};
+                Arrays.asList(
+                        ColumnFunctionPair.withColumn("id"),
+                        ColumnFunctionPair.withColumn("tag_name"),
+                        ColumnFunctionPair.withColumn("tag_type"),
+                        ColumnFunctionPair.withColumn("data_id"),
+                        ColumnFunctionPair.withColumn("group_id"),
+                        ColumnFunctionPair.withColumn("tenant_id")));
+        final Object[] args = new Object[]{configId, tagName, StringUtils.EMPTY, dataId, group, tenant};
         EmbeddedStorageContextHolder.addSqlContext(sql, args);
     }
     
@@ -594,13 +614,11 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 configInfo.getEncryptedDataKey() == null ? StringUtils.EMPTY : configInfo.getEncryptedDataKey();
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
-        Timestamp time = new Timestamp(System.currentTimeMillis());
         MapperContext context = new MapperContext();
         context.putUpdateParameter(FieldConstant.CONTENT, configInfo.getContent());
         context.putUpdateParameter(FieldConstant.MD5, md5Tmp);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -632,18 +650,25 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         final String schema = configAdvanceInfo == null ? null : (String) configAdvanceInfo.get("schema");
         final String encryptedDataKey =
                 configInfo.getEncryptedDataKey() == null ? StringUtils.EMPTY : configInfo.getEncryptedDataKey();
-        
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
         final String sql = configInfoMapper.update(
-                Arrays.asList("content", "md5", "src_ip", "src_user", "gmt_modified", "app_name", "c_desc", "c_use",
-                        "effect", "type", "c_schema", "encrypted_data_key"),
+                Arrays.asList(
+                        ColumnFunctionPair.withColumn("content"),
+                        ColumnFunctionPair.withColumn("md5"),
+                        ColumnFunctionPair.withColumn("src_ip"),
+                        ColumnFunctionPair.withColumn("src_user"),
+                        ColumnFunctionPair.withColumnAndFunction("gmt_modified", TrustedSqlFunctionEnum.CURRENT_TIMESTAMP),
+                        ColumnFunctionPair.withColumn("app_name"),
+                        ColumnFunctionPair.withColumn("c_desc"),
+                        ColumnFunctionPair.withColumn("c_use"),
+                        ColumnFunctionPair.withColumn("effect"),
+                        ColumnFunctionPair.withColumn("type"),
+                        ColumnFunctionPair.withColumn("c_schema"),
+                        ColumnFunctionPair.withColumn("encrypted_data_key")),
                 Arrays.asList("data_id", "group_id", "tenant_id"));
-        Timestamp time = new Timestamp(System.currentTimeMillis());
-        
-        final Object[] args = new Object[] {configInfo.getContent(), md5Tmp, srcIp, srcUser, time, appNameTmp, desc,
+        final Object[] args = new Object[]{configInfo.getContent(), md5Tmp, srcIp, srcUser, appNameTmp, desc,
                 use, effect, type, schema, encryptedDataKey, configInfo.getDataId(), configInfo.getGroup(), tenantTmp};
-        
         EmbeddedStorageContextHolder.addSqlContext(sql, args);
     }
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedHistoryConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedHistoryConfigInfoPersistServiceImpl.java
@@ -38,6 +38,7 @@ import com.alibaba.nacos.plugin.datasource.constants.CommonConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.HistoryConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.model.ColumnFunctionPair;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 import com.alibaba.nacos.sys.env.EnvUtil;
@@ -95,15 +96,26 @@ public class EmbeddedHistoryConfigInfoPersistServiceImpl implements HistoryConfi
         String tenantTmp = StringUtils.defaultEmptyIfBlank(configInfo.getTenant());
         final String md5Tmp = MD5Utils.md5Hex(configInfo.getContent(), Constants.ENCODE);
         String encryptedDataKey = StringUtils.defaultEmptyIfBlank(configInfo.getEncryptedDataKey());
-        
+
         HistoryConfigInfoMapper historyConfigInfoMapper = mapperManager.findMapper(
                 dataSourceService.getDataSourceType(), TableConstant.HIS_CONFIG_INFO);
         final String sql = historyConfigInfoMapper.insert(
-                Arrays.asList("id", "data_id", "group_id", "tenant_id", "app_name", "content", "md5", "src_ip",
-                        "src_user", "gmt_modified", "op_type", "encrypted_data_key"));
-        final Object[] args = new Object[] {configHistoryId, configInfo.getDataId(), configInfo.getGroup(), tenantTmp,
+                Arrays.asList(
+                        ColumnFunctionPair.withColumn("id"),
+                        ColumnFunctionPair.withColumn("data_id"),
+                        ColumnFunctionPair.withColumn("group_id"),
+                        ColumnFunctionPair.withColumn("tenant_id"),
+                        ColumnFunctionPair.withColumn("app_name"),
+                        ColumnFunctionPair.withColumn("content"),
+                        ColumnFunctionPair.withColumn("md5"),
+                        ColumnFunctionPair.withColumn("src_ip"),
+                        ColumnFunctionPair.withColumn("src_user"),
+                        ColumnFunctionPair.withColumn("gmt_modified"),
+                        ColumnFunctionPair.withColumn("op_type"),
+                        ColumnFunctionPair.withColumn("encrypted_data_key")));
+        final Object[] args = new Object[]{configHistoryId, configInfo.getDataId(), configInfo.getGroup(), tenantTmp,
                 appNameTmp, configInfo.getContent(), md5Tmp, srcIp, srcUser, time, ops, encryptedDataKey};
-        
+
         EmbeddedStorageContextHolder.addSqlContext(sql, args);
     }
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalHistoryConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalHistoryConfigInfoPersistServiceImpl.java
@@ -35,6 +35,7 @@ import com.alibaba.nacos.plugin.datasource.constants.CommonConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.HistoryConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.model.ColumnFunctionPair;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 import com.alibaba.nacos.sys.env.EnvUtil;
@@ -93,15 +94,25 @@ public class ExternalHistoryConfigInfoPersistServiceImpl implements HistoryConfi
         String tenantTmp = StringUtils.defaultEmptyIfBlank(configInfo.getTenant());
         final String md5Tmp = MD5Utils.md5Hex(configInfo.getContent(), Constants.ENCODE);
         String encryptedDataKey = StringUtils.defaultEmptyIfBlank(configInfo.getEncryptedDataKey());
-        
         try {
             HistoryConfigInfoMapper historyConfigInfoMapper = mapperManager.findMapper(
                     dataSourceService.getDataSourceType(), TableConstant.HIS_CONFIG_INFO);
             jt.update(historyConfigInfoMapper.insert(
-                            Arrays.asList("id", "data_id", "group_id", "tenant_id", "app_name", "content", "md5", "src_ip",
-                                    "src_user", "gmt_modified", "op_type", "encrypted_data_key")), id, configInfo.getDataId(),
-                    configInfo.getGroup(), tenantTmp, appNameTmp, configInfo.getContent(), md5Tmp, srcIp, srcUser, time,
-                    ops, encryptedDataKey);
+                            Arrays.asList(
+                                    ColumnFunctionPair.withColumn("id"),
+                                    ColumnFunctionPair.withColumn("data_id"),
+                                    ColumnFunctionPair.withColumn("group_id"),
+                                    ColumnFunctionPair.withColumn("tenant_id"),
+                                    ColumnFunctionPair.withColumn("app_name"),
+                                    ColumnFunctionPair.withColumn("content"),
+                                    ColumnFunctionPair.withColumn("md5"),
+                                    ColumnFunctionPair.withColumn("src_ip"),
+                                    ColumnFunctionPair.withColumn("src_user"),
+                                    ColumnFunctionPair.withColumn("gmt_modified"),
+                                    ColumnFunctionPair.withColumn("op_type"),
+                                    ColumnFunctionPair.withColumn("encrypted_data_key"))),
+                    id, configInfo.getDataId(), configInfo.getGroup(), tenantTmp, appNameTmp,
+                    configInfo.getContent(), md5Tmp, srcIp, srcUser, time, ops, encryptedDataKey);
         } catch (DataAccessException e) {
             LogUtil.FATAL_LOG.error("[db-error] " + e, e);
             throw e;

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImplTest.java
@@ -37,7 +37,6 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -125,7 +124,7 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
         //verify update to be invoked
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(configInfo.getContent()), eq(configInfo.getMd5()),
-                        eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(configInfo.getAppName()),
+                        eq(betaIps), eq(srcIp), eq(srcUser), eq(configInfo.getAppName()),
                         eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group), eq(tenant)), times(1));
         
     }
@@ -163,7 +162,7 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(dataId), eq(group), eq(tenant),
                         eq(configInfo.getAppName()), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(betaIps), eq(srcIp),
-                        eq(srcUser), any(Timestamp.class), any(Timestamp.class), eq(configInfo.getEncryptedDataKey())), times(1));
+                        eq(srcUser), eq(configInfo.getEncryptedDataKey())), times(1));
     }
     
     @Test
@@ -202,7 +201,7 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
         //verify cas update to be invoked
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(configInfo.getContent()),
-                        eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class),
+                        eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(betaIps), eq(srcIp), eq(srcUser),
                         eq(appName), eq(dataId), eq(group), eq(tenant), eq(configInfo.getMd5())), times(1));
         
     }
@@ -240,7 +239,7 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(dataId), eq(group), eq(tenant),
                         eq(configInfo.getAppName()), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(betaIps), eq(srcIp),
-                        eq(srcUser), any(Timestamp.class), any(Timestamp.class), eq(configInfo.getEncryptedDataKey())), times(1));
+                        eq(srcUser), eq(configInfo.getEncryptedDataKey())), times(1));
         
     }
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
@@ -164,8 +164,8 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         //expect insert config info invoked.
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), anyLong(), eq(dataId), eq(group), eq(tenant), eq(appName),
-                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class),
-                        any(Timestamp.class), eq(desc), eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDataKey)), times(1));
+                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser),
+                        eq(desc), eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDataKey)), times(1));
         //expect insert config tags
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), anyLong(), eq("tag1"), eq(StringUtils.EMPTY), eq(dataId),
@@ -221,8 +221,8 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         //expect insert config info invoked.
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), anyLong(), eq(dataId), eq(group), eq(tenant), eq(appName),
-                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class),
-                        any(Timestamp.class), eq(desc), eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDatakey)), times(1));
+                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser),
+                        eq(desc), eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDatakey)), times(1));
         //expect insert config tags
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), anyLong(), eq("tag1"), eq(StringUtils.EMPTY), eq(dataId),
@@ -281,7 +281,7 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         
         //expect update config info invoked.
         embeddedStorageContextHolderMockedStatic.verify(() -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(content),
-                eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName), eq(desc),
+                eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), eq(appName), eq(desc),
                 eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDataKey), eq(dataId), eq(group), eq(tenant)), times(1));
         
         //expect insert config tags
@@ -347,7 +347,7 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         //expect update config info invoked.
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(eq(Boolean.TRUE), anyString(), eq(content),
-                        eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName),
+                        eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), eq(appName),
                         eq(desc), eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDataKey), eq(dataId), eq(group), eq(tenant),
                         eq(casMd5)), times(1));
         

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoTagPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoTagPersistServiceImplTest.java
@@ -45,7 +45,6 @@ import java.util.List;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_TAG_WRAPPER_ROW_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -121,8 +120,7 @@ class EmbeddedConfigInfoTagPersistServiceImplTest {
         //mock insert invoked.
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(dataId), eq(group), eq(tenant), eq(tag), eq(appName),
-                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class),
-                        any(Timestamp.class)), times(1));
+                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser)), times(1));
         assertEquals(configInfoStateWrapper.getId(), configOperateResult.getId());
         assertEquals(configInfoStateWrapper.getLastModified(), configOperateResult.getLastModified());
         
@@ -151,7 +149,7 @@ class EmbeddedConfigInfoTagPersistServiceImplTest {
         ConfigOperateResult configOperateResult = embeddedConfigInfoTagPersistService.insertOrUpdateTag(configInfo, tag, srcIp, srcUser);
         //verify update to be invoked
         embeddedStorageContextHolderMockedStatic.verify(() -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(content),
-                eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName),
+                eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), eq(appName),
                 eq(dataId), eq(group), eq(tenant), eq(tag)), times(1));
         assertEquals(configInfoStateWrapper.getId(), configOperateResult.getId());
         assertEquals(configInfoStateWrapper.getLastModified(), configOperateResult.getLastModified());
@@ -185,8 +183,7 @@ class EmbeddedConfigInfoTagPersistServiceImplTest {
         //mock insert invoked.
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(dataId), eq(group), eq(tenant), eq(tag), eq(appName),
-                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class),
-                        any(Timestamp.class)), times(1));
+                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser)), times(1));
         assertEquals(configInfoStateWrapper.getId(), configOperateResult.getId());
         assertEquals(configInfoStateWrapper.getLastModified(), configOperateResult.getLastModified());
         
@@ -218,7 +215,7 @@ class EmbeddedConfigInfoTagPersistServiceImplTest {
         ConfigOperateResult configOperateResult = embeddedConfigInfoTagPersistService.insertOrUpdateTagCas(configInfo, tag, srcIp, srcUser);
         //verify update to be invoked
         embeddedStorageContextHolderMockedStatic.verify(() -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(content),
-                eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName),
+                eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), eq(appName),
                 eq(dataId), eq(group), eq(tenant), eq(tag), eq(configInfo.getMd5())), times(1));
         assertEquals(configInfoStateWrapper.getId(), configOperateResult.getId());
         assertEquals(configInfoStateWrapper.getLastModified(), configOperateResult.getLastModified());

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoAggrPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoAggrPersistServiceImplTest.java
@@ -38,7 +38,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -50,7 +49,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -130,8 +128,7 @@ class ExternalConfigInfoAggrPersistServiceImplTest {
         when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant, datumId}), eq(String.class))).thenThrow(
                 new EmptyResultDataAccessException(1));
         //mock insert success
-        when(jdbcTemplate.update(anyString(), eq(dataId), eq(group), eq(tenant), eq(datumId), eq(appName), eq(content),
-                any(Timestamp.class))).thenReturn(1);
+        when(jdbcTemplate.update(anyString(), eq(dataId), eq(group), eq(tenant), eq(datumId), eq(appName), eq(content))).thenReturn(1);
         
         //execute
         boolean result = externalConfigInfoAggrPersistService.addAggrConfigInfo(dataId, group, tenant, datumId, appName, content);
@@ -152,12 +149,10 @@ class ExternalConfigInfoAggrPersistServiceImplTest {
         when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant, datumId}), eq(String.class))).thenReturn(
                 existContent);
         //mock update success,return 1
-        when(jdbcTemplate.update(anyString(), eq(content), any(Timestamp.class), eq(dataId), eq(group), eq(tenant),
-                eq(datumId))).thenReturn(1);
+        when(jdbcTemplate.update(anyString(), eq(content), eq(dataId), eq(group), eq(tenant), eq(datumId))).thenReturn(1);
         //mock update content
         boolean result = externalConfigInfoAggrPersistService.addAggrConfigInfo(dataId, group, tenant, datumId, appName, content);
         assertTrue(result);
-        
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImplTest.java
@@ -41,7 +41,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,7 +49,6 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -129,8 +127,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         //verify update to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser),
-                        any(Timestamp.class), eq(configInfo.getAppName()), eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group),
-                        eq(tenant));
+                        eq(configInfo.getAppName()), eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group), eq(tenant));
     }
     
     @Test
@@ -165,8 +162,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         //verify add to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(dataId), eq(group), eq(tenant), eq(configInfo.getAppName()), eq(configInfo.getContent()),
-                        eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), any(Timestamp.class),
-                        eq(configInfo.getEncryptedDataKey()));
+                        eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), eq(configInfo.getEncryptedDataKey()));
         
     }
     
@@ -195,7 +191,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         
         // mock update throw CannotGetJdbcConnectionException
         when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser),
-                any(Timestamp.class), eq(configInfo.getAppName()), eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group),
+                eq(configInfo.getAppName()), eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group),
                 eq(tenant))).thenThrow(new CannotGetJdbcConnectionException("mock fail"));
         //execute of update& expect.
         try {
@@ -210,7 +206,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
                 eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
         //mock add throw CannotGetJdbcConnectionException
         when(jdbcTemplate.update(anyString(), eq(dataId), eq(group), eq(tenant), eq(configInfo.getAppName()), eq(configInfo.getContent()),
-                eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), any(Timestamp.class),
+                eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser),
                 eq(configInfo.getEncryptedDataKey()))).thenThrow(new CannotGetJdbcConnectionException("mock fail add"));
         //execute of add& expect.
         try {
@@ -259,7 +255,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         configInfo.setMd5("casMd5");
         //mock cas update
         when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)),
-                eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName), eq(dataId), eq(group), eq(tenant),
+                eq(betaIps), eq(srcIp), eq(srcUser), eq(appName), eq(dataId), eq(group), eq(tenant),
                 eq(configInfo.getMd5()))).thenReturn(1);
         
         ConfigOperateResult configOperateResult = externalConfigInfoBetaPersistService.insertOrUpdateBetaCas(configInfo, betaIps, srcIp,
@@ -270,7 +266,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         //verify cas update to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(configInfo.getContent()), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(betaIps),
-                        eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName), eq(dataId), eq(group), eq(tenant),
+                        eq(srcIp), eq(srcUser), eq(appName), eq(dataId), eq(group), eq(tenant),
                         eq(configInfo.getMd5()));
         
     }
@@ -307,8 +303,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         //verify add to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(dataId), eq(group), eq(tenant), eq(configInfo.getAppName()), eq(configInfo.getContent()),
-                        eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), any(Timestamp.class),
-                        eq(configInfo.getEncryptedDataKey()));
+                        eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), eq(configInfo.getEncryptedDataKey()));
         
     }
     
@@ -337,7 +332,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         configInfo.setMd5("casMd5");
         // mock update throw CannotGetJdbcConnectionException
         when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)),
-                eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName), eq(dataId), eq(group), eq(tenant),
+                eq(betaIps), eq(srcIp), eq(srcUser), eq(appName), eq(dataId), eq(group), eq(tenant),
                 eq(configInfo.getMd5()))).thenThrow(new CannotGetJdbcConnectionException("mock fail"));
         //execute of update& expect.
         try {
@@ -353,7 +348,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         //mock add throw CannotGetJdbcConnectionException
         when(jdbcTemplate.update(anyString(), eq(dataId), eq(group), eq(tenant), eq(configInfo.getAppName()), eq(configInfo.getContent()),
                 eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(betaIps), eq(srcIp), eq(srcUser),
-                any(Timestamp.class), any(Timestamp.class), eq(configInfo.getEncryptedDataKey()))).thenThrow(
+                eq(configInfo.getEncryptedDataKey()))).thenThrow(
                 new CannotGetJdbcConnectionException("mock fail add"));
         
         //execute of add& expect.

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
@@ -34,7 +34,9 @@ import com.alibaba.nacos.persistence.datasource.DataSourceService;
 import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
 import com.alibaba.nacos.persistence.model.Page;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
+import com.alibaba.nacos.plugin.datasource.enums.TrustedSqlFunctionEnum;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.model.ColumnFunctionPair;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -151,12 +153,24 @@ class ExternalConfigInfoPersistServiceImplTest {
         Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class), eq(generatedKeyHolder))).thenReturn(1);
         Mockito.when(jdbcTemplate.update(eq(externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                 TableConstant.CONFIG_TAGS_RELATION)
-                        .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(insertConfigIndoId),
+                        .insert(Arrays.asList(
+                                ColumnFunctionPair.withColumn("id"),
+                                ColumnFunctionPair.withColumn("tag_name"),
+                                ColumnFunctionPair.withColumn("tag_type"),
+                                ColumnFunctionPair.withColumn("data_id"),
+                                ColumnFunctionPair.withColumn("group_id"),
+                                ColumnFunctionPair.withColumn("tenant_id")))), eq(insertConfigIndoId),
                 eq("tag1"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
         Mockito.when(jdbcTemplate.update(eq(externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                 TableConstant.CONFIG_TAGS_RELATION)
-                        .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(insertConfigIndoId),
-                eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
+                        .insert(Arrays.asList(
+                                ColumnFunctionPair.withColumn("id"),
+                                ColumnFunctionPair.withColumn("tag_name"),
+                                ColumnFunctionPair.withColumn("tag_type"),
+                                ColumnFunctionPair.withColumn("data_id"),
+                                ColumnFunctionPair.withColumn("group_id"),
+                                ColumnFunctionPair.withColumn("tenant_id")))),
+                eq(insertConfigIndoId), eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
         String srcIp = "srcIp";
         String srcUser = "srcUser";
         //mock insert config info
@@ -170,13 +184,25 @@ class ExternalConfigInfoPersistServiceImplTest {
         Mockito.verify(jdbcTemplate, times(1)).update(eq(
                         externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                         TableConstant.CONFIG_TAGS_RELATION)
-                                .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(insertConfigIndoId),
-                eq("tag1"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
+                                .insert(Arrays.asList(
+                                        ColumnFunctionPair.withColumn("id"),
+                                        ColumnFunctionPair.withColumn("tag_name"),
+                                        ColumnFunctionPair.withColumn("tag_type"),
+                                        ColumnFunctionPair.withColumn("data_id"),
+                                        ColumnFunctionPair.withColumn("group_id"),
+                                        ColumnFunctionPair.withColumn("tenant_id")))),
+                eq(insertConfigIndoId), eq("tag1"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
         Mockito.verify(jdbcTemplate, times(1)).update(eq(
                         externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                         TableConstant.CONFIG_TAGS_RELATION)
-                                .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(insertConfigIndoId),
-                eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
+                                .insert(Arrays.asList(
+                                        ColumnFunctionPair.withColumn("id"),
+                                        ColumnFunctionPair.withColumn("tag_name"),
+                                        ColumnFunctionPair.withColumn("tag_type"),
+                                        ColumnFunctionPair.withColumn("data_id"),
+                                        ColumnFunctionPair.withColumn("group_id"),
+                                        ColumnFunctionPair.withColumn("tenant_id")))),
+                eq(insertConfigIndoId), eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
         
         //expect insert history info
         Mockito.verify(historyConfigInfoPersistService, times(1))
@@ -205,12 +231,24 @@ class ExternalConfigInfoPersistServiceImplTest {
         Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class), eq(generatedKeyHolder))).thenReturn(1);
         Mockito.when(jdbcTemplate.update(eq(externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                 TableConstant.CONFIG_TAGS_RELATION)
-                        .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(insertConfigIndoId),
-                eq("tag1"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
+                        .insert(Arrays.asList(
+                                ColumnFunctionPair.withColumn("id"),
+                                ColumnFunctionPair.withColumn("tag_name"),
+                                ColumnFunctionPair.withColumn("tag_type"),
+                                ColumnFunctionPair.withColumn("data_id"),
+                                ColumnFunctionPair.withColumn("group_id"),
+                                ColumnFunctionPair.withColumn("tenant_id")))),
+                eq(insertConfigIndoId), eq("tag1"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
         Mockito.when(jdbcTemplate.update(eq(externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                 TableConstant.CONFIG_TAGS_RELATION)
-                        .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(insertConfigIndoId),
-                eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
+                        .insert(Arrays.asList(
+                                ColumnFunctionPair.withColumn("id"),
+                                ColumnFunctionPair.withColumn("tag_name"),
+                                ColumnFunctionPair.withColumn("tag_type"),
+                                ColumnFunctionPair.withColumn("data_id"),
+                                ColumnFunctionPair.withColumn("group_id"),
+                                ColumnFunctionPair.withColumn("tenant_id")))),
+                eq(insertConfigIndoId), eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
         String srcIp = "srcIp";
         String srcUser = "srcUser";
         //mock insert config info
@@ -224,13 +262,25 @@ class ExternalConfigInfoPersistServiceImplTest {
         Mockito.verify(jdbcTemplate, times(1)).update(eq(
                         externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                         TableConstant.CONFIG_TAGS_RELATION)
-                                .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(insertConfigIndoId),
-                eq("tag1"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
+                                .insert(Arrays.asList(
+                                        ColumnFunctionPair.withColumn("id"),
+                                        ColumnFunctionPair.withColumn("tag_name"),
+                                        ColumnFunctionPair.withColumn("tag_type"),
+                                        ColumnFunctionPair.withColumn("data_id"),
+                                        ColumnFunctionPair.withColumn("group_id"),
+                                        ColumnFunctionPair.withColumn("tenant_id")))),
+                eq(insertConfigIndoId), eq("tag1"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
         Mockito.verify(jdbcTemplate, times(1)).update(eq(
                         externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                         TableConstant.CONFIG_TAGS_RELATION)
-                                .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(insertConfigIndoId),
-                eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
+                                .insert(Arrays.asList(
+                                        ColumnFunctionPair.withColumn("id"),
+                                        ColumnFunctionPair.withColumn("tag_name"),
+                                        ColumnFunctionPair.withColumn("tag_type"),
+                                        ColumnFunctionPair.withColumn("data_id"),
+                                        ColumnFunctionPair.withColumn("group_id"),
+                                        ColumnFunctionPair.withColumn("tenant_id")))),
+                eq(insertConfigIndoId), eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
         
         //expect insert history info
         Mockito.verify(historyConfigInfoPersistService, times(1))
@@ -301,9 +351,20 @@ class ExternalConfigInfoPersistServiceImplTest {
         String srcUser = "srcUser";
         //mock update config info
         Mockito.when(jdbcTemplate.update(eq(externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                                TableConstant.CONFIG_INFO)
-                        .update(Arrays.asList("content", "md5", "src_ip", "src_user", "gmt_modified", "app_name", "c_desc", "c_use", "effect",
-                                "type", "c_schema", "encrypted_data_key"), Arrays.asList("data_id", "group_id", "tenant_id"))),
+                        TableConstant.CONFIG_INFO).update(Arrays.asList(
+                                ColumnFunctionPair.withColumn("content"),
+                                ColumnFunctionPair.withColumn("md5"),
+                                ColumnFunctionPair.withColumn("src_ip"),
+                                ColumnFunctionPair.withColumn("src_user"),
+                                ColumnFunctionPair.withColumnAndFunction("gmt_modified", TrustedSqlFunctionEnum.CURRENT_TIMESTAMP),
+                                ColumnFunctionPair.withColumn("app_name"),
+                                ColumnFunctionPair.withColumn("c_desc"),
+                                ColumnFunctionPair.withColumn("c_use"),
+                                ColumnFunctionPair.withColumn("effect"),
+                                ColumnFunctionPair.withColumn("type"),
+                                ColumnFunctionPair.withColumn("c_schema"),
+                                ColumnFunctionPair.withColumn("encrypted_data_key")),
+                        Arrays.asList("data_id", "group_id", "tenant_id"))),
                 eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(srcIp), eq(srcUser), any(), eq(configInfoWrapperOld.getAppName()),
                 eq(configAdvanceInfo.get("desc")), eq(configAdvanceInfo.get("use")), eq(configAdvanceInfo.get("effect")),
                 eq(configAdvanceInfo.get("type")), eq(configAdvanceInfo.get("schema")), eq(encryptedDataKey), eq(configInfo.getDataId()),
@@ -312,8 +373,14 @@ class ExternalConfigInfoPersistServiceImplTest {
         //mock insert config tags.
         Mockito.when(jdbcTemplate.update(eq(externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                 TableConstant.CONFIG_TAGS_RELATION)
-                        .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(12345678765L), anyString(),
-                eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
+                        .insert(Arrays.asList(
+                                ColumnFunctionPair.withColumn("id"),
+                                ColumnFunctionPair.withColumn("tag_name"),
+                                ColumnFunctionPair.withColumn("tag_type"),
+                                ColumnFunctionPair.withColumn("data_id"),
+                                ColumnFunctionPair.withColumn("group_id"),
+                                ColumnFunctionPair.withColumn("tenant_id")))),
+                eq(12345678765L), anyString(), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
         
         //mock insert his config info
         Mockito.doNothing().when(historyConfigInfoPersistService)
@@ -326,12 +393,24 @@ class ExternalConfigInfoPersistServiceImplTest {
         Mockito.verify(jdbcTemplate, times(1)).update(eq(
                         externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                         TableConstant.CONFIG_TAGS_RELATION)
-                                .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))),
+                                .insert(Arrays.asList(
+                                        ColumnFunctionPair.withColumn("id"),
+                                        ColumnFunctionPair.withColumn("tag_name"),
+                                        ColumnFunctionPair.withColumn("tag_type"),
+                                        ColumnFunctionPair.withColumn("data_id"),
+                                        ColumnFunctionPair.withColumn("group_id"),
+                                        ColumnFunctionPair.withColumn("tenant_id")))),
                 eq(configInfoWrapperOld.getId()), eq("tag1"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
         Mockito.verify(jdbcTemplate, times(1)).update(eq(
                         externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                         TableConstant.CONFIG_TAGS_RELATION)
-                                .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))),
+                                .insert(Arrays.asList(
+                                        ColumnFunctionPair.withColumn("id"),
+                                        ColumnFunctionPair.withColumn("tag_name"),
+                                        ColumnFunctionPair.withColumn("tag_type"),
+                                        ColumnFunctionPair.withColumn("data_id"),
+                                        ColumnFunctionPair.withColumn("group_id"),
+                                        ColumnFunctionPair.withColumn("tenant_id")))),
                 eq(configInfoWrapperOld.getId()), eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
         
         //expect insert history info
@@ -343,7 +422,6 @@ class ExternalConfigInfoPersistServiceImplTest {
     
     @Test
     void testInsertOrUpdateCasOfUpdateConfigSuccess() {
-        
         Map<String, Object> configAdvanceInfo = new HashMap<>();
         configAdvanceInfo.put("config_tags", "tag1,tag2");
         configAdvanceInfo.put("desc", "desc11");
@@ -379,15 +457,21 @@ class ExternalConfigInfoPersistServiceImplTest {
         String srcUser = "srcUser";
         //mock update config info cas
         Mockito.when(jdbcTemplate.update(anyString(), eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp),
-                eq(srcUser), any(Timestamp.class), eq(configInfoWrapperOld.getAppName()), eq(configAdvanceInfo.get("desc")),
+                eq(srcUser), eq(configInfoWrapperOld.getAppName()), eq(configAdvanceInfo.get("desc")),
                 eq(configAdvanceInfo.get("use")), eq(configAdvanceInfo.get("effect")), eq(configAdvanceInfo.get("type")),
                 eq(configAdvanceInfo.get("schema")), eq(encryptedDataKey), eq(dataId), eq(group), eq(tenant), eq(casMd5))).thenReturn(1);
         
         //mock insert config tags.
         Mockito.when(jdbcTemplate.update(eq(externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                 TableConstant.CONFIG_TAGS_RELATION)
-                        .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(configInfoWrapperOld.getId()),
-                anyString(), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
+                        .insert(Arrays.asList(
+                                ColumnFunctionPair.withColumn("id"),
+                                ColumnFunctionPair.withColumn("tag_name"),
+                                ColumnFunctionPair.withColumn("tag_type"),
+                                ColumnFunctionPair.withColumn("data_id"),
+                                ColumnFunctionPair.withColumn("group_id"),
+                                ColumnFunctionPair.withColumn("tenant_id")))),
+                eq(configInfoWrapperOld.getId()), anyString(), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
         
         //mock insert his config info
         Mockito.doNothing().when(historyConfigInfoPersistService)
@@ -398,7 +482,7 @@ class ExternalConfigInfoPersistServiceImplTest {
         //expect update config cas
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser),
-                        any(Timestamp.class), eq(configInfoWrapperOld.getAppName()), eq(configAdvanceInfo.get("desc")),
+                        eq(configInfoWrapperOld.getAppName()), eq(configAdvanceInfo.get("desc")),
                         eq(configAdvanceInfo.get("use")), eq(configAdvanceInfo.get("effect")), eq(configAdvanceInfo.get("type")),
                         eq(configAdvanceInfo.get("schema")), eq(encryptedDataKey), eq(dataId), eq(group), eq(tenant), eq(casMd5));
         
@@ -406,12 +490,24 @@ class ExternalConfigInfoPersistServiceImplTest {
         Mockito.verify(jdbcTemplate, times(1)).update(eq(
                         externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                         TableConstant.CONFIG_TAGS_RELATION)
-                                .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))),
+                                .insert(Arrays.asList(
+                                        ColumnFunctionPair.withColumn("id"),
+                                        ColumnFunctionPair.withColumn("tag_name"),
+                                        ColumnFunctionPair.withColumn("tag_type"),
+                                        ColumnFunctionPair.withColumn("data_id"),
+                                        ColumnFunctionPair.withColumn("group_id"),
+                                        ColumnFunctionPair.withColumn("tenant_id")))),
                 eq(configInfoWrapperOld.getId()), eq("tag1"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
         Mockito.verify(jdbcTemplate, times(1)).update(eq(
                         externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                         TableConstant.CONFIG_TAGS_RELATION)
-                                .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))),
+                                .insert(Arrays.asList(
+                                        ColumnFunctionPair.withColumn("id"),
+                                        ColumnFunctionPair.withColumn("tag_name"),
+                                        ColumnFunctionPair.withColumn("tag_type"),
+                                        ColumnFunctionPair.withColumn("data_id"),
+                                        ColumnFunctionPair.withColumn("group_id"),
+                                        ColumnFunctionPair.withColumn("tenant_id")))),
                 eq(configInfoWrapperOld.getId()), eq("tag2"), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant));
         
         //expect insert history info
@@ -448,8 +544,6 @@ class ExternalConfigInfoPersistServiceImplTest {
         externalConfigInfoPersistService.createPsForInsertConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo, mockConnection,
                 configInfoMapper);
         Mockito.verify(preparedStatement, times(14)).setString(anyInt(), anyString());
-        Mockito.verify(preparedStatement, times(2)).setTimestamp(anyInt(), any(Timestamp.class));
-        
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoTagPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoTagPersistServiceImplTest.java
@@ -51,7 +51,6 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -115,7 +114,7 @@ class ExternalConfigInfoTagPersistServiceImplTest {
         configInfoStateWrapper.setLastModified(System.currentTimeMillis());
         configInfoStateWrapper.setId(234567890L);
         String tag = "tag123";
-        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant, tag}),
+        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[]{dataId, group, tenant, tag}),
                         eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenThrow(new EmptyResultDataAccessException(1))
                 .thenReturn(configInfoStateWrapper);
         String srcIp = "ip345678";
@@ -124,10 +123,10 @@ class ExternalConfigInfoTagPersistServiceImplTest {
         //verify insert to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(dataId), eq(group), eq(tenant), eq(tag), eq(appName), eq(configInfo.getContent()),
-                        eq(configInfo.getMd5()), eq(srcIp), eq(srcUser), any(Timestamp.class), any(Timestamp.class));
+                        eq(configInfo.getMd5()), eq(srcIp), eq(srcUser));
         assertEquals(configInfoStateWrapper.getId(), configOperateResult.getId());
         assertEquals(configInfoStateWrapper.getLastModified(), configOperateResult.getLastModified());
-        
+
     }
     
     @Test
@@ -152,7 +151,7 @@ class ExternalConfigInfoTagPersistServiceImplTest {
         ConfigOperateResult configOperateResult = externalConfigInfoTagPersistService.insertOrUpdateTag(configInfo, tag, srcIp, srcUser);
         //verify update to be invoked
         Mockito.verify(jdbcTemplate, times(1))
-                .update(anyString(), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(srcIp), eq(srcUser), any(Timestamp.class),
+                .update(anyString(), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(srcIp), eq(srcUser),
                         eq(appName), eq(dataId), eq(group), eq(tenant), eq(tag));
         assertEquals(configInfoStateWrapper.getId(), configOperateResult.getId());
         assertEquals(configInfoStateWrapper.getLastModified(), configOperateResult.getLastModified());
@@ -184,8 +183,7 @@ class ExternalConfigInfoTagPersistServiceImplTest {
         //verify insert to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(dataId), eq(group), eq(tenant), eq(tag), eq(appName), eq(configInfo.getContent()),
-                        eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser),
-                        any(Timestamp.class), any(Timestamp.class));
+                        eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser));
         assertEquals(configInfoStateWrapper.getId(), configOperateResult.getId());
         assertEquals(configInfoStateWrapper.getLastModified(), configOperateResult.getLastModified());
         
@@ -214,13 +212,13 @@ class ExternalConfigInfoTagPersistServiceImplTest {
         
         //mock cas update return 1
         Mockito.when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()),
-                eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class),
+                eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser),
                 eq(appName), eq(dataId), eq(group), eq(tenant), eq(tag), eq(configInfo.getMd5()))).thenReturn(1);
         ConfigOperateResult configOperateResult = externalConfigInfoTagPersistService.insertOrUpdateTagCas(configInfo, tag, srcIp, srcUser);
         //verify update to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(configInfo.getContent()), eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)),
-                        eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName), eq(dataId), eq(group), eq(tenant), eq(tag),
+                        eq(srcIp), eq(srcUser), eq(appName), eq(dataId), eq(group), eq(tenant), eq(tag),
                         eq(configInfo.getMd5()));
         assertEquals(configInfoStateWrapper.getId(), configOperateResult.getId());
         assertEquals(configInfoStateWrapper.getLastModified(), configOperateResult.getLastModified());
@@ -253,11 +251,11 @@ class ExternalConfigInfoTagPersistServiceImplTest {
             assertEquals("state query throw exception", e.getMessage());
         }
         //mock get state return null,and execute add throw CannotGetJdbcConnectionException
-        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant, tag}),
+        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[]{dataId, group, tenant, tag}),
                 eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
         Mockito.when(jdbcTemplate.update(anyString(), eq(dataId), eq(group), eq(tenant), eq(tag), eq(appName), eq(configInfo.getContent()),
-                eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class),
-                any(Timestamp.class))).thenThrow(new CannotGetJdbcConnectionException("throw exception add config tag"));
+                        eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser)))
+                .thenThrow(new CannotGetJdbcConnectionException("throw exception add config tag"));
         try {
             externalConfigInfoTagPersistService.insertOrUpdateTagCas(configInfo, tag, srcIp, srcUser);
             assertTrue(false);
@@ -269,7 +267,7 @@ class ExternalConfigInfoTagPersistServiceImplTest {
         Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant, tag}),
                 eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(configInfoStateWrapper);
         Mockito.when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()),
-                        eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class),
+                        eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser),
                         eq(appName), eq(dataId), eq(group), eq(tenant), eq(tag), eq(configInfo.getMd5())))
                 .thenThrow(new CannotGetJdbcConnectionException("throw exception update config tag"));
         try {

--- a/core/src/main/java/com/alibaba/nacos/core/namespace/repository/NamespacePersistService.java
+++ b/core/src/main/java/com/alibaba/nacos/core/namespace/repository/NamespacePersistService.java
@@ -39,10 +39,8 @@ public interface NamespacePersistService {
      * @param tenantName     tenant name
      * @param tenantDesc     tenant description
      * @param createResource create resource
-     * @param time           time
      */
-    void insertTenantInfoAtomic(String kp, String tenantId, String tenantName, String tenantDesc, String createResource,
-            final long time);
+    void insertTenantInfoAtomic(String kp, String tenantId, String tenantName, String tenantDesc, String createResource);
     
     //------------------------------------------delete---------------------------------------------//
     

--- a/core/src/main/java/com/alibaba/nacos/core/service/NamespaceOperationService.java
+++ b/core/src/main/java/com/alibaba/nacos/core/service/NamespaceOperationService.java
@@ -122,8 +122,7 @@ public class NamespaceOperationService {
         }
         
         namespacePersistService
-                .insertTenantInfoAtomic(DEFAULT_KP, namespaceId, namespaceName, namespaceDesc, DEFAULT_CREATE_SOURCE,
-                        System.currentTimeMillis());
+                .insertTenantInfoAtomic(DEFAULT_KP, namespaceId, namespaceName, namespaceDesc, DEFAULT_CREATE_SOURCE);
         return true;
     }
     

--- a/core/src/test/java/com/alibaba/nacos/core/namespace/repository/EmbeddedNamespacePersistServiceTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/namespace/repository/EmbeddedNamespacePersistServiceTest.java
@@ -80,8 +80,7 @@ class EmbeddedNamespacePersistServiceTest {
         when(databaseOperate.update(anyList())).thenReturn(true);
         when(dataSourceService.getDataSourceType()).thenReturn("derby");
         
-        embeddedNamespacePersistService.insertTenantInfoAtomic(kp, namespaceId, namespaceName, namespaceDesc, createRes,
-                System.currentTimeMillis());
+        embeddedNamespacePersistService.insertTenantInfoAtomic(kp, namespaceId, namespaceName, namespaceDesc, createRes);
         
         verify(databaseOperate).update(anyList());
     }
@@ -96,10 +95,9 @@ class EmbeddedNamespacePersistServiceTest {
         String createRes = "nacos";
         when(databaseOperate.update(anyList())).thenReturn(false);
         when(dataSourceService.getDataSourceType()).thenReturn("derby");
-        
+
         assertThrows(NacosRuntimeException.class,
-                () -> embeddedNamespacePersistService.insertTenantInfoAtomic(kp, namespaceId, namespaceName, namespaceDesc, createRes,
-                        System.currentTimeMillis()));
+                () -> embeddedNamespacePersistService.insertTenantInfoAtomic(kp, namespaceId, namespaceName, namespaceDesc, createRes));
         
         verify(databaseOperate).update(anyList());
     }

--- a/core/src/test/java/com/alibaba/nacos/core/namespace/repository/ExternalNamespacePersistServiceTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/namespace/repository/ExternalNamespacePersistServiceTest.java
@@ -21,7 +21,6 @@ import com.alibaba.nacos.persistence.configuration.DatasourceConfiguration;
 import com.alibaba.nacos.persistence.datasource.DataSourceService;
 import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
 import com.alibaba.nacos.persistence.exception.NJdbcException;
-import com.alibaba.nacos.persistence.repository.embedded.operate.DatabaseOperate;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,17 +44,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ExternalNamespacePersistServiceTest {
-    
-    @Mock
-    private DatabaseOperate databaseOperate;
-    
+
     @Mock
     private DataSourceService dataSourceService;
     
@@ -86,14 +81,12 @@ class ExternalNamespacePersistServiceTest {
         String namespaceName = "namespaceName";
         String namespaceDesc = "namespaceDesc";
         when(dataSourceService.getDataSourceType()).thenReturn("mysql");
-        externalNamespacePersistService.insertTenantInfoAtomic(kp, namespaceId, namespaceName, namespaceDesc, "nacos",
-                System.currentTimeMillis());
+        externalNamespacePersistService.insertTenantInfoAtomic(kp, namespaceId, namespaceName, namespaceDesc, "nacos");
         
-        when(jt.update(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyLong(), anyLong())).thenThrow(
+        when(jt.update(anyString(), anyString(), anyString(), anyString(), anyString(), anyString())).thenThrow(
                 new NJdbcException("test"));
         assertThrows(DataAccessException.class,
-                () -> externalNamespacePersistService.insertTenantInfoAtomic(kp, namespaceId, namespaceName, namespaceDesc, "nacos",
-                        System.currentTimeMillis()));
+                () -> externalNamespacePersistService.insertTenantInfoAtomic(kp, namespaceId, namespaceName, namespaceDesc, "nacos"));
         
     }
     
@@ -117,8 +110,8 @@ class ExternalNamespacePersistServiceTest {
         String namespaceDesc = "namespaceDesc";
         when(dataSourceService.getDataSourceType()).thenReturn("mysql");
         externalNamespacePersistService.updateTenantNameAtomic(kp, namespaceId, namespaceName, namespaceDesc);
-        
-        when(jt.update(anyString(), anyString(), anyString(), anyLong(), anyString(), anyString())).thenThrow(new NJdbcException("test"));
+
+        when(jt.update(anyString(), anyString(), anyString(), anyString(), anyString())).thenThrow(new NJdbcException("test"));
         assertThrows(DataAccessException.class,
                 () -> externalNamespacePersistService.updateTenantNameAtomic(kp, namespaceId, namespaceName, namespaceDesc));
     }

--- a/core/src/test/java/com/alibaba/nacos/core/service/NamespaceOperationServiceTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/service/NamespaceOperationServiceTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -133,7 +132,7 @@ class NamespaceOperationServiceTest {
         when(namespacePersistService.tenantInfoCountByTenantId(anyString())).thenReturn(0);
         namespaceOperationService.createNamespace(TEST_NAMESPACE_ID, TEST_NAMESPACE_NAME, TEST_NAMESPACE_DESC);
         verify(namespacePersistService).insertTenantInfoAtomic(eq(DEFAULT_KP), eq(TEST_NAMESPACE_ID), eq(TEST_NAMESPACE_NAME),
-                eq(TEST_NAMESPACE_DESC), any(), anyLong());
+                eq(TEST_NAMESPACE_DESC), any());
     }
     
     @Test

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/enums/TrustedSqlFunctionEnum.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/enums/TrustedSqlFunctionEnum.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.enums;
+
+/**
+ * The TrustedSqlFunctionEnum enum class is used to enumerate and manage a list of trusted built-in SQL functions.
+ * By using this enum, you can verify whether a given SQL function is part of the trusted functions list
+ * to avoid potential SQL injection risks.
+ *
+ * @author blake.qiu
+ */
+public enum TrustedSqlFunctionEnum {
+
+    /**
+     * CURRENT_TIMESTAMP.
+     */
+    CURRENT_TIMESTAMP("CURRENT_TIMESTAMP"),
+
+    /**
+     * NOW().
+     */
+    NOW("NOW()");
+
+    private final String function;
+
+    TrustedSqlFunctionEnum(String function) {
+        this.function = function;
+    }
+
+    public String getFunction() {
+        return function;
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoBetaMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoBetaMapper.java
@@ -42,17 +42,17 @@ public interface ConfigInfoBetaMapper extends Mapper {
      * @return The result of updating beta configuration information.
      */
     default MapperResult updateConfigInfo4BetaCas(MapperContext context) {
-        final String sql = "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,src_ip = ?,src_user = ?,gmt_modified = ?,app_name = ? "
+        final String sql = "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,"
+                + "src_ip = ?,src_user = ?,gmt_modified = CURRENT_TIMESTAMP,app_name = ? "
                 + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND (md5 = ? OR md5 is null OR md5 = '')";
-    
+
         List<Object> paramList = new ArrayList<>();
-        
+
         paramList.add(context.getUpdateParameter(FieldConstant.CONTENT));
         paramList.add(context.getUpdateParameter(FieldConstant.MD5));
         paramList.add(context.getUpdateParameter(FieldConstant.BETA_IPS));
         paramList.add(context.getUpdateParameter(FieldConstant.SRC_IP));
         paramList.add(context.getUpdateParameter(FieldConstant.SRC_USER));
-        paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
         paramList.add(context.getUpdateParameter(FieldConstant.APP_NAME));
     
         paramList.add(context.getWhereParameter(FieldConstant.DATA_ID));

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
@@ -492,7 +492,6 @@ public interface ConfigInfoMapper extends Mapper {
         paramList.add(context.getUpdateParameter(FieldConstant.MD5));
         paramList.add(context.getUpdateParameter(FieldConstant.SRC_IP));
         paramList.add(context.getUpdateParameter(FieldConstant.SRC_USER));
-        paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
         paramList.add(context.getUpdateParameter(FieldConstant.APP_NAME));
         paramList.add(context.getUpdateParameter(FieldConstant.C_DESC));
         paramList.add(context.getUpdateParameter(FieldConstant.C_USE));
@@ -504,7 +503,7 @@ public interface ConfigInfoMapper extends Mapper {
         paramList.add(context.getWhereParameter(FieldConstant.GROUP_ID));
         paramList.add(context.getWhereParameter(FieldConstant.TENANT_ID));
         paramList.add(context.getWhereParameter(FieldConstant.MD5));
-        String sql = "UPDATE config_info SET " + "content=?, md5 = ?, src_ip=?,src_user=?,gmt_modified=?,"
+        String sql = "UPDATE config_info SET " + "content=?, md5 = ?, src_ip=?,src_user=?,gmt_modified=CURRENT_TIMESTAMP,"
                 + " app_name=?,c_desc=?,c_use=?,effect=?,type=?,c_schema=?,encrypted_data_key=? "
                 + "WHERE data_id=? AND group_id=? AND tenant_id=? AND (md5=? OR md5 IS NULL OR md5='')";
         return new MapperResult(sql, paramList);

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoTagMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoTagMapper.java
@@ -44,7 +44,6 @@ public interface ConfigInfoTagMapper extends Mapper {
         Object md5 = context.getUpdateParameter(FieldConstant.MD5);
         Object srcIp = context.getUpdateParameter(FieldConstant.SRC_IP);
         Object srcUser = context.getUpdateParameter(FieldConstant.SRC_USER);
-        Object gmtModified = context.getUpdateParameter(FieldConstant.GMT_MODIFIED);
         Object appName = context.getUpdateParameter(FieldConstant.APP_NAME);
         
         Object dataId = context.getWhereParameter(FieldConstant.DATA_ID);
@@ -53,10 +52,10 @@ public interface ConfigInfoTagMapper extends Mapper {
         Object tagId = context.getWhereParameter(FieldConstant.TAG_ID);
         Object oldMd5 = context.getWhereParameter(FieldConstant.MD5);
         String sql =
-                "UPDATE config_info_tag SET content = ?, md5 = ?, src_ip = ?,src_user = ?,gmt_modified = ?,app_name = ? "
+                "UPDATE config_info_tag SET content = ?, md5 = ?, src_ip = ?,src_user = ?,gmt_modified = CURRENT_TIMESTAMP,app_name = ? "
                         + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND tag_id = ? AND (md5 = ? OR md5 IS NULL OR md5 = '')";
         return new MapperResult(sql,
-                CollectionUtils.list(content, md5, srcIp, srcUser, gmtModified, appName, dataId, groupId, tenantId,
+                CollectionUtils.list(content, md5, srcIp, srcUser, appName, dataId, groupId, tenantId,
                         tagId, oldMd5));
     }
     

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/Mapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/Mapper.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.plugin.datasource.mapper;
 
+import com.alibaba.nacos.plugin.datasource.model.ColumnFunctionPair;
+
 import java.util.List;
 
 /**
@@ -25,7 +27,7 @@ import java.util.List;
  **/
 
 public interface Mapper {
-    
+
     /**
      * The select method contains columns and where params.
      * @param columns The columns
@@ -33,29 +35,32 @@ public interface Mapper {
      * @return The sql of select
      */
     String select(List<String> columns, List<String> where);
-    
+
     /**
-     * The insert method contains columns.
-     * @param columns The columns
+     * The insert method contains columnFunctionPairs.
+     *
+     * @param columnFunctionPairs the columnFunctionPairs.
      * @return The sql of insert
      */
-    String insert(List<String> columns);
-    
+    String insert(List<ColumnFunctionPair> columnFunctionPairs);
+
     /**
-     * The update method contains columns and where params.
-     * @param columns The columns
-     * @param where The where params
+     * The update method contains columnFunctionPairs and where params.
+     *
+     * @param columnFunctionPairs The columnFunctionPairs
+     * @param where               The where params
      * @return The sql of update
      */
-    String update(List<String> columns, List<String> where);
-    
+    String update(List<ColumnFunctionPair> columnFunctionPairs, List<String> where);
+
     /**
      * The delete method contains.
+     *
      * @param params The params
      * @return The sql of delete
      */
     String delete(List<String> params);
-    
+
     /**
      * The count method contains where params.
      *
@@ -63,19 +68,19 @@ public interface Mapper {
      * @return The sql of count
      */
     String count(List<String> where);
-    
+
     /**
      * Get the name of table.
      * @return The name of table.
      */
     String getTableName();
-    
+
     /**
      * Get the datasource name.
      * @return The name of datasource.
      */
     String getDataSource();
-    
+
     /**
      * Get config_info table primary keys name.
      * The old default value: Statement.RETURN_GENERATED_KEYS

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/model/ColumnFunctionPair.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/model/ColumnFunctionPair.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.model;
+
+import com.alibaba.nacos.plugin.datasource.enums.TrustedSqlFunctionEnum;
+
+import java.util.Objects;
+
+/**
+ * Column function pair.
+ *
+ * @author blake.qiu
+ */
+public class ColumnFunctionPair {
+    private final String column;
+
+    private final TrustedSqlFunctionEnum functionEnum;
+
+    public ColumnFunctionPair(String column) {
+        this.column = column;
+        this.functionEnum = null;
+    }
+
+    public ColumnFunctionPair(String column, TrustedSqlFunctionEnum functionEnum) {
+        this.column = column;
+        this.functionEnum = functionEnum;
+    }
+
+    /**
+     * New ColumnFunctionPair with column.
+     *
+     * @param columnName columnName
+     * @return ColumnFunctionPair
+     */
+    public static ColumnFunctionPair withColumn(String columnName) {
+        return new ColumnFunctionPair(columnName);
+    }
+
+    /**
+     * New ColumnFunctionPair with column and function.
+     *
+     * @param columnName columnName
+     * @param function   function
+     * @return ColumnFunctionPair
+     */
+    public static ColumnFunctionPair withColumnAndFunction(String columnName, TrustedSqlFunctionEnum function) {
+        return new ColumnFunctionPair(columnName, function);
+    }
+
+    public String getColumn() {
+        return column;
+    }
+
+    public String getFunction() {
+        return functionEnum == null ? null : functionEnum.getFunction();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ColumnFunctionPair that = (ColumnFunctionPair) o;
+        return Objects.equals(getColumn(), that.getColumn());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getColumn());
+    }
+
+    @Override
+    public String toString() {
+        return "ColumnFunctionPair{"
+                + "column='" + column + '\''
+                + ", function='" + this.getFunction() + '\''
+                + '}';
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/enums/TrustedSqlFunctionEnumTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/enums/TrustedSqlFunctionEnumTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.enums;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Trusted sql function enum test.
+ *
+ * @author blake.qiu
+ */
+public class TrustedSqlFunctionEnumTest {
+    @Test
+    public void testGetFunction() {
+        TrustedSqlFunctionEnum currentTimestamp = TrustedSqlFunctionEnum.CURRENT_TIMESTAMP;
+        Assert.assertEquals("CURRENT_TIMESTAMP", currentTimestamp.getFunction());
+        TrustedSqlFunctionEnum now = TrustedSqlFunctionEnum.NOW;
+        Assert.assertEquals("NOW()", now.getFunction());
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoBetaMapperByDerbyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoBetaMapperByDerbyTest.java
@@ -72,7 +72,6 @@ public class ConfigInfoBetaMapperByDerbyTest {
         String newMD5 = "newMD5";
         String srcIp = "1.1.1.1";
         Object srcUser = "nacos";
-        Object time = new Timestamp(System.currentTimeMillis());
         Object appNameTmp = "newAppName";
         Object desc = "description";
         Object use = "use";
@@ -86,7 +85,6 @@ public class ConfigInfoBetaMapperByDerbyTest {
         context.putUpdateParameter(FieldConstant.BETA_IPS, betaIps);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -107,11 +105,10 @@ public class ConfigInfoBetaMapperByDerbyTest {
         
         String sql = mapperResult.getSql();
         Assert.assertEquals(sql, "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,src_ip = ?,src_user = ?,"
-                + "gmt_modified = ?,app_name = ? WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND "
+                + "gmt_modified = CURRENT_TIMESTAMP,app_name = ? WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND "
                 + "(md5 = ? OR md5 is null OR md5 = '')");
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(),
-                new Object[] {newContent, newMD5, betaIps, srcIp, srcUser, time, appNameTmp, dataId, group, tenantId,
-                        md5});
+                new Object[]{newContent, newMD5, betaIps, srcIp, srcUser, appNameTmp, dataId, group, tenantId, md5});
     }
     
     @Test

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
@@ -328,7 +328,6 @@ public class ConfigInfoMapperByDerbyTest {
         String newMD5 = "newMD5";
         String srcIp = "1.1.1.1";
         Object srcUser = "nacos";
-        Object time = new Timestamp(System.currentTimeMillis());
         Object appNameTmp = "newAppName";
         Object desc = "description";
         Object use = "use";
@@ -340,7 +339,6 @@ public class ConfigInfoMapperByDerbyTest {
         context.putUpdateParameter(FieldConstant.MD5, newMD5);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -359,11 +357,11 @@ public class ConfigInfoMapperByDerbyTest {
         
         MapperResult mapperResult = configInfoMapperByDerby.updateConfigInfoAtomicCas(context);
         Assert.assertEquals(mapperResult.getSql(), "UPDATE config_info SET "
-                + "content=?, md5 = ?, src_ip=?,src_user=?,gmt_modified=?, app_name=?,c_desc=?,c_use=?,"
+                + "content=?, md5 = ?, src_ip=?,src_user=?,gmt_modified=CURRENT_TIMESTAMP, app_name=?,c_desc=?,c_use=?,"
                 + "effect=?,type=?,c_schema=?,encrypted_data_key=? "
                 + "WHERE data_id=? AND group_id=? AND tenant_id=? AND (md5=? OR md5 IS NULL OR md5='')");
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(),
-                new Object[] {newContent, newMD5, srcIp, srcUser, time, appNameTmp, desc, use, effect, type, schema,
+                new Object[] {newContent, newMD5, srcIp, srcUser, appNameTmp, desc, use, effect, type, schema,
                         encrypedDataKey, dataId, group, tenantId, md5});
     }
 }

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoTagMapperByDerbyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoTagMapperByDerbyTest.java
@@ -73,7 +73,6 @@ public class ConfigInfoTagMapperByDerbyTest {
         String newMD5 = "newMD5";
         String srcIp = "1.1.1.1";
         Object srcUser = "nacos";
-        Object time = new Timestamp(System.currentTimeMillis());
         Object appNameTmp = "newAppName";
         Object desc = "description";
         Object use = "use";
@@ -85,7 +84,6 @@ public class ConfigInfoTagMapperByDerbyTest {
         context.putUpdateParameter(FieldConstant.MD5, newMD5);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -107,12 +105,11 @@ public class ConfigInfoTagMapperByDerbyTest {
         MapperResult mapperResult = configInfoTagMapperByDerby.updateConfigInfo4TagCas(context);
         
         Assert.assertEquals(mapperResult.getSql(),
-                "UPDATE config_info_tag SET content = ?, md5 = ?, src_ip = ?,src_user = ?,gmt_modified = ?,"
+                "UPDATE config_info_tag SET content = ?, md5 = ?, src_ip = ?,src_user = ?,gmt_modified = CURRENT_TIMESTAMP,"
                         + "app_name = ? WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND tag_id = ? AND "
                         + "(md5 = ? OR md5 IS NULL OR md5 = '')");
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(),
-                new Object[] {newContent, newMD5, srcIp, srcUser, time, appNameTmp, dataId, group, tenantId, tagId,
-                        md5});
+                new Object[]{newContent, newMD5, srcIp, srcUser, appNameTmp, dataId, group, tenantId, tagId, md5});
     }
     
     @Test

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoBetaMapperByMySqlTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoBetaMapperByMySqlTest.java
@@ -72,7 +72,6 @@ public class ConfigInfoBetaMapperByMySqlTest {
         String newMD5 = "newMD5";
         String srcIp = "1.1.1.1";
         Object srcUser = "nacos";
-        Object time = new Timestamp(System.currentTimeMillis());
         Object appNameTmp = "newAppName";
         Object desc = "description";
         Object use = "use";
@@ -86,7 +85,6 @@ public class ConfigInfoBetaMapperByMySqlTest {
         context.putUpdateParameter(FieldConstant.BETA_IPS, betaIps);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -106,12 +104,12 @@ public class ConfigInfoBetaMapperByMySqlTest {
         MapperResult mapperResult = configInfoBetaMapperByMySql.updateConfigInfo4BetaCas(context);
         
         String sql = mapperResult.getSql();
-        List<Object> paramList = mapperResult.getParamList();
         Assert.assertEquals(sql,
-                "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,src_ip = ?,src_user = ?,gmt_modified = ?,app_name = ? "
+                "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,"
+                        + "src_ip = ?,src_user = ?,gmt_modified = CURRENT_TIMESTAMP,app_name = ? "
                         + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND (md5 = ? OR md5 is null OR md5 = '')");
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(),
-                new Object[] {newContent, newMD5, betaIps, srcIp, srcUser, time, appNameTmp, dataId, group, tenantId,
+                new Object[]{newContent, newMD5, betaIps, srcIp, srcUser, appNameTmp, dataId, group, tenantId,
                         md5});
     }
     

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
@@ -358,11 +358,11 @@ public class ConfigInfoMapperByMySqlTest {
         
         MapperResult mapperResult = configInfoMapperByMySql.updateConfigInfoAtomicCas(context);
         Assert.assertEquals(mapperResult.getSql(), "UPDATE config_info SET "
-                + "content=?, md5 = ?, src_ip=?,src_user=?,gmt_modified=?, app_name=?,c_desc=?,"
+                + "content=?, md5 = ?, src_ip=?,src_user=?,gmt_modified=CURRENT_TIMESTAMP, app_name=?,c_desc=?,"
                 + "c_use=?,effect=?,type=?,c_schema=?,encrypted_data_key=? "
                 + "WHERE data_id=? AND group_id=? AND tenant_id=? AND (md5=? OR md5 IS NULL OR md5='')");
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(),
-                new Object[] {newContent, newMD5, srcIp, srcUser, time, appNameTmp, desc, use, effect, type, schema,
+                new Object[]{newContent, newMD5, srcIp, srcUser, appNameTmp, desc, use, effect, type, schema,
                         encryptedDataKey, dataId, group, tenantId, md5});
     }
 }

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoTagMapperByMySqlTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoTagMapperByMySqlTest.java
@@ -73,7 +73,6 @@ public class ConfigInfoTagMapperByMySqlTest {
         String newMD5 = "newMD5";
         String srcIp = "1.1.1.1";
         Object srcUser = "nacos";
-        Object time = new Timestamp(System.currentTimeMillis());
         Object appNameTmp = "newAppName";
         Object desc = "description";
         Object use = "use";
@@ -85,7 +84,6 @@ public class ConfigInfoTagMapperByMySqlTest {
         context.putUpdateParameter(FieldConstant.MD5, newMD5);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -107,12 +105,11 @@ public class ConfigInfoTagMapperByMySqlTest {
         MapperResult mapperResult = configInfoTagMapperByMySql.updateConfigInfo4TagCas(context);
         
         Assert.assertEquals(mapperResult.getSql(),
-                "UPDATE config_info_tag SET content = ?, md5 = ?, src_ip = ?,src_user = ?,gmt_modified = ?,"
+                "UPDATE config_info_tag SET content = ?, md5 = ?, src_ip = ?,src_user = ?,gmt_modified = CURRENT_TIMESTAMP,"
                         + "app_name = ? WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND tag_id = ? AND "
                         + "(md5 = ? OR md5 IS NULL OR md5 = '')");
         Assert.assertArrayEquals(mapperResult.getParamList().toArray(),
-                new Object[] {newContent, newMD5, srcIp, srcUser, time, appNameTmp, dataId, group, tenantId, tagId,
-                        md5});
+                new Object[]{newContent, newMD5, srcIp, srcUser, appNameTmp, dataId, group, tenantId, tagId, md5});
     }
     
     @Test

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
@@ -16,7 +16,9 @@
 
 package com.alibaba.nacos.plugin.datasource.mapper;
 
+import com.alibaba.nacos.plugin.datasource.enums.TrustedSqlFunctionEnum;
 import com.alibaba.nacos.plugin.datasource.impl.mysql.TenantInfoMapperByMySql;
+import com.alibaba.nacos.plugin.datasource.model.ColumnFunctionPair;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,25 +39,48 @@ public class AbstractMapperTest {
         String sql = abstractMapper.select(Arrays.asList("id", "name"), Arrays.asList("id"));
         Assert.assertEquals(sql, "SELECT id,name FROM tenant_info WHERE id = ?");
     }
-    
+
     @Test
     public void testInsert() {
-        String sql = abstractMapper.insert(Arrays.asList("id", "name"));
-        Assert.assertEquals(sql, "INSERT INTO tenant_info(id, name) VALUES(?,?)");
+        String sql = abstractMapper.insert(Arrays.asList(
+                ColumnFunctionPair.withColumn("id"),
+                ColumnFunctionPair.withColumn("name")));
+        Assert.assertEquals(sql, "INSERT INTO tenant_info (id, name) VALUES (?, ?)");
     }
-    
+
+    @Test
+    public void testInsertWithFunction() {
+        String sql = abstractMapper.insert(Arrays.asList(
+                ColumnFunctionPair.withColumn("id"),
+                ColumnFunctionPair.withColumn("name"),
+                ColumnFunctionPair.withColumnAndFunction("gmt_modified", TrustedSqlFunctionEnum.CURRENT_TIMESTAMP)));
+        Assert.assertEquals(sql, "INSERT INTO tenant_info (id, name, gmt_modified) VALUES (?, ?, CURRENT_TIMESTAMP)");
+    }
+
     @Test
     public void testUpdate() {
-        String sql = abstractMapper.update(Arrays.asList("id", "name"), Arrays.asList("id"));
-        Assert.assertEquals(sql, "UPDATE tenant_info SET id = ?,name = ? WHERE id = ?");
+        String sql = abstractMapper.update(Arrays.asList(
+                ColumnFunctionPair.withColumn("id"),
+                ColumnFunctionPair.withColumn("name")), Arrays.asList("id"));
+        Assert.assertEquals(sql, "UPDATE tenant_info SET id = ?, name = ? WHERE id = ?");
     }
-    
+
+    @Test
+    public void testUpdateWithFunction() {
+        String sql = abstractMapper.update(Arrays.asList(
+                        ColumnFunctionPair.withColumn("id"),
+                        ColumnFunctionPair.withColumn("name"),
+                        ColumnFunctionPair.withColumnAndFunction("gmt_modified", TrustedSqlFunctionEnum.CURRENT_TIMESTAMP)),
+                Arrays.asList("id"));
+        Assert.assertEquals(sql, "UPDATE tenant_info SET id = ?, name = ?, gmt_modified = CURRENT_TIMESTAMP WHERE id = ?");
+    }
+
     @Test
     public void testDelete() {
         String sql = abstractMapper.delete(Arrays.asList("id"));
         Assert.assertEquals(sql, "DELETE FROM tenant_info WHERE id = ? ");
     }
-    
+
     @Test
     public void testCount() {
         String sql = abstractMapper.count(Arrays.asList("id"));

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/model/ColumnFunctionPairTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/model/ColumnFunctionPairTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.model;
+
+import com.alibaba.nacos.plugin.datasource.enums.TrustedSqlFunctionEnum;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Column function pair Test.
+ *
+ * @author blake.qiu
+ */
+public class ColumnFunctionPairTest {
+    @Test
+    public void testBuildWithColumn() {
+        ColumnFunctionPair columnFunctionPair = ColumnFunctionPair.withColumn("column");
+        Assert.assertNotNull(columnFunctionPair);
+        Assert.assertEquals("column", columnFunctionPair.getColumn());
+        Assert.assertNull(columnFunctionPair.getFunction());
+    }
+
+    @Test
+    public void testBuildWithColumnAndFunction() {
+        ColumnFunctionPair columnFunctionPair = ColumnFunctionPair.withColumnAndFunction("column", null);
+        Assert.assertNotNull(columnFunctionPair);
+        Assert.assertEquals("column", columnFunctionPair.getColumn());
+        Assert.assertNull(columnFunctionPair.getFunction());
+
+        ColumnFunctionPair columnFunctionPair2 = ColumnFunctionPair.withColumnAndFunction("column", TrustedSqlFunctionEnum.CURRENT_TIMESTAMP);
+        Assert.assertNotNull(columnFunctionPair2);
+        Assert.assertEquals("column", columnFunctionPair.getColumn());
+        Assert.assertEquals(TrustedSqlFunctionEnum.CURRENT_TIMESTAMP.getFunction(), columnFunctionPair2.getFunction());
+
+        ColumnFunctionPair columnFunctionPair3 = ColumnFunctionPair.withColumnAndFunction("column", TrustedSqlFunctionEnum.NOW);
+        Assert.assertNotNull(columnFunctionPair3);
+        Assert.assertEquals("column", columnFunctionPair.getColumn());
+        Assert.assertEquals(TrustedSqlFunctionEnum.NOW.getFunction(), columnFunctionPair3.getFunction());
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxyTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.plugin.datasource.proxy;
 
 import com.alibaba.nacos.plugin.datasource.mapper.Mapper;
+import com.alibaba.nacos.plugin.datasource.model.ColumnFunctionPair;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,22 +41,22 @@ public class MapperProxyTest {
             public String select(List<String> columns, List<String> where) {
                 return "select-test";
             }
-    
+
             @Override
-            public String insert(List<String> columns) {
+            public String insert(List<ColumnFunctionPair> columnFunctionPairs) {
                 return "insert-test";
             }
-    
+
             @Override
-            public String update(List<String> columns, List<String> where) {
+            public String update(List<ColumnFunctionPair> columnFunctionPairs, List<String> where) {
                 return "update-test";
             }
-    
+
             @Override
             public String delete(List<String> params) {
                 return "delete-test";
             }
-    
+
             @Override
             public String count(List<String> where) {
                 return "count-test";


### PR DESCRIPTION
## What is the purpose of the change

XXXXX

fix(#12231 ): When inserting and updating configurations in the database, the time-related field values need to be set using the time obtained from the database's built-in time function.

XX

fix(#12231 ): When inserting and updating configurations in the database, the time-related field values need to be set using the time obtained from the database's built-in time function.

XXXX

fix(#12231 ): When inserting and updating configurations in the database, the time-related field values need to be set using the time obtained from the database's built-in time function.