### PR TITLE
Refactor: Remove obsolete p3c-pmd plugin and cleanup annotations

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/SimpleSyncEffectService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/SimpleSyncEffectService.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 @Service
 public class SimpleSyncEffectService implements SyncEffectService {
     

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/a2a/SecurityScheme.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/a2a/SecurityScheme.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
  *
  * @author KiteSoar
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public class SecurityScheme extends HashMap<String, Object> {
     
     private static final long serialVersionUID = -708604225878249736L;

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/registry/ServerVersionDetail.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/registry/ServerVersionDetail.java
@@ -23,8 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * 
  * @author xinluo
  */
-@SuppressWarnings({"checkstyle:MethodName", "checkstyle:ParameterName", "checkstyle:MemberName", 
-        "checkstyle:SummaryJavadoc", "PMD.LowerCamelCaseVariableNamingRule"})
+@SuppressWarnings({"checkstyle:MethodName", "checkstyle:ParameterName", "checkstyle:MemberName", "checkstyle:SummaryJavadoc"})
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServerVersionDetail {
 

--- a/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
+++ b/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
@@ -374,7 +374,6 @@ public class Constants {
     /**
      * The constants in AI directory.
      */
-    @SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
     public static class AI {
         
         public static final String AI_MODULE = "ai";

--- a/api/src/main/java/com/alibaba/nacos/api/config/listener/AbstractSharedListener.java
+++ b/api/src/main/java/com/alibaba/nacos/api/config/listener/AbstractSharedListener.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Executor;
  *
  * @author Nacos
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class AbstractSharedListener implements Listener {
     
     private volatile String dataId;

--- a/api/src/main/java/com/alibaba/nacos/api/remote/request/InternalRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/request/InternalRequest.java
@@ -24,7 +24,6 @@ import static com.alibaba.nacos.api.common.Constants.Remote.INTERNAL_MODULE;
  * @author liuzunfei
  * @version $Id: InternalRequest.java, v 0.1 2020年07月22日 8:33 PM liuzunfei Exp $
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class InternalRequest extends Request {
     
     @Override

--- a/api/src/main/java/com/alibaba/nacos/api/remote/request/Request.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/request/Request.java
@@ -25,7 +25,6 @@ import java.util.TreeMap;
  *
  * @author liuzunfei
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class Request implements Payload {
     
     private final Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);

--- a/api/src/main/java/com/alibaba/nacos/api/remote/request/ServerRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/request/ServerRequest.java
@@ -22,7 +22,6 @@ package com.alibaba.nacos.api.remote.request;
  * @author liuzunfei
  * @version $Id: ServerPushResponse.java, v 0.1 2020年07月20日 1:21 PM liuzunfei Exp $
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class ServerRequest extends Request {
 
 }

--- a/api/src/main/java/com/alibaba/nacos/api/remote/response/Response.java
+++ b/api/src/main/java/com/alibaba/nacos/api/remote/response/Response.java
@@ -24,7 +24,6 @@ import com.alibaba.nacos.api.remote.Payload;
  * @author liuzunfei
  * @version $Id: Response.java, v 0.1 2020年07月13日 6:03 PM liuzunfei Exp $
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class Response implements Payload {
     
     int resultCode = ResponseCode.SUCCESS.getCode();

--- a/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
@@ -59,7 +59,6 @@ import java.util.Set;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 public class NacosAiService implements AiService {
     
     private static final Logger LOGGER = LogUtils.logger(NacosAiService.class);

--- a/client/src/main/java/com/alibaba/nacos/client/config/NacosConfigService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/NacosConfigService.java
@@ -53,7 +53,6 @@ import static com.alibaba.nacos.api.common.Constants.ALL_PATTERN;
  *
  * @author Nacos
  */
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 public class NacosConfigService implements ConfigService {
     
     private static final Logger LOGGER = LogUtils.logger(NacosConfigService.class);

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
@@ -416,7 +416,6 @@ public class CacheData {
         return stringBuilder.toString();
     }
     
-    @SuppressWarnings("PMD.MethodTooLongRule")
     private void safeNotifyListener(final String dataId, final String group, final String content, final String type,
             final String md5, final String encryptedDataKey, final ManagerListenerWrap listenerWrap) {
         final Listener listener = listenerWrap.listener;
@@ -510,7 +509,6 @@ public class CacheData {
         }
     }
     
-    @SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
     abstract class NotifyTask implements Runnable {
         
         boolean async = false;

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -528,7 +528,6 @@ public class ClientWorker implements Closeable {
         return StringUtils.isBlank(group) ? Constants.DEFAULT_GROUP : group.trim();
     }
     
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
     public ClientWorker(final ConfigFilterChainManager configFilterChainManager,
             ConfigServerListManager serverListManager, final NacosClientProperties properties) throws NacosException {
         this.configFilterChainManager = configFilterChainManager;
@@ -769,7 +768,6 @@ public class ClientWorker implements Closeable {
             return response;
         }
         
-        @SuppressWarnings("PMD.MethodTooLongRule")
         private void initRpcClientHandler(final RpcClient rpcClientInner) {
             /*
              * Register Config Change /Config ReSync Handler
@@ -1088,7 +1086,6 @@ public class ClientWorker implements Closeable {
             }
         }
         
-        @SuppressWarnings("PMD.MethodTooLongRule")
         private boolean checkListenCache(Map<String, List<CacheData>> listenCachesMap) throws NacosException {
             
             final AtomicBoolean hasChangedKeys = new AtomicBoolean(false);

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
@@ -108,7 +108,6 @@ public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber implements C
     /**
      * start.
      */
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
     public void start() {
         fuzzyWatcherExecutor = Executors.newSingleThreadScheduledExecutor(
                 new NameThreadFactory("com.alibaba.nacos.client.fuzzy-watcher-executor")

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigTransportClient.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigTransportClient.java
@@ -44,7 +44,6 @@ import java.util.concurrent.TimeUnit;
  * @author liuzunfei
  * @version $Id: ConfigTransportClient.java, v 0.1 2020年08月24日 2:01 PM liuzunfei Exp $
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class ConfigTransportClient {
     
     private static final String CONFIG_INFO_HEADER = "exConfigInfo";
@@ -145,7 +144,6 @@ public abstract class ConfigTransportClient {
     /**
      * base start client.
      */
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
     public void start() throws NacosException {
         securityProxy.login(this.properties);
         this.loginScheduledExecutor =

--- a/client/src/main/java/com/alibaba/nacos/client/config/listener/impl/PropertiesListener.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/listener/impl/PropertiesListener.java
@@ -30,7 +30,6 @@ import java.util.Properties;
  *
  * @author Nacos
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class PropertiesListener extends AbstractListener {
     
     private static final Logger LOGGER = LogUtils.logger(PropertiesListener.class);

--- a/client/src/main/java/com/alibaba/nacos/client/lock/NacosLockService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/lock/NacosLockService.java
@@ -39,7 +39,6 @@ import static com.alibaba.nacos.client.constant.Constants.Security.SECURITY_INFO
  * @author 985492783@qq.com
  * @date 2023/8/24 19:51
  */
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 public class NacosLockService implements LockService {
     
     private final LockGrpcClient lockGrpcClient;

--- a/client/src/main/java/com/alibaba/nacos/client/lock/core/NLock.java
+++ b/client/src/main/java/com/alibaba/nacos/client/lock/core/NLock.java
@@ -25,7 +25,6 @@ import com.alibaba.nacos.api.lock.model.LockInstance;
  * @author 985492783@qq.com
  * @date 2023/8/24 19:52
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class NLock extends LockInstance {
     
     private static final long serialVersionUID = -346054842454875524L;

--- a/client/src/main/java/com/alibaba/nacos/client/lock/core/NLockFactory.java
+++ b/client/src/main/java/com/alibaba/nacos/client/lock/core/NLockFactory.java
@@ -22,7 +22,6 @@ package com.alibaba.nacos.client.lock.core;
  * @author 985492783@qq.com
  * @date 2023/8/27 15:23
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class NLockFactory {
     
     /**

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingMaintainService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingMaintainService.java
@@ -51,7 +51,6 @@ import static com.alibaba.nacos.client.utils.LogUtils.NAMING_LOGGER;
  * @since 1.0.1
  * @deprecated Use {@link com.alibaba.nacos.api.naming.maintain.NamingMaintainService} in nacos-maintainer-client article tp replaced.
  */
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 @Deprecated
 public class NacosNamingMaintainService implements NamingMaintainService {
     

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -71,7 +71,6 @@ import static com.alibaba.nacos.client.utils.LogUtils.NAMING_LOGGER;
  *
  * @author nkorange
  */
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 public class NacosNamingService implements NamingService {
     
     private static final String DEFAULT_NAMING_LOG_FILE_PATH = "naming.log";

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/DiskCache.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/DiskCache.java
@@ -115,7 +115,6 @@ public class DiskCache {
      * @return Service info
      * @throws UnsupportedEncodingException if the file is not encoded in UTF-8
      */
-    @SuppressWarnings("PMD.UndefineMagicConstantRule")
     public static Map<String, ServiceInfo> parseServiceInfoFromCache(File file) throws UnsupportedEncodingException {
         Map<String, ServiceInfo> result = new HashMap<>(1);
         String fileName = URLDecoder.decode(file.getName(), "UTF-8");

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/NamingFuzzyWatchServiceListHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/NamingFuzzyWatchServiceListHolder.java
@@ -105,7 +105,6 @@ public class NamingFuzzyWatchServiceListHolder extends SmartSubscriber implement
     /**
      * start.
      */
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
     public void start() {
         
         executorService = Executors.newSingleThreadScheduledExecutor(

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/redo/data/NamingRedoData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/redo/data/NamingRedoData.java
@@ -25,7 +25,6 @@ import java.util.Objects;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class NamingRedoData<T> extends RedoData<T> {
     
     private final String serviceName;

--- a/client/src/main/java/com/alibaba/nacos/client/redo/data/RedoData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/redo/data/RedoData.java
@@ -23,7 +23,6 @@ import java.util.Objects;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class RedoData<T> {
     
     /**

--- a/client/src/main/java/com/alibaba/nacos/client/utils/PreInitUtils.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/PreInitUtils.java
@@ -34,7 +34,6 @@ public class PreInitUtils {
     /**
      * Async pre load cost component.
      */
-    @SuppressWarnings("PMD.AvoidManuallyCreateThreadRule")
     public static void asyncPreLoadCostComponent() {
         Thread preLoadThread = new Thread(() -> {
             // Jackson util will init static {@code ObjectMapper}, which will cost hundreds milliseconds.

--- a/common/src/main/java/com/alibaba/nacos/common/executor/ExecutorFactory.java
+++ b/common/src/main/java/com/alibaba/nacos/common/executor/ExecutorFactory.java
@@ -36,8 +36,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings({"PMD.ThreadPoolCreationRule", "checkstyle:overloadmethodsdeclarationorder",
-        "checkstyle:missingjavadocmethod"})
+@SuppressWarnings({"checkstyle:overloadmethodsdeclarationorder", "checkstyle:missingjavadocmethod"})
 public final class ExecutorFactory {
     
     public static ExecutorService newSingleExecutorService() {

--- a/common/src/main/java/com/alibaba/nacos/common/notify/Event.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/Event.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  * @author zongtanghu
  */
-@SuppressWarnings({"PMD.AbstractClassShouldStartWithAbstractNamingRule"})
 public abstract class Event implements Serializable {
     
     private static final long serialVersionUID = -3731383194964997493L;

--- a/common/src/main/java/com/alibaba/nacos/common/notify/SlowEvent.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/SlowEvent.java
@@ -22,7 +22,6 @@ package com.alibaba.nacos.common.notify;
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  * @author zongtanghu
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class SlowEvent extends Event {
     
     @Override

--- a/common/src/main/java/com/alibaba/nacos/common/notify/listener/SmartSubscriber.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/listener/SmartSubscriber.java
@@ -26,7 +26,6 @@ import java.util.List;
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  * @author zongtanghu
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class SmartSubscriber extends Subscriber<Event> {
     
     /**

--- a/common/src/main/java/com/alibaba/nacos/common/notify/listener/Subscriber.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/listener/Subscriber.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Executor;
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  * @author zongtanghu
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class Subscriber<T extends Event> {
     
     /**

--- a/common/src/main/java/com/alibaba/nacos/common/packagescan/classreading/ClassReader.java
+++ b/common/src/main/java/com/alibaba/nacos/common/packagescan/classreading/ClassReader.java
@@ -166,7 +166,7 @@ public class ClassReader {
     public ClassReader(
             final byte[] classFileBuffer,
             final int classFileOffset,
-            final int classFileLength) { // NOPMD(UnusedFormalParameter) used for backward compatibility.
+            final int classFileLength) {
         this(classFileBuffer, classFileOffset, /* checkClassVersion = */ true);
     }
 

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/Connection.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/Connection.java
@@ -28,7 +28,6 @@ import java.util.Map;
  * @author liuzunfei
  * @version $Id: Connection.java, v 0.1 2020年08月09日 1:32 PM liuzunfei Exp $
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class Connection implements Requester {
     
     private String connectionId;

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
@@ -66,7 +66,6 @@ import static com.alibaba.nacos.api.exception.NacosException.SERVER_ERROR;
  * @author liuzunfei
  * @version $Id: RpcClient.java, v 0.1 2020年07月13日 9:15 PM liuzunfei Exp $
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class RpcClient implements Closeable {
     
     private static final Logger LOGGER = LoggerFactory.getLogger("com.alibaba.nacos.common.remote.client");
@@ -236,7 +235,6 @@ public abstract class RpcClient implements Closeable {
     /**
      * Start this client.
      */
-    @SuppressWarnings("PMD.MethodTooLongRule")
     public final void start() throws NacosException {
         
         boolean success = rpcClientStatus.compareAndSet(RpcClientStatus.INITIALIZED, RpcClientStatus.STARTING);
@@ -471,7 +469,6 @@ public abstract class RpcClient implements Closeable {
     /**
      * switch server .
      */
-    @SuppressWarnings("PMD.MethodTooLongRule")
     protected void reconnect(final ServerInfo recommendServerInfo, boolean onRequestFail) {
         
         try {
@@ -898,7 +895,6 @@ public abstract class RpcClient implements Closeable {
      * @param serverAddress address.
      * @return
      */
-    @SuppressWarnings("PMD.UndefineMagicConstantRule")
     private ServerInfo resolveServerInfo(String serverAddress) {
         Matcher matcher = EXCLUDE_PROTOCOL_PATTERN.matcher(serverAddress);
         if (matcher.find()) {

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClient.java
@@ -76,7 +76,6 @@ import java.util.concurrent.TimeUnit;
  * @author liuzunfei
  * @version $Id: GrpcClient.java, v 0.1 2020年07月13日 9:16 PM liuzunfei Exp $
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class GrpcClient extends RpcClient {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(GrpcClient.class);

--- a/common/src/main/java/com/alibaba/nacos/common/utils/CollectionUtils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/CollectionUtils.java
@@ -311,7 +311,6 @@ public final class CollectionUtils {
         throw new IllegalArgumentException(buildExceptionMessage(iterator, first));
     }
     
-    @SuppressWarnings("PMD.UndefineMagicConstantRule")
     private static <T> String buildExceptionMessage(Iterator<T> iterator, T first) {
         StringBuilder msg = new StringBuilder();
         msg.append("expected one element but was: <");

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InetAddressValidator.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
  *
  * @author Dynatrace LLC
  */
-@SuppressWarnings({"checkstyle:AbbreviationAsWordInName", "PMD.ClassNamingShouldBeCamelRule"})
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class InetAddressValidator {
     
     private InetAddressValidator() {

--- a/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/InternetAddressUtil.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
  *
  * @author Nacos
  */
-@SuppressWarnings({"checkstyle:AbbreviationAsWordInName", "PMD.ClassNamingShouldBeCamelRule"})
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class InternetAddressUtil {
     
     private InternetAddressUtil() {

--- a/common/src/main/java/com/alibaba/nacos/common/utils/MD5Utils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/MD5Utils.java
@@ -24,7 +24,6 @@ import java.security.NoSuchAlgorithmException;
  *
  * @author nacos
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class MD5Utils {
 
     private MD5Utils() {

--- a/config/src/main/java/com/alibaba/nacos/config/server/manager/TaskManagerMBean.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/manager/TaskManagerMBean.java
@@ -21,7 +21,6 @@ package com.alibaba.nacos.config.server.manager;
  *
  * @author Nacos
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public interface TaskManagerMBean {
     
     /**

--- a/config/src/main/java/com/alibaba/nacos/config/server/model/AclInfo.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/AclInfo.java
@@ -24,7 +24,6 @@ import java.util.List;
  *
  * @author Nacos
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class AclInfo implements Serializable {
     
     private static final long serialVersionUID = 1383026926036269457L;

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigMigrateService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigMigrateService.java
@@ -114,7 +114,6 @@ public class ConfigMigrateService {
      */
     NamespacePersistService namespacePersistService;
     
-    
     /**
      * The Old table version.
      */
@@ -511,7 +510,6 @@ public class ConfigMigrateService {
         
     }
     
-    @SuppressWarnings("PMD.MethodTooLongRule")
     private void doCheckNamespaceMigrate() throws Exception {
         final long startTime = System.currentTimeMillis();
         int maxNamespaceMigrateRetryTimes = EnvUtil.getProperty("nacos.namespace.migrate.retry.times", Integer.class,
@@ -1063,7 +1061,6 @@ public class ConfigMigrateService {
         return configAdvanceInfo;
     }
     
-    @SuppressWarnings("PMD.MethodTooLongRule")
     private void doCheckMigrate() throws Exception {
         
         int migrateMulti = EnvUtil.getProperty("nacos.gray.migrate.executor.multi", Integer.class, Integer.valueOf(4));

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
@@ -84,7 +84,6 @@ public class ConfigOperationService {
      *
      * @throws NacosException NacosException.
      */
-    @SuppressWarnings("PMD.MethodTooLongRule")
     public Boolean publishConfig(ConfigForm configForm, ConfigRequestInfo configRequestInfo, String encryptedDataKey) throws NacosException {
         Map<String, Object> configAdvanceInfo = getConfigAdvanceInfo(configForm);
         ParamUtils.checkParam(configAdvanceInfo);

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigSubService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigSubService.java
@@ -67,7 +67,6 @@ public class ConfigSubService {
     
     private ServerMemberManager memberManager;
     
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
     public ConfigSubService(ServerMemberManager memberManager) {
         this.memberManager = memberManager;
     }
@@ -113,7 +112,6 @@ public class ConfigSubService {
         }
     }
     
-    @SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
     abstract static class ClusterJob<T> {
         
         private String url;

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/LongPollingService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/LongPollingService.java
@@ -227,7 +227,6 @@ public class LongPollingService {
         return null != req.getHeader(LONG_POLLING_HEADER);
     }
     
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
     public LongPollingService() {
         allSubs = new ConcurrentLinkedQueue<>();
         

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/capacity/CapacityService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/capacity/CapacityService.java
@@ -66,7 +66,6 @@ public class CapacityService {
      * Init.
      */
     @PostConstruct
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
     public void init() {
         // All servers have jobs that modify usage, idempotent.
         ConfigExecutor.scheduleCorrectUsageTask(() -> {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpChangeConfigWorker.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpChangeConfigWorker.java
@@ -70,7 +70,6 @@ public class DumpChangeConfigWorker implements Runnable {
      * do check change.
      */
     @Override
-    @SuppressWarnings("PMD.MethodTooLongRule")
     public void run() {
         try {
             if (!PropertyUtil.isDumpChangeOn()) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpChangeGrayConfigWorker.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpChangeGrayConfigWorker.java
@@ -61,7 +61,6 @@ public class DumpChangeGrayConfigWorker implements Runnable {
     }
     
     @Override
-    @SuppressWarnings("PMD.MethodTooLongRule")
     public void run() {
         try {
             if (!PropertyUtil.isDumpChangeOn()) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpService.java
@@ -58,7 +58,6 @@ import static com.alibaba.nacos.config.server.utils.LogUtil.DUMP_LOG;
  *
  * @author Nacos
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class DumpService {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(DumpService.class);

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRawDiskService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRawDiskService.java
@@ -38,7 +38,6 @@ import static com.alibaba.nacos.config.server.constant.Constants.ENCODE_UTF8;
  *
  * @author zunfei.lzf
  */
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 public class ConfigRawDiskService implements ConfigDiskService {
     
     private static final String BASE_DIR = File.separator + "data" + File.separator + "config-data";

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRocksDbDiskService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRocksDbDiskService.java
@@ -40,7 +40,7 @@ import static com.alibaba.nacos.config.server.constant.Constants.NULL;
  *
  * @author shiyiyue
  */
-@SuppressWarnings({"PMD.ServiceOrDaoClassShouldEndWithImplRule", "PMD.LowerCamelCaseVariableNamingRule"})
+
 public class ConfigRocksDbDiskService implements ConfigDiskService {
     
     private static final String ROCKSDB_DATA = File.separator + "rocksdata" + File.separator;
@@ -289,7 +289,6 @@ public class ConfigRocksDbDiskService implements ConfigDiskService {
      *
      * @return
      */
-    @SuppressWarnings("PMD.UndefineMagicConstantRule")
     private long getSuitFormalCacheSizeMB(String dir) {
         
         boolean formal = BASE_DIR.equals(dir);

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessor.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessor.java
@@ -52,7 +52,6 @@ public class DumpAllProcessor implements NacosTaskProcessor {
     }
     
     @Override
-    @SuppressWarnings("PMD.MethodTooLongRule")
     public boolean process(NacosTask task) {
         if (!(task instanceof DumpAllTask)) {
             DEFAULT_LOG.error(

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImpl.java
@@ -59,7 +59,7 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings({"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnEmbeddedStorage.class)
 @Service("embeddedConfigInfoBetaPersistServiceImpl")
 public class EmbeddedConfigInfoBetaPersistServiceImpl implements ConfigInfoBetaPersistService {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoGrayPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoGrayPersistServiceImpl.java
@@ -66,7 +66,7 @@ import static com.alibaba.nacos.config.server.utils.PropertyUtil.GRAY_MIGRATE_FL
  *
  * @author rong
  */
-@SuppressWarnings({"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnEmbeddedStorage.class)
 @Service("embeddedConfigInfoGrayPersistServiceImpl")
 public class EmbeddedConfigInfoGrayPersistServiceImpl implements ConfigInfoGrayPersistService {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
@@ -93,7 +93,7 @@ import static com.alibaba.nacos.persistence.repository.RowMapperManager.MAP_ROW_
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings({"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength", "PMD.MethodTooLongRule"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnEmbeddedStorage.class)
 @Service("embeddedConfigInfoPersistServiceImpl")
 public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistService {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoTagPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoTagPersistServiceImpl.java
@@ -59,7 +59,7 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings({"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnEmbeddedStorage.class)
 @Service("embeddedConfigInfoTagPersistServiceImpl")
 public class EmbeddedConfigInfoTagPersistServiceImpl implements ConfigInfoTagPersistService {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedHistoryConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedHistoryConfigInfoPersistServiceImpl.java
@@ -58,7 +58,7 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings({"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnEmbeddedStorage.class)
 @Service("embeddedHistoryConfigInfoPersistServiceImpl")
 public class EmbeddedHistoryConfigInfoPersistServiceImpl implements HistoryConfigInfoPersistService {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImpl.java
@@ -57,7 +57,7 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings(value = {"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnExternalStorage.class)
 @Service("externalConfigInfoBetaPersistServiceImpl")
 public class ExternalConfigInfoBetaPersistServiceImpl implements ConfigInfoBetaPersistService {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoGrayPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoGrayPersistServiceImpl.java
@@ -61,13 +61,12 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.utils.PropertyUtil.GRAY_MIGRATE_FLAG;
 
-
 /**
  * ExternalConfigInfoGrayPersistServiceImpl.
  *
  * @author rong
  */
-@SuppressWarnings(value = {"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnExternalStorage.class)
 @Service("externalConfigInfoGrayPersistServiceImpl")
 public class ExternalConfigInfoGrayPersistServiceImpl implements ConfigInfoGrayPersistService {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -94,7 +94,7 @@ import static com.alibaba.nacos.config.server.utils.PropertyUtil.CONFIG_MIGRATE_
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings(value = {"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnExternalStorage.class)
 @Service("externalConfigInfoPersistServiceImpl")
 public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistService {
@@ -205,7 +205,6 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
             }
         });
     }
-    
     
     /**
      * insert or update config.

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoTagPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoTagPersistServiceImpl.java
@@ -59,7 +59,7 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings(value = {"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnExternalStorage.class)
 @Service("externalConfigInfoTagPersistServiceImpl")
 public class ExternalConfigInfoTagPersistServiceImpl implements ConfigInfoTagPersistService {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalHistoryConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalHistoryConfigInfoPersistServiceImpl.java
@@ -59,7 +59,7 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings(value = {"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnExternalStorage.class)
 @Service("externalHistoryConfigInfoPersistServiceImpl")
 public class ExternalHistoryConfigInfoPersistServiceImpl implements HistoryConfigInfoPersistService {

--- a/config/src/main/java/com/alibaba/nacos/config/server/utils/MD5Util.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/utils/MD5Util.java
@@ -44,7 +44,6 @@ import static com.alibaba.nacos.config.server.constant.Constants.WORD_SEPARATOR;
  *
  * @author Nacos
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class MD5Util {
     
     /**

--- a/consistency/src/main/java/com/alibaba/nacos/consistency/ProtocolMetaData.java
+++ b/consistency/src/main/java/com/alibaba/nacos/consistency/ProtocolMetaData.java
@@ -32,7 +32,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.Rule:CollectionInitShouldAssignCapacityRule")
 public final class ProtocolMetaData {
     
     private final Map<String, MetaData> metaDataMap = new ConcurrentHashMap<>(4);
@@ -93,7 +92,6 @@ public final class ProtocolMetaData {
         metaDataMap.computeIfAbsent(group, s -> new MetaData(group)).unSubscribe(key, observer);
     }
     
-    @SuppressWarnings("PMD.ThreadPoolCreationRule")
     public static final class MetaData {
         
         private final Map<String, ValueItem> itemMap = new ConcurrentHashMap<>(8);

--- a/consistency/src/main/java/com/alibaba/nacos/consistency/RequestProcessor.java
+++ b/consistency/src/main/java/com/alibaba/nacos/consistency/RequestProcessor.java
@@ -27,7 +27,6 @@ import com.alibaba.nacos.consistency.entity.WriteRequest;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class RequestProcessor {
     
     /**

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/MemberChangeListener.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/MemberChangeListener.java
@@ -24,7 +24,6 @@ import com.alibaba.nacos.common.notify.listener.Subscriber;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class MemberChangeListener extends Subscriber<MembersChangeEvent> {
     
     /**

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/MemberUtil.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/MemberUtil.java
@@ -76,7 +76,6 @@ public class MemberUtil {
      * @param member ip:port
      * @return {@link Member}
      */
-    @SuppressWarnings("PMD.UndefineMagicConstantRule")
     public static Member singleParse(String member) {
         // Nacos default port is 8848
         int defaultPort = EnvUtil.getProperty(SERVER_PORT_PROPERTY, Integer.class, DEFAULT_SERVER_PORT);

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/Task.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/Task.java
@@ -24,7 +24,6 @@ import com.alibaba.nacos.core.utils.Loggers;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class Task implements Runnable {
     
     protected volatile boolean shutdown = false;

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/lookup/AddressServerMemberLookup.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/lookup/AddressServerMemberLookup.java
@@ -130,7 +130,6 @@ public class AddressServerMemberLookup extends AbstractMemberLookup {
         Loggers.CORE.info("ADDRESS_SERVER_URL:" + addressServerUrl);
     }
     
-    @SuppressWarnings("PMD.UndefineMagicConstantRule")
     private void run() throws NacosException {
         // With the address server, you need to perform a synchronous member node pull at startup
         // Repeat three times, successfully jump out

--- a/core/src/main/java/com/alibaba/nacos/core/control/http/HttpTpsCheckRequestParser.java
+++ b/core/src/main/java/com/alibaba/nacos/core/control/http/HttpTpsCheckRequestParser.java
@@ -27,7 +27,6 @@ import jakarta.servlet.http.HttpServletRequest;
  *
  * @author shiyiyue
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class HttpTpsCheckRequestParser {
     
     public HttpTpsCheckRequestParser() {

--- a/core/src/main/java/com/alibaba/nacos/core/control/remote/RemoteTpsCheckRequestParser.java
+++ b/core/src/main/java/com/alibaba/nacos/core/control/remote/RemoteTpsCheckRequestParser.java
@@ -27,7 +27,6 @@ import com.alibaba.nacos.plugin.control.tps.request.TpsCheckRequest;
  *
  * @author shiyiyue
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class RemoteTpsCheckRequestParser {
     
     public RemoteTpsCheckRequestParser() {

--- a/core/src/main/java/com/alibaba/nacos/core/controller/v3/ServerLoaderControllerV3.java
+++ b/core/src/main/java/com/alibaba/nacos/core/controller/v3/ServerLoaderControllerV3.java
@@ -48,7 +48,6 @@ import static com.alibaba.nacos.core.utils.Commons.NACOS_ADMIN_CORE_CONTEXT_V3;
 @NacosApi
 @RestController
 @RequestMapping(NACOS_ADMIN_CORE_CONTEXT_V3 + "/loader")
-@SuppressWarnings("PMD.MethodTooLongRule")
 public class ServerLoaderControllerV3 {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(ServerLoaderControllerV3.class);

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftMaintainService.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftMaintainService.java
@@ -31,7 +31,6 @@ import java.util.Objects;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class JRaftMaintainService {
     
     private final JRaftServer raftServer;

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JSnapshotOperation.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JSnapshotOperation.java
@@ -29,7 +29,6 @@ import com.google.protobuf.ZeroByteStringHelper;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 interface JSnapshotOperation {
     
     /**

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/NacosClosure.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/NacosClosure.java
@@ -67,7 +67,6 @@ public class NacosClosure implements Closure {
     
     // Pass the Throwable inside the state machine to the outer layer
     
-    @SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
     public static class NacosStatus extends Status {
         
         private Status status;

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/exception/JRaftException.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/exception/JRaftException.java
@@ -21,7 +21,6 @@ package com.alibaba.nacos.core.distributed.raft.exception;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class JRaftException extends RuntimeException {
     
     private static final long serialVersionUID = 8802314713344513544L;

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftConstants.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftConstants.java
@@ -21,7 +21,6 @@ package com.alibaba.nacos.core.distributed.raft.utils;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class JRaftConstants {
     
     public static final String JRAFT_EXTEND_INFO_KEY = JRaftLogOperation.class.getCanonicalName();

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftLogOperation.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftLogOperation.java
@@ -21,7 +21,6 @@ package com.alibaba.nacos.core.distributed.raft.utils;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class JRaftLogOperation {
     
     public static final String MODIFY_OPERATION = "modify";

--- a/core/src/main/java/com/alibaba/nacos/core/monitor/topn/BaseTopNCounter.java
+++ b/core/src/main/java/com/alibaba/nacos/core/monitor/topn/BaseTopNCounter.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public abstract class BaseTopNCounter<T> {
     
     private final Comparator<Pair<String, AtomicInteger>> comparator;

--- a/core/src/main/java/com/alibaba/nacos/core/monitor/topn/FixedSizePriorityQueue.java
+++ b/core/src/main/java/com/alibaba/nacos/core/monitor/topn/FixedSizePriorityQueue.java
@@ -25,7 +25,6 @@ import java.util.List;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.UndefineMagicConstantRule")
 public class FixedSizePriorityQueue<T> {
     
     private Object[] elements;

--- a/core/src/main/java/com/alibaba/nacos/core/monitor/topn/StringTopNCounter.java
+++ b/core/src/main/java/com/alibaba/nacos/core/monitor/topn/StringTopNCounter.java
@@ -21,7 +21,6 @@ package com.alibaba.nacos.core.monitor.topn;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class StringTopNCounter extends BaseTopNCounter<String> {
     
     @Override

--- a/core/src/main/java/com/alibaba/nacos/core/monitor/topn/TopNConfig.java
+++ b/core/src/main/java/com/alibaba/nacos/core/monitor/topn/TopNConfig.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class TopNConfig extends AbstractDynamicConfig {
     
     private static final String TOP_N = "topN";

--- a/core/src/main/java/com/alibaba/nacos/core/namespace/repository/EmbeddedNamespacePersistServiceImpl.java
+++ b/core/src/main/java/com/alibaba/nacos/core/namespace/repository/EmbeddedNamespacePersistServiceImpl.java
@@ -46,7 +46,7 @@ import static com.alibaba.nacos.core.namespace.repository.NamespaceRowMapperInje
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings({"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnEmbeddedStorage.class)
 @Service("embeddedOtherPersistServiceImpl")
 public class EmbeddedNamespacePersistServiceImpl implements NamespacePersistService {

--- a/core/src/main/java/com/alibaba/nacos/core/namespace/repository/ExternalNamespacePersistServiceImpl.java
+++ b/core/src/main/java/com/alibaba/nacos/core/namespace/repository/ExternalNamespacePersistServiceImpl.java
@@ -46,7 +46,7 @@ import static com.alibaba.nacos.core.namespace.repository.NamespaceRowMapperInje
  *
  * @author lixiaoshuang
  */
-@SuppressWarnings(value = {"PMD.MethodReturnWrapperTypeRule", "checkstyle:linelength"})
+@SuppressWarnings("checkstyle:linelength")
 @Conditional(value = ConditionOnExternalStorage.class)
 @Service("externalOtherPersistServiceImpl")
 public class ExternalNamespacePersistServiceImpl implements NamespacePersistService {

--- a/core/src/main/java/com/alibaba/nacos/core/remote/ClientConnectionEventListener.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/ClientConnectionEventListener.java
@@ -26,7 +26,6 @@ import javax.annotation.PostConstruct;
  * @author liuzunfei
  * @version $Id: ClientConnectionEventListener.java, v 0.1 2020年07月16日 3:06 PM liuzunfei Exp $
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class ClientConnectionEventListener {
     
     /**

--- a/core/src/main/java/com/alibaba/nacos/core/remote/Connection.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/Connection.java
@@ -28,7 +28,6 @@ import java.util.Map;
  * @author liuzunfei
  * @version $Id: Connection.java, v 0.1 2020年07月13日 7:08 PM liuzunfei Exp $
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class Connection implements Requester {
     
     private boolean traced = false;

--- a/core/src/main/java/com/alibaba/nacos/core/remote/RequestHandler.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/RequestHandler.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author liuzunfei
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class RequestHandler<T extends Request, S extends Response> {
     
     @Autowired

--- a/core/src/main/java/com/alibaba/nacos/core/remote/RuntimeConnectionEjector.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/RuntimeConnectionEjector.java
@@ -23,7 +23,6 @@ package com.alibaba.nacos.core.remote;
  *
  * @author shiyiyue
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class RuntimeConnectionEjector {
     
     /**

--- a/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcRequestAcceptor.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcRequestAcceptor.java
@@ -80,7 +80,6 @@ public class GrpcRequestAcceptor extends RequestGrpc.RequestImplBase {
     }
     
     @Override
-    @SuppressWarnings("PMD.MethodTooLongRule")
     public void request(Payload grpcRequest, StreamObserver<Payload> responseObserver) {
         
         traceIfNecessary(grpcRequest, true);

--- a/core/src/main/java/com/alibaba/nacos/core/remote/grpc/filter/NacosGrpcServerTransportFilter.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/grpc/filter/NacosGrpcServerTransportFilter.java
@@ -23,7 +23,6 @@ import io.grpc.ServerTransportFilter;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class NacosGrpcServerTransportFilter extends ServerTransportFilter {
     
     public static final String SDK_FILTER = "SDK";

--- a/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
+++ b/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
@@ -100,7 +100,6 @@ public class K8sSyncServer {
      *
      * @throws IOException io exception
      */
-    @SuppressWarnings("PMD.MethodTooLongRule")
     public void startInformer() throws IOException {
         ApiClient apiClient;
         CoreV1Api coreV1Api;

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationServiceProxy.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationServiceProxy.java
@@ -37,7 +37,6 @@ import java.util.List;
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
 @DependsOn("namingSubscriberServiceV2Impl")
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 @Component
 public class ClientOperationServiceProxy implements ClientOperationService {
     

--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/HealthCheckReactor.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/HealthCheckReactor.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @author nacos
  */
-@SuppressWarnings("PMD.ThreadPoolCreationRule")
 public class HealthCheckReactor {
     
     private static Map<String, ScheduledFuture> futureMap = new ConcurrentHashMap<>();

--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/MysqlHealthCheckProcessor.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/MysqlHealthCheckProcessor.java
@@ -49,7 +49,6 @@ import static com.alibaba.nacos.naming.misc.Loggers.SRV_LOG;
  * @author xiweng.yy
  */
 @Component
-@SuppressWarnings("PMD.ThreadPoolCreationRule")
 public class MysqlHealthCheckProcessor implements HealthCheckProcessorV2 {
     
     public static final String TYPE = HealthCheckType.MYSQL.name();

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/GlobalExecutor.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/GlobalExecutor.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author nacos
  */
-@SuppressWarnings({"checkstyle:indentation", "PMD.ThreadPoolCreationRule"})
+@SuppressWarnings("checkstyle:indentation")
 public class GlobalExecutor {
     
     private static final long SERVER_STATUS_UPDATE_PERIOD = TimeUnit.SECONDS.toMillis(5);

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchDomain.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchDomain.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
  * @author nacos
  */
 @Component
-@SuppressWarnings("PMD")
 public class SwitchDomain implements Record, Cloneable {
     
     private static final long serialVersionUID = 7619505097145337232L;

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
@@ -104,7 +104,6 @@ public class SwitchManager extends RequestProcessor4CP {
      * @param debug whether debug
      * @throws Exception exception
      */
-    @SuppressWarnings("PMD")
     public void update(String entry, String value, boolean debug) throws Exception {
         
         this.requestLock.lock();

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/UtilsAndCommons.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/UtilsAndCommons.java
@@ -40,7 +40,6 @@ import java.util.Map;
  * @author nacos
  * @author jifengnan
  */
-@SuppressWarnings("PMD.ThreadPoolCreationle")
 public class UtilsAndCommons {
     
     // ********************** Nacos HTTP Context ************************ \\

--- a/naming/src/main/java/com/alibaba/nacos/naming/monitor/ServiceTopNCounter.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/monitor/ServiceTopNCounter.java
@@ -25,7 +25,6 @@ import com.alibaba.nacos.naming.misc.UtilsAndCommons;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class ServiceTopNCounter extends BaseTopNCounter<Service> {
     
     public ServiceTopNCounter() {

--- a/naming/src/main/java/com/alibaba/nacos/naming/push/v2/executor/PushExecutorDelegate.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/push/v2/executor/PushExecutorDelegate.java
@@ -30,7 +30,6 @@ import java.util.Optional;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 @Component
 public class PushExecutorDelegate implements PushExecutor {
     

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImpl.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImpl.java
@@ -269,7 +269,6 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
         }
     }
     
-    @SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
     class CheckDbHealthTask implements Runnable {
         
         @Override

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/repository/PaginationHelper.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/repository/PaginationHelper.java
@@ -25,7 +25,6 @@ import org.springframework.jdbc.core.RowMapper;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.AbstractMethodOrInterfaceMethodMustUseJavadocRule")
 public interface PaginationHelper<E> {
     
     Page<E> fetchPage(final String sqlCountRows, final String sqlFetchRows, final Object[] args, final int pageNo,

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/repository/embedded/hook/EmbeddedApplyHook.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/repository/embedded/hook/EmbeddedApplyHook.java
@@ -25,7 +25,6 @@ import com.alibaba.nacos.consistency.entity.WriteRequest;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class EmbeddedApplyHook {
     
     protected EmbeddedApplyHook() {

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/repository/embedded/operate/BaseDatabaseOperate.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/repository/embedded/operate/BaseDatabaseOperate.java
@@ -42,7 +42,6 @@ import java.util.stream.IntStream;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.AbstractMethodOrInterfaceMethodMustUseJavadocRule")
 public interface BaseDatabaseOperate extends DatabaseOperate {
     
     Logger LOGGER = LoggerFactory.getLogger(BaseDatabaseOperate.class);

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/repository/embedded/sql/ModifyRequest.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/repository/embedded/sql/ModifyRequest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.ClassNamingShouldBeCamelRule")
 public class ModifyRequest implements Serializable {
     
     private static final long serialVersionUID = 4548851816596520564L;

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthPluginService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthPluginService.java
@@ -43,7 +43,6 @@ import java.util.List;
  *
  * @author xiweng.yy
  */
-@SuppressWarnings("PMD.ServiceOrDaoClassShouldEndWithImplRule")
 public class NacosAuthPluginService implements AuthPluginService {
     
     private static final List<String> IDENTITY_NAMES = new LinkedList<String>() {

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/jwt/NacosJwtParser.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/jwt/NacosJwtParser.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
  * @author Weizhan▪Yun
  * @date 2023/1/15 21:38
  */
-@SuppressWarnings("PMD.UndefineMagicConstantRule")
 public class NacosJwtParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(NacosJwtParser.class);

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/AuthPaginationHelper.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/AuthPaginationHelper.java
@@ -20,14 +20,12 @@ import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 import org.springframework.jdbc.core.RowMapper;
 
-
 /**
  * Auth plugin Pagination Helper.
  *
  * @param <E> Generic class
  * @author huangKeMing
  */
-@SuppressWarnings("PMD.AbstractMethodOrInterfaceMethodMustUseJavadocRule")
 public interface AuthPaginationHelper<E> {
     
     Page<E> fetchPage(final String sqlCountRows, final String sqlFetchRows, final Object[] args, final int pageNo,

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/PermissionPersistService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/PermissionPersistService.java
@@ -24,7 +24,6 @@ import com.alibaba.nacos.api.model.Page;
  * @author nkorange
  * @since 1.2.0
  */
-@SuppressWarnings("PMD.AbstractMethodOrInterfaceMethodMustUseJavadocRule")
 public interface PermissionPersistService {
 
     /**

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/RolePersistService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/RolePersistService.java
@@ -26,7 +26,6 @@ import java.util.List;
  * @author nkorange
  * @since 1.2.0
  */
-@SuppressWarnings("PMD.AbstractMethodOrInterfaceMethodMustUseJavadocRule")
 public interface RolePersistService {
 
     /**

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/UserPersistService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/UserPersistService.java
@@ -26,7 +26,6 @@ import java.util.List;
  * @author nkorange
  * @since 1.2.0
  */
-@SuppressWarnings("PMD.AbstractMethodOrInterfaceMethodMustUseJavadocRule")
 public interface UserPersistService {
 
     /**

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/connection/ConnectionControlManager.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/connection/ConnectionControlManager.java
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
  *
  * @author shiyiyu
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class ConnectionControlManager {
     
     private final ConnectionControlRuleParser connectionControlRuleParser;

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/TpsControlManager.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/TpsControlManager.java
@@ -35,7 +35,6 @@ import java.util.Map;
  *
  * @author shiyiyue
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class TpsControlManager {
     
     private final TpsControlRuleParser tpsControlRuleParser;

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/RateCounter.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/RateCounter.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @author zunfei.lzf
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class RateCounter {
     
     /**

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/RuleBarrier.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/RuleBarrier.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @author shiyiyue
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class RuleBarrier {
     
     private TimeUnit period;

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/SimpleCountRuleBarrier.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/SimpleCountRuleBarrier.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @author shiyiyue
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class SimpleCountRuleBarrier extends RuleBarrier {
     
     RateCounter rateCounter;

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/TpsBarrier.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/TpsBarrier.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @author shiyiyue
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class TpsBarrier {
     
     protected RuleBarrierCreator ruleBarrierCreator;

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <maven-pmd-plugin.version>3.16.0</maven-pmd-plugin.version>
+
         <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
         <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
@@ -125,7 +125,6 @@
         <maven-easyj-version>1.1.5</maven-easyj-version>
         <!-- dependency version related to plugin -->
         <extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
-        <p3c-pmd.version>2.1.1</p3c-pmd.version>
         
         <!-- dependency version -->
         <nacos.logback.adapter.version>1.1.4</nacos.logback.adapter.version>
@@ -272,53 +271,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>${maven-pmd-plugin.version}</version>
-                <configuration>
-                    <rulesets>
-                        <ruleset>rulesets/java/ali-comment.xml</ruleset>
-                        <ruleset>rulesets/java/ali-concurrent.xml</ruleset>
-                        <ruleset>rulesets/java/ali-constant.xml</ruleset>
-                        <ruleset>rulesets/java/ali-exception.xml</ruleset>
-                        <ruleset>rulesets/java/ali-flowcontrol.xml</ruleset>
-                        <ruleset>rulesets/java/ali-naming.xml</ruleset>
-                        <ruleset>rulesets/java/ali-oop.xml</ruleset>
-                        <ruleset>rulesets/java/ali-orm.xml</ruleset>
-                        <ruleset>rulesets/java/ali-other.xml</ruleset>
-                        <ruleset>rulesets/java/ali-set.xml</ruleset>
-                    </rulesets>
-                    <printFailingErrors>true</printFailingErrors>
-                    <excludes>
-                        <exclude>**/consistency/entity/*.java</exclude>
-                        <exclude>**/istio/model/mcp/*.java</exclude>
-                        <exclude>**/istio/model/naming/*.java</exclude>
-                        <exclude>**/istio/model/*.java</exclude>
-                        <exclude>**/api/grpc/auto/*.java</exclude>
-                        <exclude>**/istio/mcp/**</exclude>
-                        <exclude>**/istio/networking/**</exclude>
-                        <exclude>**/google/protobuf/**</exclude>
-                        <exclude>**/common/packagescan/classreading/*.java</exclude>
-                        <exclude>**/common/packagescan/resource/*.java</exclude>
-                        <exclude>**/common/packagescan/util/*.java</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.alibaba.p3c</groupId>
-                        <artifactId>p3c-pmd</artifactId>
-                        <version>${p3c-pmd.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/sys/src/main/java/com/alibaba/nacos/sys/env/OriginTrackedPropertiesLoader.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/env/OriginTrackedPropertiesLoader.java
@@ -35,7 +35,6 @@ import java.util.Map;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.UndefineMagicConstantRule")
 public class OriginTrackedPropertiesLoader {
     
     private final Resource resource;

--- a/sys/src/main/java/com/alibaba/nacos/sys/file/FileWatcher.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/file/FileWatcher.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Executor;
  *
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
-@SuppressWarnings("PMD.AbstractClassShouldStartWithAbstractNamingRule")
 public abstract class FileWatcher {
     
     /**

--- a/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/utils/InetUtils.java
@@ -53,7 +53,6 @@ import static com.alibaba.nacos.sys.env.Constants.NACOS_REMOTE_GRPC_LISTEN_IP;
  *
  * @author Nacos
  */
-@SuppressWarnings("PMD.LowerCamelCaseVariableNamingRule")
 public class InetUtils {
     
     private static final Logger LOG = LoggerFactory.getLogger(InetUtils.class);
@@ -282,7 +281,7 @@ public class InetUtils {
     /**
      * {@link com.alibaba.nacos.core.cluster.ServerMemberManager} is listener.
      */
-    @SuppressWarnings({"PMD.ClassNamingShouldBeCamelRule", "checkstyle:AbbreviationAsWordInName"})
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     public static class IPChangeEvent extends SlowEvent {
         
         private String oldIP;


### PR DESCRIPTION
## Description
This PR removes the `p3c-pmd` plugin and cleans up related `@SuppressWarnings("PMD...")` annotations across the codebase.

The `alibaba/p3c` project has been unmaintained for years and relies on an outdated PMD version (6.x), causing massive build warnings and incompatibility with modern tooling. Nacos already uses **Checkstyle** for code style and **SpotBugs** for bug detection, making `p3c-pmd` redundant.

**Changes:**
1.  Removed `maven-pmd-plugin` and `p3c-pmd` dependency from the root `pom.xml`.
2.  Removed 90+ `@SuppressWarnings("PMD.xxx")` annotations and `// NOPMD` comments from 80+ files.

**Fixes:** #14455

> **Note:** Implemented based on the detailed analysis and proposal by @cxhello in #14455.

## 描述 (Chinese)
移除已过时的 `p3c-pmd` 插件，并清理代码中相关的 `@SuppressWarnings` 注解。

`alibaba/p3c` 项目已多年未维护，且依赖过旧的 PMD 版本，导致构建时产生大量警告。Nacos 目前已使用 **Checkstyle** 和 **SpotBugs** 覆盖了代码风格和潜在 Bug 的检查，`p3c-pmd` 功能冗余。

**修改点：**
1.  从根 `pom.xml` 中移除了 `maven-pmd-plugin` 及 `p3c-pmd` 依赖。
2.  批量清理了 80+ 个文件中的 90+ 个 `@SuppressWarnings("PMD.xxx")` 注解及 `// NOPMD` 注释。

**修复:** #14455

> **注：** 基于 @cxhello 在 #14455 中提供的详细分析与建议实现。