### PR TITLE
feat(#12405): The LDAP default password is a fixed value 'nacos' and cannot be customized.

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProvider.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProvider.java
@@ -94,11 +94,10 @@ public class LdapAuthenticationProvider implements AuthenticationProvider {
         try {
             userDetails = userDetailsService.loadUserByUsername(AuthConstants.LDAP_PREFIX + username);
         } catch (UsernameNotFoundException exception) {
-            String nacosPassword = PasswordEncoderUtil.encode(AuthConstants.LDAP_DEFAULT_PASSWORD);
-            userDetailsService.createUser(AuthConstants.LDAP_PREFIX + username, nacosPassword);
+            userDetailsService.createUser(AuthConstants.LDAP_PREFIX + username, AuthConstants.LDAP_DEFAULT_ENCODED_PASSWORD);
             User user = new User();
             user.setUsername(AuthConstants.LDAP_PREFIX + username);
-            user.setPassword(nacosPassword);
+            user.setPassword(AuthConstants.LDAP_DEFAULT_ENCODED_PASSWORD);
             userDetails = new NacosUserDetails(user);
         }
         return new UsernamePasswordAuthenticationToken(userDetails, password, userDetails.getAuthorities());

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
@@ -73,11 +73,8 @@ public class AuthConstants {
      * LDAP Ignore partial result exception.
      */
     public static final String NACOS_CORE_AUTH_IGNORE_PARTIAL_RESULT_EXCEPTION = "nacos.core.auth.ldap.ignore.partial.result.exception";
-    
-    @Deprecated
-    public static final String LDAP_DEFAULT_PASSWORD = "nacos";
-    
-    public static final String LDAP_DEFAULT_ENCODED_PASSWORD = PasswordEncoderUtil.encode(LDAP_DEFAULT_PASSWORD);
+
+    public static final String LDAP_DEFAULT_ENCODED_PASSWORD = PasswordEncoderUtil.encode(System.getProperty("ldap.default.password", "nacos"));
     
     public static final String LDAP_PREFIX = "LDAP_";
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProviderTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/LdapAuthenticationProviderTest.java
@@ -81,7 +81,7 @@ class LdapAuthenticationProviderTest {
     
     private List<RoleInfo> roleInfos = new ArrayList<>();
     
-    private String defaultPassWord = "nacos";
+    private String defaultPassWord = System.getProperty("ldap.default.password", "nacos");
     
     @BeforeEach
     void setUp() throws NoSuchMethodException {


### PR DESCRIPTION
## What is the purpose of the change

feat(#12405 ) The LDAP default password can be customized by setting a JVM system property.

-Dldap.default.password=yourLdapDeafultPassword

## Brief changelog

feat(#12405 ) The LDAP default password can be customized by setting a JVM system property.

-Dldap.default.password=yourLdapDeafultPassword

## Verifying this change

feat(#12405 ) The LDAP default password can be customized by setting a JVM system property.

-Dldap.default.password=yourLdapDeafultPassword