### PR TITLE
bugfix：修复 nacos client 不会调 listener 方法的问题

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/core/ServiceInfoUpdateService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/core/ServiceInfoUpdateService.java
@@ -193,7 +193,7 @@ public class ServiceInfoUpdateService implements Closeable {
                 ServiceInfo serviceObj = serviceInfoHolder.getServiceInfoMap().get(serviceKey);
                 if (serviceObj == null) {
                     serviceObj = namingClientProxy.queryInstancesOfService(serviceName, groupName, clusters, false);
-                    serviceInfoHolder.processServiceInfo(serviceObj);
+                    serviceInfoHolder.processServiceInfo(serviceObj, false);
                     // TODO multiple time can be configured.
                     delayTime = serviceObj.getCacheMillis() * DEFAULT_UPDATE_CACHE_TIME_MULTIPLE;
                     lastRefTime = serviceObj.getLastRefTime();
@@ -202,7 +202,7 @@ public class ServiceInfoUpdateService implements Closeable {
                 
                 if (serviceObj.getLastRefTime() <= lastRefTime) {
                     serviceObj = namingClientProxy.queryInstancesOfService(serviceName, groupName, clusters, false);
-                    serviceInfoHolder.processServiceInfo(serviceObj);
+                    serviceInfoHolder.processServiceInfo(serviceObj, false);
                 }
                 lastRefTime = serviceObj.getLastRefTime();
                 if (CollectionUtils.isEmpty(serviceObj.getHosts())) {

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/NamingClientProxyDelegate.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/NamingClientProxyDelegate.java
@@ -172,7 +172,7 @@ public class NamingClientProxyDelegate implements NamingClientProxy {
         if (null == result || !isSubscribed(serviceName, groupName, clusters)) {
             result = grpcClientProxy.subscribe(serviceName, groupName, clusters);
         }
-        serviceInfoHolder.processServiceInfo(result);
+        serviceInfoHolder.processServiceInfo(result, true);
         return result;
     }
     

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingPushRequestHandler.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingPushRequestHandler.java
@@ -41,7 +41,7 @@ public class NamingPushRequestHandler implements ServerRequestHandler {
     public Response requestReply(Request request, Connection connection) {
         if (request instanceof NotifySubscriberRequest) {
             NotifySubscriberRequest notifyRequest = (NotifySubscriberRequest) request;
-            serviceInfoHolder.processServiceInfo(notifyRequest.getServiceInfo());
+            serviceInfoHolder.processServiceInfo(notifyRequest.getServiceInfo(), false);
             return new NotifySubscriberResponse();
         }
         return null;

--- a/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolderTest.java
@@ -85,7 +85,7 @@ class ServiceInfoHolderTest {
         hosts.add(instance2);
         info.setHosts(hosts);
         
-        ServiceInfo actual1 = holder.processServiceInfo(info);
+        ServiceInfo actual1 = holder.processServiceInfo(info, false);
         assertEquals(info, actual1);
         
         Instance newInstance1 = createInstance("1.1.1.1", 1);
@@ -97,7 +97,7 @@ class ServiceInfoHolderTest {
         ServiceInfo info2 = new ServiceInfo("a@@b@@c");
         info2.setHosts(hosts2);
         
-        ServiceInfo actual2 = holder.processServiceInfo(info2);
+        ServiceInfo actual2 = holder.processServiceInfo(info2, false);
         assertEquals(info2, actual2);
     }
     
@@ -116,7 +116,7 @@ class ServiceInfoHolderTest {
         try (MockedStatic<MetricsMonitor> mockedMetricsMonitor = Mockito.mockStatic(MetricsMonitor.class)) {
             mockedMetricsMonitor.when(MetricsMonitor::getServiceInfoMapSizeMonitor).thenReturn(mockGaugeChild);
             
-            holder.processServiceInfo(info);
+            holder.processServiceInfo(info, false);
             
             verify(mockGaugeChild, times(1)).set(1);
         }
@@ -134,7 +134,7 @@ class ServiceInfoHolderTest {
         info.setHosts(hosts);
         
         try (MockedStatic<MetricsMonitor> mockedMetricsMonitor = Mockito.mockStatic(MetricsMonitor.class)) {
-            holder.processServiceInfo(info);
+            holder.processServiceInfo(info, false);
             
             mockedMetricsMonitor.verify(MetricsMonitor::getServiceInfoMapSizeMonitor, never());
         }
@@ -156,7 +156,7 @@ class ServiceInfoHolderTest {
         try (MockedStatic<MetricsMonitor> mockedMetricsMonitor = Mockito.mockStatic(MetricsMonitor.class)) {
             mockedMetricsMonitor.when(MetricsMonitor::getServiceInfoMapSizeMonitor).thenReturn(mockGaugeChild);
             
-            holder.processServiceInfo(info);
+            holder.processServiceInfo(info, false);
             
             verify(mockGaugeChild, times(1)).set(1);
         }
@@ -180,7 +180,7 @@ class ServiceInfoHolderTest {
             mockedMetricsMonitor.when(MetricsMonitor::getServiceInfoMapSizeMonitor).thenReturn(mockGaugeChild);
             doThrow(exception).when(mockGaugeChild).set(anyInt());
             
-            ServiceInfo actual2 = holder.processServiceInfo(info);
+            ServiceInfo actual2 = holder.processServiceInfo(info, false);
             
             assertEquals(info, actual2);
         }
@@ -208,7 +208,7 @@ class ServiceInfoHolderTest {
     void testProcessServiceInfo2() {
         String json = "{\"groupName\":\"a\",\"name\":\"b\",\"clusters\":\"c\"}";
         
-        ServiceInfo actual = holder.processServiceInfo(json);
+        ServiceInfo actual = holder.processServiceInfo(json, false);
         ServiceInfo expect = new ServiceInfo("a@@b@@c");
         expect.setJsonFromServer(json);
         assertEquals(expect.getKey(), actual.getKey());
@@ -227,11 +227,11 @@ class ServiceInfoHolderTest {
         nacosClientProperties.setProperty(PropertyKeyConst.NAMING_PUSH_EMPTY_PROTECTION, "true");
         holder.shutdown();
         holder = new ServiceInfoHolder("aa", "scope-001", nacosClientProperties);
-        holder.processServiceInfo(oldInfo);
+        holder.processServiceInfo(oldInfo, false);
         
         ServiceInfo newInfo = new ServiceInfo("a@@b@@c");
         
-        final ServiceInfo actual = holder.processServiceInfo(newInfo);
+        final ServiceInfo actual = holder.processServiceInfo(newInfo, false);
         
         assertEquals(oldInfo.getKey(), actual.getKey());
         assertEquals(2, actual.getHosts().size());
@@ -239,7 +239,7 @@ class ServiceInfoHolderTest {
     
     @Test
     void testProcessNullServiceInfo() {
-        assertNull(holder.processServiceInfo(new ServiceInfo()));
+        assertNull(holder.processServiceInfo(new ServiceInfo(), false));
     }
     
     @Test
@@ -252,10 +252,10 @@ class ServiceInfoHolderTest {
         hosts.add(instance2);
         info.setHosts(hosts);
         info.setLastRefTime(System.currentTimeMillis());
-        holder.processServiceInfo(info);
+        holder.processServiceInfo(info, false);
         ServiceInfo olderInfo = new ServiceInfo("a@@b@@c");
         olderInfo.setLastRefTime(0L);
-        final ServiceInfo actual = holder.processServiceInfo(olderInfo);
+        final ServiceInfo actual = holder.processServiceInfo(olderInfo, false);
         assertEquals(olderInfo, actual);
     }
     
@@ -267,7 +267,7 @@ class ServiceInfoHolderTest {
         hosts.add(instance1);
         info.setHosts(hosts);
         
-        ServiceInfo expect = holder.processServiceInfo(info);
+        ServiceInfo expect = holder.processServiceInfo(info, false);
         String serviceName = "b";
         String groupName = "a";
         ServiceInfo actual = holder.getServiceInfo(serviceName, groupName);

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/NamingClientProxyDelegateTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/NamingClientProxyDelegateTest.java
@@ -298,7 +298,7 @@ class NamingClientProxyDelegateTest {
         ServiceInfo actual = delegate.subscribe(serviceName, groupName, clusters);
         assertEquals(info, actual);
         verify(mockGrpcClient, times(1)).subscribe(serviceName, groupName, clusters);
-        verify(holder, times(1)).processServiceInfo(info);
+        verify(holder, times(1)).processServiceInfo(info, false);
         
     }
     

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingPushRequestHandlerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/NamingPushRequestHandlerTest.java
@@ -49,7 +49,7 @@ class NamingPushRequestHandlerTest {
         Response response = handler.requestReply(req, new TestConnection(new RpcClient.ServerInfo()));
         //then
         assertTrue(response instanceof NotifySubscriberResponse);
-        verify(holder, times(1)).processServiceInfo(info);
+        verify(holder, times(1)).processServiceInfo(info, false);
     }
     
     @Test


### PR DESCRIPTION
# 问题描述

当订阅的时候，Nacos client 有可能不会回调 listener 方法

# 复现步骤：

1、执行  getAllInstance 方法，触发 subscribe 逻辑，更新 ServiceInfoHolder 的数据；
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/37c38357-83e7-411b-a467-6695ca25b0f6" />

2、执行 subscribe 方法， 手动订阅，再次更新 ServiceInfoHolder 的数据；

3、由于步骤1和步骤2中，ServiceInfoHolder 的数据一致，所以步骤2中不会触发 listener 方法的回调。详细流程如下图：

![Pasted Graphic_副本](https://github.com/user-attachments/assets/b07d58a2-2097-47ce-9fee-a86e671bdb41)


# 解决思路
添加一个参数，设置是否强制通知 listener 方法。比如，当用户手动执行 subscribe 方法的时候，强制回到 listener 方法，确保会走用户的回调逻辑
