### PR TITLE
[ISSUE #13205] Implement `SafeBcryptPasswordEncoder` to address password length vulnerability

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthConfig.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthConfig.java
@@ -42,7 +42,6 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -163,7 +162,7 @@ public class NacosAuthConfig {
     
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return new SafeBcryptPasswordEncoder();
     }
     
     @Bean

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/SafeBcryptPasswordEncoder.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/SafeBcryptPasswordEncoder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl;
+
+import com.alibaba.nacos.plugin.auth.impl.constant.AuthConstants;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * BCrypt encoder that fixes the password length vulnerability.
+ *
+ * <p>Problem solved: When password length exceeds 72 characters, the original {@link BCryptPasswordEncoder}
+ * only matches the first 72 characters, which could lead to different passwords being
+ * validated as matching (e.g., passwords {@code "A".repeat(73)} and {@code "A".repeat(80)}
+ * would be considered identical).
+ *
+ * <p>Fix logic: Adds length validation in {@link #matches(CharSequence, String)},
+ * returning false directly if the password length exceeds 72.
+ *
+ * <p><strong>Recommendation:</strong> It is advised to add password length validation
+ * during user registration/password modification to prevent login failures caused
+ * by historical data issues.
+ *
+ * @see <a href="https://github.com/advisories/GHSA-mg83-c7gq-rv5c">Spring Security Password Length Vulnerability Advisory</a>
+ * @author linwumignshi
+ */
+public class SafeBcryptPasswordEncoder extends BCryptPasswordEncoder {
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        // Reject excessively long passwords immediately
+        if (rawPassword != null && rawPassword.length() > AuthConstants.MAX_PASSWORD_LENGTH) {
+            return false;
+        }
+        return super.matches(rawPassword, encodedPassword);
+    }
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
@@ -77,4 +77,9 @@ public class AuthConstants {
     public static final String LDAP_DEFAULT_ENCODED_PASSWORD = PasswordEncoderUtil.encode(System.getProperty("ldap.default.password", "nacos"));
     
     public static final String LDAP_PREFIX = "LDAP_";
+    
+    /**
+     * Maximum allowed password length.
+     */
+    public static final int MAX_PASSWORD_LENGTH = 72;
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/utils/PasswordEncoderUtil.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/utils/PasswordEncoderUtil.java
@@ -16,7 +16,8 @@
 
 package com.alibaba.nacos.plugin.auth.impl.utils;
 
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import com.alibaba.nacos.plugin.auth.impl.SafeBcryptPasswordEncoder;
+import com.alibaba.nacos.plugin.auth.impl.constant.AuthConstants;
 
 /**
  * Password encoder tool.
@@ -26,10 +27,22 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 public class PasswordEncoderUtil {
     
     public static Boolean matches(String raw, String encoded) {
-        return new BCryptPasswordEncoder().matches(raw, encoded);
+        return new SafeBcryptPasswordEncoder().matches(raw, encoded);
     }
     
+    /**
+     * Encode password.
+     *
+     * @param raw password
+     * @return encoded password
+     */
     public static String encode(String raw) {
-        return new BCryptPasswordEncoder().encode(raw);
+        if (raw == null) {
+            throw new IllegalArgumentException("Password cannot be null");
+        }
+        if (raw.length() > AuthConstants.MAX_PASSWORD_LENGTH) {
+            throw new IllegalArgumentException("Password length must not exceed " + AuthConstants.MAX_PASSWORD_LENGTH + " characters");
+        }
+        return new SafeBcryptPasswordEncoder().encode(raw);
     }
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/SafeBcryptPasswordEncoderTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/SafeBcryptPasswordEncoderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl;
+
+import com.alibaba.nacos.plugin.auth.impl.constant.AuthConstants;
+import org.apache.commons.lang.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * SafeBcryptPasswordEncoderTest.
+ *
+ * @author linuwmingshi
+ */
+public class SafeBcryptPasswordEncoderTest {
+    
+    /**
+     * SafeBCryptPasswordEncoder.
+     */
+    private static final SafeBcryptPasswordEncoder ENCODER = new SafeBcryptPasswordEncoder();
+    
+    @Test
+    void testValidPasswordLength() {
+        String rawPassword =  StringUtils.repeat("A", AuthConstants.MAX_PASSWORD_LENGTH);
+        String encodedPassword = ENCODER.encode(rawPassword);
+        
+        assertTrue(ENCODER.matches(rawPassword, encodedPassword), "72-character rawPassword should match");
+    }
+    
+    @Test
+    void testExcessivePasswordLength() {
+        String rawPassword = StringUtils.repeat("A", AuthConstants.MAX_PASSWORD_LENGTH + 1);
+        String encodedPassword = ENCODER.encode(rawPassword.substring(0, AuthConstants.MAX_PASSWORD_LENGTH));
+        
+        assertFalse(ENCODER.matches(rawPassword, encodedPassword), "73-character rawPassword should be rejected");
+    }
+    
+    @Test
+    void testEdgeCase() {
+        String rawPassword72 = StringUtils.repeat("A", AuthConstants.MAX_PASSWORD_LENGTH);
+        String rawPassword73 = rawPassword72 + "A";
+        String encodedPassword = ENCODER.encode(rawPassword72);
+        
+        assertTrue(ENCODER.matches(rawPassword72, encodedPassword), "72-character password must pass");
+        assertFalse(ENCODER.matches(rawPassword73, encodedPassword), "73-character password must fail");
+    }
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/utils/PasswordEncoderUtilTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/utils/PasswordEncoderUtilTest.java
@@ -16,10 +16,15 @@
 
 package com.alibaba.nacos.plugin.auth.impl.utils;
 
+import com.alibaba.nacos.plugin.auth.impl.SafeBcryptPasswordEncoder;
+import com.alibaba.nacos.plugin.auth.impl.constant.AuthConstants;
+import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -49,5 +54,21 @@ class PasswordEncoderUtilTest {
         assertFalse(result2);
         Boolean matches = PasswordEncoderUtil.matches("nacos", PasswordEncoderUtil.encode("nacos"));
         assertTrue(matches);
+    }
+    
+    @Test
+    void enforcePasswordLength() {
+        String raw72Password =  StringUtils.repeat("A", AuthConstants.MAX_PASSWORD_LENGTH);
+        String encodedPassword = PasswordEncoderUtil.encode(raw72Password);
+        
+        assertThrows(IllegalArgumentException.class, () -> PasswordEncoderUtil.encode(null));
+        
+        String raw73Password = raw72Password.concat("A");
+        assertThrows(IllegalArgumentException.class, () -> PasswordEncoderUtil.encode(raw73Password));
+        
+        assertTrue(new BCryptPasswordEncoder().matches(raw73Password, encodedPassword));
+        assertFalse(new SafeBcryptPasswordEncoder().matches(raw73Password, encodedPassword));
+        assertFalse(PasswordEncoderUtil.matches(raw73Password, encodedPassword));
+    
     }
 }


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fix #13205

BCryptPasswordEncoder.matches(CharSequence,String) will incorrectly return true for passwords larger than 72 characters as long as the first 72 characters are the same.

## Brief changelog

Implement `SafeBcryptPasswordEncoder` to address password length vulnerability

## Verifying this change

`com.alibaba.nacos.plugin.auth.impl.SafeBcryptPasswordEncoderTest`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

