### PR TITLE
fix(#12231): When inserting and updating configurations in the database, the time-related field values need to be set using the time obtained from the database's built-in time function.

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImpl.java
@@ -125,20 +125,20 @@ public class EmbeddedConfigInfoBetaPersistServiceImpl implements ConfigInfoBetaP
             String md5 = MD5Utils.md5Hex(configInfo.getContent(), Constants.ENCODE);
             ConfigInfoBetaMapper configInfoBetaMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                     TableConstant.CONFIG_INFO_BETA);
-            Timestamp time = new Timestamp(System.currentTimeMillis());
-            
+
             final String sql = configInfoBetaMapper.insert(
                     Arrays.asList("data_id", "group_id", "tenant_id", "app_name", "content", "md5", "beta_ips",
-                            "src_ip", "src_user", "gmt_create", "gmt_modified", "encrypted_data_key"));
-            final Object[] args = new Object[] {configInfo.getDataId(), configInfo.getGroup(), tenantTmp, appNameTmp,
-                    configInfo.getContent(), md5, betaIps, srcIp, srcUser, time, time, encryptedDataKey};
-            
+                            "src_ip", "src_user", "gmt_create@NOW()", "gmt_modified@NOW()", "encrypted_data_key"));
+            final Object[] args = new Object[]{configInfo.getDataId(), configInfo.getGroup(), tenantTmp, appNameTmp,
+                    configInfo.getContent(), md5, betaIps, srcIp, srcUser, encryptedDataKey};
+
+            Timestamp time = new Timestamp(System.currentTimeMillis());
             EmbeddedStorageContextUtils.onModifyConfigBetaInfo(configInfo, betaIps, srcIp, time);
             EmbeddedStorageContextHolder.addSqlContext(sql, args);
-            
+
             databaseOperate.blockUpdate();
             return getBetaOperateResult(configInfo.getDataId(), configInfo.getGroup(), tenantTmp);
-            
+
         } finally {
             EmbeddedStorageContextHolder.cleanAllContext();
         }
@@ -203,20 +203,20 @@ public class EmbeddedConfigInfoBetaPersistServiceImpl implements ConfigInfoBetaP
             String md5 = MD5Utils.md5Hex(configInfo.getContent(), Constants.ENCODE);
             ConfigInfoBetaMapper configInfoBetaMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                     TableConstant.CONFIG_INFO_BETA);
-            Timestamp time = new Timestamp(System.currentTimeMillis());
             final String sql = configInfoBetaMapper.update(
-                    Arrays.asList("content", "md5", "beta_ips", "src_ip", "src_user", "gmt_modified", "app_name",
-                            "encrypted_data_key"), Arrays.asList("data_id", "group_id", "tenant_id"));
-            
-            final Object[] args = new Object[] {configInfo.getContent(), md5, betaIps, srcIp, srcUser, time, appNameTmp,
+                    Arrays.asList("content", "md5", "beta_ips", "src_ip", "src_user", "gmt_modified@NOW()",
+                            "app_name", "encrypted_data_key"), Arrays.asList("data_id", "group_id", "tenant_id"));
+
+            final Object[] args = new Object[]{configInfo.getContent(), md5, betaIps, srcIp, srcUser, appNameTmp,
                     encryptedDataKey, configInfo.getDataId(), configInfo.getGroup(), tenantTmp};
-            
+
+            Timestamp time = new Timestamp(System.currentTimeMillis());
             EmbeddedStorageContextUtils.onModifyConfigBetaInfo(configInfo, betaIps, srcIp, time);
             EmbeddedStorageContextHolder.addSqlContext(sql, args);
-            
+
             databaseOperate.blockUpdate();
             return getBetaOperateResult(configInfo.getDataId(), configInfo.getGroup(), tenantTmp);
-            
+
         } finally {
             EmbeddedStorageContextHolder.cleanAllContext();
         }
@@ -234,29 +234,28 @@ public class EmbeddedConfigInfoBetaPersistServiceImpl implements ConfigInfoBetaP
             
             ConfigInfoBetaMapper configInfoBetaMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                     TableConstant.CONFIG_INFO_BETA);
-            Timestamp time = new Timestamp(System.currentTimeMillis());
             MapperContext context = new MapperContext();
             context.putUpdateParameter(FieldConstant.CONTENT, configInfo.getContent());
             context.putUpdateParameter(FieldConstant.MD5, md5);
             context.putUpdateParameter(FieldConstant.BETA_IPS, betaIps);
             context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
             context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-            context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
             context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
-            
+
             context.putWhereParameter(FieldConstant.DATA_ID, configInfo.getDataId());
             context.putWhereParameter(FieldConstant.GROUP_ID, configInfo.getGroup());
             context.putWhereParameter(FieldConstant.TENANT_ID, tenantTmp);
             context.putWhereParameter(FieldConstant.MD5, configInfo.getMd5());
             MapperResult mapperResult = configInfoBetaMapper.updateConfigInfo4BetaCas(context);
-            
+
             final String sql = mapperResult.getSql();
             List<Object> paramList = mapperResult.getParamList();
             final Object[] args = paramList.toArray();
-            
+
+            Timestamp time = new Timestamp(System.currentTimeMillis());
             EmbeddedStorageContextUtils.onModifyConfigBetaInfo(configInfo, betaIps, srcIp, time);
             EmbeddedStorageContextHolder.addSqlContext(sql, args);
-            
+
             boolean success = databaseOperate.blockUpdate();
             if (success) {
                 return getBetaOperateResult(configInfo.getDataId(), configInfo.getGroup(), tenantTmp);

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
@@ -215,8 +215,8 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
             
             addConfigTagsRelation(configId, configTags, configInfo.getDataId(), configInfo.getGroup(),
                     configInfo.getTenant());
+
             Timestamp now = new Timestamp(System.currentTimeMillis());
-            
             historyConfigInfoPersistService.insertConfigHistoryAtomic(hisId, configInfo, srcIp, srcUser, now, "I");
             EmbeddedStorageContextUtils.onModifyConfigInfo(configInfo, srcIp, now);
             databaseOperate.blockUpdate(consumer);
@@ -264,15 +264,13 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 configInfo.getEncryptedDataKey() == null ? StringUtils.EMPTY : configInfo.getEncryptedDataKey();
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
-        Timestamp time = new Timestamp(System.currentTimeMillis());
-        
+
         final String sql = configInfoMapper.insert(
                 Arrays.asList("id", "data_id", "group_id", "tenant_id", "app_name", "content", "md5", "src_ip",
-                        "src_user", "gmt_create", "gmt_modified", "c_desc", "c_use", "effect", "type", "c_schema",
-                        "encrypted_data_key"));
-        final Object[] args = new Object[] {id, configInfo.getDataId(), configInfo.getGroup(), tenantTmp, appNameTmp,
-                configInfo.getContent(), md5Tmp, srcIp, srcUser, time, time, desc, use, effect, type, schema,
-                encryptedDataKey};
+                        "src_user", "gmt_create@NOW()", "gmt_modified@NOW()", "c_desc", "c_use", "effect",
+                        "type", "c_schema", "encrypted_data_key"));
+        final Object[] args = new Object[]{id, configInfo.getDataId(), configInfo.getGroup(), tenantTmp, appNameTmp,
+                configInfo.getContent(), md5Tmp, srcIp, srcUser, desc, use, effect, type, schema, encryptedDataKey};
         EmbeddedStorageContextHolder.addSqlContext(sql, args);
         return id;
     }
@@ -522,14 +520,11 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
             }
             
             Timestamp time = new Timestamp(System.currentTimeMillis());
-            
             historyConfigInfoPersistService.insertConfigHistoryAtomic(oldConfigInfo.getId(), oldConfigInfo, srcIp,
                     srcUser, time, "U");
-            
             EmbeddedStorageContextUtils.onModifyConfigInfo(configInfo, srcIp, time);
             databaseOperate.blockUpdate();
             return getConfigInfoOperateResult(configInfo.getDataId(), configInfo.getGroup(), tenantTmp);
-            
         } finally {
             EmbeddedStorageContextHolder.cleanAllContext();
         }
@@ -563,11 +558,10 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 addConfigTagsRelation(oldConfigInfo.getId(), configTags, configInfo.getDataId(), configInfo.getGroup(),
                         configInfo.getTenant());
             }
+
             Timestamp time = new Timestamp(System.currentTimeMillis());
-            
             historyConfigInfoPersistService.insertConfigHistoryAtomic(oldConfigInfo.getId(), oldConfigInfo, srcIp,
                     srcUser, time, "U");
