### PR TITLE
[ISSUE #14538] Replace new Random() with ThreadLocalRandom

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/core/NamingServerListManager.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/core/NamingServerListManager.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -63,7 +63,7 @@ public class NamingServerListManager extends AbstractServerListManager {
         if (serverList.isEmpty()) {
             throw new NacosLoadException("serverList is empty,please check configuration");
         } else {
-            currentIndex.set(new Random().nextInt(serverList.size()));
+            currentIndex.set(ThreadLocalRandom.current().nextInt(serverList.size()));
         }
         if (serverListProvider instanceof PropertiesListProvider) {
             if (serverList.size() == 1) {

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -55,7 +55,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.alibaba.nacos.client.utils.LogUtils.NAMING_LOGGER;
 import static com.alibaba.nacos.common.constant.RequestUrlConstants.HTTPS_PREFIX;
@@ -375,8 +375,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
                 }
             }
         } else {
-            Random random = new Random();
-            int index = random.nextInt(servers.size());
+            int index = ThreadLocalRandom.current().nextInt(servers.size());
             
             for (int i = 0; i < servers.size(); i++) {
                 String server = servers.get(index);

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/RpcClient.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -436,12 +436,11 @@ public abstract class RpcClient implements Closeable {
             return false;
         }
         int reTryTimes = rpcClientConfig.healthCheckRetryTimes();
-        Random random = new Random();
         while (reTryTimes >= 0) {
             reTryTimes--;
             try {
                 if (reTryTimes > 1) {
-                    Thread.sleep(random.nextInt(500));
+                    Thread.sleep(ThreadLocalRandom.current().nextInt(500));
                 }
                 Response response = this.currentConnection
                         .request(healthCheckRequest, rpcClientConfig.healthCheckTimeOut());

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/LongPollingService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/LongPollingService.java
@@ -45,7 +45,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
@@ -198,7 +198,7 @@ public class LongPollingService {
         if (!connectionCheckResponse.isSuccess()) {
             RpcScheduledExecutor.CONTROL_SCHEDULER.schedule(
                     () -> generate503Response(asyncContext, rsp, connectionCheckResponse.getMessage()),
-                    1000L + new Random().nextInt(2000), TimeUnit.MILLISECONDS);
+                    1000L + ThreadLocalRandom.current().nextInt(2000), TimeUnit.MILLISECONDS);
             return;
         }
         

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpService.java
@@ -48,7 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Timestamp;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.nacos.config.server.utils.LogUtil.DUMP_LOG;
@@ -231,8 +231,7 @@ public abstract class DumpService {
             }
             if (!EnvUtil.getStandaloneMode()) {
                 
-                Random random = new Random();
-                long initialDelay = random.nextInt(INITIAL_DELAY_IN_MINUTE) + 10;
+                long initialDelay = ThreadLocalRandom.current().nextInt(INITIAL_DELAY_IN_MINUTE) + 10;
                 LogUtil.DEFAULT_LOG.warn("initialDelay:{}", initialDelay);
                 
                 ConfigExecutor.scheduleConfigTask(new DumpAllProcessorRunner(), initialDelay,
@@ -243,12 +242,14 @@ public abstract class DumpService {
                 ConfigExecutor.scheduleConfigChangeTask(
                         new DumpChangeConfigWorker(this.configInfoPersistService, this.historyConfigInfoPersistService,
                                 this.configMigrateService,
-                                currentTime), random.nextInt((int) PropertyUtil.getDumpChangeWorkerInterval()),
+                                currentTime),
+                        ThreadLocalRandom.current().nextInt((int) PropertyUtil.getDumpChangeWorkerInterval()),
                         TimeUnit.MILLISECONDS);
                 ConfigExecutor.scheduleConfigChangeTask(
                         new DumpChangeGrayConfigWorker(this.configInfoGrayPersistService, currentTime,
                                 this.historyConfigInfoPersistService, this.configMigrateService),
-                        random.nextInt((int) PropertyUtil.getDumpChangeWorkerInterval()), TimeUnit.MILLISECONDS);
+                        ThreadLocalRandom.current().nextInt((int) PropertyUtil.getDumpChangeWorkerInterval()),
+                        TimeUnit.MILLISECONDS);
             }
             
             HistoryConfigCleaner cleaner = HistoryConfigCleanerManager.getHistoryConfigCleaner(

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
@@ -78,7 +78,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -264,8 +264,7 @@ public class JRaftServer {
             RaftExecutor.executeByCommon(() -> registerSelfToCluster(groupName, localPeerId, configuration));
             
             // Turn on the leader auto refresh for this group
-            Random random = new Random();
-            long period = nodeOptions.getElectionTimeoutMs() + random.nextInt(5 * 1000);
+            long period = nodeOptions.getElectionTimeoutMs() + ThreadLocalRandom.current().nextInt(5 * 1000);
             RaftExecutor.scheduleRaftMemberRefreshJob(() -> refreshRouteTable(groupName),
                     nodeOptions.getElectionTimeoutMs(), period, TimeUnit.MILLISECONDS);
             multiRaftGroup.put(groupName, new RaftGroupTuple(node, processor, raftGroupService, machine));

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/address/DefaultServerListManager.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/address/DefaultServerListManager.java
@@ -24,7 +24,7 @@ import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.maintainer.client.remote.HttpClientManager;
 
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -47,7 +47,7 @@ public class DefaultServerListManager extends AbstractServerListManager {
         if (serverList.isEmpty()) {
             throw new NacosLoadException("serverList is empty,please check configuration");
         } else {
-            currentIndex.set(new Random().nextInt(serverList.size()));
+            currentIndex.set(ThreadLocalRandom.current().nextInt(serverList.size()));
         }
     }
     

--- a/style/spotbugs-exclude.xml
+++ b/style/spotbugs-exclude.xml
@@ -29,8 +29,6 @@
     <!-- spotbugs:check can be enabled. They will be removed one by one via     -->
     <!-- follow-up PRs that fix the underlying issues (ratchet approach).       -->
 
-    <!-- DMI_RANDOM_USED_ONLY_ONCE: 7 occurrences, Random instance not reused -->
-    <Match><Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/></Match>
     <!-- MS_SHOULD_BE_FINAL: 7 occurrences, static field should be final -->
     <Match><Bug pattern="MS_SHOULD_BE_FINAL"/></Match>
     <!-- HE_EQUALS_USE_HASHCODE: 3 occurrences, equals without hashCode -->


### PR DESCRIPTION
Fixes https://github.com/alibaba/nacos/issues/14538

## What is the purpose of the change

Fix all `DMI_RANDOM_USED_ONLY_ONCE` SpotBugs warnings by replacing single-use `new Random()` instances with `ThreadLocalRandom.current()`, continuing the ratchet approach from #14469.

## Brief changelog

- `new Random().nextInt(...)` → `ThreadLocalRandom.current().nextInt(...)` across 7 files (8 occurrences)
- Remove unused `import java.util.Random` from all affected files
- Remove `DMI_RANDOM_USED_ONLY_ONCE` exclusion from `style/spotbugs-exclude.xml`

Affected modules: common (RpcClient), core (JRaftServer), config (LongPollingService, DumpService), client (NamingServerListManager, NamingHttpClientProxy), maintainer-client (DefaultServerListManager).

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.