### PR TITLE
[ISSUE #14094] fix(naming): validate serviceName and groupName in SubscribeServiceRequestHandler

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/remote/rpc/handler/SubscribeServiceRequestHandler.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/remote/rpc/handler/SubscribeServiceRequestHandler.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.api.remote.request.RequestMeta;
 import com.alibaba.nacos.api.remote.response.ResponseCode;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.common.notify.NotifyCenter;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.trace.event.naming.SubscribeServiceTraceEvent;
 import com.alibaba.nacos.common.trace.event.naming.UnsubscribeServiceTraceEvent;
 import com.alibaba.nacos.core.context.RequestContextHolder;
@@ -74,6 +75,13 @@ public class SubscribeServiceRequestHandler extends RequestHandler<SubscribeServ
         String namespaceId = request.getNamespace();
         String serviceName = request.getServiceName();
         String groupName = request.getGroupName();
+        if (StringUtils.isBlank(serviceName)) {
+            throw new NacosException(NacosException.INVALID_PARAM,
+                    "Param 'serviceName' is illegal, serviceName is blank");
+        }
+        if (StringUtils.isBlank(groupName)) {
+            throw new NacosException(NacosException.INVALID_PARAM, "Param 'groupName' is illegal, groupName is blank");
+        }
         String app = RequestContextHolder.getContext().getBasicContext().getApp();
         String groupedServiceName = NamingUtils.getGroupedName(serviceName, groupName);
         Service service = Service.newService(namespaceId, groupName, serviceName, true);

--- a/naming/src/test/java/com/alibaba/nacos/naming/remote/rpc/handler/SubscribeServiceRequestHandlerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/remote/rpc/handler/SubscribeServiceRequestHandlerTest.java
@@ -38,6 +38,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import java.util.Arrays;
@@ -45,6 +47,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * {@link SubscribeServiceRequestHandler} unit tests.
@@ -53,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @date 2021-09-18 18:25
  */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class SubscribeServiceRequestHandlerTest {
     
     @InjectMocks
@@ -113,5 +117,33 @@ class SubscribeServiceRequestHandlerTest {
         subscribeServiceResponse = subscribeServiceRequestHandler.handle(subscribeServiceRequest, new RequestMeta());
         assertEquals("C", subscribeServiceResponse.getServiceInfo().getName());
         Mockito.verify(clientOperationService).subscribeService(Mockito.any(), Mockito.any(), Mockito.anyString());
+    }
+    
+    @Test
+    void testHandleWithBlankServiceName() {
+        SubscribeServiceRequest subscribeServiceRequest = new SubscribeServiceRequest();
+        subscribeServiceRequest.setNamespace("A");
+        subscribeServiceRequest.setGroupName("B");
+        subscribeServiceRequest.setServiceName("");
+        subscribeServiceRequest.setSubscribe(true);
+        
+        NacosException exception = assertThrows(NacosException.class,
+                () -> subscribeServiceRequestHandler.handle(subscribeServiceRequest, new RequestMeta()));
+        assertEquals(NacosException.INVALID_PARAM, exception.getErrCode());
+        assertEquals("Param 'serviceName' is illegal, serviceName is blank", exception.getErrMsg());
+    }
+    
+    @Test
+    void testHandleWithBlankGroupName() {
+        SubscribeServiceRequest subscribeServiceRequest = new SubscribeServiceRequest();
+        subscribeServiceRequest.setNamespace("A");
+        subscribeServiceRequest.setGroupName("");
+        subscribeServiceRequest.setServiceName("C");
+        subscribeServiceRequest.setSubscribe(true);
+        
+        NacosException exception = assertThrows(NacosException.class,
+                () -> subscribeServiceRequestHandler.handle(subscribeServiceRequest, new RequestMeta()));
+        assertEquals(NacosException.INVALID_PARAM, exception.getErrCode());
+        assertEquals("Param 'groupName' is illegal, groupName is blank", exception.getErrMsg());
     }
 }


### PR DESCRIPTION
## Summary
- Add parameter validation for `serviceName` and `groupName` in `SubscribeServiceRequestHandler` before calling `NamingUtils.getGroupedName()`
- Throw `NacosException` with `INVALID_PARAM` (400) error code instead of letting `IllegalArgumentException` propagate as 500 error
- Add unit tests for blank serviceName and groupName scenarios

## Root Cause
When gRPC subscribe request contains blank `serviceName` or `groupName`, `NamingUtils.getGroupedName()` throws `IllegalArgumentException`. The `ErrorResponse.build(Throwable)` method treats this as an unknown exception and returns error code 500 (FAIL). This causes SDK clients to:
1. Retry the invalid request infinitely
2. Become UNHEALTHY after retry exhaustion
3. Affect other valid service subscriptions

## Solution
Validate parameters in the handler before calling `getGroupedName()`, throwing `NacosException` with `INVALID_PARAM` (400) error code. This allows:
- SDK to distinguish client errors (400, should not retry) from server errors (500, can retry)
- Immediate error return without affecting client health status

## Test plan
- [x] Add unit tests for blank serviceName validation
- [x] Add unit tests for blank groupName validation
- [x] Run existing SubscribeServiceRequestHandlerTest

Fixes #14094