### PR TITLE
fix: 关闭控制台登录时请求的Authorization为null

### DIFF
--- a/console-ui/src/globalLib.js
+++ b/console-ui/src/globalLib.js
@@ -540,7 +540,7 @@ const request = (function(_global) {
           config.beforeSend && config.beforeSend(xhr);
         },
         headers: {
-          Authorization: localStorage.getItem('token'),
+          Authorization: localStorage.getItem('token') || undefined,
           AccessToken: accessTokenInHeader,
         },
       })


### PR DESCRIPTION

## What is the purpose of the change

关闭nacos控制台的登录，使用nginx的auth_basic限制控制台访问的时候，部分接口的请求Authorization会被置为null，导致auth_basic无法正常使用

## Brief changelog

token不存在时Authorization置为undefined

## Verifying this change

能正常用nginx的auth_basic了


