### PR TITLE
[ISSUE #13752]: fix NPE and ignore InterruptedException stack log

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/notify/DefaultPublisher.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/DefaultPublisher.java
@@ -112,6 +112,8 @@ public class DefaultPublisher extends Thread implements EventPublisher {
                 receiveEvent(event);
                 UPDATER.compareAndSet(this, lastEventSequence, Math.max(lastEventSequence, event.sequence()));
             }
+        } catch (InterruptedException e) {
+            // [issue #13752] ignore stack log
         } catch (Throwable ex) {
             LOGGER.error("Event listener exception : ", ex);
         }

--- a/common/src/main/java/com/alibaba/nacos/common/notify/NotifyCenter.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/NotifyCenter.java
@@ -150,9 +150,6 @@ public class NotifyCenter {
         }
         
         LOGGER.info("[NotifyCenter] Completed destruction of Publisher");
-
-        // help gc
-        INSTANCE = null;
     }
     
     /**

--- a/common/src/main/java/com/alibaba/nacos/common/task/engine/TaskExecuteWorker.java
+++ b/common/src/main/java/com/alibaba/nacos/common/task/engine/TaskExecuteWorker.java
@@ -122,6 +122,8 @@ public final class TaskExecuteWorker implements NacosTaskProcessor, Closeable {
                     if (duration > 1000L) {
                         log.warn("task {} takes {}ms", task, duration);
                     }
+                } catch (InterruptedException e) {
+                    // [issue #13752] ignore stack log
                 } catch (Throwable e) {
                     log.error("[TASK-FAILED] " + e, e);
                 }


### PR DESCRIPTION
关联 https://github.com/alibaba/nacos/issues/13752

1. 修复空指针问题
2. 忽略 InterruptedException 相关的无效堆栈日志