### PR TITLE
feat: add overwrite option for agent spec and skill uploads

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
@@ -151,10 +151,11 @@ public class AgentSpecAdminController {
     @ExtractorManager.Extractor(httpExtractor = ExtractorManager.DefaultHttpExtractor.class)
     public Result<String> uploadAgentSpec(HttpServletRequest request,
             @RequestParam(value = "namespaceId", required = false) String namespaceId,
+            @RequestParam(value = "overwrite", required = false, defaultValue = "false") boolean overwrite,
             @RequestParam("file") MultipartFile file) throws NacosException {
         namespaceId = NamespaceUtil.processNamespaceParameter(namespaceId);
         byte[] zipBytes = AgentSpecRequestUtil.validateAndExtractZipBytes(file);
-        String agentSpecName = agentSpecOperationService.uploadAgentSpecFromZip(namespaceId, zipBytes);
+        String agentSpecName = agentSpecOperationService.uploadAgentSpecFromZip(namespaceId, zipBytes, overwrite);
         return Result.success(agentSpecName);
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
@@ -167,10 +167,11 @@ public class SkillAdminController {
     @ExtractorManager.Extractor(httpExtractor = ExtractorManager.DefaultHttpExtractor.class)
     public Result<String> uploadSkill(HttpServletRequest request,
             @RequestParam(value = "namespaceId", required = false) String namespaceId,
+            @RequestParam(value = "overwrite", required = false, defaultValue = "false") boolean overwrite,
             @RequestParam("file") MultipartFile file) throws NacosException {
         namespaceId = NamespaceUtil.processNamespaceParameter(namespaceId);
         byte[] zipBytes = SkillRequestUtil.validateAndExtractZipBytes(file);
-        String skillName = skillOperationService.uploadSkillFromZip(namespaceId, zipBytes);
+        String skillName = skillOperationService.uploadSkillFromZip(namespaceId, zipBytes, overwrite);
         return Result.success(skillName);
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationService.java
@@ -99,7 +99,20 @@ public interface AgentSpecOperationService {
      * @return agentspec name
      * @throws NacosException if upload failed
      */
-    String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
+    default String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        return uploadAgentSpecFromZip(namespaceId, zipBytes, false);
+    }
+    
+    /**
+     * Upload agentspec from zip file.
+     *
+        * @param namespaceId namespace ID
+        * @param zipBytes zip file bytes
+        * @param overwrite whether to overwrite the current editable draft when the agentspec already exists
+        * @return agentspec name
+        * @throws NacosException if upload failed
+     */
+    String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
     
     /**
      * Search agentspecs for runtime client usage. Only returns enabled agentspecs that have at least one online

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -370,11 +370,15 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     }
     
     @Override
-    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite)
+            throws NacosException {
         AgentSpec agentSpec = AgentSpecZipParser.parseAgentSpecFromZip(zipBytes, namespaceId);
         if (agentSpec == null || StringUtils.isBlank(agentSpec.getName())) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "AgentSpec name is required");
+        }
+        if (overwrite) {
+            return overwriteUploadedAgentSpec(namespaceId, agentSpec);
         }
         String name = agentSpec.getName();
         AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_AGENTSPEC);
@@ -393,6 +397,42 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         String newVersion = nextVersion(namespaceId, name);
         createDraftWithAgentSpec(namespaceId, agentSpec, newVersion, meta, false);
         return name;
+    }
+
+    private String overwriteUploadedAgentSpec(String namespaceId, AgentSpec agentSpec) throws NacosException {
+        String name = agentSpec.getName();
+        AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_AGENTSPEC);
+        if (meta == null) {
+            createDraftWithAgentSpec(namespaceId, agentSpec, "v1", null, true);
+            return name;
+        }
+
+        AgentSpecVersionInfo info = requireVersionInfo(meta);
+        String editing = info.getEditingVersion();
+        if (StringUtils.isNotBlank(editing)) {
+            overwriteEditingDraft(namespaceId, agentSpec, meta, editing);
+            return name;
+        }
+
+        String newVersion = nextVersion(namespaceId, name);
+        createDraftWithAgentSpec(namespaceId, agentSpec, newVersion, meta, false);
+        return name;
+    }
+
+    private void overwriteEditingDraft(String namespaceId, AgentSpec agentSpec, AiResource meta, String editing)
+            throws NacosException {
+        AiResourceVersion versionRow = aiResourceVersionPersistService.find(namespaceId, agentSpec.getName(),
+                RESOURCE_TYPE_AGENTSPEC, editing);
+        if (versionRow == null || !VERSION_STATUS_DRAFT.equalsIgnoreCase(versionRow.getStatus())) {
+            throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                    "Current editing version is not draft: " + editing);
+        }
+        long uniformId = System.currentTimeMillis();
+        writeAgentSpecToStorage(namespaceId, agentSpec, editing, uniformId);
+        aiResourceVersionPersistService.updateStorageAndDesc(namespaceId, agentSpec.getName(),
+                RESOURCE_TYPE_AGENTSPEC, editing, buildStorageJson(namespaceId, agentSpec.getName(), editing),
+                agentSpec.getDescription());
+        bumpMetaDescription(namespaceId, meta, agentSpec.getDescription());
     }
     
     @Override

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationService.java
@@ -42,7 +42,20 @@ public interface SkillOperationService {
      * @return skill name
      * @throws NacosException if upload failed
      */
-    String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
+    default String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        return uploadSkillFromZip(namespaceId, zipBytes, false);
+    }
+
+    /**
+     * Upload skill from zip file.
+     *
+     * @param namespaceId namespace ID
+     * @param zipBytes zip file bytes
+     * @param overwrite whether to overwrite the current editable draft when the skill already exists
+     * @return skill name
+     * @throws NacosException if upload failed
+     */
+    String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
 
     /**
      * Get skill detail for admin usage. Returns version governance metadata and all version summaries.

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -135,10 +135,13 @@ public class SkillOperationServiceImpl implements SkillOperationService {
     }
 
     @Override
-    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException {
         Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, namespaceId);
         if (skill == null || StringUtils.isBlank(skill.getName())) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING, "Skill name is required");
+        }
+        if (overwrite) {
+            return overwriteUploadedSkill(namespaceId, skill);
         }
         String name = skill.getName();
         AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL);
@@ -159,6 +162,41 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         String newVersion = nextVersion(namespaceId, name);
         createDraftWithSkill(namespaceId, skill, newVersion, meta, false);
         return name;
+    }
+
+    private String overwriteUploadedSkill(String namespaceId, Skill skill) throws NacosException {
+        String name = skill.getName();
+        AiResource meta = aiResourcePersistService.find(namespaceId, name, RESOURCE_TYPE_SKILL);
+        if (meta == null) {
+            createDraftWithSkill(namespaceId, skill, "v1", null, true);
+            return name;
+        }
+
+        DataFilterHelper.doWriteCheck(meta);
+        SkillVersionInfo info = requireVersionInfo(meta);
+        String editing = info.getEditingVersion();
+        if (StringUtils.isNotBlank(editing)) {
+            overwriteEditingDraft(namespaceId, skill, meta, editing);
+            return name;
+        }
+
+        String newVersion = nextVersion(namespaceId, name);
+        createDraftWithSkill(namespaceId, skill, newVersion, meta, false);
+        return name;
+    }
+
+    private void overwriteEditingDraft(String namespaceId, Skill skill, AiResource meta, String editing)
+            throws NacosException {
+        AiResourceVersion versionRow = aiResourceVersionPersistService.find(namespaceId, skill.getName(),
+                RESOURCE_TYPE_SKILL, editing);
+        if (versionRow == null || !VERSION_STATUS_DRAFT.equalsIgnoreCase(versionRow.getStatus())) {
+            throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                    "Current editing version is not draft: " + editing);
+        }
+        List<String> files = writeSkillToStorage(namespaceId, skill, editing);
+        aiResourceVersionPersistService.updateStorage(namespaceId, skill.getName(), RESOURCE_TYPE_SKILL, editing,
+                buildStorageJson(namespaceId, skill.getName(), editing, files));
+        bumpMetaDescription(namespaceId, meta, skill.getDescription());
     }
 
     @Override

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
@@ -41,17 +41,27 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.StandardEnvironment;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.Executors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import com.alibaba.nacos.api.model.Page;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -168,5 +178,72 @@ class AgentSpecOperationServiceImplTest {
         assertEquals("v1", version);
         verify(aiResourceVersionPersistService).insert(any(AiResourceVersion.class));
         verify(storage, times(1)).save(any(StorageKey.class), any(byte[].class));
+    }
+
+    @Test
+    void uploadAgentSpecFromZipWithOverwriteUpdatesExistingDraft() throws NacosException, IOException {
+        String namespaceId = "public";
+        byte[] zipBytes = createValidZipBytes();
+        AiResource meta = new AiResource();
+        meta.setNamespaceId(namespaceId);
+        meta.setName("test-agentspec");
+        meta.setType("agentspec");
+        meta.setStatus("enable");
+        meta.setVersionInfo("{\"editingVersion\":\"v2\",\"labels\":{},\"onlineCnt\":1}");
+        AiResourceVersion version = new AiResourceVersion();
+        version.setVersion("v2");
+        version.setStatus("draft");
+        when(aiResourcePersistService.find(eq(namespaceId), eq("test-agentspec"), anyString())).thenReturn(meta);
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq("test-agentspec"), anyString(), eq("v2")))
+                .thenReturn(version);
+
+        String result = service.uploadAgentSpecFromZip(namespaceId, zipBytes, true);
+
+        assertEquals("test-agentspec", result);
+        verify(aiResourceVersionPersistService).updateStorageAndDesc(eq(namespaceId), eq("test-agentspec"),
+                anyString(), eq("v2"), anyString(), isNull());
+        verify(aiResourceVersionPersistService, never()).insert(argThat(inserted -> inserted != null
+                && "test-agentspec".equals(inserted.getName()) && "v2".equals(inserted.getVersion())));
+    }
+
+    @Test
+    void uploadAgentSpecFromZipWithOverwriteCreatesDraftWhenNoEditingDraftExists() throws NacosException,
+            IOException {
+        String namespaceId = "public";
+        byte[] zipBytes = createValidZipBytes();
+        AiResource meta = new AiResource();
+        meta.setNamespaceId(namespaceId);
+        meta.setName("test-agentspec");
+        meta.setType("agentspec");
+        meta.setStatus("enable");
+        meta.setMetaVersion(3L);
+        meta.setVersionInfo("{\"reviewingVersion\":\"v2\",\"labels\":{},\"onlineCnt\":1}");
+        Page<AiResourceVersion> versions = new Page<>();
+        AiResourceVersion v2 = new AiResourceVersion();
+        v2.setVersion("v2");
+        versions.setPageItems(java.util.List.of(v2));
+        when(aiResourcePersistService.find(eq(namespaceId), eq("test-agentspec"), anyString())).thenReturn(meta);
+        when(aiResourceVersionPersistService.listAll(eq(namespaceId), eq("test-agentspec"), anyInt(), anyInt()))
+                .thenReturn(versions);
+        when(aiResourcePersistService.updateMetaCas(eq(namespaceId), eq("test-agentspec"), anyString(), eq(3L), any()))
+                .thenReturn(true);
+
+        String result = service.uploadAgentSpecFromZip(namespaceId, zipBytes, true);
+
+        assertEquals("test-agentspec", result);
+        verify(aiResourceVersionPersistService).insert(argThat(inserted -> inserted != null
+                && "test-agentspec".equals(inserted.getName()) && "v3".equals(inserted.getVersion())));
+    }
+
+    private byte[] createValidZipBytes() throws IOException {
+        String manifest = "{\"version\":\"1.0\",\"worker\":{\"suggested_name\":\"test-agentspec\"}}";
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            ZipEntry manifestEntry = new ZipEntry("manifest.json");
+            zos.putNextEntry(manifestEntry);
+            zos.write(manifest.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
@@ -69,6 +69,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -258,6 +259,62 @@ class SkillOperationServiceImplTest {
         // Then
         assertNotNull(result);
         verify(storage, times(1)).save(any(StorageKey.class), any(byte[].class));
+    }
+
+    @Test
+    void testUploadSkillFromZipWithOverwriteUpdatesExistingDraft() throws NacosException, IOException {
+        String namespaceId = "test-namespace";
+        byte[] zipBytes = createValidZipBytes();
+        AiResource meta = new AiResource();
+        meta.setNamespaceId(namespaceId);
+        meta.setName("test-skill");
+        meta.setType("skill");
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"editingVersion\":\"v3\",\"labels\":{},\"onlineCnt\":1}");
+        com.alibaba.nacos.ai.model.AiResourceVersion version = new com.alibaba.nacos.ai.model.AiResourceVersion();
+        version.setVersion("v3");
+        version.setStatus("draft");
+        when(aiResourcePersistService.find(eq(namespaceId), eq("test-skill"), anyString())).thenReturn(meta);
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq("test-skill"), anyString(), eq("v3")))
+                .thenReturn(version);
+
+        String result = skillOperationService.uploadSkillFromZip(namespaceId, zipBytes, true);
+
+        assertEquals("test-skill", result);
+        verify(aiResourceVersionPersistService).updateStorage(eq(namespaceId), eq("test-skill"), anyString(),
+                eq("v3"), anyString());
+        verify(aiResourceVersionPersistService, never()).insert(argThat(inserted -> inserted != null
+                && "test-skill".equals(inserted.getName()) && "v3".equals(inserted.getVersion())));
+    }
+
+    @Test
+    void testUploadSkillFromZipWithOverwriteCreatesDraftForExistingSkillWithoutEditing() throws NacosException,
+            IOException {
+        String namespaceId = "test-namespace";
+        byte[] zipBytes = createValidZipBytes();
+        AiResource meta = new AiResource();
+        meta.setNamespaceId(namespaceId);
+        meta.setName("test-skill");
+        meta.setType("skill");
+        meta.setStatus("enable");
+        meta.setMetaVersion(2L);
+        meta.setVersionInfo("{\"reviewingVersion\":\"v2\",\"labels\":{},\"onlineCnt\":1}");
+        Page<com.alibaba.nacos.ai.model.AiResourceVersion> versions = new Page<>();
+        com.alibaba.nacos.ai.model.AiResourceVersion v1 = new com.alibaba.nacos.ai.model.AiResourceVersion();
+        v1.setVersion("v2");
+        versions.setPageItems(List.of(v1));
+        when(aiResourcePersistService.find(eq(namespaceId), eq("test-skill"), anyString())).thenReturn(meta);
+        when(aiResourceVersionPersistService.listAll(eq(namespaceId), eq("test-skill"), anyInt(), anyInt()))
+                .thenReturn(versions);
+        when(aiResourcePersistService.updateMetaCas(eq(namespaceId), eq("test-skill"), anyString(), eq(2L), any()))
+                .thenReturn(true);
+
+        String result = skillOperationService.uploadSkillFromZip(namespaceId, zipBytes, true);
+
+        assertEquals("test-skill", result);
+        verify(aiResourceVersionPersistService).insert(argThat(inserted -> inserted != null
+                && "test-skill".equals(inserted.getName()) && "v3".equals(inserted.getVersion())));
     }
     
     /**

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAgentSpecController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAgentSpecController.java
@@ -143,10 +143,11 @@ public class ConsoleAgentSpecController {
     @ExtractorManager.Extractor(httpExtractor = ExtractorManager.DefaultHttpExtractor.class)
     public Result<String> uploadAgentSpec(HttpServletRequest request,
             @RequestParam(value = "namespaceId", required = false) String namespaceId,
+            @RequestParam(value = "overwrite", required = false, defaultValue = "false") boolean overwrite,
             @RequestParam("file") MultipartFile file) throws NacosException {
         namespaceId = NamespaceUtil.processNamespaceParameter(namespaceId);
         byte[] zipBytes = AgentSpecRequestUtil.validateAndExtractZipBytes(file);
-        String agentSpecName = agentSpecProxy.uploadAgentSpecFromZip(namespaceId, zipBytes);
+        String agentSpecName = agentSpecProxy.uploadAgentSpecFromZip(namespaceId, zipBytes, overwrite);
         return Result.success(agentSpecName);
     }
     

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
@@ -159,10 +159,11 @@ public class ConsoleSkillController {
     @ExtractorManager.Extractor(httpExtractor = ExtractorManager.DefaultHttpExtractor.class)
     public Result<String> uploadSkill(HttpServletRequest request,
             @RequestParam(value = "namespaceId", required = false) String namespaceId,
+            @RequestParam(value = "overwrite", required = false, defaultValue = "false") boolean overwrite,
             @RequestParam("file") MultipartFile file) throws NacosException {
         namespaceId = NamespaceUtil.processNamespaceParameter(namespaceId);
         byte[] zipBytes = SkillRequestUtil.validateAndExtractZipBytes(file);
-        String skillName = skillProxy.uploadSkillFromZip(namespaceId, zipBytes);
+        String skillName = skillProxy.uploadSkillFromZip(namespaceId, zipBytes, overwrite);
         return Result.success(skillName);
     }
     

--- a/console/src/main/java/com/alibaba/nacos/console/handler/ai/AgentSpecHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/ai/AgentSpecHandler.java
@@ -83,7 +83,20 @@ public interface AgentSpecHandler {
      * @return agentspec name
      * @throws NacosException if upload failed
      */
-    String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
+    default String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        return uploadAgentSpecFromZip(namespaceId, zipBytes, false);
+    }
+
+    /**
+     * Upload agentspec from zip file.
+     *
+     * @param namespaceId namespace ID
+     * @param zipBytes zip file bytes
+     * @param overwrite whether to overwrite the current editable draft when the agentspec already exists
+     * @return agentspec name
+     * @throws NacosException if upload failed
+     */
+    String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
 
     /**
      * Create draft version based on latest or a specified version.

--- a/console/src/main/java/com/alibaba/nacos/console/handler/ai/SkillHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/ai/SkillHandler.java
@@ -92,7 +92,20 @@ public interface SkillHandler {
      * @return skill name
      * @throws NacosException if upload failed
      */
-    String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
+    default String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        return uploadSkillFromZip(namespaceId, zipBytes, false);
+    }
+
+    /**
+     * Upload skill from zip file.
+     *
+     * @param namespaceId namespace ID
+     * @param zipBytes zip file bytes
+     * @param overwrite whether to overwrite the current editable draft when the skill already exists
+     * @return skill name
+     * @throws NacosException if upload failed
+     */
+    String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
 
     /**
      * Create draft version based on latest or a specified version.

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/AgentSpecInnerHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/AgentSpecInnerHandler.java
@@ -85,8 +85,9 @@ public class AgentSpecInnerHandler implements AgentSpecHandler {
     }
     
     @Override
-    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
-        return agentSpecOperationService.uploadAgentSpecFromZip(namespaceId, zipBytes);
+    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite)
+            throws NacosException {
+        return agentSpecOperationService.uploadAgentSpecFromZip(namespaceId, zipBytes, overwrite);
     }
 
     @Override

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/SkillInnerHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/SkillInnerHandler.java
@@ -86,8 +86,8 @@ public class SkillInnerHandler implements SkillHandler {
     }
     
     @Override
-    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
-        return skillOperationService.uploadSkillFromZip(namespaceId, zipBytes);
+    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException {
+        return skillOperationService.uploadSkillFromZip(namespaceId, zipBytes, overwrite);
     }
 
     @Override

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/AgentSpecNoopHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/AgentSpecNoopHandler.java
@@ -75,7 +75,8 @@ public class AgentSpecNoopHandler implements AgentSpecHandler {
     }
     
     @Override
-    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite)
+            throws NacosException {
         throw new NacosApiException(NacosException.SERVER_NOT_IMPLEMENTED, ErrorCode.API_FUNCTION_DISABLED,
                 AGENTSPEC_NOT_ENABLED_MESSAGE);
     }

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/SkillNoopHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/SkillNoopHandler.java
@@ -80,7 +80,7 @@ public class SkillNoopHandler implements SkillHandler {
     }
     
     @Override
-    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException {
         throw new NacosApiException(NacosException.SERVER_NOT_IMPLEMENTED, ErrorCode.API_FUNCTION_DISABLED,
                 SKILL_NOT_ENABLED_MESSAGE);
     }

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/AgentSpecRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/AgentSpecRemoteHandler.java
@@ -114,8 +114,9 @@ public class AgentSpecRemoteHandler implements AgentSpecHandler {
     }
     
     @Override
-    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
-        return clientHolder.getAiMaintainerService().uploadAgentSpecFromZip(namespaceId, zipBytes);
+    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite)
+            throws NacosException {
+        return clientHolder.getAiMaintainerService().uploadAgentSpecFromZip(namespaceId, zipBytes, overwrite);
     }
 
     @Override

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillRemoteHandler.java
@@ -115,8 +115,8 @@ public class SkillRemoteHandler implements SkillHandler {
     }
     
     @Override
-    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
-        return clientHolder.getAiMaintainerService().uploadSkillFromZip(namespaceId, zipBytes);
+    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException {
+        return clientHolder.getAiMaintainerService().uploadSkillFromZip(namespaceId, zipBytes, overwrite);
     }
 
     @Override

--- a/console/src/main/java/com/alibaba/nacos/console/proxy/ai/AgentSpecProxy.java
+++ b/console/src/main/java/com/alibaba/nacos/console/proxy/ai/AgentSpecProxy.java
@@ -65,7 +65,12 @@ public class AgentSpecProxy {
     }
     
     public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
-        return agentSpecHandler.uploadAgentSpecFromZip(namespaceId, zipBytes);
+        return uploadAgentSpecFromZip(namespaceId, zipBytes, false);
+    }
+
+    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite)
+            throws NacosException {
+        return agentSpecHandler.uploadAgentSpecFromZip(namespaceId, zipBytes, overwrite);
     }
     
     public String createDraft(AgentSpecDraftCreateForm form) throws NacosException {

--- a/console/src/main/java/com/alibaba/nacos/console/proxy/ai/SkillProxy.java
+++ b/console/src/main/java/com/alibaba/nacos/console/proxy/ai/SkillProxy.java
@@ -68,7 +68,11 @@ public class SkillProxy {
     }
     
     public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
-        return skillHandler.uploadSkillFromZip(namespaceId, zipBytes);
+        return uploadSkillFromZip(namespaceId, zipBytes, false);
+    }
+
+    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException {
+        return skillHandler.uploadSkillFromZip(namespaceId, zipBytes, overwrite);
     }
 
     public String createDraft(SkillDraftCreateForm form) throws NacosException {

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerService.java
@@ -107,7 +107,20 @@ public interface AgentSpecMaintainerService {
      * @return agentspec name
      * @throws NacosException if fail to upload agentspec
      */
-    String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
+    default String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        return uploadAgentSpecFromZip(namespaceId, zipBytes, false);
+    }
+
+    /**
+     * Upload agentspec from zip file.
+     *
+     * @param namespaceId namespace ID
+     * @param zipBytes zip file bytes
+     * @param overwrite whether to overwrite the current editable draft when the agentspec already exists
+     * @return agentspec name
+     * @throws NacosException if fail to upload agentspec
+     */
+    String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
     
     /**
      * Upload agentspec from zip file with default namespace.
@@ -117,7 +130,7 @@ public interface AgentSpecMaintainerService {
      * @throws NacosException if fail to upload agentspec
      */
     default String uploadAgentSpecFromZip(byte[] zipBytes) throws NacosException {
-        return uploadAgentSpecFromZip(Constants.DEFAULT_NAMESPACE_ID, zipBytes);
+        return uploadAgentSpecFromZip(Constants.DEFAULT_NAMESPACE_ID, zipBytes, false);
     }
     
     /**

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerServiceImpl.java
@@ -107,10 +107,12 @@ public class AgentSpecMaintainerServiceImpl implements AgentSpecMaintainerServic
     }
     
     @Override
-    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite)
+            throws NacosException {
         namespaceId = resolveNamespace(namespaceId);
         Map<String, String> params = new HashMap<>(4);
         params.put("namespaceId", namespaceId);
+        params.put("overwrite", String.valueOf(overwrite));
         RequestResource resource = buildRequestResource(namespaceId, null);
         HttpRequest httpRequest = buildHttpRequestBuilder(resource).setHttpMethod(HttpMethod.POST)
                 .setPath(Constants.AdminApiPath.AI_AGENTSPEC_UPLOAD_ADMIN_PATH).setParamValue(params)

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/NacosAiMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/NacosAiMaintainerServiceImpl.java
@@ -612,12 +612,13 @@ public class NacosAiMaintainerServiceImpl implements AiMaintainerService {
     }
     
     @Override
-    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+    public String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException {
         if (StringUtils.isBlank(namespaceId)) {
             namespaceId = com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
         }
         Map<String, String> params = new HashMap<>(4);
         params.put("namespaceId", namespaceId);
+        params.put("overwrite", String.valueOf(overwrite));
         RequestResource resource = buildRequestResource(namespaceId, null);
         HttpRequest httpRequest = buildHttpRequestBuilder(resource).setHttpMethod(HttpMethod.POST)
                 .setPath(Constants.AdminApiPath.AI_SKILL_UPLOAD_ADMIN_PATH).setParamValue(params)
@@ -832,12 +833,14 @@ public class NacosAiMaintainerServiceImpl implements AiMaintainerService {
     }
     
     @Override
-    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+    public String uploadAgentSpecFromZip(String namespaceId, byte[] zipBytes, boolean overwrite)
+            throws NacosException {
         if (StringUtils.isBlank(namespaceId)) {
             namespaceId = com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
         }
         Map<String, String> params = new HashMap<>(4);
         params.put("namespaceId", namespaceId);
+        params.put("overwrite", String.valueOf(overwrite));
         RequestResource resource = buildRequestResource(namespaceId, null);
         HttpRequest httpRequest = buildHttpRequestBuilder(resource).setHttpMethod(HttpMethod.POST)
                 .setPath(Constants.AdminApiPath.AI_AGENTSPEC_UPLOAD_ADMIN_PATH).setParamValue(params)

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerService.java
@@ -105,7 +105,20 @@ public interface SkillMaintainerService {
      * @return skill name
      * @throws NacosException if fail to upload skill
      */
