### PR TITLE
[ISSUE#13600] Use targetNamespaceId for clone options

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
+++ b/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
@@ -55,6 +55,8 @@ public class Constants {
 
     public static final String NAMESPACE_ID = "namespaceId";
 
+    public static final String TARGET_NAMESPACE_ID = "targetNamespaceId";
+
     public static final String LAST_MODIFIED = "Last-Modified";
     
     public static final String ACCEPT_ENCODING = "Accept-Encoding";

--- a/auth/src/main/java/com/alibaba/nacos/auth/parser/http/ConfigHttpResourceParser.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/parser/http/ConfigHttpResourceParser.java
@@ -32,7 +32,11 @@ public class ConfigHttpResourceParser extends AbstractHttpResourceParser {
     
     @Override
     protected String getNamespaceId(HttpServletRequest request) {
-        String namespaceId = request.getParameter(Constants.NAMESPACE_ID);
+        // For clone operations, prioritize targetNamespaceId
+        String namespaceId = request.getParameter(Constants.TARGET_NAMESPACE_ID);
+        if (StringUtils.isBlank(namespaceId)) {
+            namespaceId = request.getParameter(Constants.NAMESPACE_ID);
+        }
         if (StringUtils.isBlank(namespaceId)) {
             namespaceId = request.getParameter(Constants.TENANT);
         }


### PR DESCRIPTION
Fixes #13600 

前端在发起克隆请求时，会把targetNamespaceId作为参数传给后端。
在Nacos 3.x中，配置克隆功能使用了@secured注解进行权限控制：
```java
@PostMapping("/clone")
@Secured(action = ActionTypes.WRITE, signType = SignType.CONFIG, apiType = ApiType.CONSOLE_API)
public Result<Map<String, Object>> cloneConfig(...)
```
克隆操作中请求参数的结构与普通配置操作不同：
普通配置操作：直接指定dataId、group、namespaceId
克隆操作：通过cfgId（配置ID）来指定要克隆的配置，然后通过targetNamespaceId指定目标命名空间
```java
@Override
protected String getNamespaceId(HttpServletRequest request) {
    String namespaceId = request.getParameter(Constants.NAMESPACE_ID);
    if (StringUtils.isBlank(namespaceId)) {
        namespaceId = request.getParameter(Constants.TENANT);
    }
    return NamespaceUtil.processNamespaceParameter(namespaceId);
}
```
当进行克隆操作时,资源解析不完整：ConfigHttpResourceParser尝试从请求参数中解析dataId、group、namespaceId，但克隆请求中这些参数可能为空或不存在,导致权限验证失败
<img width="1696" height="628" alt="image" src="https://github.com/user-attachments/assets/baaf2bc7-6504-42b6-b9ae-28a309236ff1" />