### PR TITLE
[ISSUE #14512] Use computeIfAbsent instead of putIfAbsent to handle return value

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
+++ b/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
@@ -227,14 +227,9 @@ public class ControllerMethodsCache {
         RequestMappingInfo requestMappingInfo = new RequestMappingInfo();
         requestMappingInfo.setPathRequestCondition(new PathRequestCondition(urlKey));
         requestMappingInfo.setParamRequestCondition(new ParamRequestCondition(requestParam));
-        List<RequestMappingInfo> requestMappingInfos = urlLookup.get(urlKey);
-        if (requestMappingInfos == null) {
-            urlLookup.putIfAbsent(urlKey, new ArrayList<>());
-            requestMappingInfos = urlLookup.get(urlKey);
-            // For issue #4701.
-            String urlKeyBackup = urlKey + "/";
-            urlLookup.putIfAbsent(urlKeyBackup, requestMappingInfos);
-        }
+        List<RequestMappingInfo> requestMappingInfos = urlLookup.computeIfAbsent(urlKey, k -> new ArrayList<>());
+        // For issue #4701.
+        urlLookup.computeIfAbsent(urlKey + "/", k -> requestMappingInfos);
         requestMappingInfos.add(requestMappingInfo);
         methods.put(requestMappingInfo, method);
     }

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/NamingFuzzyWatchContextService.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/NamingFuzzyWatchContextService.java
@@ -325,7 +325,6 @@ public class NamingFuzzyWatchContextService extends SmartSubscriber {
                             NamingUtils.getServiceKey(service.getNamespace(), service.getGroup(), service.getName()));
                 }
             }
-            matchedServiceKeysMap.putIfAbsent(completedPattern, matchedServices);
             Loggers.SRV_LOG.info("FUZZY_WATCH: pattern {} match {} services, overMatchCount={},cost {}ms",
                     completedPattern, matchedServices.size(), overMatchCount,
                     System.currentTimeMillis() - matchBeginTime);

--- a/style/spotbugs-exclude.xml
+++ b/style/spotbugs-exclude.xml
@@ -31,10 +31,8 @@
 
     <!-- MS_SHOULD_BE_FINAL: 7 occurrences, static field should be final -->
     <Match><Bug pattern="MS_SHOULD_BE_FINAL"/></Match>
-<!-- DMI_BLOCKING_METHODS_ON_URL: 2 occurrences, URL.equals/hashCode triggers DNS -->
+    <!-- DMI_BLOCKING_METHODS_ON_URL: 2 occurrences, URL.equals/hashCode triggers DNS -->
     <Match><Bug pattern="DMI_BLOCKING_METHODS_ON_URL"/></Match>
-    <!-- RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED: 2 occurrences, concurrency risk -->
-    <Match><Bug pattern="RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED"/></Match>
     <!-- SE_BAD_FIELD: 1 occurrence (High), non-serializable field in serializable class -->
     <Match><Bug pattern="SE_BAD_FIELD"/></Match>
 


### PR DESCRIPTION
Fixes https://github.com/alibaba/nacos/issues/14512

## What is the purpose of the change

Fix SpotBugs `RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED` warnings by replacing `putIfAbsent` with `computeIfAbsent` and removing dead code.

## Brief changelog

- `ControllerMethodsCache.addUrlAndMethodRelation`: Replace `putIfAbsent` + `get` pattern with atomic `computeIfAbsent`, simplifying the null-check logic
- `NamingFuzzyWatchContextService.initWatchMatchService`: Remove redundant `putIfAbsent` call after `computeIfAbsent` on the same key (dead code)
- Remove `RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED` exclusion from `spotbugs-exclude.xml`

## Verifying this change

SpotBugs checks pass after removing the global exclusion.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.