### PR TITLE
fix: replace printStackTrace with LOGGER.warn in ClientWorker

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -691,7 +691,7 @@ public class ClientWorker implements Closeable {
                         try {
                             entry.getValue().shutdown();
                         } catch (NacosException nacosException) {
-                            nacosException.printStackTrace();
+                            LOGGER.warn("Failed to shutdown rpc client {}", entry.getKey(), nacosException);
                         }
                         LOGGER.info("Remove rpc client {}", entry.getKey());
                         iterator.remove();


### PR DESCRIPTION
## Description
Replace NacosException.printStackTrace() with proper LOGGER.warn() to use Nacos logging framework instead of console output.

## Changes
- Modified: `client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java`

Replace the printStackTrace() call with proper logging:
```java
// Before
nacosException.printStackTrace();

// After
LOGGER.warn("Failed to shutdown rpc client {}", entry.getKey(), nacosException);
```

This ensures proper error logging using Nacos built-in logging framework.