### PR TITLE
[ISSUE #13863] Make multiple pids into a single line in shutdown.sh

### DIFF
--- a/distribution/bin/shutdown.sh
+++ b/distribution/bin/shutdown.sh
@@ -15,7 +15,7 @@
 cd `dirname $0`/../target
 target_dir=`pwd`
 
-pid=`pgrep -f nacos.nacos`
+pid=`pgrep -f nacos.nacos | xargs`
 if [ -z "$pid" ] ; then
         echo "No nacosServer running."
         exit -1;


### PR DESCRIPTION
## What is the purpose of the change
Make the multiple pids output by shutdown.sh into one line, separated with a space.  

Closes #13863.  

## Brief changelog
Add `| xargs` after `pgrep`.  

## Verifying this change
Test:  
```bash
$ sh bin/shutdown.sh
The nacosServer(9591 9853) is running...
Send shutdown request to nacosServer(9591 9853) OK
```

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

