### PR TITLE
fix(workflow): remove duplicate close-issue-label in stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,6 @@ jobs:
           days-before-issue-stale: 7
           days-before-issue-close: 7
           stale-issue-label: "expired"
-          close-issue-label: "expired"
           stale-issue-message: "This issue has been open 7 days with no activity. This will be closed in 7 days."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as expired."
           days-before-pr-stale: -1


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fix label conflict in stale workflow where `close-issue-label` and `stale-issue-label` are both set to "expired", causing unnecessary label add/remove operations.

## Brief changelog

  - Remove `close-issue-label: "expired"` from `.github/workflows/stale.yml`
  - Keep `stale-issue-label: "expired"` for marking stale issues
  - Issues will retain the "expired" label when closed without additional label operations

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

