### PR TITLE
[ISSUE #13546] help gc

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
@@ -33,6 +33,7 @@ import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.common.utils.NumberUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.common.utils.ThreadUtils;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -89,6 +90,8 @@ public class CacheData {
                             new NameThreadFactory("com.alibaba.nacos.client.notify.block.monitor"),
                             new ThreadPoolExecutor.DiscardPolicy());
                     scheduledExecutor.setRemoveOnCancelPolicy(true);
+                    // it will shut down when jvm exit.
+                    ThreadUtils.addShutdownHook(CacheData::shutdownScheduledExecutor);
                 }
             }
         }
@@ -96,7 +99,7 @@ public class CacheData {
     }
     
     public static void shutdownScheduledExecutor() {
-        if (scheduledExecutor != null) {
+        if (scheduledExecutor != null && !scheduledExecutor.isShutdown()) {
             try {
                 scheduledExecutor.shutdown();
                 // help gc

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
@@ -75,8 +75,11 @@ public class CacheData {
         }
         return notifyWarnTimeout;
     }
-    
-    static ScheduledThreadPoolExecutor scheduledExecutor;
+
+    /**
+     * double check lock initialization of scheduledExecutor.
+     */
+    static volatile ScheduledThreadPoolExecutor scheduledExecutor;
     
     static ScheduledThreadPoolExecutor getNotifyBlockMonitor() {
         if (scheduledExecutor == null) {
@@ -92,6 +95,18 @@ public class CacheData {
         return scheduledExecutor;
     }
     
+    public static void shutdownScheduledExecutor() {
+        if (scheduledExecutor != null) {
+            try {
+                scheduledExecutor.shutdown();
+                // help gc
+                scheduledExecutor = null;
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
     static boolean initSnapshot;
     
     static {

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
@@ -97,7 +97,10 @@ public class CacheData {
         }
         return scheduledExecutor;
     }
-    
+
+    /**
+     * shutdownScheduledExecutor.
+     */
     public static void shutdownScheduledExecutor() {
         if (scheduledExecutor != null && !scheduledExecutor.isShutdown()) {
             try {

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -693,7 +693,7 @@ public class ClientWorker implements Closeable {
                     NotifyCenter.deregisterSubscriber(subscriber);
                 }
 
-                multiTaskExecutor.values().forEach((executor) ->{
+                multiTaskExecutor.values().forEach((executor) -> {
                     if (executor != null && !executor.isShutdown()) {
                         LOGGER.info("Shutdown multi task executor {}", executor);
                         executor.shutdown();

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -693,8 +693,6 @@ public class ClientWorker implements Closeable {
                 if (subscriber != null) {
                     NotifyCenter.deregisterSubscriber(subscriber);
                 }
-                // Shutdown NotifyCenter, include all subscribers and publishers
-                NotifyCenter.shutdown();
 
                 multiTaskExecutor.values().forEach((executor) ->{
                     if (executor != null && !executor.isShutdown()) {

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -620,7 +620,6 @@ public class ClientWorker implements Closeable {
             // help gc
             configFuzzyWatchGroupKeyHolder = null;
         }
-        CacheData.shutdownScheduledExecutor();
         if (agent != null) {
             agent.shutdown();
         }

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
@@ -129,7 +129,7 @@ public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber implements C
     }
 
     /**
-     * Deregistering it from the NotifyCenter and clearing.
+     * Deregistering it from the NotifyCenter.
      */
     @Override
     public void shutdown() {

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.client.config.common.GroupKey;
 import com.alibaba.nacos.client.utils.LogUtils;
+import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.Event;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.notify.listener.SmartSubscriber;
@@ -68,7 +69,7 @@ import static com.alibaba.nacos.api.model.v2.ErrorCode.FUZZY_WATCH_PATTERN_OVER_
  *
  * @author shiyiyue
  */
-public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber {
+public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber implements Closeable {
     
     private static final Logger LOGGER = LogUtils.logger(ClientWorker.class);
     
@@ -125,6 +126,15 @@ public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber {
                 }
             }
         });
+    }
+
+    /**
+     * Deregistering it from the NotifyCenter and clearing.
+     */
+    @Override
+    public void shutdown() {
+        // deregister subscriber which registered in constructor
+        NotifyCenter.deregisterSubscriber(this);
     }
     
     /**

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -636,11 +636,7 @@ public class NacosNamingService implements NamingService {
         serviceInfoHolder.shutdown();
         clientProxy.shutdown();
         namingFuzzyWatchServiceListHolder.shutdown();
-        // NotifyCenter#shutdown will shutdown all subscribers and publishers, so we don't need to
-        // NotifyCenter.deregisterSubscriber(changeNotifier);
-
-        // Shutdown NotifyCenter, include all subscribers and publishers
-        NotifyCenter.shutdown();
+        NotifyCenter.deregisterSubscriber(changeNotifier);
     }
     
     private void batchCheckAndStripGroupNamePrefix(List<Instance> instances, String groupName) throws NacosException {

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -636,7 +636,11 @@ public class NacosNamingService implements NamingService {
         serviceInfoHolder.shutdown();
         clientProxy.shutdown();
         namingFuzzyWatchServiceListHolder.shutdown();
-        NotifyCenter.deregisterSubscriber(changeNotifier);
+        // NotifyCenter#shutdown will shutdown all subscribers and publishers, so we don't need to
+        // NotifyCenter.deregisterSubscriber(changeNotifier);
+
+        // Shutdown NotifyCenter, include all subscribers and publishers
+        NotifyCenter.shutdown();
     }
     
     private void batchCheckAndStripGroupNamePrefix(List<Instance> instances, String groupName) throws NacosException {

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/NamingFuzzyWatchServiceListHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/NamingFuzzyWatchServiceListHolder.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.client.naming.event.NamingFuzzyWatchNotifyEvent;
 import com.alibaba.nacos.client.naming.remote.gprc.NamingGrpcClientProxy;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.common.executor.NameThreadFactory;
+import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.Event;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.notify.listener.SmartSubscriber;
@@ -58,7 +59,7 @@ import static com.alibaba.nacos.api.model.v2.ErrorCode.FUZZY_WATCH_PATTERN_OVER_
  *
  * @author tanyongquan
  */
-public class NamingFuzzyWatchServiceListHolder extends SmartSubscriber {
+public class NamingFuzzyWatchServiceListHolder extends SmartSubscriber implements Closeable {
     
     private static final Logger LOGGER = LogUtils.logger(NamingFuzzyWatchServiceListHolder.class);
     
@@ -92,7 +93,10 @@ public class NamingFuzzyWatchServiceListHolder extends SmartSubscriber {
     /**
      * shut down.
      */
+    @Override
     public void shutdown() {
+        // deregister subscriber which registered in constructor
+        NotifyCenter.deregisterSubscriber(this);
         if (executorService != null && !executorService.isShutdown()) {
             executorService.shutdown();
         }

--- a/common/src/main/java/com/alibaba/nacos/common/notify/DefaultPublisher.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/DefaultPublisher.java
@@ -153,6 +153,8 @@ public class DefaultPublisher extends Thread implements EventPublisher {
     public void shutdown() {
         this.shutdown = true;
         this.queue.clear();
+        // Interrupt the thread to stop processing events: queue.take().
+        this.interrupt();
     }
     
     public boolean isInitialized() {

--- a/common/src/main/java/com/alibaba/nacos/common/notify/NotifyCenter.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/NotifyCenter.java
@@ -54,7 +54,7 @@ public class NotifyCenter {
     
     private static final EventPublisherFactory DEFAULT_PUBLISHER_FACTORY;
     
-    private static final NotifyCenter INSTANCE = new NotifyCenter();
+    private static NotifyCenter INSTANCE = new NotifyCenter();
     
     private DefaultSharePublisher sharePublisher;
     
@@ -149,6 +149,9 @@ public class NotifyCenter {
         }
         
         LOGGER.info("[NotifyCenter] Completed destruction of Publisher");
+
+        // help gc
+        INSTANCE = null;
     }
     
     /**

--- a/common/src/main/java/com/alibaba/nacos/common/notify/NotifyCenter.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/NotifyCenter.java
@@ -53,7 +53,8 @@ public class NotifyCenter {
     private static final AtomicBoolean CLOSED = new AtomicBoolean(false);
     
     private static final EventPublisherFactory DEFAULT_PUBLISHER_FACTORY;
-    
+
+    @SuppressWarnings("checkstyle:StaticVariableName")
     private static NotifyCenter INSTANCE = new NotifyCenter();
     
     private DefaultSharePublisher sharePublisher;


### PR DESCRIPTION
在本地启动 NacosConfigService 和 NacosNamingService 后分析内存快照发现的确有资源未被及时回收，我觉得可以分为两种情况讨论：

### 1 资源创建后未关闭

- ClientWorker.ConfigRpcTransportClient#multiTaskExecutor: 线程池未关闭
- CacheData#scheduledExecutor: 线程池未关闭，并发现了双重检测锁创建线程池时未将变量使用 voliatile 修饰的问题

### 2 资源卸载的钩子方法未能及时触发

如题，也是这个 ISSUE 中主要的问题。

NotifyCenter 的静态代码块中注册了钩子方法 ThreadUtils.addShutdownHook(NotifyCenter::shutdown);，在 System.exit 等条件下会被触发到，而从 ISSUE 中的描述来看，他主动手动去卸载了这些能够在钩子方法中卸载的资源，说明在 war 部署并关闭应用时，这个钩子方法没有被执行到，所以导致了一系列的 DefaultPublisher 和 DefaultSharePublisher 线程没有被关闭。

同样地，还有 ThreadPoolManager#resourcesManager 中被统一管理的线程池资源也是采用了在静态代码块中注册钩子方法来完成卸载的，如果 war 包应用关闭时无法触发这个钩子方法，这里面的线程池也不会被回收。

我在代码里添加了主动调用 NotifyCenter#shutdown 的逻辑以达成释放 DefaultPublisher 等线程资源的目的，但是这样改我觉得不优雅，麻烦有时间帮忙 Review。并且我在 DefaultPublisher#shutdown 方法中添加了 this.interrupt(); 逻辑帮助线程关闭。

此外，ThreadPoolManager 中的资源我不清楚在哪里主动调用 shutdown 方法更合适，所以其中的线程池资源在不触发钩子方法的情况下还是不会被释放掉。

希望听取更多的意见。

排查过程简单写了博客记录一下，希望能对理解问题有所帮助：[关于 Nacos 在 war 包部署应用关闭部分资源未释放的原因分析](https://juejin.cn/spost/7531639037674291242)