### PR TITLE
[ISSUE #12719] refresh the client's access token

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/auth/impl/NacosAuthLoginConstant.java
+++ b/client/src/main/java/com/alibaba/nacos/client/auth/impl/NacosAuthLoginConstant.java
@@ -36,6 +36,8 @@ public class NacosAuthLoginConstant {
     public static final String COLON = ":";
     
     public static final String SERVER = "server";
-    
-    
+
+    public static final int RELOGIN_CODE = 403;
+
+    public static final String NEXTREFRESHTIME = "nextRefreshTime";
 }

--- a/client/src/main/java/com/alibaba/nacos/client/auth/impl/NacosClientAuthServiceImpl.java
+++ b/client/src/main/java/com/alibaba/nacos/client/auth/impl/NacosClientAuthServiceImpl.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.client.auth.impl;
 import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.client.auth.impl.process.HttpLoginProcessor;
+import com.alibaba.nacos.common.utils.NumberUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.auth.api.LoginIdentityContext;
 import com.alibaba.nacos.plugin.auth.api.RequestResource;
@@ -58,8 +59,8 @@ public class NacosClientAuthServiceImpl extends AbstractClientAuthService {
      * A context to take with when sending request to Nacos server.
      */
     private volatile LoginIdentityContext loginIdentityContext = new LoginIdentityContext();
-    
-    
+
+
     /**
      * Login to servers.
      *
@@ -69,16 +70,19 @@ public class NacosClientAuthServiceImpl extends AbstractClientAuthService {
     @Override
     public Boolean login(Properties properties) {
         try {
-            if ((System.currentTimeMillis() - lastRefreshTime) < TimeUnit.SECONDS
-                    .toMillis(tokenTtl - tokenRefreshWindow)) {
+
+            String nextRefreshTimeStr = loginIdentityContext.getParameter(NacosAuthLoginConstant.NEXTREFRESHTIME);
+            long nextRefreshTime = NumberUtils.toLong(nextRefreshTimeStr, 0);
+
+            if (System.currentTimeMillis() < nextRefreshTime) {
                 return true;
             }
-            
+
             if (StringUtils.isBlank(properties.getProperty(PropertyKeyConst.USERNAME))) {
-                lastRefreshTime = System.currentTimeMillis();
+                loginIdentityContext.setParameter(NacosAuthLoginConstant.NEXTREFRESHTIME, "0");
                 return true;
             }
-            
+
             for (String server : this.serverList) {
                 HttpLoginProcessor httpLoginProcessor = new HttpLoginProcessor(nacosRestTemplate);
                 properties.setProperty(NacosAuthLoginConstant.SERVER, server);
@@ -87,11 +91,11 @@ public class NacosClientAuthServiceImpl extends AbstractClientAuthService {
                     if (identityContext.getAllKey().contains(NacosAuthLoginConstant.ACCESSTOKEN)) {
                         tokenTtl = Long.parseLong(identityContext.getParameter(NacosAuthLoginConstant.TOKENTTL));
                         tokenRefreshWindow = tokenTtl / 10;
-                        lastRefreshTime = System.currentTimeMillis();
-
+                        nextRefreshTime = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(tokenTtl - tokenRefreshWindow);
                         LoginIdentityContext newCtx = new LoginIdentityContext();
                         newCtx.setParameter(NacosAuthLoginConstant.ACCESSTOKEN,
                                 identityContext.getParameter(NacosAuthLoginConstant.ACCESSTOKEN));
+                        newCtx.setParameter(NacosAuthLoginConstant.NEXTREFRESHTIME, String.valueOf(nextRefreshTime));
                         this.loginIdentityContext = newCtx;
                     }
                     return true;

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/AbstractNamingClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/AbstractNamingClientProxy.java
@@ -54,4 +54,8 @@ public abstract class AbstractNamingClientProxy extends Subscriber<ServerListCha
         result.put(APP_FILED, AppNameUtils.getAppName());
         return result;
     }
+
+    protected void reLogin() {
+        securityProxy.reLogin();
+    }
 }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.api.selector.AbstractSelector;
 import com.alibaba.nacos.api.selector.ExpressionSelector;
 import com.alibaba.nacos.api.selector.SelectorType;
 import com.alibaba.nacos.client.address.ServerListChangeEvent;
+import com.alibaba.nacos.client.auth.impl.NacosAuthLoginConstant;
 import com.alibaba.nacos.client.env.NacosClientProperties;
 import com.alibaba.nacos.client.monitor.MetricsMonitor;
 import com.alibaba.nacos.client.naming.core.NamingServerListManager;
@@ -73,7 +74,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
     private static final int DEFAULT_SERVER_PORT = 8848;
     
     private static final String MODULE_NAME = "Naming";
-    
+
     private static final String IP_PARAM = "ip";
     
     private static final String PORT_PARAM = "port";
@@ -440,6 +441,12 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
             if (HttpStatus.SC_NOT_MODIFIED == restResult.getCode()) {
                 return StringUtils.EMPTY;
             }
+
+            // If the 403 login operation is triggered, refresh the accessToken of the client
+            if (NacosAuthLoginConstant.RELOGIN_CODE == restResult.getCode()) {
+                reLogin();
+            }
+
             throw new NacosException(restResult.getCode(), restResult.getMessage());
         } catch (NacosException e) {
             NAMING_LOGGER.error("[NA] failed to request", e);

--- a/client/src/main/java/com/alibaba/nacos/client/security/SecurityProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/security/SecurityProxy.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.client.security;
 
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.client.auth.impl.NacosAuthLoginConstant;
 import com.alibaba.nacos.plugin.auth.spi.client.ClientAuthPluginManager;
 import com.alibaba.nacos.plugin.auth.api.LoginIdentityContext;
 import com.alibaba.nacos.plugin.auth.spi.client.ClientAuthService;
@@ -38,6 +39,8 @@ import java.util.Properties;
 public class SecurityProxy implements Closeable {
     
     private ClientAuthPluginManager clientAuthPluginManager;
+
+    private Properties properties;
     
     /**
      * Construct from serverList, nacosRestTemplate, init client auth plugin.
@@ -57,6 +60,7 @@ public class SecurityProxy implements Closeable {
      * @param properties login identity information.
      */
     public void login(Properties properties) {
+        this.properties = properties;
         if (clientAuthPluginManager.getAuthServiceSpiImplSet().isEmpty()) {
             return;
         }
@@ -84,5 +88,20 @@ public class SecurityProxy implements Closeable {
     @Override
     public void shutdown() throws NacosException {
         clientAuthPluginManager.shutdown();
+    }
+
+    /**
+     * Login again to refresh the accessToken.
+     */
+    public void reLogin() {
+        if (clientAuthPluginManager.getAuthServiceSpiImplSet().isEmpty()) {
+            return;
+        }
+        for (ClientAuthService clientAuthService : clientAuthPluginManager.getAuthServiceSpiImplSet()) {
+            LoginIdentityContext loginIdentityContext = clientAuthService.getLoginIdentityContext(null);
+            if (loginIdentityContext != null) {
+                loginIdentityContext.setParameter(NacosAuthLoginConstant.NEXTREFRESHTIME, "0");
+            }
+        }
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxyTest.java
@@ -709,4 +709,21 @@ class NamingGrpcClientProxyTest {
         String appName = config.labels().get(Constants.APPNAME);
         assertNotNull(appName);
     }
+
+    @Test
+    void testResponseCode403Exception() throws NacosException {
+        Throwable exception = assertThrows(NacosException.class, () -> {
+
+            when(this.rpcClient.request(Mockito.any())).thenReturn(ErrorResponse.build(403, "Invalid signature"));
+
+            try {
+                client.registerService(SERVICE_NAME, GROUP_NAME, instance);
+            } catch (NacosException ex) {
+                assertNull(ex.getCause());
+
+                throw ex;
+            }
+        });
+        assertTrue(exception.getMessage().contains("Invalid signature"));
+    }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxyTest.java
@@ -645,4 +645,29 @@ class NamingHttpClientProxyTest {
         });
         
     }
+
+    @Test
+    void testCallServerFail403() throws Exception {
+        //given
+        NacosRestTemplate nacosRestTemplate = mock(NacosRestTemplate.class);
+
+        when(nacosRestTemplate.exchangeForm(any(), any(), any(), any(), any(), any())).thenAnswer(invocationOnMock -> {
+            //return url
+            HttpRestResult<Object> res = new HttpRestResult<Object>();
+            res.setMessage("Invalid signature");
+            res.setCode(403);
+            return res;
+        });
+
+        final Field nacosRestTemplateField = NamingHttpClientProxy.class.getDeclaredField("nacosRestTemplate");
+        nacosRestTemplateField.setAccessible(true);
+        nacosRestTemplateField.set(clientProxy, nacosRestTemplate);
+        String api = "/api";
+        Map<String, String> params = new HashMap<>();
+        Map<String, String> body = new HashMap<>();
+        String method = HttpMethod.GET;
+        String curServer = "127.0.0.1";
+        //then
+        assertThrows(NacosException.class, () -> clientProxy.callServer(api, params, body, curServer, method));
+    }
 }


### PR DESCRIPTION

## What is the purpose of the change

[issues#12719](https://github.com/alibaba/nacos/issues/12719
)

## Brief changelog
Modify the login logic in the NacosClientAuthServiceImpl code to record the refresh time of the token in the 'LoginIdentity Context'.

When the response code is determined to be 403 on the client side, set the parameter 'NextRefreshTime' in 'Login Identity Context' to 0.

After waiting for the timer task for 5 seconds, enter the login process and refresh the token.

---------------------------------------------------------------------------------------------------------------------------------------

1. 修改代码NacosClientAuthServiceImpl中的登录逻辑，将Token下一次的刷新时间记录到 LoginIdentityContext 中。
2. 在 client 端判断response code 为 403 时将 LoginIdentityContext 里面的参数 nextRefreshTime（下一次刷新时间） 设置为 0。
3. 等待定时器任务5秒后进入登录流程，进行Token刷新。

## Verifying this change
Modify the nacos.cre.auth.plugin.nacos.token.secreet.key parameter in the application and observe whether the client performs a re login operation