### PR TITLE
[ISSUE #14469] Enable SpotBugs check enforcement in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,5 +18,5 @@ Follow this checklist to help us incorporate your contribution quickly and easil
 * [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
 * [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 * [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
-* [ ] Run `mvn -B clean package apache-rat:check findbugs:findbugs -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
+* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: "Print maven version"
         run: mvn -version
       - name: "Check with Maven"
-        run: mvn -B clean package apache-rat:check spotbugs:spotbugs -DskipTests -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        run: mvn -B clean package apache-rat:check spotbugs:check -DskipTests -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - name: "Build with Maven"
         run: mvn -Prelease-nacos -DskipTests clean install -U -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - name: "Test With Maven"

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-        <soptbugs-maven-plugin.version>4.8.6.2</soptbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
         <sonar-maven-plugin.version>3.0.2</sonar-maven-plugin.version>
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
@@ -414,7 +414,12 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>${soptbugs-maven-plugin.version}</version>
+                <version>${spotbugs-maven-plugin.version}</version>
+                <configuration>
+                    <excludeFilterFile>style/spotbugs-exclude.xml</excludeFilterFile>
+                    <effort>Max</effort>
+                    <threshold>High</threshold>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
@@ -610,7 +615,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>${soptbugs-maven-plugin.version}</version>
+                <version>${spotbugs-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/style/spotbugs-exclude.xml
+++ b/style/spotbugs-exclude.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 1999-2026 Alibaba Group Holding Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<FindBugsFilter>
+    <!-- ==================== Generated code / Third-party ported code ==================== -->
+    <Match><Package name="com.alibaba.nacos.api.grpc.auto"/></Match>
+    <Match><Package name="~com\.alibaba\.nacos\.consistency\.entity\..*"/></Match>
+    <Match><Package name="~com\.alibaba\.nacos\.istio\..*"/></Match>
+    <Match><Package name="~com\.google\.protobuf\..*"/></Match>
+    <!-- packagescan ported from Spring Framework, already excluded in JaCoCo/RAT -->
+    <Match><Package name="~com\.alibaba\.nacos\.common\.packagescan\..*"/></Match>
+
+    <!-- ==================== Existing High bug patterns ==================== -->
+    <!-- The following exclusions suppress existing High-priority bugs so that   -->
+    <!-- spotbugs:check can be enabled. They will be removed one by one via     -->
+    <!-- follow-up PRs that fix the underlying issues (ratchet approach).       -->
+
+    <!-- DM_DEFAULT_ENCODING: 12 occurrences, missing explicit charset -->
+    <Match><Bug pattern="DM_DEFAULT_ENCODING"/></Match>
+    <!-- DMI_RANDOM_USED_ONLY_ONCE: 7 occurrences, Random instance not reused -->
+    <Match><Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/></Match>
+    <!-- MS_SHOULD_BE_FINAL: 7 occurrences, static field should be final -->
+    <Match><Bug pattern="MS_SHOULD_BE_FINAL"/></Match>
+    <!-- DM_BOXED_PRIMITIVE_FOR_PARSING: 4 occurrences, unnecessary boxing -->
+    <Match><Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING"/></Match>
+    <!-- HE_EQUALS_USE_HASHCODE: 3 occurrences, equals without hashCode -->
+    <Match><Bug pattern="HE_EQUALS_USE_HASHCODE"/></Match>
+    <!-- EQ_DONT_DEFINE_EQUALS_FOR_ENUM: 2 occurrences, enum should not override equals -->
+    <Match><Bug pattern="EQ_DONT_DEFINE_EQUALS_FOR_ENUM"/></Match>
+    <!-- DMI_BLOCKING_METHODS_ON_URL: 2 occurrences, URL.equals/hashCode triggers DNS -->
+    <Match><Bug pattern="DMI_BLOCKING_METHODS_ON_URL"/></Match>
+    <!-- CN_IDIOM_NO_SUPER_CALL: 1 occurrence, clone() without super.clone() -->
+    <Match><Bug pattern="CN_IDIOM_NO_SUPER_CALL"/></Match>
+    <!-- NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE: 1 occurrence -->
+    <Match><Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"/></Match>
+    <!-- NS_DANGEROUS_NON_SHORT_CIRCUIT: 1 occurrence, & instead of && -->
+    <Match><Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT"/></Match>
+    <!-- RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT: 1 occurrence -->
+    <Match><Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/></Match>
+    <!-- RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED: 2 occurrences, concurrency risk -->
+    <Match><Bug pattern="RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED"/></Match>
+    <!-- SE_BAD_FIELD: 1 occurrence (High), non-serializable field in serializable class -->
+    <Match><Bug pattern="SE_BAD_FIELD"/></Match>
+    <!-- ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD: 1 occurrence -->
+    <Match><Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"/></Match>
+</FindBugsFilter>


### PR DESCRIPTION
Fixes https://github.com/alibaba/nacos/issues/14469

## What is the purpose of the change

Following the removal of p3c-pmd in #14455, SpotBugs is the only static bug detection tool remaining. However, it was configured but not enforced — CI used `spotbugs:spotbugs` (report only), so detected bugs never blocked builds.

This PR enables `spotbugs:check` enforcement using a **ratchet approach**: suppress all existing High-level issues via an exclude filter, so new code introducing novel High-priority bug types will be blocked immediately. Existing issues will be fixed in follow-up PRs by gradually removing exclusions.

## Brief changelog

- Fix property typo: `soptbugs-maven-plugin.version` → `spotbugs-maven-plugin.version`
- Add SpotBugs plugin `<configuration>` with `effort=Max`, `threshold=High`, and `excludeFilterFile`
- Create `style/spotbugs-exclude.xml` — excludes generated/ported code (istio, protobuf, packagescan) and 14 existing High-level bug patterns
- Switch CI from `spotbugs:spotbugs` to `spotbugs:check`
- Update PR template from `findbugs:findbugs` to `spotbugs:check`

## Verifying this change

- [x] Local `mvn compile spotbugs:check -DskipTests -Drat.skip=true` passes (all 46 modules SUCCESS)
- [ ] No Java source code was modified — only build config, CI workflow, and PR template