### PR TITLE
fix: add --add-opens JVM options for JDK 17+ in startup-native.sh

### DIFF
--- a/distribution/bin/startup-native.sh
+++ b/distribution/bin/startup-native.sh
@@ -101,6 +101,9 @@ if [[ "${NACOS_TYPE}" == "Java" ]]; then
     JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
     if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]]; then
         RUN_CMD="${RUN_CMD} -Xlog:gc*:file=${BASE_DIR}/logs/nacos_gc.log:time,tags:filecount=10,filesize=102400"
+        RUN_CMD="${RUN_CMD} --add-opens=java.base/java.lang=ALL-UNNAMED"
+        RUN_CMD="${RUN_CMD} --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
+        RUN_CMD="${RUN_CMD} --add-opens=java.base/java.util=ALL-UNNAMED"
     else
         JAVA_OPT_EXT_FIX="-Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext"
         RUN_CMD="${RUN_CMD} -Xloggc:${BASE_DIR}/logs/nacos_gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"


### PR DESCRIPTION
## Summary
- `startup.sh` already adds `--add-opens` flags when Java >= 9, but `startup-native.sh` was missing them
- This causes `InaccessibleObjectException` on JDK 17+ when using the distribution package startup script
- Added the same three `--add-opens` options to keep both scripts consistent:
  - `--add-opens=java.base/java.lang=ALL-UNNAMED`
  - `--add-opens=java.base/java.lang.reflect=ALL-UNNAMED`
  - `--add-opens=java.base/java.util=ALL-UNNAMED`

## Test plan
- [ ] Verify `startup-native.sh` launches correctly on JDK 17+
- [ ] Confirm no `InaccessibleObjectException` on reflection operations

🤖 Generated with [Qoder][https://qoder.com]