### PR TITLE
feat：add overrideExisting endpoint when update mcpserver

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/McpAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/McpAdminController.java
@@ -133,7 +133,7 @@ public class McpAdminController {
         McpToolSpecification mcpTools = McpRequestUtil.parseMcpTools(mcpForm);
         McpEndpointSpec endpointSpec = McpRequestUtil.parseMcpEndpointSpec(basicInfo, mcpForm);
         mcpServerOperationService.updateMcpServer(mcpForm.getNamespaceId(), mcpForm.getLatest(), basicInfo, mcpTools,
-                endpointSpec);
+                endpointSpec, mcpForm.isOverrideExisting());
         return Result.success("ok");
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/mcp/admin/McpUpdateForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/mcp/admin/McpUpdateForm.java
@@ -29,6 +29,8 @@ public class McpUpdateForm extends McpDetailForm {
     private static final long serialVersionUID = 4144251088520249913L;
     
     private boolean latest = true;
+
+    private boolean overrideExisting = false;
     
     public Boolean getLatest() {
         return latest;
@@ -36,5 +38,13 @@ public class McpUpdateForm extends McpDetailForm {
     
     public void setLatest(Boolean publish) {
         this.latest = publish;
+    }
+
+    public boolean isOverrideExisting() {
+        return overrideExisting;
+    }
+
+    public void setOverrideExisting(boolean overrideExisting) {
+        this.overrideExisting = overrideExisting;
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
@@ -161,7 +161,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
         Boolean isLatest = mcpServerBasicInfo.getVersionDetail().getIs_latest();
         boolean isPublish = isLatest != null && isLatest;
         mcpServerOperationService.updateMcpServer(namespaceId, isPublish, mcpServerBasicInfo, toolSpecification,
-                endpointSpecification);
+                endpointSpecification, Boolean.FALSE);
         
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
@@ -268,7 +268,7 @@ public class McpServerImportService {
             McpEndpointSpec endpointSpec = convertToEndpointSpec(server);
 
             if (item.isExists() && overrideExisting) {
-                operationService.updateMcpServer(namespaceId, true, basicInfo, toolSpec, endpointSpec);
+                operationService.updateMcpServer(namespaceId, true, basicInfo, toolSpec, endpointSpec, overrideExisting);
             } else {
                 operationService.createMcpServer(namespaceId, basicInfo, toolSpec, endpointSpec);
             }

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/McpAdminControllerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/McpAdminControllerTest.java
@@ -218,7 +218,21 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("ok", result.getData());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
-                any(McpServerBasicInfo.class), isNull(), isNull());
+                any(McpServerBasicInfo.class), isNull(), isNull(), eq(false));
+    }
+
+    @Test
+    void updateMcpServerWithOverrideExisting() throws Exception {
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.put(Constants.MCP_ADMIN_PATH)
+                .param("serverSpecification", MCP_SERVER_SPEC);
+        MockHttpServletResponse response = mockMvc.perform(builder).andReturn().getResponse();
+        assertEquals(200, response.getStatus());
+        Result<String> result = JacksonUtils.toObj(response.getContentAsString(), new TypeReference<>() {
+        });
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        assertEquals("ok", result.getData());
+        verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
+                any(McpServerBasicInfo.class), isNull(), isNull(), eq(true));
     }
     
     @Test