-            
             EmbeddedStorageContextUtils.onModifyConfigInfo(configInfo, srcIp, time);
             boolean success = databaseOperate.blockUpdate();
             if (success) {
@@ -594,13 +588,11 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 configInfo.getEncryptedDataKey() == null ? StringUtils.EMPTY : configInfo.getEncryptedDataKey();
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
-        Timestamp time = new Timestamp(System.currentTimeMillis());
         MapperContext context = new MapperContext();
         context.putUpdateParameter(FieldConstant.CONTENT, configInfo.getContent());
         context.putUpdateParameter(FieldConstant.MD5, md5Tmp);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -632,18 +624,17 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         final String schema = configAdvanceInfo == null ? null : (String) configAdvanceInfo.get("schema");
         final String encryptedDataKey =
                 configInfo.getEncryptedDataKey() == null ? StringUtils.EMPTY : configInfo.getEncryptedDataKey();
-        
+
         ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.CONFIG_INFO);
         final String sql = configInfoMapper.update(
-                Arrays.asList("content", "md5", "src_ip", "src_user", "gmt_modified", "app_name", "c_desc", "c_use",
-                        "effect", "type", "c_schema", "encrypted_data_key"),
+                Arrays.asList("content", "md5", "src_ip", "src_user", "gmt_modified@NOW()", "app_name",
+                        "c_desc", "c_use", "effect", "type", "c_schema", "encrypted_data_key"),
                 Arrays.asList("data_id", "group_id", "tenant_id"));
-        Timestamp time = new Timestamp(System.currentTimeMillis());
-        
-        final Object[] args = new Object[] {configInfo.getContent(), md5Tmp, srcIp, srcUser, time, appNameTmp, desc,
+
+        final Object[] args = new Object[]{configInfo.getContent(), md5Tmp, srcIp, srcUser, appNameTmp, desc,
                 use, effect, type, schema, encryptedDataKey, configInfo.getDataId(), configInfo.getGroup(), tenantTmp};
-        
+
         EmbeddedStorageContextHolder.addSqlContext(sql, args);
     }
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImpl.java
@@ -46,7 +46,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 
@@ -94,13 +93,12 @@ public class ExternalConfigInfoBetaPersistServiceImpl implements ConfigInfoBetaP
         try {
             ConfigInfoBetaMapper configInfoBetaMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                     TableConstant.CONFIG_INFO_BETA);
-            Timestamp time = new Timestamp(System.currentTimeMillis());
             
             jt.update(configInfoBetaMapper.insert(
                             Arrays.asList("data_id", "group_id", "tenant_id", "app_name", "content", "md5", "beta_ips",
-                                    "src_ip", "src_user", "gmt_create", "gmt_modified", "encrypted_data_key")),
+                                    "src_ip", "src_user", "gmt_create@NOW()", "gmt_modified@NOW()", "encrypted_data_key")),
                     configInfo.getDataId(), configInfo.getGroup(), tenantTmp, appNameTmp, configInfo.getContent(), md5,
-                    betaIps, srcIp, srcUser, time, time, encryptedDataKey);
+                    betaIps, srcIp, srcUser, encryptedDataKey);
             return getBetaOperateResult(configInfo.getDataId(), configInfo.getGroup(), tenantTmp);
             
         } catch (CannotGetJdbcConnectionException e) {
@@ -165,12 +163,11 @@ public class ExternalConfigInfoBetaPersistServiceImpl implements ConfigInfoBetaP
         try {
             ConfigInfoBetaMapper configInfoBetaMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                     TableConstant.CONFIG_INFO_BETA);
-            Timestamp time = new Timestamp(System.currentTimeMillis());
-            
+
             jt.update(configInfoBetaMapper.update(
-                            Arrays.asList("content", "md5", "beta_ips", "src_ip", "src_user", "gmt_modified", "app_name",
-                                    "encrypted_data_key"), Arrays.asList("data_id", "group_id", "tenant_id")),
-                    configInfo.getContent(), md5, betaIps, srcIp, srcUser, time, appNameTmp, encryptedDataKey,
+                            Arrays.asList("content", "md5", "beta_ips", "src_ip", "src_user", "gmt_modified@NOW()",
+                                    "app_name", "encrypted_data_key"), Arrays.asList("data_id", "group_id", "tenant_id")),
+                    configInfo.getContent(), md5, betaIps, srcIp, srcUser, appNameTmp, encryptedDataKey,
                     configInfo.getDataId(), configInfo.getGroup(), tenantTmp);
             return getBetaOperateResult(configInfo.getDataId(), configInfo.getGroup(), tenantTmp);
             
@@ -214,15 +211,13 @@ public class ExternalConfigInfoBetaPersistServiceImpl implements ConfigInfoBetaP
         try {
             ConfigInfoBetaMapper configInfoBetaMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                     TableConstant.CONFIG_INFO_BETA);
-            Timestamp time = new Timestamp(System.currentTimeMillis());
-            
+
             MapperContext context = new MapperContext();
             context.putUpdateParameter(FieldConstant.CONTENT, configInfo.getContent());
             context.putUpdateParameter(FieldConstant.MD5, md5);
             context.putUpdateParameter(FieldConstant.BETA_IPS, betaIps);
             context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
             context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-            context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
             context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
             
             context.putWhereParameter(FieldConstant.DATA_ID, configInfo.getDataId());

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -234,11 +234,8 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
     PreparedStatement createPsForInsertConfigInfo(final String srcIp, final String srcUser, final ConfigInfo configInfo,
             Map<String, Object> configAdvanceInfo, Connection connection, ConfigInfoMapper configInfoMapper)
             throws SQLException {
-        
-        Timestamp now = new Timestamp(System.currentTimeMillis());
         final String appNameTmp = StringUtils.defaultEmptyIfBlank(configInfo.getAppName());
         final String tenantTmp = StringUtils.defaultEmptyIfBlank(configInfo.getTenant());
-        
         final String desc = configAdvanceInfo == null ? null : (String) configAdvanceInfo.get("desc");
         final String use = configAdvanceInfo == null ? null : (String) configAdvanceInfo.get("use");
         final String effect = configAdvanceInfo == null ? null : (String) configAdvanceInfo.get("effect");
@@ -246,12 +243,11 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         final String schema = configAdvanceInfo == null ? null : (String) configAdvanceInfo.get("schema");
         final String encryptedDataKey =
                 configInfo.getEncryptedDataKey() == null ? StringUtils.EMPTY : configInfo.getEncryptedDataKey();
-        
         final String md5Tmp = MD5Utils.md5Hex(configInfo.getContent(), Constants.ENCODE);
-        
+
         String insertSql = configInfoMapper.insert(
                 Arrays.asList("data_id", "group_id", "tenant_id", "app_name", "content", "md5", "src_ip", "src_user",
-                        "gmt_create", "gmt_modified", "c_desc", "c_use", "effect", "type", "c_schema",
+                        "gmt_create@NOW()", "gmt_modified@NOW()", "c_desc", "c_use", "effect", "type", "c_schema",
                         "encrypted_data_key"));
         PreparedStatement ps = connection.prepareStatement(insertSql, configInfoMapper.getPrimaryKeyGeneratedKeys());
         ps.setString(1, configInfo.getDataId());
@@ -262,14 +258,12 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         ps.setString(6, md5Tmp);
         ps.setString(7, srcIp);
         ps.setString(8, srcUser);
-        ps.setTimestamp(9, now);
-        ps.setTimestamp(10, now);
-        ps.setString(11, desc);
-        ps.setString(12, use);
-        ps.setString(13, effect);
-        ps.setString(14, type);
-        ps.setString(15, schema);
-        ps.setString(16, encryptedDataKey);
+        ps.setString(9, desc);
+        ps.setString(10, use);
+        ps.setString(11, effect);
+        ps.setString(12, type);
+        ps.setString(13, schema);
+        ps.setString(14, encryptedDataKey);
         return ps;
     }
     
@@ -528,8 +522,8 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                     addConfigTagsRelation(oldConfigInfo.getId(), configTags, configInfo.getDataId(),
                             configInfo.getGroup(), configInfo.getTenant());
                 }
+
                 Timestamp now = new Timestamp(System.currentTimeMillis());
