### PR TITLE
[ISSUE #13485]  Fix the comment about "remote executors thread times of processors" - the default is 16

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/utils/RemoteUtils.java
+++ b/core/src/main/java/com/alibaba/nacos/core/utils/RemoteUtils.java
@@ -39,7 +39,7 @@ public class RemoteUtils {
     private static final int REMOTE_EXECUTOR_QUEUE_SIZE = 1 << 14;
     
     /**
-     * get remote executors thread times of processors,default is 64. see the usage of this method for detail.
+     * get remote executors thread times of processors,default is 16. see the usage of this method for detail.
      *
      * @return times of processors.
      */


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fix the comment about "remote executors thread times of processors" 

## Brief changelog

 Fix the comment about "remote executors thread times of processors" - the default is 16

## Verifying this change



Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

