### PR TITLE
Fix deprecated Log4j2 package scanning warnings (#13902)

### DIFF
--- a/logger-adapter-impl/log4j2-adapter/pom.xml
+++ b/logger-adapter-impl/log4j2-adapter/pom.xml
@@ -51,5 +51,24 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <!-- Log4j annotation processor plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-core</artifactId>
+                            <version>${log4j.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/logger-adapter-impl/log4j2-adapter/src/main/java/com/alibaba/nacos/logger/adapter/log4j2/Log4J2NacosLoggingAdapter.java
+++ b/logger-adapter-impl/log4j2-adapter/src/main/java/com/alibaba/nacos/logger/adapter/log4j2/Log4J2NacosLoggingAdapter.java
@@ -48,8 +48,6 @@ public class Log4J2NacosLoggingAdapter implements NacosLoggingAdapter {
     
     private static final String NACOS_LOGGER_PREFIX = "com.alibaba.nacos";
     
-    private static final String NACOS_LOG4J2_PLUGIN_PACKAGE = "com.alibaba.nacos.client.logging.log4j2";
-    
     private static final String APPENDER_MARK = "ASYNC_NAMING";
     
     private static final String LOG4J2_CLASSES = "org.apache.logging.slf4j.Log4jLogger";
@@ -101,7 +99,6 @@ public class Log4J2NacosLoggingAdapter implements NacosLoggingAdapter {
         
         // load and start nacos configuration
         Configuration configuration = loadConfiguration(loggerContext, location);
-        configuration.getPluginPackages().add(NACOS_LOG4J2_PLUGIN_PACKAGE);
         configuration.start();
         
         // append loggers and appenders to contextConfiguration

--- a/logger-adapter-impl/log4j2-adapter/src/main/resources/nacos-log4j2.xml
+++ b/logger-adapter-impl/log4j2-adapter/src/main/resources/nacos-log4j2.xml
@@ -122,5 +122,9 @@
             additivity="false">
             <AppenderRef ref="ASYNC_NAMING"/>
         </Logger>
+
+        <Root level="${nacosClientProperty:root.log.level:-WARN}">
+          <AppenderRef ref="ASYNC_CONFIG"/>
+        </Root>
     </Loggers>
 </Configuration>

--- a/logger-adapter-impl/log4j2-adapter/src/main/resources/nacos-log4j2.xml
+++ b/logger-adapter-impl/log4j2-adapter/src/main/resources/nacos-log4j2.xml
@@ -122,5 +122,10 @@
             additivity="false">
             <AppenderRef ref="ASYNC_NAMING"/>
         </Logger>
+        
+        <Logger name="com.alibaba.nacos.client.ai" level="${nacosClientProperty:com.alibaba.nacos.ai.log.level:-info}"
+            additivity="false">
+            <AppenderRef ref="ASYNC_AI"/>
+        </Logger>
     </Loggers>
 </Configuration>

--- a/logger-adapter-impl/log4j2-adapter/src/main/resources/nacos-log4j2.xml
+++ b/logger-adapter-impl/log4j2-adapter/src/main/resources/nacos-log4j2.xml
@@ -122,10 +122,5 @@
             additivity="false">
             <AppenderRef ref="ASYNC_NAMING"/>
         </Logger>
-        
-        <Logger name="com.alibaba.nacos.client.ai" level="${nacosClientProperty:com.alibaba.nacos.ai.log.level:-info}"
-            additivity="false">
-            <AppenderRef ref="ASYNC_AI"/>
-        </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Fix https://github.com/alibaba/nacos/issues/12102 deprecated Log4j2 package scanning warnings

this pr has been merge in develop branch, and this is another PR for v2.x-develop.
## Brief changelog
According to Log4j 2.19.1 updates, package scanning functionality has been deprecated (LOG4J2-3644), requiring removal of:

PluginManager.addPackage() method calls
packages attribute in configuration files
Key changes:

Removed deprecated PluginManager.addPackage() call from Log4J2NacosLoggingAdapter.java
Removed packages attribute from nacos-log4j2.xml configuration file
Configured Maven compiler plugin to use Log4j annotation processor for automatic plugin descriptor generation
The new implementation uses Log4j annotation processor to automatically discover https://github.com/plugin annotated classes during compilation,
generating Log4j2Plugins.dat file for modern plugin discovery mechanism.

This maintains full functionality of NacosClientPropertiesLookup plugin
while eliminating all deprecated method warnings.

Resolves warning:
WARN The use of package scanning to locate Log4j plugins is deprecated.

[log4j Registering plugins](https://logging.apache.org/log4j/2.x/manual/plugins.html#plugin-registry)

