### PR TITLE
[noissue] bin/startup.sh, refactoring, extract variable

### DIFF
--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -144,7 +144,8 @@ logfile="${BASE_DIR}/logs/nacos.log"
 if [ ! -f "$logfile" ]; then
   touch "$logfile"
 fi
-echo "$JAVA $JAVA_OPT_EXT_FIX ${JAVA_OPT}" > "$logfile" 2>&1
+
+echo "$JAVA $JAVA_OPT_EXT_FIX ${JAVA_OPT}" > "$logfile"
 
 if [[ "$JAVA_OPT_EXT_FIX" == "" ]]; then
   nohup "$JAVA" ${JAVA_OPT} nacos.nacos >> "$logfile" 2>&1 &

--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -140,17 +140,16 @@ else
     echo "nacos is starting with cluster"
 fi
 
-# check the start.out log output file
-if [ ! -f "${BASE_DIR}/logs/start.out" ]; then
-  touch "${BASE_DIR}/logs/start.out"
+logfile="${BASE_DIR}/logs/nacos.log"
+if [ ! -f "$logfile" ]; then
+  touch "$logfile"
 fi
-# start
-echo "$JAVA $JAVA_OPT_EXT_FIX ${JAVA_OPT}" > ${BASE_DIR}/logs/start.out 2>&1 &
+echo "$JAVA $JAVA_OPT_EXT_FIX ${JAVA_OPT}" > "$logfile" 2>&1
 
 if [[ "$JAVA_OPT_EXT_FIX" == "" ]]; then
-  nohup "$JAVA" ${JAVA_OPT} nacos.nacos >> ${BASE_DIR}/logs/start.out 2>&1 &
+  nohup "$JAVA" ${JAVA_OPT} nacos.nacos >> "$logfile" 2>&1 &
 else
-  nohup "$JAVA" "$JAVA_OPT_EXT_FIX" ${JAVA_OPT} nacos.nacos >> ${BASE_DIR}/logs/start.out 2>&1 &
+  nohup "$JAVA" "$JAVA_OPT_EXT_FIX" ${JAVA_OPT} nacos.nacos >> "$logfile" 2>&1 &
 fi
 
-echo "nacos is starting. you can check the ${BASE_DIR}/logs/start.out"
+echo "nacos is starting. you can check the ${logfile}"

--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -140,7 +140,7 @@ else
     echo "nacos is starting with cluster"
 fi
 
-logfile="${BASE_DIR}/logs/nacos.log"
+logfile="${BASE_DIR}/logs/startup.log"
 if [ ! -f "$logfile" ]; then
   touch "$logfile"
 fi


### PR DESCRIPTION
## What is the purpose of the change

refactoring startup script

## Brief changelog

1. use a variable to store the log file path, instead of hard-coded multiple times.
2. the log file contains stdout & stderr, startup.log file is preferred. start.out may mean output only.
3. the echo command is not needed to run in background. And also no need to redirect stderr to stdout.
4. variable/string concatenation style. pure variable in quotes, no curly braces needed, as "$var" . String and variable in quotes, braces needed, as "some string ${var}continue".