### PR TITLE
test(ai): add comprehensive pipeline and agent spec tests with backwa…

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -571,7 +571,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         
         // Build context for pipeline execution
         PublishPipelineContext ctx = new PublishPipelineContext();
-        ctx.setResourceType(PublishPipelineResourceType.SKILL);
+        ctx.setResourceType(PublishPipelineResourceType.AGENTSPEC);
         ctx.setNamespaceId(namespaceId);
         ctx.setResourceName(name);
         ctx.setVersion(finalTarget);
@@ -579,7 +579,12 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         String executionId = publishPipelineExecutor.execute(ctx,
                 result -> onPipelineComplete(namespaceId, name, finalTarget, result));
         if (StringUtils.isBlank(executionId)) {
-            // Pipeline disabled or no matched nodes -> publish directly
+            // Pipeline disabled or no matched nodes -> transition to reviewing then publish directly
+            aiResourceVersionPersistService.updateStatus(namespaceId, name, RESOURCE_TYPE_AGENTSPEC, finalTarget,
+                    VERSION_STATUS_REVIEWING);
+            info.setEditingVersion(null);
+            info.setReviewingVersion(finalTarget);
+            updateMetaVersionInfoCas(namespaceId, meta, info);
             publish(namespaceId, name, finalTarget, true);
             return finalTarget;
         }

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineBackwardCompatibilityTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineBackwardCompatibilityTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeConfig;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResult;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests verifying backward compatibility of SKILL and PROMPT routing
+ * after adding the AGENTSPEC resource type.
+ *
+ * <p>Validates: Requirements 5.1, 5.2</p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PublishPipelineBackwardCompatibilityTest {
+
+    private static final String PLUGIN_SKILL_ID = "plugin-skill-only";
+
+    private static final String PLUGIN_AGENTSPEC_ID = "plugin-agentspec-only";
+
+    private static final String PLUGIN_PROMPT_ID = "plugin-prompt-only";
+
+    private static final String PLUGIN_SKILL_LOW_ORDER_ID = "plugin-skill-low";
+
+    private static final String PLUGIN_SKILL_HIGH_ORDER_ID = "plugin-skill-high";
+
+    private PublishPipelineManager manager;
+
+    private List<PipelineNodeConfig> allNodes;
+
+    @BeforeEach
+    void setUp() {
+        manager = new PublishPipelineManager();
+
+        List<PublishPipelineServiceBuilder> builders = new ArrayList<>();
+
+        // Plugin supporting only SKILL
+        builders.add(createBuilder(PLUGIN_SKILL_ID, 1,
+                new PublishPipelineResourceType[]{PublishPipelineResourceType.SKILL}));
+
+        // Plugin supporting only AGENTSPEC
+        builders.add(createBuilder(PLUGIN_AGENTSPEC_ID, 2,
+                new PublishPipelineResourceType[]{PublishPipelineResourceType.AGENTSPEC}));
+
+        // Plugin supporting only PROMPT
+        builders.add(createBuilder(PLUGIN_PROMPT_ID, 3,
+                new PublishPipelineResourceType[]{PublishPipelineResourceType.PROMPT}));
+
+        PipelineConfig config = new PipelineConfig();
+        config.setEnabled(true);
+        config.setNodes(new ArrayList<>());
+
+        manager.initWithBuilders(builders, config);
+
+        // Build nodes list referencing all three plugins
+        allNodes = new ArrayList<>();
+        for (String id : new String[]{PLUGIN_SKILL_ID, PLUGIN_AGENTSPEC_ID, PLUGIN_PROMPT_ID}) {
+            PipelineNodeConfig node = new PipelineNodeConfig();
+            node.setPipelineId(id);
+            node.setProperties(new Properties());
+            allNodes.add(node);
+        }
+    }
+
+    /**
+     * SKILL routing returns only the SKILL plugin; the AGENTSPEC plugin is NOT included.
+     *
+     * <p>Validates: Requirement 5.1 — SKILL Pipeline execution flow behavior is unchanged after adding AGENTSPEC.</p>
+     */
+    @Test
+    void testSkillRoutingUnchangedAfterAgentspecAddition() {
+        List<PublishPipelineService> result = manager.getPipelineServices(
+                PublishPipelineResourceType.SKILL, allNodes);
+
+        Set<String> resultIds = result.stream()
+                .map(PublishPipelineService::pipelineId)
+                .collect(Collectors.toSet());
+
+        assertEquals(1, result.size(),
+                "Exactly 1 plugin should be returned for SKILL routing");
+        assertTrue(resultIds.contains(PLUGIN_SKILL_ID),
+                "SKILL-only plugin should be included in SKILL routing");
+        assertFalse(resultIds.contains(PLUGIN_AGENTSPEC_ID),
+                "AGENTSPEC-only plugin should NOT be included in SKILL routing");
+        assertFalse(resultIds.contains(PLUGIN_PROMPT_ID),
+                "PROMPT-only plugin should NOT be included in SKILL routing");
+    }
+
+    /**
+     * PROMPT routing returns only the PROMPT plugin; the AGENTSPEC plugin is NOT included.
+     *
+     * <p>Validates: Requirement 5.2 — PROMPT Pipeline execution flow behavior is unchanged after adding AGENTSPEC.</p>
+     */
+    @Test
+    void testPromptRoutingUnchangedAfterAgentspecAddition() {
+        List<PublishPipelineService> result = manager.getPipelineServices(
+                PublishPipelineResourceType.PROMPT, allNodes);
+
+        Set<String> resultIds = result.stream()
+                .map(PublishPipelineService::pipelineId)
+                .collect(Collectors.toSet());
+
+        assertEquals(1, result.size(),
+                "Exactly 1 plugin should be returned for PROMPT routing");
+        assertTrue(resultIds.contains(PLUGIN_PROMPT_ID),
+                "PROMPT-only plugin should be included in PROMPT routing");
+        assertFalse(resultIds.contains(PLUGIN_AGENTSPEC_ID),
+                "AGENTSPEC-only plugin should NOT be included in PROMPT routing");
+        assertFalse(resultIds.contains(PLUGIN_SKILL_ID),
+                "SKILL-only plugin should NOT be included in PROMPT routing");
+    }
+
+    /**
+     * Multiple SKILL plugins are returned sorted by order ascending, unaffected by AGENTSPEC presence.
+     *
+     * <p>Validates: Requirement 5.1 — SKILL plugin ordering is preserved after adding AGENTSPEC.</p>
+     */
+    @Test
+    void testSkillPluginOrderPreservedAfterAgentspecAddition() {
+        // Re-initialize with multiple SKILL plugins and an AGENTSPEC plugin
+        PublishPipelineManager orderManager = new PublishPipelineManager();
+
+        List<PublishPipelineServiceBuilder> builders = new ArrayList<>();
+        builders.add(createBuilder(PLUGIN_SKILL_HIGH_ORDER_ID, 10,
+                new PublishPipelineResourceType[]{PublishPipelineResourceType.SKILL}));
+        builders.add(createBuilder(PLUGIN_AGENTSPEC_ID, 5,
+                new PublishPipelineResourceType[]{PublishPipelineResourceType.AGENTSPEC}));
+        builders.add(createBuilder(PLUGIN_SKILL_LOW_ORDER_ID, 1,
+                new PublishPipelineResourceType[]{PublishPipelineResourceType.SKILL}));
+
+        PipelineConfig config = new PipelineConfig();
+        config.setEnabled(true);
+        config.setNodes(new ArrayList<>());
+
+        orderManager.initWithBuilders(builders, config);
+
+        List<PipelineNodeConfig> nodes = new ArrayList<>();
+        for (String id : new String[]{PLUGIN_SKILL_HIGH_ORDER_ID, PLUGIN_AGENTSPEC_ID, PLUGIN_SKILL_LOW_ORDER_ID}) {
+            PipelineNodeConfig node = new PipelineNodeConfig();
+            node.setPipelineId(id);
+            node.setProperties(new Properties());
+            nodes.add(node);
+        }
+
+        List<PublishPipelineService> result = orderManager.getPipelineServices(
+                PublishPipelineResourceType.SKILL, nodes);
+
+        assertEquals(2, result.size(),
+                "Exactly 2 SKILL plugins should be returned");
+        assertEquals(PLUGIN_SKILL_LOW_ORDER_ID, result.get(0).pipelineId(),
+                "Lower-order SKILL plugin should come first");
+        assertEquals(PLUGIN_SKILL_HIGH_ORDER_ID, result.get(1).pipelineId(),
+                "Higher-order SKILL plugin should come second");
+
+        // Verify AGENTSPEC plugin is not in the SKILL results
+        Set<String> resultIds = result.stream()
+                .map(PublishPipelineService::pipelineId)
+                .collect(Collectors.toSet());
+        assertFalse(resultIds.contains(PLUGIN_AGENTSPEC_ID),
+                "AGENTSPEC plugin should NOT appear in SKILL routing results");
+    }
+
+    private PublishPipelineServiceBuilder createBuilder(String pipelineId, int order,
+            PublishPipelineResourceType[] supportedTypes) {
+        return new PublishPipelineServiceBuilder() {
+            @Override
+            public String pipelineId() {
+                return pipelineId;
+            }
+
+            @Override
+            public PublishPipelineService build(Properties properties) {
+                return new PublishPipelineService() {
+                    @Override
+                    public String pipelineId() {
+                        return pipelineId;
+                    }
+
+                    @Override
+                    public PublishPipelineResult execute(PublishPipelineContext context) {
+                        return null;
+                    }
+
+                    @Override
+                    public int getPreferOrder() {
+                        return order;
+                    }
+
+                    @Override
+                    public PublishPipelineResourceType[] pipelineResourceTypes() {
+                        return supportedTypes;
+                    }
+                };
+            }
+        };
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineManagerRoutingTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/PublishPipelineManagerRoutingTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline;
+
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeConfig;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResult;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService;
+import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineServiceBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests verifying Pipeline routing isolation between resource types.
+ *
+ * <p>Validates: Requirements 3.1, 3.2, 3.3</p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PublishPipelineManagerRoutingTest {
+    
+    private static final String PLUGIN_A_ID = "plugin-skill-only";
+    
+    private static final String PLUGIN_B_ID = "plugin-agentspec-only";
+    
+    private static final String PLUGIN_C_ID = "plugin-dual-support";
+    
+    private PublishPipelineManager manager;
+    
+    private List<PipelineNodeConfig> allNodes;
+    
+    @BeforeEach
+    void setUp() {
+        manager = new PublishPipelineManager();
+        
+        List<PublishPipelineServiceBuilder> builders = new ArrayList<>();
+        
+        // Plugin A: supports only SKILL
+        builders.add(createBuilder(PLUGIN_A_ID, 1,
+                new PublishPipelineResourceType[]{PublishPipelineResourceType.SKILL}));
+        
+        // Plugin B: supports only AGENTSPEC
+        builders.add(createBuilder(PLUGIN_B_ID, 2,
+                new PublishPipelineResourceType[]{PublishPipelineResourceType.AGENTSPEC}));
+        
+        // Plugin C: supports both SKILL and AGENTSPEC
+        builders.add(createBuilder(PLUGIN_C_ID, 3,
+                new PublishPipelineResourceType[]{PublishPipelineResourceType.SKILL,
+                        PublishPipelineResourceType.AGENTSPEC}));
+        
+        PipelineConfig config = new PipelineConfig();
+        config.setEnabled(true);
+        config.setNodes(new ArrayList<>());
+        
+        manager.initWithBuilders(builders, config);
+        
+        // Build nodes list referencing all three plugins
+        allNodes = new ArrayList<>();
+        for (String id : new String[]{PLUGIN_A_ID, PLUGIN_B_ID, PLUGIN_C_ID}) {
+            PipelineNodeConfig node = new PipelineNodeConfig();
+            node.setPipelineId(id);
+            node.setProperties(new Properties());
+            allNodes.add(node);
+        }
+    }
+    
+    /**
+     * getPipelineServices(AGENTSPEC, allNodes) returns Plugin B and Plugin C but NOT Plugin A.
+     *
+     * <p>Validates: Requirement 3.1 — AGENTSPEC requests only return plugins that declare AGENTSPEC support.</p>
+     */
+    @Test
+    void testAgentspecRoutingOnlyReturnsAgentspecPlugins() {
+        List<PublishPipelineService> result = manager.getPipelineServices(
+                PublishPipelineResourceType.AGENTSPEC, allNodes);
+        
+        Set<String> resultIds = result.stream()
+                .map(PublishPipelineService::pipelineId)
+                .collect(Collectors.toSet());
+        
+        assertTrue(resultIds.contains(PLUGIN_B_ID),
+                "AGENTSPEC-only plugin should be included in AGENTSPEC routing");
+        assertTrue(resultIds.contains(PLUGIN_C_ID),
+                "Dual-support plugin should be included in AGENTSPEC routing");
+        assertFalse(resultIds.contains(PLUGIN_A_ID),
+                "SKILL-only plugin should NOT be included in AGENTSPEC routing");
+        assertEquals(2, result.size(),
+                "Exactly 2 plugins should be returned for AGENTSPEC routing");
+    }
+    
+    /**
+     * getPipelineServices(AGENTSPEC, allNodes) does NOT contain Plugin A (SKILL-only).
+     *
+     * <p>Validates: Requirement 3.2 — SKILL-only plugins are not routed to AGENTSPEC requests.</p>
+     */
+    @Test
+    void testSkillOnlyPluginNotRoutedToAgentspec() {
+        List<PublishPipelineService> result = manager.getPipelineServices(
+                PublishPipelineResourceType.AGENTSPEC, allNodes);
+        
+        Set<String> resultIds = result.stream()
+                .map(PublishPipelineService::pipelineId)
+                .collect(Collectors.toSet());
+        
+        assertFalse(resultIds.contains(PLUGIN_A_ID),
+                "SKILL-only plugin must NOT be routed to AGENTSPEC requests");
+    }
+    
+    /**
+     * Plugin C (dual support) appears in both SKILL and AGENTSPEC routing results.
+     * Plugin A appears only in SKILL results. Plugin B appears only in AGENTSPEC results.
+     *
+     * <p>Validates: Requirement 3.3 — dual-support plugins are routed to both resource types.</p>
+     */
+    @Test
+    void testDualSupportPluginRoutedToBothTypes() {
+        List<PublishPipelineService> skillResult = manager.getPipelineServices(
+                PublishPipelineResourceType.SKILL, allNodes);
+        List<PublishPipelineService> agentspecResult = manager.getPipelineServices(
+                PublishPipelineResourceType.AGENTSPEC, allNodes);
+        
+        Set<String> skillIds = skillResult.stream()
+                .map(PublishPipelineService::pipelineId)
+                .collect(Collectors.toSet());
+        Set<String> agentspecIds = agentspecResult.stream()
+                .map(PublishPipelineService::pipelineId)
+                .collect(Collectors.toSet());
+        
+        // SKILL routing: contains A and C
+        assertTrue(skillIds.contains(PLUGIN_A_ID),
+                "SKILL-only plugin should be in SKILL routing");
+        assertTrue(skillIds.contains(PLUGIN_C_ID),
+                "Dual-support plugin should be in SKILL routing");
+        
+        // AGENTSPEC routing: contains B and C
+        assertTrue(agentspecIds.contains(PLUGIN_B_ID),
+                "AGENTSPEC-only plugin should be in AGENTSPEC routing");
+        assertTrue(agentspecIds.contains(PLUGIN_C_ID),
+                "Dual-support plugin should be in AGENTSPEC routing");
+        
+        // Dual-support plugin C is in both
+        assertTrue(skillIds.contains(PLUGIN_C_ID) && agentspecIds.contains(PLUGIN_C_ID),
+                "Dual-support plugin must appear in both SKILL and AGENTSPEC routing");
+    }
+    
+    private PublishPipelineServiceBuilder createBuilder(String pipelineId, int order,
+            PublishPipelineResourceType[] supportedTypes) {
+        return new PublishPipelineServiceBuilder() {
+            @Override
+            public String pipelineId() {
+                return pipelineId;
+            }
+            
+            @Override
+            public PublishPipelineService build(Properties properties) {
+                return new PublishPipelineService() {
+                    @Override
+                    public String pipelineId() {
+                        return pipelineId;
+                    }
+                    
+                    @Override
+                    public PublishPipelineResult execute(PublishPipelineContext context) {
+                        return null;
+                    }
+                    
+                    @Override
+                    public int getPreferOrder() {
+                        return order;
+                    }
+                    
+                    @Override
+                    public PublishPipelineResourceType[] pipelineResourceTypes() {
+                        return supportedTypes;
+                    }
+                };
+            }
+        };
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PublishPipelineResourceTypePropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PublishPipelineResourceTypePropertyTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.Arbitrary;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Property-based tests for PublishPipelineResourceType enum.
+ *
+ * <p><b>Validates: Requirements 1.2, 1.3, 1.4</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PublishPipelineResourceTypePropertyTest {
+    
+    /**
+     * Property 1: Enum serialization/deserialization roundtrip consistency.
+     *
+     * <p>For any PublishPipelineResourceType enum value (including AGENTSPEC),
+     * {@code valueOf(e.name())} should return an enum equal to the original value.</p>
+     *
+     * <p><b>Validates: Requirements 1.2, 1.3, 1.4</b></p>
+     */
+    @Property
+    void enumSerializationRoundtrip(@ForAll("resourceTypes") PublishPipelineResourceType original) {
+        String serialized = original.name();
+        PublishPipelineResourceType deserialized = PublishPipelineResourceType.valueOf(serialized);
+        assertEquals(original, deserialized,
+                "valueOf(name()) should return the original enum value for " + original);
+    }
+    
+    @Provide
+    Arbitrary<PublishPipelineResourceType> resourceTypes() {
+        return Arbitraries.of(PublishPipelineResourceType.values());
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PublishPipelineResourceTypeTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PublishPipelineResourceTypeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.pipeline.model;
+
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link PublishPipelineResourceType} enum.
+ *
+ * <p>Validates: Requirements 1.1, 1.4</p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class PublishPipelineResourceTypeTest {
+    
+    @Test
+    void testAgentspecEnumValueExists() {
+        assertNotNull(PublishPipelineResourceType.AGENTSPEC);
+    }
+    
+    @Test
+    void testValuesContainsAllThreeTypes() {
+        PublishPipelineResourceType[] values = PublishPipelineResourceType.values();
+        assertEquals(3, values.length, "PublishPipelineResourceType should have exactly 3 values");
+        
+        Set<PublishPipelineResourceType> valueSet = Arrays.stream(values).collect(Collectors.toSet());
+        assertTrue(valueSet.contains(PublishPipelineResourceType.SKILL), "values() should contain SKILL");
+        assertTrue(valueSet.contains(PublishPipelineResourceType.PROMPT), "values() should contain PROMPT");
+        assertTrue(valueSet.contains(PublishPipelineResourceType.AGENTSPEC), "values() should contain AGENTSPEC");
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecPipelineCompletionPropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecPipelineCompletionPropertyTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agentspecs;
+
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
+import com.alibaba.nacos.ai.pipeline.model.PipelineCallback;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionResult;
+import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
+import com.alibaba.nacos.ai.pipeline.model.PipelineNodeResult;
+import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Property 4: Pipeline completion state consistency.
+ *
+ * <p>For any Pipeline execution result, when APPROVED the publishPipelineInfo status
+ * is updated to APPROVED; when REJECTED the version status reverts to draft,
+ * reviewingVersion is cleared, editingVersion is restored.</p>
+ *
+ * <p><b>Validates: Requirements 4.1, 4.2</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class AgentSpecPipelineCompletionPropertyTest {
+
+    private static final String RESOURCE_TYPE_AGENTSPEC = "agentspec";
+
+    /**
+     * Property 4a: For any APPROVED pipeline result, the publishPipelineInfo
+     * is updated with APPROVED status.
+     */
+    @Property(tries = 50)
+    void pipelineApprovedUpdatesStatusToApproved(
+            @ForAll("approvedResults") ApprovedInput input) throws Exception {
+
+        // Mock dependencies
+        final AiResourcePersistService aiResourcePersistService = mock(AiResourcePersistService.class);
+        final AiResourceVersionPersistService aiResourceVersionPersistService =
+                mock(AiResourceVersionPersistService.class);
+        final PublishPipelineExecutor publishPipelineExecutor = mock(PublishPipelineExecutor.class);
+        final PipelineExecutionRepository pipelineExecutionRepository = mock(PipelineExecutionRepository.class);
+
+        // Build valid meta with versionInfo containing editingVersion
+        AiResource meta = buildMeta(input.namespaceId, input.name, input.version);
+        when(aiResourcePersistService.find(eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC)))
+                .thenReturn(meta);
+
+        // Build valid version row
+        AiResourceVersion versionRow = buildVersionRow(input.namespaceId, input.name, input.version);
+        when(aiResourceVersionPersistService.find(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version)))
+                .thenReturn(versionRow);
+
+        // Mock updateMetaCas to return true
+        when(aiResourcePersistService.updateMetaCas(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), any(Long.class), any()))
+                .thenReturn(true);
+
+        // Capture the callback from execute()
+        ArgumentCaptor<PipelineCallback> callbackCaptor = ArgumentCaptor.forClass(PipelineCallback.class);
+        when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), callbackCaptor.capture()))
+                .thenReturn("exec-" + input.executionId);
+
+        // Construct service and call submit to trigger pipeline
+        AgentSpecOperationServiceImpl service = new AgentSpecOperationServiceImpl(
+                aiResourcePersistService, aiResourceVersionPersistService,
+                publishPipelineExecutor, pipelineExecutionRepository);
+        service.submit(input.namespaceId, input.name, input.version);
+
+        // Build APPROVED result and invoke the captured callback
+        PipelineExecutionResult result = new PipelineExecutionResult();
+        result.setExecutionId(input.executionId);
+        result.setStatus(PipelineExecutionStatus.APPROVED);
+        result.setPipeline(input.nodeResults);
+
+        PipelineCallback callback = callbackCaptor.getValue();
+        callback.onComplete(result);
+
+        // Verify: updatePublishPipelineInfo was called and the JSON contains APPROVED
+        ArgumentCaptor<String> pipelineInfoCaptor = ArgumentCaptor.forClass(String.class);
+        // Called twice: once during submit (IN_PROGRESS), once during callback (APPROVED)
+        verify(aiResourceVersionPersistService, org.mockito.Mockito.atLeast(2))
+                .updatePublishPipelineInfo(eq(input.namespaceId), eq(input.name),
+                        eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version), pipelineInfoCaptor.capture());
+
+        // The last call should contain APPROVED
+        List<String> allValues = pipelineInfoCaptor.getAllValues();
+        String lastPipelineInfoJson = allValues.get(allValues.size() - 1);
+        assertTrue(lastPipelineInfoJson.contains("APPROVED"),
+                "publishPipelineInfo should contain APPROVED status after approved callback, but was: "
+                        + lastPipelineInfoJson);
+    }
+
+    /**
+     * Property 4b: For any REJECTED pipeline result, the version status reverts to draft
+     * and meta pointers are updated (reviewingVersion cleared, editingVersion restored).
+     */
+    @Property(tries = 50)
+    void pipelineRejectedRevertsVersionToDraft(
+            @ForAll("rejectedResults") RejectedInput input) throws Exception {
+
+        // Mock dependencies
+        final AiResourcePersistService aiResourcePersistService = mock(AiResourcePersistService.class);
+        final AiResourceVersionPersistService aiResourceVersionPersistService =
+                mock(AiResourceVersionPersistService.class);
+        final PublishPipelineExecutor publishPipelineExecutor = mock(PublishPipelineExecutor.class);
+        final PipelineExecutionRepository pipelineExecutionRepository = mock(PipelineExecutionRepository.class);
+
+        // Build valid meta with versionInfo containing editingVersion
+        AiResource meta = buildMeta(input.namespaceId, input.name, input.version);
+        when(aiResourcePersistService.find(eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC)))
+                .thenReturn(meta);
+
+        // Build valid version row
+        AiResourceVersion versionRow = buildVersionRow(input.namespaceId, input.name, input.version);
+        when(aiResourceVersionPersistService.find(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version)))
+                .thenReturn(versionRow);
+
+        // Mock updateMetaCas to return true
+        when(aiResourcePersistService.updateMetaCas(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), any(Long.class), any()))
+                .thenReturn(true);
+
+        // Capture the callback from execute()
+        ArgumentCaptor<PipelineCallback> callbackCaptor = ArgumentCaptor.forClass(PipelineCallback.class);
+        when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), callbackCaptor.capture()))
+                .thenReturn("exec-" + input.executionId);
+
+        // After submit(), the meta's reviewingVersion will be set to the version.
+        // For the callback's find() call, return meta with reviewingVersion set.
+        AiResource reviewingMeta = buildMetaWithReviewingVersion(input.namespaceId, input.name, input.version);
+        // First call returns editingVersion meta (for submit), subsequent calls return reviewingVersion meta (for callback)
+        when(aiResourcePersistService.find(eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC)))
+                .thenReturn(meta)
+                .thenReturn(reviewingMeta);
+
+        // Construct service and call submit to trigger pipeline
+        AgentSpecOperationServiceImpl service = new AgentSpecOperationServiceImpl(
+                aiResourcePersistService, aiResourceVersionPersistService,
+                publishPipelineExecutor, pipelineExecutionRepository);
+        service.submit(input.namespaceId, input.name, input.version);
+
+        // Build REJECTED result and invoke the captured callback
+        PipelineExecutionResult result = new PipelineExecutionResult();
+        result.setExecutionId(input.executionId);
+        result.setStatus(PipelineExecutionStatus.REJECTED);
+        result.setPipeline(input.nodeResults);
+
+        PipelineCallback callback = callbackCaptor.getValue();
+        callback.onComplete(result);
+
+        // Verify: version status was reverted to "draft"
+        // updateStatus is called twice: once during submit (reviewing), once during callback (draft)
+        ArgumentCaptor<String> statusCaptor = ArgumentCaptor.forClass(String.class);
+        verify(aiResourceVersionPersistService, org.mockito.Mockito.atLeast(2))
+                .updateStatus(eq(input.namespaceId), eq(input.name),
+                        eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version), statusCaptor.capture());
+
+        List<String> allStatuses = statusCaptor.getAllValues();
+        String lastStatus = allStatuses.get(allStatuses.size() - 1);
+        assertTrue("draft".equals(lastStatus),
+                "Version status should be reverted to 'draft' after REJECTED callback, but was: " + lastStatus);
+
+        // Verify: updatePublishPipelineInfo was called with REJECTED
+        ArgumentCaptor<String> pipelineInfoCaptor = ArgumentCaptor.forClass(String.class);
+        verify(aiResourceVersionPersistService, org.mockito.Mockito.atLeast(2))
+                .updatePublishPipelineInfo(eq(input.namespaceId), eq(input.name),
+                        eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version), pipelineInfoCaptor.capture());
+
+        List<String> allPipelineInfos = pipelineInfoCaptor.getAllValues();
+        String lastPipelineInfo = allPipelineInfos.get(allPipelineInfos.size() - 1);
+        assertTrue(lastPipelineInfo.contains("REJECTED"),
+                "publishPipelineInfo should contain REJECTED status after rejected callback, but was: "
+                        + lastPipelineInfo);
+
+        // Verify: meta was updated (updateMetaCas called at least twice: once for submit, once for callback rollback)
+        verify(aiResourcePersistService, org.mockito.Mockito.atLeast(2))
+                .updateMetaCas(eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC),
+                        any(Long.class), any());
+    }
+
+    // ---- Helper methods ----
+
+    private static AiResource buildMeta(String namespaceId, String name, String version) {
+        AiResource meta = new AiResource();
+        meta.setNamespaceId(namespaceId);
+        meta.setName(name);
+        meta.setType(RESOURCE_TYPE_AGENTSPEC);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"editingVersion\":\"" + version
+                + "\",\"onlineCnt\":0,\"labels\":{}}");
+        return meta;
+    }
+
+    private static AiResource buildMetaWithReviewingVersion(String namespaceId, String name, String version) {
+        AiResource meta = new AiResource();
+        meta.setNamespaceId(namespaceId);
+        meta.setName(name);
+        meta.setType(RESOURCE_TYPE_AGENTSPEC);
+        meta.setStatus("enable");
+        meta.setMetaVersion(2L);
+        meta.setVersionInfo("{\"reviewingVersion\":\"" + version
+                + "\",\"onlineCnt\":0,\"labels\":{}}");
+        return meta;
+    }
+
+    private static AiResourceVersion buildVersionRow(String namespaceId, String name, String version) {
+        AiResourceVersion versionRow = new AiResourceVersion();
+        versionRow.setNamespaceId(namespaceId);
+        versionRow.setName(name);
+        versionRow.setType(RESOURCE_TYPE_AGENTSPEC);
+        versionRow.setVersion(version);
+        versionRow.setStatus("draft");
+        return versionRow;
+    }
+
+    // ---- Test input models ----
+
+    static class ApprovedInput {
+        final String namespaceId;
+        final String name;
+        final String version;
+        final String executionId;
+        final List<PipelineNodeResult> nodeResults;
+
+        ApprovedInput(String namespaceId, String name, String version,
+                String executionId, List<PipelineNodeResult> nodeResults) {
+            this.namespaceId = namespaceId;
+            this.name = name;
+            this.version = version;
+            this.executionId = executionId;
+            this.nodeResults = nodeResults;
+        }
+
+        @Override
+        public String toString() {
+            return "ApprovedInput{ns='" + namespaceId + "', name='" + name
+                    + "', version='" + version + "', execId='" + executionId + "'}";
+        }
+    }
+
+    static class RejectedInput {
+        final String namespaceId;
+        final String name;
+        final String version;
+        final String executionId;
+        final List<PipelineNodeResult> nodeResults;
+
+        RejectedInput(String namespaceId, String name, String version,
+                String executionId, List<PipelineNodeResult> nodeResults) {
+            this.namespaceId = namespaceId;
+            this.name = name;
+            this.version = version;
+            this.executionId = executionId;
+            this.nodeResults = nodeResults;
+        }
+
+        @Override
+        public String toString() {
+            return "RejectedInput{ns='" + namespaceId + "', name='" + name
+                    + "', version='" + version + "', execId='" + executionId + "'}";
+        }
+    }
+
+    // ---- Arbitraries ----
+
+    @Provide
+    Arbitrary<ApprovedInput> approvedResults() {
+        Arbitrary<String> namespaceIds = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> names = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> versions = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> executionIds = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(30);
+        Arbitrary<List<PipelineNodeResult>> nodeResults = pipelineNodeResults();
+
+        return Combinators.combine(namespaceIds, names, versions, executionIds, nodeResults)
+                .as(ApprovedInput::new);
+    }
+
+    @Provide
+    Arbitrary<RejectedInput> rejectedResults() {
+        Arbitrary<String> namespaceIds = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> names = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> versions = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> executionIds = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(30);
+        Arbitrary<List<PipelineNodeResult>> nodeResults = pipelineNodeResults();
+
+        return Combinators.combine(namespaceIds, names, versions, executionIds, nodeResults)
+                .as(RejectedInput::new);
+    }
+
+    private Arbitrary<List<PipelineNodeResult>> pipelineNodeResults() {
+        Arbitrary<PipelineNodeResult> singleNode = Combinators.combine(
+                Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(10),
+                Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20),
+                Arbitraries.of(true, false),
+                Arbitraries.strings().alpha().ofMaxLength(50),
+                Arbitraries.longs().between(0, 10000)
+        ).as((nodeId, executedAt, passed, message, durationMs) -> {
+            PipelineNodeResult r = new PipelineNodeResult();
+            r.setNodeId(nodeId);
+            r.setExecutedAt(executedAt);
+            r.setPassed(passed);
+            r.setMessage(message);
+            r.setDurationMs(durationMs);
+            return r;
+        });
+
+        return singleNode.list().ofMinSize(0).ofMaxSize(5);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecSubmitPipelineAvailabilityPropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecSubmitPipelineAvailabilityPropertyTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agentspecs;
+
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
+import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Property 5: Submit behavior consistency with Pipeline availability.
+ *
+ * <p>When Pipeline is not enabled or has no matching nodes, submit directly publishes
+ * and version status becomes online; when Pipeline is enabled and has matching nodes,
+ * version status becomes reviewing, editingVersion is cleared, reviewingVersion is set.</p>
+ *
+ * <p><b>Validates: Requirements 4.3, 4.4</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class AgentSpecSubmitPipelineAvailabilityPropertyTest {
+
+    private static final String RESOURCE_TYPE_AGENTSPEC = "agentspec";
+
+    /**
+     * Property 5a: When Pipeline is not enabled or has no matching nodes (execute returns null),
+     * submit directly publishes and version status becomes online.
+     *
+     * <p><b>Validates: Requirements 4.3</b></p>
+     */
+    @Property(tries = 50)
+    void submitDirectlyPublishesWhenPipelineDisabled(
+            @ForAll("submitInputs") SubmitInput input) throws Exception {
+
+        // Mock dependencies
+        final AiResourcePersistService aiResourcePersistService = mock(AiResourcePersistService.class);
+        final AiResourceVersionPersistService aiResourceVersionPersistService =
+                mock(AiResourceVersionPersistService.class);
+        final PublishPipelineExecutor publishPipelineExecutor = mock(PublishPipelineExecutor.class);
+        final PipelineExecutionRepository pipelineExecutionRepository = mock(PipelineExecutionRepository.class);
+
+        // Build meta with editingVersion
+        AiResource meta = buildMeta(input.namespaceId, input.name, input.version);
+        when(aiResourcePersistService.find(eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC)))
+                .thenReturn(meta);
+
+        // Build version row as draft for submit's find(), then as reviewing for publish's find()
+        AiResourceVersion draftVersion = buildVersionRow(input.namespaceId, input.name, input.version, "draft");
+        AiResourceVersion reviewingVersion = buildVersionRow(input.namespaceId, input.name, input.version, "reviewing");
+        // submit() calls find() once, then publish() calls find() again
+        when(aiResourceVersionPersistService.find(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version)))
+                .thenReturn(draftVersion)
+                .thenReturn(reviewingVersion);
+
+        // Pipeline executor returns null -> pipeline disabled / no matching nodes
+        when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), any()))
+                .thenReturn(null);
+
+        // Mock updateMetaCas to return true
+        when(aiResourcePersistService.updateMetaCas(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), any(Long.class), any()))
+                .thenReturn(true);
+
+        // Construct service and call submit
+        AgentSpecOperationServiceImpl service = new AgentSpecOperationServiceImpl(
+                aiResourcePersistService, aiResourceVersionPersistService,
+                publishPipelineExecutor, pipelineExecutionRepository);
+        String result = service.submit(input.namespaceId, input.name, input.version);
+
+        assertEquals(input.version, result, "submit should return the version");
+
+        // Verify: updateStatus was called with "online" (from publish path)
+        ArgumentCaptor<String> statusCaptor = ArgumentCaptor.forClass(String.class);
+        verify(aiResourceVersionPersistService).updateStatus(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC),
+                eq(input.version), statusCaptor.capture());
+        assertEquals("online", statusCaptor.getValue(),
+                "Version status should become 'online' when pipeline is disabled");
+
+        // Verify: updatePublishPipelineInfo was NOT called (no pipeline execution)
+        verify(aiResourceVersionPersistService, never()).updatePublishPipelineInfo(
+                any(), any(), any(), any(), any());
+    }
+
+    /**
+     * Property 5b: When Pipeline is enabled and has matching nodes (execute returns non-blank executionId),
+     * version status becomes reviewing, editingVersion is cleared, reviewingVersion is set.
+     *
+     * <p><b>Validates: Requirements 4.4</b></p>
+     */
+    @Property(tries = 50)
+    void submitSetsReviewingWhenPipelineEnabled(
+            @ForAll("submitWithPipelineInputs") SubmitWithPipelineInput input) throws Exception {
+
+        // Mock dependencies
+        final AiResourcePersistService aiResourcePersistService = mock(AiResourcePersistService.class);
+        final AiResourceVersionPersistService aiResourceVersionPersistService =
+                mock(AiResourceVersionPersistService.class);
+        final PublishPipelineExecutor publishPipelineExecutor = mock(PublishPipelineExecutor.class);
+        final PipelineExecutionRepository pipelineExecutionRepository = mock(PipelineExecutionRepository.class);
+
+        // Build meta with editingVersion
+        AiResource meta = buildMeta(input.namespaceId, input.name, input.version);
+        when(aiResourcePersistService.find(eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC)))
+                .thenReturn(meta);
+
+        // Build version row as draft
+        AiResourceVersion draftVersion = buildVersionRow(input.namespaceId, input.name, input.version, "draft");
+        when(aiResourceVersionPersistService.find(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version)))
+                .thenReturn(draftVersion);
+
+        // Pipeline executor returns a non-blank executionId -> pipeline enabled with matching nodes
+        when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), any()))
+                .thenReturn(input.executionId);
+
+        // Mock updateMetaCas to return true
+        when(aiResourcePersistService.updateMetaCas(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), any(Long.class), any()))
+                .thenReturn(true);
+
+        // Construct service and call submit
+        AgentSpecOperationServiceImpl service = new AgentSpecOperationServiceImpl(
+                aiResourcePersistService, aiResourceVersionPersistService,
+                publishPipelineExecutor, pipelineExecutionRepository);
+        String result = service.submit(input.namespaceId, input.name, input.version);
+
+        assertEquals(input.version, result, "submit should return the version");
+
+        // Verify: updateStatus was called with "reviewing"
+        ArgumentCaptor<String> statusCaptor = ArgumentCaptor.forClass(String.class);
+        verify(aiResourceVersionPersistService).updateStatus(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC),
+                eq(input.version), statusCaptor.capture());
+        assertEquals("reviewing", statusCaptor.getValue(),
+                "Version status should become 'reviewing' when pipeline is enabled");
+
+        // Verify: updateMetaCas was called (editingVersion cleared, reviewingVersion set)
+        ArgumentCaptor<AiResource> metaCaptor = ArgumentCaptor.forClass(AiResource.class);
+        verify(aiResourcePersistService).updateMetaCas(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC),
+                any(Long.class), metaCaptor.capture());
+        String updatedVersionInfo = metaCaptor.getValue().getVersionInfo();
+        assertTrue(updatedVersionInfo.contains("\"reviewingVersion\":\"" + input.version + "\""),
+                "Meta should have reviewingVersion set to " + input.version
+                        + ", but versionInfo was: " + updatedVersionInfo);
+        assertTrue(!updatedVersionInfo.contains("\"editingVersion\":\"" + input.version + "\""),
+                "Meta should have editingVersion cleared, but versionInfo was: " + updatedVersionInfo);
+
+        // Verify: updatePublishPipelineInfo was called with IN_PROGRESS
+        ArgumentCaptor<String> pipelineInfoCaptor = ArgumentCaptor.forClass(String.class);
+        verify(aiResourceVersionPersistService).updatePublishPipelineInfo(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC),
+                eq(input.version), pipelineInfoCaptor.capture());
+        String pipelineInfoJson = pipelineInfoCaptor.getValue();
+        assertTrue(pipelineInfoJson.contains("IN_PROGRESS"),
+                "publishPipelineInfo should contain IN_PROGRESS status, but was: " + pipelineInfoJson);
+        assertTrue(pipelineInfoJson.contains(input.executionId),
+                "publishPipelineInfo should contain executionId '" + input.executionId
+                        + "', but was: " + pipelineInfoJson);
+    }
+
+    // ---- Helper methods ----
+
+    private static AiResource buildMeta(String namespaceId, String name, String version) {
+        AiResource meta = new AiResource();
+        meta.setNamespaceId(namespaceId);
+        meta.setName(name);
+        meta.setType(RESOURCE_TYPE_AGENTSPEC);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"editingVersion\":\"" + version
+                + "\",\"onlineCnt\":0,\"labels\":{}}");
+        return meta;
+    }
+
+    private static AiResourceVersion buildVersionRow(String namespaceId, String name,
+            String version, String status) {
+        AiResourceVersion versionRow = new AiResourceVersion();
+        versionRow.setNamespaceId(namespaceId);
+        versionRow.setName(name);
+        versionRow.setType(RESOURCE_TYPE_AGENTSPEC);
+        versionRow.setVersion(version);
+        versionRow.setStatus(status);
+        return versionRow;
+    }
+
+    // ---- Test input models ----
+
+    static class SubmitInput {
+        final String namespaceId;
+        final String name;
+        final String version;
+
+        SubmitInput(String namespaceId, String name, String version) {
+            this.namespaceId = namespaceId;
+            this.name = name;
+            this.version = version;
+        }
+
+        @Override
+        public String toString() {
+            return "SubmitInput{ns='" + namespaceId + "', name='" + name
+                    + "', version='" + version + "'}";
+        }
+    }
+
+    static class SubmitWithPipelineInput {
+        final String namespaceId;
+        final String name;
+        final String version;
+        final String executionId;
+
+        SubmitWithPipelineInput(String namespaceId, String name, String version, String executionId) {
+            this.namespaceId = namespaceId;
+            this.name = name;
+            this.version = version;
+            this.executionId = executionId;
+        }
+
+        @Override
+        public String toString() {
+            return "SubmitWithPipelineInput{ns='" + namespaceId + "', name='" + name
+                    + "', version='" + version + "', execId='" + executionId + "'}";
+        }
+    }
+
+    // ---- Arbitraries ----
+
+    @Provide
+    Arbitrary<SubmitInput> submitInputs() {
+        Arbitrary<String> namespaceIds = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> names = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> versions = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+
+        return Combinators.combine(namespaceIds, names, versions).as(SubmitInput::new);
+    }
+
+    @Provide
+    Arbitrary<SubmitWithPipelineInput> submitWithPipelineInputs() {
+        Arbitrary<String> namespaceIds = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> names = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> versions = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> executionIds = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(30);
+
+        return Combinators.combine(namespaceIds, names, versions, executionIds)
+                .as(SubmitWithPipelineInput::new);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecSubmitResourceTypePropertyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecSubmitResourceTypePropertyTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agentspecs;
+
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
+import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Property 2: Submit resource type correctness.
+ *
+ * <p>For any AgentSpec submit operation, the PublishPipelineContext's resourceType
+ * is always {@link PublishPipelineResourceType#AGENTSPEC}.</p>
+ *
+ * <p><b>Validates: Requirements 2.1, 2.2</b></p>
+ *
+ * @author kiro
+ * @since 3.2.0
+ */
+class AgentSpecSubmitResourceTypePropertyTest {
+
+    private static final String RESOURCE_TYPE_AGENTSPEC = "agentspec";
+
+    /**
+     * Property 2: For any valid namespaceId, name, and version strings, calling submit()
+     * on AgentSpecOperationServiceImpl always passes a PublishPipelineContext with
+     * resourceType == AGENTSPEC to the PublishPipelineExecutor.
+     */
+    @Property(tries = 50)
+    void submitAlwaysSetsResourceTypeToAgentSpec(
+            @ForAll("submitInputs") SubmitInput input) throws Exception {
+
+        // Mock dependencies
+        final AiResourcePersistService aiResourcePersistService = mock(AiResourcePersistService.class);
+        final AiResourceVersionPersistService aiResourceVersionPersistService =
+                mock(AiResourceVersionPersistService.class);
+        final PublishPipelineExecutor publishPipelineExecutor = mock(PublishPipelineExecutor.class);
+        final PipelineExecutionRepository pipelineExecutionRepository = mock(PipelineExecutionRepository.class);
+
+        // Build a valid AiResource with versionInfo JSON containing editingVersion
+        AiResource meta = buildMeta(input);
+        when(aiResourcePersistService.find(eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC)))
+                .thenReturn(meta);
+
+        // Build a valid AiResourceVersion
+        AiResourceVersion versionRow = buildVersionRow(input);
+        when(aiResourceVersionPersistService.find(
+                eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version)))
+                .thenReturn(versionRow);
+
+        // Pipeline executor returns null (pipeline disabled) so submit() won't try to update reviewing status
+        when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), any()))
+                .thenReturn(null);
+
+        // Construct the service under test and call submit
+        AgentSpecOperationServiceImpl service = new AgentSpecOperationServiceImpl(
+                aiResourcePersistService, aiResourceVersionPersistService,
+                publishPipelineExecutor, pipelineExecutionRepository);
+        try {
+            service.submit(input.namespaceId, input.name, input.version);
+        } catch (Exception e) {
+            // publish() may fail due to unmocked storage, but the context was already captured
+        }
+
+        // Capture the PublishPipelineContext passed to execute()
+        ArgumentCaptor<PublishPipelineContext> captor = ArgumentCaptor.forClass(PublishPipelineContext.class);
+        verify(publishPipelineExecutor).execute(captor.capture(), any());
+
+        PublishPipelineContext capturedCtx = captor.getValue();
+        assertNotNull(capturedCtx, "PublishPipelineContext should not be null");
+        assertEquals(PublishPipelineResourceType.AGENTSPEC, capturedCtx.getResourceType(),
+                "resourceType must always be AGENTSPEC for AgentSpec submit, but was: "
+                        + capturedCtx.getResourceType());
+    }
+
+    private static AiResource buildMeta(SubmitInput input) {
+        AiResource meta = new AiResource();
+        meta.setNamespaceId(input.namespaceId);
+        meta.setName(input.name);
+        meta.setType(RESOURCE_TYPE_AGENTSPEC);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"editingVersion\":\"" + input.version
+                + "\",\"onlineCnt\":0,\"labels\":{}}");
+        return meta;
+    }
+
+    private static AiResourceVersion buildVersionRow(SubmitInput input) {
+        AiResourceVersion versionRow = new AiResourceVersion();
+        versionRow.setNamespaceId(input.namespaceId);
+        versionRow.setName(input.name);
+        versionRow.setType(RESOURCE_TYPE_AGENTSPEC);
+        versionRow.setVersion(input.version);
+        versionRow.setStatus("draft");
+        return versionRow;
+    }
+
+    // ---- Test input model ----
+
+    static class SubmitInput {
+        final String namespaceId;
+        final String name;
+        final String version;
+
+        SubmitInput(String namespaceId, String name, String version) {
+            this.namespaceId = namespaceId;
+            this.name = name;
+            this.version = version;
+        }
+
+        @Override
+        public String toString() {
+            return "SubmitInput{namespaceId='" + namespaceId + "', name='" + name
+                    + "', version='" + version + "'}";
+        }
+    }
+
+    // ---- Arbitraries ----
+
+    @Provide
+    Arbitrary<SubmitInput> submitInputs() {
+        Arbitrary<String> namespaceIds = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> names = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+        Arbitrary<String> versions = Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(20);
+
+        return Combinators.combine(namespaceIds, names, versions).as(SubmitInput::new);
+    }
+}