-                
                 historyConfigInfoPersistService.insertConfigHistoryAtomic(oldConfigInfo.getId(), oldConfigInfo, srcIp,
                         srcUser, now, "U");
                 return getConfigInfoOperateResult(configInfo.getDataId(), configInfo.getGroup(),
@@ -615,14 +609,12 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         try {
             ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                     TableConstant.CONFIG_INFO);
-            Timestamp now = new Timestamp(System.currentTimeMillis());
-            
+
             MapperContext context = new MapperContext();
             context.putUpdateParameter(FieldConstant.CONTENT, configInfo.getContent());
             context.putUpdateParameter(FieldConstant.MD5, md5Tmp);
             context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
             context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-            context.putUpdateParameter(FieldConstant.GMT_MODIFIED, now);
             context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
             context.putUpdateParameter(FieldConstant.C_DESC, desc);
             context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -656,18 +648,15 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         String schema = configAdvanceInfo == null ? null : (String) configAdvanceInfo.get("schema");
         final String encryptedDataKey =
                 configInfo.getEncryptedDataKey() == null ? StringUtils.EMPTY : configInfo.getEncryptedDataKey();
-        
         try {
             ConfigInfoMapper configInfoMapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                     TableConstant.CONFIG_INFO);
-            Timestamp now = new Timestamp(System.currentTimeMillis());
-            
             jt.update(configInfoMapper.update(
-                            Arrays.asList("content", "md5", "src_ip", "src_user", "gmt_modified", "app_name", "c_desc", "c_use",
-                                    "effect", "type", "c_schema", "encrypted_data_key"),
-                            Arrays.asList("data_id", "group_id", "tenant_id")), configInfo.getContent(), md5Tmp, srcIp, srcUser,
-                    now, appNameTmp, desc, use, effect, type, schema, encryptedDataKey, configInfo.getDataId(),
-                    configInfo.getGroup(), tenantTmp);
+                            Arrays.asList("content", "md5", "src_ip", "src_user", "gmt_modified@NOW()",
+                                    "app_name", "c_desc", "c_use", "effect", "type", "c_schema", "encrypted_data_key"),
+                            Arrays.asList("data_id", "group_id", "tenant_id")),
+                    configInfo.getContent(), md5Tmp, srcIp, srcUser, appNameTmp, desc, use, effect, type, schema,
+                    encryptedDataKey, configInfo.getDataId(), configInfo.getGroup(), tenantTmp);
         } catch (CannotGetJdbcConnectionException e) {
             LogUtil.FATAL_LOG.error("[db-error] " + e, e);
             throw e;

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImplTest.java
@@ -37,7 +37,6 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -124,10 +123,9 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
         assertEquals(mockedConfigInfoStateWrapper.getLastModified(), configOperateResult.getLastModified());
         //verify update to be invoked
         embeddedStorageContextHolderMockedStatic.verify(
-                () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(configInfo.getContent()), eq(configInfo.getMd5()),
-                        eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(configInfo.getAppName()),
+                () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(configInfo.getContent()),
+                        eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), eq(configInfo.getAppName()),
                         eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group), eq(tenant)), times(1));
-        
     }
     
     @Test
@@ -162,8 +160,8 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
         //verify add to be invoked
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(dataId), eq(group), eq(tenant),
-                        eq(configInfo.getAppName()), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(betaIps), eq(srcIp),
-                        eq(srcUser), any(Timestamp.class), any(Timestamp.class), eq(configInfo.getEncryptedDataKey())), times(1));
+                        eq(configInfo.getAppName()), eq(configInfo.getContent()), eq(configInfo.getMd5()),
+                        eq(betaIps), eq(srcIp), eq(srcUser), eq(configInfo.getEncryptedDataKey())), times(1));
     }
     
     @Test
@@ -202,7 +200,7 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
         //verify cas update to be invoked
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(configInfo.getContent()),
-                        eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class),
+                        eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(betaIps), eq(srcIp), eq(srcUser),
                         eq(appName), eq(dataId), eq(group), eq(tenant), eq(configInfo.getMd5())), times(1));
         
     }
@@ -239,8 +237,8 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
         //verify add to be invoked
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(dataId), eq(group), eq(tenant),
-                        eq(configInfo.getAppName()), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(betaIps), eq(srcIp),
-                        eq(srcUser), any(Timestamp.class), any(Timestamp.class), eq(configInfo.getEncryptedDataKey())), times(1));
+                        eq(configInfo.getAppName()), eq(configInfo.getContent()), eq(configInfo.getMd5()),
+                        eq(betaIps), eq(srcIp), eq(srcUser), eq(configInfo.getEncryptedDataKey())), times(1));
         
     }
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
@@ -164,8 +164,8 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         //expect insert config info invoked.
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), anyLong(), eq(dataId), eq(group), eq(tenant), eq(appName),
-                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class),
-                        any(Timestamp.class), eq(desc), eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDataKey)), times(1));
+                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), eq(desc),
+                        eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDataKey)), times(1));
         //expect insert config tags
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), anyLong(), eq("tag1"), eq(StringUtils.EMPTY), eq(dataId),
@@ -221,8 +221,8 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         //expect insert config info invoked.
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), anyLong(), eq(dataId), eq(group), eq(tenant), eq(appName),
-                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class),
-                        any(Timestamp.class), eq(desc), eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDatakey)), times(1));
+                        eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser),
+                        eq(desc), eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDatakey)), times(1));
         //expect insert config tags
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), anyLong(), eq("tag1"), eq(StringUtils.EMPTY), eq(dataId),
@@ -281,7 +281,7 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         
         //expect update config info invoked.
         embeddedStorageContextHolderMockedStatic.verify(() -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(content),
-                eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName), eq(desc),
+                eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), eq(appName), eq(desc),
                 eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDataKey), eq(dataId), eq(group), eq(tenant)), times(1));
         
         //expect insert config tags
@@ -347,7 +347,7 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         //expect update config info invoked.
         embeddedStorageContextHolderMockedStatic.verify(
                 () -> EmbeddedStorageContextHolder.addSqlContext(eq(Boolean.TRUE), anyString(), eq(content),
-                        eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName),
+                        eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser), eq(appName),
                         eq(desc), eq(use), eq(effect), eq(type), eq(schema), eq(encryptedDataKey), eq(dataId), eq(group), eq(tenant),
                         eq(casMd5)), times(1));
         

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImplTest.java
@@ -41,7 +41,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,7 +49,6 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -129,8 +127,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         //verify update to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser),
-                        any(Timestamp.class), eq(configInfo.getAppName()), eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group),
-                        eq(tenant));
+                        eq(configInfo.getAppName()), eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group), eq(tenant));
     }
     
     @Test
@@ -165,8 +162,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         //verify add to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(dataId), eq(group), eq(tenant), eq(configInfo.getAppName()), eq(configInfo.getContent()),
-                        eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), any(Timestamp.class),
-                        eq(configInfo.getEncryptedDataKey()));
+                        eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), eq(configInfo.getEncryptedDataKey()));
         
     }
     
@@ -195,7 +191,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         
         // mock update throw CannotGetJdbcConnectionException
         when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser),
-                any(Timestamp.class), eq(configInfo.getAppName()), eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group),
+                eq(configInfo.getAppName()), eq(configInfo.getEncryptedDataKey()), eq(dataId), eq(group),
                 eq(tenant))).thenThrow(new CannotGetJdbcConnectionException("mock fail"));
         //execute of update& expect.
         try {
@@ -204,13 +200,13 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         } catch (Exception exception) {
             assertEquals("mock fail", exception.getMessage());
         }
-        
+
         //mock query return null
-        when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant}),
+        when(jdbcTemplate.queryForObject(anyString(), eq(new Object[]{dataId, group, tenant}),
                 eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
         //mock add throw CannotGetJdbcConnectionException
-        when(jdbcTemplate.update(anyString(), eq(dataId), eq(group), eq(tenant), eq(configInfo.getAppName()), eq(configInfo.getContent()),
-                eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), any(Timestamp.class),
+        when(jdbcTemplate.update(anyString(), eq(dataId), eq(group), eq(tenant), eq(configInfo.getAppName()),
+                eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser),
                 eq(configInfo.getEncryptedDataKey()))).thenThrow(new CannotGetJdbcConnectionException("mock fail add"));
         //execute of add& expect.
         try {
@@ -219,7 +215,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         } catch (Exception exception) {
             assertEquals("mock fail add", exception.getMessage());
         }
-        
+
         //mock query throw CannotGetJdbcConnectionException
         when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant}),
                 eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenThrow(new CannotGetJdbcConnectionException("get c fail"));
@@ -259,7 +255,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         configInfo.setMd5("casMd5");
         //mock cas update
         when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)),
-                eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName), eq(dataId), eq(group), eq(tenant),
+                eq(betaIps), eq(srcIp), eq(srcUser), eq(appName), eq(dataId), eq(group), eq(tenant),
                 eq(configInfo.getMd5()))).thenReturn(1);
         
         ConfigOperateResult configOperateResult = externalConfigInfoBetaPersistService.insertOrUpdateBetaCas(configInfo, betaIps, srcIp,
@@ -270,8 +266,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         //verify cas update to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(configInfo.getContent()), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(betaIps),
-                        eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName), eq(dataId), eq(group), eq(tenant),
-                        eq(configInfo.getMd5()));
+                        eq(srcIp), eq(srcUser), eq(appName), eq(dataId), eq(group), eq(tenant), eq(configInfo.getMd5()));
         
     }
     
@@ -307,8 +302,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         //verify add to be invoked
         Mockito.verify(jdbcTemplate, times(1))
                 .update(anyString(), eq(dataId), eq(group), eq(tenant), eq(configInfo.getAppName()), eq(configInfo.getContent()),
-                        eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), any(Timestamp.class),
-                        eq(configInfo.getEncryptedDataKey()));
+                        eq(configInfo.getMd5()), eq(betaIps), eq(srcIp), eq(srcUser), eq(configInfo.getEncryptedDataKey()));
         
     }
     
@@ -337,7 +331,7 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
         configInfo.setMd5("casMd5");
         // mock update throw CannotGetJdbcConnectionException
         when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)),
