### PR TITLE
[issue #13522] Ldap Configuration Bean is not loaded into Spring Bean

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/autoconfiguration/NacosAuthPluginInnerAutoConfig.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/autoconfiguration/NacosAuthPluginInnerAutoConfig.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.plugin.auth.impl.configuration.core.NacosAuthPluginCore
 import com.alibaba.nacos.plugin.auth.impl.configuration.core.NacosAuthPluginInnerServiceConfig;
 import com.alibaba.nacos.plugin.auth.impl.configuration.persistence.NacosAuthPluginPersistenceConfig;
 import com.alibaba.nacos.plugin.auth.impl.configuration.web.NacosAuthPluginWebConfig;
+import com.alibaba.nacos.plugin.auth.impl.ldap.LdapAuthPluginConfig;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -33,7 +34,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Conditional(ConditionOnInnerDatasource.class)
 @Import({NacosAuthPluginPersistenceConfig.class, NacosAuthPluginInnerServiceConfig.class,
-        NacosAuthPluginCoreConfig.class, NacosAuthPluginWebConfig.class})
+        NacosAuthPluginCoreConfig.class, NacosAuthPluginWebConfig.class, LdapAuthPluginConfig.class})
 public class NacosAuthPluginInnerAutoConfig {
 
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/autoconfiguration/NacosAuthPluginRemoteAutoConfig.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/autoconfiguration/NacosAuthPluginRemoteAutoConfig.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.plugin.auth.impl.configuration.core.NacosAuthPluginCore
 import com.alibaba.nacos.plugin.auth.impl.configuration.core.NacosAuthPluginRemoteServiceConfig;
 import com.alibaba.nacos.plugin.auth.impl.configuration.persistence.NacosAuthPluginPersistenceConfig;
 import com.alibaba.nacos.plugin.auth.impl.configuration.web.NacosAuthPluginControllerConfig;
+import com.alibaba.nacos.plugin.auth.impl.ldap.LdapAuthPluginConfig;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -33,7 +34,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Conditional(ConditionOnRemoteDatasource.class)
 @Import({NacosAuthPluginPersistenceConfig.class, NacosAuthPluginRemoteServiceConfig.class,
-        NacosAuthPluginCoreConfig.class, NacosAuthPluginControllerConfig.class})
+        NacosAuthPluginCoreConfig.class, NacosAuthPluginControllerConfig.class, LdapAuthPluginConfig.class})
 public class NacosAuthPluginRemoteAutoConfig {
 
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/core/NacosAuthPluginCoreConfig.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/core/NacosAuthPluginCoreConfig.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.auth.impl.configuration.core;
 
+import com.alibaba.nacos.plugin.auth.impl.condition.ConditionOnNacosAuth;
 import com.alibaba.nacos.plugin.auth.impl.configuration.AuthConfigs;
 import com.alibaba.nacos.auth.config.NacosAuthConfigHolder;
 import com.alibaba.nacos.core.auth.NacosServerAuthConfig;
@@ -67,7 +68,7 @@ public class NacosAuthPluginCoreConfig {
     
     @Bean
     @ConditionalOnMissingBean
-    @Conditional(value = ConditionOnInnerDatasource.class)
+    @Conditional(value = {ConditionOnInnerDatasource.class, ConditionOnNacosAuth.class})
     public GlobalAuthenticationConfigurerAdapter authenticationConfigurer() {
         return new GlobalAuthenticationConfigurerAdapter() {
             @Override
@@ -88,6 +89,7 @@ public class NacosAuthPluginCoreConfig {
     
     @Bean
     @ConditionalOnMissingBean
+    @Conditional(value = ConditionOnNacosAuth.class)
     public IAuthenticationManager defaultAuthenticationManager(NacosUserService userDetailsService,
             TokenManagerDelegate jwtTokenManager, NacosRoleService roleService) {
         return new DefaultAuthenticationManager(userDetailsService, jwtTokenManager, roleService);

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/ldap/LdapAuthPluginConfig.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/ldap/LdapAuthPluginConfig.java
@@ -24,8 +24,6 @@ import com.alibaba.nacos.plugin.auth.impl.roles.NacosRoleService;
 import com.alibaba.nacos.plugin.auth.impl.token.TokenManagerDelegate;
 import com.alibaba.nacos.plugin.auth.impl.users.NacosUserService;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -40,7 +38,6 @@ import org.springframework.security.config.annotation.authentication.configurati
  * @author onewe
  */
 @Configuration(proxyBeanMethods = false)
-@EnableAutoConfiguration(exclude = LdapAutoConfiguration.class)
 @Conditional(ConditionOnLdapAuth.class)
 public class LdapAuthPluginConfig {
     


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fix the issue [13522](https://github.com/alibaba/nacos/issues/13522).

In Nacos 3.0, auth plugins are loaded via Spring SPI. 

1. The annotation `@Configuration` on `LdapAuthPluginConfig` doesn't work at all. So we have to put the `LdapAuthPluginConfig` into `@imports` of `NacosAuthPluginInnerAutoConfig` and `NacosAuthPluginRemoteAutoConfig`

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/bcd1c1ad-61c5-47e0-a0d4-5bd598d25034" />

2. When LDAP Beans like `LdapAuthenticationManager` and  `GlobalAuthenticationConfigurerAdapter` are loaded into Spring,  they may conflict with those loaded by `NacosAuthPluginCoreConfig`. So I have to add `ConditionOnNacosAuth.class` to those beans in `NacosAuthPluginCoreConfig`

