### PR TITLE
[#13867] fix: service NullPointerException when getSpec()

### DIFF
--- a/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
+++ b/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
@@ -256,7 +256,6 @@ public class K8sSyncServer {
                 }
             }
         });
-        factory.startAllRegisteredInformers();
 
         // Wait until the cache of each informer has been fully synced before proceeding.
         // This ensures that the local cache contains the latest and complete resource data.


### PR DESCRIPTION
#13867 
之前的处理：先启动serviceInformer， 再启动endpointInformer。
这次的变更：删除冗余的factory.startAllRegisteredInformers();