### PR TITLE
[ISSUE #14471] Remove DM_BOXED_PRIMITIVE_FOR_PARSING SpotBugs exclusion

### DIFF
--- a/style/spotbugs-exclude.xml
+++ b/style/spotbugs-exclude.xml
@@ -35,8 +35,6 @@
     <Match><Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/></Match>
     <!-- MS_SHOULD_BE_FINAL: 7 occurrences, static field should be final -->
     <Match><Bug pattern="MS_SHOULD_BE_FINAL"/></Match>
-    <!-- DM_BOXED_PRIMITIVE_FOR_PARSING: 4 occurrences, unnecessary boxing -->
-    <Match><Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING"/></Match>
     <!-- HE_EQUALS_USE_HASHCODE: 3 occurrences, equals without hashCode -->
     <Match><Bug pattern="HE_EQUALS_USE_HASHCODE"/></Match>
     <!-- EQ_DONT_DEFINE_EQUALS_FOR_ENUM: 2 occurrences, enum should not override equals -->


### PR DESCRIPTION
Fixes https://github.com/alibaba/nacos/issues/14471

## What is the purpose of the change

Follow-up to #14469 (SpotBugs check enforcement). The `DM_BOXED_PRIMITIVE_FOR_PARSING` bugs were fixed in #14475, so the exclusion in `spotbugs-exclude.xml` is no longer needed. Removing it ensures future occurrences are caught by CI.

## Brief changelog

- Remove `DM_BOXED_PRIMITIVE_FOR_PARSING` pattern exclusion from `style/spotbugs-exclude.xml`

## Verifying this change

- [x] Local `mvn compile spotbugs:check -DskipTests -Drat.skip=true` passes (all 46 modules SUCCESS)