### PR TITLE
Add uploadSkill API to admin controller and extract common RemoteServerConnector

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
@@ -41,7 +41,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Skill admin controller.
@@ -139,5 +142,25 @@ public class SkillAdminController {
         return Result.success(
                 skillOperationService.listSkills(skillListForm.getNamespaceId(), skillListForm.getSkillName(),
                         skillListForm.getSearch(), pageForm.getPageNo(), pageForm.getPageSize()));
+    }
+
+    /**
+     * Upload skill from zip file.
+     *
+     * @param request HTTP servlet request
+     * @param namespaceId namespace ID
+     * @param file zip file containing skill
+     * @return result of the upload operation
+     * @throws NacosException if the upload fails
+     */
+    @PostMapping(value = "/upload", consumes = "multipart/form-data")
+    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.ADMIN_API)
+    @ExtractorManager.Extractor(httpExtractor = ExtractorManager.DefaultHttpExtractor.class)
+    public Result<String> uploadSkill(HttpServletRequest request,
+            @RequestParam(value = "namespaceId", required = false) String namespaceId,
+            @RequestParam("file") MultipartFile file) throws NacosException {
+        byte[] zipBytes = SkillRequestUtil.validateAndExtractZipBytes(file);
+        String skillName = skillOperationService.uploadSkillFromZip(namespaceId, zipBytes);
+        return Result.success(skillName);
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillRequestUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillRequestUtil.java
@@ -16,8 +16,10 @@
 
 package com.alibaba.nacos.ai.utils;
 
+import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.form.skills.admin.SkillDetailForm;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
@@ -26,6 +28,9 @@ import com.alibaba.nacos.common.utils.StringUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 /**
  * Skill request util.
@@ -73,6 +78,33 @@ public class SkillRequestUtil {
         if (StringUtils.isEmpty(fieldValue)) {
             throw new NacosApiException(NacosApiException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "Required parameter `skillCard." + fieldName + "` not present");
+        }
+    }
+
+    /**
+     * Validate uploaded skill zip file and extract bytes.
+     *
+     * <p>Validates the file is not null/empty, checks file size against the maximum limit,
+     * and extracts the file bytes. This method is shared by both admin and console upload endpoints.</p>
+     *
+     * @param file the uploaded multipart file
+     * @return the file bytes
+     * @throws NacosException if validation fails or file reading fails
+     */
+    public static byte[] validateAndExtractZipBytes(MultipartFile file) throws NacosException {
+        if (file == null || file.isEmpty()) {
+            throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.DATA_EMPTY, "File is required");
+        }
+        if (file.getSize() > Constants.Skills.MAX_UPLOAD_ZIP_BYTES) {
+            throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                    "Skill zip size must not exceed " + (Constants.Skills.MAX_UPLOAD_ZIP_BYTES / 1024 / 1024)
+                            + "MB, current: " + (file.getSize() / 1024 / 1024) + "MB");
+        }
+        try {
+            return file.getBytes();
+        } catch (IOException e) {
+            throw new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.PARSING_DATA_FAILED,
+                    "Failed to read file: " + e.getMessage());
         }
     }
 }

--- a/console/src/main/java/com/alibaba/nacos/console/NacosConsole.java
+++ b/console/src/main/java/com/alibaba/nacos/console/NacosConsole.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.console;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -28,6 +29,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * @author xiweng.yy
  */
 @SpringBootApplication(exclude = LdapAutoConfiguration.class)
