### PR TITLE
feat(ai): implement publish pipeline execution framework

### DIFF
--- a/ai/pom.xml
+++ b/ai/pom.xml
@@ -42,6 +42,10 @@
             <groupId>com.alibaba.nacos</groupId>
             <artifactId>nacos-config</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba.nacos</groupId>
+            <artifactId>nacos-ai-plugin</artifactId>
+        </dependency>
         
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -51,6 +55,34 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test-autoconfigure</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <version>1.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/PipelineConfiguration.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/PipelineConfiguration.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.config;
+
+import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
+import com.alibaba.nacos.ai.pipeline.PublishPipelineManager;
+import com.alibaba.nacos.ai.pipeline.config.FilePipelineConfigProvider;
+import com.alibaba.nacos.ai.pipeline.config.PipelineConfigProvider;
+import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
+import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepositoryImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Spring configuration for the publish pipeline components.
+ *
+ * @author kiro
+ */
+@Configuration
+public class PipelineConfiguration {
+    
+    @Bean
+    public PipelineConfigProvider pipelineConfigProvider() {
+        return FilePipelineConfigProvider.getInstance();
+    }
+    
+    @Bean
+    public PublishPipelineManager publishPipelineManager(PipelineConfigProvider configProvider) {
+        PublishPipelineManager manager = new PublishPipelineManager();
+        manager.init(configProvider.getConfig());
+        return manager;
+    }
+    
+    @Bean
+    public PipelineExecutionRepository pipelineExecutionRepository() {
+        return new PipelineExecutionRepositoryImpl();
+    }
+    
+    @Bean("pipelineExecutor")
+    public ExecutorService pipelineExecutor() {
+        return Executors.newFixedThreadPool(4, new ThreadFactory() {
+            
+            private final AtomicInteger counter = new AtomicInteger(0);
+            
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r, "pipeline-executor-" + counter.getAndIncrement());
+                thread.setDaemon(true);
+                return thread;
+            }
+        });
+    }
+    
+    @Bean
+    public PublishPipelineExecutor publishPipelineExecutor(PublishPipelineManager pipelineManager,
+            PipelineConfigProvider configProvider, PipelineExecutionRepository executionRepository,
+            ExecutorService pipelineExecutor) {
+        return new PublishPipelineExecutor(pipelineManager, configProvider, executionRepository, pipelineExecutor);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/PublishPipelineExecutor.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/PublishPipelineExecutor.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline;
+
+import com.alibaba.nacos.ai.pipeline.config.PipelineConfigProvider;
+import com.alibaba.nacos.ai.pipeline.model.PipelineCallback;
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecution;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionResult;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeResult;
+import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResult;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Core pipeline execution engine. Asynchronously executes pipeline nodes in serial order,
+ * persists execution state, and notifies the caller via callback.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public class PublishPipelineExecutor {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(PublishPipelineExecutor.class);
+    
+    private final PublishPipelineManager pipelineManager;
+    
+    private final PipelineConfigProvider configProvider;
+    
+    private final PipelineExecutionRepository executionRepository;
+    
+    private final ExecutorService asyncExecutor;
+    
+    public PublishPipelineExecutor(PublishPipelineManager pipelineManager, PipelineConfigProvider configProvider,
+            PipelineExecutionRepository executionRepository, ExecutorService asyncExecutor) {
+        this.pipelineManager = pipelineManager;
+        this.configProvider = configProvider;
+        this.executionRepository = executionRepository;
+        this.asyncExecutor = asyncExecutor;
+    }
+    
+    /**
+     * Asynchronously execute the pipeline.
+     *
+     * <ol>
+     *   <li>Check config: if not enabled, return null (no record, no callback)</li>
+     *   <li>Get matching services: if empty, return null (no record, no callback)</li>
+     *   <li>Create PipelineExecution with IN_PROGRESS status and persist</li>
+     *   <li>Return executionId immediately</li>
+     *   <li>Submit async task to execute nodes serially, update state, and invoke callback</li>
+     * </ol>
+     *
+     * @param context  pipeline context containing resource metadata
+     * @param callback async callback, invoked exactly once when pipeline execution completes
+     * @return executionId, or null if pipeline is not enabled or no matching nodes
+     */
+    public String execute(PublishPipelineContext context, PipelineCallback callback) {
+        // Step 1: Check config
+        PipelineConfig config = configProvider.getConfig();
+        if (!config.isEnabled()) {
+            return null;
+        }
+        
+        // Step 2: Get matching pipeline services
+        List<PublishPipelineService> services = pipelineManager.getPipelineServices(context.getResourceType(),
+                config.getNodes());
+        if (services.isEmpty()) {
+            return null;
+        }
+        
+        // Step 3: Create execution record
+        String executionId = UUID.randomUUID().toString();
+        long now = System.currentTimeMillis();
+        
+        PipelineExecution execution = new PipelineExecution();
+        execution.setExecutionId(executionId);
+        execution.setResourceType(context.getResourceType().name());
+        execution.setResourceName(context.getResourceName());
+        execution.setNamespaceId(context.getNamespaceId());
+        execution.setVersion(context.getVersion());
+        execution.setStatus(PipelineExecutionStatus.IN_PROGRESS);
+        execution.setPipeline(new ArrayList<>());
+        execution.setCreateTime(now);
+        execution.setUpdateTime(now);
+        
+        try {
+            executionRepository.save(execution);
+        } catch (Exception e) {
+            LOG.error("Failed to save initial pipeline execution record for executionId={}", executionId, e);
+        }
+        
+        // Step 4: Submit async task
+        asyncExecutor.submit(() -> {
+            try {
+                boolean allPassed = true;
+                
+                for (PublishPipelineService service : services) {
+                    long startTime = System.currentTimeMillis();
+                    String executedAt = Instant.now().toString();
+                    PipelineNodeResult nodeResult = new PipelineNodeResult();
+                    nodeResult.setNodeId(service.pipelineId());
+                    nodeResult.setExecutedAt(executedAt);
+                    
+                    try {
+                        PublishPipelineResult pipelineResult = service.execute(context);
+                        long endTime = System.currentTimeMillis();
+                        nodeResult.setPassed(pipelineResult.isPassed());
+                        nodeResult.setMessage(pipelineResult.getMessage());
+                        nodeResult.setDurationMs(endTime - startTime);
+                        
+                        if (!pipelineResult.isPassed()) {
+                            allPassed = false;
+                        }
+                    } catch (Exception e) {
+                        long endTime = System.currentTimeMillis();
+                        nodeResult.setPassed(false);
+                        nodeResult.setMessage(e.getMessage());
+                        nodeResult.setDurationMs(endTime - startTime);
+                        allPassed = false;
+                    }
+                    
+                    execution.getPipeline().add(nodeResult);
+                    execution.setUpdateTime(System.currentTimeMillis());
+                    
+                    try {
+                        executionRepository.update(execution);
+                    } catch (Exception e) {
+                        LOG.error("Failed to update pipeline execution record for executionId={}", executionId, e);
+                    }
+                    
+                    if (!allPassed) {
+                        break;
+                    }
+                }
+                
+                // Set final status
+                PipelineExecutionStatus finalStatus = allPassed
+                        ? PipelineExecutionStatus.APPROVED : PipelineExecutionStatus.REJECTED;
+                execution.setStatus(finalStatus);
+                execution.setUpdateTime(System.currentTimeMillis());
+                
+                try {
+                    executionRepository.update(execution);
+                } catch (Exception e) {
+                    LOG.error("Failed to update final pipeline execution status for executionId={}", executionId, e);
+                }
+                
+                // Build result and invoke callback
+                PipelineExecutionResult result = new PipelineExecutionResult();
+                result.setExecutionId(executionId);
+                result.setStatus(finalStatus);
+                result.setPipeline(execution.getPipeline());
+                callback.onComplete(result);
+            } catch (Exception e) {
+                LOG.error("Unexpected error during pipeline execution for executionId={}", executionId, e);
+                // Ensure callback is called even on unexpected errors
+                PipelineExecutionResult result = new PipelineExecutionResult();
+                result.setExecutionId(executionId);
+                result.setStatus(PipelineExecutionStatus.REJECTED);
+                result.setPipeline(execution.getPipeline());
+                callback.onComplete(result);
+            }
+        });
+        
+        return executionId;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/PublishPipelineManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/PublishPipelineManager.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeConfig;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Manager for loading, caching and querying publish pipeline SPI plugins.
+ *
+ * <p>Uses {@link ServiceLoader} to discover all {@link PublishPipelineServiceBuilder} implementations,
+ * builds {@link PublishPipelineService} instances with per-node configuration properties, and caches
+ * them by pipelineId for runtime lookup.</p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public class PublishPipelineManager {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(PublishPipelineManager.class);
+    
+    /**
+     * Cached pipeline services keyed by pipelineId.
+     */
+    private final Map<String, PublishPipelineService> serviceMap = new HashMap<>();
+    
+    /**
+     * Initialize the manager by loading all SPI builders and building pipeline service instances.
+     *
+     * <p>For each builder, looks up the corresponding node configuration from the config. If found,
+     * passes the node's properties to {@code builder.build(properties)}; otherwise passes empty Properties.
+     * If a builder throws an exception, it is logged and skipped.</p>
+     *
+     * @param config the pipeline configuration containing node properties
+     */
+    public void init(PipelineConfig config) {
+        ServiceLoader<PublishPipelineServiceBuilder> builders = ServiceLoader.load(PublishPipelineServiceBuilder.class);
+        initWithBuilders(builders, config);
+    }
+    
+    /**
+     * Initialize the manager with the given builders and config. Package-private for testability.
+     *
+     * @param builders iterable of pipeline service builders
+     * @param config   the pipeline configuration containing node properties
+     */
+    void initWithBuilders(Iterable<PublishPipelineServiceBuilder> builders, PipelineConfig config) {
+        Map<String, PipelineNodeConfig> nodeConfigMap = new HashMap<>();
+        if (config.getNodes() != null) {
+            for (PipelineNodeConfig node : config.getNodes()) {
+                if (node.getPipelineId() != null) {
+                    nodeConfigMap.put(node.getPipelineId(), node);
+                }
+            }
+        }
+        
+        for (PublishPipelineServiceBuilder builder : builders) {
+            try {
+                PipelineNodeConfig nodeConfig = nodeConfigMap.get(builder.pipelineId());
+                Properties properties = (nodeConfig != null && nodeConfig.getProperties() != null)
+                        ? nodeConfig.getProperties() : new Properties();
+                PublishPipelineService service = builder.build(properties);
+                if (service != null && service.pipelineId() != null) {
+                    serviceMap.put(service.pipelineId(), service);
+                    LOG.info("Loaded pipeline plugin: {}", service.pipelineId());
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to load pipeline plugin: {}", builder.pipelineId(), e);
+            }
+        }
+    }
+    
+    /**
+     * Get pipeline services matching the given resource type and node configuration list.
+     *
+     * <p>Filters services that support the specified resource type and whose pipelineId is present
+     * in the nodes list. Results are sorted by {@link PublishPipelineService#getPreferOrder()} ascending.</p>
+     *
+     * @param resourceType the resource type to filter by
+     * @param nodes        the configured pipeline nodes to match against
+     * @return sorted list of matching pipeline services, never null, no null elements
+     */
+    public List<PublishPipelineService> getPipelineServices(PublishPipelineResourceType resourceType,
+            List<PipelineNodeConfig> nodes) {
+        Set<String> pipelineIds = nodes.stream()
+                .map(PipelineNodeConfig::getPipelineId)
+                .collect(Collectors.toSet());
+        
+        return serviceMap.values().stream()
+                .filter(service -> pipelineIds.contains(service.pipelineId()))
+                .filter(service -> supportsResourceType(service, resourceType))
+                .sorted((a, b) -> Integer.compare(a.getPreferOrder(), b.getPreferOrder()))
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Get all loaded pipeline services.
+     *
+     * @return collection of all cached pipeline services
+     */
+    public Collection<PublishPipelineService> getAllServices() {
+        return serviceMap.values();
+    }
+    
+    private boolean supportsResourceType(PublishPipelineService service, PublishPipelineResourceType resourceType) {
+        PublishPipelineResourceType[] types = service.pipelineResourceTypes();
+        if (types == null) {
+            return false;
+        }
+        return Arrays.asList(types).contains(resourceType);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/config/FilePipelineConfigProvider.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/config/FilePipelineConfigProvider.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.config;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeConfig;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.core.config.AbstractDynamicConfig;
+import com.alibaba.nacos.sys.env.EnvUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * File-based (application.properties) implementation of {@link PipelineConfigProvider}.
+ *
+ * <p>Reads configuration from EnvUtil with the following keys:
+ * <ul>
+ *   <li>{@code nacos.ai.pipeline.enabled} - boolean, default false</li>
+ *   <li>{@code nacos.ai.pipeline.nodes} - comma-separated pipeline IDs</li>
+ *   <li>{@code nacos.ai.pipeline.node.{pipelineId}.props} - comma-separated property key names</li>
+ *   <li>{@code nacos.ai.pipeline.node.{pipelineId}.{key}} - individual property values</li>
+ * </ul>
+ *
+ * <p>Follows the singleton pattern like PushConfig.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public class FilePipelineConfigProvider extends AbstractDynamicConfig implements PipelineConfigProvider {
+    
+    private static final String CONFIG_NAME = "PipelineConfig";
+    
+    private static final String KEY_ENABLED = "nacos.ai.pipeline.enabled";
+    
+    private static final String KEY_NODES = "nacos.ai.pipeline.nodes";
+    
+    private static final String KEY_NODE_PREFIX = "nacos.ai.pipeline.node.";
+    
+    private static final String KEY_PROPS_SUFFIX = ".props";
+    
+    private static final FilePipelineConfigProvider INSTANCE = new FilePipelineConfigProvider();
+    
+    private volatile PipelineConfig currentConfig;
+    
+    private FilePipelineConfigProvider() {
+        super(CONFIG_NAME);
+        resetConfig();
+    }
+    
+    public static FilePipelineConfigProvider getInstance() {
+        return INSTANCE;
+    }
+    
+    @Override
+    public PipelineConfig getConfig() {
+        return currentConfig;
+    }
+    
+    @Override
+    public String type() {
+        return "file";
+    }
+    
+    @Override
+    protected void getConfigFromEnv() {
+        try {
+            boolean enabled = EnvUtil.getProperty(KEY_ENABLED, Boolean.class, false);
+            String nodesStr = EnvUtil.getProperty(KEY_NODES, "");
+            
+            List<PipelineNodeConfig> nodes;
+            if (StringUtils.isBlank(nodesStr)) {
+                nodes = Collections.emptyList();
+            } else {
+                String[] nodeIds = nodesStr.split(",");
+                nodes = new ArrayList<>(nodeIds.length);
+                for (String nodeId : nodeIds) {
+                    String trimmedId = nodeId.trim();
+                    if (StringUtils.isNotBlank(trimmedId)) {
+                        PipelineNodeConfig nodeConfig = new PipelineNodeConfig();
+                        nodeConfig.setPipelineId(trimmedId);
+                        nodeConfig.setProperties(readNodeProperties(trimmedId));
+                        nodes.add(nodeConfig);
+                    }
+                }
+            }
+            
+            PipelineConfig config = new PipelineConfig();
+            config.setEnabled(enabled);
+            config.setNodes(nodes);
+            this.currentConfig = config;
+        } catch (Exception e) {
+            PipelineConfig defaultConfig = new PipelineConfig();
+            defaultConfig.setEnabled(false);
+            defaultConfig.setNodes(Collections.emptyList());
+            this.currentConfig = defaultConfig;
+            throw e;
+        }
+    }
+    
+    /**
+     * Read custom properties for a specific pipeline node.
+     *
+     * <p>Reads {@code nacos.ai.pipeline.node.{pipelineId}.props} as a comma-separated list of property key names,
+     * then reads each {@code nacos.ai.pipeline.node.{pipelineId}.{key}} value.
+     *
+     * @param pipelineId the pipeline node ID
+     * @return properties for this node, empty if no props configured
+     */
+    private Properties readNodeProperties(String pipelineId) {
+        Properties properties = new Properties();
+        String propsKey = KEY_NODE_PREFIX + pipelineId + KEY_PROPS_SUFFIX;
+        String propsStr = EnvUtil.getProperty(propsKey, "");
+        if (StringUtils.isBlank(propsStr)) {
+            return properties;
+        }
+        String[] propKeys = propsStr.split(",");
+        for (String propKey : propKeys) {
+            String trimmedKey = propKey.trim();
+            if (StringUtils.isNotBlank(trimmedKey)) {
+                String fullKey = KEY_NODE_PREFIX + pipelineId + "." + trimmedKey;
+                String value = EnvUtil.getProperty(fullKey);
+                if (value != null) {
+                    properties.setProperty(trimmedKey, value);
+                }
+            }
+        }
+        return properties;
+    }
+    
+    @Override
+    protected String printConfig() {
+        PipelineConfig config = this.currentConfig;
+        if (config == null) {
+            return "PipelineConfig{null}";
+        }
+        StringBuilder sb = new StringBuilder("PipelineConfig{enabled=");
+        sb.append(config.isEnabled());
+        sb.append(", nodes=[");
+        List<PipelineNodeConfig> nodes = config.getNodes();
+        if (nodes != null) {
+            for (int i = 0; i < nodes.size(); i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                sb.append(nodes.get(i).getPipelineId());
+            }
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/config/PipelineConfigProvider.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/config/PipelineConfigProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.config;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+
+/**
+ * Abstract provider for pipeline configuration, decoupling the config source (file, database, etc.).
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public interface PipelineConfigProvider {
+    
+    /**
+     * Get the current pipeline configuration.
+     *
+     * @return pipeline configuration, never null
+     */
+    PipelineConfig getConfig();
+    
+    /**
+     * Configuration source type identifier, e.g. "file", "database".
+     *
+     * @return type string
+     */
+    String type();
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineCallback.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineCallback.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+/**
+ * Callback interface for pipeline execution completion notification.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public interface PipelineCallback {
+    
+    /**
+     * Called when pipeline execution completes.
+     *
+     * @param result the execution result containing status and node details
+     */
+    void onComplete(PipelineExecutionResult result);
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineConfig.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+import java.util.List;
+
+/**
+ * Pipeline global configuration, containing enabled flag and ordered node list.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public class PipelineConfig {
+    
+    /**
+     * Whether the pipeline is globally enabled.
+     */
+    private boolean enabled;
+    
+    /**
+     * Ordered list of pipeline node configurations.
+     */
+    private List<PipelineNodeConfig> nodes;
+    
+    public PipelineConfig() {
+    }
+    
+    public boolean isEnabled() {
+        return enabled;
+    }
+    
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+    
+    public List<PipelineNodeConfig> getNodes() {
+        return nodes;
+    }
+    
+    public void setNodes(List<PipelineNodeConfig> nodes) {
+        this.nodes = nodes;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineExecution.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineExecution.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+import java.util.List;
+
+/**
+ * Pipeline execution record entity, persisted to the database.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public class PipelineExecution {
+    
+    /**
+     * Execution ID (UUID).
+     */
+    private String executionId;
+    
+    /**
+     * Resource type.
+     */
+    private String resourceType;
+    
+    /**
+     * Resource name.
+     */
+    private String resourceName;
+    
+    /**
+     * Namespace ID.
+     */
+    private String namespaceId;
+    
+    /**
+     * Resource version.
+     */
+    private String version;
+    
+    /**
+     * Execution status: IN_PROGRESS, APPROVED, REJECTED.
+     */
+    private PipelineExecutionStatus status;
+    
+    /**
+     * Node execution details list (serialized as JSON in the pipeline field).
+     */
+    private List<PipelineNodeResult> pipeline;
+    
+    /**
+     * Creation time.
+     */
+    private long createTime;
+    
+    /**
+     * Last update time.
+     */
+    private long updateTime;
+    
+    public PipelineExecution() {
+    }
+    
+    public String getExecutionId() {
+        return executionId;
+    }
+    
+    public void setExecutionId(String executionId) {
+        this.executionId = executionId;
+    }
+    
+    public String getResourceType() {
+        return resourceType;
+    }
+    
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+    
+    public String getResourceName() {
+        return resourceName;
+    }
+    
+    public void setResourceName(String resourceName) {
+        this.resourceName = resourceName;
+    }
+    
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+    
+    public void setNamespaceId(String namespaceId) {
+        this.namespaceId = namespaceId;
+    }
+    
+    public String getVersion() {
+        return version;
+    }
+    
+    public void setVersion(String version) {
+        this.version = version;
+    }
+    
+    public PipelineExecutionStatus getStatus() {
+        return status;
+    }
+    
+    public void setStatus(PipelineExecutionStatus status) {
+        this.status = status;
+    }
+    
+    public List<PipelineNodeResult> getPipeline() {
+        return pipeline;
+    }
+    
+    public void setPipeline(List<PipelineNodeResult> pipeline) {
+        this.pipeline = pipeline;
+    }
+    
+    public long getCreateTime() {
+        return createTime;
+    }
+    
+    public void setCreateTime(long createTime) {
+        this.createTime = createTime;
+    }
+    
+    public long getUpdateTime() {
+        return updateTime;
+    }
+    
+    public void setUpdateTime(long updateTime) {
+        this.updateTime = updateTime;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineExecutionResult.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineExecutionResult.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+import java.util.List;
+
+/**
+ * Pipeline execution result returned to the caller via callback.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public class PipelineExecutionResult {
+    
+    /**
+     * Execution ID.
+     */
+    private String executionId;
+    
+    /**
+     * Final status: APPROVED or REJECTED.
+     */
+    private PipelineExecutionStatus status;
+    
+    /**
+     * Node execution details.
+     */
+    private List<PipelineNodeResult> pipeline;
+    
+    public PipelineExecutionResult() {
+    }
+    
+    public String getExecutionId() {
+        return executionId;
+    }
+    
+    public void setExecutionId(String executionId) {
+        this.executionId = executionId;
+    }
+    
+    public PipelineExecutionStatus getStatus() {
+        return status;
+    }
+    
+    public void setStatus(PipelineExecutionStatus status) {
+        this.status = status;
+    }
+    
+    public List<PipelineNodeResult> getPipeline() {
+        return pipeline;
+    }
+    
+    public void setPipeline(List<PipelineNodeResult> pipeline) {
+        this.pipeline = pipeline;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineExecutionStatus.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineExecutionStatus.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+/**
+ * Pipeline execution status enumeration.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public enum PipelineExecutionStatus {
+    
+    /**
+     * Pipeline is currently executing.
+     */
+    IN_PROGRESS,
+    
+    /**
+     * All pipeline nodes passed.
+     */
+    APPROVED,
+    
+    /**
+     * At least one pipeline node rejected.
+     */
+    REJECTED
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineNodeConfig.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineNodeConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+import java.util.Properties;
+
+/**
+ * Configuration for a single pipeline node, containing the node ID and custom properties.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public class PipelineNodeConfig {
+    
+    /**
+     * Node ID, corresponding to {@code PublishPipelineService.pipelineId()}.
+     */
+    private String pipelineId;
+    
+    /**
+     * Custom configuration properties for this node (e.g. endpoint, timeout).
+     */
+    private Properties properties;
+    
+    public PipelineNodeConfig() {
+    }
+    
+    public String getPipelineId() {
+        return pipelineId;
+    }
+    
+    public void setPipelineId(String pipelineId) {
+        this.pipelineId = pipelineId;
+    }
+    
+    public Properties getProperties() {
+        return properties;
+    }
+    
+    public void setProperties(Properties properties) {
+        this.properties = properties;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineNodeResult.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/model/PipelineNodeResult.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+import java.util.Objects;
+
+/**
+ * Result of a single pipeline node execution, stored as JSON in the pipeline field.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public class PipelineNodeResult {
+    
+    /**
+     * Node ID, corresponding to {@code PublishPipelineService.pipelineId()}.
+     */
+    private String nodeId;
+    
+    /**
+     * Execution time.
+     */
+    private String executedAt;
+    
+    /**
+     * Whether the node passed.
+     */
+    private boolean passed;
+    
+    /**
+     * Review message or error description.
+     */
+    private String message;
+    
+    /**
+     * Execution duration in milliseconds.
+     */
+    private long durationMs;
+    
+    public PipelineNodeResult() {
+    }
+    
+    public String getNodeId() {
+        return nodeId;
+    }
+    
+    public void setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+    }
+    
+    public String getExecutedAt() {
+        return executedAt;
+    }
+    
+    public void setExecutedAt(String executedAt) {
+        this.executedAt = executedAt;
+    }
+    
+    public boolean isPassed() {
+        return passed;
+    }
+    
+    public void setPassed(boolean passed) {
+        this.passed = passed;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+    
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    
+    public long getDurationMs() {
+        return durationMs;
+    }
+    
+    public void setDurationMs(long durationMs) {
+        this.durationMs = durationMs;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PipelineNodeResult that = (PipelineNodeResult) o;
+        return passed == that.passed && durationMs == that.durationMs
+                && Objects.equals(nodeId, that.nodeId)
+                && Objects.equals(executedAt, that.executedAt)
+                && Objects.equals(message, that.message);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodeId, executedAt, passed, message, durationMs);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/repository/PipelineExecutionRepository.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/repository/PipelineExecutionRepository.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.repository;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecution;
+
+/**
+ * Repository interface for pipeline execution record persistence.
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public interface PipelineExecutionRepository {
+    
+    /**
+     * Insert a new pipeline execution record.
+     *
+     * @param execution the execution record to save
+     */
+    void save(PipelineExecution execution);
+    
+    /**
+     * Update an existing pipeline execution record (status and pipeline JSON).
+     *
+     * @param execution the execution record to update
+     */
+    void update(PipelineExecution execution);
+    
+    /**
+     * Find a pipeline execution record by execution ID.
+     *
+     * @param executionId the execution ID
+     * @return the execution record, or null if not found
+     */
+    PipelineExecution findById(String executionId);
+    
+    /**
+     * Find the most recent pipeline execution record by resource information.
+     *
+     * @param resourceType the resource type
+     * @param resourceName the resource name
+     * @param namespaceId  the namespace ID
+     * @param version      the resource version
+     * @return the most recent matching execution record, or null if not found
+     */
+    PipelineExecution findByResource(String resourceType, String resourceName, String namespaceId, String version);
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/repository/PipelineExecutionRepositoryImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/repository/PipelineExecutionRepositoryImpl.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.repository;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecution;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeResult;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * JDBC-based implementation of {@link PipelineExecutionRepository}.
+ *
+ * <p>Uses {@link DynamicDataSource} to obtain a {@link JdbcTemplate} and persists pipeline execution
+ * records to the {@code pipeline_execution} table. The pipeline field (List of PipelineNodeResult)
+ * is serialized/deserialized as JSON using {@link JacksonUtils}.</p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+public class PipelineExecutionRepositoryImpl implements PipelineExecutionRepository {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(PipelineExecutionRepositoryImpl.class);
+    
+    private static final String SQL_INSERT = "INSERT INTO pipeline_execution "
+            + "(execution_id, resource_type, resource_name, namespace_id, version, status, pipeline, create_time, update_time) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    
+    private static final String SQL_UPDATE = "UPDATE pipeline_execution SET status=?, pipeline=?, update_time=? "
+            + "WHERE execution_id=?";
+    
+    private static final String SQL_FIND_BY_ID = "SELECT * FROM pipeline_execution WHERE execution_id=?";
+    
+    private static final String SQL_FIND_BY_RESOURCE = "SELECT * FROM pipeline_execution "
+            + "WHERE resource_type=? AND resource_name=? AND namespace_id=? AND version=? "
+            + "ORDER BY create_time DESC LIMIT 1";
+    
+    private static final PipelineExecutionRowMapper ROW_MAPPER = new PipelineExecutionRowMapper();
+    
+    private final JdbcTemplate injectedJdbcTemplate;
+    
+    /**
+     * Default constructor. Uses {@link DynamicDataSource} to obtain the JdbcTemplate.
+     */
+    public PipelineExecutionRepositoryImpl() {
+        this.injectedJdbcTemplate = null;
+    }
+    
+    /**
+     * Constructor for testing. Accepts a JdbcTemplate directly.
+     *
+     * @param jdbcTemplate the JdbcTemplate to use
+     */
+    public PipelineExecutionRepositoryImpl(JdbcTemplate jdbcTemplate) {
+        this.injectedJdbcTemplate = jdbcTemplate;
+    }
+    
+    private JdbcTemplate getJdbcTemplate() {
+        if (injectedJdbcTemplate != null) {
+            return injectedJdbcTemplate;
+        }
+        return DynamicDataSource.getInstance().getDataSource().getJdbcTemplate();
+    }
+    
+    @Override
+    public void save(PipelineExecution execution) {
+        String pipelineJson = JacksonUtils.toJson(execution.getPipeline());
+        getJdbcTemplate().update(SQL_INSERT, execution.getExecutionId(), execution.getResourceType(),
+                execution.getResourceName(), execution.getNamespaceId(), execution.getVersion(),
+                execution.getStatus().name(), pipelineJson, execution.getCreateTime(), execution.getUpdateTime());
+    }
+    
+    @Override
+    public void update(PipelineExecution execution) {
+        String pipelineJson = JacksonUtils.toJson(execution.getPipeline());
+        getJdbcTemplate().update(SQL_UPDATE, execution.getStatus().name(), pipelineJson,
+                execution.getUpdateTime(), execution.getExecutionId());
+    }
+    
+    @Override
+    public PipelineExecution findById(String executionId) {
+        try {
+            return getJdbcTemplate().queryForObject(SQL_FIND_BY_ID, ROW_MAPPER, executionId);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+    
+    @Override
+    public PipelineExecution findByResource(String resourceType, String resourceName, String namespaceId,
+            String version) {
+        try {
+            return getJdbcTemplate().queryForObject(SQL_FIND_BY_RESOURCE, ROW_MAPPER, resourceType, resourceName,
+                    namespaceId, version);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+    
+    /**
+     * RowMapper for mapping ResultSet rows to PipelineExecution objects.
+     */
+    private static class PipelineExecutionRowMapper implements RowMapper<PipelineExecution> {
+        
+        @Override
+        public PipelineExecution mapRow(ResultSet rs, int rowNum) throws SQLException {
+            PipelineExecution execution = new PipelineExecution();
+            execution.setExecutionId(rs.getString("execution_id"));
+            execution.setResourceType(rs.getString("resource_type"));
+            execution.setResourceName(rs.getString("resource_name"));
+            execution.setNamespaceId(rs.getString("namespace_id"));
+            execution.setVersion(rs.getString("version"));
+            execution.setStatus(PipelineExecutionStatus.valueOf(rs.getString("status")));
+            
+            String pipelineJson = rs.getString("pipeline");
+            List<PipelineNodeResult> pipeline = JacksonUtils.toObj(pipelineJson,
+                    new TypeReference<List<PipelineNodeResult>>() { });
+            execution.setPipeline(pipeline);
+            
+            execution.setCreateTime(rs.getLong("create_time"));
+            execution.setUpdateTime(rs.getLong("update_time"));
+            return execution;
+        }
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineExecutorPropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineExecutorPropertyTest.java
@@ -1,0 +1,928 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline;
+
+import com.alibaba.nacos.ai.pipeline.config.PipelineConfigProvider;
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecution;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionResult;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeResult;
+import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResult;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Property-based tests for PublishPipelineExecutor.
+ *
+ * <p><b>Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 2.4, 6.4, 7.1, 7.2</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PublishPipelineExecutorPropertyTest {
+    
+    // ---- Synchronous executor for deterministic testing ----
+    
+    private static ExecutorService directExecutor() {
+        return new AbstractExecutorService() {
+            private volatile boolean shutdown = false;
+            
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+            
+            @Override
+            public void shutdown() {
+                shutdown = true;
+            }
+            
+            @Override
+            public List<Runnable> shutdownNow() {
+                shutdown = true;
+                return Collections.emptyList();
+            }
+            
+            @Override
+            public boolean isShutdown() {
+                return shutdown;
+            }
+            
+            @Override
+            public boolean isTerminated() {
+                return shutdown;
+            }
+            
+            @Override
+            public boolean awaitTermination(long timeout, TimeUnit unit) {
+                return true;
+            }
+        };
+    }
+    
+    // ---- No-op repository ----
+    
+    private static PipelineExecutionRepository noOpRepository() {
+        return new PipelineExecutionRepository() {
+            @Override
+            public void save(PipelineExecution execution) {
+            }
+            
+            @Override
+            public void update(PipelineExecution execution) {
+            }
+            
+            @Override
+            public PipelineExecution findById(String executionId) {
+                return null;
+            }
+            
+            @Override
+            public PipelineExecution findByResource(String resourceType, String resourceName,
+                    String namespaceId, String version) {
+                return null;
+            }
+        };
+    }
+    
+    // ---- Tracking repository that counts save calls ----
+    
+    private static class TrackingRepository implements PipelineExecutionRepository {
+        
+        final AtomicInteger saveCount = new AtomicInteger(0);
+        
+        final AtomicInteger updateCount = new AtomicInteger(0);
+        
+        @Override
+        public void save(PipelineExecution execution) {
+            saveCount.incrementAndGet();
+        }
+        
+        @Override
+        public void update(PipelineExecution execution) {
+            updateCount.incrementAndGet();
+        }
+        
+        @Override
+        public PipelineExecution findById(String executionId) {
+            return null;
+        }
+        
+        @Override
+        public PipelineExecution findByResource(String resourceType, String resourceName,
+                String namespaceId, String version) {
+            return null;
+        }
+    }
+    
+    // ---- Throwing repository ----
+    
+    private static PipelineExecutionRepository throwingRepository() {
+        return new PipelineExecutionRepository() {
+            @Override
+            public void save(PipelineExecution execution) {
+                throw new RuntimeException("Simulated save failure");
+            }
+            
+            @Override
+            public void update(PipelineExecution execution) {
+                throw new RuntimeException("Simulated update failure");
+            }
+            
+            @Override
+            public PipelineExecution findById(String executionId) {
+                return null;
+            }
+            
+            @Override
+            public PipelineExecution findByResource(String resourceType, String resourceName,
+                    String namespaceId, String version) {
+                return null;
+            }
+        };
+    }
+    
+    // ---- Helper: build a PublishPipelineContext ----
+    
+    private static PublishPipelineContext buildContext(PublishPipelineResourceType resourceType,
+            String resourceName, String namespaceId, String version) {
+        PublishPipelineContext ctx = new PublishPipelineContext();
+        ctx.setResourceType(resourceType);
+        ctx.setResourceName(resourceName);
+        ctx.setNamespaceId(namespaceId);
+        ctx.setVersion(version);
+        return ctx;
+    }
+    
+    // ---- Helper: create a passing PublishPipelineService ----
+    
+    private static PublishPipelineService passingService(String id, int order,
+            PublishPipelineResourceType... types) {
+        return new PublishPipelineService() {
+            @Override
+            public String pipelineId() {
+                return id;
+            }
+            
+            @Override
+            public PublishPipelineResult execute(PublishPipelineContext context) {
+                return PublishPipelineResult.pass("OK from " + id);
+            }
+            
+            @Override
+            public int getPreferOrder() {
+                return order;
+            }
+            
+            @Override
+            public PublishPipelineResourceType[] pipelineResourceTypes() {
+                return types;
+            }
+        };
+    }
+    
+    // ---- Helper: create a failing PublishPipelineService ----
+    
+    private static PublishPipelineService failingService(String id, int order,
+            PublishPipelineResourceType... types) {
+        return new PublishPipelineService() {
+            @Override
+            public String pipelineId() {
+                return id;
+            }
+            
+            @Override
+            public PublishPipelineResult execute(PublishPipelineContext context) {
+                return PublishPipelineResult.reject("Rejected by " + id);
+            }
+            
+            @Override
+            public int getPreferOrder() {
+                return order;
+            }
+            
+            @Override
+            public PublishPipelineResourceType[] pipelineResourceTypes() {
+                return types;
+            }
+        };
+    }
+    
+    // ---- Helper: create a throwing PublishPipelineService ----
+    
+    private static PublishPipelineService throwingService(String id, int order,
+            String exceptionMsg, PublishPipelineResourceType... types) {
+        return new PublishPipelineService() {
+            @Override
+            public String pipelineId() {
+                return id;
+            }
+            
+            @Override
+            public PublishPipelineResult execute(PublishPipelineContext context) {
+                throw new RuntimeException(exceptionMsg);
+            }
+            
+            @Override
+            public int getPreferOrder() {
+                return order;
+            }
+            
+            @Override
+            public PublishPipelineResourceType[] pipelineResourceTypes() {
+                return types;
+            }
+        };
+    }
+    
+    // ---- Helper: create a PublishPipelineServiceBuilder from a service ----
+    
+    private static PublishPipelineServiceBuilder builderFor(PublishPipelineService service) {
+        return new PublishPipelineServiceBuilder() {
+            @Override
+            public String pipelineId() {
+                return service.pipelineId();
+            }
+            
+            @Override
+            public PublishPipelineService build(Properties properties) {
+                return service;
+            }
+        };
+    }
+    
+    // ---- Helper: build a PipelineConfig with given enabled flag and node ids ----
+    
+    private static PipelineConfig buildConfig(boolean enabled, List<String> nodeIds) {
+        PipelineConfig config = new PipelineConfig();
+        config.setEnabled(enabled);
+        List<PipelineNodeConfig> nodes = new ArrayList<>();
+        for (String id : nodeIds) {
+            PipelineNodeConfig nc = new PipelineNodeConfig();
+            nc.setPipelineId(id);
+            nc.setProperties(new Properties());
+            nodes.add(nc);
+        }
+        config.setNodes(nodes);
+        return config;
+    }
+    
+    // ---- Helper: build a PublishPipelineManager loaded with given services ----
+    
+    private static PublishPipelineManager buildManager(List<PublishPipelineService> services,
+            PipelineConfig config) {
+        PublishPipelineManager manager = new PublishPipelineManager();
+        List<PublishPipelineServiceBuilder> builders = services.stream()
+                .map(PublishPipelineExecutorPropertyTest::builderFor)
+                .collect(Collectors.toList());
+        manager.initWithBuilders(builders, config);
+        return manager;
+    }
+    
+    // ---- Helper: build a PipelineConfigProvider returning a fixed config ----
+    
+    private static PipelineConfigProvider fixedConfigProvider(PipelineConfig config) {
+        return new PipelineConfigProvider() {
+            @Override
+            public PipelineConfig getConfig() {
+                return config;
+            }
+            
+            @Override
+            public String type() {
+                return "test";
+            }
+        };
+    }
+
+    // ======================================================================
+    // Property 1 (Task 6.2): Enabled config → execute returns executionId
+    // ======================================================================
+    
+    /**
+     * Property 1: For any valid PublishPipelineContext and enabled config with matching nodes,
+     * execute(context, callback) returns a non-null executionId.
+     *
+     * <p><b>Validates: Requirements 1.1</b></p>
+     */
+    @Property
+    void enabledConfigReturnsExecutionId(@ForAll("validExecutionInputs") ExecutionInput input) {
+        PipelineConfig config = buildConfig(true, input.nodeIds);
+        List<PublishPipelineService> services = input.nodeIds.stream()
+                .map(id -> passingService(id, input.nodeIds.indexOf(id),
+                        PublishPipelineResourceType.values()))
+                .collect(Collectors.toList());
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, noOpRepository(), directExecutor());
+        
+        PublishPipelineContext ctx = buildContext(input.resourceType, input.resourceName,
+                input.namespaceId, input.version);
+        
+        AtomicReference<PipelineExecutionResult> resultRef = new AtomicReference<>();
+        String executionId = executor.execute(ctx, resultRef::set);
+        
+        assertNotNull(executionId, "executionId should be non-null when pipeline is enabled with matching nodes");
+    }
+    
+    @Provide
+    Arbitrary<ExecutionInput> validExecutionInputs() {
+        Arbitrary<List<String>> nodeIds = Arbitraries.strings().alpha().ofMinLength(3).ofMaxLength(10)
+                .map(String::toLowerCase)
+                .list().ofMinSize(1).ofMaxSize(5)
+                .filter(list -> list.stream().distinct().count() == list.size());
+        Arbitrary<PublishPipelineResourceType> resourceTypes = Arbitraries.of(PublishPipelineResourceType.values());
+        Arbitrary<String> resourceNames = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> namespaceIds = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(10);
+        Arbitrary<String> versions = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(5)
+                .map(s -> "v" + s);
+        
+        return Combinators.combine(nodeIds, resourceTypes, resourceNames, namespaceIds, versions)
+                .as(ExecutionInput::new);
+    }
+    
+    // ======================================================================
+    // Property 2 (Task 6.3): Disabled or no matching nodes → no side effects
+    // ======================================================================
+    
+    /**
+     * Property 2: When pipeline is disabled OR nodes list is empty, execute returns null,
+     * no records are saved, and callback is NOT called.
+     *
+     * <p><b>Validates: Requirements 1.2, 1.3</b></p>
+     */
+    @Property
+    void disabledOrNoMatchingNodesHasNoSideEffects(
+            @ForAll("disabledOrEmptyInputs") DisabledOrEmptyInput input) {
+        PipelineConfig config = buildConfig(input.enabled, input.nodeIds);
+        
+        // Even if we have services loaded, if config is disabled or nodes don't match, should return null
+        List<PublishPipelineService> services = new ArrayList<>();
+        if (!input.nodeIds.isEmpty()) {
+            // Load services with IDs that do NOT match the node IDs (to simulate no matching nodes)
+            services.add(passingService("non-matching-service", 0, PublishPipelineResourceType.values()));
+        }
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        TrackingRepository trackingRepo = new TrackingRepository();
+        
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, trackingRepo, directExecutor());
+        
+        PublishPipelineContext ctx = buildContext(PublishPipelineResourceType.SKILL,
+                "test-resource", "ns", "v1");
+        
+        AtomicInteger callbackCount = new AtomicInteger(0);
+        String executionId = executor.execute(ctx, result -> callbackCount.incrementAndGet());
+        
+        assertNull(executionId, "executionId should be null when pipeline is disabled or no matching nodes");
+        assertEquals(0, trackingRepo.saveCount.get(), "No records should be saved");
+        assertEquals(0, callbackCount.get(), "Callback should not be called");
+    }
+    
+    @Provide
+    Arbitrary<DisabledOrEmptyInput> disabledOrEmptyInputs() {
+        // Case 1: disabled config with any nodes
+        Arbitrary<DisabledOrEmptyInput> disabledCase = Arbitraries.strings().alpha()
+                .ofMinLength(3).ofMaxLength(8).map(String::toLowerCase)
+                .list().ofMinSize(0).ofMaxSize(3)
+                .map(ids -> new DisabledOrEmptyInput(false, ids));
+        
+        // Case 2: enabled config but empty nodes
+        Arbitrary<DisabledOrEmptyInput> emptyNodesCase = Arbitraries.just(
+                new DisabledOrEmptyInput(true, Collections.emptyList()));
+        
+        return Arbitraries.oneOf(disabledCase, emptyNodesCase);
+    }
+    
+    // ======================================================================
+    // Property 3 (Task 6.4): Callback called exactly once
+    // ======================================================================
+    
+    /**
+     * Property 3: For any valid execution scenario (enabled, matching nodes, all pass or some fail),
+     * callback.onComplete() is called exactly once, and result.status is APPROVED or REJECTED.
+     *
+     * <p><b>Validates: Requirements 1.4, 1.5</b></p>
+     */
+    @Property
+    void callbackCalledExactlyOnce(@ForAll("callbackTestInputs") CallbackTestInput input) {
+        PipelineConfig config = buildConfig(true, input.nodeIds);
+        
+        List<PublishPipelineService> services = new ArrayList<>();
+        for (int i = 0; i < input.nodeIds.size(); i++) {
+            String id = input.nodeIds.get(i);
+            int order = i;
+            if (i == input.failAtIndex && input.failAtIndex >= 0) {
+                services.add(failingService(id, order, PublishPipelineResourceType.values()));
+            } else {
+                services.add(passingService(id, order, PublishPipelineResourceType.values()));
+            }
+        }
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, noOpRepository(), directExecutor());
+        
+        PublishPipelineContext ctx = buildContext(input.resourceType, "res", "ns", "v1");
+        
+        AtomicInteger callbackCount = new AtomicInteger(0);
+        AtomicReference<PipelineExecutionResult> resultRef = new AtomicReference<>();
+        
+        String executionId = executor.execute(ctx, result -> {
+            callbackCount.incrementAndGet();
+            resultRef.set(result);
+        });
+        
+        assertNotNull(executionId);
+        assertEquals(1, callbackCount.get(), "Callback should be called exactly once");
+        
+        PipelineExecutionResult result = resultRef.get();
+        assertNotNull(result);
+        assertTrue(result.getStatus() == PipelineExecutionStatus.APPROVED
+                        || result.getStatus() == PipelineExecutionStatus.REJECTED,
+                "Status should be APPROVED or REJECTED, got: " + result.getStatus());
+    }
+    
+    @Provide
+    Arbitrary<CallbackTestInput> callbackTestInputs() {
+        Arbitrary<List<String>> nodeIds = Arbitraries.strings().alpha().ofMinLength(3).ofMaxLength(8)
+                .map(String::toLowerCase)
+                .list().ofMinSize(1).ofMaxSize(5)
+                .filter(list -> list.stream().distinct().count() == list.size());
+        Arbitrary<PublishPipelineResourceType> resourceTypes = Arbitraries.of(PublishPipelineResourceType.values());
+        
+        return Combinators.combine(nodeIds, resourceTypes).flatAs((ids, rt) -> {
+            // failAtIndex: -1 means all pass, 0..size-1 means fail at that index
+            Arbitrary<Integer> failIdx = Arbitraries.integers().between(-1, ids.size() - 1);
+            return failIdx.map(idx -> new CallbackTestInput(ids, rt, idx));
+        });
+    }
+    
+    // ======================================================================
+    // Property 5 (Task 6.5): Fail-stop — no nodes after rejected node
+    // ======================================================================
+    
+    /**
+     * Property 5: When a node fails, no subsequent nodes appear in the pipeline result,
+     * and the overall status is REJECTED.
+     *
+     * <p><b>Validates: Requirements 2.2, 6.4</b></p>
+     */
+    @Property
+    void failStopNoNodesAfterRejection(@ForAll("failStopInputs") FailStopInput input) {
+        PipelineConfig config = buildConfig(true, input.nodeIds);
+        
+        List<PublishPipelineService> services = new ArrayList<>();
+        for (int i = 0; i < input.nodeIds.size(); i++) {
+            String id = input.nodeIds.get(i);
+            int order = i;
+            if (i == input.failAtIndex) {
+                services.add(failingService(id, order, PublishPipelineResourceType.values()));
+            } else {
+                services.add(passingService(id, order, PublishPipelineResourceType.values()));
+            }
+        }
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, noOpRepository(), directExecutor());
+        
+        PublishPipelineContext ctx = buildContext(PublishPipelineResourceType.SKILL, "res", "ns", "v1");
+        
+        AtomicReference<PipelineExecutionResult> resultRef = new AtomicReference<>();
+        executor.execute(ctx, resultRef::set);
+        
+        PipelineExecutionResult result = resultRef.get();
+        assertNotNull(result);
+        assertEquals(PipelineExecutionStatus.REJECTED, result.getStatus(),
+                "Status should be REJECTED when a node fails");
+        
+        List<PipelineNodeResult> pipeline = result.getPipeline();
+        // The pipeline should contain exactly failAtIndex + 1 nodes (0..failAtIndex)
+        assertEquals(input.failAtIndex + 1, pipeline.size(),
+                "Pipeline should contain exactly failAtIndex+1 nodes, no more");
+        
+        // The last node should be the failed one
+        PipelineNodeResult lastNode = pipeline.get(pipeline.size() - 1);
+        assertFalse(lastNode.isPassed(), "The last node in pipeline should be the failed node");
+        
+        // All nodes before the last should have passed
+        for (int i = 0; i < pipeline.size() - 1; i++) {
+            assertTrue(pipeline.get(i).isPassed(),
+                    "Node at index " + i + " should have passed");
+        }
+    }
+    
+    @Provide
+    Arbitrary<FailStopInput> failStopInputs() {
+        Arbitrary<List<String>> nodeIds = Arbitraries.strings().alpha().ofMinLength(3).ofMaxLength(8)
+                .map(String::toLowerCase)
+                .list().ofMinSize(1).ofMaxSize(6)
+                .filter(list -> list.stream().distinct().count() == list.size());
+        
+        return nodeIds.flatMap(ids -> {
+            Arbitrary<Integer> failIdx = Arbitraries.integers().between(0, ids.size() - 1);
+            return failIdx.map(idx -> new FailStopInput(ids, idx));
+        });
+    }
+    
+    // ======================================================================
+    // Property 6 (Task 6.6): Exception treated as failure
+    // ======================================================================
+    
+    /**
+     * Property 6: When a node throws an exception, that node has passed=false and
+     * message contains the exception info.
+     *
+     * <p><b>Validates: Requirements 2.4, 7.1</b></p>
+     */
+    @Property
+    void exceptionTreatedAsFailure(@ForAll("exceptionInputs") ExceptionInput input) {
+        PipelineConfig config = buildConfig(true, input.nodeIds);
+        
+        List<PublishPipelineService> services = new ArrayList<>();
+        for (int i = 0; i < input.nodeIds.size(); i++) {
+            String id = input.nodeIds.get(i);
+            int order = i;
+            if (i == input.throwAtIndex) {
+                services.add(throwingService(id, order, input.exceptionMessage,
+                        PublishPipelineResourceType.values()));
+            } else {
+                services.add(passingService(id, order, PublishPipelineResourceType.values()));
+            }
+        }
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, noOpRepository(), directExecutor());
+        
+        PublishPipelineContext ctx = buildContext(PublishPipelineResourceType.SKILL, "res", "ns", "v1");
+        
+        AtomicReference<PipelineExecutionResult> resultRef = new AtomicReference<>();
+        executor.execute(ctx, resultRef::set);
+        
+        PipelineExecutionResult result = resultRef.get();
+        assertNotNull(result);
+        
+        List<PipelineNodeResult> pipeline = result.getPipeline();
+        // The throwing node should be at index throwAtIndex
+        assertTrue(pipeline.size() > input.throwAtIndex,
+                "Pipeline should contain the throwing node");
+        
+        PipelineNodeResult throwingNode = pipeline.get(input.throwAtIndex);
+        assertFalse(throwingNode.isPassed(),
+                "Throwing node should have passed=false");
+        assertNotNull(throwingNode.getMessage(),
+                "Throwing node message should not be null");
+        assertTrue(throwingNode.getMessage().contains(input.exceptionMessage),
+                "Throwing node message should contain exception info: '" + input.exceptionMessage
+                        + "' but was: '" + throwingNode.getMessage() + "'");
+        
+        // No nodes after the throwing node
+        assertEquals(input.throwAtIndex + 1, pipeline.size(),
+                "No nodes should appear after the throwing node");
+    }
+    
+    @Provide
+    Arbitrary<ExceptionInput> exceptionInputs() {
+        Arbitrary<List<String>> nodeIds = Arbitraries.strings().alpha().ofMinLength(3).ofMaxLength(8)
+                .map(String::toLowerCase)
+                .list().ofMinSize(1).ofMaxSize(5)
+                .filter(list -> list.stream().distinct().count() == list.size());
+        Arbitrary<String> exceptionMsgs = Arbitraries.strings().alpha().ofMinLength(5).ofMaxLength(30);
+        
+        return Combinators.combine(nodeIds, exceptionMsgs).flatAs((ids, msg) -> {
+            Arbitrary<Integer> throwIdx = Arbitraries.integers().between(0, ids.size() - 1);
+            return throwIdx.map(idx -> new ExceptionInput(ids, idx, msg));
+        });
+    }
+    
+    // ======================================================================
+    // Property 7 (Task 6.7): Nodes executed in order ascending by getPreferOrder()
+    // ======================================================================
+    
+    /**
+     * Property 7: Pipeline result nodes appear in order ascending by getPreferOrder().
+     *
+     * <p><b>Validates: Requirements 2.1</b></p>
+     */
+    @Property
+    void nodesExecutedInOrderAscending(@ForAll("orderTestInputs") OrderTestInput input) {
+        PipelineConfig config = buildConfig(true, input.nodeIds);
+        
+        List<PublishPipelineService> services = new ArrayList<>();
+        for (int i = 0; i < input.nodeIds.size(); i++) {
+            services.add(passingService(input.nodeIds.get(i), input.orders.get(i),
+                    PublishPipelineResourceType.values()));
+        }
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, noOpRepository(), directExecutor());
+        
+        PublishPipelineContext ctx = buildContext(PublishPipelineResourceType.SKILL, "res", "ns", "v1");
+        
+        AtomicReference<PipelineExecutionResult> resultRef = new AtomicReference<>();
+        executor.execute(ctx, resultRef::set);
+        
+        PipelineExecutionResult result = resultRef.get();
+        assertNotNull(result);
+        
+        List<PipelineNodeResult> pipeline = result.getPipeline();
+        
+        // Build a map from nodeId to order for verification
+        java.util.Map<String, Integer> nodeOrderMap = new java.util.HashMap<>();
+        for (int i = 0; i < input.nodeIds.size(); i++) {
+            nodeOrderMap.put(input.nodeIds.get(i), input.orders.get(i));
+        }
+        
+        // Verify nodes appear in ascending order
+        for (int i = 1; i < pipeline.size(); i++) {
+            int prevOrder = nodeOrderMap.getOrDefault(pipeline.get(i - 1).getNodeId(), 0);
+            int currOrder = nodeOrderMap.getOrDefault(pipeline.get(i).getNodeId(), 0);
+            assertTrue(prevOrder <= currOrder,
+                    "Nodes should be in ascending order by preferOrder, but node '"
+                            + pipeline.get(i - 1).getNodeId() + "' (order=" + prevOrder
+                            + ") appeared before '" + pipeline.get(i).getNodeId()
+                            + "' (order=" + currOrder + ")");
+        }
+    }
+    
+    @Provide
+    Arbitrary<OrderTestInput> orderTestInputs() {
+        Arbitrary<List<String>> nodeIds = Arbitraries.strings().alpha().ofMinLength(3).ofMaxLength(8)
+                .map(String::toLowerCase)
+                .list().ofMinSize(2).ofMaxSize(6)
+                .filter(list -> list.stream().distinct().count() == list.size());
+        
+        return nodeIds.flatMap(ids -> {
+            Arbitrary<List<Integer>> orders = Arbitraries.integers().between(0, 1000)
+                    .list().ofSize(ids.size());
+            return orders.map(ords -> new OrderTestInput(ids, ords));
+        });
+    }
+    
+    // ======================================================================
+    // Property 13 (Task 6.8): Persistence failure doesn't block callback
+    // ======================================================================
+    
+    /**
+     * Property 13: When PipelineExecutionRepository throws exceptions on save/update,
+     * callback.onComplete() is still called.
+     *
+     * <p><b>Validates: Requirements 7.2</b></p>
+     */
+    @Property
+    void persistenceFailureDoesNotBlockCallback(
+            @ForAll("persistenceFailureInputs") PersistenceFailureInput input) {
+        PipelineConfig config = buildConfig(true, input.nodeIds);
+        
+        List<PublishPipelineService> services = new ArrayList<>();
+        for (int i = 0; i < input.nodeIds.size(); i++) {
+            String id = input.nodeIds.get(i);
+            int order = i;
+            if (input.hasFailingNode && i == input.nodeIds.size() - 1) {
+                services.add(failingService(id, order, PublishPipelineResourceType.values()));
+            } else {
+                services.add(passingService(id, order, PublishPipelineResourceType.values()));
+            }
+        }
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        
+        // Use throwing repository
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, throwingRepository(), directExecutor());
+        
+        PublishPipelineContext ctx = buildContext(PublishPipelineResourceType.SKILL, "res", "ns", "v1");
+        
+        AtomicInteger callbackCount = new AtomicInteger(0);
+        AtomicReference<PipelineExecutionResult> resultRef = new AtomicReference<>();
+        
+        String executionId = executor.execute(ctx, result -> {
+            callbackCount.incrementAndGet();
+            resultRef.set(result);
+        });
+        
+        assertNotNull(executionId, "executionId should still be returned despite persistence failures");
+        assertEquals(1, callbackCount.get(),
+                "Callback should be called exactly once even when repository throws");
+        
+        PipelineExecutionResult result = resultRef.get();
+        assertNotNull(result, "Result should not be null");
+        assertTrue(result.getStatus() == PipelineExecutionStatus.APPROVED
+                        || result.getStatus() == PipelineExecutionStatus.REJECTED,
+                "Status should be APPROVED or REJECTED");
+    }
+    
+    @Provide
+    Arbitrary<PersistenceFailureInput> persistenceFailureInputs() {
+        Arbitrary<List<String>> nodeIds = Arbitraries.strings().alpha().ofMinLength(3).ofMaxLength(8)
+                .map(String::toLowerCase)
+                .list().ofMinSize(1).ofMaxSize(4)
+                .filter(list -> list.stream().distinct().count() == list.size());
+        Arbitrary<Boolean> hasFailingNode = Arbitraries.of(true, false);
+        
+        return Combinators.combine(nodeIds, hasFailingNode).as(PersistenceFailureInput::new);
+    }
+    
+    // ======================================================================
+    // Input data classes
+    // ======================================================================
+    
+    static class ExecutionInput {
+        
+        final List<String> nodeIds;
+        
+        final PublishPipelineResourceType resourceType;
+        
+        final String resourceName;
+        
+        final String namespaceId;
+        
+        final String version;
+        
+        ExecutionInput(List<String> nodeIds, PublishPipelineResourceType resourceType,
+                String resourceName, String namespaceId, String version) {
+            this.nodeIds = nodeIds;
+            this.resourceType = resourceType;
+            this.resourceName = resourceName;
+            this.namespaceId = namespaceId;
+            this.version = version;
+        }
+        
+        @Override
+        public String toString() {
+            return "ExecutionInput{nodeIds=" + nodeIds + ", resourceType=" + resourceType
+                    + ", resourceName='" + resourceName + "', namespaceId='" + namespaceId
+                    + "', version='" + version + "'}";
+        }
+    }
+    
+    static class DisabledOrEmptyInput {
+        
+        final boolean enabled;
+        
+        final List<String> nodeIds;
+        
+        DisabledOrEmptyInput(boolean enabled, List<String> nodeIds) {
+            this.enabled = enabled;
+            this.nodeIds = nodeIds;
+        }
+        
+        @Override
+        public String toString() {
+            return "DisabledOrEmptyInput{enabled=" + enabled + ", nodeIds=" + nodeIds + "}";
+        }
+    }
+    
+    static class CallbackTestInput {
+        
+        final List<String> nodeIds;
+        
+        final PublishPipelineResourceType resourceType;
+        
+        final int failAtIndex;
+        
+        CallbackTestInput(List<String> nodeIds, PublishPipelineResourceType resourceType, int failAtIndex) {
+            this.nodeIds = nodeIds;
+            this.resourceType = resourceType;
+            this.failAtIndex = failAtIndex;
+        }
+        
+        @Override
+        public String toString() {
+            return "CallbackTestInput{nodeIds=" + nodeIds + ", resourceType=" + resourceType
+                    + ", failAtIndex=" + failAtIndex + "}";
+        }
+    }
+    
+    static class FailStopInput {
+        
+        final List<String> nodeIds;
+        
+        final int failAtIndex;
+        
+        FailStopInput(List<String> nodeIds, int failAtIndex) {
+            this.nodeIds = nodeIds;
+            this.failAtIndex = failAtIndex;
+        }
+        
+        @Override
+        public String toString() {
+            return "FailStopInput{nodeIds=" + nodeIds + ", failAtIndex=" + failAtIndex + "}";
+        }
+    }
+    
+    static class ExceptionInput {
+        
+        final List<String> nodeIds;
+        
+        final int throwAtIndex;
+        
+        final String exceptionMessage;
+        
+        ExceptionInput(List<String> nodeIds, int throwAtIndex, String exceptionMessage) {
+            this.nodeIds = nodeIds;
+            this.throwAtIndex = throwAtIndex;
+            this.exceptionMessage = exceptionMessage;
+        }
+        
+        @Override
+        public String toString() {
+            return "ExceptionInput{nodeIds=" + nodeIds + ", throwAtIndex=" + throwAtIndex
+                    + ", exceptionMessage='" + exceptionMessage + "'}";
+        }
+    }
+    
+    static class OrderTestInput {
+        
+        final List<String> nodeIds;
+        
+        final List<Integer> orders;
+        
+        OrderTestInput(List<String> nodeIds, List<Integer> orders) {
+            this.nodeIds = nodeIds;
+            this.orders = orders;
+        }
+        
+        @Override
+        public String toString() {
+            return "OrderTestInput{nodeIds=" + nodeIds + ", orders=" + orders + "}";
+        }
+    }
+    
+    static class PersistenceFailureInput {
+        
+        final List<String> nodeIds;
+        
+        final boolean hasFailingNode;
+        
+        PersistenceFailureInput(List<String> nodeIds, boolean hasFailingNode) {
+            this.nodeIds = nodeIds;
+            this.hasFailingNode = hasFailingNode;
+        }
+        
+        @Override
+        public String toString() {
+            return "PersistenceFailureInput{nodeIds=" + nodeIds
+                    + ", hasFailingNode=" + hasFailingNode + "}";
+        }
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineIntegrationTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineIntegrationTest.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline;
+
+import com.alibaba.nacos.ai.pipeline.config.PipelineConfigProvider;
+import com.alibaba.nacos.ai.pipeline.model.PipelineCallback;
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecution;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionResult;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeResult;
+import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepositoryImpl;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResult;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for the publish pipeline end-to-end flow.
+ *
+ * <p>Wires together PublishPipelineExecutor, PublishPipelineManager,
+ * PipelineExecutionRepositoryImpl (backed by H2), and mock pipeline services
+ * to verify the full pipeline lifecycle without Spring Boot.</p>
+ *
+ * <p><b>Validates: Requirements 1.1, 1.2, 1.4</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PublishPipelineIntegrationTest {
+    
+    private static final String CREATE_TABLE_SQL = "CREATE TABLE IF NOT EXISTS pipeline_execution ("
+            + "execution_id  VARCHAR(64)  PRIMARY KEY, "
+            + "resource_type VARCHAR(32)  NOT NULL, "
+            + "resource_name VARCHAR(256) NOT NULL, "
+            + "namespace_id  VARCHAR(128), "
+            + "version       VARCHAR(64), "
+            + "status        VARCHAR(32)  NOT NULL, "
+            + "pipeline      TEXT         NOT NULL, "
+            + "create_time   BIGINT       NOT NULL, "
+            + "update_time   BIGINT       NOT NULL)";
+    
+    private JdbcTemplate jdbcTemplate;
+    
+    private PipelineExecutionRepositoryImpl repository;
+    
+    @BeforeEach
+    void setUp() {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:integration_test_" + System.nanoTime() + ";DB_CLOSE_DELAY=-1");
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.execute(CREATE_TABLE_SQL);
+        repository = new PipelineExecutionRepositoryImpl(jdbcTemplate);
+    }
+    
+    // ---- Synchronous executor for deterministic testing ----
+    
+    private static ExecutorService directExecutor() {
+        return new AbstractExecutorService() {
+            private volatile boolean shutdown = false;
+            
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+            
+            @Override
+            public void shutdown() {
+                shutdown = true;
+            }
+            
+            @Override
+            public List<Runnable> shutdownNow() {
+                shutdown = true;
+                return Collections.emptyList();
+            }
+            
+            @Override
+            public boolean isShutdown() {
+                return shutdown;
+            }
+            
+            @Override
+            public boolean isTerminated() {
+                return shutdown;
+            }
+            
+            @Override
+            public boolean awaitTermination(long timeout, TimeUnit unit) {
+                return true;
+            }
+        };
+    }
+    
+    // ---- Helper: create a passing PublishPipelineService ----
+    
+    private static PublishPipelineService passingService(String id, int order) {
+        return new PublishPipelineService() {
+            @Override
+            public String pipelineId() {
+                return id;
+            }
+            
+            @Override
+            public PublishPipelineResult execute(PublishPipelineContext context) {
+                return PublishPipelineResult.pass("OK from " + id);
+            }
+            
+            @Override
+            public int getPreferOrder() {
+                return order;
+            }
+            
+            @Override
+            public PublishPipelineResourceType[] pipelineResourceTypes() {
+                return PublishPipelineResourceType.values();
+            }
+        };
+    }
+    
+    // ---- Helper: create a failing PublishPipelineService ----
+    
+    private static PublishPipelineService failingService(String id, int order) {
+        return new PublishPipelineService() {
+            @Override
+            public String pipelineId() {
+                return id;
+            }
+            
+            @Override
+            public PublishPipelineResult execute(PublishPipelineContext context) {
+                return PublishPipelineResult.reject("Rejected by " + id);
+            }
+            
+            @Override
+            public int getPreferOrder() {
+                return order;
+            }
+            
+            @Override
+            public PublishPipelineResourceType[] pipelineResourceTypes() {
+                return PublishPipelineResourceType.values();
+            }
+        };
+    }
+    
+    // ---- Helper: create a builder from a service ----
+    
+    private static PublishPipelineServiceBuilder builderFor(PublishPipelineService service) {
+        return new PublishPipelineServiceBuilder() {
+            @Override
+            public String pipelineId() {
+                return service.pipelineId();
+            }
+            
+            @Override
+            public PublishPipelineService build(Properties properties) {
+                return service;
+            }
+        };
+    }
+    
+    // ---- Helper: build PipelineConfig ----
+    
+    private static PipelineConfig buildConfig(boolean enabled, List<String> nodeIds) {
+        PipelineConfig config = new PipelineConfig();
+        config.setEnabled(enabled);
+        List<PipelineNodeConfig> nodes = new ArrayList<>();
+        for (String id : nodeIds) {
+            PipelineNodeConfig nc = new PipelineNodeConfig();
+            nc.setPipelineId(id);
+            nc.setProperties(new Properties());
+            nodes.add(nc);
+        }
+        config.setNodes(nodes);
+        return config;
+    }
+    
+    // ---- Helper: build PipelineConfigProvider ----
+    
+    private static PipelineConfigProvider fixedConfigProvider(PipelineConfig config) {
+        return new PipelineConfigProvider() {
+            @Override
+            public PipelineConfig getConfig() {
+                return config;
+            }
+            
+            @Override
+            public String type() {
+                return "test";
+            }
+        };
+    }
+    
+    // ---- Helper: build PublishPipelineManager with given services ----
+    
+    private static PublishPipelineManager buildManager(List<PublishPipelineService> services,
+            PipelineConfig config) {
+        PublishPipelineManager manager = new PublishPipelineManager();
+        List<PublishPipelineServiceBuilder> builders = new ArrayList<>();
+        for (PublishPipelineService service : services) {
+            builders.add(builderFor(service));
+        }
+        manager.initWithBuilders(builders, config);
+        return manager;
+    }
+    
+    // ---- Helper: build PublishPipelineContext ----
+    
+    private static PublishPipelineContext buildContext() {
+        PublishPipelineContext ctx = new PublishPipelineContext();
+        ctx.setResourceType(PublishPipelineResourceType.SKILL);
+        ctx.setResourceName("test-skill");
+        ctx.setNamespaceId("public");
+        ctx.setVersion("v1");
+        return ctx;
+    }
+    
+    // ======================================================================
+    // Test 1: End-to-end Skill publish triggers pipeline, execution record
+    //         persisted, callback called with APPROVED status
+    // ======================================================================
+    
+    /**
+     * End-to-end test: enabled pipeline with two passing nodes.
+     * Verifies executionId returned, callback called with APPROVED, DB record correct.
+     *
+     * <p><b>Validates: Requirements 1.1, 1.4</b></p>
+     */
+    @Test
+    void endToEndAllNodesPassed() {
+        List<String> nodeIds = List.of("ai-review", "security-scan");
+        PipelineConfig config = buildConfig(true, nodeIds);
+        
+        List<PublishPipelineService> services = List.of(
+                passingService("ai-review", 1),
+                passingService("security-scan", 2));
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, repository, directExecutor());
+        
+        AtomicReference<PipelineExecutionResult> resultRef = new AtomicReference<>();
+        AtomicInteger callbackCount = new AtomicInteger(0);
+        PipelineCallback callback = result -> {
+            callbackCount.incrementAndGet();
+            resultRef.set(result);
+        };
+        
+        String executionId = executor.execute(buildContext(), callback);
+        
+        // Verify: execute returns non-null executionId
+        assertNotNull(executionId, "executionId should be non-null");
+        
+        // Verify: callback called with APPROVED status
+        assertEquals(1, callbackCount.get(), "Callback should be called exactly once");
+        PipelineExecutionResult result = resultRef.get();
+        assertNotNull(result);
+        assertEquals(PipelineExecutionStatus.APPROVED, result.getStatus());
+        
+        // Verify: findById returns the execution record with correct status and pipeline nodes
+        PipelineExecution dbRecord = repository.findById(executionId);
+        assertNotNull(dbRecord, "Execution record should be persisted in DB");
+        assertEquals(PipelineExecutionStatus.APPROVED, dbRecord.getStatus());
+        assertEquals("SKILL", dbRecord.getResourceType());
+        assertEquals("test-skill", dbRecord.getResourceName());
+        assertEquals("public", dbRecord.getNamespaceId());
+        assertEquals("v1", dbRecord.getVersion());
+        
+        // Verify: pipeline has 2 nodes, both passed
+        List<PipelineNodeResult> pipeline = dbRecord.getPipeline();
+        assertEquals(2, pipeline.size(), "Pipeline should have 2 nodes");
+        assertEquals("ai-review", pipeline.get(0).getNodeId());
+        assertTrue(pipeline.get(0).isPassed());
+        assertEquals("security-scan", pipeline.get(1).getNodeId());
+        assertTrue(pipeline.get(1).isPassed());
+    }
+    
+    // ======================================================================
+    // Test 2: Pipeline not enabled → direct pass-through
+    // ======================================================================
+    
+    /**
+     * When pipeline is disabled, execute returns null, no callback, no DB records.
+     *
+     * <p><b>Validates: Requirements 1.2</b></p>
+     */
+    @Test
+    void pipelineNotEnabledDirectPassThrough() {
+        PipelineConfig config = buildConfig(false, List.of("ai-review", "security-scan"));
+        
+        List<PublishPipelineService> services = List.of(
+                passingService("ai-review", 1),
+                passingService("security-scan", 2));
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, repository, directExecutor());
+        
+        AtomicInteger callbackCount = new AtomicInteger(0);
+        PipelineCallback callback = result -> callbackCount.incrementAndGet();
+        
+        String executionId = executor.execute(buildContext(), callback);
+        
+        // Verify: execute returns null
+        assertNull(executionId, "executionId should be null when pipeline is disabled");
+        
+        // Verify: callback NOT called
+        assertEquals(0, callbackCount.get(), "Callback should not be called");
+        
+        // Verify: no records in database
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM pipeline_execution", Integer.class);
+        assertEquals(0, count, "No records should exist in database");
+    }
+    
+    // ======================================================================
+    // Test 3: One node rejects → pipeline stops, REJECTED status
+    // ======================================================================
+    
+    /**
+     * When the second node rejects, pipeline stops with REJECTED status.
+     * First node passed, second node failed.
+     *
+     * <p><b>Validates: Requirements 1.1, 1.4</b></p>
+     */
+    @Test
+    void oneNodeRejectsPipelineStopsRejected() {
+        List<String> nodeIds = List.of("ai-review", "security-scan");
+        PipelineConfig config = buildConfig(true, nodeIds);
+        
+        List<PublishPipelineService> services = List.of(
+                passingService("ai-review", 1),
+                failingService("security-scan", 2));
+        
+        PublishPipelineManager manager = buildManager(services, config);
+        PipelineConfigProvider configProvider = fixedConfigProvider(config);
+        
+        PublishPipelineExecutor executor = new PublishPipelineExecutor(
+                manager, configProvider, repository, directExecutor());
+        
+        AtomicReference<PipelineExecutionResult> resultRef = new AtomicReference<>();
+        AtomicInteger callbackCount = new AtomicInteger(0);
+        PipelineCallback callback = result -> {
+            callbackCount.incrementAndGet();
+            resultRef.set(result);
+        };
+        
+        String executionId = executor.execute(buildContext(), callback);
+        
+        // Verify: execute returns non-null executionId
+        assertNotNull(executionId);
+        
+        // Verify: callback called with REJECTED status
+        assertEquals(1, callbackCount.get(), "Callback should be called exactly once");
+        PipelineExecutionResult result = resultRef.get();
+        assertNotNull(result);
+        assertEquals(PipelineExecutionStatus.REJECTED, result.getStatus());
+        
+        // Verify: pipeline has 2 nodes, first passed, second failed
+        List<PipelineNodeResult> pipeline = result.getPipeline();
+        assertEquals(2, pipeline.size(), "Pipeline should have 2 nodes");
+        assertTrue(pipeline.get(0).isPassed(), "First node (ai-review) should have passed");
+        assertFalse(pipeline.get(1).isPassed(), "Second node (security-scan) should have failed");
+        
+        // Verify: execution record in DB has REJECTED status
+        PipelineExecution dbRecord = repository.findById(executionId);
+        assertNotNull(dbRecord, "Execution record should be persisted in DB");
+        assertEquals(PipelineExecutionStatus.REJECTED, dbRecord.getStatus());
+        assertEquals(2, dbRecord.getPipeline().size());
+        assertTrue(dbRecord.getPipeline().get(0).isPassed());
+        assertFalse(dbRecord.getPipeline().get(1).isPassed());
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineManagerPropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineManagerPropertyTest.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeConfig;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Property-based tests for PublishPipelineManager.
+ *
+ * <p><b>Validates: Requirements 5.2, 5.3, 5.4</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PublishPipelineManagerPropertyTest {
+    
+    /**
+     * Property 11: SPI loading fault tolerance — single Builder exception doesn't affect other plugins.
+     *
+     * <p>For any set of PublishPipelineServiceBuilder instances where some builders' build() throws
+     * an exception, PublishPipelineManager should still successfully load all non-throwing builders'
+     * services. Throwing builders' services should not appear in getAllServices().</p>
+     *
+     * <p><b>Validates: Requirements 5.2</b></p>
+     */
+    @Property
+    void spiLoadingFaultTolerance(@ForAll("builderDescriptorSets") BuilderDescriptorSet descriptorSet) {
+        PublishPipelineManager manager = new PublishPipelineManager();
+        
+        List<PublishPipelineServiceBuilder> builders = new ArrayList<>();
+        for (BuilderDescriptor desc : descriptorSet.descriptors) {
+            builders.add(createMockBuilder(desc));
+        }
+        
+        PipelineConfig config = new PipelineConfig();
+        config.setEnabled(true);
+        config.setNodes(new ArrayList<>());
+        
+        // Should not throw even if some builders fail
+        manager.initWithBuilders(builders, config);
+        
+        Collection<PublishPipelineService> loadedServices = manager.getAllServices();
+        
+        Set<String> normalIds = descriptorSet.descriptors.stream()
+                .filter(d -> !d.shouldThrow)
+                .map(d -> d.pipelineId)
+                .collect(Collectors.toSet());
+        
+        Set<String> failingIds = descriptorSet.descriptors.stream()
+                .filter(d -> d.shouldThrow)
+                .map(d -> d.pipelineId)
+                .collect(Collectors.toSet());
+        
+        Set<String> loadedIds = loadedServices.stream()
+                .map(PublishPipelineService::pipelineId)
+                .collect(Collectors.toSet());
+        
+        // All normal builders should be loaded
+        for (String normalId : normalIds) {
+            assertTrue(loadedIds.contains(normalId),
+                    "Normal builder '" + normalId + "' should be loaded but was not");
+        }
+        
+        // No failing builder should be loaded
+        for (String failingId : failingIds) {
+            assertFalse(loadedIds.contains(failingId),
+                    "Failing builder '" + failingId + "' should NOT be loaded but was");
+        }
+    }
+    
+    @Provide
+    Arbitrary<BuilderDescriptorSet> builderDescriptorSets() {
+        return builderDescriptor()
+                .list().ofMinSize(1).ofMaxSize(8)
+                .filter(list -> list.stream().map(d -> d.pipelineId).distinct().count() == list.size())
+                .filter(list -> list.stream().anyMatch(d -> !d.shouldThrow))
+                .map(BuilderDescriptorSet::new);
+    }
+    
+    private Arbitrary<BuilderDescriptor> builderDescriptor() {
+        Arbitrary<String> pipelineIds = Arbitraries.strings().alpha().ofMinLength(3).ofMaxLength(12)
+                .map(String::toLowerCase);
+        Arbitrary<Boolean> shouldThrow = Arbitraries.of(true, false);
+        Arbitrary<Integer> orders = Arbitraries.integers().between(0, 1000);
+        
+        return Combinators.combine(pipelineIds, shouldThrow, orders).as(BuilderDescriptor::new);
+    }
+    
+    private PublishPipelineServiceBuilder createMockBuilder(BuilderDescriptor desc) {
+        return new PublishPipelineServiceBuilder() {
+            @Override
+            public String pipelineId() {
+                return desc.pipelineId;
+            }
+            
+            @Override
+            public PublishPipelineService build(Properties properties) {
+                if (desc.shouldThrow) {
+                    throw new RuntimeException("Simulated build failure for " + desc.pipelineId);
+                }
+                return new PublishPipelineService() {
+                    @Override
+                    public String pipelineId() {
+                        return desc.pipelineId;
+                    }
+                    
+                    @Override
+                    public com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResult execute(
+                            com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext context) {
+                        return null;
+                    }
+                    
+                    @Override
+                    public int getPreferOrder() {
+                        return desc.order;
+                    }
+                    
+                    @Override
+                    public PublishPipelineResourceType[] pipelineResourceTypes() {
+                        return PublishPipelineResourceType.values();
+                    }
+                };
+            }
+        };
+    }
+    
+    /**
+     * Descriptor for a single builder in the test.
+     */
+    static class BuilderDescriptor {
+        
+        final String pipelineId;
+        
+        final boolean shouldThrow;
+        
+        final int order;
+        
+        BuilderDescriptor(String pipelineId, boolean shouldThrow, int order) {
+            this.pipelineId = pipelineId;
+            this.shouldThrow = shouldThrow;
+            this.order = order;
+        }
+        
+        @Override
+        public String toString() {
+            return "BuilderDescriptor{pipelineId='" + pipelineId + "', shouldThrow=" + shouldThrow
+                    + ", order=" + order + "}";
+        }
+    }
+    
+    /**
+     * Set of builder descriptors for a single test run.
+     */
+    static class BuilderDescriptorSet {
+        
+        final List<BuilderDescriptor> descriptors;
+        
+        BuilderDescriptorSet(List<BuilderDescriptor> descriptors) {
+            this.descriptors = descriptors;
+        }
+        
+        @Override
+        public String toString() {
+            return "BuilderDescriptorSet{descriptors=" + descriptors + "}";
+        }
+    }
+    
+    // ---- Property 12: getPipelineServices filtering and sorting ----
+    
+    /**
+     * Property 12: getPipelineServices filtering and sorting.
+     *
+     * <p>For any resourceType and nodes configuration list, getPipelineServices returns a service list
+     * where every service supports the given resourceType, every service's pipelineId is in the nodes list,
+     * the list is sorted by getPreferOrder() ascending, and contains no null elements.
+     * Additionally, no service that matches both criteria is excluded from the result.</p>
+     *
+     * <p><b>Validates: Requirements 5.3, 5.4</b></p>
+     */
+    @Property
+    void getPipelineServicesFilteringAndSorting(@ForAll("filterTestInputs") FilterTestInput input) {
+        PublishPipelineManager manager = new PublishPipelineManager();
+        
+        // Build all services (none should throw) and load them into the manager
+        List<PublishPipelineServiceBuilder> builders = new ArrayList<>();
+        for (ServiceDescriptor desc : input.allServices) {
+            builders.add(createServiceBuilder(desc));
+        }
+        
+        PipelineConfig config = new PipelineConfig();
+        config.setEnabled(true);
+        config.setNodes(new ArrayList<>());
+        manager.initWithBuilders(builders, config);
+        
+        // Build the nodes list (subset of pipelineIds to include)
+        List<PipelineNodeConfig> nodes = new ArrayList<>();
+        for (String nodeId : input.includedPipelineIds) {
+            PipelineNodeConfig nodeConfig = new PipelineNodeConfig();
+            nodeConfig.setPipelineId(nodeId);
+            nodeConfig.setProperties(new Properties());
+            nodes.add(nodeConfig);
+        }
+        
+        // Call the method under test
+        List<PublishPipelineService> result = manager.getPipelineServices(input.targetResourceType, nodes);
+        
+        // Compute expected matching pipelineIds
+        Set<String> nodeIdSet = new HashSet<>(input.includedPipelineIds);
+        Set<String> expectedIds = input.allServices.stream()
+                .filter(d -> nodeIdSet.contains(d.pipelineId))
+                .filter(d -> Arrays.asList(d.supportedTypes).contains(input.targetResourceType))
+                .map(d -> d.pipelineId)
+                .collect(Collectors.toSet());
+        
+        // 1. No null elements
+        for (PublishPipelineService service : result) {
+            assertNotNull(service, "Result list should not contain null elements");
+        }
+        
+        // 2. Every returned service supports the given resourceType
+        for (PublishPipelineService service : result) {
+            assertTrue(
+                    Arrays.asList(service.pipelineResourceTypes()).contains(input.targetResourceType),
+                    "Service '" + service.pipelineId() + "' should support " + input.targetResourceType);
+        }
+        
+        // 3. Every returned service's pipelineId is in the nodes list
+        for (PublishPipelineService service : result) {
+            assertTrue(nodeIdSet.contains(service.pipelineId()),
+                    "Service '" + service.pipelineId() + "' should be in the nodes list");
+        }
+        
+        // 4. Sorted by getPreferOrder() ascending
+        for (int i = 1; i < result.size(); i++) {
+            assertTrue(result.get(i - 1).getPreferOrder() <= result.get(i).getPreferOrder(),
+                    "Result should be sorted by preferOrder ascending, but index " + (i - 1)
+                            + " (order=" + result.get(i - 1).getPreferOrder() + ") > index " + i
+                            + " (order=" + result.get(i).getPreferOrder() + ")");
+        }
+        
+        // 5. No services that match both criteria are excluded (completeness)
+        Set<String> resultIds = result.stream()
+                .map(PublishPipelineService::pipelineId)
+                .collect(Collectors.toSet());
+        for (String expectedId : expectedIds) {
+            assertTrue(resultIds.contains(expectedId),
+                    "Service '" + expectedId + "' matches both criteria but was not in the result");
+        }
+    }
+    
+    @Provide
+    Arbitrary<FilterTestInput> filterTestInputs() {
+        Arbitrary<PublishPipelineResourceType> resourceTypes = Arbitraries.of(PublishPipelineResourceType.values());
+        
+        Arbitrary<List<ServiceDescriptor>> serviceDescriptors = serviceDescriptor()
+                .list().ofMinSize(1).ofMaxSize(10)
+                .filter(list -> list.stream().map(d -> d.pipelineId).distinct().count() == list.size());
+        
+        return Combinators.combine(serviceDescriptors, resourceTypes).as((services, targetType) -> {
+            // Pick a random subset of pipelineIds to include in nodes
+            List<String> allIds = services.stream().map(d -> d.pipelineId).collect(Collectors.toList());
+            return new FilterTestInput(services, targetType, allIds);
+        }).flatMap(input -> {
+            // Generate a subset of pipelineIds for the nodes list
+            List<String> allIds = input.allServices.stream()
+                    .map(d -> d.pipelineId).collect(Collectors.toList());
+            return Arbitraries.of(allIds).set().ofMinSize(0).ofMaxSize(allIds.size())
+                    .map(subset -> new FilterTestInput(
+                            input.allServices, input.targetResourceType, new ArrayList<>(subset)));
+        });
+    }
+    
+    private Arbitrary<ServiceDescriptor> serviceDescriptor() {
+        Arbitrary<String> pipelineIds = Arbitraries.strings().alpha().ofMinLength(3).ofMaxLength(12)
+                .map(String::toLowerCase);
+        Arbitrary<Integer> orders = Arbitraries.integers().between(0, 1000);
+        Arbitrary<PublishPipelineResourceType[]> supportedTypes = Arbitraries.of(PublishPipelineResourceType.values())
+                .set().ofMinSize(1).ofMaxSize(PublishPipelineResourceType.values().length)
+                .map(set -> set.toArray(new PublishPipelineResourceType[0]));
+        
+        return Combinators.combine(pipelineIds, orders, supportedTypes).as(ServiceDescriptor::new);
+    }
+    
+    private PublishPipelineServiceBuilder createServiceBuilder(ServiceDescriptor desc) {
+        return new PublishPipelineServiceBuilder() {
+            @Override
+            public String pipelineId() {
+                return desc.pipelineId;
+            }
+            
+            @Override
+            public PublishPipelineService build(Properties properties) {
+                return new PublishPipelineService() {
+                    @Override
+                    public String pipelineId() {
+                        return desc.pipelineId;
+                    }
+                    
+                    @Override
+                    public com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResult execute(
+                            com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext context) {
+                        return null;
+                    }
+                    
+                    @Override
+                    public int getPreferOrder() {
+                        return desc.order;
+                    }
+                    
+                    @Override
+                    public PublishPipelineResourceType[] pipelineResourceTypes() {
+                        return desc.supportedTypes;
+                    }
+                };
+            }
+        };
+    }
+    
+    /**
+     * Descriptor for a pipeline service with its supported resource types.
+     */
+    static class ServiceDescriptor {
+        
+        final String pipelineId;
+        
+        final int order;
+        
+        final PublishPipelineResourceType[] supportedTypes;
+        
+        ServiceDescriptor(String pipelineId, int order, PublishPipelineResourceType[] supportedTypes) {
+            this.pipelineId = pipelineId;
+            this.order = order;
+            this.supportedTypes = supportedTypes;
+        }
+        
+        @Override
+        public String toString() {
+            return "ServiceDescriptor{pipelineId='" + pipelineId + "', order=" + order
+                    + ", supportedTypes=" + Arrays.toString(supportedTypes) + "}";
+        }
+    }
+    
+    /**
+     * Input data for the getPipelineServices filtering and sorting property test.
+     */
+    static class FilterTestInput {
+        
+        final List<ServiceDescriptor> allServices;
+        
+        final PublishPipelineResourceType targetResourceType;
+        
+        final List<String> includedPipelineIds;
+        
+        FilterTestInput(List<ServiceDescriptor> allServices, PublishPipelineResourceType targetResourceType,
+                List<String> includedPipelineIds) {
+            this.allServices = allServices;
+            this.targetResourceType = targetResourceType;
+            this.includedPipelineIds = includedPipelineIds;
+        }
+        
+        @Override
+        public String toString() {
+            return "FilterTestInput{allServices=" + allServices + ", targetResourceType=" + targetResourceType
+                    + ", includedPipelineIds=" + includedPipelineIds + "}";
+        }
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/config/FilePipelineConfigProviderPropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/config/FilePipelineConfigProviderPropertyTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.config;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeConfig;
+import com.alibaba.nacos.common.notify.NotifyCenter;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+/**
+ * Property-based test for FilePipelineConfigProvider configuration parsing correctness.
+ *
+ * <p><b>Validates: Requirements 4.3, 4.4</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class FilePipelineConfigProviderPropertyTest {
+    
+    /**
+     * Property 10: Configuration parsing correctness.
+     *
+     * <p>For any valid combination of {@code nacos.ai.pipeline.enabled},
+     * {@code nacos.ai.pipeline.nodes}, and {@code nacos.ai.pipeline.node.{pipelineId}.*}
+     * config entries, FilePipelineConfigProvider should parse them into a PipelineConfig
+     * whose enabled value, nodes list, and per-node Properties all match the original config.</p>
+     *
+     * <p><b>Validates: Requirements 4.3, 4.4</b></p>
+     */
+    @Property
+    void configParsingCorrectness(@ForAll boolean enabled,
+            @ForAll("validNodeConfigs") List<NodeTestData> nodeConfigs) {
+        
+        // Build lookup maps for all expected EnvUtil.getProperty calls
+        Map<String, String> singleArgProps = new HashMap<>();
+        Map<String, String> twoArgProps = new HashMap<>();
+        
+        String nodesStr = nodeConfigs.stream().map(n -> n.pipelineId).collect(Collectors.joining(","));
+        twoArgProps.put("nacos.ai.pipeline.nodes", nodesStr);
+        
+        for (NodeTestData node : nodeConfigs) {
+            String propsKey = "nacos.ai.pipeline.node." + node.pipelineId + ".props";
+            twoArgProps.put(propsKey, String.join(",", node.propertyKeys()));
+            
+            for (String key : node.propertyKeys()) {
+                String fullKey = "nacos.ai.pipeline.node." + node.pipelineId + "." + key;
+                singleArgProps.put(fullKey, node.properties.getProperty(key));
+            }
+        }
+        
+        try (MockedStatic<EnvUtil> envMock = Mockito.mockStatic(EnvUtil.class);
+                MockedStatic<NotifyCenter> notifyMock = Mockito.mockStatic(NotifyCenter.class)) {
+            
+            // Single-arg getProperty: look up from map, default null
+            envMock.when(() -> EnvUtil.getProperty(anyString()))
+                    .thenAnswer(inv -> singleArgProps.get(inv.<String>getArgument(0)));
+            
+            // Two-arg getProperty(key, defaultValue): look up from map, fall back to default
+            envMock.when(() -> EnvUtil.getProperty(anyString(), anyString()))
+                    .thenAnswer(inv -> {
+                        String key = inv.getArgument(0);
+                        String defaultVal = inv.getArgument(1);
+                        return twoArgProps.getOrDefault(key, defaultVal);
+                    });
+            
+            // Three-arg getProperty(key, Class, defaultValue): handle enabled flag
+            envMock.when(() -> EnvUtil.getProperty(anyString(), any(Class.class), any()))
+                    .thenAnswer(inv -> {
+                        String key = inv.getArgument(0);
+                        if ("nacos.ai.pipeline.enabled".equals(key)) {
+                            return enabled;
+                        }
+                        return inv.getArgument(2);
+                    });
+            
+            // Create a fresh instance via reflection (bypassing singleton)
+            FilePipelineConfigProvider provider = createFreshInstance();
+            
+            // Verify parsed config
+            PipelineConfig config = provider.getConfig();
+            assertNotNull(config, "Parsed config should not be null");
+            assertEquals(enabled, config.isEnabled(), "Enabled flag should match");
+            assertNotNull(config.getNodes(), "Nodes list should not be null");
+            assertEquals(nodeConfigs.size(), config.getNodes().size(),
+                    "Number of parsed nodes should match input");
+            
+            for (int i = 0; i < nodeConfigs.size(); i++) {
+                NodeTestData expected = nodeConfigs.get(i);
+                PipelineNodeConfig actual = config.getNodes().get(i);
+                assertEquals(expected.pipelineId, actual.getPipelineId(),
+                        "Node pipelineId at index " + i + " should match");
+                assertNotNull(actual.getProperties(),
+                        "Node properties at index " + i + " should not be null");
+                
+                for (String key : expected.propertyKeys()) {
+                    assertEquals(expected.properties.getProperty(key),
+                            actual.getProperties().getProperty(key),
+                            "Property '" + key + "' for node '" + expected.pipelineId + "' should match");
+                }
+                assertEquals(expected.propertyKeys().size(), actual.getProperties().size(),
+                        "Number of properties for node '" + expected.pipelineId + "' should match");
+            }
+        }
+    }
+    
+    /**
+     * Property 14: Configuration error tolerance.
+     *
+     * <p>For any malformed configuration scenario where {@code EnvUtil.getProperty} throws a
+     * {@link RuntimeException}, FilePipelineConfigProvider should fall back to default config
+     * (enabled=false, nodes is empty list).</p>
+     *
+     * <p><b>Validates: Requirements 7.3</b></p>
+     */
+    @Property
+    void configErrorTolerance(@ForAll("errorScenarios") ErrorScenario scenario) {
+        
+        try (MockedStatic<EnvUtil> envMock = Mockito.mockStatic(EnvUtil.class);
+                MockedStatic<NotifyCenter> notifyMock = Mockito.mockStatic(NotifyCenter.class)) {
+            
+            // Mock three-arg getProperty(key, Class, defaultValue) for enabled flag
+            envMock.when(() -> EnvUtil.getProperty(anyString(), any(Class.class), any()))
+                    .thenAnswer(inv -> {
+                        if (scenario.failOnEnabled) {
+                            throw new RuntimeException(scenario.errorMessage);
+                        }
+                        String key = inv.getArgument(0);
+                        if ("nacos.ai.pipeline.enabled".equals(key)) {
+                            return false;
+                        }
+                        return inv.getArgument(2);
+                    });
+            
+            // Mock two-arg getProperty(key, defaultValue) for nodes
+            envMock.when(() -> EnvUtil.getProperty(anyString(), anyString()))
+                    .thenAnswer(inv -> {
+                        if (scenario.failOnNodes) {
+                            throw new RuntimeException(scenario.errorMessage);
+                        }
+                        return inv.<String>getArgument(1);
+                    });
+            
+            // Mock single-arg getProperty(key) - not expected to be called in error scenarios
+            envMock.when(() -> EnvUtil.getProperty(anyString()))
+                    .thenAnswer(inv -> {
+                        throw new RuntimeException(scenario.errorMessage);
+                    });
+            
+            // Create a fresh instance - constructor triggers resetConfig() -> getConfigFromEnv()
+            FilePipelineConfigProvider provider = createFreshInstance();
+            
+            // Verify fallback to default config
+            PipelineConfig config = provider.getConfig();
+            assertNotNull(config, "Config should not be null even on error");
+            assertFalse(config.isEnabled(), "Default config should have enabled=false");
+            assertNotNull(config.getNodes(), "Default config nodes should not be null");
+            assertTrue(config.getNodes().isEmpty(), "Default config should have empty nodes list");
+        }
+    }
+    
+    @Provide
+    Arbitrary<ErrorScenario> errorScenarios() {
+        Arbitrary<Boolean> failOnEnabled = Arbitraries.of(true, false);
+        Arbitrary<Boolean> failOnNodes = Arbitraries.of(true, false);
+        Arbitrary<String> errorMessages = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(50);
+        
+        return Combinators.combine(failOnEnabled, failOnNodes, errorMessages)
+                .as(ErrorScenario::new)
+                .filter(s -> s.failOnEnabled || s.failOnNodes);
+    }
+    
+    /**
+     * Test data holder for an error scenario.
+     */
+    static class ErrorScenario {
+        
+        final boolean failOnEnabled;
+        
+        final boolean failOnNodes;
+        
+        final String errorMessage;
+        
+        ErrorScenario(boolean failOnEnabled, boolean failOnNodes, String errorMessage) {
+            this.failOnEnabled = failOnEnabled;
+            this.failOnNodes = failOnNodes;
+            this.errorMessage = errorMessage;
+        }
+        
+        @Override
+        public String toString() {
+            return "ErrorScenario{failOnEnabled=" + failOnEnabled
+                    + ", failOnNodes=" + failOnNodes
+                    + ", errorMessage='" + errorMessage + "'}";
+        }
+    }
+    
+    /**
+     * Creates a fresh FilePipelineConfigProvider instance via reflection, bypassing the singleton.
+     * The constructor calls resetConfig() which calls getConfigFromEnv(), so EnvUtil must be mocked first.
+     */
+    private FilePipelineConfigProvider createFreshInstance() {
+        try {
+            Constructor<FilePipelineConfigProvider> constructor =
+                    FilePipelineConfigProvider.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create FilePipelineConfigProvider instance via reflection", e);
+        }
+    }
+    
+    @Provide
+    Arbitrary<List<NodeTestData>> validNodeConfigs() {
+        return nodeTestData().list().ofMinSize(0).ofMaxSize(5)
+                .filter(list -> list.stream().map(n -> n.pipelineId).distinct().count() == list.size());
+    }
+    
+    private Arbitrary<NodeTestData> nodeTestData() {
+        Arbitrary<String> pipelineIds = Arbitraries.strings().alpha().ofMinLength(2).ofMaxLength(12)
+                .map(String::toLowerCase);
+        Arbitrary<Properties> props = nodeProperties();
+        
+        return Combinators.combine(pipelineIds, props).as(NodeTestData::new);
+    }
+    
+    private Arbitrary<Properties> nodeProperties() {
+        Arbitrary<String> keys = Arbitraries.strings().alpha().ofMinLength(2).ofMaxLength(10)
+                .map(String::toLowerCase);
+        Arbitrary<String> values = Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(20);
+        
+        return Combinators.combine(keys, values).as((k, v) -> {
+            Properties p = new Properties();
+            p.setProperty(k, v);
+            return p;
+        }).list().ofMinSize(0).ofMaxSize(3).map(propsList -> {
+            Properties merged = new Properties();
+            for (Properties p : propsList) {
+                merged.putAll(p);
+            }
+            return merged;
+        });
+    }
+    
+    /**
+     * Test data holder for a single pipeline node configuration.
+     */
+    static class NodeTestData {
+        
+        final String pipelineId;
+        
+        final Properties properties;
+        
+        NodeTestData(String pipelineId, Properties properties) {
+            this.pipelineId = pipelineId;
+            this.properties = properties;
+        }
+        
+        List<String> propertyKeys() {
+            return new ArrayList<>(properties.stringPropertyNames());
+        }
+        
+        @Override
+        public String toString() {
+            return "NodeTestData{pipelineId='" + pipelineId + "', properties=" + properties + "}";
+        }
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PipelineExecutionStatusPropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PipelineExecutionStatusPropertyTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Property-based test for PipelineExecutionStatus consistency with pipeline node results.
+ *
+ * <p><b>Validates: Requirements 2.3, 6.3</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PipelineExecutionStatusPropertyTest {
+    
+    /**
+     * Property 4: Status consistency — APPROVED if and only if all nodes passed.
+     *
+     * <p>For any completed PipelineExecution, status == APPROVED if and only if
+     * all nodes in the pipeline list have passed == true. Conversely, if any node
+     * has passed == false, the status must be REJECTED.</p>
+     *
+     * <p><b>Validates: Requirements 2.3, 6.3</b></p>
+     */
+    @Property
+    void statusApprovedIfAndOnlyIfAllNodesPassed(@ForAll("completedPipelineExecution") PipelineExecution execution) {
+        boolean allNodesPassed = execution.getPipeline().stream().allMatch(PipelineNodeResult::isPassed);
+        
+        if (execution.getStatus() == PipelineExecutionStatus.APPROVED) {
+            assertTrue(allNodesPassed,
+                    "APPROVED execution must have all nodes passed, but found a failed node");
+        }
+        
+        if (allNodesPassed) {
+            assertEquals(PipelineExecutionStatus.APPROVED, execution.getStatus(),
+                    "Execution with all nodes passed must be APPROVED, but was " + execution.getStatus());
+        }
+        
+        if (!allNodesPassed) {
+            assertEquals(PipelineExecutionStatus.REJECTED, execution.getStatus(),
+                    "Execution with a failed node must be REJECTED, but was " + execution.getStatus());
+        }
+    }
+    
+    @Provide
+    Arbitrary<PipelineExecution> completedPipelineExecution() {
+        return Arbitraries.oneOf(approvedExecution(), rejectedExecution());
+    }
+    
+    private Arbitrary<PipelineExecution> approvedExecution() {
+        Arbitrary<List<PipelineNodeResult>> allPassedNodes = allPassedNodeResult()
+                .list().ofMinSize(1).ofMaxSize(10);
+        
+        return Combinators.combine(executionId(), resourceType(), resourceName(), namespaceId(), version(),
+                        allPassedNodes, timestamp(), timestamp())
+                .as((execId, resType, resName, nsId, ver, nodes, createTime, updateTime) -> {
+                    PipelineExecution execution = new PipelineExecution();
+                    execution.setExecutionId(execId);
+                    execution.setResourceType(resType);
+                    execution.setResourceName(resName);
+                    execution.setNamespaceId(nsId);
+                    execution.setVersion(ver);
+                    execution.setStatus(PipelineExecutionStatus.APPROVED);
+                    execution.setPipeline(nodes);
+                    execution.setCreateTime(createTime);
+                    execution.setUpdateTime(updateTime);
+                    return execution;
+                });
+    }
+    
+    private Arbitrary<PipelineExecution> rejectedExecution() {
+        Arbitrary<List<PipelineNodeResult>> nodesWithAtLeastOneFailed = mixedNodeResults();
+        
+        return Combinators.combine(executionId(), resourceType(), resourceName(), namespaceId(), version(),
+                        nodesWithAtLeastOneFailed, timestamp(), timestamp())
+                .as((execId, resType, resName, nsId, ver, nodes, createTime, updateTime) -> {
+                    PipelineExecution execution = new PipelineExecution();
+                    execution.setExecutionId(execId);
+                    execution.setResourceType(resType);
+                    execution.setResourceName(resName);
+                    execution.setNamespaceId(nsId);
+                    execution.setVersion(ver);
+                    execution.setStatus(PipelineExecutionStatus.REJECTED);
+                    execution.setPipeline(nodes);
+                    execution.setCreateTime(createTime);
+                    execution.setUpdateTime(updateTime);
+                    return execution;
+                });
+    }
+    
+    /**
+     * Generates a list of nodes where at least one node has passed=false.
+     * Passed nodes come first, followed by exactly one failed node (matching the pipeline
+     * fail-fast semantics where no nodes execute after a failure).
+     */
+    private Arbitrary<List<PipelineNodeResult>> mixedNodeResults() {
+        Arbitrary<List<PipelineNodeResult>> passedPrefix = allPassedNodeResult()
+                .list().ofMinSize(0).ofMaxSize(5);
+        Arbitrary<PipelineNodeResult> failedNode = failedNodeResult();
+        
+        return Combinators.combine(passedPrefix, failedNode).as((prefix, failed) -> {
+            prefix.add(failed);
+            return prefix;
+        });
+    }
+    
+    private Arbitrary<PipelineNodeResult> allPassedNodeResult() {
+        return Combinators.combine(nodeId(), executedAt(), message(), duration())
+                .as((nId, execAt, msg, dur) -> {
+                    PipelineNodeResult result = new PipelineNodeResult();
+                    result.setNodeId(nId);
+                    result.setExecutedAt(execAt);
+                    result.setPassed(true);
+                    result.setMessage(msg);
+                    result.setDurationMs(dur);
+                    return result;
+                });
+    }
+    
+    private Arbitrary<PipelineNodeResult> failedNodeResult() {
+        return Combinators.combine(nodeId(), executedAt(), message(), duration())
+                .as((nId, execAt, msg, dur) -> {
+                    PipelineNodeResult result = new PipelineNodeResult();
+                    result.setNodeId(nId);
+                    result.setExecutedAt(execAt);
+                    result.setPassed(false);
+                    result.setMessage(msg);
+                    result.setDurationMs(dur);
+                    return result;
+                });
+    }
+    
+    private Arbitrary<String> executionId() {
+        return Arbitraries.strings().alpha().numeric().ofMinLength(8).ofMaxLength(36);
+    }
+    
+    private Arbitrary<String> resourceType() {
+        return Arbitraries.of("SKILL", "PROMPT", "CONFIG");
+    }
+    
+    private Arbitrary<String> resourceName() {
+        return Arbitraries.strings().alpha().numeric().withChars('-', '_').ofMinLength(1).ofMaxLength(30);
+    }
+    
+    private Arbitrary<String> namespaceId() {
+        return Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(20);
+    }
+    
+    private Arbitrary<String> version() {
+        return Arbitraries.strings().alpha().numeric().withChars('.').ofMinLength(1).ofMaxLength(10);
+    }
+    
+    private Arbitrary<String> nodeId() {
+        return Arbitraries.strings().alpha().numeric().withChars('-').ofMinLength(1).ofMaxLength(20);
+    }
+    
+    private Arbitrary<String> executedAt() {
+        return Arbitraries.strings().alpha().numeric().withChars('-', ':', 'T', 'Z')
+                .ofMinLength(10).ofMaxLength(25);
+    }
+    
+    private Arbitrary<String> message() {
+        return Arbitraries.strings().alpha().numeric().withChars(' ', '.', ',')
+                .ofMinLength(0).ofMaxLength(50);
+    }
+    
+    private Arbitrary<Long> duration() {
+        return Arbitraries.longs().between(0, 1_000_000L);
+    }
+    
+    private Arbitrary<Long> timestamp() {
+        return Arbitraries.longs().between(0, System.currentTimeMillis());
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PipelineNodeResultPropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PipelineNodeResultPropertyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Property-based test for PipelineNodeResult JSON serialization round-trip.
+ *
+ * <p><b>Validates: Requirements 6.2</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PipelineNodeResultPropertyTest {
+    
+    /**
+     * Property 9: PipelineNodeResult JSON serialization round-trip.
+     *
+     * <p>For any list of PipelineNodeResult, serializing to JSON and deserializing back
+     * should produce an equivalent list of objects.</p>
+     *
+     * <p><b>Validates: Requirements 6.2</b></p>
+     */
+    @Property
+    void jsonSerializationRoundTrip(@ForAll("pipelineNodeResultList") List<PipelineNodeResult> original) {
+        String json = JacksonUtils.toJson(original);
+        List<PipelineNodeResult> deserialized = JacksonUtils.toObj(json, new TypeReference<List<PipelineNodeResult>>() { });
+        assertEquals(original, deserialized);
+    }
+    
+    @Provide
+    Arbitrary<List<PipelineNodeResult>> pipelineNodeResultList() {
+        return pipelineNodeResult().list().ofMinSize(0).ofMaxSize(10);
+    }
+    
+    private Arbitrary<PipelineNodeResult> pipelineNodeResult() {
+        Arbitrary<String> nodeIds = Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> executedAts = Arbitraries.strings().alpha().numeric()
+                .withChars('-', ':', 'T', 'Z').ofMinLength(10).ofMaxLength(25);
+        Arbitrary<Boolean> passedValues = Arbitraries.of(true, false);
+        Arbitrary<String> messages = Arbitraries.strings().alpha().numeric().withChars(' ', '.', ',')
+                .ofMinLength(0).ofMaxLength(50);
+        Arbitrary<Long> durations = Arbitraries.longs().between(0, 1_000_000L);
+        
+        return Combinators.combine(nodeIds, executedAts, passedValues, messages, durations)
+                .as((nodeId, executedAt, passed, message, durationMs) -> {
+                    PipelineNodeResult result = new PipelineNodeResult();
+                    result.setNodeId(nodeId);
+                    result.setExecutedAt(executedAt);
+                    result.setPassed(passed);
+                    result.setMessage(message);
+                    result.setDurationMs(durationMs);
+                    return result;
+                });
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/repository/PipelineExecutionRepositoryPropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/repository/PipelineExecutionRepositoryPropertyTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.repository;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecution;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeResult;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.lifecycle.AfterTry;
+import net.jqwik.api.lifecycle.BeforeContainer;
+import org.h2.jdbcx.JdbcDataSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Property-based test for PipelineExecution persistence round-trip.
+ *
+ * <p><b>Validates: Requirements 3.4, 3.5</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PipelineExecutionRepositoryPropertyTest {
+
+    private static final String CREATE_TABLE_SQL = "CREATE TABLE IF NOT EXISTS pipeline_execution ("
+            + "execution_id  VARCHAR(64)  PRIMARY KEY, "
+            + "resource_type VARCHAR(32)  NOT NULL, "
+            + "resource_name VARCHAR(256) NOT NULL, "
+            + "namespace_id  VARCHAR(128), "
+            + "version       VARCHAR(64), "
+            + "status        VARCHAR(32)  NOT NULL, "
+            + "pipeline      TEXT         NOT NULL, "
+            + "create_time   BIGINT       NOT NULL, "
+            + "update_time   BIGINT       NOT NULL)";
+    
+    private static JdbcTemplate jdbcTemplate;
+    
+    private static PipelineExecutionRepositoryImpl repository;
+    
+    @BeforeContainer
+    static void setUp() {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:pipeline_test;DB_CLOSE_DELAY=-1");
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.execute(CREATE_TABLE_SQL);
+        repository = new PipelineExecutionRepositoryImpl(jdbcTemplate);
+    }
+    
+    @AfterTry
+    void cleanUp() {
+        jdbcTemplate.execute("DELETE FROM pipeline_execution");
+    }
+    
+    /**
+     * Property 8: Execution record persistence round-trip.
+     *
+     * <p>For any PipelineExecution, saving it and then finding by executionId should return
+     * an equivalent record. Finding by resource info should also return a matching record.</p>
+     *
+     * <p><b>Validates: Requirements 3.4, 3.5</b></p>
+     */
+    @Property(tries = 50)
+    void persistenceRoundTrip(@ForAll("pipelineExecutions") PipelineExecution original) {
+        repository.save(original);
+        
+        // Verify findById returns equivalent record
+        PipelineExecution foundById = repository.findById(original.getExecutionId());
+        assertNotNull(foundById, "findById should return a non-null record");
+        assertExecutionEquals(original, foundById);
+        
+        // Verify findByResource returns matching record
+        PipelineExecution foundByResource = repository.findByResource(
+                original.getResourceType(), original.getResourceName(),
+                original.getNamespaceId(), original.getVersion());
+        assertNotNull(foundByResource, "findByResource should return a non-null record");
+        assertExecutionEquals(original, foundByResource);
+    }
+    
+    private void assertExecutionEquals(PipelineExecution expected, PipelineExecution actual) {
+        assertEquals(expected.getExecutionId(), actual.getExecutionId());
+        assertEquals(expected.getResourceType(), actual.getResourceType());
+        assertEquals(expected.getResourceName(), actual.getResourceName());
+        assertEquals(expected.getNamespaceId(), actual.getNamespaceId());
+        assertEquals(expected.getVersion(), actual.getVersion());
+        assertEquals(expected.getStatus(), actual.getStatus());
+        assertEquals(expected.getCreateTime(), actual.getCreateTime());
+        assertEquals(expected.getUpdateTime(), actual.getUpdateTime());
+        assertEquals(expected.getPipeline().size(), actual.getPipeline().size());
+        for (int i = 0; i < expected.getPipeline().size(); i++) {
+            PipelineNodeResult expectedNode = expected.getPipeline().get(i);
+            PipelineNodeResult actualNode = actual.getPipeline().get(i);
+            assertEquals(expectedNode, actualNode);
+        }
+    }
+    
+    @Provide
+    Arbitrary<PipelineExecution> pipelineExecutions() {
+        Arbitrary<String> executionIds = Arbitraries.create(() -> UUID.randomUUID().toString());
+        Arbitrary<String> resourceTypes = Arbitraries.of("SKILL", "PROMPT", "CONFIG");
+        Arbitrary<String> resourceNames = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(30);
+        Arbitrary<String> namespaceIds = Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> versions = Arbitraries.strings().alpha().numeric().withChars('.').ofMinLength(1).ofMaxLength(10);
+        Arbitrary<PipelineExecutionStatus> statuses = Arbitraries.of(
+                PipelineExecutionStatus.APPROVED, PipelineExecutionStatus.REJECTED);
+        Arbitrary<List<PipelineNodeResult>> pipelines = pipelineNodeResult().list().ofMinSize(0).ofMaxSize(5);
+        Arbitrary<Long> times = Arbitraries.longs().between(1_000_000_000L, 2_000_000_000L);
+        
+        return Combinators.combine(executionIds, resourceTypes, resourceNames, namespaceIds,
+                        versions, statuses, pipelines, times)
+                .as((id, resType, resName, nsId, ver, status, pipeline, time) -> {
+                    PipelineExecution execution = new PipelineExecution();
+                    execution.setExecutionId(id);
+                    execution.setResourceType(resType);
+                    execution.setResourceName(resName);
+                    execution.setNamespaceId(nsId);
+                    execution.setVersion(ver);
+                    execution.setStatus(status);
+                    execution.setPipeline(pipeline != null ? pipeline : new ArrayList<>());
+                    execution.setCreateTime(time);
+                    execution.setUpdateTime(time);
+                    return execution;
+                });
+    }
+    
+    private Arbitrary<PipelineNodeResult> pipelineNodeResult() {
+        Arbitrary<String> nodeIds = Arbitraries.strings().alpha().numeric().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> executedAts = Arbitraries.strings().alpha().numeric()
+                .withChars('-', ':', 'T', 'Z').ofMinLength(10).ofMaxLength(25);
+        Arbitrary<Boolean> passedValues = Arbitraries.of(true, false);
+        Arbitrary<String> messages = Arbitraries.strings().alpha().numeric().withChars(' ', '.', ',')
+                .ofMinLength(0).ofMaxLength(50);
+        Arbitrary<Long> durations = Arbitraries.longs().between(0, 1_000_000L);
+        
+        return Combinators.combine(nodeIds, executedAts, passedValues, messages, durations)
+                .as((nodeId, executedAt, passed, message, durationMs) -> {
+                    PipelineNodeResult result = new PipelineNodeResult();
+                    result.setNodeId(nodeId);
+                    result.setExecutedAt(executedAt);
+                    result.setPassed(passed);
+                    result.setMessage(message);
+                    result.setDurationMs(durationMs);
+                    return result;
+                });
+    }
+}

--- a/config/src/main/resources/META-INF/mysql-schema.sql
+++ b/config/src/main/resources/META-INF/mysql-schema.sql
@@ -174,3 +174,19 @@ CREATE TABLE `permissions` (
                                UNIQUE INDEX `uk_role_permission` (`role`,`resource`,`action`) USING BTREE
 );
 
+
+/******************************************/
+/*   表名称 = pipeline_execution           */
+/******************************************/
+CREATE TABLE `pipeline_execution` (
+    `execution_id`  varchar(64)  NOT NULL COMMENT '执行ID',
+    `resource_type` varchar(32)  NOT NULL COMMENT '资源类型',
+    `resource_name` varchar(256) NOT NULL COMMENT '资源名称',
+    `namespace_id`  varchar(128) DEFAULT NULL COMMENT '命名空间ID',
+    `version`       varchar(64)  DEFAULT NULL COMMENT '版本',
+    `status`        varchar(32)  NOT NULL COMMENT '执行状态',
+    `pipeline`      longtext     NOT NULL COMMENT 'pipeline节点结果JSON',
+    `create_time`   bigint(20)   NOT NULL COMMENT '创建时间',
+    `update_time`   bigint(20)   NOT NULL COMMENT '修改时间',
+    PRIMARY KEY (`execution_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='AI资源发布审核Pipeline执行记录';

--- a/console/src/main/resources/META-INF/derby-schema.sql
+++ b/console/src/main/resources/META-INF/derby-schema.sql
@@ -239,3 +239,19 @@ ALTER TABLE config_info_beta ADD  src_ip varchar(50)  DEFAULT NULL  ;
 ALTER TABLE his_config_info ADD publish_type varchar(50)  DEFAULT 'formal';
 ALTER TABLE his_config_info ADD ext_info CLOB   DEFAULT NULL ;
 ALTER TABLE his_config_info ADD gray_name varchar(128) DEFAULT NULL;
+
+/******************************************/
+/*   AI pipeline execution                */
+/******************************************/
+
+CREATE TABLE pipeline_execution (
+    execution_id  VARCHAR(64)  NOT NULL PRIMARY KEY,
+    resource_type VARCHAR(32)  NOT NULL,
+    resource_name VARCHAR(256) NOT NULL,
+    namespace_id  VARCHAR(128) DEFAULT NULL,
+    version       VARCHAR(64)  DEFAULT NULL,
+    status        VARCHAR(32)  NOT NULL,
+    pipeline      CLOB         NOT NULL,
+    create_time   BIGINT       NOT NULL,
+    update_time   BIGINT       NOT NULL
+);

--- a/distribution/conf/mysql-schema.sql
+++ b/distribution/conf/mysql-schema.sql
@@ -177,3 +177,19 @@ CREATE TABLE `permissions` (
                                UNIQUE INDEX `uk_role_permission` (`role`,`resource`,`action`) USING BTREE
 );
 
+
+/******************************************/
+/*   表名称 = pipeline_execution           */
+/******************************************/
+CREATE TABLE `pipeline_execution` (
+    `execution_id`  varchar(64)  NOT NULL COMMENT '执行ID',
+    `resource_type` varchar(32)  NOT NULL COMMENT '资源类型',
+    `resource_name` varchar(256) NOT NULL COMMENT '资源名称',
+    `namespace_id`  varchar(128) DEFAULT NULL COMMENT '命名空间ID',
+    `version`       varchar(64)  DEFAULT NULL COMMENT '版本',
+    `status`        varchar(32)  NOT NULL COMMENT '执行状态',
+    `pipeline`      longtext     NOT NULL COMMENT 'pipeline节点结果JSON',
+    `create_time`   bigint(20)   NOT NULL COMMENT '创建时间',
+    `update_time`   bigint(20)   NOT NULL COMMENT '修改时间',
+    PRIMARY KEY (`execution_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='AI资源发布审核Pipeline执行记录';

--- a/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineResult.java
+++ b/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineResult.java
@@ -19,8 +19,6 @@ package com.alibaba.nacos.plugin.ai.pipeline.model;
 /**
  * Result of a single publish pipeline plugin execution.
  *
- * <p>Simplified to two core fields: whether the review passed and the review comments.</p>
- *
  * @author mosong.lp
  * @since 3.2.0
  */
@@ -33,37 +31,31 @@ public class PublishPipelineResult {
     private boolean passed;
 
     /**
-     * Review comments. Contains review opinions, suggestions, error descriptions, etc.
+     * Review message. Contains review opinions, suggestions, error descriptions, etc.
      * When passed is false, this should describe the reason for rejection.
      */
-    private String comments;
+    private String message;
 
     public PublishPipelineResult() {
     }
 
-    public PublishPipelineResult(boolean passed, String comments) {
+    public PublishPipelineResult(boolean passed, String message) {
         this.passed = passed;
-        this.comments = comments;
+        this.message = message;
     }
 
     /**
-     * Create a passed result with comments.
-     *
-     * @param comments review comments
-     * @return a passed result
+     * Create a passed result.
      */
-    public static PublishPipelineResult pass(String comments) {
-        return new PublishPipelineResult(true, comments);
+    public static PublishPipelineResult pass(String message) {
+        return new PublishPipelineResult(true, message);
     }
 
     /**
-     * Create a rejected result with comments.
-     *
-     * @param comments rejection reason and suggestions
-     * @return a rejected result
+     * Create a rejected result.
      */
-    public static PublishPipelineResult reject(String comments) {
-        return new PublishPipelineResult(false, comments);
+    public static PublishPipelineResult reject(String message) {
+        return new PublishPipelineResult(false, message);
     }
 
     public boolean isPassed() {
@@ -74,17 +66,17 @@ public class PublishPipelineResult {
         this.passed = passed;
     }
 
-    public String getComments() {
-        return comments;
+    public String getMessage() {
+        return message;
     }
 
-    public void setComments(String comments) {
-        this.comments = comments;
+    public void setMessage(String message) {
+        this.message = message;
     }
 
     @Override
     public String toString() {
-        return "PublishPipelineResult{passed=" + passed + ", comments='" + comments + "'}";
+        return "PublishPipelineResult{passed=" + passed + ", message='" + message + "'}";
     }
 }
 

--- a/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/spi/PublishPipelineServiceBuilder.java
+++ b/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/spi/PublishPipelineServiceBuilder.java
@@ -16,12 +16,18 @@
 
 package com.alibaba.nacos.plugin.ai.pipeline.spi;
 
+import java.util.Properties;
+
 /**
  * Builder SPI for creating {@link PublishPipelineService} instances.
  *
  * <p>Since SPI-loaded classes are instantiated via no-arg constructors, this builder pattern allows
  * creating pipeline service implementations. Each pipeline plugin should implement this builder and
  * register it via SPI (META-INF/services).</p>
+ *
+ * <p>The {@link #build(Properties)} method receives per-node configuration properties from the
+ * pipeline config (e.g. {@code nacos.ai.pipeline.node.{pipelineId}.*}), allowing each plugin
+ * to be initialized with custom parameters such as API endpoints, timeouts, etc.</p>
  *
  * @author mosong.lp
  * @since 3.2.0
@@ -36,10 +42,15 @@ public interface PublishPipelineServiceBuilder {
     String pipelineId();
 
     /**
-     * Build a {@link PublishPipelineService} instance.
+     * Build a {@link PublishPipelineService} instance with the given configuration properties.
      *
+     * <p>The properties are sourced from pipeline configuration, keyed by this builder's
+     * {@link #pipelineId()}. For example, if pipelineId is "ai-review", properties may contain
+     * entries like "endpoint", "timeout", etc.</p>
+     *
+     * @param properties per-node configuration properties, never null (may be empty)
      * @return a fully initialized {@link PublishPipelineService} instance
      */
-    PublishPipelineService build();
+    PublishPipelineService build(Properties properties);
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -865,6 +865,11 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>nacos-ai-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>nacos-auth</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1148,4 +1153,3 @@
     </dependencyManagement>
 
 </project>
-


### PR DESCRIPTION
## What is the purpose of the change

Add a pluggable, async publish review pipeline for AI resources (Skill, Prompt, etc.). When a resource is published, the pipeline orchestrates multiple review nodes (loaded via SPI) in serial order. Each node can approve or reject; a single rejection short-circuits the remaining nodes. The entire execution runs asynchronously — the caller receives an `executionId` immediately and gets notified via callback when the pipeline completes. Execution records are persisted to the database for auditability.

## Brief changelog

- Add `PipelineConfig`, `PipelineExecution`, `PipelineExecutionResult`, `PipelineExecutionStatus`, `PipelineNodeConfig`, `PipelineNodeResult`, `PipelineCallback` model/enum/interface classes in `ai` module
- Add `PipelineConfigProvider` SPI with `FilePipelineConfigProvider` implementation (reads from `application.properties`, extends `AbstractDynamicConfig` for hot-reload)
- Add `PublishPipelineManager` for SPI-based plugin loading via `ServiceLoader<PublishPipelineServiceBuilder>`, with fault-tolerant init (single builder failure doesn't block others)
- Add `PipelineExecutionRepository` / `PipelineExecutionRepositoryImpl` for JDBC-based persistence using `DynamicDataSource`, with JSON serialization of node results
- Add `PublishPipelineExecutor` as the async execution engine: config check → node matching → record creation → async serial execution → fail-fast on rejection → guaranteed single callback
- Add `PipelineConfiguration` Spring `@Configuration` to wire all beans and the executor thread pool
- Append `pipeline_execution` table DDL to `derby-schema.sql` (embedded) and `mysql-schema.sql` (external)
- Update `PublishPipelineResult` and `PublishPipelineServiceBuilder` in `plugin/ai` module
- Add `nacos-ai-plugin` dependency to `ai/pom.xml`; add test dependencies: jqwik, jackson-databind, h2, mockito-core, mockito-inline
- Add 14 property-based tests (jqwik) covering all 14 correctness properties defined in the design spec, plus 3 integration tests

## Verifying this change

This change is verified by 17 new automated tests (all passing):

| Test class | Properties covered |
|---|---|
| `PipelineNodeResultPropertyTest` | P9: JSON serialization round-trip |
| `PipelineExecutionStatusPropertyTest` | P4: APPROVED iff all nodes passed |
| `FilePipelineConfigProviderPropertyTest` | P10: config parsing correctness, P14: malformed config tolerance |
| `PublishPipelineManagerPropertyTest` | P11: SPI fault tolerance, P12: filtering & sorting |
| `PipelineExecutionRepositoryPropertyTest` | P8: persistence round-trip (H2 in-memory) |
| `PublishPipelineExecutorPropertyTest` | P1: returns executionId, P2: no side effects when disabled, P3: callback exactly once, P5: fail-stop, P6: exception = failure, P7: node order, P13: persistence failure doesn't block callback |
| `PublishPipelineIntegrationTest` | End-to-end: all pass, disabled pipeline, single rejection |

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
