### PR TITLE
Fix: Correct synchronization lock and add volatile for tpsControlMana…

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcConnection.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcConnection.java
@@ -54,7 +54,7 @@ public class GrpcConnection extends Connection {
     
     private Channel channel;
     
-    private static TpsControlManager tpsControlManager;
+    private static volatile TpsControlManager tpsControlManager;
     
     public GrpcConnection(ConnectionMeta metaInfo, StreamObserver streamObserver, Channel channel) {
         super(metaInfo);
@@ -108,7 +108,7 @@ public class GrpcConnection extends Connection {
             boolean ready = ((ServerCallStreamObserver<?>) streamObserver).isReady();
             if (!ready) {
                 if (tpsControlManager == null) {
-                    synchronized (GrpcConnection.class.getClass()) {
+                    synchronized (GrpcConnection.class) {
                         if (tpsControlManager == null) {
                             tpsControlManager = ControlManagerCenter.getInstance().getTpsControlManager();
                             tpsControlManager.registerTpsPoint("SERVER_PUSH_BLOCK");


### PR DESCRIPTION
Fix: Correct synchronization lock and add volatile for tpsControlManager

This PR addresses two thread-safety issues in the double-checked locking pattern for tpsControlManager initialization:

1. Fixed incorrect synchronization lock object:
   Changed from `GrpcConnection.class.getClass()` to `GrpcConnection.class` to ensure proper lock scope is properly scoped to the current class, preventing unnecessary global lock contention with other classes using similar locking patterns.

2. Added volatile modifier to tpsControlManager:
   Added the `volatile` keyword to the tpsControlManager variable to ensure proper visibility of the initialized instance across multiple threads, which is a critical part of the double-checked locking pattern to prevent race conditions in instance initialization.

These changes improve both the correctness and performance of the concurrent initialization logic.