+@ComponentScan(basePackages = {"com.alibaba.nacos.console", "com.alibaba.nacos.copilot"})
 @PropertySource("classpath:nacos-console.properties")
 @EnableScheduling
 public class NacosConsole {

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.console.controller.v3.ai;
 
 import com.alibaba.nacos.ai.constant.Constants;
-import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.ai.form.skills.admin.SkillDetailForm;
 import com.alibaba.nacos.ai.form.skills.admin.SkillForm;
 import com.alibaba.nacos.ai.form.skills.admin.SkillListForm;
@@ -157,20 +156,8 @@ public class ConsoleSkillController {
     public Result<String> uploadSkill(HttpServletRequest request,
             @RequestParam(value = "namespaceId", required = false) String namespaceId,
             @RequestParam("file") MultipartFile file) throws NacosException {
-        if (file == null || file.isEmpty()) {
-            return Result.failure(com.alibaba.nacos.api.model.v2.ErrorCode.DATA_EMPTY, "File is required");
-        }
-        if (file.getSize() > Constants.Skills.MAX_UPLOAD_ZIP_BYTES) {
-            return Result.failure(ErrorCode.PARAMETER_VALIDATE_ERROR,
-                    "Skill zip size must not exceed " + (Constants.Skills.MAX_UPLOAD_ZIP_BYTES / 1024 / 1024)
-                            + "MB, current: " + (file.getSize() / 1024 / 1024) + "MB");
-        }
-        try {
-            String skillName = skillProxy.uploadSkillFromZip(namespaceId, file.getBytes());
-            return Result.success(skillName);
-        } catch (java.io.IOException e) {
-            return Result.failure(com.alibaba.nacos.api.model.v2.ErrorCode.PARSING_DATA_FAILED,
-                    "Failed to read file: " + e.getMessage());
-        }
+        byte[] zipBytes = SkillRequestUtil.validateAndExtractZipBytes(file);
+        String skillName = skillProxy.uploadSkillFromZip(namespaceId, zipBytes);
+        return Result.success(skillName);
     }
 }

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/RemoteServerConnector.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/RemoteServerConnector.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.impl.remote;
+
+import com.alibaba.nacos.api.common.NodeState;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.api.model.response.NacosMember;
+import com.alibaba.nacos.auth.config.NacosAuthConfig;
+import com.alibaba.nacos.auth.config.NacosAuthConfigHolder;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.console.config.NacosConsoleAuthConfig;
+import com.alibaba.nacos.console.handler.core.ClusterHandler;
+import com.alibaba.nacos.core.cluster.Member;
+import com.alibaba.nacos.core.cluster.NacosMemberManager;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.apache.hc.core5.http.HttpRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Common connector for remote server operations in console deployment mode.
+ *
+ * <p>Provides shared functionality for remote HTTP forwarding services, including
+ * healthy member selection, authentication identity injection, and server context path resolution.</p>
+ *
+ * @author nacos
+ */
+@Component
+@EnabledRemoteHandler
+public class RemoteServerConnector {
+    
+    private final NacosMemberManager memberManager;
+    
+    private final ClusterHandler remoteClusterHandler;
+    
+    public RemoteServerConnector(NacosMemberManager memberManager, ClusterHandler remoteClusterHandler) {
+        this.memberManager = memberManager;
+        this.remoteClusterHandler = remoteClusterHandler;
+    }
+    
+    /**
+     * Add authentication identity headers to the HTTP request.
+     *
+     * @param request the HTTP request to add auth headers to
+     */
+    public void addAuthIdentity(HttpRequest request) {
+        NacosAuthConfig authConfig = NacosAuthConfigHolder.getInstance()
+                .getNacosAuthConfigByScope(NacosConsoleAuthConfig.NACOS_CONSOLE_AUTH_SCOPE);
+        if (StringUtils.isNotBlank(authConfig.getServerIdentityKey())) {
+            request.setHeader(authConfig.getServerIdentityKey(), authConfig.getServerIdentityValue());
+        }
+    }
+    
+    /**
+     * Get the server context path for remote server.
+     *
+     * @return server context path, defaults to "/nacos"
+     */
+    public String getServerContextPath() {
+        return EnvUtil.getProperty("nacos.console.remote.server.context-path", "/nacos");
+    }
+    
+    /**
+     * Randomly select one healthy member from the cluster.
+     *
+     * @return a healthy cluster member
+     * @throws NacosException if no healthy server node is found
+     */
+    public Member randomOneHealthyMember() throws NacosException {
+        Collection<Member> allMembers = memberManager.allMembers();
+        Collection<? extends NacosMember> membersWithState = remoteClusterHandler.getNodeList("");
+        Map<String, NodeState> nodeStateMap = membersWithState.stream()
+                .collect(Collectors.toMap(NacosMember::getAddress, NacosMember::getState));
+        allMembers.removeIf(node -> !NodeState.UP.equals(nodeStateMap.get(node.getAddress())));
+        if (CollectionUtils.isEmpty(allMembers)) {
+            throw new NacosRuntimeException(NacosException.SERVER_ERROR, "No healthy server node found.");
+        }
+        return allMembers.parallelStream().findAny().orElseThrow();
+    }
+}

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillRemoteHandler.java
@@ -46,8 +46,11 @@ public class SkillRemoteHandler implements SkillHandler {
     
     private final NacosMaintainerClientHolder clientHolder;
     
-    public SkillRemoteHandler(NacosMaintainerClientHolder clientHolder) {
+    private final SkillUploadService skillUploadService;
+    
+    public SkillRemoteHandler(NacosMaintainerClientHolder clientHolder, SkillUploadService skillUploadService) {
         this.clientHolder = clientHolder;
+        this.skillUploadService = skillUploadService;
     }
     
     @Override
@@ -89,6 +92,6 @@ public class SkillRemoteHandler implements SkillHandler {
     
     @Override
     public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
-        return clientHolder.getAiMaintainerService().uploadSkillFromZip(namespaceId, zipBytes);
+        return skillUploadService.uploadSkillFromZip(namespaceId, zipBytes);
     }
 }

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillUploadService.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillUploadService.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.impl.remote.ai;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.http.HttpUtils;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.console.handler.impl.remote.EnabledRemoteHandler;
+import com.alibaba.nacos.console.handler.impl.remote.RemoteServerConnector;
+import com.alibaba.nacos.core.cluster.Member;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.hc.client5.http.HttpResponseException;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Nacos skill upload service for remote server via HTTP multipart POST.
+ *
+ * <p>In console deployment mode, the maintainer client cannot properly send multipart file uploads.
+ * This service directly constructs HTTP multipart requests to forward zip files to the remote admin server,
+ * similar to {@link com.alibaba.nacos.console.handler.impl.remote.config.ConfigImportAndExportService}.</p>
+ *
+ * @author nacos
+ */
+@Service
+@EnabledRemoteHandler
+public class SkillUploadService {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkillUploadService.class);
+    
+    private static final String REMOTE_SKILL_UPLOAD_URL = "http://%s%s/v3/admin/ai/skills/upload";
+    
+    private final RemoteServerConnector remoteServerConnector;
+    
+    public SkillUploadService(RemoteServerConnector remoteServerConnector) {
+        this.remoteServerConnector = remoteServerConnector;
+    }
+    
+    /**
+     * Upload skill zip to remote server via HTTP multipart POST.
+     *
+     * @param namespaceId namespace ID
+     * @param zipBytes    zip file bytes
+     * @return skill name from server response
+     * @throws NacosException if upload fails
+     */
+    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        String serverContextPath = remoteServerConnector.getServerContextPath();
+        Member serverMember = remoteServerConnector.randomOneHealthyMember();
+        String url = String.format(REMOTE_SKILL_UPLOAD_URL, serverMember.getAddress(), serverContextPath);
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            Query query = Query.newInstance().addParam("namespaceId", namespaceId);
+            URI uri = HttpUtils.buildUri(url, query);
+            HttpPost httpPost = new HttpPost(uri);
+            remoteServerConnector.addAuthIdentity(httpPost);
+            MultipartEntityBuilder multipartEntityBuilder = MultipartEntityBuilder.create();
+            multipartEntityBuilder.addBinaryBody("file", new ByteArrayInputStream(zipBytes),
+                    ContentType.APPLICATION_OCTET_STREAM, "skill.zip");
+            HttpEntity entity = multipartEntityBuilder.build();
+            httpPost.setEntity(entity);
+            String executeResult = httpClient.execute(httpPost, new BasicHttpClientResponseHandler());
+            Result<String> result = JacksonUtils.toObj(executeResult, new TypeReference<>() {
+            });
+            return result.getData();
+        } catch (HttpResponseException responseException) {
+            LOGGER.error("Upload skill zip to server {} failed with code {}: ", serverMember.getAddress(),
+                    responseException.getStatusCode());
+            throw new NacosRuntimeException(responseException.getStatusCode(), responseException.getMessage());
+        } catch (IOException | URISyntaxException e) {
+            LOGGER.error("Upload skill zip to server {} failed: ", serverMember.getAddress(), e);
+            throw new NacosRuntimeException(NacosException.SERVER_ERROR, "Upload skill zip to server failed.");
+        }
+    }
+    
+}

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/config/ConfigImportAndExportService.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/config/ConfigImportAndExportService.java
@@ -17,28 +17,20 @@
 package com.alibaba.nacos.console.handler.impl.remote.config;
 
 import com.alibaba.nacos.api.common.Constants;
