### PR TITLE
[ISSUE #14486] Remove unnecessary equals() override in enum classes

### DIFF
--- a/plugin/config/src/main/java/com/alibaba/nacos/plugin/config/constants/ConfigChangeExecuteTypes.java
+++ b/plugin/config/src/main/java/com/alibaba/nacos/plugin/config/constants/ConfigChangeExecuteTypes.java
@@ -29,9 +29,5 @@ public enum ConfigChangeExecuteTypes {
     /**
      * Execute after pointcut.
      */
-    EXECUTE_AFTER_TYPE;
-    
-    public boolean equals(ConfigChangeExecuteTypes configChangeExecuteTypes) {
-        return this.compareTo(configChangeExecuteTypes) == 0;
-    }
+    EXECUTE_AFTER_TYPE
 }

--- a/plugin/config/src/main/java/com/alibaba/nacos/plugin/config/constants/ConfigChangePointCutTypes.java
+++ b/plugin/config/src/main/java/com/alibaba/nacos/plugin/config/constants/ConfigChangePointCutTypes.java
@@ -57,8 +57,4 @@ public enum ConfigChangePointCutTypes {
     public String value() {
         return value;
     }
-    
-    public boolean equals(ConfigChangePointCutTypes configChangePointCutTypes) {
-        return this.compareTo(configChangePointCutTypes) == 0;
-    }
 }

--- a/style/spotbugs-exclude.xml
+++ b/style/spotbugs-exclude.xml
@@ -39,8 +39,6 @@
     <Match><Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING"/></Match>
     <!-- HE_EQUALS_USE_HASHCODE: 3 occurrences, equals without hashCode -->
     <Match><Bug pattern="HE_EQUALS_USE_HASHCODE"/></Match>
-    <!-- EQ_DONT_DEFINE_EQUALS_FOR_ENUM: 2 occurrences, enum should not override equals -->
-    <Match><Bug pattern="EQ_DONT_DEFINE_EQUALS_FOR_ENUM"/></Match>
     <!-- DMI_BLOCKING_METHODS_ON_URL: 2 occurrences, URL.equals/hashCode triggers DNS -->
     <Match><Bug pattern="DMI_BLOCKING_METHODS_ON_URL"/></Match>
     <!-- CN_IDIOM_NO_SUPER_CALL: 1 occurrence, clone() without super.clone() -->


### PR DESCRIPTION
Fixes https://github.com/alibaba/nacos/issues/14486

## What is the purpose of the change

Remove custom `equals()` methods from two enum classes. Java enums are singletons where `==` and the inherited `Object.equals()` already behave correctly. Defining a custom `equals()` on an enum is flagged by SpotBugs as `EQ_DONT_DEFINE_EQUALS_FOR_ENUM`.

## Brief changelog

- `ConfigChangeExecuteTypes.java`: Remove `equals(ConfigChangeExecuteTypes)` method
- `ConfigChangePointCutTypes.java`: Remove `equals(ConfigChangePointCutTypes)` method
- `style/spotbugs-exclude.xml`: Remove `EQ_DONT_DEFINE_EQUALS_FOR_ENUM` exclusion

Both methods used `this.compareTo(other) == 0`, which is equivalent to `this == other` for enums — completely redundant. The only call site (`ConfigChangeAspect.java`) will automatically fall back to `Object.equals()`, with identical behavior for enums.

## Verifying this change

- `mvn compile spotbugs:check -DskipTests -pl plugin/config -am` passes locally
- No unit test changes needed as behavior is identical