### PR TITLE
[ISSUE #12342] Resolve the Hessian package conflict issue.

### DIFF
--- a/consistency/pom.xml
+++ b/consistency/pom.xml
@@ -59,7 +59,7 @@
             <artifactId>nacos-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.caucho</groupId>
+            <groupId>com.alipay.sofa</groupId>
             <artifactId>hessian</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <proto-google-common-protos.version>2.17.0</proto-google-common-protos.version>
         <protobuf-java.version>3.22.3</protobuf-java.version>
         <protoc-gen-grpc-java.version>${grpc-java.version}</protoc-gen-grpc-java.version>
-        <hessian.version>4.0.63</hessian.version>
+        <hessian.version>4.0.4</hessian.version>
         <mockito.version>4.11.0</mockito.version>
         <HikariCP.version>3.4.2</HikariCP.version>
         <jraft-core.version>1.3.14</jraft-core.version>
@@ -845,7 +845,7 @@
             <!-- hessian -->
             
             <dependency>
-                <groupId>com.caucho</groupId>
+                <groupId>com.alipay.sofa</groupId>
                 <artifactId>hessian</artifactId>
                 <version>${hessian.version}</version>
             </dependency>


### PR DESCRIPTION
## What is the purpose of the change
fixes #12342 
Resolve the Hessian package conflict issue.

## Brief changelog
Replaced the jraft-core Hessian dependency version `3.3.6` and the original Nacos project dependency on `com.caucho:hessian:4.0.63` with `com.alipay.sofa:hessian:4.0.4`.

## Verifying this change
We have been using this solution in our production environment since version 2.2.x, and it has been validated across versions 2.3.3 and 2.4.0.1. Throughout the use of this solution for service startup, as a configuration center, and as a registration center, no issues have been encountered.