### PR TITLE
 fix endpoint cluster name

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/PropertyKeyConst.java
+++ b/api/src/main/java/com/alibaba/nacos/api/PropertyKeyConst.java
@@ -35,6 +35,8 @@ public class PropertyKeyConst {
     
     public static final String ENDPOINT_CONTEXT_PATH = "endpointContextPath";
     
+    public static final String ENDPOINT_CLUSTER_NAME = "endpointClusterName";
+    
     public static final String SERVER_NAME = "serverName";
     
     public static final String NAMESPACE = "namespace";

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListManager.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ServerListManager.java
@@ -293,7 +293,8 @@ public class ServerListManager implements Closeable {
     }
     
     private void initServerListName(NacosClientProperties properties) {
-        String serverListNameTmp = properties.getProperty(PropertyKeyConst.CLUSTER_NAME);
+        String serverListNameTmp = properties.getProperty(PropertyKeyConst.ENDPOINT_CLUSTER_NAME,
+                properties.getProperty(PropertyKeyConst.CLUSTER_NAME));
         if (!StringUtils.isBlank(serverListNameTmp)) {
             this.serverListName = serverListNameTmp;
         }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/core/ServerListManager.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/core/ServerListManager.java
@@ -111,7 +111,7 @@ public class ServerListManager implements ServerListFactory, Closeable {
             if (!StringUtils.isBlank(contentPathTmp)) {
                 this.contentPath = contentPathTmp;
             }
-            String serverListNameTmp = properties.getProperty(PropertyKeyConst.CLUSTER_NAME);
+            String serverListNameTmp = properties.getProperty(PropertyKeyConst.ENDPOINT_CLUSTER_NAME);
             if (!StringUtils.isBlank(serverListNameTmp)) {
                 this.serverListName = serverListNameTmp;
             }

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ServerListManagerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ServerListManagerTest.java
@@ -236,6 +236,34 @@ class ServerListManagerTest {
     }
     
     @Test
+    void testWithEndpointClusterName() throws NacosException {
+        Properties properties = new Properties();
+        String endpoint = "127.0.0.1";
+        properties.setProperty(PropertyKeyConst.ENDPOINT, endpoint);
+        String endpointPort = "9090";
+        properties.setProperty(PropertyKeyConst.ENDPOINT_PORT, endpointPort);
+        String testEndpointClusterName = "testEndpointClusterName";
+        properties.setProperty(PropertyKeyConst.ENDPOINT_CLUSTER_NAME, testEndpointClusterName);
+        String testClusterName = "testClusterName";
+        properties.setProperty(PropertyKeyConst.CLUSTER_NAME, testClusterName);
+        String endpointContextPath = "/endpointContextPath";
+        properties.setProperty(PropertyKeyConst.ENDPOINT_CONTEXT_PATH, endpointContextPath);
+        String contextPath = "/contextPath";
+        properties.setProperty(PropertyKeyConst.CONTEXT_PATH, contextPath);
+        final NacosClientProperties clientProperties = NacosClientProperties.PROTOTYPE.derive(properties);
+        ServerListManager serverListManager = new ServerListManager(clientProperties);
+        assertTrue(serverListManager.addressServerUrl.contains(endpointContextPath));
+        assertTrue(serverListManager.getName().contains("endpointContextPath"));
+        
+        assertTrue(serverListManager.addressServerUrl.contains(testEndpointClusterName));
+        assertTrue(serverListManager.getName().contains(testEndpointClusterName));
+    
+        assertFalse(serverListManager.addressServerUrl.contains(testClusterName));
+        assertFalse(serverListManager.getName().contains(testClusterName));
+    
+    }
+    
+    @Test
     void testWithoutEndpointContextPath() throws NacosException {
         Properties properties = new Properties();
         String endpoint = "127.0.0.1";

--- a/client/src/test/java/com/alibaba/nacos/client/naming/core/ServerListManagerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/core/ServerListManagerTest.java
@@ -199,7 +199,7 @@ class ServerListManagerTest {
     @Test
     void testConstructWithEndpointWithCustomPathAndName() throws Exception {
         clientProperties.setProperty(PropertyKeyConst.CONTEXT_PATH, "aaa");
-        clientProperties.setProperty(PropertyKeyConst.CLUSTER_NAME, "bbb");
+        clientProperties.setProperty(PropertyKeyConst.ENDPOINT_CLUSTER_NAME, "bbb");
         clientProperties.setProperty(PropertyKeyConst.ENDPOINT, "127.0.0.1");
         Mockito.reset(nacosRestTemplate);
         Mockito.when(nacosRestTemplate.get(eq("http://127.0.0.1:8080/aaa/bbb"), any(), any(), any()))
@@ -213,7 +213,7 @@ class ServerListManagerTest {
     @Test
     void testConstructWithEndpointWithEndpointPathAndName() throws Exception {
         clientProperties.setProperty(PropertyKeyConst.ENDPOINT_CONTEXT_PATH, "aaa");
-        clientProperties.setProperty(PropertyKeyConst.CLUSTER_NAME, "bbb");
+        clientProperties.setProperty(PropertyKeyConst.ENDPOINT_CLUSTER_NAME, "bbb");
         clientProperties.setProperty(PropertyKeyConst.ENDPOINT, "127.0.0.1");
         Mockito.reset(nacosRestTemplate);
         Mockito.when(nacosRestTemplate.get(eq("http://127.0.0.1:8080/aaa/bbb"), any(), any(), any()))
@@ -228,7 +228,7 @@ class ServerListManagerTest {
     void testConstructEndpointContextPathPriority() throws Exception {
         clientProperties.setProperty(PropertyKeyConst.ENDPOINT_CONTEXT_PATH, "aaa");
         clientProperties.setProperty(PropertyKeyConst.CONTEXT_PATH, "bbb");
-        clientProperties.setProperty(PropertyKeyConst.CLUSTER_NAME, "ccc");
+        clientProperties.setProperty(PropertyKeyConst.ENDPOINT_CLUSTER_NAME, "ccc");
         clientProperties.setProperty(PropertyKeyConst.ENDPOINT, "127.0.0.1");
         Mockito.reset(nacosRestTemplate);
         Mockito.when(nacosRestTemplate.get(eq("http://127.0.0.1:8080/aaa/ccc"), any(), any(), any()))
@@ -243,7 +243,7 @@ class ServerListManagerTest {
     void testConstructEndpointContextPathIsEmpty() throws Exception {
         clientProperties.setProperty(PropertyKeyConst.ENDPOINT_CONTEXT_PATH, "");
         clientProperties.setProperty(PropertyKeyConst.CONTEXT_PATH, "bbb");
-        clientProperties.setProperty(PropertyKeyConst.CLUSTER_NAME, "ccc");
+        clientProperties.setProperty(PropertyKeyConst.ENDPOINT_CLUSTER_NAME, "ccc");
         clientProperties.setProperty(PropertyKeyConst.ENDPOINT, "127.0.0.1");
         Mockito.reset(nacosRestTemplate);
         Mockito.when(nacosRestTemplate.get(eq("http://127.0.0.1:8080/bbb/ccc"), any(), any(), any()))


### PR DESCRIPTION

## What is the purpose of the change

1.add endpoint cluster name to split the cluster name params used for naming endpoint and spring cloud instance registry.  
2.add endpoint cluster name to instead  cluster name param ,  using cluster name for compatibility.
