### PR TITLE
fix(skill): fix SKILL.md multi-line description loss during ZIP upload

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
@@ -316,44 +316,96 @@ public class SkillZipParser {
     private static Map<String, String> parseYamlFrontMatter(String yamlContent) {
         Map<String, String> result = new HashMap<>(4);
         String[] lines = yamlContent.split("\\n");
-        
+
+        String pendingKey = null;
+        StringBuilder pendingValue = null;
+
         for (String line : lines) {
+            // If we're accumulating a multi-line double-quoted value
+            if (pendingKey != null) {
+                pendingValue.append("\n").append(line);
+                String accumulated = pendingValue.toString().trim();
+                if (accumulated.endsWith(DOUBLE_QUOTE) && !accumulated.endsWith("\\" + DOUBLE_QUOTE)) {
+                    // Closing quote found — store the complete value
+                    String value = accumulated.substring(1, accumulated.length() - 1);
+                    result.put(pendingKey, unescapeDoubleQuotedYamlValue(value));
+                    pendingKey = null;
+                    pendingValue = null;
+                }
+                continue;
+            }
+
             line = line.trim();
             if (line.isEmpty() || line.startsWith("#")) {
                 continue;
             }
-            
+
             int colonIndex = line.indexOf(':');
             if (colonIndex > 0) {
                 String key = line.substring(0, colonIndex).trim();
                 String value = line.substring(colonIndex + 1).trim();
-                boolean hasDoubleQuotes = value.startsWith(DOUBLE_QUOTE) && value.endsWith(DOUBLE_QUOTE);
+                boolean hasDoubleQuotes = value.length() > 1 && value.startsWith(DOUBLE_QUOTE)
+                        && value.endsWith(DOUBLE_QUOTE) && !value.endsWith("\\" + DOUBLE_QUOTE);
                 boolean hasSingleQuotes = value.startsWith(SINGLE_QUOTE) && value.endsWith(SINGLE_QUOTE);
-                if (hasDoubleQuotes) {
+
+                if (value.startsWith(DOUBLE_QUOTE) && !hasDoubleQuotes) {
+                    // Opening quote without closing — start multi-line accumulation
+                    pendingKey = key;
+                    pendingValue = new StringBuilder(value);
+                } else if (hasDoubleQuotes) {
                     value = value.substring(1, value.length() - 1);
-                    value = unescapeDoubleQuotedYamlValue(value);
+                    result.put(key, unescapeDoubleQuotedYamlValue(value));
                 } else if (hasSingleQuotes) {
                     value = value.substring(1, value.length() - 1);
                     value = value.replace(DOUBLE_SINGLE_QUOTE, SINGLE_QUOTE);
+                    result.put(key, value);
+                } else {
+                    result.put(key, value);
                 }
-                result.put(key, value);
             }
         }
-        
+
         return result;
     }
 
     /**
-     * Minimal unescape for double-quoted YAML scalar values.
-     * Only revert the escape sequences that are emitted by SKILL.md exporters:
-     * - \\\\ -> \
-     * - \\\" -> "
+     * Unescape double-quoted YAML scalar values using single-pass processing.
+     * Handles the following escape sequences:
+     * - \\\\ -> \  (escaped backslash)
+     * - \\\" -> "  (escaped double quote)
+     * - \\n  -> newline (escaped newline)
      */
     private static String unescapeDoubleQuotedYamlValue(String value) {
         if (StringUtils.isBlank(value)) {
             return value;
         }
-        return value.replace(DOUBLE_BACKSLASH, BACKSLASH).replace(ESCAPED_DOUBLE_QUOTE, DOUBLE_QUOTE);
+        StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\\' && i + 1 < value.length()) {
+                char next = value.charAt(i + 1);
+                switch (next) {
+                    case '\\':
+                        sb.append('\\');
+                        i++;
+                        break;
+                    case '"':
+                        sb.append('"');
+                        i++;
+                        break;
+                    case 'n':
+                        sb.append('\n');
+                        i++;
+                        break;
+                    default:
+                        sb.append(c);
+                        break;
+                }
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
     
     private static String extractInstruction(String markdownContent) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserTest.java
@@ -102,6 +102,69 @@ class SkillZipParserTest {
     }
     
     @Test
+    void testParseSkillFromZipWithMultilineDescription() throws Exception {
+        // Given: SKILL.md with multi-line description in double-quoted YAML value
+        byte[] zipBytes = createZipWithMultilineDescription();
+
+        // When
+        Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, "test-namespace");
+
+        // Then: full multi-line description is preserved
+        assertNotNull(skill);
+        assertEquals("test-skill", skill.getName());
+        assertEquals("Line 1\nLine 2\nLine 3", skill.getDescription());
+    }
+
+    @Test
+    void testParseSkillFromZipWithEscapedNewlineDescription() throws Exception {
+        // Given: SKILL.md with escaped \n in double-quoted description (single-line in YAML)
+        byte[] zipBytes = createZipWithEscapedNewlineDescription();
+
+        // When
+        Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, "test-namespace");
+
+        // Then: escaped \n is converted to actual newline
+        assertNotNull(skill);
+        assertEquals("First line\nSecond line", skill.getDescription());
+    }
+
+    @Test
+    void testParseSkillFromZipWithBackslashNInDescription() throws Exception {
+        // Given: description containing literal backslash+n (not a newline)
+        byte[] zipBytes = createZipWithLiteralBackslashN();
+
+        // When
+        Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, "test-namespace");
+
+        // Then: literal \n text is preserved (not converted to newline)
+        assertNotNull(skill);
+        assertEquals("path\\name", skill.getDescription());
+    }
+
+    @Test
+    void testRoundTripMultilineDescription() throws Exception {
+        // Given: a skill with multi-line description exported then re-imported
+        String multilineDesc = "Line 1\nLine 2\nLine 3";
+        Skill original = new Skill();
+        original.setName("roundtrip-skill");
+        original.setDescription(multilineDesc);
+        original.setInstruction("Test instruction");
+
+        // Export to markdown
+        String markdown = SkillUtils.toMarkdown(original);
+
+        // Create ZIP from the exported markdown
+        byte[] zipBytes = createZipFromMarkdown(markdown);
+
+        // Re-import
+        Skill reimported = SkillZipParser.parseSkillFromZip(zipBytes, "test-namespace");
+
+        // Then: description survives the round-trip
+        assertNotNull(reimported);
+        assertEquals(multilineDesc, reimported.getDescription());
+    }
+
+    @Test
     void testParseSkillFromZipWithoutSkillMd() throws IOException {
         // Given
         byte[] zipBytes = createZipWithoutSkillMd();
@@ -459,6 +522,80 @@ class SkillZipParserTest {
             entry = new ZipEntry("test-skill/canvas-fonts/font.ttf");
             zos.putNextEntry(entry);
             zos.write(new byte[] { 0, 1, 2, 3 }); // minimal binary content
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Create a zip with multi-line description using literal newlines inside double quotes.
+     */
+    private byte[] createZipWithMultilineDescription() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            ZipEntry entry = new ZipEntry("SKILL.md");
+            zos.putNextEntry(entry);
+            // Multi-line: literal newlines inside double-quoted YAML value
+            String skillMd = "---\n"
+                    + "name: test-skill\n"
+                    + "description: \"Line 1\nLine 2\nLine 3\"\n"
+                    + "---\n\n"
+                    + "This is a test instruction";
+            zos.write(skillMd.getBytes());
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Create a zip with escaped \\n in description (single-line in YAML file).
+     */
+    private byte[] createZipWithEscapedNewlineDescription() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            ZipEntry entry = new ZipEntry("SKILL.md");
+            zos.putNextEntry(entry);
+            // Escaped \n on a single line — common format from Nacos export
+            String skillMd = "---\n"
+                    + "name: test-skill\n"
+                    + "description: \"First line\\nSecond line\"\n"
+                    + "---\n\n"
+                    + "This is a test instruction";
+            zos.write(skillMd.getBytes());
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Create a zip with literal backslash+n (\\n) in description — not a newline.
+     */
+    private byte[] createZipWithLiteralBackslashN() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            ZipEntry entry = new ZipEntry("SKILL.md");
+            zos.putNextEntry(entry);
+            // \\\\n in Java string = \\n in the file = literal backslash + n after unescape
+            String skillMd = "---\n"
+                    + "name: test-skill\n"
+                    + "description: \"path\\\\name\"\n"
+                    + "---\n\n"
+                    + "This is a test instruction";
+            zos.write(skillMd.getBytes());
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Create a zip from raw SKILL.md markdown content.
+     */
+    private byte[] createZipFromMarkdown(String markdown) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            ZipEntry entry = new ZipEntry("SKILL.md");
+            zos.putNextEntry(entry);
+            zos.write(markdown.getBytes());
             zos.closeEntry();
         }
         return baos.toByteArray();

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/skills/SkillUtils.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/skills/SkillUtils.java
@@ -110,8 +110,9 @@ public class SkillUtils {
         // If value contains special characters, wrap in double quotes
         if (value.contains(COLON) || value.contains(DOUBLE_QUOTE) || value.contains(SINGLE_QUOTE)
             || value.contains(NEWLINE)) {
-            // Escape double quotes in the value
-            return DOUBLE_QUOTE + value.replace(DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE) + DOUBLE_QUOTE;
+            // Escape backslashes, double quotes, and newlines in the value
+            return DOUBLE_QUOTE + value.replace("\\", "\\\\").replace(DOUBLE_QUOTE, ESCAPED_DOUBLE_QUOTE)
+                    .replace(NEWLINE, "\\n") + DOUBLE_QUOTE;
         }
         
         return value;

--- a/api/src/test/java/com/alibaba/nacos/api/ai/model/skills/SkillUtilsTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/model/skills/SkillUtilsTest.java
@@ -79,6 +79,20 @@ class SkillUtilsTest {
     }
     
     @Test
+    void testToMarkdownWithMultilineDescription() {
+        // Given
+        Skill skill = createValidSkill();
+        skill.setDescription("Line 1\nLine 2\nLine 3");
+
+        // When
+        String markdown = SkillUtils.toMarkdown(skill);
+
+        // Then: newlines are escaped as \n inside double quotes, keeping YAML on one line
+        assertNotNull(markdown);
+        assertTrue(markdown.contains("description: \"Line 1\\nLine 2\\nLine 3\""));
+    }
+
+    @Test
     void testSyncToLocalWithOverwriteStrategy() throws IOException {
         // Given
         Skill skill = createValidSkill();


### PR DESCRIPTION
## Problem

When uploading a Skill ZIP file containing a SKILL.md with a multi-line `description` in YAML front matter, the description is truncated to only the first line. The remaining lines and any `metadata` fields are silently discarded. Downloading the ZIP after upload also produces the truncated content, not the original.

## Root Cause

Two issues combine to cause this:

1. **Export side** (`SkillUtils.escapeYamlValue`): When description contains newlines, the value is wrapped in double quotes but literal newline characters are placed inside the quotes instead of being escaped as `\n`. This produces invalid single-line YAML when re-imported.

2. **Import side** (`SkillZipParser.parseYamlFrontMatter`): The parser splits YAML content by `\n` and processes each line independently. Multi-line double-quoted values are broken across lines and only the first line is captured.

## Fix

### Export (`SkillUtils.escapeYamlValue`)
- Escape backslashes first (`\` → `\\`), then double quotes (`"` → `\"`), then newlines (`\n` → `\n` text)
- This ensures each YAML field stays on a single line in the exported SKILL.md

### Import (`SkillZipParser.parseYamlFrontMatter`)
- Support multi-line double-quoted YAML values by tracking open/close quotes across lines
- When an opening `"` is found without a matching close on the same line, accumulate subsequent lines until the closing `"` is found

### Import (`SkillZipParser.unescapeDoubleQuotedYamlValue`)
- Rewrite as single-pass character-by-character unescape to correctly handle `\\`, `\"`, and `\n` escape sequences without ordering conflicts that chained `.replace()` calls would cause

## Tests Added

- `testParseSkillFromZipWithMultilineDescription` — literal newlines inside double-quoted YAML value are preserved
- `testParseSkillFromZipWithEscapedNewlineDescription` — escaped `\n` in single-line YAML is converted to actual newline
- `testParseSkillFromZipWithBackslashNInDescription` — literal `\\n` (backslash + n) is not confused with newline escape
- `testRoundTripMultilineDescription` — multi-line description survives export → ZIP → re-import cycle
- `testToMarkdownWithMultilineDescription` — verifies exported YAML keeps description on single line with `\n` escapes

## Impact

- Fixes loss of multi-line description content during Skill ZIP upload
- Fixes round-trip integrity: upload → download now preserves original content
- Backward compatible: existing single-line descriptions and previously exported SKILL.md files parse correctly

Fixes #14712