### PR TITLE
feat(config): 新增标签表达式灰度规则支持

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpenApiController.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpenApiController.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.common.utils.ConnLabelsUtils;
 import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.model.ConfigCacheGray;
@@ -98,7 +99,7 @@ public class ConfigOpenApiController {
         request.setTenant(configForm.getNamespaceId());
         request.setGroup(configForm.getGroup());
         request.setDataId(configForm.getDataId());
-        Map<String, String> appLabels = new HashMap<>(4);
+        Map<String, String> appLabels = new HashMap<>(ConnLabelsUtils.parseRawLabels(configForm.getLabels()));
         appLabels.put(BetaGrayRule.CLIENT_IP_LABEL, sourceIp);
         request.setAppLabels(appLabels);
         return request;

--- a/config/src/main/java/com/alibaba/nacos/config/server/model/form/ConfigForm.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/form/ConfigForm.java
@@ -44,6 +44,8 @@ public class ConfigForm implements NacosForm, Cloneable {
     
     private String content;
     
+    private String labels;
+    
     private String tag;
     
     private String appName;
@@ -53,6 +55,8 @@ public class ConfigForm implements NacosForm, Cloneable {
     private String configTags;
     
     private String encryptedDataKey;
+    
+    private String grayType;
     
     private String grayName;
     
@@ -135,6 +139,14 @@ public class ConfigForm implements NacosForm, Cloneable {
         this.content = content;
     }
     
+    public String getLabels() {
+        return labels;
+    }
+    
+    public void setLabels(String labels) {
+        this.labels = labels;
+    }
+    
     public String getTag() {
         return tag;
     }
@@ -213,6 +225,14 @@ public class ConfigForm implements NacosForm, Cloneable {
     
     public void setEncryptedDataKey(String encryptedDataKey) {
         this.encryptedDataKey = encryptedDataKey;
+    }
+    
+    public String getGrayType() {
+        return grayType;
+    }
+    
+    public void setGrayType(String grayType) {
+        this.grayType = grayType;
     }
     
     public String getGrayName() {

--- a/config/src/main/java/com/alibaba/nacos/config/server/model/gray/LabelExpressionGrayRule.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/gray/LabelExpressionGrayRule.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model.gray;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.utils.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LabelExpressionGrayRule extends AbstractGrayRule {
+    
+    private static final Pattern CONDITION_PATTERN = Pattern.compile(
+            "\\s*([A-Za-z0-9_.-]+)\\s*==\\s*'([^']*)'\\s*");
+    
+    public static final String TYPE_LABEL_EXPR = "label_expr";
+    
+    public static final String VERSION = "1.0.0";
+    
+    // Outer list is OR groups; inner list is AND conditions.
+    // 外层表示 OR 分组，内层表示 AND 条件。
+    private List<List<Condition>> orGroups;
+    
+    public LabelExpressionGrayRule() {
+        super();
+    }
+    
+    public LabelExpressionGrayRule(String rawGrayRuleExp, int priority) {
+        super(rawGrayRuleExp, priority);
+    }
+    
+    @Override
+    protected void parse(String rawGrayRule) throws NacosException {
+        // Reject blank expressions early.
+        // 空表达式直接判为非法。
+        if (StringUtils.isBlank(rawGrayRule)) {
+            throw new NacosException(NacosException.INVALID_PARAM, "Label expression can not be blank.");
+        }
+        
+        List<List<Condition>> parsedGroups = new ArrayList<>();
+        // Split by OR first.
+        // 先按 OR 拆分。
+        String[] orParts = rawGrayRule.split("\\|\\|");
+        for (String orPart : orParts) {
+            List<Condition> andConditions = new ArrayList<>();
+            // Then split each group by AND.
+            // 再按 AND 拆分组内条件。
+            String[] andParts = orPart.split("&&");
+            for (String andPart : andParts) {
+                // Parse atomic condition: key == 'value'.
+                // 解析原子条件：key == 'value'。
+                Matcher matcher = CONDITION_PATTERN.matcher(andPart);
+                if (!matcher.matches()) {
+                    // Any invalid segment makes the whole rule invalid.
+                    // 任一片段非法则整条规则非法。
+                    throw new NacosException(NacosException.INVALID_PARAM,
+                            "Invalid label expression segment: " + andPart);
+                }
+                andConditions.add(new Condition(matcher.group(1), matcher.group(2)));
+            }
+            // Guard against empty groups.
+            // 保护空分组场景。
+            if (andConditions.isEmpty()) {
+                throw new NacosException(NacosException.INVALID_PARAM, "Label expression can not be empty.");
+            }
+            parsedGroups.add(andConditions);
+        }
+        // Replace parsed result only after full validation.
+        // 全部校验通过后再整体替换结果。
+        if (parsedGroups.isEmpty()) {
+            throw new NacosException(NacosException.INVALID_PARAM, "Label expression can not be empty.");
+        }
+        this.orGroups = parsedGroups;
+    }
+    
+    @Override
+    public boolean match(Map<String, String> labels) {
+        if (!isValid() || labels == null || labels.isEmpty()) {
+            return false;
+        }
+        
+        // Match succeeds if any OR group matches.
+        // 任一 OR 分组命中即可。
+        for (List<Condition> andGroup : orGroups) {
+            boolean matched = true;
+            // All conditions inside one group must pass.
+            // 同组内条件必须全部满足。
+            for (Condition condition : andGroup) {
+                if (!condition.match(labels)) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    @Override
+    public String getType() {
+        return TYPE_LABEL_EXPR;
+    }
+    
+    @Override
+    public String getVersion() {
+        return VERSION;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LabelExpressionGrayRule that = (LabelExpressionGrayRule) o;
+        return priority == that.priority && Objects.equals(rawGrayRuleExp, that.rawGrayRuleExp);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(rawGrayRuleExp, priority);
+    }
+    
+    private static final class Condition {
+        
+        private final String key;
+        
+        private final String value;
+        
+        private Condition(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+        
+        private boolean match(Map<String, String> labels) {
+            return value.equals(labels.get(key));
+        }
+    }
+}

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
@@ -120,6 +120,13 @@ public class ConfigOperationService {
             publishConfigGray(TagGrayRule.TYPE_TAG, configForm, configRequestInfo);
             return Boolean.TRUE;
         }
+        // generic gray publish
+        if (isGenericGrayPublish(configForm)) {
+            validateGenericGrayPublish(configForm);
+            configMigrateService.publishConfigGrayMigrate(configForm.getGrayType(), configForm, configRequestInfo);
+            publishConfigGray(configForm.getGrayType(), configForm, configRequestInfo);
+            return Boolean.TRUE;
+        }
         
         ConfigOperateResult configOperateResult;
         
@@ -171,6 +178,31 @@ public class ConfigOperationService {
                 configForm.getContent());
         
         return true;
+    }
+    
+    private boolean isGenericGrayPublish(ConfigForm configForm) {
+        return StringUtils.isNotBlank(configForm.getGrayType()) || StringUtils.isNotBlank(configForm.getGrayName())
+                || StringUtils.isNotBlank(configForm.getGrayRuleExp())
+                || StringUtils.isNotBlank(configForm.getGrayVersion());
+    }
+    
+    private void validateGenericGrayPublish(ConfigForm configForm) throws NacosApiException {
+        if (StringUtils.isBlank(configForm.getGrayType())) {
+            throw new NacosApiException(HttpStatus.BAD_REQUEST.value(), ErrorCode.PARAMETER_MISSING,
+                    "Required parameter 'grayType' type String is not present");
+        }
+        if (StringUtils.isBlank(configForm.getGrayName())) {
+            throw new NacosApiException(HttpStatus.BAD_REQUEST.value(), ErrorCode.PARAMETER_MISSING,
+                    "Required parameter 'grayName' type String is not present");
+        }
+        if (StringUtils.isBlank(configForm.getGrayRuleExp())) {
+            throw new NacosApiException(HttpStatus.BAD_REQUEST.value(), ErrorCode.PARAMETER_MISSING,
+                    "Required parameter 'grayRuleExp' type String is not present");
+        }
+        if (StringUtils.isBlank(configForm.getGrayVersion())) {
+            throw new NacosApiException(HttpStatus.BAD_REQUEST.value(), ErrorCode.PARAMETER_MISSING,
+                    "Required parameter 'grayVersion' type String is not present");
+        }
     }
     
     /**

--- a/config/src/main/resources/META-INF/services/com.alibaba.nacos.config.server.model.gray.GrayRule
+++ b/config/src/main/resources/META-INF/services/com.alibaba.nacos.config.server.model.gray.GrayRule
@@ -18,3 +18,4 @@
 
 com.alibaba.nacos.config.server.model.gray.BetaGrayRule
 com.alibaba.nacos.config.server.model.gray.TagGrayRule
+com.alibaba.nacos.config.server.model.gray.LabelExpressionGrayRule

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpenApiControllerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpenApiControllerTest.java
@@ -30,10 +30,13 @@ import com.alibaba.nacos.config.server.model.gray.TagGrayRule;
 import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.alibaba.nacos.core.context.RequestContextHolder;
 import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
@@ -44,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,6 +63,11 @@ class ConfigOpenApiControllerTest {
         MockEnvironment mockEnvironment = new MockEnvironment();
         EnvUtil.setEnvironment(mockEnvironment);
         configOpenApiController = new ConfigOpenApiController(configQueryChainService);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.removeContext();
     }
     
     @Test
@@ -152,5 +161,34 @@ class ConfigOpenApiControllerTest {
         assertEquals(response.getLastModified(), actual.getData().getLastModified());
         assertFalse(actual.getData().isBeta());
         assertEquals("1.1.1.1", actual.getData().getTag());
+    }
+    
+    @Test
+    void testGetConfigShouldBuildAppLabelsFromLabelsAndClientIp() throws NacosApiException,
+            UnsupportedEncodingException {
+        RequestContextHolder.getContext().getBasicContext().getAddressContext().setSourceIp("127.0.0.1");
+        ConfigQueryChainResponse response = new ConfigQueryChainResponse();
+        response.setContent("test");
+        response.setMd5("testMd5");
+        response.setConfigType("text");
+        response.setEncryptedDataKey(null);
+        response.setLastModified(System.currentTimeMillis());
+        response.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(response);
+        
+        ConfigFormV3 configForm = new ConfigFormV3();
+        configForm.setDataId("test");
+        configForm.setGroupName("test");
+        configForm.setLabels("region=hz,env=prod,appVersion=2.3.1");
+        
+        configOpenApiController.getConfig(configForm);
+        
+        ArgumentCaptor<ConfigQueryChainRequest> captor = ArgumentCaptor.forClass(ConfigQueryChainRequest.class);
+        verify(configQueryChainService).handle(captor.capture());
+        ConfigQueryChainRequest actualRequest = captor.getValue();
+        assertEquals("hz", actualRequest.getAppLabels().get("region"));
+        assertEquals("prod", actualRequest.getAppLabels().get("env"));
+        assertEquals("2.3.1", actualRequest.getAppLabels().get("appVersion"));
+        assertEquals("127.0.0.1", actualRequest.getAppLabels().get(BetaGrayRule.CLIENT_IP_LABEL));
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/gray/LabelExpressionGrayRuleTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/gray/LabelExpressionGrayRuleTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model.gray;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LabelExpressionGrayRuleTest {
+    
+    @Test
+    void matchShouldReturnTrueForSingleLabelExpression() {
+        GrayRule rule = new LabelExpressionGrayRule("region == 'hz'", 100);
+        
+        assertTrue(rule.isValid());
+        assertTrue(rule.match(Map.of("region", "hz")));
+        assertFalse(rule.match(Map.of("region", "sh")));
+    }
+    
+    @Test
+    void matchShouldRequireAllConditionsForAndExpression() {
+        GrayRule rule = new LabelExpressionGrayRule("env == 'prod' && appVersion == '2.3.1'", 100);
+        
+        assertTrue(rule.isValid());
+        assertTrue(rule.match(Map.of("env", "prod", "appVersion", "2.3.1")));
+        assertFalse(rule.match(Map.of("env", "prod", "appVersion", "2.3.0")));
+        assertFalse(rule.match(Map.of("env", "test", "appVersion", "2.3.1")));
+    }
+    
+    @Test
+    void matchShouldReturnTrueWhenAnyConditionMatchesForOrExpression() {
+        GrayRule rule = new LabelExpressionGrayRule("cluster == 'canary' || tenant == 'vip'", 100);
+        
+        assertTrue(rule.isValid());
+        assertTrue(rule.match(Map.of("cluster", "canary", "tenant", "normal")));
+        assertTrue(rule.match(Map.of("cluster", "default", "tenant", "vip")));
+        assertFalse(rule.match(Map.of("cluster", "default", "tenant", "normal")));
+    }
+    
+    @Test
+    void matchShouldReturnFalseWhenExpectedLabelDoesNotExist() {
+        GrayRule rule = new LabelExpressionGrayRule("region == 'hz'", 100);
+        
+        assertTrue(rule.isValid());
+        assertFalse(rule.match(Map.of("env", "prod")));
+        assertFalse(rule.match(Map.of()));
+    }
+    
+    @Test
+    void invalidExpressionShouldMarkRuleAsInvalid() {
+        GrayRule rule = new LabelExpressionGrayRule("env = 'prod' &&", 100);
+        
+        assertFalse(rule.isValid());
+        assertFalse(rule.match(Map.of("env", "prod")));
+    }
+    
+    @Test
+    void shouldExposeExpectedTypeVersionAndPriority() {
+        GrayRule rule = new LabelExpressionGrayRule("region == 'hz'", 123);
+        
+        assertEquals("label_expr", rule.getType());
+        assertEquals("1.0.0", rule.getVersion());
+        assertEquals(123, rule.getPriority());
+        assertEquals("region == 'hz'", rule.getRawGrayRuleExp());
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigOperationServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigOperationServiceTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.config.server.service;
 
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigOperateResult;
 import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
@@ -216,6 +217,49 @@ class ConfigOperationServiceTest {
         assertEquals("test", capturedConfigInfo.getDataId());
         assertEquals("test", capturedConfigInfo.getGroup());
         assertEquals("test content", capturedConfigInfo.getContent());
+    }
+    
+    @Test
+    void testPublishConfigGenericGray() throws NacosException {
+        ConfigForm configForm = new ConfigForm();
+        configForm.setDataId("test");
+        configForm.setGroup("test");
+        configForm.setContent("test content");
+        configForm.setGrayType("label_expr");
+        configForm.setGrayName("gray-rule-1");
+        configForm.setGrayRuleExp("region == 'hz'");
+        configForm.setGrayVersion("1.0.0");
+        configForm.setGrayPriority(100);
+        
+        ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
+        
+        when(configInfoGrayPersistService.insertOrUpdateGray(any(ConfigInfo.class), eq("gray-rule-1"), anyString(),
+                eq(configRequestInfo.getSrcIp()), eq(configForm.getSrcUser()))).thenReturn(new ConfigOperateResult());
+        
+        Boolean result = configOperationService.publishConfig(configForm, configRequestInfo, "");
+        
+        assertTrue(result);
+        verify(configMigrateService).publishConfigGrayMigrate(eq("label_expr"), eq(configForm), eq(configRequestInfo));
+        verify(configInfoGrayPersistService).insertOrUpdateGray(any(ConfigInfo.class), eq("gray-rule-1"), anyString(),
+                eq(configRequestInfo.getSrcIp()), eq(configForm.getSrcUser()));
+    }
+    
+    @Test
+    void testPublishConfigGenericGrayWithMissingGrayType() {
+        ConfigForm configForm = new ConfigForm();
+        configForm.setDataId("test");
+        configForm.setGroup("test");
+        configForm.setContent("test content");
+        configForm.setGrayName("gray-rule-1");
+        configForm.setGrayRuleExp("region == 'hz'");
+        configForm.setGrayVersion("1.0.0");
+        
+        ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+                () -> configOperationService.publishConfig(configForm, configRequestInfo, ""));
+        
+        assertEquals("Required parameter 'grayType' type String is not present", exception.getErrMsg());
     }
     
     @Test


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

当前 Nacos 配置中心的灰度能力主要基于 beta/tag 等内置规则，规则类型相对固定，在更复杂的灰度分流场景下扩展性有限。

本次修改在兼容既有 beta/tag 灰度能力的基础上，补充了基于 labels 表达式的通用灰度规则能力，使配置发布与查询链路可以根据请求标签信息匹配灰度配置，支持更灵活的灰度场景。

当前暂未找到完全对应的现有 issue，因此先提交 PR 说明实现方案与验证结果；如有需要，我可以进一步补充对应 issue 并关联。

## Brief changelog

- 新增 `LabelExpressionGrayRule` 并通过 SPI 注册规则实现
- 支持标签表达式解析，当前支持 `&&` 和 `||`
- 在 `ConfigForm` 中新增 `labels` 和 `grayType` 字段
- 复用 `ConnLabelsUtils` 将原始标签字符串解析为应用标签映射
- 在 `ConfigOperationService` 中补充通用灰度发布逻辑
- 在配置查询链路中透传 `labels`，参与灰度规则匹配
- 补充规则解析、发布校验、查询链路构建等相关单元测试
- 修复标签表达式规则初始化过程中解析结果被覆盖的问题，保证运行时能够正确命中灰度规则

## Verifying this change

单元测试：

- `./mvnw -pl config -Dtest=LabelExpressionGrayRuleTest,ConfigOpenApiControllerTest,ConfigOperationServiceTest test`

本地联调验证：

1. 发布正式配置
2. 发布灰度配置，并指定：
   - `grayType=label_expr`
   - `grayRuleExp=region == 'hz' && env == 'prod'`
3. 不携带 `labels` 查询配置，确认返回正式配置
4. 携带 `labels=region=hz,env=prod` 查询配置，确认返回灰度配置

联调结果：

- 不带 `labels` 时返回 `mode: formal`
- 带匹配标签时返回 `mode: gray`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in test module.
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
