### PR TITLE
Fix spelling errors in comments

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/client/Client.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/client/Client.java
@@ -138,7 +138,7 @@ public interface Client {
     boolean isExpire(long currentTime);
     
     /**
-     * Release current client and release resources if neccessary.
+     * Release current client and release resources if necessary.
      */
     void release();
     

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
@@ -78,7 +78,7 @@ public interface ConfigInfoMapper extends Mapper {
      * id,data_id,group_id,tenant_id,app_name,content FROM config_info WHERE tenant_id LIKE ? AND app_name=? LIMIT startRow, pageSize
      *
      * @param context The context of startRow, pageSize
-     * @return The sql of querying configration information based on group.
+     * @return The sql of querying configuration information based on group.
      */
     MapperResult findConfigInfoByAppFetchRows(MapperContext context);
     


### PR DESCRIPTION
## What is the purpose of the change

Fixes #12254.

This pull request corrects several spelling mistakes in code comments to improve readability and maintain code quality.  
These changes do not affect any runtime logic or behavior.

## Brief changelog

- Fix typo in `ConfigInfoMapper#findConfigInfoByAppFetchRows` comment:  
  `configration` → `configuration`
- Fix typo in `Client#release` comment:  
  `neccessary` → `necessary`