### PR TITLE
[ISSUES #14394]: remove ineffective ThreadLocal in MD5Utils

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/MD5Utils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/MD5Utils.java
@@ -33,14 +33,6 @@ public class MD5Utils {
     private static final char[] DIGITS_LOWER = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd',
             'e', 'f'};
     
-    private static final ThreadLocal<MessageDigest> MESSAGE_DIGEST_LOCAL = ThreadLocal.withInitial(() -> {
-        try {
-            return MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            return null;
-        }
-    });
-    
     /**
      * Calculate MD5 hex string.
      *
@@ -49,15 +41,8 @@ public class MD5Utils {
      * @throws NoSuchAlgorithmException if can't load md5 digest spi.
      */
     public static String md5Hex(byte[] bytes) throws NoSuchAlgorithmException {
-        try {
-            MessageDigest messageDigest = MESSAGE_DIGEST_LOCAL.get();
-            if (messageDigest != null) {
-                return encodeHexString(messageDigest.digest(bytes));
-            }
-            throw new NoSuchAlgorithmException("MessageDigest get MD5 instance error");
-        } finally {
-            MESSAGE_DIGEST_LOCAL.remove();
-        }
+        MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+        return encodeHexString(messageDigest.digest(bytes));
     }
     
     /**


### PR DESCRIPTION
ThreadLocal was removed in finally, so it never cached MessageDigest; use MessageDigest.getInstance("MD5") per call instead.

Related: #14394

## What is the purpose of the change

Fix ineffective ThreadLocal caching in `MD5Utils.md5Hex(byte[])`. The previous implementation always called `ThreadLocal.remove()` in `finally`, so each call would create a new `MessageDigest` anyway while adding extra ThreadLocal overhead. This change simplifies the logic by creating a fresh `MessageDigest` per call.

## Brief changelog

- Remove `ThreadLocal<MessageDigest>` from `MD5Utils`
- Create `MessageDigest` locally in `md5Hex(byte[])`

## Verifying this change

- `JAVA_HOME=D:\code\Environment\JDK\JDK17`
- `./mvnw -pl common test`