### PR TITLE
Fix missing mock setup for publishConfig in Skill operation tests

### DIFF
--- a/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
@@ -96,6 +96,9 @@ class SkillOperationServiceImplTest {
         // Given
         Skill skill = createValidSkill();
         String namespaceId = "test-namespace";
+        when(configOperationService.publishConfig(any(ConfigForm.class),
+                any(ConfigRequestInfo.class), isNull()))
+                .thenReturn(Boolean.TRUE);
         
         // When
         String result = skillOperationService.registerSkill(skill, namespaceId);
@@ -112,6 +115,9 @@ class SkillOperationServiceImplTest {
         // Given
         Skill skill = createValidSkillWithResources();
         String namespaceId = "test-namespace";
+        when(configOperationService.publishConfig(any(ConfigForm.class),
+                any(ConfigRequestInfo.class), isNull()))
+                .thenReturn(Boolean.TRUE);
         
         // When
         String result = skillOperationService.registerSkill(skill, namespaceId);
@@ -222,6 +228,9 @@ class SkillOperationServiceImplTest {
         ConfigQueryChainResponse response = createMockConfigResponse();
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
                 .thenReturn(response);
+        when(configOperationService.publishConfig(any(ConfigForm.class),
+                any(ConfigRequestInfo.class), isNull()))
+                .thenReturn(Boolean.TRUE);
         
         // When
         skillOperationService.updateSkill(skill, namespaceId);
@@ -306,6 +315,9 @@ class SkillOperationServiceImplTest {
         // Given
         String namespaceId = "test-namespace";
         byte[] zipBytes = createValidZipBytes();
+        when(configOperationService.publishConfig(any(ConfigForm.class),
+                any(ConfigRequestInfo.class), isNull()))
+                .thenReturn(Boolean.TRUE);
         
         // When
         String result = skillOperationService.uploadSkillFromZip(namespaceId, zipBytes);


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Added mock stubbing for configOperationService.publishConfig() in SkillOperationServiceImplTest to ensure it returns Boolean.TRUE during test execution.

## Brief changelog

Added when(configOperationService.publishConfig(...)).thenReturn(Boolean.TRUE) mock setup in 4 test methods:
testRegisterSkill
testRegisterSkillWithResources
testUpdateSkill
testUploadSkillFromZip

## Verifying this change

Run SkillOperationServiceImplTest — all 4 updated test cases pass successfully
 No existing tests broken by this change
 Mock arguments match the actual method signature: publishConfig(ConfigForm, ConfigRequestInfo, null)
 Verified publishConfig is invoked during skill registration, update, and zip upload flows

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

