### PR TITLE
fix: replace Long.valueOf(s) with Long.parseLong(s) to avoid redundant unboxing.

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
@@ -67,7 +67,7 @@ public class CacheData {
     static long initNotifyWarnTimeout() {
         String notifyTimeouts = System.getProperty("nacos.listener.notify.warn.timeout");
         if (StringUtils.isNotBlank(notifyTimeouts) && NumberUtils.isDigits(notifyTimeouts)) {
-            notifyWarnTimeout = Long.valueOf(notifyTimeouts);
+            notifyWarnTimeout = Long.parseLong(notifyTimeouts);
             LOGGER.info("config listener notify warn timeout millis is set to {}", notifyWarnTimeout);
         } else {
             LOGGER.info("config listener notify warn timeout millis use default {} millis ",

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/RateCounter.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/tps/barrier/RateCounter.java
@@ -84,7 +84,7 @@ public abstract class RateCounter {
     public static long getTrimMillsOfMinute(long timeStamp) {
         String millString = String.valueOf(timeStamp);
         String substring = millString.substring(0, millString.length() - 3);
-        return Long.valueOf(Long.valueOf(substring) / 60 * 60 + "000");
+        return Long.parseLong(Long.parseLong(substring) / 60 * 60 + "000");
     }
     
     /**
@@ -96,7 +96,7 @@ public abstract class RateCounter {
     public static long getTrimMillsOfSecond(long timeStamp) {
         String millString = String.valueOf(timeStamp);
         String substring = millString.substring(0, millString.length() - 3);
-        return Long.valueOf(substring + "000");
+        return Long.parseLong(substring + "000");
     }
     
     /**
@@ -108,6 +108,6 @@ public abstract class RateCounter {
     public static long getTrimMillsOfHour(long timeStamp) {
         String millString = String.valueOf(timeStamp);
         String substring = millString.substring(0, millString.length() - 3);
-        return Long.valueOf(Long.valueOf(substring) / (60 * 60) * (60 * 60) + "000");
+        return Long.parseLong(Long.parseLong(substring) / (60 * 60) * (60 * 60) + "000");
     }
 }


### PR DESCRIPTION
fix: replace Long.valueOf(s) with Long.parseLong(s) to avoid redundant unboxing.