### PR TITLE
Refactor skill storage model and accelerate skill loading via nacos-config cache

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationService.java
@@ -31,7 +31,19 @@ import java.util.Map;
  * @author nacos
  */
 public interface SkillOperationService {
-    
+
+    // ========== Admin APIs ==========
+
+    /**
+     * Upload skill from zip file.
+     *
+     * @param namespaceId namespace ID
+     * @param zipBytes zip file bytes
+     * @return skill name
+     * @throws NacosException if upload failed
+     */
+    String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
+
     /**
      * Get skill detail for admin usage. Returns full skill content plus version governance info.
      *
@@ -41,7 +53,7 @@ public interface SkillOperationService {
      * @throws NacosException if skill not found
      */
     SkillAdminDetail getSkillDetail(String namespaceId, String skillName) throws NacosException;
-    
+
     /**
      * Delete skill.
      *
@@ -50,7 +62,7 @@ public interface SkillOperationService {
      * @throws NacosException if delete failed
      */
     void deleteSkill(String namespaceId, String skillName) throws NacosException;
-    
+
     /**
      * List skills with pagination for admin usage. Returns full governance metadata.
      *
@@ -63,40 +75,10 @@ public interface SkillOperationService {
      * @throws NacosException if query failed
      */
     Page<SkillAdminListItem> listSkills(String namespaceId, String skillName, String search, int pageNo, int pageSize) throws NacosException;
-    
-    /**
-     * Upload skill from zip file.
-     *
-     * @param namespaceId namespace ID
-     * @param zipBytes zip file bytes
-     * @return skill name
-     * @throws NacosException if upload failed
-     */
-    String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
-
-    /**
-     * Search skills for runtime client usage. Only returns enabled skills that have at least one online version.
-     * Returns only name and description for client consumption.
-     *
-     * @param namespaceId namespace ID
-     * @param keyword keyword (optional)
-     * @param pageNo page number
-     * @param pageSize page size
-     */
-    Page<SkillBasicInfo> searchSkills(String namespaceId, String keyword, int pageNo, int pageSize) throws NacosException;
-
-    /**
-     * Query skill for runtime client usage. Priority: label > version > latest(label).
-     *
-     * @param namespaceId namespace ID
-     * @param name skill name
-     * @param version explicit version (optional)
-     * @param label route label, e.g. latest/stable (optional)
-     */
-    Skill querySkill(String namespaceId, String name, String version, String label) throws NacosException;
 
     /**
      * Create a new draft version based on latest or specified version.
+     * If no base version is specified and no online version exists, an empty skill draft will be created.
      *
      * @param namespaceId namespace ID
      * @param name skill name
@@ -143,4 +125,27 @@ public interface SkillOperationService {
      * @param online true means online/enable, false means offline/disable
      */
     void changeOnlineStatus(String namespaceId, String name, String scope, String version, boolean online) throws NacosException;
+
+    // ========== Client APIs ==========
+
+    /**
+     * Search skills for runtime client usage. Only returns enabled skills that have at least one online version.
+     * Returns only name and description for client consumption.
+     *
+     * @param namespaceId namespace ID
+     * @param keyword keyword (optional)
+     * @param pageNo page number
+     * @param pageSize page size
+     */
+    Page<SkillBasicInfo> searchSkills(String namespaceId, String keyword, int pageNo, int pageSize) throws NacosException;
+
+    /**
+     * Query skill for runtime client usage. Priority: label > version > latest(label).
+     *
+     * @param namespaceId namespace ID
+     * @param name skill name
+     * @param version explicit version (optional)
+     * @param label route label, e.g. latest/stable (optional)
+     */
+    Skill querySkill(String namespaceId, String name, String version, String label) throws NacosException;
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -99,6 +99,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
 
     private static final String LABEL_LATEST = "latest";
 
+    private static final String SKILL_MD_RESOURCE_NAME = "SKILL.md";
+
     private static final String SCOPE_SKILL = "skill";
 
     private static final int MAX_WORKING_VERSION_RETRY = 3;
@@ -124,62 +126,32 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         this.pipelineExecutionRepository = pipelineExecutionRepository;
     }
 
-    private void createDraftWithSkill(String namespaceId, Skill skill, String version, AiResource existedMeta,
-            boolean isNewSkill) throws NacosException {
-        String skillName = skill.getName();
-        long uniformId = System.currentTimeMillis();
-
-        // 1) write storage for draft version (provider + key, raw bytes)
-        byte[] mainContent = buildMainContent(skill, uniformId);
-        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(resolveSkillStorageProvider(), namespaceId,
-                skillName, version, NacosConfigAiResourceStorage.getMainFilePath());
-        storageRouter.route(mainKey).save(mainKey, mainContent);
-
-        if (skill.getResource() != null && !skill.getResource().isEmpty()) {
-            for (Map.Entry<String, SkillResource> entry : skill.getResource().entrySet()) {
-                SkillResource resource = entry.getValue();
-                String path = NacosConfigAiResourceStorage.getResourceFilePath(resource.getType(), resource.getName());
-                byte[] resourceContent = buildResourceContent(resource, uniformId);
-                StorageKey resourceKey = NacosConfigAiResourceStorage.buildStorageKey(resolveSkillStorageProvider(),
-                        namespaceId, skillName, version, path);
-                storageRouter.route(resourceKey).save(resourceKey, resourceContent);
-            }
+    @Override
+    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, namespaceId);
+        if (skill == null || StringUtils.isBlank(skill.getName())) {
+            throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING, "Skill name is required");
+        }
+        String name = skill.getName();
+        AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL);
+        if (meta == null) {
+            // New skill: create meta row and first draft version v1
+            String version = "v1";
+            createDraftWithSkill(namespaceId, skill, version, null, true);
+            return name;
         }
 
-        // 2) insert draft version row
-        AiResourceVersion versionRow = new AiResourceVersion();
-        versionRow.setNamespaceId(namespaceId);
-        versionRow.setName(skillName);
-        versionRow.setType(RESOURCE_TYPE_SKILL);
-        versionRow.setAuthor(DEFAULT_AUTHOR);
-        versionRow.setStatus(VERSION_STATUS_DRAFT);
-        versionRow.setVersion(version);
-        versionRow.setDesc(skill.getDescription());
-        versionRow.setStorage(buildStorageJson(namespaceId, skillName, version));
-        aiResourceVersionPersistService.insert(versionRow);
-
-        // 3) create or update meta for editingVersion
-        if (isNewSkill) {
-            AiResource meta = new AiResource();
-            meta.setNamespaceId(namespaceId);
-            meta.setName(skillName);
-            meta.setType(RESOURCE_TYPE_SKILL);
-            meta.setStatus(META_STATUS_ENABLE);
-            meta.setDesc(skill.getDescription());
-            SkillVersionInfo info = new SkillVersionInfo();
-            info.setEditingVersion(version);
-            info.setOnlineCnt(0);
-            info.setLabels(new HashMap<>(4));
-            meta.setVersionInfo(JacksonUtils.toJson(info));
-            meta.setMetaVersion(1L);
-            aiResourcePersistService.insert(meta);
-        } else if (existedMeta != null) {
-            SkillVersionInfo info = requireVersionInfo(existedMeta);
-            info.setEditingVersion(version);
-            updateMetaVersionInfoCas(namespaceId, existedMeta, info);
+        SkillVersionInfo info = requireVersionInfo(meta);
+        if (StringUtils.isNotBlank(info.getEditingVersion()) || StringUtils.isNotBlank(info.getReviewingVersion())) {
+            throw new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
+                    "There is already a working version (editing/reviewing), cannot upload");
         }
+
+        String newVersion = nextVersion(namespaceId, name);
+        createDraftWithSkill(namespaceId, skill, newVersion, meta, false);
+        return name;
     }
-    
+
     @Override
     public SkillAdminDetail getSkillDetail(String namespaceId, String skillName) throws NacosException {
         AiResource meta = aiResourcePersistService.find(namespaceId, skillName, RESOURCE_TYPE_SKILL);
@@ -190,24 +162,21 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         SkillVersionInfo versionInfo = requireVersionInfo(meta);
         String version = resolveVersion(meta, null, null);
 
-        // Load skill content from storage (best-effort, may be blank if no published version yet)
-        Skill skill = null;
-        if (StringUtils.isNotBlank(version)) {
-            try {
-                skill = loadSkillFromStorage(namespaceId, skillName, version);
-            } catch (NacosException ignored) {
-                // version row exists but storage missing, return meta info only
-            }
-        }
-
-        // Load version row for status info
+        // Load version row first (needed for storage JSON and status info)
+        AiResourceVersion versionRow = null;
         String versionStatus = null;
         if (StringUtils.isNotBlank(version)) {
-            AiResourceVersion versionRow = aiResourceVersionPersistService.find(namespaceId, skillName,
+            versionRow = aiResourceVersionPersistService.find(namespaceId, skillName,
                     RESOURCE_TYPE_SKILL, version);
             if (versionRow != null) {
                 versionStatus = versionRow.getStatus();
             }
+        }
+
+        // Load skill content from storage
+        Skill skill = null;
+        if (versionRow != null) {
+            skill = loadSkillFromStorage(namespaceId, skillName, version, versionRow.getStorage());
         }
 
         // Load all version summaries
@@ -251,22 +220,28 @@ public class SkillOperationServiceImpl implements SkillOperationService {
             return;
         }
 
-        // Delete in reverse order of creation: meta -> version rows -> storage files
+        // Delete in strict reverse order of creation (storage -> version -> meta -> index):
+        // 1) index config first: cut off client discovery immediately
+        deleteSkillIndexConfig(namespaceId, skillName);
+
+        // 2) meta: admin API can no longer find the skill
         aiResourcePersistService.delete(namespaceId, skillName, RESOURCE_TYPE_SKILL);
 
+        // 3) version rows (list before delete to get storage info)
         Page<AiResourceVersion> versions = aiResourceVersionPersistService.listAll(namespaceId, skillName, 1, 200);
         aiResourceVersionPersistService.deleteByNameAndType(namespaceId, skillName, RESOURCE_TYPE_SKILL);
 
+        // 4) storage files
         if (versions != null && versions.getPageItems() != null) {
             for (AiResourceVersion v : versions.getPageItems()) {
                 if (v == null || StringUtils.isBlank(v.getVersion())) {
                     continue;
                 }
-                deleteSkillStorageForVersion(namespaceId, skillName, v.getVersion());
+                deleteSkillStorageForVersion(namespaceId, skillName, v.getVersion(), v.getStorage());
             }
         }
     }
-    
+
     @Override
     public Page<SkillAdminListItem> listSkills(String namespaceId, String skillName, String search, int pageNo,
             int pageSize) throws NacosException {
@@ -312,126 +287,62 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         result.setPageNumber(pageNo);
         return result;
     }
-    
-    @Override
-    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
-        Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, namespaceId);
-        if (skill == null || StringUtils.isBlank(skill.getName())) {
-            throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING, "Skill name is required");
-        }
-        String name = skill.getName();
-        AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL);
-        if (meta == null) {
-            // New skill: create meta row and first draft version v1
-            String version = "v1";
-            createDraftWithSkill(namespaceId, skill, version, null, true);
-            return name;
-        }
-
-        SkillVersionInfo info = requireVersionInfo(meta);
-        if (StringUtils.isNotBlank(info.getEditingVersion()) || StringUtils.isNotBlank(info.getReviewingVersion())) {
-            throw new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
-                    "There is already a working version (editing/reviewing), cannot upload");
-        }
-
-        String newVersion = nextVersion(namespaceId, name);
-        createDraftWithSkill(namespaceId, skill, newVersion, meta, false);
-        return name;
-    }
-
-    @Override
-    public Page<SkillBasicInfo> searchSkills(String namespaceId, String keyword, int pageNo, int pageSize)
-            throws NacosException {
-        String nameLike = StringUtils.isBlank(keyword) ? null : (Constants.ALL_PATTERN + keyword + Constants.ALL_PATTERN);
-        Page<AiResource> metaPage = aiResourcePersistService.list(namespaceId, RESOURCE_TYPE_SKILL, nameLike, null, pageNo,
-                pageSize);
-        List<SkillBasicInfo> items = new ArrayList<>();
-        if (metaPage != null && metaPage.getPageItems() != null) {
-            for (AiResource meta : metaPage.getPageItems()) {
-                if (meta == null) {
-                    continue;
-                }
-                if (!META_STATUS_ENABLE.equalsIgnoreCase(meta.getStatus())) {
-                    continue;
-                }
-                SkillVersionInfo info = parseVersionInfo(meta.getVersionInfo());
-                if (info == null || info.getOnlineCnt() == null || info.getOnlineCnt() <= 0) {
-                    continue;
-                }
-                // Client only receives name and description
-                SkillBasicInfo basicInfo = new SkillBasicInfo();
-                basicInfo.setName(meta.getName());
-                basicInfo.setDescription(meta.getDesc());
-                items.add(basicInfo);
-            }
-        }
-        Page<SkillBasicInfo> result = new Page<>();
-        result.setPageItems(items);
-        result.setTotalCount(metaPage == null ? 0 : metaPage.getTotalCount());
-        result.setPagesAvailable(metaPage == null ? 0 : metaPage.getPagesAvailable());
-        result.setPageNumber(pageNo);
-        return result;
-    }
-
-    @Override
-    public Skill querySkill(String namespaceId, String name, String version, String label) throws NacosException {
-        AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL);
-        if (meta == null) {
-            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND, "Skill not found: " + name);
-        }
-        if (!META_STATUS_ENABLE.equalsIgnoreCase(meta.getStatus())) {
-            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND, "Skill disabled: " + name);
-        }
-        String resolved = resolveVersion(meta, version, label);
-        if (StringUtils.isBlank(resolved)) {
-            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
-                    "Skill version not found: " + name);
-        }
-        AiResourceVersion versionRow = aiResourceVersionPersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL, resolved);
-        if (versionRow == null || !VERSION_STATUS_ONLINE.equalsIgnoreCase(versionRow.getStatus())) {
-            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
-                    "Skill version not online: " + name);
-        }
-        return loadSkillFromStorage(namespaceId, name, resolved);
-    }
 
     @Override
     public String createDraft(String namespaceId, String name, String basedOnVersion) throws NacosException {
-        AiResource meta = requireMeta(namespaceId, name);
+        AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL);
+
+        if (meta == null) {
+            // Brand-new skill: meta does not exist yet, always create an empty draft
+            if (StringUtils.isNotBlank(basedOnVersion)) {
+                throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                        "Skill not found: " + name + ", cannot use basedOnVersion for a brand-new skill");
+            }
+            Skill emptySkill = new Skill();
+            emptySkill.setName(name);
+            emptySkill.setNamespaceId(namespaceId);
+            createDraftWithSkill(namespaceId, emptySkill, "v1", null, true);
+            return "v1";
+        }
+
         SkillVersionInfo info = requireVersionInfo(meta);
         if (StringUtils.isNotBlank(info.getEditingVersion()) || StringUtils.isNotBlank(info.getReviewingVersion())) {
             throw new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
                     "There is already a working version (editing/reviewing), cannot create draft");
         }
 
