### PR TITLE
Fix default sql in the comment to be consistent with the implementation

### DIFF
--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
@@ -73,7 +73,7 @@ public interface ConfigInfoMapper extends Mapper {
     
     /**
      * Query configuration information based on group. <br/>The default sql: SELECT
-     * id,data_id,group_id,tenant_id,app_name,content FROM config_info WHERE tenant_id LIKE ? AND app_name=?
+     * id,data_id,group_id,tenant_id,app_name,content FROM config_info WHERE tenant_id LIKE ? AND app_name=? LIMIT startRow, pageSize
      *
      * @param context The context of startRow, pageSize
      * @return The sql of querying configration information based on group.
@@ -114,7 +114,7 @@ public interface ConfigInfoMapper extends Mapper {
     /**
      * Query all configuration information by page. The default sql: SELECT data_id,group_id,app_name  FROM ( SELECT id
      * FROM config_info WHERE tenant_id LIKE ? ORDER BY id LIMIT startRow, pageSize ) g, config_info t WHERE g.id = t.id
-     * "
+     *
      *
      * @param context The context of startRow, pageSize
      * @return The sql of querying all configuration information.
@@ -131,9 +131,9 @@ public interface ConfigInfoMapper extends Mapper {
     MapperResult findAllConfigInfoBaseFetchRows(MapperContext context);
     
     /**
-     * Query all config info. The default sql: SELECT
-     * id,data_id,group_id,tenant_id,app_name,content,md5,gmt_modified,type,encrypted_data_key FROM config_info WHERE id
-     * > ? ORDER BY id ASC LIMIT startRow,pageSize
+     * Query all config info. The default sql: "SELECT
+     * id,data_id,group_id,tenant_id,app_name,"+ (needContent ? "content," : "") + "md5,gmt_modified,type,encrypted_data_key FROM config_info WHERE id
+     * > ? ORDER BY id ASC LIMIT startRow,pageSize"
      *
      * @param context     The context of startRow, pageSize
      * @return The sql of querying all config info.
@@ -141,8 +141,8 @@ public interface ConfigInfoMapper extends Mapper {
     MapperResult findAllConfigInfoFragment(MapperContext context);
     
     /**
-     * Query change config. <br/>The default sql: SELECT data_id, group_id, tenant_id, app_name, content,
-     * gmt_modified,encrypted_data_key FROM config_info WHERE gmt_modified >=? AND gmt_modified <= ?
+     * Query change config. <br/>The default sql: SELECT id, data_id, group_id, tenant_id, app_name, md5,
+     * gmt_modified,encrypted_data_key FROM config_info WHERE gmt_modified >=? AND id > ? ORDER BY id LIMIT pageSize
      *
      * @param context sql paramMap
      * @return The sql of querying change config.
@@ -207,7 +207,7 @@ public interface ConfigInfoMapper extends Mapper {
     
     /**
      * According to the time period and configuration conditions to query the eligible configuration. The default sql:
-     * SELECT id,data_id,group_id,tenant_id,app_name,content,type,md5,gmt_modified FROM config_info WHERE ...
+     * SELECT id,data_id,group_id,tenant_id,app_name,type,md5,gmt_modified FROM config_info WHERE ...
      *
      * @param context The map of params, the key is the parameter name(dataId, groupId, tenantId, appName, startTime,
      *                endTime, content, startTime, endTime), the value is the key's value.
@@ -365,7 +365,7 @@ public interface ConfigInfoMapper extends Mapper {
     
     /**
      * Query configuration information based on group. The default sql: SELECT id,data_id,group_id,content FROM
-     * config_info WHERE group_id=? AND tenant_id=?
+     * config_info WHERE group_id=? AND tenant_id=? LIMIT startRow, pageSize
      *
      * @param context The context of startRow, pageSize
      * @return Query configuration information based on group.


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.
按文档指示，该修改是小型修改，无需创建对应issue

## What is the purpose of the change

修改mapper接口当中过时的注释内容，以使得注释中的sql内容和默认mysql实现类中的一致。
否则自己扩展datasource插件的时候，很容易被过时的注释混淆，导致连接其他数据库时的行为和期望行为不一致。

## Brief changelog

增加注释中缺少的LIMIT字段，删除多余的字段等。

## Verifying this change

修改注释后，注释中的sql内容和默认mysql当中实现的一致。


