### PR TITLE
[ISSUE #14622] fix: exclude json-schema-validator 3.0.0 from agentscope-core to resolve NoClassDefFoundError

### DIFF
--- a/copilot/pom.xml
+++ b/copilot/pom.xml
@@ -61,6 +61,12 @@
             <groupId>io.agentscope</groupId>
             <artifactId>agentscope-core</artifactId>
             <version>1.0.7</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.networknt</groupId>
+                    <artifactId>json-schema-validator</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.agentscope</groupId>


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fix #14622 

## Brief changelog

agentscope-core:1.0.7 directly depends on json-schema-validator:3.0.0 (Jackson 3), which overrides the 1.5.7 version required by mcp-json-jackson2:0.14.1 (Jackson 2). This causes NoClassDefFoundError for SpecVersion$VersionFlag when using the 'Auto import from MCP Server' feature, since SpecVersion.VersionFlag was renamed to SpecificationVersion in json-schema-validator 2.0.0+.

Excluding json-schema-validator from agentscope-core allows mcp's transitive dependency (1.5.7) to take effect, resolving the conflict.

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

