### PR TITLE
[ISSUE #14533] Fix DM_DEFAULT_ENCODING: add explicit charset to avoid platform-dependent encoding

### DIFF
--- a/client-basic/src/main/java/com/alibaba/nacos/client/auth/ram/utils/SignUtil.java
+++ b/client-basic/src/main/java/com/alibaba/nacos/client/auth/ram/utils/SignUtil.java
@@ -44,7 +44,7 @@ public class SignUtil {
     public static String sign(String data, String key) throws Exception {
         try {
             byte[] signature = sign(data.getBytes(UTF8), key.getBytes(UTF8), SignUtil.SigningAlgorithm.HmacSHA1);
-            return new String(Base64.encodeBase64(signature));
+            return new String(Base64.encodeBase64(signature), UTF8);
         } catch (Exception ex) {
             throw new Exception("Unable to calculate a request signature: " + ex.getMessage(), ex);
         }

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigHttpClientManager.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigHttpClientManager.java
@@ -39,6 +39,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.alibaba.nacos.client.utils.LogUtils.NAMING_LOGGER;
@@ -151,7 +152,7 @@ public class ConfigHttpClientManager implements Closeable {
         
         @Override
         public InputStream getBody() throws IOException {
-            return new ByteArrayInputStream("More than client-side current limit threshold".getBytes());
+            return new ByteArrayInputStream("More than client-side current limit threshold".getBytes(StandardCharsets.UTF_8));
         }
         
         @Override

--- a/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
@@ -112,7 +113,7 @@ public class JdkHttpClientRequest implements HttpClientRequest {
             }
             if (bodyStr != null) {
                 conn.setDoOutput(true);
-                byte[] b = bodyStr.getBytes();
+                byte[] b = bodyStr.getBytes(StandardCharsets.UTF_8);
                 conn.setRequestProperty(CONTENT_LENGTH, String.valueOf(b.length));
                 OutputStream outputStream = conn.getOutputStream();
                 outputStream.write(b, 0, b.length);
@@ -135,11 +136,11 @@ public class JdkHttpClientRequest implements HttpClientRequest {
         sb.append("Content-Type: ").append(Files.probeContentType(file.toPath())).append(LINE_FEED).append(LINE_FEED);
         
         byte[] fileBytes = Files.readAllBytes(file.toPath());
-        byte[] boundaryBytes = (LINE_FEED + "--" + boundary + "--" + LINE_FEED).getBytes();
+        byte[] boundaryBytes = (LINE_FEED + "--" + boundary + "--" + LINE_FEED).getBytes(StandardCharsets.UTF_8);
         
         conn.setDoOutput(true);
         try (OutputStream outputStream = conn.getOutputStream()) {
-            outputStream.write(sb.toString().getBytes());
+            outputStream.write(sb.toString().getBytes(StandardCharsets.UTF_8));
             outputStream.write(fileBytes);
             outputStream.write(boundaryBytes);
             outputStream.flush();

--- a/common/src/main/java/com/alibaba/nacos/common/utils/ExceptionUtil.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/ExceptionUtil.java
@@ -18,6 +18,8 @@ package com.alibaba.nacos.common.utils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
@@ -62,9 +64,14 @@ public class ExceptionUtil {
         }
         
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        final PrintStream ps = new PrintStream(out);
-        t.printStackTrace(ps);
-        ps.flush();
-        return out.toString();
+        try {
+            final PrintStream ps = new PrintStream(out, false, StandardCharsets.UTF_8.name());
+            t.printStackTrace(ps);
+            ps.flush();
+            return new String(out.toByteArray(), StandardCharsets.UTF_8);
+        } catch (UnsupportedEncodingException e) {
+            // Should never happen since UTF-8 is always supported
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/config/src/main/java/com/alibaba/nacos/config/server/utils/PropertyUtil.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/utils/PropertyUtil.java
@@ -24,7 +24,8 @@ import org.springframework.context.ConfigurableApplicationContext;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -412,7 +413,7 @@ public class PropertyUtil implements ApplicationContextInitializer<ConfigurableA
                     "/sys/fs/cgroup/memory/memory.limit_in_bytes");
         }
         File file = new File(limitMemoryFile);
-        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+        try (BufferedReader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
             long memoryLimit = Long.parseLong(reader.readLine().trim());
             return Optional.of(memoryLimit / 1024L / 1024L);
         } catch (IOException | NumberFormatException ignored) {

--- a/core/src/main/java/com/alibaba/nacos/core/utils/ReuseHttpServletRequest.java
+++ b/core/src/main/java/com/alibaba/nacos/core/utils/ReuseHttpServletRequest.java
@@ -86,7 +86,7 @@ public class ReuseHttpServletRequest extends HttpServletRequestWrapper implement
     
     @Override
     public BufferedReader getReader() throws IOException {
-        return new BufferedReader(new InputStreamReader(getInputStream()));
+        return new BufferedReader(new InputStreamReader(getInputStream(), StandardCharsets.UTF_8));
     }
     
     @Override

--- a/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
+++ b/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
@@ -47,8 +47,10 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -428,7 +430,10 @@ public class K8sSyncServer {
         String kubeConfigPath = k8sSyncConfig.getKubeConfig();
 
         // loading the out-of-cluster config, a kubeconfig from file-system
-        ApiClient apiClient = ClientBuilder.kubeconfig(KubeConfig.loadKubeConfig(new FileReader(kubeConfigPath))).build();
+        ApiClient apiClient = ClientBuilder
+                .kubeconfig(KubeConfig.loadKubeConfig(
+                        Files.newBufferedReader(Paths.get(kubeConfigPath), StandardCharsets.UTF_8)))
+                .build();
 
         // set the global default api-client to the in-cluster one from above
         Configuration.setDefaultApiClient(apiClient);

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/HttpClient.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/HttpClient.java
@@ -36,6 +36,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -216,7 +217,7 @@ public class HttpClient {
      */
     public static void asyncHttpPostLarge(String url, List<String> headers, String content, Callback<String> callback)
             throws Exception {
-        asyncHttpPostLarge(url, headers, content.getBytes(), callback);
+        asyncHttpPostLarge(url, headers, content.getBytes(StandardCharsets.UTF_8), callback);
     }
     
     /**

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
@@ -46,6 +46,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.file.Paths;
@@ -514,7 +515,7 @@ public class SwitchManager extends RequestProcessor4CP {
         if (1 != keys.size()) {
             return false;
         }
-        String keyString = new String(keys.get(0));
+        String keyString = new String(keys.get(0), StandardCharsets.UTF_8);
         return !KeyBuilder.getSwitchDomainKey().equals(keyString);
     }
     

--- a/style/spotbugs-exclude.xml
+++ b/style/spotbugs-exclude.xml
@@ -29,8 +29,6 @@
     <!-- spotbugs:check can be enabled. They will be removed one by one via     -->
     <!-- follow-up PRs that fix the underlying issues (ratchet approach).       -->
 
-    <!-- DM_DEFAULT_ENCODING: 12 occurrences, missing explicit charset -->
-    <Match><Bug pattern="DM_DEFAULT_ENCODING"/></Match>
     <!-- DMI_RANDOM_USED_ONLY_ONCE: 7 occurrences, Random instance not reused -->
     <Match><Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/></Match>
     <!-- MS_SHOULD_BE_FINAL: 7 occurrences, static field should be final -->

--- a/sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java
@@ -175,7 +175,7 @@ public final class DiskUtils {
      * @return content
      */
     public static String readFile(InputStream is) {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
             StringBuilder textBuilder = new StringBuilder();
             String lineTxt = null;
             while ((lineTxt = reader.readLine()) != null) {


### PR DESCRIPTION
Fixes https://github.com/alibaba/nacos/issues/14533

## What is the purpose of the change

Fix all `DM_DEFAULT_ENCODING` SpotBugs warnings by adding explicit `StandardCharsets.UTF_8` charset, continuing the ratchet approach from #14469.

## Brief changelog

- `String.getBytes()` → `.getBytes(StandardCharsets.UTF_8)` (SignUtil, ConfigHttpClientManager, JdkHttpClientRequest ×3, HttpClient)
- `new String(byte[])` → `new String(byte[], StandardCharsets.UTF_8)` (SwitchManager)
- `new PrintStream(out)` → `new PrintStream(out, false, "UTF-8")` and `out.toString()` → `new String(out.toByteArray(), UTF_8)` (ExceptionUtil, Java 8 compatible)
- `new FileReader(...)` → `Files.newBufferedReader(..., UTF_8)` (PropertyUtil, K8sSyncServer)
- `new InputStreamReader(is)` → `new InputStreamReader(is, UTF_8)` (ReuseHttpServletRequest, DiskUtils)
- Remove `DM_DEFAULT_ENCODING` exclusion from `style/spotbugs-exclude.xml`

## Verifying this change

- [x] `mvn compile spotbugs:check -DskipTests` passes with 0 `DM_DEFAULT_ENCODING` bugs
- [x] `mvn checkstyle:check` passes (line length verified)
- [x] Java 8 compatibility maintained for `client-basic`, `client`, `common` modules (`PrintStream(OutputStream, boolean, String)` overload used instead of Java 10+ `Charset` overload)