### PR TITLE
[ISSUE #12621] 优化 nacos.core.member.lookup.type=address-server 参数时的处理逻辑，避免集群重启宕机隐患

### DIFF
--- a/core/src/main/resources/META-INF/logback/nacos.xml
+++ b/core/src/main/resources/META-INF/logback/nacos.xml
@@ -349,4 +349,9 @@
         <appender-ref ref="CONSOLE"/>
         <level value="INFO"/>
     </logger>
+  
+    <logger name="com.alibaba.nacos.core.cluster.lookup.AddressServerMemberLookup">
+        <appender-ref ref="CONSOLE"/>
+        <level value="INFO"/>
+    </logger>
 </configuration>


### PR DESCRIPTION
对应ISSUE： https://github.com/alibaba/nacos/issues/12621
