### PR TITLE
fix(#12333): fixed auth Plugin resource parser can't parser v2 config openAPI namespaceId.

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
+++ b/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
@@ -43,10 +43,14 @@ public class Constants {
     
     public static final String NULL = "";
     
-    public static final String DATAID = "dataId";
-    
+    public static final String DATA_ID = "dataId";
+
+    public static final String TENANT = "tenant";
+
     public static final String GROUP = "group";
-    
+
+    public static final String NAMESPACE_ID = "namespaceId";
+
     public static final String LAST_MODIFIED = "Last-Modified";
     
     public static final String ACCEPT_ENCODING = "Accept-Encoding";

--- a/auth/src/main/java/com/alibaba/nacos/auth/parser/grpc/ConfigGrpcResourceParser.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/parser/grpc/ConfigGrpcResourceParser.java
@@ -67,7 +67,7 @@ public class ConfigGrpcResourceParser extends AbstractGrpcResourceParser {
             dataId = ((AbstractConfigRequest) request).getDataId();
         } else {
             dataId = (String) ReflectUtils
-                    .getFieldValue(request, com.alibaba.nacos.api.common.Constants.DATAID, StringUtils.EMPTY);
+                    .getFieldValue(request, com.alibaba.nacos.api.common.Constants.DATA_ID, StringUtils.EMPTY);
         }
         return StringUtils.isBlank(dataId) ? StringUtils.EMPTY : dataId;
     }

--- a/auth/src/main/java/com/alibaba/nacos/auth/parser/http/ConfigHttpResourceParser.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/parser/http/ConfigHttpResourceParser.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.auth.parser.http;
 
+import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 
@@ -31,8 +32,11 @@ public class ConfigHttpResourceParser extends AbstractHttpResourceParser {
     
     @Override
     protected String getNamespaceId(HttpServletRequest request) {
-        return NamespaceUtil.processNamespaceParameter(request.getParameter("tenant"));
-        
+        String namespaceId = request.getParameter(Constants.NAMESPACE_ID);
+        if (StringUtils.isBlank(namespaceId)) {
+            namespaceId = request.getParameter(Constants.TENANT);
+        }
+        return NamespaceUtil.processNamespaceParameter(namespaceId);
     }
     
     @Override
@@ -43,7 +47,7 @@ public class ConfigHttpResourceParser extends AbstractHttpResourceParser {
     
     @Override
     protected String getResourceName(HttpServletRequest request) {
-        String dataId = request.getParameter(com.alibaba.nacos.api.common.Constants.DATAID);
+        String dataId = request.getParameter(com.alibaba.nacos.api.common.Constants.DATA_ID);
         return StringUtils.isBlank(dataId) ? StringUtils.EMPTY : dataId;
     }
     

--- a/auth/src/test/java/com/alibaba/nacos/auth/HttpProtocolAuthServiceTest.java
+++ b/auth/src/test/java/com/alibaba/nacos/auth/HttpProtocolAuthServiceTest.java
@@ -67,7 +67,7 @@ class HttpProtocolAuthServiceTest {
         Mockito.when(request.getParameter(eq(CommonParams.SERVICE_NAME))).thenReturn("testS");
         Mockito.when(request.getParameter(eq("tenant"))).thenReturn("testCNs");
         Mockito.when(request.getParameter(eq(Constants.GROUP))).thenReturn("testCG");
-        Mockito.when(request.getParameter(eq(Constants.DATAID))).thenReturn("testD");
+        Mockito.when(request.getParameter(eq(Constants.DATA_ID))).thenReturn("testD");
     }
     
     @Test
@@ -109,7 +109,7 @@ class HttpProtocolAuthServiceTest {
         Resource actual = httpProtocolAuthService.parseResource(request, secured);
         assertEquals(SignType.CONFIG, actual.getType());
         assertEquals("testD", actual.getName());
-        assertEquals("testCNs", actual.getNamespaceId());
+        assertEquals("testNNs", actual.getNamespaceId());
         assertEquals("testCG", actual.getGroup());
         assertNotNull(actual.getProperties());
     }

--- a/auth/src/test/java/com/alibaba/nacos/auth/parser/http/ConfigHttpResourceParserTest.java
+++ b/auth/src/test/java/com/alibaba/nacos/auth/parser/http/ConfigHttpResourceParserTest.java
@@ -56,9 +56,38 @@ class ConfigHttpResourceParserTest {
         Secured secured = getMethodSecure();
         Mockito.when(request.getParameter(eq("tenant"))).thenReturn("testNs");
         Mockito.when(request.getParameter(eq(Constants.GROUP))).thenReturn("testG");
-        Mockito.when(request.getParameter(eq(Constants.DATAID))).thenReturn("testD");
+        Mockito.when(request.getParameter(eq(Constants.DATA_ID))).thenReturn("testD");
         Resource actual = resourceParser.parse(request, secured);
         assertEquals("testNs", actual.getNamespaceId());
+        assertEquals("testG", actual.getGroup());
+        assertEquals("testD", actual.getName());
+        assertEquals(Constants.Config.CONFIG_MODULE, actual.getType());
+    }
+
+    @Test
+    @Secured(signType = Constants.Config.CONFIG_MODULE)
+    void testParseWithNamespaceId() throws NoSuchMethodException {
+        Secured secured = getMethodSecure();
+        Mockito.when(request.getParameter(eq("namespaceId"))).thenReturn("testNs");
+        Mockito.when(request.getParameter(eq(Constants.GROUP))).thenReturn("testG");
+        Mockito.when(request.getParameter(eq(Constants.DATA_ID))).thenReturn("testD");
+        Resource actual = resourceParser.parse(request, secured);
+        assertEquals("testNs", actual.getNamespaceId());
+        assertEquals("testG", actual.getGroup());
+        assertEquals("testD", actual.getName());
+        assertEquals(Constants.Config.CONFIG_MODULE, actual.getType());
+    }
+
+    @Test
+    @Secured(signType = Constants.Config.CONFIG_MODULE)
+    void testParseWithNamespaceIdFirst() throws NoSuchMethodException {
+        Secured secured = getMethodSecure();
+        Mockito.when(request.getParameter(eq("tenant"))).thenReturn("testNs");
+        Mockito.when(request.getParameter(eq("namespaceId"))).thenReturn("testNsFirst");
+        Mockito.when(request.getParameter(eq(Constants.GROUP))).thenReturn("testG");
+        Mockito.when(request.getParameter(eq(Constants.DATA_ID))).thenReturn("testD");
+        Resource actual = resourceParser.parse(request, secured);
+        assertEquals("testNsFirst", actual.getNamespaceId());
         assertEquals("testG", actual.getGroup());
         assertEquals("testD", actual.getName());
         assertEquals(Constants.Config.CONFIG_MODULE, actual.getType());
@@ -69,7 +98,7 @@ class ConfigHttpResourceParserTest {
     void testParseWithoutNamespace() throws NoSuchMethodException {
         Secured secured = getMethodSecure();
         Mockito.when(request.getParameter(eq(Constants.GROUP))).thenReturn("testG");
-        Mockito.when(request.getParameter(eq(Constants.DATAID))).thenReturn("testD");
+        Mockito.when(request.getParameter(eq(Constants.DATA_ID))).thenReturn("testD");
         Resource actual = resourceParser.parse(request, secured);
         assertEquals(StringUtils.EMPTY, actual.getNamespaceId());
         assertEquals("testG", actual.getGroup());
@@ -82,7 +111,7 @@ class ConfigHttpResourceParserTest {
     void testParseWithoutGroup() throws NoSuchMethodException {
         Secured secured = getMethodSecure();
         Mockito.when(request.getParameter(eq("tenant"))).thenReturn("testNs");
-        Mockito.when(request.getParameter(eq(Constants.DATAID))).thenReturn("testD");
+        Mockito.when(request.getParameter(eq(Constants.DATA_ID))).thenReturn("testD");
         Resource actual = resourceParser.parse(request, secured);
         assertEquals("testNs", actual.getNamespaceId());
         assertEquals(StringUtils.EMPTY, actual.getGroup());


### PR DESCRIPTION
## What is the purpose of the change

fix(#12333 ): fixed auth Plugin resource parser can't parser v2 config openAPI namespaceId.

## Brief changelog

fix(#12333 ): fixed auth Plugin resource parser can't parser v2 config openAPI namespaceId.

## Verifying this change

fix(#12333 ): fixed auth Plugin resource parser can't parser v2 config openAPI namespaceId.