### PR TITLE
[ISSUE #13345] fix apiClient readTimeout must be zero

### DIFF
--- a/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
+++ b/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
@@ -105,11 +105,10 @@ public class K8sSyncServer {
         
         if (k8sSyncConfig.isOutsideCluster()) {
             apiClient = getOutsideApiClient();
-            coreV1Api = new CoreV1Api();
         } else {
-            coreV1Api = new CoreV1Api();
-            apiClient = coreV1Api.getApiClient();
+            apiClient = ClientBuilder.defaultClient();
         }
+        coreV1Api = new CoreV1Api(apiClient);
 
         OkHttpClient httpClient = apiClient.getHttpClient().newBuilder().build();
         apiClient.setHttpClient(httpClient);
@@ -407,11 +406,7 @@ public class K8sSyncServer {
         String kubeConfigPath = k8sSyncConfig.getKubeConfig();
     
         // loading the out-of-cluster config, a kubeconfig from file-system
-        ApiClient apiClient = ClientBuilder.kubeconfig(KubeConfig.loadKubeConfig(new FileReader(kubeConfigPath))).build();
-        
-        // set the global default api-client to the in-cluster one from above
-        Configuration.setDefaultApiClient(apiClient);
-        return apiClient;
+        return ClientBuilder.kubeconfig(KubeConfig.loadKubeConfig(new FileReader(kubeConfigPath))).build();
     }
     
     /**


### PR DESCRIPTION
#13345

## What is the purpose of the change

- fix apiClient readTimeout must be zero

## Brief changelog

- get apiClient from `ClientBuilder` like `getOutsideApiClient` method
- pass the apiClient to `CoreV1Api`  explicitly rather than set `Configuration.setDefaultApiClient`