### PR TITLE
test(auth): improve readability of LDAP auth integration test

### DIFF
--- a/test/core-test/src/test/java/com/alibaba/nacos/test/core/auth/LdapAuthCoreITCase.java
+++ b/test/core-test/src/test/java/com/alibaba/nacos/test/core/auth/LdapAuthCoreITCase.java
@@ -33,6 +33,15 @@ import org.springframework.test.annotation.DirtiesContext;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Integration test for LDAP authentication in Nacos core module.
+ *
+ * <p>This test verifies LDAP-based login behavior against an external LDAP server.
+ * It depends on LDAP configuration and environment availability.
+ *
+ * <p>Note: This is an integration test and may be skipped in environments
+ * where LDAP service is not available.
+ */
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 @Suite
 @SelectClasses({LdapAuthCoreITCase.NonTlsTest.class, LdapAuthCoreITCase.TlsTest.class})


### PR DESCRIPTION
### What does this PR do?

This PR improves the readability and maintainability of the LDAP authentication
integration test by adding clearer documentation.

### Why is this needed?

The LDAP auth integration test depends on external services and specific setup.
Clear documentation helps contributors better understand its purpose and usage.

### Scope of change

- Tests only
- No behavior changes
- No production code changes

