### PR TITLE
[ISSUE #13922]: add thread poll allow core thread timeout config

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/DefaultGrpcClientConfig.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/DefaultGrpcClientConfig.java
@@ -64,6 +64,8 @@ public class DefaultGrpcClientConfig implements GrpcClientConfig {
     
     private final long capabilityNegotiationTimeout;
     
+    private final boolean allowCoreThreadTimeOut;
+    
     private final Map<String, String> labels;
     
     private RpcClientTlsConfig tlsConfig = new RpcClientTlsConfig();
@@ -89,6 +91,7 @@ public class DefaultGrpcClientConfig implements GrpcClientConfig {
         this.healthCheckTimeOut = builder.healthCheckTimeOut;
         this.channelKeepAliveTimeout = builder.channelKeepAliveTimeout;
         this.capabilityNegotiationTimeout = builder.capabilityNegotiationTimeout;
+        this.allowCoreThreadTimeOut = builder.allowCoreThreadTimeOut;
         this.labels = builder.labels;
         this.labels.put("tls.enable", "false");
         if (Objects.nonNull(builder.tlsConfig)) {
@@ -178,6 +181,11 @@ public class DefaultGrpcClientConfig implements GrpcClientConfig {
     }
     
     @Override
+    public boolean allowCoreThreadTimeOut() {
+        return this.allowCoreThreadTimeOut;
+    }
+    
+    @Override
     public int healthCheckRetryTimes() {
         return healthCheckRetryTimes;
     }
@@ -227,6 +235,8 @@ public class DefaultGrpcClientConfig implements GrpcClientConfig {
         private long healthCheckTimeOut = 3000L;
         
         private long capabilityNegotiationTimeout = 5000L;
+        
+        private boolean allowCoreThreadTimeOut = false;
         
         private final Map<String, String> labels = new HashMap<>();
         
@@ -307,6 +317,10 @@ public class DefaultGrpcClientConfig implements GrpcClientConfig {
             if (properties.containsKey(GrpcConstants.GRPC_CHANNEL_KEEP_ALIVE_TIMEOUT)) {
                 this.channelKeepAliveTimeout = Integer.parseInt(
                         properties.getProperty(GrpcConstants.GRPC_CHANNEL_KEEP_ALIVE_TIMEOUT));
+            }
+            if (properties.containsKey(GrpcConstants.GRPC_THREADPOOL_ALLOW_CORE_THREAD_TIMEOUT)) {
+                this.allowCoreThreadTimeOut = Boolean.parseBoolean(
+                        properties.getProperty(GrpcConstants.GRPC_THREADPOOL_ALLOW_CORE_THREAD_TIMEOUT));
             }
             this.tlsConfig = tlsConfig;
             return this;
@@ -417,6 +431,17 @@ public class DefaultGrpcClientConfig implements GrpcClientConfig {
         
         public Builder setCapabilityNegotiationTimeout(long capabilityNegotiationTimeout) {
             this.capabilityNegotiationTimeout = capabilityNegotiationTimeout;
+            return this;
+        }
+        
+        /**
+         * set allowCoreThreadTimeOut.
+         *
+         * @param allowCoreThreadTimeOut allowCoreThreadTimeOut flag
+         * @return builder
+         */
+        public Builder setAllowCoreThreadTimeOut(boolean allowCoreThreadTimeOut) {
+            this.allowCoreThreadTimeOut = allowCoreThreadTimeOut;
             return this;
         }
         

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClient.java
@@ -167,7 +167,7 @@ public abstract class GrpcClient extends RpcClient {
                 new LinkedBlockingQueue<>(clientConfig.threadPoolQueueSize()),
                 new ThreadFactoryBuilder().daemon(true).nameFormat("nacos-grpc-client-executor-" + serverIp + "-%d")
                         .build());
-        grpcExecutor.allowCoreThreadTimeOut(true);
+        grpcExecutor.allowCoreThreadTimeOut(clientConfig.allowCoreThreadTimeOut());
         return grpcExecutor;
     }
     

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClientConfig.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClientConfig.java
@@ -110,4 +110,11 @@ public interface GrpcClientConfig extends RpcClientConfig {
      * @return timeout of connection setup
      */
     long capabilityNegotiationTimeout();
+    
+    /**
+     * get allowCoreThreadTimeOut flag for thread pool.
+     *
+     * @return allowCoreThreadTimeOut flag
+     */
+    boolean allowCoreThreadTimeOut();
 }

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcConstants.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcConstants.java
@@ -82,6 +82,9 @@ public class GrpcConstants {
     @GRpcConfigLabel
     public static final String GRPC_CHANNEL_CAPABILITY_NEGOTIATION_TIMEOUT = NACOS_CLIENT_GRPC + ".channel.capability.negotiation.timeout";
 
+    @GRpcConfigLabel
+    public static final String GRPC_THREADPOOL_ALLOW_CORE_THREAD_TIMEOUT = NACOS_CLIENT_GRPC + ".pool.core.timeout";
+
     private static final Set<String> CONFIG_NAMES = new HashSet<>();
     
     @Documented

--- a/common/src/test/java/com/alibaba/nacos/common/remote/client/grpc/DefaultGrpcClientConfigTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/remote/client/grpc/DefaultGrpcClientConfigTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class DefaultGrpcClientConfigTest {
     
@@ -60,6 +61,7 @@ class DefaultGrpcClientConfigTest {
         assertEquals(3, config.healthCheckRetryTimes());
         assertEquals(3000L, config.healthCheckTimeOut());
         assertEquals(5000L, config.capabilityNegotiationTimeout());
+        assertFalse(config.allowCoreThreadTimeOut());
         assertEquals(1, config.labels().size());
         assertNotNull(config.tlsConfig());
     }
@@ -82,6 +84,7 @@ class DefaultGrpcClientConfigTest {
         properties.setProperty(GrpcConstants.GRPC_HEALTHCHECK_RETRY_TIMES, "3");
         properties.setProperty(GrpcConstants.GRPC_HEALTHCHECK_TIMEOUT, "3000");
         properties.setProperty(GrpcConstants.GRPC_CHANNEL_CAPABILITY_NEGOTIATION_TIMEOUT, "5000");
+        properties.setProperty(GrpcConstants.GRPC_THREADPOOL_ALLOW_CORE_THREAD_TIMEOUT, "false");
         
         DefaultGrpcClientConfig config = (DefaultGrpcClientConfig) DefaultGrpcClientConfig.newBuilder()
                 .fromProperties(properties, null).build();
@@ -101,6 +104,7 @@ class DefaultGrpcClientConfigTest {
         assertEquals(3, config.healthCheckRetryTimes());
         assertEquals(3000, config.healthCheckTimeOut());
         assertEquals(5000, config.capabilityNegotiationTimeout());
+        assertEquals(false, config.allowCoreThreadTimeOut());
         assertEquals(1, config.labels().size());
         assertNotNull(config.tlsConfig());
     }
@@ -269,5 +273,21 @@ class DefaultGrpcClientConfigTest {
         DefaultGrpcClientConfig config = (DefaultGrpcClientConfig) builder.build();
         config.setTlsConfig(tlsConfig);
         assertEquals(tlsConfig, config.tlsConfig());
+    }
+    
+    @Test
+    void testSetAllowCoreThreadTimeOut() {
+        boolean allowCoreThreadTimeOut = false;
+        DefaultGrpcClientConfig.Builder builder = DefaultGrpcClientConfig.newBuilder();
+        builder.setAllowCoreThreadTimeOut(allowCoreThreadTimeOut);
+        DefaultGrpcClientConfig config = (DefaultGrpcClientConfig) builder.build();
+        assertEquals(allowCoreThreadTimeOut, config.allowCoreThreadTimeOut());
+        
+        // Test with true value
+        allowCoreThreadTimeOut = true;
+        builder = DefaultGrpcClientConfig.newBuilder();
+        builder.setAllowCoreThreadTimeOut(allowCoreThreadTimeOut);
+        config = (DefaultGrpcClientConfig) builder.build();
+        assertEquals(allowCoreThreadTimeOut, config.allowCoreThreadTimeOut());
     }
 }


### PR DESCRIPTION
关联 ISSUE #13922 

为 Nacos Client 的 grpcExecutor 添加了针对线程池的 GRPC_THREADPOOL_ALLOW_CORE_THREAD_TIMEOUT 的配置

原来的默认值是 true，但在本次 ISSUE 中将默认值修改成了 false，考虑到在这个 ISSUE 中提到的：“Currently, we have explicitly set nacos.remote.client.grpc.pool.core.size=4, nacos.remote.client.grpc.pool.max.size=16, and nacos.remote.client.grpc.pool.alive=90000, disabled the automatic inference of the number of threads based on the number of CPU cores, increased the KeepAlive of the thread pool to avoid frequent thread creation, **but cannot avoid the periodic creation and destruction of threads**.”，**依然无法改变线程周期性创建和销毁的问题**，所以我认为大家可能普遍都会存在这个问题，才考虑将默认值修改成了 false

@KomachiSion (*^▽^*)，请帮忙 Review~