@@ -232,7 +246,7 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("ok", result.getData());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
-                any(McpServerBasicInfo.class), isNull(), isNull());
+                any(McpServerBasicInfo.class), isNull(), isNull(), eq(false));
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/McpAdminControllerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/McpAdminControllerTest.java
@@ -224,7 +224,7 @@ class McpAdminControllerTest {
     @Test
     void updateMcpServerWithOverrideExisting() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.put(Constants.MCP_ADMIN_PATH)
-                .param("serverSpecification", MCP_SERVER_SPEC);
+                .param("serverSpecification", MCP_SERVER_SPEC).param("overrideExisting", "true");
         MockHttpServletResponse response = mockMvc.perform(builder).andReturn().getResponse();
         assertEquals(200, response.getStatus());
         Result<String> result = JacksonUtils.toObj(response.getContentAsString(), new TypeReference<>() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
@@ -181,25 +181,6 @@ class ReleaseMcpServerRequestHandlerTest {
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
                 eq(request.getServerSpecification()), isNull(), isNotNull(), eq(false));
     }
-
-    @Test
-    void handleReleaseNewVersionWithOverrideExisting() throws NacosException {
-        ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
-        request.setServerSpecification(buildMockServerSpecification(false, false));
-        String id = UUID.randomUUID().toString();
-        when(mcpServerOperationService.getMcpServerDetail(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, "test",
-                "1.0.0")).thenThrow(
-                new NacosApiException(NacosException.NOT_FOUND, ErrorCode.MCP_SEVER_VERSION_NOT_FOUND, ""));
-        when(meta.getConnectionId()).thenReturn("111");
-        McpServerIndexData indexData = McpServerIndexData.newIndexData(id, AiConstants.Mcp.MCP_DEFAULT_NAMESPACE);
-        when(mcpServerIndex.getMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "test")).thenReturn(indexData);
-        when(endpointOperationService.generateService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "test::1.0.0")).thenReturn(
-                Service.newService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, Constants.MCP_SERVER_ENDPOINT_GROUP, "test"));
-        ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
-        assertEquals(id, response.getMcpId());
-        verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
-                eq(request.getServerSpecification()), isNull(), isNotNull(), eq(true));
-    }
     
     @Test
     void handleReleaseNewVersionWithoutLatestWithSpecifiedEndpoint() throws NacosException {

--- a/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
@@ -179,7 +179,26 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
-                eq(request.getServerSpecification()), isNull(), isNotNull());
+                eq(request.getServerSpecification()), isNull(), isNotNull(), eq(false));
+    }
+
+    @Test
+    void handleReleaseNewVersionWithOverrideExisting() throws NacosException {
+        ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
+        request.setServerSpecification(buildMockServerSpecification(false, false));
+        String id = UUID.randomUUID().toString();
+        when(mcpServerOperationService.getMcpServerDetail(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, "test",
+                "1.0.0")).thenThrow(
+                new NacosApiException(NacosException.NOT_FOUND, ErrorCode.MCP_SEVER_VERSION_NOT_FOUND, ""));
+        when(meta.getConnectionId()).thenReturn("111");
+        McpServerIndexData indexData = McpServerIndexData.newIndexData(id, AiConstants.Mcp.MCP_DEFAULT_NAMESPACE);
+        when(mcpServerIndex.getMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "test")).thenReturn(indexData);
+        when(endpointOperationService.generateService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "test::1.0.0")).thenReturn(
+                Service.newService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, Constants.MCP_SERVER_ENDPOINT_GROUP, "test"));
+        ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
+        assertEquals(id, response.getMcpId());
+        verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
+                eq(request.getServerSpecification()), isNull(), isNotNull(), eq(true));
     }
     
     @Test
@@ -197,7 +216,7 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
-                eq(request.getServerSpecification()), isNull(), isNotNull());
+                eq(request.getServerSpecification()), isNull(), isNotNull(), eq(false));
         verify(endpointOperationService, never()).generateService(anyString(), anyString());
     }
     
@@ -217,7 +236,7 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
-                eq(request.getServerSpecification()), isNull(), isNotNull());
+                eq(request.getServerSpecification()), isNull(), isNotNull(), eq(false));
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpEndpointOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpEndpointOperationServiceTest.java
@@ -83,15 +83,15 @@ class McpEndpointOperationServiceTest {
         McpEndpointSpec mcpEndpointSpec = new McpEndpointSpec();
         mcpEndpointSpec.setType(AiConstants.Mcp.MCP_ENDPOINT_TYPE_REF);
         assertThrows(NacosApiException.class, () -> endpointOperationService.createMcpServerEndpointServiceIfNecessary(
-                        AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec),
+                        AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec, false),
                 "`namespaceId`, `groupName`, `serviceName` should be in remoteServerConfig data if type is `REF`");
         mcpEndpointSpec.getData().put("namespaceId", AiConstants.Mcp.MCP_DEFAULT_NAMESPACE);
         assertThrows(NacosApiException.class, () -> endpointOperationService.createMcpServerEndpointServiceIfNecessary(
-                        AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec),
+                        AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec, false),
                 "`namespaceId`, `groupName`, `serviceName` should be in remoteServerConfig data if type is `REF`");
         mcpEndpointSpec.getData().put("groupName", "groupName");
         assertThrows(NacosApiException.class, () -> endpointOperationService.createMcpServerEndpointServiceIfNecessary(
-                        AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec),
+                        AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec, false),
                 "`namespaceId`, `groupName`, `serviceName` should be in remoteServerConfig data if type is `REF`");
     }
     
