### PR TITLE
[ISSUE #12282]Fix the issue where monitoring data cannot be found thr…

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/enums/ConfigSearchRequestTypeEnum.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/enums/ConfigSearchRequestTypeEnum.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.enums;
+
+/**
+ * Config search request type enum.
+ *
+ * @author hmydk
+ */
+public enum ConfigSearchRequestTypeEnum {
+    
+    /**
+     * ip.
+     */
+    IP("IP"),
+    
+    /**
+     * config.
+     */
+    CONFIG("config");
+    
+    
+    private final String type;
+    
+    ConfigSearchRequestTypeEnum(String type) {
+        this.type = type;
+    }
+    
+    /**
+     * check type is legal.
+     *
+     * @param type type
+     * @return true or false
+     */
+    public static boolean checkTypeLegal(String type) {
+        for (ConfigSearchRequestTypeEnum configSearchRequestTypeEnum : ConfigSearchRequestTypeEnum.values()) {
+            if (configSearchRequestTypeEnum.getType().equals(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    public String getType() {
+        return type;
+    }
+}

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigSubService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigSubService.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.common.model.RestResult;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
+import com.alibaba.nacos.config.server.enums.ConfigSearchRequestTypeEnum;
 import com.alibaba.nacos.config.server.model.ListenerCheckResult;
 import com.alibaba.nacos.config.server.model.SampleResult;
 import com.alibaba.nacos.config.server.service.notify.HttpClientManager;
@@ -85,7 +86,7 @@ public class ConfigSubService {
     
     static class ClusterListenerJob extends ClusterJob<SampleResult> {
         
-        static final String URL = Constants.COMMUNICATION_CONTROLLER_PATH + "/configWatchers";
+        static final String URL = Constants.COMMUNICATION_CONTROLLER_PATH + "/config";
         
         ClusterListenerJob(Map<String, String> params, CompletionService<SampleResult> completionService,
                 ServerMemberManager serverMemberManager) {
@@ -295,7 +296,8 @@ public class ConfigSubService {
     
     public SampleResult getCollectSampleResult(String dataId, String group, String tenant, int sampleTime)
             throws Exception {
-        Map<String, String> params = new HashMap<>(5);
+        Map<String, String> params = new HashMap<>(4);
+        params.put("type", ConfigSearchRequestTypeEnum.CONFIG.getType());
         params.put("dataId", dataId);
         params.put("group", group);
         if (!StringUtils.isBlank(tenant)) {
@@ -316,7 +318,8 @@ public class ConfigSubService {
     }
     
     public SampleResult getCollectSampleResultByIp(String ip, int sampleTime) {
-        Map<String, String> params = new HashMap<>(50);
+        Map<String, String> params = new HashMap<>(2);
+        params.put("type", ConfigSearchRequestTypeEnum.IP.getType());
         params.put("ip", ip);
         BlockingQueue<Future<SampleResult>> queue = new LinkedBlockingDeque<>(memberManager.getServerList().size());
         CompletionService<SampleResult> completionService = new ExecutorCompletionService<>(

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/LongPollingService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/LongPollingService.java
@@ -70,7 +70,7 @@ public class LongPollingService {
     
     private Map<String, Long> retainIps = new ConcurrentHashMap<>();
     
-    public SampleResult getSubscribleInfo(String dataId, String group, String tenant) {
+    public SampleResult getSubscribeInfo(String dataId, String group, String tenant) {
         String groupKey = GroupKey.getKeyTenant(dataId, group, tenant);
         SampleResult sampleResult = new SampleResult();
         Map<String, String> lisentersGroupkeyStatus = new HashMap<>(50);
@@ -123,7 +123,7 @@ public class LongPollingService {
     public SampleResult getCollectSubscribleInfo(String dataId, String group, String tenant) {
         List<SampleResult> sampleResultLst = new ArrayList<>(50);
         for (int i = 0; i < SAMPLE_TIMES; i++) {
-            SampleResult sampleTmp = getSubscribleInfo(dataId, group, tenant);
+            SampleResult sampleTmp = getSubscribeInfo(dataId, group, tenant);
             if (sampleTmp != null) {
                 sampleResultLst.add(sampleTmp);
             }


### PR DESCRIPTION


## What is the purpose of the change

#12282  Fix the issue where monitoring data cannot be found through the IP dimension in the ListeningQuery


## Brief changelog

Add new query methods in the `CommunicationController` to support both IP and config queries. Additionally, mark `@GetMapping("/configWatchers")` and `@GetMapping("/watcherConfigs") `as **@Deprecated**.
## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