-                eq(betaIps), eq(srcIp), eq(srcUser), any(Timestamp.class), eq(appName), eq(dataId), eq(group), eq(tenant),
+                eq(betaIps), eq(srcIp), eq(srcUser), eq(appName), eq(dataId), eq(group), eq(tenant),
                 eq(configInfo.getMd5()))).thenThrow(new CannotGetJdbcConnectionException("mock fail"));
         //execute of update& expect.
         try {
@@ -352,8 +346,8 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
                 eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
         //mock add throw CannotGetJdbcConnectionException
         when(jdbcTemplate.update(anyString(), eq(dataId), eq(group), eq(tenant), eq(configInfo.getAppName()), eq(configInfo.getContent()),
-                eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(betaIps), eq(srcIp), eq(srcUser),
-                any(Timestamp.class), any(Timestamp.class), eq(configInfo.getEncryptedDataKey()))).thenThrow(
+                eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), eq(betaIps), eq(srcIp),
+                eq(srcUser), eq(configInfo.getEncryptedDataKey()))).thenThrow(
                 new CannotGetJdbcConnectionException("mock fail add"));
         
         //execute of add& expect.

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
@@ -302,9 +302,9 @@ class ExternalConfigInfoPersistServiceImplTest {
         //mock update config info
         Mockito.when(jdbcTemplate.update(eq(externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                 TableConstant.CONFIG_INFO)
-                        .update(Arrays.asList("content", "md5", "src_ip", "src_user", "gmt_modified", "app_name", "c_desc", "c_use", "effect",
-                                "type", "c_schema", "encrypted_data_key"), Arrays.asList("data_id", "group_id", "tenant_id"))),
-                eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(srcIp), eq(srcUser), any(), eq(configInfoWrapperOld.getAppName()),
+                        .update(Arrays.asList("content", "md5", "src_ip", "src_user", "gmt_modified@NOW()", "app_name", "c_desc", "c_use",
+                                "effect", "type", "c_schema", "encrypted_data_key"), Arrays.asList("data_id", "group_id", "tenant_id"))),
+                eq(configInfo.getContent()), eq(configInfo.getMd5()), eq(srcIp), eq(srcUser), eq(configInfoWrapperOld.getAppName()),
                 eq(configAdvanceInfo.get("desc")), eq(configAdvanceInfo.get("use")), eq(configAdvanceInfo.get("effect")),
                 eq(configAdvanceInfo.get("type")), eq(configAdvanceInfo.get("schema")), eq(encryptedDataKey), eq(configInfo.getDataId()),
                 eq(configInfo.getGroup()), eq(tenant))).thenReturn(1);
@@ -343,7 +343,6 @@ class ExternalConfigInfoPersistServiceImplTest {
     
     @Test
     void testInsertOrUpdateCasOfUpdateConfigSuccess() {
-        
         Map<String, Object> configAdvanceInfo = new HashMap<>();
         configAdvanceInfo.put("config_tags", "tag1,tag2");
         configAdvanceInfo.put("desc", "desc11");
@@ -373,22 +372,22 @@ class ExternalConfigInfoPersistServiceImplTest {
         configInfoWrapperOld.setAppName("old_app11");
         configInfoWrapperOld.setMd5("old_md5");
         configInfoWrapperOld.setId(123456799L);
-        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant}), eq(CONFIG_INFO_WRAPPER_ROW_MAPPER)))
+        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[]{dataId, group, tenant}), eq(CONFIG_INFO_WRAPPER_ROW_MAPPER)))
                 .thenReturn(configInfoWrapperOld);
         String srcIp = "srcIp";
         String srcUser = "srcUser";
         //mock update config info cas
-        Mockito.when(jdbcTemplate.update(anyString(), eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp),
-                eq(srcUser), any(Timestamp.class), eq(configInfoWrapperOld.getAppName()), eq(configAdvanceInfo.get("desc")),
+        Mockito.when(jdbcTemplate.update(anyString(), eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)),
+                eq(srcIp), eq(srcUser), eq(configInfoWrapperOld.getAppName()), eq(configAdvanceInfo.get("desc")),
                 eq(configAdvanceInfo.get("use")), eq(configAdvanceInfo.get("effect")), eq(configAdvanceInfo.get("type")),
                 eq(configAdvanceInfo.get("schema")), eq(encryptedDataKey), eq(dataId), eq(group), eq(tenant), eq(casMd5))).thenReturn(1);
-        
+
         //mock insert config tags.
         Mockito.when(jdbcTemplate.update(eq(externalConfigInfoPersistService.mapperManager.findMapper(dataSourceService.getDataSourceType(),
                                 TableConstant.CONFIG_TAGS_RELATION)
                         .insert(Arrays.asList("id", "tag_name", "tag_type", "data_id", "group_id", "tenant_id"))), eq(configInfoWrapperOld.getId()),
                 anyString(), eq(StringUtils.EMPTY), eq(dataId), eq(group), eq(tenant))).thenReturn(1);
