### PR TITLE
fox#13565 Optimize error logs for MCP server not found scenario

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
@@ -215,7 +215,8 @@ public class McpServerOperationService {
         ConfigQueryChainResponse response = configQueryChainService.handle(request);
         if (McpConfigUtils.isConfigNotFound(response.getStatus())) {
             throw new NacosApiException(NacosApiException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
-                    String.format("mcp server `%s` not found", mcpServerId));
+                     String.format("Mcp server [ID: %s] not found in namespace [%s]. Response: %s",
+                            mcpServerId, namespaceId, response.getMessage()));
         }
         
         return JacksonUtils.toObj(response.getContent(), McpServerVersionInfo.class);


### PR DESCRIPTION
Purpose of the Change
Improve clarity and diagnostic value of error logs when MCP server version information is not found. The original error message was ambiguous and contained formatting issues, making debugging difficult.