### PR TITLE
docs: replace defunct Travis CI badge with GitHub Actions CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Nacos: Dynamic  *Na*ming and *Co*nfiguration *S*ervice
 
 [![Gitter](https://badges.gitter.im/alibaba/nacos.svg)](https://gitter.im/alibaba/nacos?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)   [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![Gitter](https://travis-ci.org/alibaba/nacos.svg?branch=master)](https://travis-ci.org/alibaba/nacos)
+[![CI](https://github.com/alibaba/nacos/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/alibaba/nacos/actions/workflows/ci.yml)
 [![](https://img.shields.io/badge/Nacos-Check%20Your%20Contribution-orange)](https://opensource.alibaba.com/contribution_leaderboard/details?projectValue=nacos)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/alibaba/nacos)
 


### PR DESCRIPTION
## Summary

The Travis CI badge in README.md links to `travis-ci.org/alibaba/nacos` which has been completely shut down. The badge shows stale/broken status.

This PR replaces it with the GitHub Actions CI workflow badge (`ci.yml`) pointing to the `develop` branch, accurately reflecting the current CI status.

## Changes

- Replace Travis CI badge URL with GitHub Actions CI badge
- Fix incorrect alt text (was labeled "Gitter" instead of CI)

## Test plan

- [x] Verify the new badge URL resolves correctly
- [x] No functional code changes