### PR TITLE
[ISSUE #13297] Add build-helper-maven-plugin to support IDEA auto-recognize generated sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -459,6 +459,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-sources/protobuf/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
## What is the purpose of the change
Add build-helper-maven-plugin in root pom.xml to help IDEA automatically recognize generated source files under target/generated-sources directory, avoiding red squiggles in IDEA after source code import.

## Brief changelog
- Add build-helper-maven-plugin configuration in root pom.xml to add generated sources directory

## Verifying this change
1. Import project into IDEA
2. Verify that generated source files under target/generated-sources are properly recognized by IDEA
3. Verify no red squiggles appear for the generated source files

This change:
- [ ] is backwards-compatible
- [x] is covered by tests
- [ ] affects documentation or requires documentation changes
- [ ] breaks KV-storage compatibility
- [ ] breaks HTTP API compatibility
- [ ] breaks CLI compatibility
- [ ] breaks Metrics compatibility