### PR TITLE
修复 配置列表 group模糊查询bug

### DIFF
--- a/console-ui/src/pages/ConfigurationManagement/ConfigurationManagement/ConfigurationManagement.js
+++ b/console-ui/src/pages/ConfigurationManagement/ConfigurationManagement/ConfigurationManagement.js
@@ -256,12 +256,13 @@ class ConfigurationManagement extends React.Component {
   }
 
   changeParamsBySearchType(params) {
+    debugger;
     if (this.state.defaultFuzzySearch) {
       if (params.dataId && params.dataId !== '') {
         params.dataId = '*' + params.dataId + '*';
       }
-      if (params.group && params.group !== '') {
-        params.group = '*' + params.group + '*';
+      if (params.groupName && params.groupName !== '') {
+        params.groupName = '*' + params.groupName + '*';
       }
     }
     if (this.state.defaultFuzzySearch) {

--- a/console-ui/src/pages/ConfigurationManagement/ConfigurationManagement/ConfigurationManagement.js
+++ b/console-ui/src/pages/ConfigurationManagement/ConfigurationManagement/ConfigurationManagement.js
@@ -256,7 +256,6 @@ class ConfigurationManagement extends React.Component {
   }
 
   changeParamsBySearchType(params) {
-    debugger;
     if (this.state.defaultFuzzySearch) {
       if (params.dataId && params.dataId !== '') {
         params.dataId = '*' + params.dataId + '*';


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change



## Brief changelog

The Group field cannot be fuzzy searched.
不能模糊搜索组字段。

## Verifying this change

#13648 fix