@@ -103,7 +103,7 @@ class McpEndpointOperationServiceTest {
         mcpEndpointSpec.getData().put("groupName", "groupName");
         mcpEndpointSpec.getData().put("serviceName", "serviceName");
         Service service = endpointOperationService.createMcpServerEndpointServiceIfNecessary(
-                AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec);
+                AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec, false);
         assertEquals(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, service.getNamespace());
         assertEquals("groupName", service.getGroup());
         assertEquals("serviceName", service.getName());
@@ -116,7 +116,7 @@ class McpEndpointOperationServiceTest {
         mcpEndpointSpec.getData().put("address", "127.0.0.1");
         mcpEndpointSpec.getData().put("port", "8848");
         Service service = endpointOperationService.createMcpServerEndpointServiceIfNecessary(
-                AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec);
+                AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec, false);
         assertEquals(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, service.getNamespace());
         assertEquals(Constants.MCP_SERVER_ENDPOINT_GROUP, service.getGroup());
         assertEquals("mcpName::1.0.0", service.getName());
@@ -137,7 +137,7 @@ class McpEndpointOperationServiceTest {
         mcpEndpointSpec.getData().put("address", "127.0.0.1");
         mcpEndpointSpec.getData().put("port", "8848");
         Service service = endpointOperationService.createMcpServerEndpointServiceIfNecessary(
-                AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec);
+                AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", "1.0.0", mcpEndpointSpec, false);
         assertEquals(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, service.getNamespace());
         assertEquals(Constants.MCP_SERVER_ENDPOINT_GROUP, service.getGroup());
         assertEquals("mcpName::1.0.0", service.getName());

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerImportServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerImportServiceTest.java
@@ -418,7 +418,7 @@ class McpServerImportServiceTest {
         assertEquals(0, response.getSuccessCount());
         assertEquals(0, response.getFailedCount());
         assertEquals(1, response.getSkippedCount()); // Server should be skipped
-        verify(operationService, never()).updateMcpServer(anyString(), anyBoolean(), any(), any(), any());
+        verify(operationService, never()).updateMcpServer(anyString(), anyBoolean(), any(), any(), any(), anyBoolean());
         verify(operationService, never()).createMcpServer(anyString(), any(), any(), any());
     }
     
@@ -464,7 +464,7 @@ class McpServerImportServiceTest {
         assertEquals(1, response.getSuccessCount());
         assertEquals(0, response.getFailedCount());
         assertEquals(0, response.getSkippedCount());
-        verify(operationService).updateMcpServer(eq("test-namespace"), eq(true), any(), any(), any());
+        verify(operationService).updateMcpServer(eq("test-namespace"), eq(true), any(), any(), any(), anyBoolean());
         verify(operationService, never()).createMcpServer(anyString(), any(), any(), any());
     }
     
@@ -511,7 +511,7 @@ class McpServerImportServiceTest {
         assertEquals(0, response.getFailedCount());
         assertEquals(0, response.getSkippedCount());
         verify(operationService).createMcpServer(eq("test-namespace"), any(), any(), any());
-        verify(operationService, never()).updateMcpServer(anyString(), anyBoolean(), any(), any(), any());
+        verify(operationService, never()).updateMcpServer(anyString(), anyBoolean(), any(), any(), any(), anyBoolean());
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
@@ -624,7 +624,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-    
+
     @Test
     void createMcpServerWithEndpointSpec() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -636,7 +636,7 @@ class McpServerOperationServiceTest {
         endpointSpec.getData().put(Constants.MCP_SERVER_ENDPOINT_ADDRESS, "127.0.0.1");
         endpointSpec.getData().put(Constants.MCP_SERVER_ENDPOINT_PORT, "8848");
         when(endpointOperationService.createMcpServerEndpointServiceIfNecessary(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
-                "mcpName", "1.0.0", endpointSpec)).thenReturn(
+                "mcpName", "1.0.0", endpointSpec, false)).thenReturn(
                 Service.newService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, Constants.MCP_SERVER_ENDPOINT_GROUP,
                         "mcpName"));
         String id = serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
@@ -695,7 +695,7 @@ class McpServerOperationServiceTest {
         endpointSpec.getData().put(Constants.MCP_SERVER_ENDPOINT_ADDRESS, "127.0.0.1");
         endpointSpec.getData().put(Constants.MCP_SERVER_ENDPOINT_PORT, "8848");
         when(endpointOperationService.createMcpServerEndpointServiceIfNecessary(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
-                "mcpName", "1.0.0", endpointSpec)).thenReturn(
+                "mcpName", "1.0.0", endpointSpec, false)).thenReturn(
                 Service.newService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, Constants.MCP_SERVER_ENDPOINT_GROUP,
                         "mcpName"));
         String actualId = serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
