### PR TITLE
fix [ISSUE #12323]  , using the  project's logback packagingData configuration instead of logback-nacos.xml's packagingData  configuration

### DIFF
--- a/logger-adapter-impl/logback-adapter-12/src/main/java/com/alibaba/nacos/logger/adapter/logback12/LogbackNacosLoggingAdapter.java
+++ b/logger-adapter-impl/logback-adapter-12/src/main/java/com/alibaba/nacos/logger/adapter/logback12/LogbackNacosLoggingAdapter.java
@@ -106,12 +106,15 @@ public class LogbackNacosLoggingAdapter implements NacosLoggingAdapter {
     
     private LoggerContext loadConfigurationOnStart(final String location) {
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        boolean isPackagingDataEnabled = loggerContext.isPackagingDataEnabled();
         configurator.setContext(loggerContext);
         if (StringUtils.isNotBlank(location)) {
             try {
                 configurator.configure(ResourceUtils.getResourceUrl(location));
             } catch (Exception e) {
                 throw new IllegalStateException("Could not initialize Logback Nacos logging from " + location, e);
+            }finally{
+                loggerContext.setPackagingDataEnabled(isPackagingDataEnabled);
             }
         }
         return loggerContext;

--- a/logger-adapter-impl/logback-adapter-12/src/main/java/com/alibaba/nacos/logger/adapter/logback12/LogbackNacosLoggingAdapter.java
+++ b/logger-adapter-impl/logback-adapter-12/src/main/java/com/alibaba/nacos/logger/adapter/logback12/LogbackNacosLoggingAdapter.java
@@ -106,15 +106,14 @@ public class LogbackNacosLoggingAdapter implements NacosLoggingAdapter {
     
     private LoggerContext loadConfigurationOnStart(final String location) {
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        boolean isPackagingDataEnabled = loggerContext.isPackagingDataEnabled();
         configurator.setContext(loggerContext);
         if (StringUtils.isNotBlank(location)) {
             try {
+                boolean isPackagingDataEnabled = loggerContext.isPackagingDataEnabled();
                 configurator.configure(ResourceUtils.getResourceUrl(location));
+                loggerContext.setPackagingDataEnabled(isPackagingDataEnabled);
             } catch (Exception e) {
                 throw new IllegalStateException("Could not initialize Logback Nacos logging from " + location, e);
-            }finally{
-                loggerContext.setPackagingDataEnabled(isPackagingDataEnabled);
             }
         }
         return loggerContext;


### PR DESCRIPTION
## What is the purpose of the change

fix issue #12323 , using project's logback packagingData configuration instead of logback-nacos.xml's packagingData configuration

## Brief changelog

Before `LogbackNacosLoggingAdapter`  loading ` logback-nocas.xml ` ，get the `isPackagingDataEnabled` property , when ` logback-nocas.xml ` is loaded , revert the `isPackagingDataEnabled` property of LoggerContext .

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
