### PR TITLE
fix(ai): strip UTF-8 BOM from SKILL.md content in SkillZipParser

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
@@ -53,6 +53,8 @@ public class SkillZipParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(SkillZipParser.class);
     
     private static final String SKILL_MD_FILE = "SKILL.md";
+    /** UTF-8 BOM character that some editors prepend to files. Must be stripped before parsing. */
+    private static final char UTF8_BOM = '\uFEFF';
     /** macOS AppleDouble/resource fork metadata file prefix (e.g. ._LICENSE.txt). Should be excluded from skill zip. */
     private static final String MACOS_METADATA_PREFIX = "._";
     private static final String INSTRUCTIONS_HEADER_WITH_SPACE = "## Instructions";
@@ -124,7 +126,7 @@ public class SkillZipParser {
                 boolean endsWithSkillMd = name.endsWith(SKILL_MD_FILE);
                 boolean isSkillMd = isSkillMdFile || isSkillMdInSubdir;
                 if (endsWithSkillMd && isSkillMd) {
-                    skillMdContent = new String(entry.data, StandardCharsets.UTF_8);
+                    skillMdContent = stripBom(new String(entry.data, StandardCharsets.UTF_8));
                     break;
                 }
             }
@@ -376,5 +378,18 @@ public class SkillZipParser {
         int lastSlash = itemName.lastIndexOf('/');
         String fileName = lastSlash >= 0 ? itemName.substring(lastSlash + 1) : itemName;
         return fileName.startsWith(MACOS_METADATA_PREFIX);
+    }
+    
+    /**
+     * Strip UTF-8 BOM character from the beginning of a string if present.
+     *
+     * @param content the string to strip BOM from
+     * @return the string without leading BOM
+     */
+    private static String stripBom(String content) {
+        if (content != null && !content.isEmpty() && content.charAt(0) == UTF8_BOM) {
+            return content.substring(1);
+        }
+        return content;
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserTest.java
@@ -483,4 +483,82 @@ class SkillZipParserTest {
         }
         return baos.toByteArray();
     }
+
+    @Test
+    void testParseSkillFromZipWithUtf8Bom() throws Exception {
+        // Given: SKILL.md content starts with UTF-8 BOM (EF BB BF)
+        byte[] zipBytes = createSkillZipWithUtf8Bom();
+
+        // When
+        Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, "test-namespace");
+
+        // Then: BOM is stripped and skill parses correctly
+        assertNotNull(skill);
+        assertEquals("test-skill", skill.getName());
+        assertEquals("Test skill description", skill.getDescription());
+        assertEquals("This is a test instruction", skill.getInstruction().trim());
+    }
+
+    @Test
+    void testParseSkillFromZipWithUtf8BomInSubdir() throws Exception {
+        // Given: SKILL.md in subdirectory with UTF-8 BOM
+        byte[] zipBytes = createSkillZipWithUtf8BomInSubdir();
+
+        // When
+        Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, "test-namespace");
+
+        // Then: BOM is stripped and skill parses correctly
+        assertNotNull(skill);
+        assertEquals("test-skill", skill.getName());
+        assertEquals("Test skill description", skill.getDescription());
+    }
+
+    /**
+     * Create a skill zip where SKILL.md content starts with UTF-8 BOM (EF BB BF).
+     */
+    private byte[] createSkillZipWithUtf8Bom() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            ZipEntry entry = new ZipEntry("SKILL.md");
+            zos.putNextEntry(entry);
+            // UTF-8 BOM bytes followed by normal SKILL.md content
+            String skillMd = "---\n"
+                    + "name: test-skill\n"
+                    + "description: Test skill description\n"
+                    + "---\n\n"
+                    + "This is a test instruction";
+            byte[] bom = new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+            byte[] content = skillMd.getBytes("UTF-8");
+            byte[] withBom = new byte[bom.length + content.length];
+            System.arraycopy(bom, 0, withBom, 0, bom.length);
+            System.arraycopy(content, 0, withBom, bom.length, content.length);
+            zos.write(withBom);
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Create a skill zip where SKILL.md in subdirectory has UTF-8 BOM.
+     */
+    private byte[] createSkillZipWithUtf8BomInSubdir() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            ZipEntry entry = new ZipEntry("test-skill/SKILL.md");
+            zos.putNextEntry(entry);
+            String skillMd = "---\n"
+                    + "name: test-skill\n"
+                    + "description: Test skill description\n"
+                    + "---\n\n"
+                    + "This is a test instruction";
+            byte[] bom = new byte[] { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
+            byte[] content = skillMd.getBytes("UTF-8");
+            byte[] withBom = new byte[bom.length + content.length];
+            System.arraycopy(bom, 0, withBom, 0, bom.length);
+            System.arraycopy(content, 0, withBom, bom.length, content.length);
+            zos.write(withBom);
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
 }


### PR DESCRIPTION
## Summary
- Strip UTF-8 BOM (`\uFEFF`) from SKILL.md content after reading from zip, before YAML front-matter parsing
- Prevents misleading "SKILL.md must contain YAML front matter" error when files are saved with BOM by editors like Windows Notepad
- Added 2 test cases covering BOM handling for both root-level and subdirectory SKILL.md

## Test plan
- [x] `testParseSkillFromZipWithUtf8Bom` - verifies root-level SKILL.md with BOM parses correctly
- [x] `testParseSkillFromZipWithUtf8BomInSubdir` - verifies subdirectory SKILL.md with BOM parses correctly
- [x] Existing `SkillZipParserTest` tests still pass (no regression)

	🤖 Generated with [Qoder][https://qoder.com]