### PR TITLE
[ISSUE #14511] Suppress SpotBugs false positives with @SuppressFBWarnings

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -68,7 +68,7 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>

--- a/common/src/main/java/com/alibaba/nacos/common/cache/decorators/LruCache.java
+++ b/common/src/main/java/com/alibaba/nacos/common/cache/decorators/LruCache.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.common.cache.decorators;
 
 import com.alibaba.nacos.common.cache.Cache;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;

--- a/style/spotbugs-exclude.xml
+++ b/style/spotbugs-exclude.xml
@@ -41,12 +41,20 @@
     <Match><Bug pattern="CN_IDIOM_NO_SUPER_CALL"/></Match>
     <!-- NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE: 1 occurrence -->
     <Match><Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"/></Match>
-    <!-- RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT: 1 occurrence -->
-    <Match><Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/></Match>
     <!-- RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED: 2 occurrences, concurrency risk -->
     <Match><Bug pattern="RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED"/></Match>
     <!-- SE_BAD_FIELD: 1 occurrence (High), non-serializable field in serializable class -->
     <Match><Bug pattern="SE_BAD_FIELD"/></Match>
-    <!-- ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD: 1 occurrence -->
-    <Match><Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"/></Match>
+
+    <!-- ==================== Targeted class-level exclusions ==================== -->
+    <!-- RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT: LruCache.get() uses LinkedHashMap.get() for LRU side effect -->
+    <Match>
+        <Class name="com.alibaba.nacos.common.cache.decorators.LruCache"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    </Match>
+    <!-- ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD: Spring ApplicationContextInitializer callback -->
+    <Match>
+        <Class name="com.alibaba.nacos.sys.utils.ApplicationUtils"/>
+        <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"/>
+    </Match>
 </FindBugsFilter>

--- a/sys/pom.xml
+++ b/sys/pom.xml
@@ -36,7 +36,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>nacos-common</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>


### PR DESCRIPTION
Fixes https://github.com/alibaba/nacos/issues/14511

## What is the purpose of the change

Suppress two SpotBugs false positive warnings using `@SuppressFBWarnings` annotation instead of global exclusions, continuing the ratchet approach from #14469.

## Brief changelog

- Add `spotbugs-annotations` dependency (`optional=true`) to `common` and `sys` modules, with version managed in root POM
- `LruCache.get()`: suppress `RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT` — `LinkedHashMap` with `accessOrder=true` makes `get()` update LRU order (intended side effect)
- `ApplicationUtils.initialize()`: suppress `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` — Spring `ApplicationContextInitializer` callback must be an instance method, writing to static field is the intended design
- Remove both patterns from `style/spotbugs-exclude.xml` so future real occurrences are caught by CI

## Verifying this change

- [x] `mvn spotbugs:check` passes with 0 bugs after removing both global exclusions
- [x] No behavioral changes — annotation is `@Retention(CLASS)`, compile-time only
- [x] `optional=true` prevents `spotbugs-annotations` from propagating to downstream consumers