### PR TITLE
fix: add null check for ALL_ABILITIES.get(mode) to prevent NPE

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/ability/constant/AbilityKey.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ability/constant/AbilityKey.java
@@ -131,7 +131,11 @@ public enum AbilityKey {
      * @return all keys
      */
     public static Collection<AbilityKey> getAllValues(AbilityMode mode) {
-        return Collections.unmodifiableCollection(ALL_ABILITIES.get(mode).values());
+        Map<String, AbilityKey> modeAbilities = ALL_ABILITIES.get(mode);
+        if (modeAbilities == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(modeAbilities.values());
     }
     
     /**
@@ -140,7 +144,11 @@ public enum AbilityKey {
      * @return all names
      */
     public static Collection<String> getAllNames(AbilityMode mode) {
-        return Collections.unmodifiableCollection(ALL_ABILITIES.get(mode).keySet());
+        Map<String, AbilityKey> modeAbilities = ALL_ABILITIES.get(mode);
+        if (modeAbilities == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(modeAbilities.keySet());
     }
     
     /**
@@ -150,7 +158,11 @@ public enum AbilityKey {
      * @return whether contains
      */
     public static boolean isLegalKey(AbilityMode mode, String name) {
-        return ALL_ABILITIES.get(mode).containsKey(name);
+        Map<String, AbilityKey> modeAbilities = ALL_ABILITIES.get(mode);
+        if (modeAbilities == null) {
+            return false;
+        }
+        return modeAbilities.containsKey(name);
     }
     
     /**
@@ -188,7 +200,11 @@ public enum AbilityKey {
      * @return enum
      */
     public static AbilityKey getEnum(AbilityMode mode, String key) {
-        return ALL_ABILITIES.get(mode).get(key);
+        Map<String, AbilityKey> modeAbilities = ALL_ABILITIES.get(mode);
+        if (modeAbilities == null) {
+            return null;
+        }
+        return modeAbilities.get(key);
     }
     
     static {


### PR DESCRIPTION
## Fix NPE in AbilityKey methods

### Problem
When `ALL_ABILITIES` doesn't contain the given `AbilityMode`, `get(mode)` returns `null`. Calling `.values()`, `.keySet()`, or `.containsKey()` on null causes `NullPointerException`.

### Solution
Add proper null checks in the following methods:
- `getAllValues(AbilityMode mode)` - returns empty list if null
- `getAllNames(AbilityMode mode)` - returns empty list if null
- `isLegalKey(AbilityMode mode, String name)` - returns false if null
- `getEnum(AbilityMode mode, String key)` - returns null if null

### Testing
- [x] Code compiles successfully

Fixes NPE when accessing non-existent AbilityMode in ALL_ABILITIES map.