### PR TITLE
fix: Clarify that nacos-cli only supports --config for connection parameters

### DIFF
--- a/skills/nacos-skill-registry/SKILL.md
+++ b/skills/nacos-skill-registry/SKILL.md
@@ -86,6 +86,8 @@ password: <user-provided-password>
 namespace: <user-provided-namespace>
 ```
 
+**IMPORTANT: After saving the config file, you MUST use `--config ~/.nacos-skill-registry.conf` in all subsequent commands. Do NOT pass host, port, username, or password as individual command-line flags — nacos-cli does not support them.**
+
 ### Step 3: Understand What They Need
 
 When a user asks for help, identify:
@@ -210,14 +212,12 @@ nacos-cli --config <their-config> skill-get <skill-name>
 
 ## Connection Reference
 
-**Command-line flags** (can override config file settings):
+**IMPORTANT: nacos-cli does NOT support `--host`, `--port`, `--user`, `--password` or `--namespace` as command-line flags. You MUST always use `--config` to pass connection settings. NEVER attempt to pass connection parameters as individual command-line flags.**
+
+The ONLY supported connection flag:
 
 | Flag | Short | Description |
 | :--- | :--- | :--- |
-| --server | -s | Nacos server address (host:port) |
-| --username | -u | Nacos username (default: nacos) |
-| --password | -p | Nacos password (default: nacos) |
-| --namespace | -n | Nacos namespace ID |
 | --config | -c | Path to configuration file |
 
 ## When No Skills Are Found
@@ -241,8 +241,9 @@ nacos-cli skill-upload /path/to/your-skill --config ~/.nacos-skill-registry.conf
 
 ## Tips for Effective Use
 
-1. **Use specific keywords**: "react testing" is better than just "testing" when filtering
-2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
-3. **Check namespaces**: Different teams may store skills in different Nacos namespaces - use `-n <namespace>` to switch
-4. **Use config files**: Save connection details to avoid typing credentials repeatedly
-5. **Keep skills updated**: Use `nacos-cli skill-sync --all` to keep local skills in sync with Nacos
+1. **Always use `--config`**: nacos-cli only accepts connection settings via config file. Never use `--host`, `--port`, `--user`, `--password`, or `--namespace` as command-line flags — they are not supported and will cause errors.
+2. **Use specific keywords**: "react testing" is better than just "testing" when filtering
+3. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+4. **Check namespaces**: Different teams may store skills in different Nacos namespaces - use `-n <namespace>` to switch
+5. **Use config files**: Save connection details to avoid typing credentials repeatedly
+6. **Keep skills updated**: Use `nacos-cli skill-sync --all` to keep local skills in sync with Nacos


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fix an issue where agents incorrectly use non-existent command-line flags like --host, --port, --user, --password when executing nacos-cli commands.

Root Cause
The original SKILL.md only demonstrated the correct approach (using --config) but never explicitly prohibited using individual connection parameter flags. Since LLMs are trained on vast amounts of CLI documentation where such flags are common, agents infer and use them based on prior
  knowledge.

## Brief changelog

Added explicit negative constraints

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