@@ -714,7 +714,7 @@ class McpServerOperationServiceTest {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo(id);
         assertThrows(NacosApiException.class,
                 () -> serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true,
-                        mockServerBasicInfo, null, null));
+                        mockServerBasicInfo, null, null, false));
     }
     
     @Test
@@ -725,7 +725,7 @@ class McpServerOperationServiceTest {
         mockServerBasicInfo.setVersion(null);
         assertThrows(NacosApiException.class,
                 () -> serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true,
-                        mockServerBasicInfo, null, null));
+                        mockServerBasicInfo, null, null, false));
     }
     
     @Test
@@ -737,7 +737,7 @@ class McpServerOperationServiceTest {
         ConfigQueryChainResponse response = mockConfigQueryChainResponse(mockServerBasicInfo);
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(response);
         serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true, mockServerBasicInfo, null,
-                null);
+                null, false);
         verify(configOperationService, times(2)).publishConfig(any(ConfigFormV3.class), any(ConfigRequestInfo.class),
                 isNull());
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
@@ -754,7 +754,7 @@ class McpServerOperationServiceTest {
         ConfigQueryChainResponse response = mockConfigQueryChainResponse(mockServerBasicInfo);
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(response);
         serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true, mockServerBasicInfo, null,
-                null);
+                null, false);
         verify(configOperationService, times(2)).publishConfig(any(ConfigFormV3.class), any(ConfigRequestInfo.class),
                 isNull());
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
@@ -771,7 +771,7 @@ class McpServerOperationServiceTest {
         ConfigQueryChainResponse response = mockConfigQueryChainResponse(mockServerBasicInfo);
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(response);
         serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true, mockServerBasicInfo, null,
-                null);
+                null, false);
         verify(configOperationService, times(2)).publishConfig(any(ConfigFormV3.class), any(ConfigRequestInfo.class),
                 isNull());
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
@@ -784,7 +784,7 @@ class McpServerOperationServiceTest {
         McpServerVersionInfo mockServerBasicInfo = mockServerVersionInfo(null);
         assertThrows(NacosApiException.class,
                 () -> serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true,
-                        mockServerBasicInfo, null, null));
+                        mockServerBasicInfo, null, null, false));
     }
     
     @Test
@@ -797,7 +797,7 @@ class McpServerOperationServiceTest {
         ConfigQueryChainResponse response = mockConfigQueryChainResponse(mockServerBasicInfo);
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(response);
         serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true, mockServerBasicInfo, null,
-                null);
+                null, false);
         verify(configOperationService, times(2)).publishConfig(any(ConfigFormV3.class), any(ConfigRequestInfo.class),
                 isNull());
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName");
@@ -821,7 +821,7 @@ class McpServerOperationServiceTest {
         toolSpecification.setEncryptData(encryptObject);
 
         serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true, updateSpec,
-                toolSpecification, null);
+                toolSpecification, null, false);
 
         verify(toolOperationService, times(1)).refreshMcpTool(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
                 any(McpServerStorageInfo.class), eq(toolSpecification));

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -847,8 +848,15 @@ class McpServerOperationServiceTest {
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(
                 mockConfigQueryChainResponse(mockServerVersionInfo(id)));
         serverOperationService.deleteMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, id, null);
