### PR TITLE
[ISSUE #13273]: 2.x support create cluseter client use nacos.remote.client.grpc config

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClientFactory.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClientFactory.java
@@ -206,4 +206,25 @@ public class RpcClientFactory {
                 clientNameInner -> new GrpcClusterClient(clientNameInner, threadPoolCoreSize, threadPoolMaxSize, labels,
                         tlsConfig));
     }
+    
+    /**
+     * create a cluster rpc client.
+     *
+     * @param clientName         client name.
+     * @param connectionType     client type.
+     * @param grpcClientConfig   grpc client config.
+     * @return rpc client.
+     */
+    public static RpcClient createClusterClient(String clientName, ConnectionType connectionType,
+            GrpcClientConfig grpcClientConfig) {
+        if (!ConnectionType.GRPC.equals(connectionType)) {
+            throw new UnsupportedOperationException("unsupported connection type :" + connectionType.getType());
+        }
+        
+        return CLIENT_MAP.computeIfAbsent(clientName, clientNameInner -> {
+            LOGGER.info("[RpcClientFactory] create a new cluster rpc client of " + clientName);
+            grpcClientConfig.setName(clientNameInner);
+            return new GrpcClusterClient(grpcClientConfig);
+        });
+    }
 }

--- a/common/src/test/java/com/alibaba/nacos/common/remote/client/RpcClientFactoryTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/remote/client/RpcClientFactoryTest.java
@@ -18,7 +18,9 @@ package com.alibaba.nacos.common.remote.client;
 
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.common.remote.ConnectionType;
+import com.alibaba.nacos.common.remote.client.grpc.DefaultGrpcClientConfig;
 import com.alibaba.nacos.common.remote.client.grpc.GrpcClientConfig;
+import com.alibaba.nacos.common.remote.client.grpc.GrpcClusterClient;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -212,5 +214,24 @@ class RpcClientFactoryTest {
         assertEquals(testClient.getLabels(), labels);
         assertEquals(testClient.getConnectionType(), ConnectionType.GRPC);
         assertEquals(testClient.getName(), "testClient");
+    }
+    
+    @Test
+    void testCreateClusterClientWithProperties() {
+        Mockito.when(rpcClientTlsConfig.getEnableTls()).thenReturn(true);
+        Properties properties = new Properties();
+        properties.setProperty("nacos.remote.client.grpc.maxinbound.message.size", "100000");
+        Map<String, String> labels = new HashMap<>();
+        labels.put("tls.enable", "false");
+        labels.put("labelKey", "labelValue");
+        GrpcClientConfig clientConfig = DefaultGrpcClientConfig.newBuilder().buildClusterFromProperties(properties)
+                .setLabels(labels).build();
+        GrpcClusterClient testClient = (GrpcClusterClient) RpcClientFactory.createClusterClient("testClient",
+                ConnectionType.GRPC, clientConfig);
+        assertEquals(testClient.getLabels(), labels);
+        assertEquals(testClient.getConnectionType(), ConnectionType.GRPC);
+        assertEquals(testClient.getName(), "testClient");
+        GrpcClientConfig testConfig = (GrpcClientConfig) testClient.rpcClientConfig;
+        assertEquals(testConfig.maxInboundMessageSize(), 100000);
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/remote/ClusterRpcClientProxy.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/remote/ClusterRpcClientProxy.java
@@ -26,9 +26,9 @@ import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.remote.ConnectionType;
 import com.alibaba.nacos.common.remote.client.RpcClient;
 import com.alibaba.nacos.common.remote.client.RpcClientFactory;
-import com.alibaba.nacos.common.remote.client.RpcClientTlsConfig;
-import com.alibaba.nacos.common.remote.client.RpcClientTlsConfigFactory;
 import com.alibaba.nacos.common.remote.client.ServerListFactory;
+import com.alibaba.nacos.common.remote.client.grpc.DefaultGrpcClientConfig;
+import com.alibaba.nacos.common.remote.client.grpc.GrpcClientConfig;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.core.cluster.Member;
@@ -163,9 +163,11 @@ public class ClusterRpcClientProxy extends MemberChangeListener {
      */
     private RpcClient buildRpcClient(ConnectionType type, Map<String, String> labels, String memberClientKey) {
         Properties properties = EnvUtil.getProperties();
-        RpcClientTlsConfig config = RpcClientTlsConfigFactory.getInstance().createClusterConfig(properties);
-        return RpcClientFactory.createClusterClient(memberClientKey, type, EnvUtil.getAvailableProcessors(2),
-                EnvUtil.getAvailableProcessors(8), labels, config);
+        GrpcClientConfig clientConfig = DefaultGrpcClientConfig.newBuilder().buildClusterFromProperties(properties)
+                .setLabels(labels).setName(memberClientKey)
+                .setThreadPoolCoreSize(EnvUtil.getAvailableProcessors(2))
+                .setThreadPoolMaxSize(EnvUtil.getAvailableProcessors(8)).build();
+        return RpcClientFactory.createClusterClient(memberClientKey, type, clientConfig);
     }
     
     /**


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

What is the purpose of the change
https://github.com/alibaba/nacos/issues/13273

Brief changelog
RpcClientFactory新增方法支持GrpcClientConfig构建GrpcClusterClient，ClusterRpcClientProxy构建GrpcClient时通过properties构建GrpcClientConfig，然后再t通过RpcClientFactory的构建方法构建。这样就可以通过nacos.remote.server.grpc.xxx相关配置设置集群间GrpcClient属性。

Verifying this change
通过测试验证配置nacos.remote.server.grpc.max-inboud-message-size可设置集群间grpc传输最值大，集群间grpc也支持nacos.remote.server.grpc.xxx相关配置，