### PR TITLE
[ISSUE #14090] Fix console remote server context-path for maintainer-client

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/NacosMaintainerClientHolder.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/NacosMaintainerClientHolder.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.console.handler.impl.remote;
 
 import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.client.utils.ContextPathUtil;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.console.cluster.RemoteServerMemberManager;
@@ -30,6 +31,7 @@ import com.alibaba.nacos.maintainer.client.config.ConfigMaintainerFactory;
 import com.alibaba.nacos.maintainer.client.config.ConfigMaintainerService;
 import com.alibaba.nacos.maintainer.client.naming.NamingMaintainerFactory;
 import com.alibaba.nacos.maintainer.client.naming.NamingMaintainerService;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -67,6 +69,13 @@ public class NacosMaintainerClientHolder extends MemberChangeListener {
         String memberAddressString = StringUtils.join(memberAddress, ",");
         Properties properties = new Properties();
         properties.setProperty(PropertyKeyConst.SERVER_ADDR, memberAddressString);
+        String remoteContextPath = EnvUtil.getProperty("nacos.console.remote.server.context-path", "/nacos");
+        remoteContextPath = StringUtils.trim(remoteContextPath);
+        remoteContextPath = ContextPathUtil.normalizeContextPath(remoteContextPath);
+        while (remoteContextPath.endsWith("/") && remoteContextPath.length() > 1) {
+            remoteContextPath = remoteContextPath.substring(0, remoteContextPath.length() - 1);
+        }
+        properties.setProperty(PropertyKeyConst.CONTEXT_PATH, remoteContextPath);
         namingMaintainerService = NamingMaintainerFactory.createNamingMaintainerService(properties);
         configMaintainerService = ConfigMaintainerFactory.createConfigMaintainerService(properties);
         aiMaintainerService = AiMaintainerFactory.createAiMaintainerService(properties);

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/NacosMaintainerClientHolder.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/NacosMaintainerClientHolder.java
@@ -50,6 +50,14 @@ public class NacosMaintainerClientHolder extends MemberChangeListener {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(NacosMaintainerClientHolder.class);
     
+    private static final String REMOTE_SERVER_CONTEXT_PATH_KEY = "nacos.console.remote.server.context-path";
+    
+    private static final String DEFAULT_REMOTE_SERVER_CONTEXT_PATH = "/nacos";
+    
+    private static final String PATH_SEPARATOR = "/";
+    
+    private static final int ROOT_PATH_LENGTH = 1;
+    
     private final RemoteServerMemberManager memberManager;
     
     private volatile NamingMaintainerService namingMaintainerService;
@@ -69,16 +77,21 @@ public class NacosMaintainerClientHolder extends MemberChangeListener {
         String memberAddressString = StringUtils.join(memberAddress, ",");
         Properties properties = new Properties();
         properties.setProperty(PropertyKeyConst.SERVER_ADDR, memberAddressString);
-        String remoteContextPath = EnvUtil.getProperty("nacos.console.remote.server.context-path", "/nacos");
-        remoteContextPath = StringUtils.trim(remoteContextPath);
-        remoteContextPath = ContextPathUtil.normalizeContextPath(remoteContextPath);
-        while (remoteContextPath.endsWith("/") && remoteContextPath.length() > 1) {
-            remoteContextPath = remoteContextPath.substring(0, remoteContextPath.length() - 1);
-        }
+        String remoteContextPath = resolveRemoteContextPath();
         properties.setProperty(PropertyKeyConst.CONTEXT_PATH, remoteContextPath);
         namingMaintainerService = NamingMaintainerFactory.createNamingMaintainerService(properties);
         configMaintainerService = ConfigMaintainerFactory.createConfigMaintainerService(properties);
         aiMaintainerService = AiMaintainerFactory.createAiMaintainerService(properties);
+    }
+    
+    static String resolveRemoteContextPath() {
+        String remoteContextPath = EnvUtil.getProperty(REMOTE_SERVER_CONTEXT_PATH_KEY, DEFAULT_REMOTE_SERVER_CONTEXT_PATH);
+        remoteContextPath = StringUtils.trim(remoteContextPath);
+        remoteContextPath = ContextPathUtil.normalizeContextPath(remoteContextPath);
+        while (remoteContextPath.endsWith(PATH_SEPARATOR) && remoteContextPath.length() > ROOT_PATH_LENGTH) {
+            remoteContextPath = remoteContextPath.substring(0, remoteContextPath.length() - 1);
+        }
+        return remoteContextPath;
     }
     
     public NamingMaintainerService getNamingMaintainerService() {

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/NacosMaintainerClientHolderTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/NacosMaintainerClientHolderTest.java
@@ -44,6 +44,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class NacosMaintainerClientHolderTest {
     
+    private static final String REMOTE_SERVER_CONTEXT_PATH_KEY = "nacos.console.remote.server.context-path";
+    
     @Mock
     RemoteServerMemberManager memberManager;
     
@@ -102,5 +104,28 @@ class NacosMaintainerClientHolderTest {
         assertEquals(namingMaintainerService, maintainerClientHolder.getNamingMaintainerService());
         assertEquals(configMaintainerService, maintainerClientHolder.getConfigMaintainerService());
         assertEquals(aiMaintainerService, maintainerClientHolder.getAiMaintainerService());
+    }
+    
+    @Test
+    void resolveRemoteContextPathWithDefaultValue() {
+        assertEquals("/nacos", NacosMaintainerClientHolder.resolveRemoteContextPath());
+    }
+    
+    @Test
+    void resolveRemoteContextPathShouldNormalizeAndTrim() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty(Constants.Auth.NACOS_CORE_AUTH_ADMIN_ENABLED, "false");
+        environment.setProperty(REMOTE_SERVER_CONTEXT_PATH_KEY, "  nacos/custom/// ");
+        EnvUtil.setEnvironment(environment);
+        assertEquals("/nacos/custom", NacosMaintainerClientHolder.resolveRemoteContextPath());
+    }
+    
+    @Test
+    void resolveRemoteContextPathShouldKeepRootPath() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty(Constants.Auth.NACOS_CORE_AUTH_ADMIN_ENABLED, "false");
+        environment.setProperty(REMOTE_SERVER_CONTEXT_PATH_KEY, " /// ");
+        EnvUtil.setEnvironment(environment);
+        assertEquals("/", NacosMaintainerClientHolder.resolveRemoteContextPath());
     }
 }


### PR DESCRIPTION
Standalone console (remote handler) uses maintainer-client to call server admin APIs (e.g. `/v3/admin/core/state`).

Previously, maintainer-client always used the default context path (`/nacos`) because `NacosMaintainerClientHolder` only set `serverAddr` and never passed `contextPath`. As a result, `nacos.console.remote.server.context-path` had no effect and requests would 404 when server is deployed under a different context path (e.g. `/aaa`).

This change maps `nacos.console.remote.server.context-path` to `contextPath` when building maintainer services.

Related: #14090

## Verifying this change

- `JAVA_HOME=D:\code\Environment\JDK\JDK17`
- `./mvnw -pl console test`