### PR TITLE
[ISSUE #13822]: separation of responsibilities of client executor and login scheduled executor

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -94,11 +94,10 @@ import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -150,7 +149,15 @@ public class ClientWorker implements Closeable {
     private boolean enableRemoteSyncConfig = false;
     
     private static final int MIN_THREAD_NUM = 2;
-    
+
+    /**
+     * One thread is busy with config listen, and the other is busy whit fuzzy config listen.
+     *
+     * @see ConfigRpcTransportClient#startInternal
+     * @see ConfigFuzzyWatchGroupKeyHolder#start
+     */
+    private static final int LOOP_CONFIG_LISTEN_THREAD_NUM = 2;
+
     private static final int THREAD_MULTIPLE = 1;
     
     private boolean enableClientMetrics = true;
@@ -538,19 +545,35 @@ public class ClientWorker implements Closeable {
         agent = new ConfigRpcTransportClient(properties, serverListManager);
         
         configFuzzyWatchGroupKeyHolder = new ConfigFuzzyWatchGroupKeyHolder(agent, uuid);
-        ScheduledExecutorService executorService = Executors.newScheduledThreadPool(initWorkerThreadCount(properties),
-                new NameThreadFactory("com.alibaba.nacos.client.Worker"));
-        agent.setExecutor(executorService);
+
+        ThreadPoolExecutor executor = instantiateClientExecutor(properties);
+        agent.setExecutor(executor);
+
         agent.start();
         configFuzzyWatchGroupKeyHolder.start();
-        
     }
     
     void initAppLabels(Properties properties) {
         this.appLabels = ConnLabelsUtils.addPrefixForEachKey(defaultLabelsCollectorManager.getLabels(properties),
                 APP_CONN_PREFIX);
     }
-    
+
+    private ThreadPoolExecutor instantiateClientExecutor(final NacosClientProperties properties) {
+        int workerThreadCount = initWorkerThreadCount(properties);
+
+        return new ThreadPoolExecutor(
+                workerThreadCount + LOOP_CONFIG_LISTEN_THREAD_NUM,
+                workerThreadCount * 2 + LOOP_CONFIG_LISTEN_THREAD_NUM,
+                60 * 5, TimeUnit.SECONDS,
+                // when corePoolSize is not enough, task will not wait in queue, because SynchronousQueue 0 capacity
+                // will create new thread to execute task util maximumPoolSize is reached
+                new SynchronousQueue<>(),
+                new NameThreadFactory("com.alibaba.nacos.client.executor"),
+                // CallerRunsPolicy ensures that tasks are not lost
+                new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+    }
+
     private int initWorkerThreadCount(NacosClientProperties properties) {
         int count = ThreadUtils.getSuitableThreadCount(THREAD_MULTIPLE);
         if (properties == null) {
@@ -842,8 +865,8 @@ public class ClientWorker implements Closeable {
         
         @Override
         public void startInternal() {
-            ScheduledExecutorService executor = getExecutor();
-            executor.schedule(() -> {
+            ThreadPoolExecutor executor = getExecutor();
+            executor.submit(() -> {
                 while (!executor.isShutdown() && !executor.isTerminated()) {
                     try {
                         listenExecutebell.poll(5L, TimeUnit.SECONDS);
@@ -861,8 +884,7 @@ public class ClientWorker implements Closeable {
                         notifyListenConfig();
                     }
                 }
-            }, 0L, TimeUnit.MILLISECONDS);
-            
+            });
         }
         
         @Override

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -102,6 +102,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.Executors;
 
 import static com.alibaba.nacos.api.common.Constants.APP_CONN_PREFIX;
 import static com.alibaba.nacos.api.common.Constants.ENCODE;
@@ -149,14 +150,6 @@ public class ClientWorker implements Closeable {
     private boolean enableRemoteSyncConfig = false;
     
     private static final int MIN_THREAD_NUM = 2;
-
-    /**
-     * One thread is busy with config listen, and the other is busy whit fuzzy config listen.
-     *
-     * @see ConfigRpcTransportClient#startInternal
-     * @see ConfigFuzzyWatchGroupKeyHolder#start
-     */
-    private static final int LOOP_CONFIG_LISTEN_THREAD_NUM = 2;
 
     private static final int THREAD_MULTIPLE = 1;
     
@@ -561,9 +554,7 @@ public class ClientWorker implements Closeable {
     private ThreadPoolExecutor instantiateClientExecutor(final NacosClientProperties properties) {
         int workerThreadCount = initWorkerThreadCount(properties);
 
-        return new ThreadPoolExecutor(
-                workerThreadCount + LOOP_CONFIG_LISTEN_THREAD_NUM,
-                workerThreadCount * 2 + LOOP_CONFIG_LISTEN_THREAD_NUM,
+        return new ThreadPoolExecutor(workerThreadCount, workerThreadCount * 2,
                 60 * 5, TimeUnit.SECONDS,
                 // when corePoolSize is not enough, task will not wait in queue, because SynchronousQueue 0 capacity
                 // will create new thread to execute task util maximumPoolSize is reached
@@ -662,7 +653,9 @@ public class ClientWorker implements Closeable {
     public class ConfigRpcTransportClient extends ConfigTransportClient {
         
         Map<String, ExecutorService> multiTaskExecutor = new HashMap<>();
-        
+
+        private ExecutorService listenExecutor;
+
         private final BlockingQueue<Object> listenExecutebell = new ArrayBlockingQueue<>(1);
         
         private final Object bellItem = new Object();
@@ -722,6 +715,10 @@ public class ClientWorker implements Closeable {
                         executor.shutdown();
                     }
                 });
+                if (listenExecutor != null && !listenExecutor.isShutdown()) {
+                    LOGGER.info("Shutdown listen config executor {}", listenExecutor);
+                    listenExecutor.shutdown();
+                }
             }
             
         }
@@ -865,12 +862,13 @@ public class ClientWorker implements Closeable {
         
         @Override
         public void startInternal() {
-            ThreadPoolExecutor executor = getExecutor();
-            executor.submit(() -> {
-                while (!executor.isShutdown() && !executor.isTerminated()) {
+            listenExecutor =
+                    Executors.newSingleThreadExecutor(new NameThreadFactory("com.alibaba.nacos.client.listen-executor"));
+            listenExecutor.submit(() -> {
+                while (!listenExecutor.isShutdown() && !listenExecutor.isTerminated()) {
                     try {
                         listenExecutebell.poll(5L, TimeUnit.SECONDS);
-                        if (executor.isShutdown() || executor.isTerminated()) {
+                        if (listenExecutor.isShutdown() || listenExecutor.isTerminated()) {
                             continue;
                         }
                         executeConfigListen();

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -106,7 +106,7 @@ public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber implements C
      * start.
      */
     public void start() {
-        ScheduledExecutorService agentExecutor = agent.getExecutor();
+        ThreadPoolExecutor agentExecutor = agent.getExecutor();
         agentExecutor.submit(() -> {
             while (!agentExecutor.isShutdown() && !agentExecutor.isTerminated()) {
                 try {

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.client.config.common.GroupKey;
 import com.alibaba.nacos.client.utils.LogUtils;
+import com.alibaba.nacos.common.executor.NameThreadFactory;
 import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.Event;
 import com.alibaba.nacos.common.notify.NotifyCenter;
@@ -49,7 +50,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -87,7 +88,9 @@ public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber implements C
     private final AtomicLong fuzzyListenLastAllSyncTime = new AtomicLong(System.currentTimeMillis());
     
     private static final long FUZZY_LISTEN_ALL_SYNC_INTERNAL = 3 * 60 * 1000;
-    
+
+    private ExecutorService fuzzyWatcherExecutor;
+
     private String taskId = "0";
     
     /**
@@ -106,12 +109,14 @@ public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber implements C
      * start.
      */
     public void start() {
-        ThreadPoolExecutor agentExecutor = agent.getExecutor();
-        agentExecutor.submit(() -> {
-            while (!agentExecutor.isShutdown() && !agentExecutor.isTerminated()) {
+        fuzzyWatcherExecutor = Executors.newSingleThreadScheduledExecutor(
+                new NameThreadFactory("com.alibaba.nacos.client.fuzzy-watcher-executor")
+        );
+        fuzzyWatcherExecutor.submit(() -> {
+            while (!fuzzyWatcherExecutor.isShutdown() && !fuzzyWatcherExecutor.isTerminated()) {
                 try {
                     fuzzyListenExecuteBell.poll(5L, TimeUnit.SECONDS);
-                    if (agentExecutor.isShutdown() || agentExecutor.isTerminated()) {
+                    if (fuzzyWatcherExecutor.isShutdown() || fuzzyWatcherExecutor.isTerminated()) {
                         continue;
                     }
                     executeConfigFuzzyListen();
@@ -129,12 +134,15 @@ public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber implements C
     }
 
     /**
-     * Deregistering it from the NotifyCenter.
+     * Deregistering it from the NotifyCenter and shutting down the executor.
      */
     @Override
     public void shutdown() {
         // deregister subscriber which registered in constructor
         NotifyCenter.deregisterSubscriber(this);
+        if (fuzzyWatcherExecutor != null && !fuzzyWatcherExecutor.isShutdown()) {
+            fuzzyWatcherExecutor.shutdown();
+        }
     }
     
     /**
@@ -384,9 +392,7 @@ public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber implements C
         for (ConfigFuzzyWatchContext context : contextLists) {
             ExecutorService executorService = agent.getExecutor();
             // Submit task for execution
-            Future<?> future = executorService.submit(() -> {
-                executeFuzzyWatchRequest(context, rpcClient);
-            });
+            Future<?> future = executorService.submit(() -> executeFuzzyWatchRequest(context, rpcClient));
             listenFutures.add(future);
         }
         

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigTransportClient.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigTransportClient.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.client.env.NacosClientProperties;
 import com.alibaba.nacos.client.security.SecurityProxy;
 import com.alibaba.nacos.client.utils.AppNameUtils;
 import com.alibaba.nacos.client.utils.ClientBasicParamUtil;
+import com.alibaba.nacos.common.executor.NameThreadFactory;
 import com.alibaba.nacos.common.utils.ConvertUtils;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.common.utils.StringUtils;
@@ -32,7 +33,9 @@ import com.alibaba.nacos.plugin.auth.api.RequestResource;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -52,7 +55,7 @@ public abstract class ConfigTransportClient {
     
     String tenant;
     
-    private ScheduledExecutorService executor;
+    private ThreadPoolExecutor executor;
     
     final ConfigServerListManager serverListManager;
     
@@ -61,11 +64,19 @@ public abstract class ConfigTransportClient {
     private int maxRetry = 3;
     
     private final long securityInfoRefreshIntervalMills = TimeUnit.SECONDS.toMillis(5);
-    
+
+    private ScheduledExecutorService loginScheduledExecutor;
+
     protected SecurityProxy securityProxy;
-    
+
+    /**
+     * Shut down to ensure resource release.
+     */
     public void shutdown() throws NacosException {
         securityProxy.shutdown();
+        if (loginScheduledExecutor != null && !loginScheduledExecutor.isShutdown()) {
+            loginScheduledExecutor.shutdown();
+        }
     }
     
     public ConfigTransportClient(NacosClientProperties properties, ConfigServerListManager serverListManager) {
@@ -123,11 +134,11 @@ public abstract class ConfigTransportClient {
         maxRetry = ConvertUtils.toInt(String.valueOf(properties.get(PropertyKeyConst.MAX_RETRY)), Constants.MAX_RETRY);
     }
     
-    public void setExecutor(ScheduledExecutorService executor) {
+    public void setExecutor(ThreadPoolExecutor executor) {
         this.executor = executor;
     }
     
-    public ScheduledExecutorService getExecutor() {
+    public ThreadPoolExecutor getExecutor() {
         return this.executor;
     }
     
@@ -136,7 +147,9 @@ public abstract class ConfigTransportClient {
      */
     public void start() throws NacosException {
         securityProxy.login(this.properties);
-        this.executor.scheduleWithFixedDelay(() -> securityProxy.login(properties), 0,
+        this.loginScheduledExecutor =
+                Executors.newScheduledThreadPool(1, new NameThreadFactory("com.alibaba.nacos.client.login"));
+        this.loginScheduledExecutor.scheduleWithFixedDelay(() -> securityProxy.login(properties), 0,
                 this.securityInfoRefreshIntervalMills, TimeUnit.MILLISECONDS);
         startInternal();
     }

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigTransportClient.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigTransportClient.java
@@ -148,7 +148,7 @@ public abstract class ConfigTransportClient {
     public void start() throws NacosException {
         securityProxy.login(this.properties);
         this.loginScheduledExecutor =
-                Executors.newScheduledThreadPool(1, new NameThreadFactory("com.alibaba.nacos.client.login"));
+                Executors.newSingleThreadScheduledExecutor(new NameThreadFactory("com.alibaba.nacos.client.login-executor"));
         this.loginScheduledExecutor.scheduleWithFixedDelay(() -> securityProxy.login(properties), 0,
                 this.securityInfoRefreshIntervalMills, TimeUnit.MILLISECONDS);
         startInternal();

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolderTest.java
@@ -42,7 +42,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -240,7 +240,7 @@ public class ConfigFuzzyWatchGroupKeyHolderTest {
         
         RpcClient rpcClient = Mockito.mock(RpcClient.class);
         when(rpcTransportClient.ensureRpcClient(eq("0"))).thenReturn(rpcClient);
-        ScheduledExecutorService scheduledExecutorService = Mockito.mock(ScheduledExecutorService.class);
+        ThreadPoolExecutor scheduledExecutorService = Mockito.mock(ThreadPoolExecutor.class);
         when(rpcTransportClient.getExecutor()).thenReturn(scheduledExecutorService);
         when(scheduledExecutorService.submit(any(Runnable.class))).thenReturn(Mockito.mock(Future.class));
         configFuzzyWatchGroupKeyHolder.executeConfigFuzzyListen();


### PR DESCRIPTION
@KomachiSion @shiyiyue1102 二位好，Hi~ o(*￣▽￣*)ブ

我对这个 ISSUE 的理解：如果只是单纯的解决表面的问题的话，可以直接将 ClientWorker#MIN_THREAD_NUM 字段调整为 3 或更大，但是如果未来出现对 ConfigTransportClient#executor 线程池中再添加一个循环的忙任务，可能还会产生同样的问题，所以我做了以下调整：

1. 线程池的职责分离：最初 ConfigTransportClient#executor 线程池用在了 ConfigTransportClient#start 定时登录任务、配置监听、模糊配置监听和处理模糊监听请求上（ConfigFuzzyWatchGroupKeyHolder#doExecuteConfigFuzzyListen），除了定时登录任务外，其他几个任务任务都不是定时任务，所以我想为定时登录创建一个线程池大小为 1 的 ScheduledExecutorService 来专门处理它，ConfigTransportClient#executor 线程池用于处理其他非定时任务
2. 因为 ConfigTransportClient#executor 线程池已经不需要处理定时任务了，所以我修改了它的类型为 ThreadPoolExecutor，用于处理其他三个配置监听的任务，因为配置监听和模糊配置监听需要长期占有 2 个线程，所以我定义了 ClientWorker#LOOP_CONFIG_LISTEN_THREAD_NUM 变量用于标识线程池中循环的忙任务数，并在创建线程池时（ClientWorker#instantiateClientExecutor），对 corePoolSize 和 maximumPoolSize 累加，保证线程池中始终为这两个任务创建专属的线程，剩余的其他线程用于处理其他任务
3. 创建线程池时指定的 SynchronousQueue 是为了让多提交的任务不在队列中等待，保证任务处理的及时性，当 corePoolSize 线程数不够时，直接创建新的线程来处理任务
4. CallerRunsPolicy 拒绝策略来保证任务不丢弃

请有时间帮忙 review~ 感谢~ 同时也听听二位的建议~