-import com.alibaba.nacos.api.common.NodeState;
 import com.alibaba.nacos.api.config.model.SameConfigPolicy;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
-import com.alibaba.nacos.api.model.response.NacosMember;
 import com.alibaba.nacos.api.model.v2.Result;
-import com.alibaba.nacos.auth.config.NacosAuthConfig;
-import com.alibaba.nacos.auth.config.NacosAuthConfigHolder;
 import com.alibaba.nacos.common.http.HttpUtils;
 import com.alibaba.nacos.common.http.param.Query;
-import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.IoUtils;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.utils.RequestUtil;
-import com.alibaba.nacos.console.config.NacosConsoleAuthConfig;
-import com.alibaba.nacos.console.handler.core.ClusterHandler;
 import com.alibaba.nacos.console.handler.impl.remote.EnabledRemoteHandler;
+import com.alibaba.nacos.console.handler.impl.remote.RemoteServerConnector;
 import com.alibaba.nacos.core.cluster.Member;
-import com.alibaba.nacos.core.cluster.NacosMemberManager;
 import com.alibaba.nacos.core.utils.WebUtils;
-import com.alibaba.nacos.sys.env.EnvUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.hc.client5.http.HttpResponseException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -51,7 +43,6 @@ import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.ProtocolException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,10 +56,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Nacos config import and export service.
@@ -85,13 +74,10 @@ public class ConfigImportAndExportService {
     
     private static final String REMOTE_CONFIG_EXPORT_URL = "http://%s%s/v3/admin/cs/config/export";
     
-    private final NacosMemberManager memberManager;
-
-    private final ClusterHandler remoteClusterHandler;
+    private final RemoteServerConnector remoteServerConnector;
     
-    public ConfigImportAndExportService(NacosMemberManager memberManager, ClusterHandler remoteClusterHandler) {
-        this.memberManager = memberManager;
-        this.remoteClusterHandler = remoteClusterHandler;
+    public ConfigImportAndExportService(RemoteServerConnector remoteServerConnector) {
+        this.remoteServerConnector = remoteServerConnector;
     }
     
     /**
@@ -107,8 +93,8 @@ public class ConfigImportAndExportService {
      */
     public Result<Map<String, Object>> importConfig(String sourceUser, String namespaceId, SameConfigPolicy policy,
             MultipartFile importFile, String sourceIp, String sourceApp) throws NacosException {
-        String serverContextPath = getServerContextPath();
-        Member serverMember = randomOneHealthyMember();
+        String serverContextPath = remoteServerConnector.getServerContextPath();
+        Member serverMember = remoteServerConnector.randomOneHealthyMember();
         String url = String.format(REMOTE_CONFIG_IMPORT_URL, serverMember.getAddress(), serverContextPath);
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             Query query = Query.newInstance().addParam("namespaceId", namespaceId).addParam("srcUser", sourceUser);
@@ -116,7 +102,7 @@ public class ConfigImportAndExportService {
             HttpPost httpPost = new HttpPost(uri);
             httpPost.setHeader(WebUtils.X_FORWARDED_FOR, sourceIp);
             httpPost.setHeader(RequestUtil.CLIENT_APPNAME_HEADER, sourceApp);
-            addAuthIdentity(httpPost);
+            remoteServerConnector.addAuthIdentity(httpPost);
             String contentTypeString = null == importFile.getContentType() ? MediaType.MULTIPART_FORM_DATA_VALUE
                     : importFile.getContentType();
             ContentType contentType = ContentType.create(contentTypeString, Constants.ENCODE);
@@ -152,15 +138,15 @@ public class ConfigImportAndExportService {
      */
     public ResponseEntity<byte[]> exportConfig(String dataId, String group, String namespaceId, String appName,
             List<Long> ids) throws Exception {
-        String serverContextPath = getServerContextPath();
-        Member serverMember = randomOneHealthyMember();
+        String serverContextPath = remoteServerConnector.getServerContextPath();
+        Member serverMember = remoteServerConnector.randomOneHealthyMember();
         String url = String.format(REMOTE_CONFIG_EXPORT_URL, serverMember.getAddress(), serverContextPath);
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             Query query = Query.newInstance().addParam("namespaceId", namespaceId).addParam("dataId", dataId)
                     .addParam("groupName", group).addParam("ids", StringUtils.join(ids, ","));
             URI uri = HttpUtils.buildUri(url, query);
             HttpGet httpGet = new HttpGet(uri);
-            addAuthIdentity(httpGet);
+            remoteServerConnector.addAuthIdentity(httpGet);
             return httpClient.execute(httpGet, new ExportHttpClientResponseHandler());
         } catch (HttpResponseException responseException) {
             LOGGER.error("Export config from server {} failed with code {}: ", serverMember.getAddress(),
@@ -170,34 +156,6 @@ public class ConfigImportAndExportService {
             LOGGER.error("Export config from server {} failed: ", serverMember.getAddress(), e);
             throw new NacosRuntimeException(NacosException.SERVER_ERROR, "Export config to server failed.");
         }
-    }
-    
-    private void addAuthIdentity(HttpRequest request) {
-        NacosAuthConfig authConfig = NacosAuthConfigHolder.getInstance()
-                .getNacosAuthConfigByScope(NacosConsoleAuthConfig.NACOS_CONSOLE_AUTH_SCOPE);
-        if (StringUtils.isNotBlank(authConfig.getServerIdentityKey())) {
-            request.setHeader(authConfig.getServerIdentityKey(), authConfig.getServerIdentityValue());
-        }
-    }
-    
-    private String getServerContextPath() {
-        return EnvUtil.getProperty("nacos.console.remote.server.context-path", "/nacos");
-    }
-    
-    private Member randomOneHealthyMember() throws NacosException {
-        // all nodes in cluster.conf
-        Collection<Member> allMembers = memberManager.allMembers();
-        // nodes with state  in cluster
-        Collection<? extends NacosMember> membersWithState = remoteClusterHandler.getNodeList("");
-        Map<String, NodeState> nodeStateMap = membersWithState
-                .stream().collect(Collectors.toMap(NacosMember::getAddress, NacosMember::getState));
-        // remove unhealthy nodes
-        allMembers.removeIf(node -> !NodeState.UP.equals(nodeStateMap.get(node.getAddress())));
-        if (CollectionUtils.isEmpty(allMembers)) {
-            throw new NacosRuntimeException(NacosException.SERVER_ERROR, "No healthy server node found.");
-        }
-
-        return allMembers.parallelStream().findAny().orElseThrow();
     }
     
     static class ExportHttpClientResponseHandler

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/RemoteServerConnectorTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/RemoteServerConnectorTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.impl.remote;
+
+import com.alibaba.nacos.api.common.NodeState;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.api.model.response.NacosMember;
+import com.alibaba.nacos.auth.config.NacosAuthConfig;
+import com.alibaba.nacos.auth.config.NacosAuthConfigHolder;
+import com.alibaba.nacos.console.config.NacosConsoleAuthConfig;
+import com.alibaba.nacos.console.handler.core.ClusterHandler;
+import com.alibaba.nacos.core.cluster.Member;
+import com.alibaba.nacos.core.cluster.NacosMemberManager;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RemoteServerConnectorTest {
+    
+    @Mock
+    NacosMemberManager memberManager;
+    
+    @Mock
+    ClusterHandler clusterHandler;
+    
+    @Mock
+    NacosConsoleAuthConfig mockNacosAuthConfig;
+    
+    NacosAuthConfig cachedConsoleAuthConfig;
+    
+    RemoteServerConnector remoteServerConnector;
+    
+    private ConfigurableEnvironment cachedEnvironment;
+    
+    @BeforeEach
+    void setUp() {
+        cachedEnvironment = EnvUtil.getEnvironment();
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("nacos.core.auth.admin.enabled", "false");
+        EnvUtil.setEnvironment(environment);
+        remoteServerConnector = new RemoteServerConnector(memberManager, clusterHandler);
+        cachedConsoleAuthConfig = NacosAuthConfigHolder.getInstance()
+                .getNacosAuthConfigByScope(NacosConsoleAuthConfig.NACOS_CONSOLE_AUTH_SCOPE);
+        Map<String, NacosAuthConfig> nacosAuthConfigMap = (Map<String, NacosAuthConfig>) ReflectionTestUtils.getField(
+                NacosAuthConfigHolder.getInstance(), "nacosAuthConfigMap");
+        nacosAuthConfigMap.put(NacosConsoleAuthConfig.NACOS_CONSOLE_AUTH_SCOPE, mockNacosAuthConfig);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        Map<String, NacosAuthConfig> nacosAuthConfigMap = (Map<String, NacosAuthConfig>) ReflectionTestUtils.getField(
+                NacosAuthConfigHolder.getInstance(), "nacosAuthConfigMap");
+        nacosAuthConfigMap.put(NacosConsoleAuthConfig.NACOS_CONSOLE_AUTH_SCOPE, cachedConsoleAuthConfig);
+        EnvUtil.setEnvironment(cachedEnvironment);
+    }
+    
+    @Test
+    void testGetServerContextPathDefault() {
+        String contextPath = remoteServerConnector.getServerContextPath();
+        assertEquals("/nacos", contextPath);
+    }
+    
+    @Test
+    void testGetServerContextPathCustom() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("nacos.console.remote.server.context-path", "/custom");
+        EnvUtil.setEnvironment(environment);
+        String contextPath = remoteServerConnector.getServerContextPath();
+        assertEquals("/custom", contextPath);
+    }
+    
+    @Test
+    void testAddAuthIdentityWithNoAuthConfig() {
+        when(mockNacosAuthConfig.getServerIdentityKey()).thenReturn("");
+        HttpPost httpPost = new HttpPost("http://localhost:8080/test");
+        remoteServerConnector.addAuthIdentity(httpPost);
+        assertNull(httpPost.getFirstHeader("serverIdentity"));
+    }
+    
+    @Test
+    void testAddAuthIdentityWithAuthConfig() {
+        when(mockNacosAuthConfig.getServerIdentityKey()).thenReturn("testKey");
+        when(mockNacosAuthConfig.getServerIdentityValue()).thenReturn("testValue");
+        HttpPost httpPost = new HttpPost("http://localhost:8080/test");
+        remoteServerConnector.addAuthIdentity(httpPost);
+        assertNotNull(httpPost.getFirstHeader("testKey"));
+        assertEquals("testValue", httpPost.getFirstHeader("testKey").getValue());
+    }
+    
+    @Test
+    void testRandomOneHealthyMember() throws NacosException {
+        Member member = new Member();
+        member.setIp("127.0.0.1");
+        member.setPort(8080);
+        member.setState(NodeState.UP);
+        Collection<Member> allMembers = new ArrayList<>();
+        allMembers.add(member);
+        when(memberManager.allMembers()).thenReturn(allMembers);
+        NacosMember nacosMember = new NacosMember();
+        nacosMember.setAddress("127.0.0.1:8080");
+        nacosMember.setState(NodeState.UP);
+        doReturn(Collections.singletonList(nacosMember)).when(clusterHandler).getNodeList("");
+        Member result = remoteServerConnector.randomOneHealthyMember();
+        assertNotNull(result);
+        assertEquals("127.0.0.1:8080", result.getAddress());
+    }
+    
+    @Test
+    void testRandomOneHealthyMemberNoHealthyNode() throws NacosException {
+        Member member = new Member();
+        member.setIp("127.0.0.1");
+        member.setPort(8080);
+        member.setState(NodeState.DOWN);
+        Collection<Member> allMembers = new ArrayList<>();
+        allMembers.add(member);
+        when(memberManager.allMembers()).thenReturn(allMembers);
+        NacosMember nacosMember = new NacosMember();
+        nacosMember.setAddress("127.0.0.1:8080");
+        nacosMember.setState(NodeState.DOWN);
+        doReturn(Collections.singletonList(nacosMember)).when(clusterHandler).getNodeList("");
+        assertThrows(NacosRuntimeException.class, () -> remoteServerConnector.randomOneHealthyMember());
+    }
+    
+    @Test
+    void testRandomOneHealthyMemberEmptyCluster() throws NacosException {
+        Collection<Member> allMembers = new ArrayList<>();
+        when(memberManager.allMembers()).thenReturn(allMembers);
+        doReturn(Collections.emptyList()).when(clusterHandler).getNodeList("");
+        assertThrows(NacosRuntimeException.class, () -> remoteServerConnector.randomOneHealthyMember());
+    }
+    
+    @Test
+    void testRandomOneHealthyMemberFiltersUnhealthy() throws NacosException {
+        Member healthyMember = new Member();
+        healthyMember.setIp("127.0.0.1");
+        healthyMember.setPort(8080);
+        healthyMember.setState(NodeState.UP);
+        Member unhealthyMember = new Member();
+        unhealthyMember.setIp("127.0.0.2");
+        unhealthyMember.setPort(8080);
+        unhealthyMember.setState(NodeState.DOWN);
+        Collection<Member> allMembers = new ArrayList<>();
+        allMembers.add(healthyMember);
+        allMembers.add(unhealthyMember);
+        when(memberManager.allMembers()).thenReturn(allMembers);
+        NacosMember nacosMemberUp = new NacosMember();
+        nacosMemberUp.setAddress("127.0.0.1:8080");
+        nacosMemberUp.setState(NodeState.UP);
+        NacosMember nacosMemberDown = new NacosMember();
+        nacosMemberDown.setAddress("127.0.0.2:8080");
+        nacosMemberDown.setState(NodeState.DOWN);
+        doReturn(java.util.List.of(nacosMemberUp, nacosMemberDown)).when(clusterHandler).getNodeList("");
+        Member result = remoteServerConnector.randomOneHealthyMember();
+        assertNotNull(result);
+        assertEquals("127.0.0.1:8080", result.getAddress());
+    }
+}

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillUploadServiceTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillUploadServiceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.impl.remote.ai;
+
+import com.alibaba.nacos.api.common.NodeState;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.console.handler.impl.remote.RemoteServerConnector;
+import com.alibaba.nacos.core.cluster.Member;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.apache.hc.client5.http.HttpResponseException;
+import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SkillUploadServiceTest {
+    
+    @Mock
+    RemoteServerConnector remoteServerConnector;
+    
+    @Mock
+    CloseableHttpClient httpClient;
+    
+    MockedStatic<HttpClients> httpClientMock;
+    
+    SkillUploadService service;
+    
+    private ConfigurableEnvironment cachedEnvironment;
+    
+    @BeforeEach
+    void setUp() throws NacosException {
+        cachedEnvironment = EnvUtil.getEnvironment();
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("nacos.core.auth.admin.enabled", "false");
+        EnvUtil.setEnvironment(environment);
+        service = new SkillUploadService(remoteServerConnector);
+        httpClientMock = Mockito.mockStatic(HttpClients.class);
+        httpClientMock.when(HttpClients::createDefault).thenReturn(httpClient);
+        Member member = new Member();
+        member.setIp("127.0.0.1");
+        member.setPort(8080);
+        member.setState(NodeState.UP);
+        when(remoteServerConnector.randomOneHealthyMember()).thenReturn(member);
+        when(remoteServerConnector.getServerContextPath()).thenReturn("/nacos");
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(cachedEnvironment);
+        httpClientMock.close();
+    }
+    
+    @Test
+    void testUploadSkillFromZip() throws IOException, NacosException {
+        byte[] zipBytes = "test zip content".getBytes();
+        when(httpClient.execute(any(ClassicHttpRequest.class), any(BasicHttpClientResponseHandler.class))).thenReturn(
+                JacksonUtils.toJson(Result.success("testSkill")));
+        String skillName = service.uploadSkillFromZip("public", zipBytes);
+        assertEquals("testSkill", skillName);
+    }
+    
+    @Test
+    void testUploadSkillFromZipWithHttpResponseException() throws IOException {
+        byte[] zipBytes = "test zip content".getBytes();
+        when(httpClient.execute(any(ClassicHttpRequest.class), any(BasicHttpClientResponseHandler.class))).thenThrow(
+                new HttpResponseException(403, "Forbidden"));
+        assertThrows(NacosRuntimeException.class, () -> service.uploadSkillFromZip("public", zipBytes));
+    }
+    
+    @Test
+    void testUploadSkillFromZipWithIoException() throws IOException {
+        byte[] zipBytes = "test zip content".getBytes();
+        when(httpClient.execute(any(ClassicHttpRequest.class), any(BasicHttpClientResponseHandler.class))).thenThrow(
+                new IOException("Connection refused"));
+        NacosRuntimeException exception = assertThrows(NacosRuntimeException.class,
+                () -> service.uploadSkillFromZip("public", zipBytes));
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+    }
+    
+    @Test
+    void testUploadSkillFromZipWithNullNamespace() throws IOException, NacosException {
+        byte[] zipBytes = "test zip content".getBytes();
+        when(httpClient.execute(any(ClassicHttpRequest.class), any(BasicHttpClientResponseHandler.class))).thenReturn(
+                JacksonUtils.toJson(Result.success("testSkill")));
+        String skillName = service.uploadSkillFromZip(null, zipBytes);
+        assertEquals("testSkill", skillName);
+    }
+}

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/config/ConfigImportAndExportServiceTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/config/ConfigImportAndExportServiceTest.java
@@ -22,9 +22,8 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.utils.JacksonUtils;
-import com.alibaba.nacos.console.handler.core.ClusterHandler;
+import com.alibaba.nacos.console.handler.impl.remote.RemoteServerConnector;
 import com.alibaba.nacos.core.cluster.Member;
-import com.alibaba.nacos.core.cluster.NacosMemberManager;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.apache.hc.client5.http.HttpResponseException;
 import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
@@ -54,8 +53,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Collection;
-import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -67,9 +64,7 @@ import static org.mockito.Mockito.when;
 class ConfigImportAndExportServiceTest {
     
     @Mock
-    NacosMemberManager memberManager;
-    @Mock
-    ClusterHandler clusterHandler;
+    RemoteServerConnector remoteServerConnector;
     
     @Mock
     CloseableHttpClient httpClient;
@@ -86,18 +81,15 @@ class ConfigImportAndExportServiceTest {
         MockEnvironment environment = new MockEnvironment();
         environment.setProperty("nacos.core.auth.admin.enabled", "false");
         EnvUtil.setEnvironment(environment);
-        service = new ConfigImportAndExportService(memberManager, clusterHandler);
+        service = new ConfigImportAndExportService(remoteServerConnector);
         httpClientMock = Mockito.mockStatic(HttpClients.class);
         httpClientMock.when(HttpClients::createDefault).thenReturn(httpClient);
         Member member = new Member();
         member.setIp("127.0.0.1");
         member.setPort(8080);
         member.setState(NodeState.UP);
-
-        Collection nacosMembers = new HashSet<>();
-        nacosMembers.add(member);
-        when(memberManager.allMembers()).thenReturn(nacosMembers);
-        when(clusterHandler.getNodeList(any())).thenReturn(nacosMembers);
+        Mockito.lenient().when(remoteServerConnector.randomOneHealthyMember()).thenReturn(member);
+        Mockito.lenient().when(remoteServerConnector.getServerContextPath()).thenReturn("/nacos");
     }
     
     @AfterEach
@@ -180,9 +172,6 @@ class ConfigImportAndExportServiceTest {
     
     @Test
     void exportHttpClientResponseHandlerHandleResponse() throws ProtocolException, IOException, NacosException {
-        // remove lenient warning
-        memberManager.allMembers();
-        clusterHandler.getNodeList("");
         ClassicHttpResponse mockResponse = Mockito.mock(ClassicHttpResponse.class);
         when(mockResponse.getHeader("Content-Disposition")).thenReturn(
                 new BasicHeader("Content-Disposition", "testDisposition"));
@@ -200,9 +189,6 @@ class ConfigImportAndExportServiceTest {
     
     @Test
     void exportHttpClientResponseHandlerHandleResponseWithException() throws ProtocolException, NacosException {
-        // remove lenient warning
-        memberManager.allMembers();
-        clusterHandler.getNodeList("");
         ClassicHttpResponse mockResponse = Mockito.mock(ClassicHttpResponse.class);
         when(mockResponse.getHeader("Content-Disposition")).thenThrow(new ProtocolException());
         ConfigImportAndExportService.ExportHttpClientResponseHandler handler = new ConfigImportAndExportService.ExportHttpClientResponseHandler();


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

This PR adds the uploadSkill API to SkillAdminController for direct admin-mode skill uploads, fixes the uploadSkillFromZip functionality being unavailable in console mode, and extracts a reusable RemoteServerConnector component to eliminate duplicated remote server communication logic.

## Brief changelog

New Features
Added uploadSkill endpoint in SkillAdminController: A new POST /upload endpoint that accepts multipart zip files for skill upload in admin mode, secured with WRITE permission.
Extracted SkillRequestUtil.validateAndExtractZipBytes(): Shared validation logic for uploaded skill zip files (null/empty check, size limit check, byte extraction) used by both admin and console upload endpoints.
Refactoring
Introduced RemoteServerConnector: Extracted common remote server communication utilities (getServerContextPath(), randomOneHealthyMember(), addAuthIdentity()) from ConfigImportAndExportService into a dedicated reusable component.
Created SkillUploadService: A new service that leverages RemoteServerConnector to forward skill zip uploads to the admin server in console (remote) mode, fixing the previously broken upload flow.
Simplified ConsoleSkillController.uploadSkill(): Replaced inline validation and error handling with the shared SkillRequestUtil.validateAndExtractZipBytes() method, reducing code duplication.
Simplified ConfigImportAndExportService: Removed duplicated addAuthIdentity(), getServerContextPath(), and randomOneHealthyMember() methods, now delegating to RemoteServerConnector.
Tests
Added RemoteServerConnectorTest: Covers context path resolution (default and custom), auth identity injection, healthy member selection, unhealthy node filtering, and empty cluster error handling.
Added SkillUploadServiceTest: Covers successful upload, HTTP error handling, IO exception handling, and null namespace scenarios.
Updated ConfigImportAndExportServiceTest: Adapted to use RemoteServerConnector mock instead of directly mocking NacosMemberManager and ClusterHandler.
## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