-        String base = StringUtils.isBlank(basedOnVersion) ? resolveVersion(meta, null, LABEL_LATEST) : basedOnVersion;
-        if (StringUtils.isBlank(base)) {
-            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
-                    "Base version not found for skill: " + name);
-        }
-
         String newVersion = nextVersion(namespaceId, name);
+        // resolveBaseVersion: explicit param > latest label > max version number; null means no version exists yet
+        String base = resolveBaseVersion(namespaceId, name, meta, basedOnVersion);
 
-        // 1) copy storage content (skill.json + resources)
-        Skill baseSkill = loadSkillFromStorage(namespaceId, name, base);
-        long uniformId = System.currentTimeMillis();
-        writeSkillToStorage(namespaceId, baseSkill, newVersion, uniformId);
+        if (StringUtils.isBlank(base)) {
+            // No version exists yet: create an empty draft
+            Skill emptySkill = new Skill();
+            emptySkill.setName(name);
+            emptySkill.setNamespaceId(namespaceId);
+            createDraftWithSkill(namespaceId, emptySkill, newVersion, meta, false);
+        } else {
+            // Copy storage content from base version
+            AiResourceVersion baseVersionRow = aiResourceVersionPersistService.find(namespaceId, name,
+                    RESOURCE_TYPE_SKILL, base);
+            Skill baseSkill = loadSkillFromStorage(namespaceId, name, base,
+                    baseVersionRow != null ? baseVersionRow.getStorage() : null);
+            List<String> files = writeSkillToStorage(namespaceId, baseSkill, newVersion);
 
-        // 2) insert draft version row
-        AiResourceVersion v = new AiResourceVersion();
-        v.setNamespaceId(namespaceId);
-        v.setName(name);
-        v.setType(RESOURCE_TYPE_SKILL);
-        v.setAuthor(DEFAULT_AUTHOR);
-        v.setStatus(VERSION_STATUS_DRAFT);
-        v.setVersion(newVersion);
-        v.setDesc(baseSkill.getDescription());
-        v.setStorage(buildStorageJson(namespaceId, name, newVersion));
-        aiResourceVersionPersistService.insert(v);
+            AiResourceVersion v = new AiResourceVersion();
+            v.setNamespaceId(namespaceId);
+            v.setName(name);
+            v.setType(RESOURCE_TYPE_SKILL);
+            v.setAuthor(DEFAULT_AUTHOR);
+            v.setStatus(VERSION_STATUS_DRAFT);
+            v.setVersion(newVersion);
+            v.setDesc(baseSkill.getDescription());
+            v.setStorage(buildStorageJson(namespaceId, name, newVersion, files));
+            aiResourceVersionPersistService.insert(v);
 
-        // 3) update meta pointers (editingVersion)
-        info.setEditingVersion(newVersion);
-        updateMetaVersionInfoCas(namespaceId, meta, info);
+            info.setEditingVersion(newVersion);
+            updateMetaVersionInfoCas(namespaceId, meta, info);
+        }
         return newVersion;
     }
 
@@ -454,10 +365,9 @@ public class SkillOperationServiceImpl implements SkillOperationService {
                     "Current editing version is not draft: " + editing);
         }
 
-        long uniformId = System.currentTimeMillis();
-        writeSkillToStorage(namespaceId, draftSkill, editing, uniformId);
+        List<String> files = writeSkillToStorage(namespaceId, draftSkill, editing);
         aiResourceVersionPersistService.updateStorage(namespaceId, name, RESOURCE_TYPE_SKILL, editing,
-                buildStorageJson(namespaceId, name, editing));
+                buildStorageJson(namespaceId, name, editing, files));
         bumpMetaDescription(namespaceId, meta, draftSkill.getDescription());
     }
 
@@ -469,13 +379,19 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         if (StringUtils.isBlank(editing)) {
             return;
         }
+        // Read version row upfront (need status check and storage info before modifying)
         AiResourceVersion v = aiResourceVersionPersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL, editing);
-        if (v != null && VERSION_STATUS_DRAFT.equalsIgnoreCase(v.getStatus())) {
-            deleteSkillStorageForVersion(namespaceId, name, editing);
-            aiResourceVersionPersistService.delete(namespaceId, name, RESOURCE_TYPE_SKILL, editing);
-        }
+
+        // Delete in reverse order of creation (storage -> version -> meta):
+        // 1) meta: clear editingVersion reference first
         info.setEditingVersion(null);
         updateMetaVersionInfoCas(namespaceId, meta, info);
+
+        // 2) version row, then storage files
+        if (v != null && VERSION_STATUS_DRAFT.equalsIgnoreCase(v.getStatus())) {
+            aiResourceVersionPersistService.delete(namespaceId, name, RESOURCE_TYPE_SKILL, editing);
+            deleteSkillStorageForVersion(namespaceId, name, editing, v.getStorage());
+        }
     }
 
     @Override
@@ -501,7 +417,7 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         final String finalTarget = target;
         
         // Build context for pipeline execution (multi-file skill representation).
-        Skill skill = loadSkillFromStorage(namespaceId, name, finalTarget);
+        Skill skill = loadSkillFromStorage(namespaceId, name, finalTarget, v.getStorage());
         SkillPipelineContext ctx = new SkillPipelineContext();
         ctx.setNamespaceId(namespaceId);
         ctx.setResourceName(name);
@@ -581,6 +497,9 @@ public class SkillOperationServiceImpl implements SkillOperationService {
             info.getLabels().put(LABEL_LATEST, version);
         }
         updateMetaVersionInfoCas(namespaceId, meta, info);
+
+        // Write skill index config for client-side config caching
+        writeSkillIndexConfig(namespaceId, name, version, parseStorageFiles(v.getStorage()));
     }
 
     @Override
@@ -600,6 +519,11 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         boolean skillScope = SCOPE_SKILL.equalsIgnoreCase(scope) || StringUtils.isBlank(version);
         if (skillScope) {
             metaEnableDisable(namespaceId, meta, online);
+            if (online) {
+                refreshSkillIndexConfig(namespaceId, name);
+            } else {
+                deleteSkillIndexConfig(namespaceId, name);
+            }
             return;
         }
 
@@ -619,42 +543,104 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         }
         updateMetaVersionInfoCas(namespaceId, meta, info);
     }
-    
-    /**
-     * Build main skill content as JSON bytes (storage-agnostic).
-     */
-    private static byte[] buildMainContent(Skill skill, long uniformId) {
-        SkillMainConfig mainConfig = new SkillMainConfig();
-        mainConfig.setName(skill.getName());
-        mainConfig.setDescription(skill.getDescription());
-        mainConfig.setInstruction(skill.getInstruction());
-        mainConfig.setUniformId(uniformId);
-        List<SkillResourceRef> resourceRefs = new ArrayList<>(
-                skill.getResource() != null ? skill.getResource().size() : 16);
-        if (skill.getResource() != null) {
-            for (Map.Entry<String, SkillResource> entry : skill.getResource().entrySet()) {
-                SkillResource resource = entry.getValue();
-                SkillResourceRef ref = new SkillResourceRef();
-                ref.setName(resource.getName());
-                ref.setType(resource.getType());
-                resourceRefs.add(ref);
+
+    @Override
+    public Page<SkillBasicInfo> searchSkills(String namespaceId, String keyword, int pageNo, int pageSize)
+            throws NacosException {
+        String nameLike = StringUtils.isBlank(keyword) ? null : (Constants.ALL_PATTERN + keyword + Constants.ALL_PATTERN);
+        Page<AiResource> metaPage = aiResourcePersistService.list(namespaceId, RESOURCE_TYPE_SKILL, nameLike, null, pageNo,
+                pageSize);
+        List<SkillBasicInfo> items = new ArrayList<>();
+        if (metaPage != null && metaPage.getPageItems() != null) {
+            for (AiResource meta : metaPage.getPageItems()) {
+                if (meta == null) {
+                    continue;
+                }
+                if (!META_STATUS_ENABLE.equalsIgnoreCase(meta.getStatus())) {
+                    continue;
+                }
+                SkillVersionInfo info = parseVersionInfo(meta.getVersionInfo());
+                if (info == null || info.getOnlineCnt() == null || info.getOnlineCnt() <= 0) {
+                    continue;
+                }
+                // Client only receives name and description
+                SkillBasicInfo basicInfo = new SkillBasicInfo();
+                basicInfo.setName(meta.getName());
+                basicInfo.setDescription(meta.getDesc());
+                items.add(basicInfo);
             }
         }
-        mainConfig.setResources(resourceRefs);
-        return JacksonUtils.toJson(mainConfig).getBytes(StandardCharsets.UTF_8);
+        Page<SkillBasicInfo> result = new Page<>();
+        result.setPageItems(items);
+        result.setTotalCount(metaPage == null ? 0 : metaPage.getTotalCount());
+        result.setPagesAvailable(metaPage == null ? 0 : metaPage.getPagesAvailable());
+        result.setPageNumber(pageNo);
+        return result;
     }
 
-    /**
-     * Build resource content as JSON bytes (storage-agnostic).
-     */
-    private static byte[] buildResourceContent(SkillResource resource, long uniformId) {
-        Map<String, Object> metadata = resource.getMetadata();
-        if (metadata == null) {
-            metadata = new HashMap<>(4);
-            resource.setMetadata(metadata);
+    @Override
+    public Skill querySkill(String namespaceId, String name, String version, String label) throws NacosException {
+        AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL);
+        if (meta == null) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND, "Skill not found: " + name);
         }
-        metadata.put("uniformId", uniformId);
-        return JacksonUtils.toJson(resource).getBytes(StandardCharsets.UTF_8);
+        if (!META_STATUS_ENABLE.equalsIgnoreCase(meta.getStatus())) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND, "Skill disabled: " + name);
+        }
+        String resolved = resolveVersion(meta, version, label);
+        if (StringUtils.isBlank(resolved)) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                    "Skill version not found: " + name);
+        }
+        AiResourceVersion versionRow = aiResourceVersionPersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL, resolved);
+        if (versionRow == null || !VERSION_STATUS_ONLINE.equalsIgnoreCase(versionRow.getStatus())) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                    "Skill version not online: " + name);
+        }
+        return loadSkillFromStorage(namespaceId, name, resolved, versionRow.getStorage());
+    }
+
+    // ========== Private methods ==========
+
+    private void createDraftWithSkill(String namespaceId, Skill skill, String version, AiResource existedMeta,
+            boolean isNewSkill) throws NacosException {
+        String skillName = skill.getName();
+
+        // 1) write all resources (including SKILL.md) to storage
+        List<String> files = writeSkillToStorage(namespaceId, skill, version);
+
+        // 2) insert draft version row
+        AiResourceVersion versionRow = new AiResourceVersion();
+        versionRow.setNamespaceId(namespaceId);
+        versionRow.setName(skillName);
+        versionRow.setType(RESOURCE_TYPE_SKILL);
+        versionRow.setAuthor(DEFAULT_AUTHOR);
+        versionRow.setStatus(VERSION_STATUS_DRAFT);
+        versionRow.setVersion(version);
+        versionRow.setDesc(skill.getDescription());
+        versionRow.setStorage(buildStorageJson(namespaceId, skillName, version, files));
+        aiResourceVersionPersistService.insert(versionRow);
+
+        // 3) create or update meta for editingVersion
+        if (isNewSkill) {
+            AiResource meta = new AiResource();
+            meta.setNamespaceId(namespaceId);
+            meta.setName(skillName);
+            meta.setType(RESOURCE_TYPE_SKILL);
+            meta.setStatus(META_STATUS_ENABLE);
+            meta.setDesc(skill.getDescription());
+            SkillVersionInfo info = new SkillVersionInfo();
+            info.setEditingVersion(version);
+            info.setOnlineCnt(0);
+            info.setLabels(new HashMap<>(4));
+            meta.setVersionInfo(JacksonUtils.toJson(info));
+            meta.setMetaVersion(1L);
+            aiResourcePersistService.insert(meta);
+        } else if (existedMeta != null) {
+            SkillVersionInfo info = requireVersionInfo(existedMeta);
+            info.setEditingVersion(version);
+            updateMetaVersionInfoCas(namespaceId, existedMeta, info);
+        }
     }
 
     private static String resolveSkillStorageProvider() {
@@ -685,6 +671,27 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         return null;
     }
 