--- a/console-ui-next/vite.config.ts
+++ b/console-ui-next/vite.config.ts
@@ -4,8 +4,6 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 
-export default defineConfig(({ command }) => ({
-  base: command === 'build' ? './' : '/',
 const isTest = !!process.env.VITEST;
 
 export default defineConfig(({ command }) => ({

--- a/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineResourceType.java
+++ b/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineResourceType.java
@@ -38,6 +38,11 @@ public enum PublishPipelineResourceType {
     /**
      * Prompt resource type.
      */
-    PROMPT
+    PROMPT,
+
+    /**
+     * AgentSpec resource type.
+     */
+    AGENTSPEC
 }
 


### PR DESCRIPTION

### What is the purpose of the change

This change adds AGENTSPEC support to the publish pipeline while preserving the existing behavior for SKILL and PROMPT resources.

The main goal is to introduce AGENTSPEC as a first-class resource type in the pipeline flow without breaking existing publish routing, resource type resolution, or compatibility assumptions in current pipeline components. It also aligns the submit/publish lifecycle so that resources enter `reviewing` before direct publish when the pipeline is disabled.

### Brief changelog

- add backward compatibility coverage to ensure SKILL and PROMPT routing remain unchanged after AGENTSPEC support is introduced
- add publish pipeline routing tests for service-level routing validation
- add resource type tests and property-based tests for publish/submit pipeline behavior
- add agent spec pipeline completion and availability property tests
- fix `AgentSpecOperationServiceImpl` to use `AGENTSPEC` resource type instead of `SKILL`
- update pipeline execution flow to transition to `reviewing` before direct publish when the pipeline is disabled
- update `vite.config.ts` and the `PublishPipelineResourceType` plugin model for compatibility
- ensure backward compatibility while extending the publish pipeline to support the new `AGENTSPEC` resource type

### Detailed changes

#### Tests added

- `PublishPipelineBackwardCompatibilityTest`
  - verifies SKILL and PROMPT routing behavior is unchanged after AGENTSPEC addition

- `PublishPipelineManagerRoutingTest`
  - validates pipeline manager routing logic for different resource types

- `PublishPipelineResourceTypePropertyTest`
  - verifies resource type properties through property-based checks

- `PublishPipelineResourceTypeTest`
  - verifies enum/resource type behavior

- `AgentSpecPipelineCompletionPropertyTest`
  - validates completion-related properties in the AGENTSPEC pipeline flow

- `AgentSpecSubmitPipelineAvailabilityPropertyTest`
  - validates pipeline availability checks during AGENTSPEC submission

- `AgentSpecSubmitResourceTypePropertyTest`
  - verifies AGENTSPEC submit resource type properties

#### Functional changes

- `AgentSpecOperationServiceImpl` now uses `AGENTSPEC` as the resource type instead of `SKILL`
- direct publish path now transitions status to `reviewing` before publish when pipeline is disabled
- compatibility adjustments were made in frontend/plugin-related configuration to keep resource type handling aligned

### Verifying this change

#### Suggested verification

- run unit tests covering publish pipeline compatibility and AGENTSPEC routing
- verify SKILL and PROMPT publish flows still route to the same pipeline services as before
- verify AGENTSPEC submit/publish flow uses `AGENTSPEC` resource type consistently
- verify direct publish transitions through `reviewing` when pipeline is disabled
- verify frontend/plugin compatibility after the resource type expansion

#### Commands

```bash
mvn -pl ai,console -am test -Dtest=PublishPipelineBackwardCompatibilityTest,PublishPipelineManagerRoutingTest,PublishPipelineResourceTypePropertyTest,PublishPipelineResourceTypeTest,AgentSpecPipelineCompletionPropertyTest,AgentSpecSubmitPipelineAvailabilityPropertyTest,AgentSpecSubmitResourceTypePropertyTest
```

If broader validation is required:

```bash
mvn -B clean package apache-rat:check spotbugs:check -DskipTests
mvn clean install -DskipITs
mvn clean test-compile failsafe:integration-test
```