-        
+
         //mock insert his config info
         Mockito.doNothing().when(historyConfigInfoPersistService)
                 .insertConfigHistoryAtomic(eq(configInfoWrapperOld.getId()), eq(configInfo), eq(srcIp), eq(srcUser), any(Timestamp.class),
@@ -397,8 +396,8 @@ class ExternalConfigInfoPersistServiceImplTest {
         externalConfigInfoPersistService.insertOrUpdateCas(srcIp, srcUser, configInfo, configAdvanceInfo);
         //expect update config cas
         Mockito.verify(jdbcTemplate, times(1))
-                .update(anyString(), eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp), eq(srcUser),
-                        any(Timestamp.class), eq(configInfoWrapperOld.getAppName()), eq(configAdvanceInfo.get("desc")),
+                .update(anyString(), eq(content), eq(MD5Utils.md5Hex(content, Constants.PERSIST_ENCODE)), eq(srcIp),
+                        eq(srcUser), eq(configInfoWrapperOld.getAppName()), eq(configAdvanceInfo.get("desc")),
                         eq(configAdvanceInfo.get("use")), eq(configAdvanceInfo.get("effect")), eq(configAdvanceInfo.get("type")),
                         eq(configAdvanceInfo.get("schema")), eq(encryptedDataKey), eq(dataId), eq(group), eq(tenant), eq(casMd5));
         
@@ -448,8 +447,6 @@ class ExternalConfigInfoPersistServiceImplTest {
         externalConfigInfoPersistService.createPsForInsertConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo, mockConnection,
                 configInfoMapper);
         Mockito.verify(preparedStatement, times(14)).setString(anyInt(), anyString());
-        Mockito.verify(preparedStatement, times(2)).setTimestamp(anyInt(), any(Timestamp.class));
-        
     }
     
     @Test

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/enums/derby/TrustedDerbylFunctionEnum.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/enums/derby/TrustedDerbylFunctionEnum.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.enums.derby;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The TrustedSqlFunctionEnum enum class is used to enumerate and manage a list of trusted built-in SQL functions.
+ * By using this enum, you can verify whether a given SQL function is part of the trusted functions list
+ * to avoid potential SQL injection risks.
+ *
+ * @author blake.qiu
+ */
+public enum TrustedDerbylFunctionEnum {
+
+    /**
+     * NOW().
+     */
+    NOW("NOW()", "CURRENT_TIMESTAMP");
+
+    private static final Map<String, TrustedDerbylFunctionEnum> LOOKUP_MAP = new HashMap<>();
+
+    static {
+        for (TrustedDerbylFunctionEnum entry : TrustedDerbylFunctionEnum.values()) {
+            LOOKUP_MAP.put(entry.functionName, entry);
+        }
+    }
+
+    private final String functionName;
+
+    private final String function;
+
+    TrustedDerbylFunctionEnum(String functionName, String function) {
+        this.functionName = functionName;
+        this.function = function;
+    }
+
+    /**
+     * Get the function name.
+     *
+     * @param functionName function name
+     * @return function
+     */
+    public static String getFunctionByName(String functionName) {
+        TrustedDerbylFunctionEnum entry = LOOKUP_MAP.get(functionName);
+        if (entry != null) {
+            return entry.function;
+        }
+        throw new IllegalArgumentException(String.format("Invalid function name: %s", functionName));
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/enums/mysql/TrustedMysqlFunctionEnum.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/enums/mysql/TrustedMysqlFunctionEnum.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.enums.mysql;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The TrustedSqlFunctionEnum enum class is used to enumerate and manage a list of trusted built-in SQL functions.
+ * By using this enum, you can verify whether a given SQL function is part of the trusted functions list
+ * to avoid potential SQL injection risks.
+ *
+ * @author blake.qiu
+ */
+public enum TrustedMysqlFunctionEnum {
+
+    /**
+     * NOW().
+     */
+    NOW("NOW()", "NOW(3)");
+
+    private static final Map<String, TrustedMysqlFunctionEnum> LOOKUP_MAP = new HashMap<>();
+
+    static {
+        for (TrustedMysqlFunctionEnum entry : TrustedMysqlFunctionEnum.values()) {
+            LOOKUP_MAP.put(entry.functionName, entry);
+        }
+    }
+
+    private final String functionName;
+
+    private final String function;
+
+    TrustedMysqlFunctionEnum(String functionName, String function) {
+        this.functionName = functionName;
+        this.function = function;
+    }
+
+    /**
+     * Get the function name.
+     *
+     * @param functionName function name
+     * @return function
+     */
+    public static String getFunctionByName(String functionName) {
+        TrustedMysqlFunctionEnum entry = LOOKUP_MAP.get(functionName);
+        if (entry != null) {
+            return entry.function;
+        }
+        throw new IllegalArgumentException(String.format("Invalid function name: %s", functionName));
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/AbstractMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/AbstractMapperByDerby.java
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-package com.alibaba.nacos.plugin.datasource.impl.mysql;
+package com.alibaba.nacos.plugin.datasource.impl.derby;
 
-import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.TenantInfoMapper;
+import com.alibaba.nacos.plugin.datasource.enums.derby.TrustedDerbylFunctionEnum;
+import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 
 /**
- * The mysql implementation of TenantInfoMapper.
+ * The abstract derby mapper contains CRUD methods.
  *
- * @author hyx
+ * @author blake.qiu
  **/
-
-public class TenantInfoMapperByMySql extends AbstractMapperByMysql implements TenantInfoMapper {
+public abstract class AbstractMapperByDerby extends AbstractMapper {
 
     @Override
-    public String getDataSource() {
-        return DataSourceConstant.MYSQL;
+    public String getFunction(String functionName) {
+        return TrustedDerbylFunctionEnum.getFunctionByName(functionName);
     }
+
 }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoAggrMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoAggrMapperByDerby.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.derby;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoAggrMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -31,8 +30,8 @@ import java.util.List;
  *
  * @author hyx
  **/
-public class ConfigInfoAggrMapperByDerby extends AbstractMapper implements ConfigInfoAggrMapper {
-    
+public class ConfigInfoAggrMapperByDerby extends AbstractMapperByDerby implements ConfigInfoAggrMapper {
+
     @Override
     public MapperResult findConfigInfoAggrByPageFetchRows(MapperContext context) {
         final Integer startRow = context.getStartRow();
@@ -40,7 +39,7 @@ public class ConfigInfoAggrMapperByDerby extends AbstractMapper implements Confi
         final String dataId = (String) context.getWhereParameter(FieldConstant.DATA_ID);
         final String groupId = (String) context.getWhereParameter(FieldConstant.GROUP_ID);
         final String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
-        
+
         String sql =
                 "SELECT data_id,group_id,tenant_id,datum_id,app_name,content FROM config_info_aggr WHERE data_id=? AND "
                         + "group_id=? AND tenant_id=? ORDER BY datum_id OFFSET " + startRow + " ROWS FETCH NEXT "

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoBetaMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoBetaMapperByDerby.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.plugin.datasource.impl.derby;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoBetaMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -31,17 +30,17 @@ import java.util.List;
  * @author hyx
  **/
 
-public class ConfigInfoBetaMapperByDerby extends AbstractMapper implements ConfigInfoBetaMapper {
+public class ConfigInfoBetaMapperByDerby extends AbstractMapperByDerby implements ConfigInfoBetaMapper {
 
     @Override
     public MapperResult findAllConfigInfoBetaForDumpAllFetchRows(MapperContext context) {
         Integer startRow = context.getStartRow();
         int pageSize = context.getPageSize();
-        
+
         String sql = "SELECT t.id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,beta_ips "
                 + " FROM (  SELECT id FROM config_info_beta ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT "
                 + pageSize + " ROWS ONLY  )" + " g, config_info_beta t WHERE g.id = t.id";
-    
+
         List<Object> paramList = new ArrayList<>();
         paramList.add(startRow);
         paramList.add(pageSize);

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
@@ -22,7 +22,6 @@ import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -38,13 +37,13 @@ import java.util.List;
  * @author hyx
  **/
 
-public class ConfigInfoMapperByDerby extends AbstractMapper implements ConfigInfoMapper {
-    
+public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements ConfigInfoMapper {
+
     @Override
     public MapperResult findConfigInfoByAppFetchRows(MapperContext context) {
         final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
         final String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
-        
+
         String sql =
                 "SELECT ID,data_id,group_id,tenant_id,app_name,content FROM config_info WHERE tenant_id LIKE ? AND "
                         + "app_name = ?" + " OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoTagMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoTagMapperByDerby.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.plugin.datasource.impl.derby;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoTagMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -30,8 +29,8 @@ import java.util.Collections;
  * @author hyx
  **/
 
-public class ConfigInfoTagMapperByDerby extends AbstractMapper implements ConfigInfoTagMapper {
-    
+public class ConfigInfoTagMapperByDerby extends AbstractMapperByDerby implements ConfigInfoTagMapper {
+
     @Override
     public MapperResult findAllConfigInfoTagForDumpAllFetchRows(MapperContext context) {
         String sql = "SELECT t.id,data_id,group_id,tenant_id,tag_id,app_name,content,md5,gmt_modified "
@@ -40,7 +39,7 @@ public class ConfigInfoTagMapperByDerby extends AbstractMapper implements Config
                 + " g, config_info_tag t  WHERE g.id = t.id";
         return new MapperResult(sql, Collections.emptyList());
     }
-    
+
     @Override
     public String getDataSource() {
         return DataSourceConstant.DERBY;

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoTagsRelationMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoTagsRelationMapperByDerby.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.derby;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigTagsRelationMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -33,8 +32,8 @@ import java.util.List;
  * @author hyx
  **/
 
-public class ConfigInfoTagsRelationMapperByDerby extends AbstractMapper implements ConfigTagsRelationMapper {
-    
+public class ConfigInfoTagsRelationMapperByDerby extends AbstractMapperByDerby implements ConfigTagsRelationMapper {
+
     @Override
     public MapperResult findConfigInfo4PageFetchRows(MapperContext context) {
         final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
@@ -43,7 +42,7 @@ public class ConfigInfoTagsRelationMapperByDerby extends AbstractMapper implemen
         final String content = (String) context.getWhereParameter(FieldConstant.CONTENT);
         final String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
         final String[] tagArr = (String[]) context.getWhereParameter(FieldConstant.TAG_ARR);
-        
+
         List<Object> paramList = new ArrayList<>();
         StringBuilder where = new StringBuilder(" WHERE ");
         final String baseSql =

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/GroupCapacityMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/GroupCapacityMapperByDerby.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.derby;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.GroupCapacityMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -29,13 +28,13 @@ import com.alibaba.nacos.plugin.datasource.model.MapperResult;
  *
  * @author lixiaoshuang
  */
-public class GroupCapacityMapperByDerby extends AbstractMapper implements GroupCapacityMapper {
-    
+public class GroupCapacityMapperByDerby extends AbstractMapperByDerby implements GroupCapacityMapper {
+
     @Override
     public String getDataSource() {
         return DataSourceConstant.DERBY;
     }
-    
+
     @Override
     public MapperResult selectGroupInfoBySize(MapperContext context) {
         String sql = "SELECT id, group_id FROM group_capacity WHERE id > ? OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY";

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/HistoryConfigInfoMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/HistoryConfigInfoMapperByDerby.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.derby;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.HistoryConfigInfoMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -30,8 +29,8 @@ import com.alibaba.nacos.plugin.datasource.model.MapperResult;
  * @author hyx
  **/
 
-public class HistoryConfigInfoMapperByDerby extends AbstractMapper implements HistoryConfigInfoMapper {
-    
+public class HistoryConfigInfoMapperByDerby extends AbstractMapperByDerby implements HistoryConfigInfoMapper {
+
     @Override
     public MapperResult removeConfigHistory(MapperContext context) {
         String sql = "DELETE FROM his_config_info WHERE id IN( "
@@ -39,7 +38,7 @@ public class HistoryConfigInfoMapperByDerby extends AbstractMapper implements Hi
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.START_TIME),
                 context.getWhereParameter(FieldConstant.LIMIT_SIZE)));
     }
-    
+
     @Override
     public MapperResult pageFindConfigHistoryFetchRows(MapperContext context) {
         String sql =

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/TenantCapacityMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/TenantCapacityMapperByDerby.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.derby;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.TenantCapacityMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -30,13 +29,13 @@ import com.alibaba.nacos.plugin.datasource.model.MapperResult;
  * @author hyx
  **/
 
-public class TenantCapacityMapperByDerby extends AbstractMapper implements TenantCapacityMapper {
-    
+public class TenantCapacityMapperByDerby extends AbstractMapperByDerby implements TenantCapacityMapper {
+
     @Override
     public String getDataSource() {
         return DataSourceConstant.DERBY;
     }
-    
+
     @Override
     public MapperResult getCapacityList4CorrectUsage(MapperContext context) {
         String sql = "SELECT id, tenant_id FROM tenant_capacity WHERE id>? OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY";

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/TenantInfoMapperByDerby.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/TenantInfoMapperByDerby.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.plugin.datasource.impl.derby;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.TenantInfoMapper;
 
 /**
@@ -26,7 +25,7 @@ import com.alibaba.nacos.plugin.datasource.mapper.TenantInfoMapper;
  * @author hyx
  **/
 
-public class TenantInfoMapperByDerby extends AbstractMapper implements TenantInfoMapper {
+public class TenantInfoMapperByDerby extends AbstractMapperByDerby implements TenantInfoMapper {
 
     @Override
     public String getDataSource() {

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/AbstractMapperByMysql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/AbstractMapperByMysql.java
@@ -16,19 +16,18 @@
 
 package com.alibaba.nacos.plugin.datasource.impl.mysql;
 
-import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.TenantInfoMapper;
+import com.alibaba.nacos.plugin.datasource.enums.mysql.TrustedMysqlFunctionEnum;
+import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 
 /**
- * The mysql implementation of TenantInfoMapper.
+ * The abstract mysql mapper contains CRUD methods.
  *
- * @author hyx
+ * @author blake.qiu
  **/
-
-public class TenantInfoMapperByMySql extends AbstractMapperByMysql implements TenantInfoMapper {
+public abstract class AbstractMapperByMysql extends AbstractMapper {
 
     @Override
-    public String getDataSource() {
-        return DataSourceConstant.MYSQL;
+    public String getFunction(String functionName) {
+        return TrustedMysqlFunctionEnum.getFunctionByName(functionName);
     }
 }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoAggrMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoAggrMapperByMySql.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.mysql;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoAggrMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -31,16 +30,16 @@ import java.util.List;
  *
  * @author hyx
  **/
-public class ConfigInfoAggrMapperByMySql extends AbstractMapper implements ConfigInfoAggrMapper {
-    
+public class ConfigInfoAggrMapperByMySql extends AbstractMapperByMysql implements ConfigInfoAggrMapper {
+
     @Override
     public MapperResult findConfigInfoAggrByPageFetchRows(MapperContext context) {
-        int startRow =  context.getStartRow();
-        int pageSize =  context.getPageSize();
+        int startRow = context.getStartRow();
+        int pageSize = context.getPageSize();
         String dataId = (String) context.getWhereParameter(FieldConstant.DATA_ID);
         String groupId = (String) context.getWhereParameter(FieldConstant.GROUP_ID);
         String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
-        
+
         String sql =
                 "SELECT data_id,group_id,tenant_id,datum_id,app_name,content FROM config_info_aggr WHERE data_id= ? AND "
                         + "group_id= ? AND tenant_id= ? ORDER BY datum_id LIMIT " + startRow + "," + pageSize;

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoBetaMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoBetaMapperByMySql.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.plugin.datasource.impl.mysql;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoBetaMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -31,7 +30,7 @@ import java.util.List;
  * @author hyx
  **/
 
-public class ConfigInfoBetaMapperByMySql extends AbstractMapper implements ConfigInfoBetaMapper {
+public class ConfigInfoBetaMapperByMySql extends AbstractMapperByMysql implements ConfigInfoBetaMapper {
 
     @Override
     public MapperResult findAllConfigInfoBetaForDumpAllFetchRows(MapperContext context) {

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
@@ -22,7 +22,6 @@ import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -38,16 +37,16 @@ import java.util.List;
  * @author hyx
  **/
 
-public class ConfigInfoMapperByMySql extends AbstractMapper implements ConfigInfoMapper {
-    
+public class ConfigInfoMapperByMySql extends AbstractMapperByMysql implements ConfigInfoMapper {
+
     private static final String DATA_ID = "dataId";
-    
+
     private static final String GROUP = "group";
-    
+
     private static final String APP_NAME = "appName";
-    
+
     private static final String CONTENT = "content";
-    
+
     private static final String TENANT = "tenant";
     
     @Override

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoTagMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoTagMapperByMySql.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.plugin.datasource.impl.mysql;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoTagMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -30,8 +29,8 @@ import java.util.Collections;
  * @author hyx
  **/
 
-public class ConfigInfoTagMapperByMySql extends AbstractMapper implements ConfigInfoTagMapper {
-    
+public class ConfigInfoTagMapperByMySql extends AbstractMapperByMysql implements ConfigInfoTagMapper {
+
     @Override
     public MapperResult findAllConfigInfoTagForDumpAllFetchRows(MapperContext context) {
         String sql = " SELECT t.id,data_id,group_id,tenant_id,tag_id,app_name,content,md5,gmt_modified "
@@ -39,7 +38,7 @@ public class ConfigInfoTagMapperByMySql extends AbstractMapper implements Config
                 + context.getPageSize() + " ) " + "g, config_info_tag t  WHERE g.id = t.id  ";
         return new MapperResult(sql, Collections.emptyList());
     }
-    
+
     @Override
     public String getDataSource() {
         return DataSourceConstant.MYSQL;

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigTagsRelationMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigTagsRelationMapperByMySql.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.mysql;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigTagsRelationMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -33,8 +32,8 @@ import java.util.List;
  * @author hyx
  **/
 
-public class ConfigTagsRelationMapperByMySql extends AbstractMapper implements ConfigTagsRelationMapper {
-    
+public class ConfigTagsRelationMapperByMySql extends AbstractMapperByMysql implements ConfigTagsRelationMapper {
+
     @Override
     public MapperResult findConfigInfo4PageFetchRows(MapperContext context) {
         final String tenant = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
@@ -43,7 +42,7 @@ public class ConfigTagsRelationMapperByMySql extends AbstractMapper implements C
         final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
         final String content = (String) context.getWhereParameter(FieldConstant.CONTENT);
         final String[] tagArr = (String[]) context.getWhereParameter(FieldConstant.TAG_ARR);
-        
+
         List<Object> paramList = new ArrayList<>();
         StringBuilder where = new StringBuilder(" WHERE ");
         final String sql =

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/GroupCapacityMapperByMysql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/GroupCapacityMapperByMysql.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.mysql;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.GroupCapacityMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -29,13 +28,13 @@ import com.alibaba.nacos.plugin.datasource.model.MapperResult;
  *
  * @author lixiaoshuang
  */
-public class GroupCapacityMapperByMysql extends AbstractMapper implements GroupCapacityMapper {
-    
+public class GroupCapacityMapperByMysql extends AbstractMapperByMysql implements GroupCapacityMapper {
+
     @Override
     public String getDataSource() {
         return DataSourceConstant.MYSQL;
     }
-    
+
     @Override
     public MapperResult selectGroupInfoBySize(MapperContext context) {
         String sql = "SELECT id, group_id FROM group_capacity WHERE id > ? LIMIT ?";

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/HistoryConfigInfoMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/HistoryConfigInfoMapperByMySql.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.mysql;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.HistoryConfigInfoMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -30,15 +29,15 @@ import com.alibaba.nacos.plugin.datasource.model.MapperResult;
  * @author hyx
  **/
 
-public class HistoryConfigInfoMapperByMySql extends AbstractMapper implements HistoryConfigInfoMapper {
-    
+public class HistoryConfigInfoMapperByMySql extends AbstractMapperByMysql implements HistoryConfigInfoMapper {
+
     @Override
     public MapperResult removeConfigHistory(MapperContext context) {
         String sql = "DELETE FROM his_config_info WHERE gmt_modified < ? LIMIT ?";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.START_TIME),
                 context.getWhereParameter(FieldConstant.LIMIT_SIZE)));
     }
-    
+
     @Override
     public MapperResult pageFindConfigHistoryFetchRows(MapperContext context) {
         String sql =

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/TenantCapacityMapperByMySql.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/TenantCapacityMapperByMySql.java
@@ -19,7 +19,6 @@ package com.alibaba.nacos.plugin.datasource.impl.mysql;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.TenantCapacityMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
@@ -30,13 +29,13 @@ import com.alibaba.nacos.plugin.datasource.model.MapperResult;
  * @author hyx
  **/
 
-public class TenantCapacityMapperByMySql extends AbstractMapper implements TenantCapacityMapper {
-    
+public class TenantCapacityMapperByMySql extends AbstractMapperByMysql implements TenantCapacityMapper {
+
     @Override
     public String getDataSource() {
         return DataSourceConstant.MYSQL;
     }
-    
+
     @Override
     public MapperResult getCapacityList4CorrectUsage(MapperContext context) {
         String sql = "SELECT id, tenant_id FROM tenant_capacity WHERE id>? LIMIT ?";

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapper.java
@@ -27,7 +27,7 @@ import java.util.List;
  **/
 
 public abstract class AbstractMapper implements Mapper {
-    
+
     @Override
     public String select(List<String> columns, List<String> where) {
         StringBuilder sql = new StringBuilder();
@@ -44,36 +44,41 @@ public abstract class AbstractMapper implements Mapper {
         sql.append("FROM ");
         sql.append(getTableName());
         sql.append(" ");
-        
+
         if (CollectionUtils.isEmpty(where)) {
             return sql.toString();
         }
-        
+
         appendWhereClause(where, sql);
         return sql.toString();
     }
-    
+
     @Override
     public String insert(List<String> columns) {
         StringBuilder sql = new StringBuilder();
         String method = "INSERT INTO ";
         sql.append(method);
         sql.append(getTableName());
-        
+
         int size = columns.size();
         sql.append("(");
         for (int i = 0; i < size; i++) {
-            sql.append(columns.get(i));
+            sql.append(columns.get(i).split("@")[0]);
             if (i != columns.size() - 1) {
                 sql.append(", ");
             }
         }
         sql.append(") ");
-        
+
         sql.append("VALUES");
         sql.append("(");
         for (int i = 0; i < size; i++) {
-            sql.append("?");
+            String[] parts = columns.get(i).split("@");
+            if (parts.length == 2) {
+                sql.append(getFunction(parts[1]));
+            } else {
+                sql.append("?");
+            }
             if (i != columns.size() - 1) {
                 sql.append(",");
             }
@@ -81,31 +86,37 @@ public abstract class AbstractMapper implements Mapper {
         sql.append(")");
         return sql.toString();
     }
-    
+
     @Override
     public String update(List<String> columns, List<String> where) {
         StringBuilder sql = new StringBuilder();
         String method = "UPDATE ";
         sql.append(method);
         sql.append(getTableName()).append(" ").append("SET ");
-        
+
         for (int i = 0; i < columns.size(); i++) {
-            sql.append(columns.get(i)).append(" = ").append("?");
+            String[] parts = columns.get(i).split("@");
+            String column = parts[0];
+            if (parts.length == 2) {
+                sql.append(column).append(" = ").append(getFunction(parts[1]));
+            } else {
+                sql.append(column).append(" = ").append("?");
+            }
             if (i != columns.size() - 1) {
                 sql.append(",");
             }
         }
-        
+
         if (CollectionUtils.isEmpty(where)) {
             return sql.toString();
         }
-        
+
         sql.append(" ");
         appendWhereClause(where, sql);
-        
+
         return sql.toString();
     }
-    
+
     @Override
     public String delete(List<String> params) {
         StringBuilder sql = new StringBuilder();
@@ -117,10 +128,10 @@ public abstract class AbstractMapper implements Mapper {
                 sql.append("AND ");
             }
         }
-        
+
         return sql.toString();
     }
-    
+
     @Override
     public String count(List<String> where) {
         StringBuilder sql = new StringBuilder();
@@ -129,21 +140,21 @@ public abstract class AbstractMapper implements Mapper {
         sql.append("COUNT(*) FROM ");
         sql.append(getTableName());
         sql.append(" ");
-        
+
         if (null == where || where.size() == 0) {
             return sql.toString();
         }
-        
+
         appendWhereClause(where, sql);
-        
+
         return sql.toString();
     }
-    
+
     @Override
     public String[] getPrimaryKeyGeneratedKeys() {
-        return new String[] {"id"};
+        return new String[]{"id"};
     }
-    
+
     private void appendWhereClause(List<String> where, StringBuilder sql) {
         sql.append("WHERE ");
         for (int i = 0; i < where.size(); i++) {

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoBetaMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoBetaMapper.java
@@ -42,17 +42,18 @@ public interface ConfigInfoBetaMapper extends Mapper {
      * @return The result of updating beta configuration information.
      */
     default MapperResult updateConfigInfo4BetaCas(MapperContext context) {
-        final String sql = "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,src_ip = ?,src_user = ?,gmt_modified = ?,app_name = ? "
+        final String sql = "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,src_ip = ?,src_user = ?,gmt_modified = "
+                + getFunction("NOW()")
+                + ",app_name = ? "
                 + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND (md5 = ? OR md5 is null OR md5 = '')";
-    
+
         List<Object> paramList = new ArrayList<>();
-        
+
         paramList.add(context.getUpdateParameter(FieldConstant.CONTENT));
         paramList.add(context.getUpdateParameter(FieldConstant.MD5));
         paramList.add(context.getUpdateParameter(FieldConstant.BETA_IPS));
         paramList.add(context.getUpdateParameter(FieldConstant.SRC_IP));
         paramList.add(context.getUpdateParameter(FieldConstant.SRC_USER));
-        paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
         paramList.add(context.getUpdateParameter(FieldConstant.APP_NAME));
     
         paramList.add(context.getWhereParameter(FieldConstant.DATA_ID));

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
@@ -492,7 +492,6 @@ public interface ConfigInfoMapper extends Mapper {
         paramList.add(context.getUpdateParameter(FieldConstant.MD5));
         paramList.add(context.getUpdateParameter(FieldConstant.SRC_IP));
         paramList.add(context.getUpdateParameter(FieldConstant.SRC_USER));
-        paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
         paramList.add(context.getUpdateParameter(FieldConstant.APP_NAME));
         paramList.add(context.getUpdateParameter(FieldConstant.C_DESC));
         paramList.add(context.getUpdateParameter(FieldConstant.C_USE));
@@ -504,8 +503,9 @@ public interface ConfigInfoMapper extends Mapper {
         paramList.add(context.getWhereParameter(FieldConstant.GROUP_ID));
         paramList.add(context.getWhereParameter(FieldConstant.TENANT_ID));
         paramList.add(context.getWhereParameter(FieldConstant.MD5));
-        String sql = "UPDATE config_info SET " + "content=?, md5 = ?, src_ip=?,src_user=?,gmt_modified=?,"
-                + " app_name=?,c_desc=?,c_use=?,effect=?,type=?,c_schema=?,encrypted_data_key=? "
+        String sql = "UPDATE config_info SET " + "content=?, md5=?, src_ip=?, src_user=?, gmt_modified="
+                + getFunction("NOW()")
+                + ", app_name=?, c_desc=?, c_use=?, effect=?, type=?, c_schema=?, encrypted_data_key=? "
                 + "WHERE data_id=? AND group_id=? AND tenant_id=? AND (md5=? OR md5 IS NULL OR md5='')";
         return new MapperResult(sql, paramList);
     }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/Mapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/Mapper.java
@@ -75,7 +75,7 @@ public interface Mapper {
      * @return The name of datasource.
      */
     String getDataSource();
-    
+
     /**
      * Get config_info table primary keys name.
      * The old default value: Statement.RETURN_GENERATED_KEYS
@@ -83,4 +83,12 @@ public interface Mapper {
      * @return an array of column names indicating the columns
      */
     String[] getPrimaryKeyGeneratedKeys();
+
+    /**
+     * Get function by functionName.
+     *
+     * @param functionName functionName
+     * @return function
+     */
+    String getFunction(String functionName);
 }

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
@@ -17,7 +17,7 @@
 package com.alibaba.nacos.plugin.datasource;
 
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
-import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
+import com.alibaba.nacos.plugin.datasource.impl.mysql.AbstractMapperByMysql;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoAggrMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.Mapper;
 import com.alibaba.nacos.plugin.datasource.mapper.TestMapper;
@@ -50,12 +50,12 @@ class MapperManagerTest {
     
     @Test
     void testJoin() {
-        MapperManager.join(new AbstractMapper() {
+        MapperManager.join(new AbstractMapperByMysql() {
             @Override
             public String getTableName() {
                 return "test";
             }
-            
+
             @Override
             public String getDataSource() {
                 return DataSourceConstant.MYSQL;

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/enums/derby/TrustedDerbyFunctionEnumTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/enums/derby/TrustedDerbyFunctionEnumTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.enums.derby;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * TrustedDerbyFunctionEnumTest.
+ *
+ * @author blake.qiu
+ */
+public class TrustedDerbyFunctionEnumTest {
+
+    @Test
+    void testGetFunctionByName() {
+        Assertions.assertEquals("CURRENT_TIMESTAMP", TrustedDerbylFunctionEnum.getFunctionByName("NOW()"));
+    }
+
+    @Test()
+    void testGetFunctionByErrorName() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> TrustedDerbylFunctionEnum.getFunctionByName("UNKNOWN"));
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/enums/mysql/TrustedMysqlFunctionEnumTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/enums/mysql/TrustedMysqlFunctionEnumTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.enums.mysql;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * TrustedMysqlFunctionEnumTest.
+ *
+ * @author blake.qiu
+ */
+public class TrustedMysqlFunctionEnumTest {
+
+    @Test
+    void testGetFunctionByName() {
+        Assertions.assertEquals("NOW(3)", TrustedMysqlFunctionEnum.getFunctionByName("NOW()"));
+    }
+
+    @Test()
+    void testGetFunctionByErrorName() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> TrustedMysqlFunctionEnum.getFunctionByName("UNKNOWN"));
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoBetaMapperByDerbyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoBetaMapperByDerbyTest.java
@@ -74,7 +74,6 @@ class ConfigInfoBetaMapperByDerbyTest {
         String newMD5 = "newMD5";
         String srcIp = "1.1.1.1";
         Object srcUser = "nacos";
-        Object time = new Timestamp(System.currentTimeMillis());
         Object appNameTmp = "newAppName";
         Object desc = "description";
         Object use = "use";
@@ -88,7 +87,6 @@ class ConfigInfoBetaMapperByDerbyTest {
         context.putUpdateParameter(FieldConstant.BETA_IPS, betaIps);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -109,9 +107,9 @@ class ConfigInfoBetaMapperByDerbyTest {
         
         String sql = mapperResult.getSql();
         assertEquals(sql, "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,src_ip = ?,src_user = ?,"
-                + "gmt_modified = ?,app_name = ? WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND "
+                + "gmt_modified = CURRENT_TIMESTAMP,app_name = ? WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND "
                 + "(md5 = ? OR md5 is null OR md5 = '')");
-        assertArrayEquals(new Object[] {newContent, newMD5, betaIps, srcIp, srcUser, time, appNameTmp, dataId, group, tenantId, md5},
+        assertArrayEquals(new Object[]{newContent, newMD5, betaIps, srcIp, srcUser, appNameTmp, dataId, group, tenantId, md5},
                 mapperResult.getParamList().toArray());
     }
     

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
@@ -317,7 +317,6 @@ class ConfigInfoMapperByDerbyTest {
         String newMD5 = "newMD5";
         String srcIp = "1.1.1.1";
         Object srcUser = "nacos";
-        Object time = new Timestamp(System.currentTimeMillis());
         Object appNameTmp = "newAppName";
         Object desc = "description";
         Object use = "use";
@@ -329,7 +328,6 @@ class ConfigInfoMapperByDerbyTest {
         context.putUpdateParameter(FieldConstant.MD5, newMD5);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -348,11 +346,11 @@ class ConfigInfoMapperByDerbyTest {
         
         MapperResult mapperResult = configInfoMapperByDerby.updateConfigInfoAtomicCas(context);
         assertEquals(mapperResult.getSql(),
-                "UPDATE config_info SET " + "content=?, md5 = ?, src_ip=?,src_user=?,gmt_modified=?, app_name=?,c_desc=?,c_use=?,"
-                        + "effect=?,type=?,c_schema=?,encrypted_data_key=? "
+                "UPDATE config_info SET " + "content=?, md5=?, src_ip=?, src_user=?, gmt_modified=CURRENT_TIMESTAMP,"
+                        + " app_name=?, c_desc=?, c_use=?, effect=?, type=?, c_schema=?, encrypted_data_key=? "
                         + "WHERE data_id=? AND group_id=? AND tenant_id=? AND (md5=? OR md5 IS NULL OR md5='')");
         assertArrayEquals(
-                new Object[] {newContent, newMD5, srcIp, srcUser, time, appNameTmp, desc, use, effect, type, schema, encrypedDataKey,
+                new Object[]{newContent, newMD5, srcIp, srcUser, appNameTmp, desc, use, effect, type, schema, encrypedDataKey,
                         dataId, group, tenantId, md5}, mapperResult.getParamList().toArray());
     }
 }

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoBetaMapperByMySqlTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoBetaMapperByMySqlTest.java
@@ -74,7 +74,6 @@ class ConfigInfoBetaMapperByMySqlTest {
         String newMD5 = "newMD5";
         String srcIp = "1.1.1.1";
         Object srcUser = "nacos";
-        Object time = new Timestamp(System.currentTimeMillis());
         Object appNameTmp = "newAppName";
         Object desc = "description";
         Object use = "use";
@@ -88,7 +87,6 @@ class ConfigInfoBetaMapperByMySqlTest {
         context.putUpdateParameter(FieldConstant.BETA_IPS, betaIps);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -108,11 +106,11 @@ class ConfigInfoBetaMapperByMySqlTest {
         MapperResult mapperResult = configInfoBetaMapperByMySql.updateConfigInfo4BetaCas(context);
         
         String sql = mapperResult.getSql();
-        List<Object> paramList = mapperResult.getParamList();
         assertEquals(sql,
-                "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,src_ip = ?,src_user = ?,gmt_modified = ?,app_name = ? "
+                "UPDATE config_info_beta SET content = ?,md5 = ?,beta_ips = ?,"
+                        + "src_ip = ?,src_user = ?,gmt_modified = NOW(3),app_name = ? "
                         + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND (md5 = ? OR md5 is null OR md5 = '')");
-        assertArrayEquals(new Object[] {newContent, newMD5, betaIps, srcIp, srcUser, time, appNameTmp, dataId, group, tenantId, md5},
+        assertArrayEquals(new Object[]{newContent, newMD5, betaIps, srcIp, srcUser, appNameTmp, dataId, group, tenantId, md5},
                 mapperResult.getParamList().toArray());
     }
     

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
@@ -315,7 +315,6 @@ class ConfigInfoMapperByMySqlTest {
         String newMD5 = "newMD5";
         String srcIp = "1.1.1.1";
         Object srcUser = "nacos";
-        Object time = new Timestamp(System.currentTimeMillis());
         Object appNameTmp = "newAppName";
         Object desc = "description";
         Object use = "use";
@@ -327,7 +326,6 @@ class ConfigInfoMapperByMySqlTest {
         context.putUpdateParameter(FieldConstant.MD5, newMD5);
         context.putUpdateParameter(FieldConstant.SRC_IP, srcIp);
         context.putUpdateParameter(FieldConstant.SRC_USER, srcUser);
-        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, time);
         context.putUpdateParameter(FieldConstant.APP_NAME, appNameTmp);
         context.putUpdateParameter(FieldConstant.C_DESC, desc);
         context.putUpdateParameter(FieldConstant.C_USE, use);
@@ -346,11 +344,11 @@ class ConfigInfoMapperByMySqlTest {
         
         MapperResult mapperResult = configInfoMapperByMySql.updateConfigInfoAtomicCas(context);
         assertEquals(mapperResult.getSql(),
-                "UPDATE config_info SET " + "content=?, md5 = ?, src_ip=?,src_user=?,gmt_modified=?, app_name=?,c_desc=?,"
-                        + "c_use=?,effect=?,type=?,c_schema=?,encrypted_data_key=? "
+                "UPDATE config_info SET " + "content=?, md5=?, src_ip=?, src_user=?, gmt_modified=NOW(3),"
+                        + " app_name=?, c_desc=?, c_use=?, effect=?, type=?, c_schema=?, encrypted_data_key=? "
                         + "WHERE data_id=? AND group_id=? AND tenant_id=? AND (md5=? OR md5 IS NULL OR md5='')");
         assertArrayEquals(
-                new Object[] {newContent, newMD5, srcIp, srcUser, time, appNameTmp, desc, use, effect, type, schema, encryptedDataKey,
-                        dataId, group, tenantId, md5}, mapperResult.getParamList().toArray());
+                new Object[]{newContent, newMD5, srcIp, srcUser, appNameTmp, desc, use, effect, type, schema,
+                        encryptedDataKey, dataId, group, tenantId, md5}, mapperResult.getParamList().toArray());
     }
 }

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/AbstractMapperTest.java
@@ -16,7 +16,9 @@
 
 package com.alibaba.nacos.plugin.datasource.mapper;
 
-import com.alibaba.nacos.plugin.datasource.impl.mysql.TenantInfoMapperByMySql;
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
+import com.alibaba.nacos.plugin.datasource.enums.mysql.TrustedMysqlFunctionEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +32,22 @@ class AbstractMapperTest {
     
     @BeforeEach
     void setUp() throws Exception {
-        abstractMapper = new TenantInfoMapperByMySql();
+        abstractMapper = new AbstractMapper() {
+            @Override
+            public String getTableName() {
+                return TableConstant.TENANT_INFO;
+            }
+
+            @Override
+            public String getDataSource() {
+                return DataSourceConstant.MYSQL;
+            }
+
+            @Override
+            public String getFunction(String functionName) {
+                return TrustedMysqlFunctionEnum.getFunctionByName(functionName);
+            }
+        };
     }
     
     @Test

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxyTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/proxy/MapperProxyTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.datasource.proxy;
 
+import com.alibaba.nacos.plugin.datasource.enums.mysql.TrustedMysqlFunctionEnum;
 import com.alibaba.nacos.plugin.datasource.mapper.Mapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,15 +67,20 @@ class MapperProxyTest {
             public String getTableName() {
                 return "test";
             }
-            
+
             @Override
             public String getDataSource() {
                 return "test";
             }
-            
+
             @Override
             public String[] getPrimaryKeyGeneratedKeys() {
                 return new String[0];
+            }
+
+            @Override
+            public String getFunction(String functionName) {
+                return TrustedMysqlFunctionEnum.getFunctionByName(functionName);
             }
         };
         Mapper proxy = mapperProxy.createProxy(mapper);


### PR DESCRIPTION
## What is the purpose of the change

fix(#12231): When inserting and updating configurations in the database, the time-related field values need to be set using the time obtained from the database's built-in time function.