-    String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
+    default String uploadSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        return uploadSkillFromZip(namespaceId, zipBytes, false);
+    }
+
+    /**
+     * Upload skill from zip file.
+     *
+     * @param namespaceId namespace ID
+     * @param zipBytes zip file bytes
+     * @param overwrite whether to overwrite the current editable draft when the skill already exists
+     * @return skill name
+     * @throws NacosException if fail to upload skill
+     */
+    String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite) throws NacosException;
     
     /**
      * Upload skill from zip file with default namespace.
@@ -115,7 +128,7 @@ public interface SkillMaintainerService {
      * @throws NacosException if fail to upload skill
      */
     default String uploadSkillFromZip(byte[] zipBytes) throws NacosException {
-        return uploadSkillFromZip(Constants.DEFAULT_NAMESPACE_ID, zipBytes);
+        return uploadSkillFromZip(Constants.DEFAULT_NAMESPACE_ID, zipBytes, false);
     }
 
     /**

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/remote/ClientHttpProxy.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/remote/ClientHttpProxy.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.common.executor.NameThreadFactory;
 import com.alibaba.nacos.common.http.HttpClientConfig;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
+import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.lifecycle.Closeable;
@@ -34,6 +35,8 @@ import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.maintainer.client.address.DefaultServerListManager;
 import com.alibaba.nacos.maintainer.client.model.HttpRequest;
 import com.alibaba.nacos.maintainer.client.utils.ParamUtil;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.alibaba.nacos.plugin.auth.api.LoginIdentityContext;
 import com.alibaba.nacos.plugin.auth.api.RequestResource;
 import com.alibaba.nacos.plugin.auth.spi.client.ClientAuthPluginManager;
@@ -130,7 +133,7 @@ public class ClientHttpProxy implements Closeable {
                 if (result.ok()) {
                     return result;
                 }
-                throw new NacosException(result.getCode(), result.getMessage());
+                throw new NacosException(result.getCode(), resolveErrorMessage(result));
             } catch (NacosException nacosException) {
                 requestException = nacosException;
                 resultCode = nacosException.getErrCode();
@@ -158,6 +161,33 @@ public class ClientHttpProxy implements Closeable {
         }
         throw new NacosException(NacosException.BAD_GATEWAY,
                 "No available server after " + maxRetry + " retries, last tried server: " + currentServerAddr);
+    }
+
+    private String resolveErrorMessage(HttpRestResult<String> result) {
+        String responseBody = result.getData();
+        if (StringUtils.isNotBlank(responseBody)) {
+            try {
+                Result<Object> response = JacksonUtils.toObj(responseBody, new TypeReference<Result<Object>>() {
+                });
+                if (response != null) {
+                    String message = response.getMessage();
+                    Object data = response.getData();
+                    if (data instanceof String && StringUtils.isNotBlank((String) data)) {
+                        if (StringUtils.isNotBlank(message) && !data.equals(message)) {
+                            return message + ": " + data;
+                        }
+                        return (String) data;
+                    }
+                    if (StringUtils.isNotBlank(message)) {
+                        return message;
+                    }
+                }
+            } catch (Exception ignored) {
+                // Fall back to the raw response body for non-Result payloads.
+            }
+            return responseBody;
+        }
+        return result.getMessage();
     }
     
     private HttpRestResult<String> executeSync(HttpRequest request, String serverAddr) throws Exception {

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/remote/ClientHttpProxyTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/remote/ClientHttpProxyTest.java
@@ -210,6 +210,30 @@ public class ClientHttpProxyTest {
         
         verify(mockNacosRestTemplate, times(1)).get(anyString(), any(), any(), any(), eq(String.class));
     }
+
+    @Test
+    void testExecuteSyncHttpRequestShouldKeepBusinessErrorMessage() throws Exception {
+        when(mockServerListManager.getCurrentServer()).thenReturn("http://127.0.0.1:8848");
+
+        HttpRestResult<Object> conflictResult = new HttpRestResult<>();
+        conflictResult.setCode(409);
+        conflictResult.setData(
+            "{\"code\":20005,\"message\":\"resource conflict\",\"data\":"
+                + "\"There is already a working version (editing/reviewing), cannot upload\"}");
+        when(mockNacosRestTemplate.get(anyString(), any(), any(), any(), eq(String.class))).thenReturn(conflictResult);
+
+        HttpRequest request = new HttpRequest("GET", "/test", new HashMap<>(), new HashMap<>(), null, REQUEST_RESOURCE);
+
+        NacosException exception = assertThrows(NacosException.class,
+                () -> clientHttpProxy.executeSyncHttpRequest(request));
+
+        assertEquals(409, exception.getErrCode());
+        assertTrue(exception.getErrMsg().contains("resource conflict"));
+        assertTrue(exception.getErrMsg()
+            .contains("There is already a working version (editing/reviewing), cannot upload"));
+
+        verify(mockNacosRestTemplate, times(4)).get(anyString(), any(), any(), any(), eq(String.class));
+    }
     
     @Test
     void testExecuteSyncHttpRequestRetryOnNoRight() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

This change adds an overwrite option for AgentSpec and Skill ZIP uploads so users can update an existing editing draft directly instead of always being blocked or forced into a new upload flow.

Previously, uploading an AgentSpec or Skill with the same name would fail when a working version already existed, and the remote/SDK layers did not expose a way to explicitly overwrite draft content. This made iterative updates to draft resources cumbersome, especially for ZIP-based upload scenarios.

With this change:
- upload APIs for AgentSpec and Skill now accept an overwrite parameter
- overwrite=false keeps the original behavior unchanged
- overwrite=true overwrites the current editing draft when it exists
- if no editing draft exists, overwrite=true creates a new draft version as before
- existing reviewing or online versions are preserved
- remote console handlers and maintainer client are updated to pass the overwrite flag through the full call chain
- HTTP client error handling is improved so business error messages from server responses are retained more clearly

## Brief changelog

- Added overwrite support to AgentSpec and Skill upload APIs
- Extended controller, handler, proxy, and maintainer client interfaces to propagate the overwrite parameter end to end
- Updated AgentSpec and Skill operation services to support overwrite semantics for uploaded ZIP content
- Implemented draft overwrite logic:
  - overwrite the existing editing draft when a draft version is present
  - create v1 when the resource does not exist
  - create the next draft version when no editing draft exists
- Preserved existing non-overwrite behavior when overwrite=false
- Improved ClientHttpProxy error handling to preserve server-side business error messages during failed HTTP requests
- Added unit tests for Skill and AgentSpec overwrite upload behavior
- Added client-side test coverage for the HTTP proxy behavior
- Verified overwrite behavior with local curl-based and SDK-based upload scenarios

## Verifying this change

Verified locally with the following checks:

- Built the project successfully with:
  - ./mvnw clean install -Prelease-nacos -DskipTests
- Validated Skill upload behavior through admin HTTP APIs:
  - first upload succeeds
  - second upload with overwrite=false is rejected as expected
  - upload with overwrite=true updates the existing draft as expected
- Validated AgentSpec upload behavior through admin HTTP APIs:
  - first upload succeeds
  - second upload with overwrite=false is rejected as expected
  - upload with overwrite=true updates the existing draft as expected
- Validated SDK behavior for uploading the same Skill twice
- Validated SDK behavior for uploading the same AgentSpec twice
- Added unit tests covering:
  - overwrite existing editing draft
  - create new draft when no editing draft exists

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like [ISSUE #123] Fix UnknownException when host config not exist. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in test module.
* [ ] Run mvn -B clean package apache-rat:check spotbugs:check -DskipTests to make sure basic checks pass. Run mvn clean install -DskipITs to make sure unit-test pass. Run mvn clean test-compile failsafe:integration-test to make sure integration-test pass.