### PR TITLE
[ISSUE #14509] fix correct logical operator in server reloading loop condition

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/service/NacosServerLoaderService.java
+++ b/core/src/main/java/com/alibaba/nacos/core/service/NacosServerLoaderService.java
@@ -134,7 +134,7 @@ public class NacosServerLoaderService {
         LOGGER.info("Low load limit server list ={}", lowLimitServer);
         AtomicBoolean result = new AtomicBoolean(true);
         
-        for (int i = 0; i < overLimitServer.size() & i < lowLimitServer.size(); i++) {
+        for (int i = 0; i < overLimitServer.size() && i < lowLimitServer.size(); i++) {
             ServerReloadRequest serverLoaderInfoRequest = new ServerReloadRequest();
             serverLoaderInfoRequest.setReloadCount(overLimitCount);
             serverLoaderInfoRequest.setReloadServer(lowLimitServer.get(i).getAddress());

--- a/style/spotbugs-exclude.xml
+++ b/style/spotbugs-exclude.xml
@@ -43,8 +43,6 @@
     <Match><Bug pattern="CN_IDIOM_NO_SUPER_CALL"/></Match>
     <!-- NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE: 1 occurrence -->
     <Match><Bug pattern="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"/></Match>
-    <!-- NS_DANGEROUS_NON_SHORT_CIRCUIT: 1 occurrence, & instead of && -->
-    <Match><Bug pattern="NS_DANGEROUS_NON_SHORT_CIRCUIT"/></Match>
     <!-- RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT: 1 occurrence -->
     <Match><Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/></Match>
     <!-- RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED: 2 occurrences, concurrency risk -->


### PR DESCRIPTION
fix correct logical operator in server reloading loop condition

close #14509

## What is the purpose of the change

This PR fixes a logical operator error in the server balance/reloading loop. The current code uses a bitwise AND (&) instead of a short-circuit logical AND (&&) for the loop termination condition. Replacing & with && ensures the loop terminates correctly as soon as the first limit is reached without unnecessary evaluation of the second condition.

## Brief changelog

 - Updated the loop condition in server reloading logic: replaced & with && when comparing i against overLimitServer.size() and lowLimitServer.size().

## Verifying this change

This is a minor logic correction. Existing unit tests covering server balance and reloading functionality should pass to ensure no regression in behavior.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

