### PR TITLE
[ISSUE #14648] Fix instance enabled status override by old metadata on re-register

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManager.java
@@ -252,6 +252,12 @@ public class NamingMetadataManager extends SmartSubscriber {
         Service service = event.getService();
         String metadataId = event.getMetadataId();
         if (containInstanceMetadata(service, metadataId)) {
+            // When instance re-register (expired=false), remove the old metadata to allow
+            // new registration values (like enabled) to take effect.
+            // Fix issue #14648: old metadata should not override new registration values
+            if (!event.isExpired()) {
+                removeInstanceMetadata(service, metadataId);
+            }
             updateExpiredInfo(event.isExpired(),
                     ExpiredMetadataInfo.newExpiredInstanceMetadata(event.getService(), event.getMetadataId()));
         }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManagerTest.java
@@ -226,15 +226,56 @@ class NamingMetadataManagerTest {
         Mockito.when(instanceMetadataEvent.getMetadataId()).thenReturn(METADATA_ID);
         Mockito.when(serviceMetadataEvent.getService()).thenReturn(service);
         Mockito.when(clientDisconnectEvent.getClient()).thenReturn(client);
-        
+
         namingMetadataManager.onEvent(instanceMetadataEvent);
         Mockito.verify(instanceMetadataEvent, Mockito.times(2)).getMetadataId();
         Mockito.verify(instanceMetadataEvent, Mockito.times(2)).getService();
-        
+
         namingMetadataManager.onEvent(serviceMetadataEvent);
         Mockito.verify(serviceMetadataEvent).getService();
-        
+
         namingMetadataManager.onEvent(clientDisconnectEvent);
         Mockito.verify(clientDisconnectEvent).getClient();
+    }
+
+    @Test
+    void testOnEventForReRegisterShouldRemoveOldMetadata() {
+        // Test for issue #14648: When instance re-register (expired=false),
+        // old metadata should be removed to allow new registration values to take effect.
+        Mockito.when(instanceMetadataEvent.getService()).thenReturn(service);
+        Mockito.when(instanceMetadataEvent.getMetadataId()).thenReturn(METADATA_ID);
+        // expired=false means re-register
+        Mockito.when(instanceMetadataEvent.isExpired()).thenReturn(false);
+
+        // Verify metadata exists before event
+        assertTrue(namingMetadataManager.containInstanceMetadata(service, METADATA_ID));
+
+        // Trigger event
+        namingMetadataManager.onEvent(instanceMetadataEvent);
+
+        // Verify old metadata is removed after re-register event
+        assertFalse(namingMetadataManager.containInstanceMetadata(service, METADATA_ID));
+    }
+
+    @Test
+    void testOnEventForExpiredShouldNotRemoveMetadata() {
+        // Test that expired=true (instance removed) should not remove metadata from instanceMetadataMap
+        // but should add to expiredMetadataInfos
+        Mockito.when(instanceMetadataEvent.getService()).thenReturn(service);
+        Mockito.when(instanceMetadataEvent.getMetadataId()).thenReturn(METADATA_ID);
+        // expired=true means instance removed
+        Mockito.when(instanceMetadataEvent.isExpired()).thenReturn(true);
+
+        // Verify metadata exists before event
+        assertTrue(namingMetadataManager.containInstanceMetadata(service, METADATA_ID));
+
+        // Trigger event
+        namingMetadataManager.onEvent(instanceMetadataEvent);
+
+        // Verify metadata is still in instanceMetadataMap (not removed)
+        assertTrue(namingMetadataManager.containInstanceMetadata(service, METADATA_ID));
+        // Verify it's added to expiredMetadataInfos
+        assertTrue(namingMetadataManager.getExpiredMetadataInfos().stream()
+                .anyMatch(info -> info.getService().equals(service) && METADATA_ID.equals(info.getMetadataId())));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

  Fixes #14648 - Fix instance enabled status override by old metadata on re-register

  When a client re-registers an instance after admin changed enabled status via console, the old InstanceMetadata was incorrectly overriding the new registration values.

  ## Root Cause Analysis

  Thanks to @wangcplus for the detailed analysis in the issue:

  1. **First registration**: Instance registered with `enabled=false` stored in `InstancePublishInfo.extendDatum`, no `InstanceMetadata` record
  2. **Admin update**: `patchInstance()` creates `InstanceMetadata{enabled=true}` in `instanceMetadataMap`
  3. **Client disconnect**: Metadata marked as expired and added to `expiredMetadataInfos` (waiting for `ExpiredMetadataCleaner`, default 5min)
  4. **Quick re-register** (< 5min): `InstanceMetadataEvent(expired=false)` fired, but old metadata remained in `instanceMetadataMap`
  5. **Query**: `InstanceUtil.updateInstanceMetadata()` unconditionally overrides `enabled` from stale `InstanceMetadata` ❌

  ## Brief changelog

  - Modified `NamingMetadataManager.handleInstanceMetadataEvent()` to remove old `InstanceMetadata` when instance re-registers (`expired=false`)
  - This ensures new registration values (enabled, weight) take effect instead of being overridden by stale metadata
  - Added unit tests to verify the fix

  ## Changes

  ### Modified files:
  - `naming/src/main/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManager.java`
    - In `handleInstanceMetadataEvent()`: remove instance metadata on re-register (expired=false)

  - `naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManagerTest.java`
    - Added `testOnEventForReRegisterShouldRemoveOldMetadata()`: verify metadata removed on re-register
    - Added `testOnEventForExpiredShouldNotRemoveMetadata()`: verify metadata kept on expire

  ## Verifying this change

  Unit tests passed:
  Tests run: 17, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS

  Test scenarios covered:
  - Re-register (expired=false): old metadata is removed from `instanceMetadataMap` ✅
  - Expire (expired=true): metadata remains in `instanceMetadataMap`, added to `expiredMetadataInfos` ✅

  ## Checklist

  * [x] Make sure there is a Github issue filed for the change
  * [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`
  * [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why
  * [x] Write necessary unit-test to verify your logic correction
  * [x] Run `mvn clean test -Dtest=NamingMetadataManagerTest -pl naming -am` to make sure unit-test pass

  ## Additional Context

  Special thanks to @wangcplus for providing the detailed root cause analysis that helped identify the server-side metadata management issue.

  Fixes #14648