-        verify(endpointOperationService, times(2)).deleteMcpServerEndpointService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
-                "mcpName");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(endpointOperationService, times(2))
+                .deleteMcpServerEndpointService(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), captor.capture());
+        List<String> allArgs = captor.getAllValues();
+        assertEquals(2, allArgs.size(), "The actual number of calls does not match the expectation.");
+        assertTrue(allArgs.contains("mcpName::1.0.0"), "Missing deletion call for version 1.0.0");
+        assertTrue(allArgs.contains("mcpName::9.9.9"), "Missing deletion call for version 9.9.9");
+
         String serverVersionDataId = McpConfigUtils.formatServerVersionInfoDataId(id);
         verify(configOperationService, times(2)).deleteConfig(serverVersionDataId, Constants.MCP_SERVER_VERSIONS_GROUP,
                 AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
@@ -871,8 +879,15 @@ class McpServerOperationServiceTest {
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(
                 mockConfigQueryChainResponse(mockServerBasicInfo));
         serverOperationService.deleteMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName", null, null);
-        verify(endpointOperationService, times(2)).deleteMcpServerEndpointService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
-                "mcpName");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(endpointOperationService, times(2))
+                .deleteMcpServerEndpointService(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), captor.capture());
+        List<String> allArgs = captor.getAllValues();
+        assertEquals(2, allArgs.size(), "The actual number of calls does not match the expectation.");
+        assertTrue(allArgs.contains("mcpName::1.0.0"), "Missing deletion call for version 1.0.0");
+        assertTrue(allArgs.contains("mcpName::9.9.9"), "Missing deletion call for version 9.9.9");
+
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName");
         verify(mcpServerIndex, times(0)).removeMcpServerById(null);
         String serverVersionDataId = McpConfigUtils.formatServerVersionInfoDataId(id);
