### PR TITLE
optimize: support resolving JAVA_HOME from symbolic links when `which…

### DIFF
--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -51,6 +51,9 @@ if [ -z "$JAVA_HOME" ]; then
         if [ -z "$JAVA_PATH" ]; then
             error_exit "Please set the JAVA_HOME variable in your environment, We need java(x64)! jdk8 or later is better!"
         fi
+        if [ -L "$JAVA_PATH" ]; then
+            JAVA_PATH=$(readlink -f "$JAVA_PATH")
+        fi
         JAVA_HOME=$(dirname "$JAVA_PATH")/..
         export JAVA_HOME=$(cd "$JAVA_HOME" && pwd)
   fi


### PR DESCRIPTION
… java` is used

Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

This change optimizes the logic for detecting JAVA_HOME in the Nacos startup script. Specifically, it adds support for resolving JAVA_HOME from symbolic links when the which java command is used. This enhancement ensures compatibility with systems where JAVA_HOME is not explicitly set but java is available via a symbolic link.

## Brief changelog

- Added a check to resolve symbolic links for JAVA_PATH when which java is used.
- Updated the logic to derive JAVA_HOME from the resolved JAVA_PATH.

## Verifying this change

To verify this change:

1. Test the script on a system where JAVA_HOME is not set but java is available via a symbolic link (e.g., /usr/bin/java -> /usr/java/jdk1.8.0_361/bin/java).
2. Ensure that the script correctly detects and sets JAVA_HOME to /usr/java/jdk1.8.0_361.
3. Test the script on systems with and without symbolic links to confirm backward compatibility.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

