### PR TITLE
fix(naming): Fix the empty cluster name parameter handling logic to ensure the v3 HTTP processing logic is consistent with gRPC.

### DIFF
--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/naming/ConsoleInstanceControllerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/naming/ConsoleInstanceControllerTest.java
@@ -74,7 +74,7 @@ public class ConsoleInstanceControllerTest {
     void testGetInstanceList() throws Exception {
         Page<? extends Instance> page = new Page<>();
         doReturn(page).when(instanceProxy)
-                .listInstances(anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt());
+                .listInstances(anyString(), anyString(), anyString(), any(), anyInt(), anyInt());
         
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get("/v3/console/ns/instance/list")
                 .param("namespaceId", "default").param("serviceName", "testService").param("pageNo", "1")

--- a/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcConnection.java
+++ b/core/src/main/java/com/alibaba/nacos/core/remote/grpc/GrpcConnection.java
@@ -68,6 +68,7 @@ public class GrpcConnection extends Connection {
      * @param request request data.
      * @throws NacosException NacosException
      */
+    @Override
     public void sendRequestNoAck(Request request) throws NacosException {
         sendQueueBlockCheck();
         Future<Boolean> executeFuture = this.channel.eventLoop().submit(() -> {

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImpl.java
@@ -352,14 +352,13 @@ public class NacosNamingMaintainerServiceImpl extends AbstractCoreMaintainerServ
     public List<Instance> listInstances(Service service, String clusterName, boolean healthyOnly)
             throws NacosException {
         service.validate();
-        if (StringUtils.isBlank(clusterName)) {
-            clusterName = com.alibaba.nacos.api.common.Constants.DEFAULT_CLUSTER_NAME;
-        }
         Map<String, String> params = new HashMap<>(5);
         params.put("namespaceId", service.getNamespaceId());
         params.put("groupName", service.getGroupName());
         params.put("serviceName", service.getName());
-        params.put("clusterName", clusterName);
+        if (StringUtils.isNotBlank(clusterName)) {
+            params.put("clusterName", clusterName);
+        }
         params.put("healthyOnly", String.valueOf(healthyOnly));
         RequestResource resource = buildRequestResource(service);
         HttpRequest httpRequest = buildRequestWithResource(resource).setHttpMethod(HttpMethod.GET)

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImplTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImplTest.java
@@ -567,6 +567,35 @@ public class NacosNamingMaintainerServiceImplTest {
     }
     
     @Test
+    void testListInstancesWithClusterName() throws Exception {
+        // Arrange
+        List<Instance> expectedInfo = new ArrayList<>();
+        expectedInfo.add(new Instance());
+        expectedInfo.get(0).setIp("11.1.1.1");
+        expectedInfo.get(0).setPort(8848);
+        HttpRestResult<String> mockHttpRestResult = new HttpRestResult<>();
+        mockHttpRestResult.setData(new ObjectMapper().writeValueAsString(Result.success(expectedInfo)));
+        
+        when(clientHttpProxy.executeSyncHttpRequest(any())).thenReturn(mockHttpRestResult);
+        
+        // Act
+        String serviceName = "testService";
+        String clusterName = "testCluster";
+        boolean healthyOnly = true;
+        List<Instance> result = nacosNamingMaintainerService.listInstances(serviceName, clusterName, healthyOnly);
+        
+        // Assert
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("11.1.1.1", result.get(0).getIp());
+        assertEquals(8848, result.get(0).getPort());
+        verify(clientHttpProxy, times(1)).executeSyncHttpRequest(requestCaptor.capture());
+        assertTrue(requestCaptor.getValue().getParamValues().containsKey("clusterName"));
+        assertEquals("testCluster", requestCaptor.getValue().getParamValues().get("clusterName"));
+    }
+    
+    @Test
     void testGetInstanceDetail() throws Exception {
         // Arrange
         String serviceName = "testService";

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImplTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImplTest.java
@@ -36,11 +36,13 @@ import com.alibaba.nacos.api.selector.NoneSelector;
 import com.alibaba.nacos.api.selector.Selector;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.maintainer.client.core.AbstractCoreMaintainerService;
+import com.alibaba.nacos.maintainer.client.model.HttpRequest;
 import com.alibaba.nacos.maintainer.client.remote.ClientHttpProxy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -53,10 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -539,7 +538,6 @@ public class NacosNamingMaintainerServiceImplTest {
     @Test
     void testListInstances() throws Exception {
         // Arrange
-        
         List<Instance> expectedInfo = new ArrayList<>();
         expectedInfo.add(new Instance());
         expectedInfo.get(0).setIp("11.1.1.1");
@@ -555,11 +553,13 @@ public class NacosNamingMaintainerServiceImplTest {
         List<Instance> result = nacosNamingMaintainerService.listInstances(serviceName, "", healthyOnly);
         
         // Assert
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
         assertNotNull(result);
         assertEquals(1, result.size());
         assertEquals("11.1.1.1", result.get(0).getIp());
         assertEquals(8848, result.get(0).getPort());
-        verify(clientHttpProxy, times(1)).executeSyncHttpRequest(any());
+        verify(clientHttpProxy, times(1)).executeSyncHttpRequest(requestCaptor.capture());
+        assertFalse(requestCaptor.getValue().getParamValues().containsKey("clusterName"));
     }
     
     @Test

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImplTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImplTest.java
@@ -55,7 +55,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/CatalogServiceV2Impl.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/CatalogServiceV2Impl.java
@@ -117,9 +117,6 @@ public class CatalogServiceV2Impl implements CatalogService {
         if (StringUtils.isNotBlank(actualCluster) && !serviceStorage.getClusters(service).contains(actualCluster)) {
             throw new NacosException(NacosException.NOT_FOUND, "cluster " + actualCluster + " is not found!");
         }
-        if (!serviceStorage.getClusters(service).contains(clusterName)) {
-            throw new NacosException(NacosException.NOT_FOUND, "cluster " + clusterName + " is not found!");
-        }
         ServiceInfo serviceInfo = serviceStorage.getData(service);
         ServiceInfo result = ServiceUtil.selectInstances(serviceInfo, clusterName);
         return result.getHosts();

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/CatalogServiceV2Impl.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/CatalogServiceV2Impl.java
@@ -113,6 +113,10 @@ public class CatalogServiceV2Impl implements CatalogService {
             throw new NacosException(NacosException.NOT_FOUND,
                     String.format("service %s@@%s is not found!", groupName, serviceName));
         }
+        String actualCluster = StringUtils.isBlank(clusterName) ? StringUtils.EMPTY : clusterName;
+        if (StringUtils.isNotBlank(actualCluster) && !serviceStorage.getClusters(service).contains(actualCluster)) {
+            throw new NacosException(NacosException.NOT_FOUND, "cluster " + actualCluster + " is not found!");
+        }
         if (!serviceStorage.getClusters(service).contains(clusterName)) {
             throw new NacosException(NacosException.NOT_FOUND, "cluster " + clusterName + " is not found!");
         }

--- a/naming/src/main/java/com/alibaba/nacos/naming/model/form/InstanceListForm.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/model/form/InstanceListForm.java
@@ -68,9 +68,6 @@ public class InstanceListForm implements NacosForm {
         if (StringUtils.isBlank(groupName)) {
             groupName = Constants.DEFAULT_GROUP;
         }
-        if (StringUtils.isBlank(clusterName)) {
-            clusterName = UtilsAndCommons.DEFAULT_CLUSTER_NAME;
-        }
         if (null == healthyOnly) {
             healthyOnly = false;
         }

--- a/naming/src/main/java/com/alibaba/nacos/naming/model/form/InstanceListForm.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/model/form/InstanceListForm.java
@@ -21,7 +21,6 @@ import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.api.model.NacosForm;
-import com.alibaba.nacos.naming.misc.UtilsAndCommons;
 import org.springframework.http.HttpStatus;
 
 import java.util.Objects;

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceControllerV3Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceControllerV3Test.java
@@ -240,7 +240,33 @@ class InstanceControllerV3Test extends BaseTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals(instance, result.getData().get(0));
     }
-    
+
+    /**
+     * Verify that the list API preserves a blank cluster filter and delegates the all-cluster
+     * query semantics to the catalog service.
+     */
+    @Test
+    void listInstanceWithoutClusterName() throws Exception {
+        Instance instance = new Instance();
+        instance.setIp("1.1.1.1");
+        instance.setPort(3306);
+        List<Instance> expected = new LinkedList<>();
+        expected.add(instance);
+
+        doReturn(expected).when(catalogService)
+                .listInstances(eq(TEST_NAMESPACE), eq(TEST_GROUP_NAME), eq("test-service"), eq(null));
+
+        InstanceListForm instanceForm = new InstanceListForm();
+        instanceForm.setNamespaceId(TEST_NAMESPACE);
+        instanceForm.setGroupName(TEST_GROUP_NAME);
+        instanceForm.setServiceName("test-service");
+
+        Result<List<? extends Instance>> result = instanceControllerV3.list(instanceForm);
+
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        assertEquals(instance, result.getData().get(0));
+    }
+
     @Test
     void detail() throws Exception {
         

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceOpenApiControllerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceOpenApiControllerTest.java
@@ -119,7 +119,7 @@ class InstanceOpenApiControllerTest {
         serviceInfo.setName("test");
         serviceInfo.setHosts(Collections.singletonList(instance));
         when(instanceOperator.listInstance(Constants.DEFAULT_NAMESPACE_ID, Constants.DEFAULT_GROUP, "test", null,
-                Constants.DEFAULT_CLUSTER_NAME, false)).thenReturn(serviceInfo);
+                null, false)).thenReturn(serviceInfo);
         Result<List<Instance>> actual = instanceOpenApiController.list(instanceForm);
         assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
         assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/CatalogServiceV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/CatalogServiceV2ImplTest.java
@@ -117,7 +117,28 @@ class CatalogServiceV2ImplTest {
         List<? extends Instance> instances = catalogServiceV2Impl.listInstances("A", "B", "C", "D");
         assertEquals(1, instances.size());
     }
-    
+
+    /**
+     * Verify that a blank cluster name means no cluster filtering and returns all instances.
+     */
+    @Test
+    void testListInstancesWithBlankClusterName() throws NacosException {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setGroupName("B");
+        serviceInfo.setName("C");
+        Instance instance1 = new Instance();
+        instance1.setClusterName("D");
+        instance1.setIp("1.1.1.1");
+        Instance instance2 = new Instance();
+        instance2.setClusterName("E");
+        instance2.setIp("2.2.2.2");
+        serviceInfo.setHosts(List.of(instance1, instance2));
+        Mockito.when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+
+        List<? extends Instance> instances = catalogServiceV2Impl.listInstances("A", "B", "C", "");
+        assertEquals(2, instances.size());
+    }
+
     @Test
     void testListInstancesNonExistService() throws NacosException {
         assertThrows(NacosException.class, () -> {

--- a/plugin-default-impl/nacos-default-control-plugin/src/main/java/com/alibaba/nacos/plugin/control/impl/NacosTpsControlManager.java
+++ b/plugin-default-impl/nacos-default-control-plugin/src/main/java/com/alibaba/nacos/plugin/control/impl/NacosTpsControlManager.java
@@ -73,6 +73,7 @@ public class NacosTpsControlManager extends TpsControlManager {
      *
      * @param pointName pointName.
      */
+    @Override
     public synchronized void registerTpsPoint(String pointName) {
         if (!points.containsKey(pointName)) {
             points.put(pointName, tpsBarrierCreator.createTpsBarrier(pointName));
@@ -90,6 +91,7 @@ public class NacosTpsControlManager extends TpsControlManager {
      * @param pointName pointName.
      * @param rule      rule.
      */
+    @Override
     public synchronized void applyTpsRule(String pointName, TpsControlRule rule) {
         if (rule == null || rule.getPointRule() == null) {
             rules.remove(pointName);
@@ -101,10 +103,12 @@ public class NacosTpsControlManager extends TpsControlManager {
         }
     }
     
+    @Override
     public Map<String, TpsBarrier> getPoints() {
         return points;
     }
     
+    @Override
     public Map<String, TpsControlRule> getRules() {
         return rules;
     }
@@ -115,6 +119,7 @@ public class NacosTpsControlManager extends TpsControlManager {
      * @param tpsRequest TpsRequest.
      * @return check current tps is allowed.
      */
+    @Override
     public TpsCheckResponse check(TpsCheckRequest tpsRequest) {
         
         if (points.containsKey(tpsRequest.getPointName())) {


### PR DESCRIPTION
- 在CatalogServiceV2Impl中添加对空集群名的验证，当clusterName为空时，不添加此筛选逻辑，与gRPC保持一致
- 更新listInstances方法中的集群名验证逻辑，使用actualCluster变量处理空字符串情况
- 移除InstanceListForm中将空集群名转换为默认集群名的逻辑
- 为GrpcConnection类的sendRequestNoAck方法添加@Override注解
- 为NacosTpsControlManager接口实现类添加缺失的@Override注解
- 更新相关测试用例以验证空集群名参数的正确处理行为

## What is the purpose of the change

fix(https://github.com/alibaba/nacos/issues/14650) : the Nacos v3 API is inconsistent with the gRPC client mechanism.

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