@@ -895,7 +910,7 @@ class McpServerOperationServiceTest {
         verify(mcpServerIndex, times(0)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null);
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
         verify(endpointOperationService).deleteMcpServerEndpointService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
-                "mcpName");
+                "mcpName::1.0.0");
         String serverVersionDataId = McpConfigUtils.formatServerVersionInfoDataId(id);
         verify(configOperationService).deleteConfig(serverVersionDataId, Constants.MCP_SERVER_VERSIONS_GROUP,
                 AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleMcpController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleMcpController.java
@@ -186,7 +186,7 @@ public class ConsoleMcpController {
         McpServerBasicInfo basicInfo = McpRequestUtil.parseMcpServerBasicInfo(mcpForm);
         McpToolSpecification mcpTools = McpRequestUtil.parseMcpTools(mcpForm);
         McpEndpointSpec endpointSpec = McpRequestUtil.parseMcpEndpointSpec(basicInfo, mcpForm);
-        mcpProxy.updateMcpServer(mcpForm.getNamespaceId(), mcpForm.getLatest(), basicInfo, mcpTools, endpointSpec);
+        mcpProxy.updateMcpServer(mcpForm.getNamespaceId(), mcpForm.getLatest(), basicInfo, mcpTools, endpointSpec, mcpForm.isOverrideExisting());
         return Result.success("ok");
     }
     

--- a/console/src/main/java/com/alibaba/nacos/console/handler/ai/McpHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/ai/McpHandler.java
@@ -86,10 +86,11 @@ public interface McpHandler {
      * @param serverSpecification   mcp server specification, see {@link McpServerBasicInfo}
      * @param toolSpecification     mcp server included tools, see {@link McpTool}, optional
      * @param endpointSpecification mcp server endpoint specification, see {@link McpEndpointSpec}, optional
+     * @param overrideExisting      if replace all the instances when update the mcp server
      * @throws NacosException any exception during handling
      */
     void updateMcpServer(String namespaceId, boolean isPublish, McpServerBasicInfo serverSpecification,
-            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException;
+            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException;
     
     /**
      * Delete existed mcp server.

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/McpInnerHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/McpInnerHandler.java
@@ -73,9 +73,9 @@ public class McpInnerHandler implements McpHandler {
     
     @Override
     public void updateMcpServer(String namespaceId, boolean isPublish, McpServerBasicInfo serverSpecification,
-            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException {
+            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException {
         mcpServerOperationService.updateMcpServer(namespaceId, isPublish, serverSpecification, toolSpecification,
-                endpointSpecification);
+                endpointSpecification, overrideExisting);
     }
     
     @Override

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/McpNoopHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/McpNoopHandler.java
@@ -66,7 +66,7 @@ public class McpNoopHandler implements McpHandler {
     
     @Override
     public void updateMcpServer(String namespaceId, boolean isPublish, McpServerBasicInfo serverSpecification,
-            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException {
+            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException {
         throw new NacosApiException(NacosException.SERVER_NOT_IMPLEMENTED, ErrorCode.API_FUNCTION_DISABLED,
                 MCP_NOT_ENABLED_MESSAGE);
     }

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/McpRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/McpRemoteHandler.java
@@ -75,9 +75,9 @@ public class McpRemoteHandler implements McpHandler {
     
     @Override
     public void updateMcpServer(String namespaceId, boolean isPublish, McpServerBasicInfo serverSpecification,
-            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException {
+            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException {
         clientHolder.getAiMaintainerService()
-                .updateMcpServer(serverSpecification.getName(), serverSpecification, toolSpecification, endpointSpecification);
+                .updateMcpServer(serverSpecification.getName(), serverSpecification, toolSpecification, endpointSpecification, overrideExisting);
     }
     
     @Override

--- a/console/src/main/java/com/alibaba/nacos/console/proxy/ai/McpProxy.java
+++ b/console/src/main/java/com/alibaba/nacos/console/proxy/ai/McpProxy.java
@@ -97,11 +97,12 @@ public class McpProxy {
      * @param serverSpecification   mcp server specification, see {@link McpServerBasicInfo}
      * @param toolSpecification     mcp server included tools, see {@link McpToolSpecification}, optional
      * @param endpointSpecification mcp server endpoint specification, see {@link McpEndpointSpec}, optional
+     * @param overrideExisting       if replace all the instances when update the mcp server
      * @throws NacosException any exception during handling
      */
     public void updateMcpServer(String namespaceId, boolean isPublish, McpServerBasicInfo serverSpecification,
-            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException {
-        mcpHandler.updateMcpServer(namespaceId, isPublish, serverSpecification, toolSpecification, endpointSpecification);
+            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException {
+        mcpHandler.updateMcpServer(namespaceId, isPublish, serverSpecification, toolSpecification, endpointSpecification, overrideExisting);
     }
     
     /**

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/ai/McpInnerHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/ai/McpInnerHandlerTest.java
@@ -85,9 +85,17 @@ class McpInnerHandlerTest {
     @Test
     void updateMcpServer() throws NacosException {
         mcpInnerHandler.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true, new McpServerBasicInfo(),
-                new McpToolSpecification(), new McpEndpointSpec());
+                new McpToolSpecification(), new McpEndpointSpec(), false);
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
-                any(McpServerBasicInfo.class), any(McpToolSpecification.class), any(McpEndpointSpec.class));
+                any(McpServerBasicInfo.class), any(McpToolSpecification.class), any(McpEndpointSpec.class), eq(false));
+    }
+
+    @Test
+    void updateMcpServerWithOverrideExisting() throws NacosException {
+        mcpInnerHandler.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true, new McpServerBasicInfo(),
+                new McpToolSpecification(), new McpEndpointSpec(), true);
+        verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
+                any(McpServerBasicInfo.class), any(McpToolSpecification.class), any(McpEndpointSpec.class), eq(true));
     }
     
     @Test

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/noop/ai/McpNoopHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/noop/ai/McpNoopHandlerTest.java
@@ -56,7 +56,7 @@ class McpNoopHandlerTest {
     
     @Test
     void updateMcpServer() {
-        assertThrows(NacosApiException.class, () -> mcpNoopHandler.updateMcpServer("", true, null, null, null),
+        assertThrows(NacosApiException.class, () -> mcpNoopHandler.updateMcpServer("", true, null, null, null, false),
                 "Nacos AI MCP module and API required both `naming` and `config` module.");
     }
     

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/ai/McpRemoteHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/ai/McpRemoteHandlerTest.java
@@ -88,9 +88,19 @@ class McpRemoteHandlerTest extends AbstractRemoteHandlerTest {
         McpServerBasicInfo mcpServerBasicInfo = new McpServerBasicInfo();
         mcpServerBasicInfo.setName("test");
         mcpRemoteHandler.updateMcpServer("", true, mcpServerBasicInfo, new McpToolSpecification(),
-                new McpEndpointSpec());
+                new McpEndpointSpec(), false);
         verify(aiMaintainerService).updateMcpServer(eq("test"), any(McpServerBasicInfo.class),
-                any(McpToolSpecification.class), any(McpEndpointSpec.class));
+                any(McpToolSpecification.class), any(McpEndpointSpec.class), eq(false));
+    }
+
+    @Test
+    void updateMcpServerWithOverrideExisting() throws NacosException {
+        McpServerBasicInfo mcpServerBasicInfo = new McpServerBasicInfo();
+        mcpServerBasicInfo.setName("test");
+        mcpRemoteHandler.updateMcpServer("", true, mcpServerBasicInfo, new McpToolSpecification(),
+                new McpEndpointSpec(), true);
+        verify(aiMaintainerService).updateMcpServer(eq("test"), any(McpServerBasicInfo.class),
+                any(McpToolSpecification.class), any(McpEndpointSpec.class), eq(true));
     }
     
     @Test

--- a/console/src/test/java/com/alibaba/nacos/console/proxy/ai/McpProxyTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/proxy/ai/McpProxyTest.java
@@ -120,9 +120,21 @@ public class McpProxyTest {
         McpEndpointSpec endpointSpecification = new McpEndpointSpec();
         
         doNothing().when(mcpHandler)
-                .updateMcpServer(NAMESPACE_ID, true, serverSpecification, toolSpecification, endpointSpecification);
+                .updateMcpServer(NAMESPACE_ID, true, serverSpecification, toolSpecification, endpointSpecification, false);
         
-        mcpProxy.updateMcpServer(NAMESPACE_ID, true, serverSpecification, toolSpecification, endpointSpecification);
+        mcpProxy.updateMcpServer(NAMESPACE_ID, true, serverSpecification, toolSpecification, endpointSpecification, false);
+    }
+
+    @Test
+    public void updateMcpServerWithOverrideExisting() throws NacosException {
+        McpServerBasicInfo serverSpecification = new McpServerBasicInfo();
+        McpToolSpecification toolSpecification = new McpToolSpecification();
+        McpEndpointSpec endpointSpecification = new McpEndpointSpec();
+
+        doNothing().when(mcpHandler)
+                .updateMcpServer(NAMESPACE_ID, true, serverSpecification, toolSpecification, endpointSpecification, true);
+
+        mcpProxy.updateMcpServer(NAMESPACE_ID, true, serverSpecification, toolSpecification, endpointSpecification, true);
     }
     
     @Test

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/McpMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/McpMaintainerService.java
@@ -411,12 +411,13 @@ public interface McpMaintainerService {
      * @param toolSpec     mcp server tools specification, see {@link McpToolSpecification}, nullable.
      * @param endpointSpec mcp server endpoint specification, see {@link McpEndpointSpec}, nullable if `type` is
      *                     {@link AiConstants.Mcp#MCP_PROTOCOL_STDIO}.
+     * @param overrideExisting      if replace all the instances when update the mcp server
      * @return {@code true} if create success, {@code false} otherwise
      * @throws NacosException if fail to create mcp server.
      */
     default boolean updateMcpServer(String mcpName, boolean isLatest, McpServerBasicInfo serverSpec, McpToolSpecification toolSpec,
-                            McpEndpointSpec endpointSpec) throws NacosException {
-        return updateMcpServer(Constants.DEFAULT_NAMESPACE_ID, mcpName, isLatest, serverSpec, toolSpec, endpointSpec);
+                            McpEndpointSpec endpointSpec, boolean overrideExisting) throws NacosException {
+        return updateMcpServer(Constants.DEFAULT_NAMESPACE_ID, mcpName, isLatest, serverSpec, toolSpec, endpointSpec, overrideExisting);
     }
 
     /**
@@ -429,11 +430,12 @@ public interface McpMaintainerService {
      * @param toolSpec     mcp server tools specification, see {@link McpToolSpecification}, nullable.
      * @param endpointSpec mcp server endpoint specification, see {@link McpEndpointSpec}, nullable if `type` is
      *                     {@link AiConstants.Mcp#MCP_PROTOCOL_STDIO}.
+     * @param overrideExisting  if replace all the instances when update the mcp server
      * @return {@code true} if create success, {@code false} otherwise
      * @throws NacosException if fail to create mcp server.
      */
     boolean updateMcpServer(String namespaceId, String mcpName, boolean isLatest, McpServerBasicInfo serverSpec, McpToolSpecification toolSpec,
-                            McpEndpointSpec endpointSpec) throws NacosException;
+                            McpEndpointSpec endpointSpec, boolean overrideExisting) throws NacosException;
     
     /**
      * Update existed mcp server to Nacos.
@@ -447,12 +449,13 @@ public interface McpMaintainerService {
      * @param toolSpec     mcp server tools specification, see {@link McpToolSpecification}, nullable.
      * @param endpointSpec mcp server endpoint specification, see {@link McpEndpointSpec}, nullable if `type` is
      *                     {@link AiConstants.Mcp#MCP_PROTOCOL_STDIO}.
+     * @param overrideExisting if replace all the instances when update the mcp server
      * @return {@code true} if update success, {@code false} otherwise
      * @throws NacosException if fail to update mcp server.
      */
     default boolean updateMcpServer(String mcpName, McpServerBasicInfo serverSpec, McpToolSpecification toolSpec,
-            McpEndpointSpec endpointSpec) throws NacosException {
-        return updateMcpServer(mcpName, true, serverSpec, toolSpec, endpointSpec);
+            McpEndpointSpec endpointSpec, boolean overrideExisting) throws NacosException {
+        return updateMcpServer(mcpName, true, serverSpec, toolSpec, endpointSpec, overrideExisting);
     }
     
     /**

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/NacosAiMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/NacosAiMaintainerServiceImpl.java
@@ -146,13 +146,14 @@ public class NacosAiMaintainerServiceImpl implements AiMaintainerService {
     
     @Override
     public boolean updateMcpServer(String namespaceId, String mcpName, boolean isLatest, McpServerBasicInfo serverSpec,
-            McpToolSpecification toolSpec, McpEndpointSpec endpointSpec) throws NacosException {
+            McpToolSpecification toolSpec, McpEndpointSpec endpointSpec, boolean overrideExisting) throws NacosException {
         if (StringUtils.isBlank(namespaceId)) {
             namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         }
         Map<String, String> params = buildFullParameters(serverSpec, toolSpec, endpointSpec);
         params.put("latest", String.valueOf(isLatest));
         params.put("namespaceId", namespaceId);
+        params.put("overrideExisting", String.valueOf(overrideExisting));
         RequestResource resource = buildRequestResource(namespaceId, mcpName);
         HttpRequest httpRequest = buildHttpRequestBuilder(resource).setHttpMethod(HttpMethod.PUT)
                 .setPath(Constants.AdminApiPath.AI_MCP_ADMIN_PATH).setParamValue(params).build();

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/NacosAiMaintainerServiceImplTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/NacosAiMaintainerServiceImplTest.java
@@ -231,7 +231,24 @@ public class NacosAiMaintainerServiceImplTest {
         final HttpRestResult<String> mockRestResult = new HttpRestResult<>();
         mockRestResult.setData(JacksonUtils.toJson(Result.success("ok")));
         when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockRestResult);
-        assertTrue(aiMaintainerService.updateMcpServer("test", serverSpec, toolSpec, null));
+        assertTrue(aiMaintainerService.updateMcpServer("test", serverSpec, toolSpec, null, false));
+    }
+
+    @Test
+    void updateMcpServerWithOverrideExisting() throws NacosException {
+        McpServerBasicInfo serverSpec = new McpServerBasicInfo();
+        serverSpec.setName("test");
+        serverSpec.setProtocol(AiConstants.Mcp.MCP_PROTOCOL_STDIO);
+        McpToolSpecification toolSpec = new McpToolSpecification();
+        McpTool mcpTool = new McpTool();
+        mcpTool.setName("testTool");
+        mcpTool.setName("testToolDescription");
+        toolSpec.setTools(Collections.singletonList(mcpTool));
+        toolSpec.setToolsMeta(Collections.singletonMap("testTool", new McpToolMeta()));
+        final HttpRestResult<String> mockRestResult = new HttpRestResult<>();
+        mockRestResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockRestResult);
+        assertTrue(aiMaintainerService.updateMcpServer("test", serverSpec, toolSpec, null, true));
     }
     
     @Test


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

#13751 

## What is the purpose of the change

1.mcpserver编辑之后出现异常，老的数据还在
2.当删除了老的mcpserver，添加新的mcpserver，新的mcpserver会出现老的endpoint的列表


## Brief changelog
1.在删除mcpserver的时候，联动删除所有的endpoint
2.在编辑mcpserver的时候，添加overrideExisting参数，用于控制是否需要覆盖之前的endpoints

第2个change的背景是，有一些用户会直接通过nacos的api给nacos中添加mcpserver，但是有时候用户会填写错endpoint的配置，这样在不改变版本号的情况下修改endpoint，目前是不行的


## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

