### PR TITLE
[ISSUE #13761]Fix: Add validation when deleting roles to prevent issues like mistakenly deleting ROLE_ADMIN.

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceDirectImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceDirectImpl.java
@@ -149,11 +149,19 @@ public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService imple
     
     @Override
     public void deleteRole(String role, String userName) {
+        if (AuthConstants.GLOBAL_ADMIN_ROLE.equals(role)) {
+            throw new IllegalArgumentException(
+                    "role '" + AuthConstants.GLOBAL_ADMIN_ROLE + "' is not permitted to delete!");
+        }
         rolePersistService.deleteRole(role, userName);
     }
     
     @Override
     public void deleteRole(String role) {
+        if (AuthConstants.GLOBAL_ADMIN_ROLE.equals(role)) {
+            throw new IllegalArgumentException(
+                    "role '" + AuthConstants.GLOBAL_ADMIN_ROLE + "' is not permitted to delete!");
+        }
         rolePersistService.deleteRole(role);
         getCachedRoleInfoMap().remove(role);
     }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceRemoteImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceRemoteImpl.java
@@ -180,6 +180,10 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService imple
     
     @Override
     public void deleteRole(String role, String userName) {
+        if (AuthConstants.GLOBAL_ADMIN_ROLE.equals(role)) {
+            throw new IllegalArgumentException(
+                    "role '" + AuthConstants.GLOBAL_ADMIN_ROLE + "' is not permitted to delete!");
+        }
         Query query = Query.newInstance().addParam("role", role).addParam("userName", userName);
         try {
             HttpRestResult<String> result = nacosRestTemplate.delete(buildRemoteRoleUrlPath(AuthConstants.ROLE_PATH),
@@ -194,6 +198,10 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService imple
     
     @Override
     public void deleteRole(String role) {
+        if (AuthConstants.GLOBAL_ADMIN_ROLE.equals(role)) {
+            throw new IllegalArgumentException(
+                    "role '" + AuthConstants.GLOBAL_ADMIN_ROLE + "' is not permitted to delete!");
+        }
         Query query = Query.newInstance().addParam("role", role);
         try {
             HttpRestResult<String> result = nacosRestTemplate.delete(buildRemoteRoleUrlPath(AuthConstants.ROLE_PATH),

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceDirectImplTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceDirectImplTest.java
@@ -38,12 +38,15 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -139,11 +142,17 @@ class NacosRoleServiceDirectImplTest {
     
     @Test
     void deleteRole() {
-        try {
-            nacosRoleService.deleteRole("role-admin");
-        } catch (Exception e) {
-            assertNull(e);
-        }
+        assertDoesNotThrow(() -> nacosRoleService.deleteRole("role-admin"));
+        assertDoesNotThrow(() -> nacosRoleService.deleteRole("mockRole", "mockUser"));
+    }
+    
+    @Test
+    void deleteAdminRole() {
+        assertThrows(IllegalArgumentException.class, () -> nacosRoleService.deleteRole(AuthConstants.GLOBAL_ADMIN_ROLE),
+                "role 'ROLE_ADMIN' is not permitted to delete!");
+        assertThrows(IllegalArgumentException.class,
+                () -> nacosRoleService.deleteRole(AuthConstants.GLOBAL_ADMIN_ROLE, "mockUser"),
+                "role 'ROLE_ADMIN' is not permitted to delete!");
     }
     
     @Test

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceDirectImplTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceDirectImplTest.java
@@ -38,7 +38,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;


### PR DESCRIPTION
## What is the purpose of the change

Add validation when deleting roles to prevent issues like mistakenly deleting ROLE_ADMIN.
fix #13761 

## Brief changelog

Add validation of ROLE_ADMIN in NacosRoleService
Add unit test

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

