### PR TITLE
feat(ai): support default values for prompt template variables

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/PromptAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/PromptAdminController.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.ai.form.prompt.PromptPublishForm;
 import com.alibaba.nacos.ai.form.prompt.PromptQueryForm;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaSummary;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVariable;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionSummary;
 import com.alibaba.nacos.ai.param.PromptHttpParamExtractor;
@@ -37,9 +38,12 @@ import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.core.paramcheck.ExtractorManager;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.constant.ApiType;
 import com.alibaba.nacos.plugin.auth.constant.SignType;
+import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -92,6 +96,7 @@ public class PromptAdminController {
                 form.getCommitMsg(),
                 form.getDescription(),
                 parseBizTags(form.getBizTags()),
+                parseVariables(form.getVariables()),
                 srcUser,
                 srcIp
         );
@@ -266,5 +271,13 @@ public class PromptAdminController {
             }
         }
         return result;
+    }
+    
+    private List<PromptVariable> parseVariables(String variables) {
+        if (StringUtils.isBlank(variables)) {
+            return null;
+        }
+        return JacksonUtils.toObj(variables, new TypeReference<List<PromptVariable>>() {
+        });
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/prompt/PromptPublishForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/prompt/PromptPublishForm.java
@@ -59,6 +59,13 @@ public class PromptPublishForm extends PromptForm {
      */
     private String bizTags;
     
+    /**
+     * Variable definitions with default values (JSON array string, optional).
+     *
+     * <p>Example: [{"name":"question","defaultValue":"Hello","description":"User question"}]</p>
+     */
+    private String variables;
+    
     @Override
     public void validate() throws NacosApiException {
         super.validate();
@@ -112,5 +119,13 @@ public class PromptPublishForm extends PromptForm {
     
     public void setBizTags(String bizTags) {
         this.bizTags = bizTags;
+    }
+    
+    public String getVariables() {
+        return variables;
+    }
+    
+    public void setVariables(String variables) {
+        this.variables = variables;
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/QueryPromptRequestHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/QueryPromptRequestHandler.java
@@ -85,6 +85,7 @@ public class QueryPromptRequestHandler extends RequestHandler<QueryPromptRequest
         prompt.setVersion(versionInfo.getVersion());
         prompt.setTemplate(versionInfo.getTemplate());
         prompt.setMd5(versionInfo.getMd5());
+        prompt.setVariables(versionInfo.getVariables());
         return prompt;
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptAdminOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptAdminOperationService.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.ai.service.prompt;
 
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaSummary;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVariable;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionSummary;
 import com.alibaba.nacos.api.exception.NacosException;
@@ -42,13 +43,15 @@ public interface PromptAdminOperationService {
      * @param commitMsg   the commit msg
      * @param description the description
      * @param bizTags     the biz tags
+     * @param variables   the prompt variable definitions with optional default values
      * @param srcUser     the src user
      * @param srcIp       the src ip
      * @return the boolean
      * @throws NacosException the nacos exception
      */
     boolean publishPromptVersion(String namespaceId, String promptKey, String version, String template, String commitMsg,
-            String description, List<String> bizTags, String srcUser, String srcIp) throws NacosException;
+            String description, List<String> bizTags, List<PromptVariable> variables, String srcUser, String srcIp)
+            throws NacosException;
     
     /**
      * Bind label boolean.

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptAdminOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptAdminOperationServiceImpl.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.api.ai.model.prompt.PromptDescriptor;
 import com.alibaba.nacos.api.ai.model.prompt.PromptLabelVersionMapping;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaSummary;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVariable;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionSummary;
 import com.alibaba.nacos.api.exception.NacosException;
@@ -82,7 +83,8 @@ public class PromptAdminOperationServiceImpl implements PromptAdminOperationServ
     
     @Override
     public boolean publishPromptVersion(String namespaceId, String promptKey, String version, String template, String commitMsg,
-            String description, List<String> bizTags, String srcUser, String srcIp) throws NacosException {
+            String description, List<String> bizTags, List<PromptVariable> variables, String srcUser, String srcIp)
+            throws NacosException {
         validatePromptKeyAndVersion(promptKey, version);
         if (!PromptVersionUtils.isValidVersion(version)) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_VALIDATE_ERROR,
@@ -119,6 +121,7 @@ public class PromptAdminOperationServiceImpl implements PromptAdminOperationServ
         versionInfo.setTemplate(template);
         versionInfo.setCommitMsg(commitMsg);
         versionInfo.setGmtModified(now);
+        versionInfo.setVariables(variables);
         publishConfig(namespaceId, versionDataId, JacksonUtils.toJson(versionInfo), srcUser, srcIp, null, false, null);
         
         mapping.getVersions().add(version);

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/Prompt.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/Prompt.java
@@ -17,6 +17,8 @@
 package com.alibaba.nacos.api.ai.model.prompt;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -50,6 +52,11 @@ public class Prompt implements Serializable {
      * MD5 hash of the prompt content (for CAS operations).
      */
     private String md5;
+    
+    /**
+     * Variable definitions with optional default values. Null for legacy prompts without variable metadata.
+     */
+    private List<PromptVariable> variables;
     
     public Prompt() {
     }
@@ -92,37 +99,58 @@ public class Prompt implements Serializable {
         this.md5 = md5;
     }
     
+    public List<PromptVariable> getVariables() {
+        return variables;
+    }
+    
+    public void setVariables(List<PromptVariable> variables) {
+        this.variables = variables;
+    }
+    
     /**
      * Render the prompt template by replacing variables with provided values.
      *
      * <p>Variables in the template are specified using {{variableName}} syntax.
-     * This method replaces each {{variableName}} with the corresponding value
-     * from the provided map.</p>
+     * This method first applies default values from variable definitions,
+     * then overrides with user-provided values.</p>
      *
      * <p>Example:
      * <pre>
      * Prompt prompt = new Prompt("greeting", "1.0.0", "Hello {{name}}, welcome to {{place}}!");
-     * Map&lt;String, String&gt; variables = new HashMap&lt;&gt;();
-     * variables.put("name", "Alice");
-     * variables.put("place", "Nacos");
-     * String result = prompt.render(variables);
+     * Map&lt;String, String&gt; userVars = new HashMap&lt;&gt;();
+     * userVars.put("name", "Alice");
+     * userVars.put("place", "Nacos");
+     * String result = prompt.render(userVars);
      * // Result: "Hello Alice, welcome to Nacos!"
      * </pre>
      * </p>
      *
-     * @param variables map of variable names to their values (key: variable name, value: replacement value)
-     * @return rendered prompt content with variables replaced, or the original template if variables is null
+     * @param userVariables map of variable names to their values (key: variable name, value: replacement value)
+     * @return rendered prompt content with variables replaced, or the original template if no values available
      */
-    public String render(Map<String, String> variables) {
+    public String render(Map<String, String> userVariables) {
         if (template == null) {
             return null;
         }
-        if (variables == null || variables.isEmpty()) {
+        
+        Map<String, String> merged = new HashMap<>();
+        if (variables != null) {
+            for (PromptVariable v : variables) {
+                if (v.getDefaultValue() != null) {
+                    merged.put(v.getName(), v.getDefaultValue());
+                }
+            }
+        }
+        if (userVariables != null) {
+            merged.putAll(userVariables);
+        }
+        
+        if (merged.isEmpty()) {
             return template;
         }
         
         String result = template;
-        for (Map.Entry<String, String> entry : variables.entrySet()) {
+        for (Map.Entry<String, String> entry : merged.entrySet()) {
             String placeholder = "{{" + entry.getKey() + "}}";
             String value = entry.getValue() != null ? entry.getValue() : "";
             result = result.replace(placeholder, value);

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptVariable.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptVariable.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.ai.model.prompt;
+
+import java.io.Serializable;
+
+/**
+ * Prompt variable definition with optional default value.
+ *
+ * <p>Represents a variable placeholder (e.g., {{variableName}}) in a prompt template,
+ * along with its optional default value and description.</p>
+ *
+ * @author nacos
+ */
+public class PromptVariable implements Serializable {
+    
+    private static final long serialVersionUID = 1L;
+    
+    /**
+     * Variable name (matches the placeholder name in template, e.g., "question" for {{question}}).
+     */
+    private String name;
+    
+    /**
+     * Default value for this variable. Null means the variable has no default (considered required).
+     */
+    private String defaultValue;
+    
+    /**
+     * Optional description explaining the purpose or expected content of this variable.
+     */
+    private String description;
+    
+    public PromptVariable() {
+    }
+    
+    public PromptVariable(String name, String defaultValue, String description) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.description = description;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+    
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    @Override
+    public String toString() {
+        return "PromptVariable{" + "name='" + name + '\'' + ", defaultValue='" + defaultValue + '\'' + ", description='"
+                + description + '\'' + '}';
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptVersionInfo.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptVersionInfo.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.api.ai.model.prompt;
 
+import java.util.List;
+
 /**
  * Prompt version information.
  *
@@ -28,6 +30,8 @@ public class PromptVersionInfo extends PromptVersionSummary {
     private String template;
     
     private String md5;
+    
+    private List<PromptVariable> variables;
     
     public String getTemplate() {
         return template;
@@ -43,5 +47,13 @@ public class PromptVersionInfo extends PromptVersionSummary {
     
     public void setMd5(String md5) {
         this.md5 = md5;
+    }
+    
+    public List<PromptVariable> getVariables() {
+        return variables;
+    }
+    
+    public void setVariables(List<PromptVariable> variables) {
+        this.variables = variables;
     }
 }

--- a/console-ui/src/pages/AI/NewPrompt/NewPrompt.js
+++ b/console-ui/src/pages/AI/NewPrompt/NewPrompt.js
@@ -40,6 +40,8 @@ class NewPrompt extends React.Component {
       loading: false,
       template: '',
       variables: [],
+      variableDefaults: {},
+      variableDescriptions: {},
       optimizeDialogVisible: false,
     };
   }
@@ -102,6 +104,13 @@ class NewPrompt extends React.Component {
 
       const namespaceId = getParams('namespace') || '';
 
+      const { variables: vars, variableDefaults, variableDescriptions } = this.state;
+      const variablesDef = vars.map(name => ({
+        name,
+        defaultValue: variableDefaults[name] || null,
+        description: variableDescriptions[name] || null,
+      }));
+
       request({
         method: 'POST',
         url: 'v3/console/ai/prompt',
@@ -112,6 +121,7 @@ class NewPrompt extends React.Component {
           description: values.description || '',
           template: template,
           commitMsg: values.commitMsg || '',
+          variables: JSON.stringify(variablesDef),
         },
         success: data => {
           this.setState({ loading: false });
@@ -289,9 +299,39 @@ class NewPrompt extends React.Component {
               {variables.length > 0 ? (
                 <div className="variables-list">
                   {variables.map((variable, index) => (
-                    <div key={index} className="variable-item">
-                      <Icon type="success" size="small" className="variable-icon" />
-                      {`{{${variable}}}`}
+                    <div
+                      key={index}
+                      className="variable-item"
+                      style={{ flexDirection: 'column', alignItems: 'stretch' }}
+                    >
+                      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+                        <Icon type="success" size="small" className="variable-icon" />
+                        <span style={{ fontWeight: 500 }}>{`{{${variable}}}`}</span>
+                      </div>
+                      <Input
+                        size="small"
+                        placeholder={locale.defaultValuePlaceholder || '默认值（可选）'}
+                        value={this.state.variableDefaults[variable] || ''}
+                        onChange={value =>
+                          this.setState(prev => ({
+                            variableDefaults: { ...prev.variableDefaults, [variable]: value },
+                          }))
+                        }
+                        style={{ marginBottom: 4 }}
+                      />
+                      <Input
+                        size="small"
+                        placeholder={locale.variableDescPlaceholder || '变量说明（可选）'}
+                        value={this.state.variableDescriptions[variable] || ''}
+                        onChange={value =>
+                          this.setState(prev => ({
+                            variableDescriptions: {
+                              ...prev.variableDescriptions,
+                              [variable]: value,
+                            },
+                          }))
+                        }
+                      />
                     </div>
                   ))}
                 </div>

--- a/console-ui/src/pages/AI/PromptDetail/PromptDetail.js
+++ b/console-ui/src/pages/AI/PromptDetail/PromptDetail.js
@@ -80,6 +80,8 @@ class PromptDetail extends React.Component {
       savingDescription: false,
       // History versions loading
       loadingHistory: false,
+      // Server-side variable definitions (with defaults)
+      serverVariables: [],
       // AI optimize dialog
       optimizeDialogVisible: false,
       // Debug functionality
@@ -131,6 +133,13 @@ class PromptDetail extends React.Component {
               const template = versionData.template || '';
               const isLatestVersion =
                 !versionData.version || metaData.latestVersion === versionData.version;
+              const svrVars = versionData.variables || [];
+              const initialVarValues = {};
+              svrVars.forEach(v => {
+                if (v.defaultValue) {
+                  initialVarValues[v.name] = v.defaultValue;
+                }
+              });
               this.setState({
                 loading: false,
                 promptData: {
@@ -140,6 +149,8 @@ class PromptDetail extends React.Component {
                 },
                 template: template,
                 variables: this.extractVariables(template),
+                serverVariables: svrVars,
+                variableValues: initialVarValues,
                 descriptionValue: metaData.description || '',
                 labelsMap: metaData.labels || {},
                 selectedLabel: label || null,
@@ -297,11 +308,13 @@ class PromptDetail extends React.Component {
 
   // Navigate to publish new version
   handlePublishNewVersion = () => {
-    const { promptKey, namespaceId, template, promptData } = this.state;
-    // Store template and metadata in sessionStorage for the publish page to use
+    const { promptKey, namespaceId, template, promptData, serverVariables } = this.state;
     sessionStorage.setItem('promptPublishTemplate', template);
     sessionStorage.setItem('promptPublishCurrentVersion', promptData?.version || '');
     sessionStorage.setItem('promptPublishDescription', promptData?.description || '');
+    if (serverVariables && serverVariables.length > 0) {
+      sessionStorage.setItem('promptPublishVariables', JSON.stringify(serverVariables));
+    }
     this.props.history.push(
       `/publishPromptVersion?namespace=${namespaceId}&promptKey=${promptKey}`
     );
@@ -525,13 +538,24 @@ class PromptDetail extends React.Component {
     this.setState({ userInput: value });
   };
 
-  // Render prompt with variable values
+  // Render prompt with variable values (user values override defaults)
   renderPromptWithVariables = () => {
-    const { template, variableValues } = this.state;
+    const { template, variableValues, serverVariables } = this.state;
+    const merged = {};
+    (serverVariables || []).forEach(v => {
+      if (v.defaultValue) {
+        merged[v.name] = v.defaultValue;
+      }
+    });
+    Object.keys(variableValues).forEach(key => {
+      if (variableValues[key]) {
+        merged[key] = variableValues[key];
+      }
+    });
     let renderedPrompt = template;
-    Object.keys(variableValues).forEach(variable => {
+    Object.keys(merged).forEach(variable => {
       const regex = new RegExp(`\\{\\{${variable}\\}\\}`, 'g');
-      renderedPrompt = renderedPrompt.replace(regex, variableValues[variable] || '');
+      renderedPrompt = renderedPrompt.replace(regex, merged[variable] || '');
     });
     return renderedPrompt;
   };
@@ -853,18 +877,42 @@ class PromptDetail extends React.Component {
                       <span className="variables-count">{variables.length}</span>
                     </div>
                     <div className="variable-list">
-                      {variables.map((variable, index) => (
-                        <div key={index} className="variable-input-item">
-                          <label className="variable-label">{`{{${variable}}}`}</label>
-                          <Input
-                            size="small"
-                            placeholder={`${locale.enterValue || '输入'} ${variable}`}
-                            value={variableValues[variable] || ''}
-                            onChange={value => this.handleVariableChange(variable, value)}
-                            disabled={debugging}
-                          />
-                        </div>
-                      ))}
+                      {variables.map((variable, index) => {
+                        const svrVar = (this.state.serverVariables || []).find(
+                          v => v.name === variable
+                        );
+                        const defaultVal = svrVar?.defaultValue;
+                        const desc = svrVar?.description;
+                        const placeholder = defaultVal
+                          ? `${locale.defaultValue || '默认值'}: ${defaultVal}`
+                          : `${locale.enterValue || '输入'} ${variable}`;
+                        return (
+                          <div key={index} className="variable-input-item">
+                            <label className="variable-label">
+                              {`{{${variable}}}`}
+                              {desc && (
+                                <span
+                                  style={{
+                                    fontWeight: 'normal',
+                                    color: '#999',
+                                    marginLeft: 4,
+                                    fontSize: 12,
+                                  }}
+                                >
+                                  {desc}
+                                </span>
+                              )}
+                            </label>
+                            <Input
+                              size="small"
+                              placeholder={placeholder}
+                              value={variableValues[variable] || ''}
+                              onChange={value => this.handleVariableChange(variable, value)}
+                              disabled={debugging}
+                            />
+                          </div>
+                        );
+                      })}
                     </div>
                   </div>
                 )}

--- a/console-ui/src/pages/AI/PublishPromptVersion/PublishPromptVersion.js
+++ b/console-ui/src/pages/AI/PublishPromptVersion/PublishPromptVersion.js
@@ -35,10 +35,24 @@ class PublishPromptVersion extends React.Component {
     super(props);
     this.field = new Field(this);
 
-    // Get data from sessionStorage (set by PromptDetail page)
     const storedTemplate = sessionStorage.getItem('promptPublishTemplate') || '';
     const storedCurrentVersion = sessionStorage.getItem('promptPublishCurrentVersion') || '';
     const storedDescription = sessionStorage.getItem('promptPublishDescription') || '';
+    const storedVariables = sessionStorage.getItem('promptPublishVariables');
+
+    let variableDefaults = {};
+    let variableDescriptions = {};
+    if (storedVariables) {
+      try {
+        const parsed = JSON.parse(storedVariables);
+        parsed.forEach(v => {
+          if (v.defaultValue) variableDefaults[v.name] = v.defaultValue;
+          if (v.description) variableDescriptions[v.name] = v.description;
+        });
+      } catch (e) {
+        // ignore parse error
+      }
+    }
 
     this.state = {
       loading: false,
@@ -48,6 +62,8 @@ class PublishPromptVersion extends React.Component {
       description: storedDescription,
       template: storedTemplate,
       variables: this.extractVariables(storedTemplate),
+      variableDefaults,
+      variableDescriptions,
     };
   }
 
@@ -59,10 +75,10 @@ class PublishPromptVersion extends React.Component {
       this.field.setValue('version', suggestedVersion);
     }
 
-    // Clean up sessionStorage
     sessionStorage.removeItem('promptPublishTemplate');
     sessionStorage.removeItem('promptPublishCurrentVersion');
     sessionStorage.removeItem('promptPublishDescription');
+    sessionStorage.removeItem('promptPublishVariables');
   }
 
   // Suggest next version (increment patch number)
@@ -147,6 +163,13 @@ class PublishPromptVersion extends React.Component {
 
       this.setState({ loading: true });
 
+      const { variables: vars, variableDefaults, variableDescriptions } = this.state;
+      const variablesDef = vars.map(name => ({
+        name,
+        defaultValue: variableDefaults[name] || null,
+        description: variableDescriptions[name] || null,
+      }));
+
       request({
         method: 'POST',
         url: 'v3/console/ai/prompt',
@@ -156,6 +179,7 @@ class PublishPromptVersion extends React.Component {
           version: values.version,
           template: template,
           commitMsg: values.commitMsg || '',
+          variables: JSON.stringify(variablesDef),
         },
         success: data => {
           this.setState({ loading: false });
@@ -298,9 +322,39 @@ class PublishPromptVersion extends React.Component {
               {variables.length > 0 ? (
                 <div className="variables-list">
                   {variables.map((variable, index) => (
-                    <div key={index} className="variable-item">
-                      <Icon type="success" size="small" className="variable-icon" />
-                      {`{{${variable}}}`}
+                    <div
+                      key={index}
+                      className="variable-item"
+                      style={{ flexDirection: 'column', alignItems: 'stretch' }}
+                    >
+                      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+                        <Icon type="success" size="small" className="variable-icon" />
+                        <span style={{ fontWeight: 500 }}>{`{{${variable}}}`}</span>
+                      </div>
+                      <Input
+                        size="small"
+                        placeholder={locale.defaultValuePlaceholder || '默认值（可选）'}
+                        value={this.state.variableDefaults[variable] || ''}
+                        onChange={value =>
+                          this.setState(prev => ({
+                            variableDefaults: { ...prev.variableDefaults, [variable]: value },
+                          }))
+                        }
+                        style={{ marginBottom: 4 }}
+                      />
+                      <Input
+                        size="small"
+                        placeholder={locale.variableDescPlaceholder || '变量说明（可选）'}
+                        value={this.state.variableDescriptions[variable] || ''}
+                        onChange={value =>
+                          this.setState(prev => ({
+                            variableDescriptions: {
+                              ...prev.variableDescriptions,
+                              [variable]: value,
+                            },
+                          }))
+                        }
+                      />
                     </div>
                   ))}
                 </div>

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/PromptInnerHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/PromptInnerHandler.java
@@ -26,15 +26,19 @@ import com.alibaba.nacos.ai.form.prompt.PromptPublishForm;
 import com.alibaba.nacos.ai.form.prompt.PromptQueryForm;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaSummary;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVariable;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionSummary;
 import com.alibaba.nacos.ai.service.prompt.PromptAdminOperationService;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.console.handler.ai.EnabledAiHandler;
 import com.alibaba.nacos.console.handler.ai.PromptHandler;
 import com.alibaba.nacos.console.handler.impl.ConditionFunctionEnabled;
 import com.alibaba.nacos.console.handler.impl.inner.EnabledInnerHandler;
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -68,6 +72,7 @@ public class PromptInnerHandler implements PromptHandler {
                 form.getCommitMsg(),
                 form.getDescription(),
                 parseBizTags(form.getBizTags()),
+                parseVariables(form.getVariables()),
                 srcUser,
                 srcIp
         );
@@ -153,5 +158,13 @@ public class PromptInnerHandler implements PromptHandler {
             }
         }
         return result;
+    }
+    
+    private List<PromptVariable> parseVariables(String variables) {
+        if (StringUtils.isBlank(variables)) {
+            return null;
+        }
+        return JacksonUtils.toObj(variables, new TypeReference<List<PromptVariable>>() {
+        });
     }
 }

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/PromptRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/PromptRemoteHandler.java
@@ -64,7 +64,8 @@ public class PromptRemoteHandler implements PromptHandler {
                 form.getTemplate(),
                 form.getCommitMsg(),
                 form.getDescription(),
-                form.getBizTags()
+                form.getBizTags(),
+                form.getVariables()
         );
     }
     

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/NacosAiMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/NacosAiMaintainerServiceImpl.java
@@ -448,6 +448,12 @@ public class NacosAiMaintainerServiceImpl implements AiMaintainerService {
     @Override
     public boolean publishPrompt(String namespaceId, String promptKey, String version, String template,
             String commitMsg, String description, String bizTags) throws NacosException {
+        return publishPrompt(namespaceId, promptKey, version, template, commitMsg, description, bizTags, null);
+    }
+    
+    @Override
+    public boolean publishPrompt(String namespaceId, String promptKey, String version, String template,
+            String commitMsg, String description, String bizTags, String variables) throws NacosException {
         if (StringUtils.isBlank(namespaceId)) {
             namespaceId = com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
         }
@@ -464,6 +470,9 @@ public class NacosAiMaintainerServiceImpl implements AiMaintainerService {
         }
         if (StringUtils.isNotBlank(bizTags)) {
             params.put("bizTags", bizTags);
+        }
+        if (StringUtils.isNotBlank(variables)) {
+            params.put("variables", variables);
         }
         RequestResource resource = buildRequestResource(namespaceId, promptKey);
         HttpRequest httpRequest = buildHttpRequestBuilder(resource).setHttpMethod(HttpMethod.POST)

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PromptMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PromptMaintainerService.java
@@ -134,6 +134,25 @@ public interface PromptMaintainerService {
             String commitMsg, String description, String bizTags) throws NacosException;
     
     /**
+     * Publish a new version of prompt with variable definitions.
+     *
+     * @param namespaceId namespace ID
+     * @param promptKey   prompt key
+     * @param version     version (must be greater than current version)
+     * @param template    prompt template content
+     * @param commitMsg   commit message
+     * @param description prompt description
+     * @param bizTags     biz tags (comma-separated)
+     * @param variables   variable definitions JSON string (optional)
+     * @return true if publish success
+     * @throws NacosException if fail to publish prompt
+     */
+    default boolean publishPrompt(String namespaceId, String promptKey, String version, String template,
+            String commitMsg, String description, String bizTags, String variables) throws NacosException {
+        return publishPrompt(namespaceId, promptKey, version, template, commitMsg, description, bizTags);
+    }
+    
+    /**
      * Publish a new version of prompt without tags.
      *
      * @param namespaceId namespace ID
@@ -147,7 +166,7 @@ public interface PromptMaintainerService {
      */
     default boolean publishPrompt(String namespaceId, String promptKey, String version, String template,
             String commitMsg, String description) throws NacosException {
-        return publishPrompt(namespaceId, promptKey, version, template, commitMsg, description, null);
+        return publishPrompt(namespaceId, promptKey, version, template, commitMsg, description, (String) null);
     }
     
     /**
@@ -162,7 +181,8 @@ public interface PromptMaintainerService {
      */
     default boolean publishPrompt(String promptKey, String version, String template, String commitMsg)
             throws NacosException {
-        return publishPrompt(Constants.DEFAULT_NAMESPACE_ID, promptKey, version, template, commitMsg, null, null);
+        return publishPrompt(Constants.DEFAULT_NAMESPACE_ID, promptKey, version, template, commitMsg, null,
+                (String) null);
     }
     
     /**


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Add PromptVariable model to allow users to configure default values and descriptions for each template variable ({{variableName}}). Variables are stored as part of version content JSON and passed through the full chain (API model, service, controller, form, handler, proxy, maintainer client, and frontend UI).

Backward compatible: old data without variables field deserializes as null, falling back to existing behavior. Interface compatibility maintained via method overloading in PromptMaintainerService.

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

