### PR TITLE
[ISSUE #14122] Add JVM --add-opens options for JDK 17+ compatibility in startup scripts

### DIFF
--- a/distribution/bin/startup.cmd
+++ b/distribution/bin/startup.cmd
@@ -85,6 +85,14 @@ if %FUNCTION_MODE% == "naming" (
     set "NACOS_OPTS=%NACOS_OPTS% -Dnacos.functionMode=naming"
 )
 
+rem set JVM options for Java 9+
+for /f tokens^=2-5^ delims^=.-_+^" %%j in ('"%JAVA%" -fullversion 2^>^&1') do set "JAVA_MAJOR_VERSION=%%j"
+if %JAVA_MAJOR_VERSION% GEQ 9 (
+    set "NACOS_JVM_OPTS=%NACOS_JVM_OPTS% --add-opens=java.base/java.lang=ALL-UNNAMED"
+    set "NACOS_JVM_OPTS=%NACOS_JVM_OPTS% --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
+    set "NACOS_JVM_OPTS=%NACOS_JVM_OPTS% --add-opens=java.base/java.util=ALL-UNNAMED"
+)
+
 rem set nacos options
 set "NACOS_OPTS=%NACOS_OPTS% -Dnacos.deployment.type=%DEPLOYMENT%"
 set "NACOS_OPTS=%NACOS_OPTS% -Dloader.path=%BASE_DIR%/plugins,%BASE_DIR%/plugins/health,%BASE_DIR%/plugins/cmdb,%BASE_DIR%/plugins/selector"

--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -192,6 +192,9 @@ JAVA_OPT="${JAVA_OPT} -Dnacos.member.list=${MEMBER_LIST}"
 JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
 if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]] ; then
   JAVA_OPT="${JAVA_OPT} -Xlog:gc*:file=${BASE_DIR}/logs/nacos_gc.log:time,tags:filecount=10,filesize=100m"
+  JAVA_OPT="${JAVA_OPT} --add-opens=java.base/java.lang=ALL-UNNAMED"
+  JAVA_OPT="${JAVA_OPT} --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
+  JAVA_OPT="${JAVA_OPT} --add-opens=java.base/java.util=ALL-UNNAMED"
 else
   JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8 "
   JAVA_OPT_EXT_FIX="-Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext"


### PR DESCRIPTION
Fixes https://github.com/alibaba/nacos/issues/14122

## What is the purpose of the change

Fix the startup error when running Nacos from source code on JDK 17+ due to JRaft reflection issues. This PR adds the necessary `--add-opens` JVM options to the startup scripts.

## Brief changelog

- Add `--add-opens` JVM options to `startup.sh` for Java 9+
- Add Java version detection and `--add-opens` JVM options to `startup.cmd` for Windows

Added JVM options:
- `--add-opens=java.base/java.lang=ALL-UNNAMED`
- `--add-opens=java.base/java.lang.reflect=ALL-UNNAMED`
- `--add-opens=java.base/java.util=ALL-UNNAMED`

## Verifying this change

1. Build the project: `mvn clean install -Prelease-nacos -DskipTests`
2. Start Nacos in standalone mode: `sh startup.sh -m standalone`
3. Verify Nacos starts successfully without JRaft reflection errors

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.