+    /**
+     * Resolves the base version to copy from when creating a draft.
+     * Priority: explicit basedOnVersion > "latest" label > highest numeric version.
+     * Returns null if no version exists yet (empty draft should be created).
+     * Throws NOT_FOUND if an explicit basedOnVersion was given but cannot be resolved.
+     */
+    private String resolveBaseVersion(String namespaceId, String name, AiResource meta, String basedOnVersion)
+            throws NacosException {
+        if (StringUtils.isNotBlank(basedOnVersion)) {
+            String resolved = resolveVersion(meta, basedOnVersion, null);
+            if (StringUtils.isBlank(resolved)) {
+                throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                        "Base version not found for skill: " + name + ", basedOnVersion: " + basedOnVersion);
+            }
+            return resolved;
+        }
+        // No explicit base: try latest label first, then fall back to highest numbered version
+        String latest = resolveVersion(meta, null, LABEL_LATEST);
+        return StringUtils.isNotBlank(latest) ? latest : maxVersionByNumber(namespaceId, name);
+    }
+
     private static SkillVersionInfo parseVersionInfo(String json) {
         if (StringUtils.isBlank(json)) {
             return null;
@@ -697,13 +704,90 @@ public class SkillOperationServiceImpl implements SkillOperationService {
     }
 
     /**
-     * Build storage metadata JSON for version row (provider + scope, storage-agnostic).
+     * Build storage metadata JSON for version row (provider + scope + file list).
      */
-    private static String buildStorageJson(String namespaceId, String skillName, String version) {
+    private static String buildStorageJson(String namespaceId, String skillName, String version, List<String> files) {
         Map<String, Object> json = new HashMap<>(4);
         json.put("provider", resolveSkillStorageProvider());
         json.put("scope", namespaceId + ":" + skillName + ":" + version);
+        json.put("files", files);
         return JacksonUtils.toJson(json);
+    }
+
+    /**
+     * Parse the file path list from storage JSON.
+     */
+    @SuppressWarnings("unchecked")
+    private static List<String> parseStorageFiles(String storageJson) {
+        if (StringUtils.isBlank(storageJson)) {
+            return null;
+        }
+        try {
+            Map<String, Object> map = JacksonUtils.toObj(storageJson, Map.class);
+            Object files = map.get("files");
+            if (files instanceof List) {
+                return (List<String>) files;
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    /**
+     * Write skill index config (manifest) to Nacos Config for client-side caching.
+     * Stored at group={@code skill_{name}}, dataId={@code skill_index.json}.
+     */
+    private void writeSkillIndexConfig(String namespaceId, String skillName, String version, List<String> files)
+            throws NacosException {
+        Map<String, Object> index = new HashMap<>(4);
+        index.put("version", version);
+        index.put("files", files);
+        String provider = resolveSkillStorageProvider();
+        StorageKey key = NacosConfigAiResourceStorage.buildManifestStorageKey(provider, namespaceId, skillName);
+        byte[] content = JacksonUtils.toJson(index).getBytes(StandardCharsets.UTF_8);
+        storageRouter.route(key).save(key, content);
+    }
+
+    /**
+     * Delete skill index config.
+     */
+    private void deleteSkillIndexConfig(String namespaceId, String skillName) throws NacosException {
+        String provider = resolveSkillStorageProvider();
+        StorageKey key = NacosConfigAiResourceStorage.buildManifestStorageKey(provider, namespaceId, skillName);
+        storageRouter.route(key).delete(key);
+    }
+
+    /**
+     * Refresh skill index config from current meta (used when skill is re-enabled).
+     * Best-effort: failures are logged but not propagated.
+     */
+    private void refreshSkillIndexConfig(String namespaceId, String name) {
+        try {
+            AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL);
+            if (meta == null) {
+                return;
+            }
+            SkillVersionInfo vInfo = parseVersionInfo(meta.getVersionInfo());
+            if (vInfo == null || vInfo.getLabels() == null) {
+                return;
+            }
+            String latestVersion = vInfo.getLabels().get(LABEL_LATEST);
+            if (StringUtils.isBlank(latestVersion)) {
+                return;
+            }
+            AiResourceVersion versionRow = aiResourceVersionPersistService.find(namespaceId, name,
+                    RESOURCE_TYPE_SKILL, latestVersion);
+            if (versionRow == null || !VERSION_STATUS_ONLINE.equalsIgnoreCase(versionRow.getStatus())) {
+                return;
+            }
+            List<String> files = parseStorageFiles(versionRow.getStorage());
+            if (files == null || files.isEmpty()) {
+                return;
+            }
+            writeSkillIndexConfig(namespaceId, name, latestVersion, files);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to refresh skill index config for {}: {}", name, e.getMessage());
+        }
     }
 
     private AiResource requireMeta(String namespaceId, String name) throws NacosException {
@@ -783,6 +867,23 @@ public class SkillOperationServiceImpl implements SkillOperationService {
     }
 
     private String nextVersion(String namespaceId, String name) {
+        return "v" + (maxVersionNumber(namespaceId, name) + 1);
+    }
+
+    /**
+     * Returns the version string with the highest numeric suffix (e.g. "v3" when versions are v1/v2/v3),
+     * or null if no numeric versions exist.
+     */
+    private String maxVersionByNumber(String namespaceId, String name) {
+        int max = maxVersionNumber(namespaceId, name);
+        return max == 0 ? null : "v" + max;
+    }
+
+    /**
+     * Returns the highest numeric version number across all existing version rows.
+     * Returns 0 if no numeric version exists.
+     */
+    private int maxVersionNumber(String namespaceId, String name) {
         Page<AiResourceVersion> page = aiResourceVersionPersistService.listAll(namespaceId, name, 1, 200);
         int max = 0;
         if (page != null && page.getPageItems() != null) {
@@ -803,24 +904,57 @@ public class SkillOperationServiceImpl implements SkillOperationService {
                 }
             }
         }
-        return "v" + (max + 1);
+        return max;
     }
 
-    private void writeSkillToStorage(String namespaceId, Skill skill, String version, long uniformId) throws NacosException {
-        byte[] mainContent = buildMainContent(skill, uniformId);
-        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(resolveSkillStorageProvider(), namespaceId,
-                skill.getName(), version, NacosConfigAiResourceStorage.getMainFilePath());
-        storageRouter.route(mainKey).save(mainKey, mainContent);
+    /**
+     * Write all skill resources to storage uniformly, including SKILL.md as a SkillResource.
+     *
+     * @return list of stored file paths (for use in buildStorageJson)
+     */
+    private List<String> writeSkillToStorage(String namespaceId, Skill skill, String version) throws NacosException {
+        String provider = resolveSkillStorageProvider();
+        String skillName = skill.getName();
+        List<String> files = new ArrayList<>();
+
+        // 1) Store SKILL.md as a SkillResource (carries name/description/instruction in metadata)
+        SkillResource skillMdResource = buildSkillMdResource(skill);
+        String mdPath = NacosConfigAiResourceStorage.getResourceFilePath(null, SKILL_MD_RESOURCE_NAME);
+        byte[] mdBytes = JacksonUtils.toJson(skillMdResource).getBytes(StandardCharsets.UTF_8);
+        StorageKey mdKey = NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId, skillName, version,
+                mdPath);
+        storageRouter.route(mdKey).save(mdKey, mdBytes);
+        files.add(mdPath);
+
+        // 2) Store each resource file
         if (skill.getResource() != null && !skill.getResource().isEmpty()) {
             for (Map.Entry<String, SkillResource> entry : skill.getResource().entrySet()) {
                 SkillResource resource = entry.getValue();
                 String path = NacosConfigAiResourceStorage.getResourceFilePath(resource.getType(), resource.getName());
-                byte[] content = buildResourceContent(resource, uniformId);
-                StorageKey resourceKey = NacosConfigAiResourceStorage.buildStorageKey(resolveSkillStorageProvider(),
-                        namespaceId, skill.getName(), version, path);
+                byte[] content = JacksonUtils.toJson(resource).getBytes(StandardCharsets.UTF_8);
+                StorageKey resourceKey = NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId, skillName,
+                        version, path);
                 storageRouter.route(resourceKey).save(resourceKey, content);
+                files.add(path);
             }
         }
+
+        return files;
+    }
+
+    /**
+     * Build SKILL.md as a SkillResource with markdown content and metadata for name/description/instruction.
+     */
+    private static SkillResource buildSkillMdResource(Skill skill) {
+        SkillResource resource = new SkillResource();
+        resource.setName(SKILL_MD_RESOURCE_NAME);
+        resource.setContent(SkillUtils.toMarkdown(skill));
+        Map<String, Object> metadata = new HashMap<>(4);
+        metadata.put("name", skill.getName());
+        metadata.put("description", skill.getDescription());
+        metadata.put("instruction", skill.getInstruction());
+        resource.setMetadata(metadata);
+        return resource;
     }
 
     private void onPipelineComplete(String namespaceId, String name, String version, PipelineExecutionResult result) {
@@ -897,57 +1031,67 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         }
     }
 
-    private Skill loadSkillFromStorage(String namespaceId, String skillName, String version) throws NacosException {
-        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(resolveSkillStorageProvider(), namespaceId,
-                skillName, version, NacosConfigAiResourceStorage.getMainFilePath());
-        byte[] mainBytes = storageRouter.route(mainKey).get(mainKey);
-        if (mainBytes == null) {
+    /**
+     * Load skill from storage by reading all resource files listed in storageJson.
+     * SKILL.md resource provides name/description/instruction; others populate the resource map.
+     */
+    private Skill loadSkillFromStorage(String namespaceId, String skillName, String version, String storageJson)
+            throws NacosException {
+        List<String> files = parseStorageFiles(storageJson);
+        if (files == null || files.isEmpty()) {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
-                    "Skill not found: " + skillName);
+                    "No files found in storage for skill: " + skillName + "@" + version);
         }
 
-        SkillMainConfig mainConfig = JacksonUtils.toObj(new String(mainBytes, StandardCharsets.UTF_8), SkillMainConfig.class);
+        String provider = resolveSkillStorageProvider();
         Skill skill = new Skill();
         skill.setNamespaceId(namespaceId);
-        skill.setName(mainConfig.getName());
-        skill.setDescription(mainConfig.getDescription());
-        skill.setInstruction(mainConfig.getInstruction());
+        Map<String, SkillResource> resourceMap = new HashMap<>(files.size());
 
-        Map<String, SkillResource> resourceMap = new HashMap<>(
-                mainConfig.getResources() != null ? mainConfig.getResources().size() : 16);
-        if (mainConfig.getResources() != null && !mainConfig.getResources().isEmpty()) {
-            for (SkillResourceRef resourceRef : mainConfig.getResources()) {
-                String resourceId = SkillUtils.generateResourceId(resourceRef.getType(), resourceRef.getName());
-                String path = NacosConfigAiResourceStorage.getResourceFilePath(resourceRef.getType(), resourceRef.getName());
-                StorageKey resourceKey = NacosConfigAiResourceStorage.buildStorageKey(resolveSkillStorageProvider(),
-                        namespaceId, skillName, version, path);
-                byte[] resourceBytes = storageRouter.route(resourceKey).get(resourceKey);
-                if (resourceBytes != null) {
-                    SkillResource resource = JacksonUtils.toObj(new String(resourceBytes, StandardCharsets.UTF_8), SkillResource.class);
-                    resourceMap.put(resourceId, resource);
+        for (String filePath : files) {
+            StorageKey key = NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId, skillName, version,
+                    filePath);
+            byte[] bytes = storageRouter.route(key).get(key);
+            if (bytes == null) {
+                continue;
+            }
+            SkillResource resource = JacksonUtils.toObj(new String(bytes, StandardCharsets.UTF_8), SkillResource.class);
+            if (resource == null) {
+                continue;
+            }
+            if (SKILL_MD_RESOURCE_NAME.equals(resource.getName())) {
+                // Extract name/description/instruction from SKILL.md metadata
+                Map<String, Object> metadata = resource.getMetadata();
+                if (metadata != null) {
+                    skill.setName((String) metadata.get("name"));
+                    skill.setDescription((String) metadata.get("description"));
+                    skill.setInstruction((String) metadata.get("instruction"));
                 }
+            } else {
+                String resourceId = SkillUtils.generateResourceId(resource.getType(), resource.getName());
+                resourceMap.put(resourceId, resource);
             }
         }
+
         skill.setResource(resourceMap);
         return skill;
     }
 
-    private void deleteSkillStorageForVersion(String namespaceId, String skillName, String version) throws NacosException {
-        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(resolveSkillStorageProvider(), namespaceId,
-                skillName, version, NacosConfigAiResourceStorage.getMainFilePath());
-        byte[] mainBytes = storageRouter.route(mainKey).get(mainKey);
-        if (mainBytes != null) {
-            SkillMainConfig mainConfig = JacksonUtils.toObj(new String(mainBytes, StandardCharsets.UTF_8), SkillMainConfig.class);
-            if (mainConfig.getResources() != null && !mainConfig.getResources().isEmpty()) {
-                for (SkillResourceRef resourceRef : mainConfig.getResources()) {
-                    String path = NacosConfigAiResourceStorage.getResourceFilePath(resourceRef.getType(), resourceRef.getName());
-                    StorageKey resourceKey = NacosConfigAiResourceStorage.buildStorageKey(resolveSkillStorageProvider(),
-                            namespaceId, skillName, version, path);
-                    storageRouter.route(resourceKey).delete(resourceKey);
-                }
-            }
+    /**
+     * Delete all storage files for a given skill version using the file list from storageJson.
+     */
+    private void deleteSkillStorageForVersion(String namespaceId, String skillName, String version, String storageJson)
+            throws NacosException {
+        List<String> files = parseStorageFiles(storageJson);
+        if (files == null || files.isEmpty()) {
+            return;
         }
-        storageRouter.route(mainKey).delete(mainKey);
+        String provider = resolveSkillStorageProvider();
+        for (String filePath : files) {
+            StorageKey key = NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId, skillName, version,
+                    filePath);
+            storageRouter.route(key).delete(key);
+        }
     }
 
     private void bumpMetaDescription(String namespaceId, AiResource meta, String description) {
@@ -980,81 +1124,6 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         }
     }
     
-    /**
-     * Skill main config (from skill.json).
-     */
-    private static class SkillMainConfig {
-        private String name;
-        private String description;
-        private String instruction;
-        private Long uniformId;
-        private List<SkillResourceRef> resources;
-        
-        public String getName() {
-            return name;
-        }
-        
-        public void setName(String name) {
-            this.name = name;
-        }
-        
-        public String getDescription() {
-            return description;
-        }
-        
-        public void setDescription(String description) {
-            this.description = description;
-        }
-        
-        public String getInstruction() {
-            return instruction;
-        }
-        
-        public void setInstruction(String instruction) {
-            this.instruction = instruction;
-        }
-        
-        public Long getUniformId() {
-            return uniformId;
-        }
-        
-        public void setUniformId(Long uniformId) {
-            this.uniformId = uniformId;
-        }
-        
-        public List<SkillResourceRef> getResources() {
-            return resources;
-        }
-        
-        public void setResources(List<SkillResourceRef> resources) {
-            this.resources = resources;
-        }
-    }
-    
-    /**
-     * Skill resource reference (in skill.json).
-     */
-    private static class SkillResourceRef {
-        private String name;
-        private String type;
-        
-        public String getName() {
-            return name;
-        }
-        
-        public void setName(String name) {
-            this.name = name;
-        }
-        
-        public String getType() {
-            return type;
-        }
-        
-        public void setType(String type) {
-            this.type = type;
-        }
-    }
-
     private static class SkillVersionInfo {
         private String editingVersion;
         private String reviewingVersion;

--- a/ai/src/main/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorage.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorage.java
@@ -37,7 +37,8 @@ import java.nio.charset.StandardCharsets;
  * Nacos Config based {@link AiResourceStorage} implementation.
  *
  * <p>StorageKey.key format (for Skill resources): {@code namespaceId:skillName:version:filePath}.
- * File path convention: main = {@link #getMainFilePath()}, resources = {@link #getResourceFilePath(String, String)}.</p>
+ * File path convention: resources = {@link #getResourceFilePath(String, String)},
+ * manifest = {@link #buildManifestStorageKey(String, String, String)}.</p>
  */
 public class NacosConfigAiResourceStorage implements AiResourceStorage {
 
@@ -50,7 +51,7 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
      * @param namespaceId namespace
      * @param skillName   skill name
      * @param version     version
-     * @param filePath    file path (use {@link #getMainFilePath()} or {@link #getResourceFilePath(String, String)})
+     * @param filePath    file path (use {@link #getResourceFilePath(String, String)})
      * @return StorageKey for route and save/get/delete
      */
     public static StorageKey buildStorageKey(String provider, String namespaceId, String skillName, String version,
@@ -60,18 +61,25 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
     }
 
     /**
-     * Main skill file path (dataId) for Nacos Config.
-     */
-    public static String getMainFilePath() {
-        return SkillUtils.SKILL_MAIN_DATA_ID;
-    }
-
-    /**
      * Resource file path (dataId) for Nacos Config, from type and name.
      */
     public static String getResourceFilePath(String type, String name) {
         String resourceId = SkillUtils.generateResourceId(type, name);
         return SkillUtils.RESOURCE_DATA_ID_PREFIX + resourceId + SkillUtils.RESOURCE_DATA_ID_SUFFIX;
+    }
+
+    /**
+     * Build StorageKey for skill manifest (index) config. The version part is left blank so the
+     * config group has no version suffix, i.e. group = "skill_{skillName}".
+     *
+     * @param provider    storage provider (e.g. {@link #TYPE})
+     * @param namespaceId namespace
+     * @param skillName   skill name
+     * @return StorageKey for manifest config
+     */
+    public static StorageKey buildManifestStorageKey(String provider, String namespaceId, String skillName) {
+        String key = namespaceId + ":" + skillName + "::" + SkillUtils.SKILL_INDEX_DATA_ID;
+        return new StorageKey(provider, key);
     }
 
     private final ConfigQueryChainService configQueryChainService;
@@ -158,8 +166,9 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
             throw new IllegalArgumentException("StorageKey.key is blank");
         }
         String[] parts = storageKey.getKey().split(":", 4);
+        // parts[2] (version) may be blank for manifest keys
         if (parts.length != 4 || StringUtils.isBlank(parts[0]) || StringUtils.isBlank(parts[1])
-                || StringUtils.isBlank(parts[2]) || StringUtils.isBlank(parts[3])) {
+                || StringUtils.isBlank(parts[3])) {
             throw new IllegalArgumentException(
                     "Invalid StorageKey.key, expected namespaceId:skillName:version:filePath, got: "
                             + storageKey.getKey());
@@ -168,7 +177,12 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
         String skillName = parts[1];
         String version = parts[2];
         String filePath = parts[3];
-        String group = SkillUtils.SKILL_GROUP_PREFIX + skillName + "__" + version;
+        String group;
+        if (StringUtils.isBlank(version)) {
+            group = SkillUtils.buildSkillGroup(skillName);
+        } else {
+            group = SkillUtils.buildSkillVersionGroup(skillName, version);
+        }
         String dataId = filePath;
         return new KeyParts(namespaceId, group, dataId);
     }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/skills/SkillUtils.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/skills/SkillUtils.java
@@ -35,14 +35,14 @@ import java.util.Map;
  * @author nacos
  */
 public class SkillUtils {
-    
+
     private static final String NEWLINE = "\n";
     private static final String EMPTY_STRING = "";
     private static final String COLON = ":";
     private static final String DOUBLE_QUOTE = "\"";
     private static final String SINGLE_QUOTE = "'";
     private static final String ESCAPED_DOUBLE_QUOTE = "\\\"";
-    
+
     /**
      * Strategy for handling existing skill directories.
      */
@@ -51,18 +51,18 @@ public class SkillUtils {
          * Overwrite existing directory (delete and recreate).
          */
         OVERWRITE,
-        
+
         /**
          * Backup existing directory by renaming it with timestamp suffix.
          */
         BACKUP,
-        
+
         /**
          * Throw exception if directory already exists.
          */
         FAIL
     }
-    
+
     /**
      * Convert Skill object to SKILL.md markdown content.
      *
@@ -73,15 +73,15 @@ public class SkillUtils {
         if (skill == null) {
             return EMPTY_STRING;
         }
-        
+
         StringBuilder markdown = new StringBuilder();
-        
+
         // YAML front matter
         markdown.append("---\n");
         markdown.append("name: ").append(escapeYamlValue(skill.getName())).append("\n");
         markdown.append("description: ").append(escapeYamlValue(skill.getDescription())).append("\n");
         markdown.append("---\n\n");
-        
+
         // Instruction content
         if (!StringUtils.isBlank(skill.getInstruction())) {
             String instruction = skill.getInstruction().trim();
@@ -91,10 +91,10 @@ public class SkillUtils {
                 markdown.append(NEWLINE);
             }
         }
-        
+
         return markdown.toString();
     }
-    
+
     /**
      * Escape YAML value to handle special characters.
      * If value contains special characters (colon, quotes, newlines), wrap it in double quotes.
@@ -106,17 +106,17 @@ public class SkillUtils {
         if (value == null) {
             return EMPTY_STRING;
         }
-        
+
         // If value contains special characters, wrap in double quotes
         if (value.contains(COLON) || value.contains(DOUBLE_QUOTE) || value.contains(SINGLE_QUOTE)
             || value.contains(NEWLINE)) {
             // Escape double quotes in the value
             return DOUBLE_QUOTE + value.replace(DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE) + DOUBLE_QUOTE;
         }
-        
+
         return value;
     }
-    
+
     /**
      * Sync Skill object to local directory.
      * Creates the skill directory structure, SKILL.md file, and resource files.
@@ -130,7 +130,7 @@ public class SkillUtils {
     public static void syncToLocal(Skill skill, String baseDir) throws IOException {
         syncToLocal(skill, baseDir, ExistingDirectoryStrategy.OVERWRITE);
     }
-    
+
     /**
      * Sync Skill object to local directory with strategy.
      * Creates the skill directory structure, SKILL.md file, and resource files.
@@ -148,27 +148,27 @@ public class SkillUtils {
         if (skill == null) {
             throw new IllegalArgumentException("Skill cannot be null");
         }
-        
+
         if (StringUtils.isBlank(skill.getName())) {
             throw new IllegalArgumentException("Skill name cannot be blank");
         }
-        
+
         if (StringUtils.isBlank(baseDir)) {
             throw new IllegalArgumentException("Base directory cannot be blank");
         }
-        
+
         if (strategy == null) {
             strategy = ExistingDirectoryStrategy.OVERWRITE;
         }
-        
+
         // Create skill directory path: {baseDir}/{skillName}
         Path basePath = Paths.get(baseDir);
         Path skillDir = basePath.resolve(skill.getName());
-        
+
         // Delegate to core implementation
         syncToLocalCore(skill, skillDir, basePath, strategy);
     }
-    
+
     /**
      * Sync Skill object to local directory with custom skill directory name.
      * Creates the skill directory structure, SKILL.md file, and resource files.
@@ -183,7 +183,7 @@ public class SkillUtils {
     public static void syncToLocal(Skill skill, String baseDir, String skillDirName) throws IOException {
         syncToLocal(skill, baseDir, skillDirName, ExistingDirectoryStrategy.OVERWRITE);
     }
-    
+
     /**
      * Sync Skill object to local directory with custom skill directory name and strategy.
      * Creates the skill directory structure, SKILL.md file, and resource files.
@@ -202,29 +202,29 @@ public class SkillUtils {
         if (skill == null) {
             throw new IllegalArgumentException("Skill cannot be null");
         }
-        
+
         if (StringUtils.isBlank(baseDir)) {
             throw new IllegalArgumentException("Base directory cannot be blank");
         }
-        
+
         if (strategy == null) {
             strategy = ExistingDirectoryStrategy.OVERWRITE;
         }
-        
+
         // Use custom directory name or fall back to skill name
         String dirName = !StringUtils.isBlank(skillDirName) ? skillDirName : skill.getName();
         if (StringUtils.isBlank(dirName)) {
             throw new IllegalArgumentException("Skill directory name cannot be blank");
         }
-        
+
         // Create skill directory path: {baseDir}/{skillDirName}
         Path basePath = Paths.get(baseDir);
         Path skillDir = basePath.resolve(dirName);
-        
+
         // Delegate to core implementation
         syncToLocalCore(skill, skillDir, basePath, strategy);
     }
-    
+
     /**
      * Core implementation for syncing Skill to local directory.
      * This method contains the common logic for all syncToLocal variants.
@@ -243,20 +243,20 @@ public class SkillUtils {
                 throw new FileAlreadyExistsException("Skill directory already exists: " + skillDir);
             }
         }
-        
+
         // Step 2: Create temporary directory and write all files
         String dirName = skillDir.getFileName().toString();
         Path tempSkillDir = basePath.resolve(dirName + ".tmp." + System.currentTimeMillis());
-        
+
         try {
             // Create temporary skill directory
             Files.createDirectories(tempSkillDir);
-            
+
             // Write SKILL.md file
             String markdownContent = toMarkdown(skill);
             Path skillMdPath = tempSkillDir.resolve("SKILL.md");
             Files.write(skillMdPath, markdownContent.getBytes(StandardCharsets.UTF_8));
-            
+
             // Write resource files
             if (skill.getResource() != null && !skill.getResource().isEmpty()) {
                 for (Map.Entry<String, SkillResource> entry : skill.getResource().entrySet()) {
@@ -264,16 +264,16 @@ public class SkillUtils {
                     if (resource == null) {
                         continue;
                     }
-                    
+
                     String resourceName = resource.getName();
                     if (StringUtils.isBlank(resourceName)) {
                         // Use key as resource name if name is blank
                         resourceName = entry.getKey();
                     }
-                    
+
                     String resourceType = resource.getType();
                     String resourceContent = resource.getContent();
-                    
+
                     // Determine resource file path
                     Path resourcePath;
                     if (!StringUtils.isBlank(resourceType)) {
@@ -285,16 +285,16 @@ public class SkillUtils {
                         // Resources without type: {tempSkillDir}/{resourceName}
                         resourcePath = tempSkillDir.resolve(resourceName);
                     }
-                    
+
                     // Write resource content (use empty string if content is null)
                     String content = resourceContent != null ? resourceContent : "";
                     Files.write(resourcePath, content.getBytes(StandardCharsets.UTF_8));
                 }
             }
-            
+
             // Step 3: All files written successfully, now handle final directory
             boolean oldDirExists = Files.exists(skillDir) && Files.isDirectory(skillDir);
-            
+
             if (!oldDirExists) {
                 // Old directory doesn't exist, directly rename temp directory to final directory
                 Files.move(tempSkillDir, skillDir, StandardCopyOption.ATOMIC_MOVE);
@@ -303,10 +303,10 @@ public class SkillUtils {
                 // Step 3.1: Rename old directory to backup directory
                 Path backupDir = createBackupDirectoryPath(skillDir);
                 Files.move(skillDir, backupDir, StandardCopyOption.ATOMIC_MOVE);
-                
+
                 // Step 3.2: Rename temp directory to final directory
                 Files.move(tempSkillDir, skillDir, StandardCopyOption.ATOMIC_MOVE);
-                
+
                 // Step 3.3: Handle backup directory based on strategy
                 if (strategy == ExistingDirectoryStrategy.OVERWRITE) {
                     // Delete backup directory
@@ -314,7 +314,7 @@ public class SkillUtils {
                 }
                 // If strategy is BACKUP, keep the backup directory (do nothing)
             }
-            
+
         } catch (Exception e) {
             // Clean up temporary directory on failure
             if (Files.exists(tempSkillDir)) {
@@ -327,7 +327,7 @@ public class SkillUtils {
             throw e;
         }
     }
-    
+
     /**
      * Create backup directory path with timestamp suffix.
      * If backup directory already exists, append counter to ensure uniqueness.
@@ -339,7 +339,7 @@ public class SkillUtils {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
         String timestamp = dateFormat.format(new Date());
         Path backupDir = skillDir.getParent().resolve(skillDir.getFileName().toString() + ".backup." + timestamp);
-        
+
         // If backup directory already exists, append counter
         int counter = 1;
         Path finalBackupDir = backupDir;
@@ -348,10 +348,10 @@ public class SkillUtils {
                     skillDir.getFileName().toString() + ".backup." + timestamp + "." + counter);
             counter++;
         }
-        
+
         return finalBackupDir;
     }
-    
+
     /**
      * Recursively delete a directory and all its contents.
      *
@@ -362,7 +362,7 @@ public class SkillUtils {
         if (!Files.exists(directory)) {
             return;
         }
-        
+
         // Delete files before directories
         Files.walk(directory)
                 .sorted((a, b) -> b.compareTo(a))
@@ -374,51 +374,63 @@ public class SkillUtils {
                     }
                 });
     }
-    
+
     /**
      * Main config dataId for skill.
+     *
+     * @deprecated No longer used. Replaced by {@link #SKILL_INDEX_DATA_ID} for the manifest
+     *             and versioned resource files for content.
      */
+    @Deprecated
     public static final String SKILL_MAIN_DATA_ID = "skill.json";
-    
+
     /**
      * Resource config dataId prefix.
      */
     public static final String RESOURCE_DATA_ID_PREFIX = "resource_";
-    
+
     /**
      * Resource config dataId suffix.
      */
     public static final String RESOURCE_DATA_ID_SUFFIX = ".json";
-    
+
     /**
      * Skill group prefix.
      */
     public static final String SKILL_GROUP_PREFIX = "skill_";
-    
-    private static final String DOUBLE_UNDERSCORE = "__";
-    private static final String FILE_EXTENSION_PATTERN = ".*\\.[a-zA-Z0-9]+$";
-    
+
     /**
-     * Configuration info containing dataId and group.
+     * Skill index config dataId for client-side config caching.
+     * Server writes a manifest config with this dataId at group {@code skill_{name}}
+     * containing the current online version and file list.
      */
-    public static class ConfigInfo {
-        private final String dataId;
-        private final String group;
-        
-        public ConfigInfo(String dataId, String group) {
-            this.dataId = dataId;
-            this.group = group;
-        }
-        
-        public String getDataId() {
-            return dataId;
-        }
-        
-        public String getGroup() {
-            return group;
-        }
+    public static final String SKILL_INDEX_DATA_ID = "skill_index.json";
+
+    private static final String DOUBLE_UNDERSCORE = "__";
+
+    /**
+     * Build the Nacos Config group for a skill (no version suffix).
+     *
+     * @param skillName name of skill
+     * @return config group string, e.g. "skill_myskill"
+     */
+    public static String buildSkillGroup(String skillName) {
+        return SKILL_GROUP_PREFIX + skillName;
     }
-    
+
+    /**
+     * Build the Nacos Config group for a specific skill version.
+     *
+     * @param skillName name of skill
+     * @param version   version string, e.g. "v1"
+     * @return config group string, e.g. "skill_myskill__v1"
+     */
+    public static String buildSkillVersionGroup(String skillName, String version) {
+        return SKILL_GROUP_PREFIX + skillName + DOUBLE_UNDERSCORE + version;
+    }
+
+    private static final String FILE_EXTENSION_PATTERN = ".*\\.[a-zA-Z0-9]+$";
+
     /**
      * Generate resource ID from resource type and name.
      * Format: {type}_{resourcename}
@@ -433,7 +445,7 @@ public class SkillUtils {
         if (resourceName == null || resourceName.trim().isEmpty()) {
             return "";
         }
-        
+
         // If resourcename ends with .xx, convert the last . to __
         String processedName = resourceName;
         if (resourceName.matches(FILE_EXTENSION_PATTERN)) {
@@ -444,7 +456,7 @@ public class SkillUtils {
                     + resourceName.substring(lastDotIndex + 1);
             }
         }
-        
+
         if (type != null && !type.trim().isEmpty()) {
             // Encode / as . so dataId has no slash (Nacos config key compatibility)
             String safeType = type.trim().replace("/", ".");
@@ -452,45 +464,5 @@ public class SkillUtils {
         } else {
             return processedName;
         }
-    }
-    
-    /**
-     * Build skill main config info (dataId and group).
-     * This is the unified method for building main config mapping.
-     *
-     * @param skillName name of skill
-     * @return ConfigInfo containing dataId and group
-     * @throws IllegalArgumentException if skillName is blank
-     */
-    public static ConfigInfo buildSkillMainConfigInfo(String skillName) {
-        if (StringUtils.isBlank(skillName)) {
-            throw new IllegalArgumentException("Skill name cannot be blank");
-        }
-        return new ConfigInfo(SKILL_MAIN_DATA_ID, SKILL_GROUP_PREFIX + skillName);
-    }
-    
-    /**
-     * Build skill resource config info (dataId and group).
-     * This is the unified method for building resource config mapping.
-     *
-     * @param skillName name of skill
-     * @param type resource type (can be null or empty)
-     * @param resourceName resource name
-     * @return ConfigInfo containing dataId and group
-     * @throws IllegalArgumentException if skillName or resourceName is blank
-     */
-    public static ConfigInfo buildSkillResourceConfigInfo(String skillName, String type, String resourceName) {
-        if (StringUtils.isBlank(skillName)) {
-            throw new IllegalArgumentException("Skill name cannot be blank");
-        }
-        if (StringUtils.isBlank(resourceName)) {
-            throw new IllegalArgumentException("Resource name cannot be blank");
-        }
-        
-        String resourceId = generateResourceId(type, resourceName);
-        String dataId = RESOURCE_DATA_ID_PREFIX + resourceId + RESOURCE_DATA_ID_SUFFIX;
-        String group = SKILL_GROUP_PREFIX + skillName;
-        
-        return new ConfigInfo(dataId, group);
     }
 }

--- a/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
@@ -36,12 +36,9 @@ import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
 import com.alibaba.nacos.api.ai.model.prompt.Prompt;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
-import com.alibaba.nacos.api.ai.model.skills.SkillResource;
-import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
-import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.naming.pojo.Instance;
@@ -59,19 +56,16 @@ import com.alibaba.nacos.client.ai.event.SkillListenerInvoker;
 import com.alibaba.nacos.client.ai.remote.AiClientProxy;
 import com.alibaba.nacos.client.ai.remote.AiGrpcClient;
 import com.alibaba.nacos.client.ai.remote.AiHttpClientProxy;
+import com.alibaba.nacos.client.config.NacosConfigService;
 import com.alibaba.nacos.client.env.NacosClientProperties;
 import com.alibaba.nacos.client.utils.ClientBasicParamUtil;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.common.notify.NotifyCenter;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import org.slf4j.Logger;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -100,25 +94,26 @@ public class NacosAiService implements AiService {
     
     private final AiChangeNotifier aiChangeNotifier;
     
-    private final ConfigService configService;
+    private final ConfigService skillConfigService;
     
     public NacosAiService(Properties properties) throws NacosException {
         NacosClientProperties clientProperties = NacosClientProperties.PROTOTYPE.derive(properties);
         LOGGER.info(ClientBasicParamUtil.getInputParameters(clientProperties.asProperties()));
         this.namespaceId = initNamespace(clientProperties);
-        this.configService = NacosFactory.createConfigService(clientProperties.asProperties());
         this.grpcClient = new AiGrpcClient(namespaceId, clientProperties);
         String transportMode = clientProperties.getProperty(AiConstants.AI_TRANSPORT_MODE,
                 AiConstants.AI_TRANSPORT_MODE_GRPC);
         if (AiConstants.AI_TRANSPORT_MODE_HTTP.equalsIgnoreCase(transportMode)) {
             LOGGER.info("AI transport mode is HTTP, using AiHttpClientProxy for prompt operations.");
-            this.aiClientProxy = new AiHttpClientProxy(namespaceId, clientProperties);
+            AiHttpClientProxy httpProxy = new AiHttpClientProxy(namespaceId, clientProperties);
+            this.aiClientProxy = httpProxy;
         } else {
             this.aiClientProxy = this.grpcClient;
         }
+        this.skillConfigService = new NacosConfigService(properties);
         this.mcpServerCacheHolder = new NacosMcpServerCacheHolder(grpcClient, clientProperties);
         this.agentCardCacheHolder = new NacosAgentCardCacheHolder(grpcClient, clientProperties);
-        this.skillCacheHolder = new NacosSkillCacheHolder(configService, this.namespaceId);
+        this.skillCacheHolder = new NacosSkillCacheHolder(this.skillConfigService, this.namespaceId);
         this.promptCacheHolder = new NacosPromptCacheHolder(this.aiClientProxy, clientProperties);
         this.aiChangeNotifier = new AiChangeNotifier();
         start();
@@ -369,141 +364,7 @@ public class NacosAiService implements AiService {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "Required parameter `skillName` not present");
         }
-        
-        // Build main config info
-        SkillUtils.ConfigInfo mainConfigInfo = SkillUtils.buildSkillMainConfigInfo(skillName);
-        
-        // Query main config (skill.json)
-        String mainConfigContent;
-        try {
-            mainConfigContent = configService.getConfig(mainConfigInfo.getDataId(), mainConfigInfo.getGroup(), 3000);
-        } catch (NacosException e) {
-            throw new NacosException(NacosException.NOT_FOUND,
-                    "Skill main configuration not found for skillName: " + skillName + ", error: " + e.getMessage());
-        }
-        
-        if (StringUtils.isBlank(mainConfigContent)) {
-            throw new NacosException(NacosException.NOT_FOUND,
-                    "Skill main configuration not found for skillName: " + skillName);
-        }
-        
-        // Parse main config
-        SkillMainConfig mainConfig;
-        try {
-            mainConfig = JacksonUtils.toObj(mainConfigContent, SkillMainConfig.class);
-        } catch (Exception e) {
-            throw new NacosException(NacosException.SERVER_ERROR,
-                    "Failed to parse  skill main configuration: " + e.getMessage(), e);
-        }
-        
-        // Build Skill object
-        Skill skill = new Skill();
-        skill.setNamespaceId(this.namespaceId);
-        skill.setName(mainConfig.getName());
-        skill.setDescription(mainConfig.getDescription());
-        skill.setInstruction(mainConfig.getInstruction());
-        
-        // Query all Resource configs
-        Map<String, SkillResource> resourceMap = new HashMap<>(
-                mainConfig.getResources() != null ? mainConfig.getResources().size() : 16);
-        if (mainConfig.getResources() != null && !mainConfig.getResources().isEmpty()) {
-            for (SkillResourceRef resourceRef : mainConfig.getResources()) {
-                // Generate resourceId from type and name
-                String resourceId = SkillUtils.generateResourceId(resourceRef.getType(), resourceRef.getName());
-                
-                // Query resource config using resourceRef info
-                SkillUtils.ConfigInfo resourceConfigInfo = SkillUtils.buildSkillResourceConfigInfo(
-                        skillName, resourceRef.getType(), resourceRef.getName());
-                String resourceContent;
-                try {
-                    resourceContent = configService.getConfig(resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), 3000);
-                } catch (NacosException e) {
-                    LOGGER.warn("Resource configuration not found: dataId={}, group={}, error={}",
-                            resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), e.getMessage());
-                    continue;
-                }
-                
-                if (StringUtils.isNotBlank(resourceContent)) {
-                    try {
-                        SkillResource resource = JacksonUtils.toObj(resourceContent, SkillResource.class);
-                        // Use resource name as key (from resource object, not resourceId)
-                        resourceMap.put(resource.getName() != null ? resource.getName() : resourceId, resource);
-                    } catch (Exception e) {
-                        LOGGER.warn("Failed to parse resource configuration: dataId={}, group={}, error={}",
-                                resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), e.getMessage());
-                    }
-                }
-            }
-        }
-        skill.setResource(resourceMap);
-        
-        return skill;
-    }
-    
-    /**
-     * Skill main config (from skill.json).
-     */
-    private static class SkillMainConfig {
-        private String name;
-        private String description;
-        private String instruction;
-        private List<SkillResourceRef> resources;
-        
-        public String getName() {
-            return name;
-        }
-        
-        public void setName(String name) {
-            this.name = name;
-        }
-        
-        public String getDescription() {
-            return description;
-        }
-        
-        public void setDescription(String description) {
-            this.description = description;
-        }
-        
-        public String getInstruction() {
-            return instruction;
-        }
-        
-        public void setInstruction(String instruction) {
-            this.instruction = instruction;
-        }
-        
-        public List<SkillResourceRef> getResources() {
-            return resources;
-        }
-        
-        public void setResources(List<SkillResourceRef> resources) {
-            this.resources = resources;
-        }
-    }
-    
-    /**
-     * Skill resource reference (in skill.json).
-     */
-    private static class SkillResourceRef {
-        private String name;
-        private String type;
-        
-        public String getName() {
-            return name;
-        }
-        
-        public void setName(String name) {
-            this.name = name;
-        }
-        
-        public String getType() {
-            return type;
-        }
-        
-        public void setType(String type) {
-            this.type = type;
-        }
+        return skillCacheHolder.querySkill(skillName);
     }
     
     @Override
@@ -622,6 +483,7 @@ public class NacosAiService implements AiService {
         if (this.aiClientProxy != this.grpcClient) {
             this.aiClientProxy.shutdown();
         }
+        this.skillConfigService.shutDown();
         this.mcpServerCacheHolder.shutdown();
         this.skillCacheHolder.shutdown();
         this.promptCacheHolder.shutdown();

--- a/client/src/main/java/com/alibaba/nacos/client/ai/cache/NacosSkillCacheHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/cache/NacosSkillCacheHolder.java
@@ -18,12 +18,10 @@ package com.alibaba.nacos.client.ai.cache;
 
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillResource;
+import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.config.listener.Listener;
 import com.alibaba.nacos.api.exception.NacosException;
-
-import java.util.concurrent.Executor;
-import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
 import com.alibaba.nacos.client.ai.event.SkillChangedEvent;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.common.lifecycle.Closeable;
@@ -39,31 +37,40 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.slf4j.Logger;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 
 /**
  * Nacos AI module skill cache holder.
  *
+ * <p>Reads skill data from Nacos Config via {@link ConfigService}, leveraging its local cache
+ * and push notifications for real-time updates. The server writes a manifest config
+ * ({@code skill_index.json}) at group {@code skill_{name}} containing the current online
+ * version and file list. Each resource file is stored under group {@code skill_{name}__{version}}
+ * with the file path as dataId.</p>
+ *
  * @author nacos
  */
 public class NacosSkillCacheHolder implements Closeable {
-    
+
     private static final Logger LOGGER = LogUtils.logger(NacosSkillCacheHolder.class);
-    
+
+    private static final String SKILL_MD_RESOURCE_NAME = "SKILL.md";
+
+    private static final long CONFIG_TIMEOUT = 3000L;
+
     private final ConfigService configService;
-    
+
     private final String namespaceId;
-    
+
     private final Map<String, Skill> skillCache;
-    
+
     private final Map<String, SkillSubscriptionInfo> subscriptionMap;
-    
+
     private final ObjectMapper objectMapper;
-    
+
     public NacosSkillCacheHolder(ConfigService configService, String namespaceId) {
         this.configService = configService;
         this.namespaceId = namespaceId;
@@ -73,9 +80,20 @@ public class NacosSkillCacheHolder implements Closeable {
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
-    
+
     /**
-     * Subscribe skill and start listening for configuration changes.
+     * Load skill from Nacos Config (leverages ConfigService local cache).
+     *
+     * @param skillName name of skill
+     * @return Skill object, null if skill not found or manifest missing
+     * @throws NacosException if error occurs
+     */
+    public Skill querySkill(String skillName) throws NacosException {
+        return loadSkillFromConfig(skillName);
+    }
+
+    /**
+     * Subscribe to skill changes via Nacos Config listeners.
      *
      * @param skillName name of skill
      * @return current Skill object, nullable if skill not found
@@ -86,67 +104,50 @@ public class NacosSkillCacheHolder implements Closeable {
             throw new NacosException(NacosException.INVALID_PARAM,
                     "Required parameter `skillName` not present");
         }
-        
-        // Check if already subscribed
+
         if (subscriptionMap.containsKey(skillName)) {
             return skillCache.get(skillName);
         }
-        
-        // Load skill initially
-        Skill skill = loadSkill(skillName);
-        
-        // Create subscription info
-        SkillSubscriptionInfo subscriptionInfo = new SkillSubscriptionInfo(skillName);
-        subscriptionInfo.setCurrentSkill(skill);
-        
-        // Build main config info
-        SkillUtils.ConfigInfo mainConfigInfo = SkillUtils.buildSkillMainConfigInfo(skillName);
-        
-        // Add listener for main config
-        Listener mainConfigListener = new SkillConfigListener(skillName, true, null);
-        try {
-            configService.addListener(mainConfigInfo.getDataId(), mainConfigInfo.getGroup(), mainConfigListener);
-            subscriptionInfo.setMainConfigListener(mainConfigListener);
-        } catch (NacosException e) {
-            LOGGER.warn("Failed to add listener for main config: skillName={}, error={}", skillName, e.getMessage());
-        }
-        
-        // Add listeners for all resource configs
-        if (skill != null && skill.getResource() != null && !skill.getResource().isEmpty()) {
-            // Load main config to get resourceId mapping
-            SkillMainConfig mainConfig = loadMainConfig(skillName, mainConfigInfo.getGroup());
-            if (mainConfig != null && mainConfig.getResources() != null && !mainConfig.getResources().isEmpty()) {
-                for (SkillResourceRef resourceRef : mainConfig.getResources()) {
-                    // Generate resourceId from type and name
-                    String resourceId = SkillUtils.generateResourceId(resourceRef.getType(), resourceRef.getName());
-                    
-                    // Build resource config info using resourceRef
-                    SkillUtils.ConfigInfo resourceConfigInfo = SkillUtils.buildSkillResourceConfigInfo(
-                            skillName, resourceRef.getType(), resourceRef.getName());
-                    Listener resourceListener = new SkillConfigListener(skillName, false, resourceId);
-                    try {
-                        configService.addListener(resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), resourceListener);
-                        subscriptionInfo.getResourceListeners().put(resourceId, resourceListener);
-                    } catch (NacosException e) {
-                        LOGGER.warn("Failed to add listener for resource config: skillName={}, resourceId={}, error={}",
-                                skillName, resourceId, e.getMessage());
-                    }
-                }
-            }
-        }
-        
-        // Cache skill and subscription info
+
+        // Initial load
+        Skill skill = loadSkillFromConfig(skillName);
         if (skill != null) {
             skillCache.put(skillName, skill);
         }
-        subscriptionMap.put(skillName, subscriptionInfo);
-        
-        LOGGER.info("Subscribed skill: {}", skillName);
+
+        // Set up subscription
+        SkillSubscriptionInfo sub = new SkillSubscriptionInfo(skillName);
+        subscriptionMap.put(skillName, sub);
+
+        SkillIndex index = loadSkillIndex(skillName);
+        if (index != null && index.files != null) {
+            sub.currentVersion = index.version;
+            sub.currentFiles = index.files;
+            subscribeResources(sub, index);
+        }
+
+        // Listen to manifest for version changes
+        Listener manifestListener = new Listener() {
+            @Override
+            public Executor getExecutor() {
+                return null;
+            }
+
+            @Override
+            public void receiveConfigInfo(String configInfo) {
+                onManifestChanged(skillName, configInfo);
+            }
+        };
+        sub.manifestListener = manifestListener;
+        configService.addListener(SkillUtils.SKILL_INDEX_DATA_ID,
+                SkillUtils.buildSkillGroup(skillName), manifestListener);
+
+        LOGGER.info("Subscribed skill via config: {}", skillName);
         return skill;
     }
-    
+
     /**
-     * Unsubscribe skill and remove all listeners.
+     * Unsubscribe from skill changes.
      *
      * @param skillName name of skill
      */
@@ -154,287 +155,186 @@ public class NacosSkillCacheHolder implements Closeable {
         if (StringUtils.isBlank(skillName)) {
             return;
         }
-        
-        SkillSubscriptionInfo subscriptionInfo = subscriptionMap.remove(skillName);
-        if (subscriptionInfo == null) {
-            return;
-        }
-        
-        // Build main config info
-        SkillUtils.ConfigInfo mainConfigInfo = SkillUtils.buildSkillMainConfigInfo(skillName);
-        
-        // Remove main config listener
-        if (subscriptionInfo.getMainConfigListener() != null) {
-            try {
-                configService.removeListener(mainConfigInfo.getDataId(), mainConfigInfo.getGroup(), 
-                        subscriptionInfo.getMainConfigListener());
-            } catch (Exception e) {
-                LOGGER.warn("Failed to remove listener for main config: skillName={}, error={}", skillName, e.getMessage());
+
+        SkillSubscriptionInfo sub = subscriptionMap.remove(skillName);
+        if (sub != null) {
+            if (sub.manifestListener != null) {
+                configService.removeListener(SkillUtils.SKILL_INDEX_DATA_ID,
+                        SkillUtils.buildSkillGroup(skillName), sub.manifestListener);
             }
+            unsubscribeResources(sub);
         }
-        
-        // Remove all resource config listeners
-        // Note: We need to load mainConfig to get resourceRef info for building ConfigInfo
-        SkillMainConfig mainConfig = loadMainConfig(skillName, mainConfigInfo.getGroup());
-        if (mainConfig != null && mainConfig.getResources() != null) {
-            Map<String, SkillResourceRef> resourceRefMap = new HashMap<>(
-                    mainConfig.getResources().size() > 0 ? (int) (mainConfig.getResources().size() / 0.75f + 1) : 16);
-            for (SkillResourceRef resourceRef : mainConfig.getResources()) {
-                String resourceId = SkillUtils.generateResourceId(resourceRef.getType(), resourceRef.getName());
-                resourceRefMap.put(resourceId, resourceRef);
-            }
-            for (Map.Entry<String, Listener> entry : subscriptionInfo.getResourceListeners().entrySet()) {
-                String resourceId = entry.getKey();
-                Listener listener = entry.getValue();
-                SkillResourceRef resourceRef = resourceRefMap.get(resourceId);
-                if (resourceRef != null) {
-                    SkillUtils.ConfigInfo resourceConfigInfo = SkillUtils.buildSkillResourceConfigInfo(
-                            skillName, resourceRef.getType(), resourceRef.getName());
-                    try {
-                        configService.removeListener(resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), listener);
-                    } catch (Exception e) {
-                        LOGGER.warn("Failed to remove listener for resource config: skillName={}, resourceId={}, error={}",
-                                skillName, resourceId, e.getMessage());
-                    }
-                }
-            }
-        }
-        
-        // Clear cache
         skillCache.remove(skillName);
-        
+
         LOGGER.info("Unsubscribed skill: {}", skillName);
     }
-    
-    /**
-     * Load skill from configuration.
-     *
-     * @param skillName name of skill
-     * @return Skill object, nullable if skill not found
-     */
-    private Skill loadSkill(String skillName) {
-        // Build main config info
-        SkillUtils.ConfigInfo mainConfigInfo = SkillUtils.buildSkillMainConfigInfo(skillName);
-        
-        // Load main config
-        SkillMainConfig mainConfig = loadMainConfig(skillName, mainConfigInfo.getGroup());
-        if (mainConfig == null) {
-            return null;
-        }
-        
-        // Build Skill object
-        Skill skill = new Skill();
-        skill.setNamespaceId(this.namespaceId);
-        skill.setName(mainConfig.getName());
-        skill.setDescription(mainConfig.getDescription());
-        skill.setInstruction(mainConfig.getInstruction());
-        
-        // Query all Resource configs
-        Map<String, SkillResource> resourceMap = new HashMap<>(
-                mainConfig.getResources() != null ? mainConfig.getResources().size() : 16);
-        if (mainConfig.getResources() != null && !mainConfig.getResources().isEmpty()) {
-            for (SkillResourceRef resourceRef : mainConfig.getResources()) {
-                // Generate resourceId from type and name
-                String resourceId = SkillUtils.generateResourceId(resourceRef.getType(), resourceRef.getName());
-                
-                // Query resource config using resourceRef info
-                SkillUtils.ConfigInfo resourceConfigInfo = SkillUtils.buildSkillResourceConfigInfo(
-                        skillName, resourceRef.getType(), resourceRef.getName());
-                String resourceContent;
-                try {
-                    resourceContent = configService.getConfig(resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), 3000);
-                } catch (NacosException e) {
-                    LOGGER.warn("Resource configuration not found: dataId={}, group={}, error={}",
-                            resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), e.getMessage());
-                    continue;
-                }
-                
-                if (StringUtils.isNotBlank(resourceContent)) {
-                    try {
-                        SkillResource resource = JacksonUtils.toObj(resourceContent, SkillResource.class);
-                        // Use resource name as key (from resource object, not resourceId)
-                        resourceMap.put(resource.getName() != null ? resource.getName() : resourceId, resource);
-                    } catch (Exception e) {
-                        LOGGER.warn("Failed to parse resource configuration: dataId={}, group={}, error={}",
-                                resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), e.getMessage());
-                    }
-                }
-            }
-        }
-        skill.setResource(resourceMap);
-        
-        return skill;
-    }
-    
-    /**
-     * Load main config from configuration.
-     *
-     * @param skillName name of skill
-     * @param skillGroup group of skill
-     * @return SkillMainConfig object, nullable if not found
-     */
-    private SkillMainConfig loadMainConfig(String skillName, String skillGroup) {
-        // Query main config (skill.json)
-        SkillUtils.ConfigInfo mainConfigInfo = SkillUtils.buildSkillMainConfigInfo(skillName);
-        String mainConfigContent;
-        try {
-            mainConfigContent = configService.getConfig(mainConfigInfo.getDataId(), skillGroup, 3000);
-        } catch (NacosException e) {
-            LOGGER.warn("Skill main configuration not found: skillName={}, error={}", skillName, e.getMessage());
-            return null;
-        }
-        
-        if (StringUtils.isBlank(mainConfigContent)) {
-            LOGGER.warn("Skill main configuration is blank: skillName={}", skillName);
-            return null;
-        }
-        
-        // Parse main config
-        try {
-            return JacksonUtils.toObj(mainConfigContent, SkillMainConfig.class);
-        } catch (Exception e) {
-            LOGGER.warn("Failed to parse skill main configuration: skillName={}, error={}", skillName, e.getMessage());
-            return null;
+
+    @Override
+    public void shutdown() throws NacosException {
+        for (String skillName : new java.util.HashSet<>(subscriptionMap.keySet())) {
+            unsubscribeSkill(skillName);
         }
     }
-    
-    /**
-     * Reload skill and check for changes.
-     *
-     * @param skillName name of skill
-     */
-    private void reloadSkill(String skillName) {
+
+    // ======================== Private methods ========================
+
+    private void onManifestChanged(String skillName, String configInfo) {
         try {
-            SkillSubscriptionInfo subscriptionInfo = subscriptionMap.get(skillName);
-            if (subscriptionInfo == null) {
+            SkillSubscriptionInfo sub = subscriptionMap.get(skillName);
+            if (sub == null) {
                 return;
             }
-            
-            Skill oldSkill = subscriptionInfo.getCurrentSkill();
-            Skill newSkill = loadSkill(skillName);
-            
+
+            SkillIndex newIndex = parseSkillIndex(configInfo);
+            String newVersion = newIndex != null ? newIndex.version : null;
+
+            if (!StringUtils.equals(sub.currentVersion, newVersion)) {
+                LOGGER.info("Skill {} manifest version changed: {} -> {}", skillName,
+                        sub.currentVersion, newVersion);
+                unsubscribeResources(sub);
+                if (newIndex != null && newIndex.files != null) {
+                    sub.currentVersion = newIndex.version;
+                    sub.currentFiles = newIndex.files;
+                    subscribeResources(sub, newIndex);
+                } else {
+                    sub.currentVersion = null;
+                    sub.currentFiles = null;
+                }
+            }
+
+            reloadAndPublish(skillName);
+        } catch (Exception e) {
+            LOGGER.error("Failed to handle manifest change for skill: {}", skillName, e);
+        }
+    }
+
+    private void onResourceChanged(String skillName) {
+        reloadAndPublish(skillName);
+    }
+
+    private void reloadAndPublish(String skillName) {
+        try {
+            Skill oldSkill = skillCache.get(skillName);
+            Skill newSkill = loadSkillFromConfig(skillName);
+
             if (isSkillChanged(oldSkill, newSkill)) {
-                LOGGER.info("Skill {} changed.", skillName);
-                subscriptionInfo.setCurrentSkill(newSkill);
+                LOGGER.info("Skill {} changed, publishing event.", skillName);
                 if (newSkill != null) {
                     skillCache.put(skillName, newSkill);
                 } else {
                     skillCache.remove(skillName);
                 }
-                
-                // Update resource listeners if resource list changed
-                updateResourceListeners(skillName, oldSkill, newSkill);
-                
-                // Publish change event
                 NotifyCenter.publishEvent(new SkillChangedEvent(skillName, newSkill));
             }
         } catch (Exception e) {
-            LOGGER.error("Failed to reload skill: skillName={}, error={}", skillName, e.getMessage(), e);
+            LOGGER.error("Failed to reload skill: {}", skillName, e);
         }
     }
-    
-    /**
-     * Update resource listeners based on resource list changes.
-     *
-     * @param skillName name of skill
-     * @param oldSkill  old skill object
-     * @param newSkill  new skill object
-     */
-    private void updateResourceListeners(String skillName, Skill oldSkill, Skill newSkill) {
-        SkillSubscriptionInfo subscriptionInfo = subscriptionMap.get(skillName);
-        if (subscriptionInfo == null) {
+
+    private Skill loadSkillFromConfig(String skillName) throws NacosException {
+        SkillIndex index = loadSkillIndex(skillName);
+        if (index == null || StringUtils.isBlank(index.version) || index.files == null || index.files.isEmpty()) {
+            return null;
+        }
+
+        String versionGroup = SkillUtils.buildSkillVersionGroup(skillName, index.version);
+        Skill skill = new Skill();
+        skill.setNamespaceId(namespaceId);
+        Map<String, SkillResource> resourceMap = new HashMap<>(index.files.size());
+
+        for (String filePath : index.files) {
+            String content = configService.getConfig(filePath, versionGroup, CONFIG_TIMEOUT);
+            if (StringUtils.isBlank(content)) {
+                continue;
+            }
+            SkillResource resource = JacksonUtils.toObj(content, SkillResource.class);
+            if (resource == null) {
+                continue;
+            }
+
+            if (SKILL_MD_RESOURCE_NAME.equals(resource.getName())) {
+                Map<String, Object> metadata = resource.getMetadata();
+                if (metadata != null) {
+                    skill.setName((String) metadata.get("name"));
+                    skill.setDescription((String) metadata.get("description"));
+                    skill.setInstruction((String) metadata.get("instruction"));
+                }
+            } else {
+                String resourceId = SkillUtils.generateResourceId(resource.getType(), resource.getName());
+                resourceMap.put(resourceId, resource);
+            }
+        }
+
+        skill.setResource(resourceMap);
+        return skill;
+    }
+
+    private SkillIndex loadSkillIndex(String skillName) throws NacosException {
+        String group = SkillUtils.buildSkillGroup(skillName);
+        String indexContent = configService.getConfig(SkillUtils.SKILL_INDEX_DATA_ID, group, CONFIG_TIMEOUT);
+        return parseSkillIndex(indexContent);
+    }
+
+    private static SkillIndex parseSkillIndex(String json) {
+        if (StringUtils.isBlank(json)) {
+            return null;
+        }
+        try {
+            return JacksonUtils.toObj(json, SkillIndex.class);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse skill index: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private void subscribeResources(SkillSubscriptionInfo sub, SkillIndex index) {
+        if (index.files == null || index.files.isEmpty() || StringUtils.isBlank(index.version)) {
             return;
         }
-        
-        SkillUtils.ConfigInfo mainConfigInfo = SkillUtils.buildSkillMainConfigInfo(skillName);
-        
-        // Load main configs to get resourceId mappings
-        SkillMainConfig oldMainConfig = oldSkill != null ? loadMainConfig(skillName, mainConfigInfo.getGroup()) : null;
-        SkillMainConfig newMainConfig = newSkill != null ? loadMainConfig(skillName, mainConfigInfo.getGroup()) : null;
-        
-        int oldResourceSize = oldMainConfig != null && oldMainConfig.getResources() != null 
-                ? oldMainConfig.getResources().size() : 0;
-        int newResourceSize = newMainConfig != null && newMainConfig.getResources() != null 
-                ? newMainConfig.getResources().size() : 0;
-        
-        Set<String> oldResourceIds = new HashSet<>(oldResourceSize > 0 ? (int) (oldResourceSize / 0.75f + 1) : 16);
-        Map<String, SkillResourceRef> oldResourceRefMap = new HashMap<>(
-                oldResourceSize > 0 ? (int) (oldResourceSize / 0.75f + 1) : 16);
-        if (oldMainConfig != null && oldMainConfig.getResources() != null) {
-            for (SkillResourceRef ref : oldMainConfig.getResources()) {
-                String resourceId = SkillUtils.generateResourceId(ref.getType(), ref.getName());
-                oldResourceIds.add(resourceId);
-                oldResourceRefMap.put(resourceId, ref);
-            }
-        }
-        Set<String> newResourceIds = new HashSet<>(newResourceSize > 0 ? (int) (newResourceSize / 0.75f + 1) : 16);
-        Map<String, SkillResourceRef> newResourceRefMap = new HashMap<>(
-                newResourceSize > 0 ? (int) (newResourceSize / 0.75f + 1) : 16);
-        if (newMainConfig != null && newMainConfig.getResources() != null) {
-            for (SkillResourceRef ref : newMainConfig.getResources()) {
-                String resourceId = SkillUtils.generateResourceId(ref.getType(), ref.getName());
-                newResourceIds.add(resourceId);
-                newResourceRefMap.put(resourceId, ref);
-            }
-        }
-        
-        // Remove listeners for deleted resources
-        Set<String> toRemove = new HashSet<>(oldResourceIds);
-        toRemove.removeAll(newResourceIds);
-        for (String resourceId : toRemove) {
-            Listener listener = subscriptionInfo.getResourceListeners().remove(resourceId);
-            if (listener != null) {
-                SkillResourceRef resourceRef = oldResourceRefMap.get(resourceId);
-                if (resourceRef != null) {
-                    SkillUtils.ConfigInfo resourceConfigInfo = SkillUtils.buildSkillResourceConfigInfo(
-                            skillName, resourceRef.getType(), resourceRef.getName());
-                    try {
-                        configService.removeListener(resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), listener);
-                    } catch (Exception e) {
-                        LOGGER.warn("Failed to remove listener for deleted resource: skillName={}, resourceId={}, error={}",
-                                skillName, resourceId, e.getMessage());
-                    }
+        String versionGroup = SkillUtils.buildSkillVersionGroup(sub.skillName, index.version);
+        sub.resourceGroup = versionGroup;
+        for (String filePath : index.files) {
+            Listener listener = new Listener() {
+                @Override
+                public Executor getExecutor() {
+                    return null;
                 }
-            }
-        }
-        
-        // Add listeners for new resources
-        Set<String> toAdd = new HashSet<>(newResourceIds);
-        toAdd.removeAll(oldResourceIds);
-        for (String resourceId : toAdd) {
-            SkillResourceRef resourceRef = newResourceRefMap.get(resourceId);
-            if (resourceRef != null) {
-                SkillUtils.ConfigInfo resourceConfigInfo = SkillUtils.buildSkillResourceConfigInfo(
-                        skillName, resourceRef.getType(), resourceRef.getName());
-                Listener resourceListener = new SkillConfigListener(skillName, false, resourceId);
-                try {
-                    configService.addListener(resourceConfigInfo.getDataId(), resourceConfigInfo.getGroup(), resourceListener);
-                    subscriptionInfo.getResourceListeners().put(resourceId, resourceListener);
-                } catch (NacosException e) {
-                    LOGGER.warn("Failed to add listener for new resource: skillName={}, resourceId={}, error={}",
-                            skillName, resourceId, e.getMessage());
+
+                @Override
+                public void receiveConfigInfo(String configInfo) {
+                    onResourceChanged(sub.skillName);
                 }
+            };
+            try {
+                configService.addListener(filePath, versionGroup, listener);
+                sub.resourceListeners.put(filePath, listener);
+            } catch (NacosException e) {
+                LOGGER.warn("Failed to add listener for {}:{}", versionGroup, filePath, e);
             }
         }
     }
-    
-    /**
-     * Check if skill has changed by comparing JSON serialization.
-     *
-     * @param oldSkill old skill object
-     * @param newSkill new skill object
-     * @return true if changed, false otherwise
-     */
+
+    private void unsubscribeResources(SkillSubscriptionInfo sub) {
+        if (StringUtils.isBlank(sub.resourceGroup)) {
+            return;
+        }
+        for (Map.Entry<String, Listener> entry : sub.resourceListeners.entrySet()) {
+            configService.removeListener(entry.getKey(), sub.resourceGroup, entry.getValue());
+        }
+        sub.resourceListeners.clear();
+        sub.resourceGroup = null;
+    }
+
     private boolean isSkillChanged(Skill oldSkill, Skill newSkill) {
         try {
             String newJson = objectMapper.writeValueAsString(newSkill);
             if (null == oldSkill) {
-                LOGGER.info("init new skill: {} -> {}", newSkill != null ? newSkill.getName() : "null", newJson);
+                LOGGER.info("Init new skill: {} -> {}", newSkill != null ? newSkill.getName() : "null", newJson);
                 return true;
             }
             String oldJson = objectMapper.writeValueAsString(oldSkill);
             if (!StringUtils.equals(oldJson, newJson)) {
-                LOGGER.info("skill changed: {} -> {}", oldJson, newJson);
+                LOGGER.info("Skill changed: {} -> {}", oldJson, newJson);
                 return true;
             }
         } catch (JsonProcessingException e) {
@@ -442,153 +342,48 @@ public class NacosSkillCacheHolder implements Closeable {
         }
         return false;
     }
-    
-    @Override
-    public void shutdown() throws NacosException {
-        // Unsubscribe all skills
-        Set<String> skillNames = new HashSet<>(subscriptionMap.keySet());
-        for (String skillName : skillNames) {
-            unsubscribeSkill(skillName);
-        }
-    }
-    
-    /**
-     * Skill configuration listener.
-     */
-    private class SkillConfigListener implements Listener {
-        
-        private final String skillName;
-        
-        private final boolean isMainConfig;
-        
-        private final String resourceName;
-        
-        public SkillConfigListener(String skillName, boolean isMainConfig, String resourceName) {
-            this.skillName = skillName;
-            this.isMainConfig = isMainConfig;
-            this.resourceName = resourceName;
-        }
-        
-        @Override
-        public Executor getExecutor() {
-            return null;
-        }
-        
-        @Override
-        public void receiveConfigInfo(String configInfo) {
-            LOGGER.info("Skill configuration changed: skillName={}, isMainConfig={}, resourceName={}",
-                    skillName, isMainConfig, resourceName);
-            // Reload skill when any configuration changes
-            reloadSkill(skillName);
-        }
-    }
-    
-    /**
-     * Skill subscription information.
-     */
+
+    // ======================== Inner classes ========================
+
     private static class SkillSubscriptionInfo {
-        
-        private final String skillName;
-        
-        private Listener mainConfigListener;
-        
-        private final Map<String, Listener> resourceListeners;
-        
-        private Skill currentSkill;
-        
-        public SkillSubscriptionInfo(String skillName) {
+
+        final String skillName;
+
+        String currentVersion;
+
+        List<String> currentFiles;
+
+        Listener manifestListener;
+
+        String resourceGroup;
+
+        final Map<String, Listener> resourceListeners = new ConcurrentHashMap<>(4);
+
+        SkillSubscriptionInfo(String skillName) {
             this.skillName = skillName;
-            this.resourceListeners = new ConcurrentHashMap<>();
-        }
-        
-        public String getSkillName() {
-            return skillName;
-        }
-        
-        public Listener getMainConfigListener() {
-            return mainConfigListener;
-        }
-        
-        public void setMainConfigListener(Listener mainConfigListener) {
-            this.mainConfigListener = mainConfigListener;
-        }
-        
-        public Map<String, Listener> getResourceListeners() {
-            return resourceListeners;
-        }
-        
-        public Skill getCurrentSkill() {
-            return currentSkill;
-        }
-        
-        public void setCurrentSkill(Skill currentSkill) {
-            this.currentSkill = currentSkill;
         }
     }
-    
-    /**
-     * Skill main config (from skill.json).
-     */
-    private static class SkillMainConfig {
-        private String name;
-        private String description;
-        private String instruction;
-        private List<SkillResourceRef> resources;
-        
-        public String getName() {
-            return name;
+
+    private static class SkillIndex {
+
+        private String version;
+
+        private List<String> files;
+
+        public String getVersion() {
+            return version;
         }
-        
-        public void setName(String name) {
-            this.name = name;
+
+        public void setVersion(String version) {
+            this.version = version;
         }
-        
-        public String getDescription() {
-            return description;
+
+        public List<String> getFiles() {
+            return files;
         }
-        
-        public void setDescription(String description) {
-            this.description = description;
-        }
-        
-        public String getInstruction() {
-            return instruction;
-        }
-        
-        public void setInstruction(String instruction) {
-            this.instruction = instruction;
-        }
-        
-        public List<SkillResourceRef> getResources() {
-            return resources;
-        }
-        
-        public void setResources(List<SkillResourceRef> resources) {
-            this.resources = resources;
-        }
-    }
-    
-    /**
-     * Skill resource reference (in skill.json).
-     */
-    private static class SkillResourceRef {
-        private String name;
-        private String type;
-        
-        public String getName() {
-            return name;
-        }
-        
-        public void setName(String name) {
-            this.name = name;
-        }
-        
-        public String getType() {
-            return type;
-        }
-        
-        public void setType(String type) {
-            this.type = type;
+
+        public void setFiles(List<String> files) {
+            this.files = files;
         }
     }
 }

--- a/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxy.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.client.ai.remote;
 
 import com.alibaba.nacos.api.ai.model.prompt.Prompt;
+import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.client.env.NacosClientProperties;
@@ -63,25 +64,27 @@ import static com.alibaba.nacos.common.constant.RequestUrlConstants.HTTP_PREFIX;
  * @author nacos
  */
 public class AiHttpClientProxy implements AiClientProxy {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AiHttpClientProxy.class);
-    
+
     private static final String PROMPT_CLIENT_PATH = "/v3/client/ai/prompt";
-    
+
+    private static final String SKILL_CLIENT_PATH = "/v3/client/ai/skills";
+
     private static final int MAX_RETRY = 3;
-    
+
     private static final boolean ENABLE_HTTPS = Boolean.getBoolean(TlsSystemConfig.TLS_ENABLE);
-    
+
     private final String namespaceId;
-    
+
     private final NacosRestTemplate nacosRestTemplate;
-    
+
     private final NamingServerListManager serverListManager;
-    
+
     private final SecurityProxy securityProxy;
-    
+
     private final ScheduledThreadPoolExecutor executorService;
-    
+
     AiHttpClientProxy() {
         this.namespaceId = null;
         this.nacosRestTemplate = null;
@@ -89,7 +92,7 @@ public class AiHttpClientProxy implements AiClientProxy {
         this.securityProxy = null;
         this.executorService = null;
     }
-    
+
     public AiHttpClientProxy(String namespaceId, NacosClientProperties properties) throws NacosException {
         this.namespaceId = namespaceId;
         this.nacosRestTemplate = NamingHttpClientManager.getInstance().getNacosRestTemplate();
@@ -103,7 +106,7 @@ public class AiHttpClientProxy implements AiClientProxy {
         this.executorService.scheduleWithFixedDelay(() -> securityProxy.login(nacosClientPropertiesView), 0,
                 SECURITY_INFO_REFRESH_INTERVAL_MILLS, TimeUnit.MILLISECONDS);
     }
-    
+
     @Override
     public Prompt queryPrompt(String promptKey, String version, String label, String md5) throws NacosException {
         Map<String, String> params = new HashMap<>(8);
@@ -118,28 +121,58 @@ public class AiHttpClientProxy implements AiClientProxy {
         if (StringUtils.isNotBlank(md5)) {
             params.put("md5", md5);
         }
-        
+
         RequestResource resource = RequestResource.aiBuilder().setNamespace(namespaceId)
                 .setGroup(com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP)
                 .setResource(null == promptKey ? StringUtils.EMPTY : promptKey).build();
-        
+
         String responseBody = reqApi(PROMPT_CLIENT_PATH, params, resource);
         Result<Prompt> result = JacksonUtils.toObj(responseBody, new TypeReference<Result<Prompt>>() {
         });
         return result.getData();
     }
-    
+
+    /**
+     * Query skill from server via HTTP REST API.
+     *
+     * @param skillName skill name
+     * @param version   explicit version (optional)
+     * @param label     route label, e.g. latest/stable (optional)
+     * @return Skill object
+     * @throws NacosException if request fails
+     */
+    public Skill querySkill(String skillName, String version, String label) throws NacosException {
+        Map<String, String> params = new HashMap<>(8);
+        params.put("namespaceId", namespaceId);
+        params.put("name", skillName);
+        if (StringUtils.isNotBlank(version)) {
+            params.put("version", version);
+        }
+        if (StringUtils.isNotBlank(label)) {
+            params.put("label", label);
+        }
+
+        RequestResource resource = RequestResource.aiBuilder().setNamespace(namespaceId)
+                .setGroup(com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP)
+                .setResource(null == skillName ? StringUtils.EMPTY : skillName).build();
+
+        String responseBody = reqApi(SKILL_CLIENT_PATH, params, resource);
+        Result<Skill> result = JacksonUtils.toObj(responseBody, new TypeReference<Result<Skill>>() {
+        });
+        return result.getData();
+    }
+
     // ===== Generic HTTP infrastructure =====
-    
+
     private String reqApi(String api, Map<String, String> params, RequestResource resource) throws NacosException {
         List<String> servers = serverListManager.getServerList();
         if (servers.isEmpty()) {
             throw new NacosException(NacosException.INVALID_PARAM, "no server available");
         }
-        
+
         NacosException exception = new NacosException();
         int index = ThreadLocalRandom.current().nextInt(servers.size());
-        
+
         for (int i = 0; i < Math.max(servers.size(), MAX_RETRY); i++) {
             String server = servers.get(index % servers.size());
             try {
@@ -152,26 +185,26 @@ public class AiHttpClientProxy implements AiClientProxy {
             }
             index = (index + 1) % servers.size();
         }
-        
+
         LOGGER.error("Request: {} failed, servers: {}, code: {}, msg: {}", api, servers, exception.getErrCode(),
                 exception.getErrMsg());
         throw new NacosException(exception.getErrCode(),
                 "Failed to request API: " + api + " after all servers(" + servers + ") tried: "
                         + exception.getMessage());
     }
-    
+
     private String callServer(String api, Map<String, String> params, String server, RequestResource resource)
             throws NacosException {
         Map<String, String> securityHeaders = securityProxy.getIdentityContext(resource);
         Header header = Header.newInstance();
         header.addAll(securityHeaders);
-        
+
         String url = buildUrl(server, api);
-        
+
         try {
             HttpRestResult<String> restResult = nacosRestTemplate.get(url, header,
                     Query.newInstance().initParams(params), String.class);
-            
+
             if (restResult.ok()) {
                 return restResult.getData();
             }
@@ -189,7 +222,7 @@ public class AiHttpClientProxy implements AiClientProxy {
             throw new NacosException(NacosException.SERVER_ERROR, e);
         }
     }
-    
+
     private String buildUrl(String serverAddr, String relativePath) {
         if (!serverAddr.startsWith(HTTP_PREFIX) && !serverAddr.startsWith(HTTPS_PREFIX)) {
             serverAddr = (ENABLE_HTTPS ? HTTPS_PREFIX : HTTP_PREFIX) + serverAddr;
@@ -197,7 +230,7 @@ public class AiHttpClientProxy implements AiClientProxy {
         String contextPath = serverListManager.getContextPath();
         return serverAddr + ContextPathUtil.normalizeContextPath(contextPath) + relativePath;
     }
-    
+
     @Override
     public void shutdown() throws NacosException {
         serverListManager.shutdown();


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

This PR contains two independent changes to the Skill subsystem:

1. **Storage model refactoring** (`SkillOperationService` layer): Each
   `SkillResource` is now persisted as an individual nacos-config item
   instead of a single monolithic JSON blob. The version row carries a
   `storage` field that records the full list of stored file keys, so
   that deletion and loading operate only on the exact files that belong
   to a given version.

2. **Client-side skill loading acceleration** (storage / client layer):
   The server publishes a lightweight manifest config (`skill_index.json`)
   to nacos-config on every `publish` / `enable` so that the client SDK
   can resolve the current version and fetch resource content from the
   local nacos-config cache, eliminating per-request database round-trips.

## Brief changelog

**Service layer (`SkillOperationService` / `SkillOperationServiceImpl`)**

- Rewrite `writeSkillToStorage`: persist each `SkillResource` as an
  individual config item and return the file list stored in
  `version.storage`
- Rewrite `loadSkillFromStorage`: accept the `storage` JSON from the
  version row and reconstruct the `Skill` from per-resource config items
- Rewrite `deleteSkillStorageForVersion`: accept the `storage` JSON and
  delete only the files that belong to the target version
- Fix `deleteSkill` deletion order to strictly reverse creation order—
  manifest index config → meta → version rows → storage files—to prevent
  dirty-read windows on the client side
- Fix `deleteDraft` deletion order: clear `editingVersion` in meta first
  before removing the version row and storage files
- Add `writeSkillIndexConfig` / `deleteSkillIndexConfig` /
  `refreshSkillIndexConfig` helpers; call them in `publish()`,
  `deleteSkill()`, and `changeOnlineStatus()` to keep the client-visible
  manifest consistent with DB state

**Storage / client layer (`SkillUtils`, `NacosConfigAiResourceStorage`, `NacosAiService`, `NacosSkillCacheHolder`, `AiHttpClientProxy`)**

- `SkillUtils`: add `SKILL_INDEX_DATA_ID` constant, `buildSkillGroup()`
  and `buildSkillVersionGroup()` helpers; deprecate `SKILL_MAIN_DATA_ID`
  and remove obsolete `ConfigInfo` inner class and its factory methods
- `NacosConfigAiResourceStorage`: add `buildManifestStorageKey()` for the
  version-free manifest key; extend `parse()` to allow a blank version
  segment so the manifest key maps to group `skill_{name}` without a
  version suffix
- `NacosAiService`: replace `AiHttpClientProxy skillHttpProxy` with a
  dedicated `ConfigService` for skill retrieval; delegate `loadSkill()`
  to `NacosSkillCacheHolder`
- `NacosSkillCacheHolder`: rewrite from HTTP polling to a two-level
  `ConfigService` listener model—manifest listener detects version
  changes and refreshes resource listeners; resource listeners trigger
  local cache update and `SkillChangedEvent` on content change
- `AiHttpClientProxy`: add `querySkill()` as a low-level HTTP fallback

## Verifying this change

- Publish a skill and verify `skill_index.json` is written to nacos-config
  with correct `version` and `files` fields
- Client `loadSkill()` should return the skill without hitting the DB
  after the first config pull (verify via nacos-config local cache)
- Delete a skill and verify no dirty data is visible to the client during
  the deletion window
- Delete a draft and verify the meta `editingVersion` is cleared first,
  preventing stale references on concurrent `getSkillDetail` calls

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.