### PR TITLE
feat: Implement Skills CLI Registry Adaptor

### DIFF
--- a/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/controller/SkillsRegistryController.java
+++ b/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/controller/SkillsRegistryController.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.controller;
+
+import com.alibaba.nacos.api.annotation.NacosApi;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.mcpregistry.form.SkillsFileQueryForm;
+import com.alibaba.nacos.mcpregistry.form.SkillsSearchForm;
+import com.alibaba.nacos.mcpregistry.model.skills.SkillsSearchResponse;
+import com.alibaba.nacos.mcpregistry.model.skills.WellKnownSkillsIndex;
+import com.alibaba.nacos.mcpregistry.service.NacosSkillsRegistryService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/**
+ * Skills CLI compatible registry endpoints hosted by the MCP registry adaptor.
+ *
+ * @author nacos
+ */
+@NacosApi
+@RestController
+public class SkillsRegistryController {
+
+    private static final String BASE_PATH = "/registry";
+
+    private static final String WELL_KNOWN_AGENT_SKILLS = BASE_PATH + "/{namespaceId}/.well-known/agent-skills";
+
+    private static final String WELL_KNOWN_SKILLS = BASE_PATH + "/{namespaceId}/.well-known/skills";
+
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+    private final NacosSkillsRegistryService nacosSkillsRegistryService;
+
+    public SkillsRegistryController(NacosSkillsRegistryService nacosSkillsRegistryService) {
+        this.nacosSkillsRegistryService = nacosSkillsRegistryService;
+    }
+
+    /**
+     * Expose well-known index.json for the skills CLI.
+     *
+     * @param namespaceId namespace to query
+     * @return well-known index payload
+     * @throws NacosException if query fails
+     */
+    @GetMapping(value = {
+            WELL_KNOWN_AGENT_SKILLS + "/index.json",
+            WELL_KNOWN_SKILLS + "/index.json"
+    }, produces = MediaType.APPLICATION_JSON_VALUE)
+    public WellKnownSkillsIndex getIndex(@PathVariable String namespaceId) throws NacosException {
+        return nacosSkillsRegistryService.buildIndex(namespaceId);
+    }
+
+    /**
+     * Expose CLI-compatible search results under the adaptor endpoint.
+     *
+     * @param namespaceId namespace to query
+     * @param form search query form
+     * @param request current HTTP request
+     * @return search response with CLI-compatible shape
+     * @throws NacosException if query fails
+     */
+    @GetMapping(value = BASE_PATH + "/{namespaceId}/api/search", produces = MediaType.APPLICATION_JSON_VALUE)
+    public SkillsSearchResponse search(@PathVariable String namespaceId, SkillsSearchForm form, HttpServletRequest request)
+            throws NacosException {
+        form.setNamespaceId(namespaceId);
+        form.validate();
+        return nacosSkillsRegistryService.search(namespaceId, form.getQ(), form.getLimit(), buildSourceBaseUrl(request,
+                namespaceId));
+    }
+
+    /**
+     * Return the exported SKILL.md for a namespace skill.
+     *
+     * @param namespaceId namespace to query
+     * @param skillName skill name
+     * @return skill markdown when the skill is exportable, otherwise 404
+     * @throws NacosException if query fails
+     */
+    @GetMapping(value = {
+            WELL_KNOWN_AGENT_SKILLS + "/{skillName}/SKILL.md",
+            WELL_KNOWN_SKILLS + "/{skillName}/SKILL.md"
+    }, produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> getSkillMarkdown(@PathVariable String namespaceId, @PathVariable String skillName)
+            throws NacosException {
+        SkillsFileQueryForm form = new SkillsFileQueryForm();
+        form.setNamespaceId(namespaceId);
+        form.setSkillName(skillName);
+        form.setFilePath("SKILL.md");
+        form.validate();
+        String content = nacosSkillsRegistryService.getSkillFileContent(namespaceId, skillName, form.getFilePath());
+        return content == null ? ResponseEntity.notFound().build()
+                : ResponseEntity.ok().contentType(MediaType.TEXT_PLAIN).body(content);
+    }
+
+    /**
+     * Return an exported text resource for a namespace skill.
+     *
+     * @param namespaceId namespace to query
+     * @param skillName skill name
+     * @param request current HTTP request
+     * @return file content when the skill and file are exportable, otherwise 404
+     * @throws NacosException if query fails
+     */
+    @GetMapping(value = {
+            WELL_KNOWN_AGENT_SKILLS + "/{skillName}/**",
+            WELL_KNOWN_SKILLS + "/{skillName}/**"
+    }, produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> getSkillFile(@PathVariable String namespaceId, @PathVariable String skillName,
+            HttpServletRequest request) throws NacosException {
+        String filePath = extractFilePath(request);
+        SkillsFileQueryForm form = new SkillsFileQueryForm();
+        form.setNamespaceId(namespaceId);
+        form.setSkillName(skillName);
+        form.setFilePath(filePath);
+        form.validate();
+        String content = nacosSkillsRegistryService.getSkillFileContent(namespaceId, skillName, form.getFilePath());
+        return content == null ? ResponseEntity.notFound().build()
+                : ResponseEntity.ok().contentType(MediaType.TEXT_PLAIN).body(content);
+    }
+
+    private String buildSourceBaseUrl(HttpServletRequest request, String namespaceId) {
+        return ServletUriComponentsBuilder.fromRequestUri(request)
+                .replacePath(BASE_PATH + "/{namespaceId}")
+                .replaceQuery(null)
+                .buildAndExpand(namespaceId)
+                .toUriString();
+    }
+
+    private String extractFilePath(HttpServletRequest request) {
+        String pathWithinMapping = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+        String bestMatchingPattern = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        String extracted = PATH_MATCHER.extractPathWithinPattern(bestMatchingPattern, pathWithinMapping);
+        if (StringUtils.isBlank(extracted)) {
+            return extracted;
+        }
+        while (extracted.startsWith("/")) {
+            extracted = extracted.substring(1);
+        }
+        return extracted;
+    }
+}

--- a/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/form/SkillsFileQueryForm.java
+++ b/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/form/SkillsFileQueryForm.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.form;
+
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.NacosForm;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.StringUtils;
+
+/**
+ * Query form for skills CLI compatible file fetch endpoint.
+ *
+ * @author nacos
+ */
+public class SkillsFileQueryForm implements NacosForm {
+
+    private String namespaceId;
+
+    private String skillName;
+
+    private String filePath;
+
+    @Override
+    public void validate() throws NacosApiException {
+        if (StringUtils.isBlank(namespaceId)) {
+            throw new NacosApiException(NacosApiException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
+                    "namespaceId is required");
+        }
+        if (StringUtils.isBlank(skillName)) {
+            throw new NacosApiException(NacosApiException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
+                    "skillName is required");
+        }
+        if (StringUtils.isBlank(filePath)) {
+            throw new NacosApiException(NacosApiException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
+                    "filePath is required");
+        }
+        if (filePath.startsWith("/") || filePath.startsWith("\\") || filePath.contains("..")) {
+            throw new NacosApiException(NacosApiException.INVALID_PARAM, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                    "filePath is invalid");
+        }
+    }
+
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+
+    public void setNamespaceId(String namespaceId) {
+        this.namespaceId = namespaceId;
+    }
+
+    public String getSkillName() {
+        return skillName;
+    }
+
+    public void setSkillName(String skillName) {
+        this.skillName = skillName;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+}

--- a/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/form/SkillsSearchForm.java
+++ b/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/form/SkillsSearchForm.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.form;
+
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.NacosForm;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.StringUtils;
+
+/**
+ * Query form for skills CLI compatible search endpoint.
+ *
+ * @author nacos
+ */
+public class SkillsSearchForm implements NacosForm {
+
+    private static final int DEFAULT_LIMIT = 10;
+
+    private static final int MAX_LIMIT = 10;
+
+    private String namespaceId;
+
+    private String q;
+
+    private Integer limit;
+
+    @Override
+    public void validate() throws NacosApiException {
+        if (StringUtils.isBlank(namespaceId)) {
+            throw new NacosApiException(NacosApiException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
+                    "namespaceId is required");
+        }
+        if (limit == null || limit <= 0) {
+            limit = DEFAULT_LIMIT;
+        }
+        if (limit > MAX_LIMIT) {
+            limit = MAX_LIMIT;
+        }
+    }
+
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+
+    public void setNamespaceId(String namespaceId) {
+        this.namespaceId = namespaceId;
+    }
+
+    public String getQ() {
+        return q;
+    }
+
+    public void setQ(String q) {
+        this.q = q;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Integer limit) {
+        this.limit = limit;
+    }
+}

--- a/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/model/skills/SkillsSearchItem.java
+++ b/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/model/skills/SkillsSearchItem.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.model.skills;
+
+/**
+ * Search result item for the skills CLI.
+ *
+ * @author nacos
+ */
+public class SkillsSearchItem {
+
+    private String id;
+
+    private String name;
+
+    private long installs;
+
+    private String source;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public long getInstalls() {
+        return installs;
+    }
+
+    public void setInstalls(long installs) {
+        this.installs = installs;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+}

--- a/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/model/skills/SkillsSearchResponse.java
+++ b/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/model/skills/SkillsSearchResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.model.skills;
+
+import java.util.List;
+
+/**
+ * Search response for the skills CLI.
+ *
+ * @author nacos
+ */
+public class SkillsSearchResponse {
+
+    private List<SkillsSearchItem> skills;
+
+    public List<SkillsSearchItem> getSkills() {
+        return skills;
+    }
+
+    public void setSkills(List<SkillsSearchItem> skills) {
+        this.skills = skills;
+    }
+}

--- a/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/model/skills/WellKnownSkillEntry.java
+++ b/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/model/skills/WellKnownSkillEntry.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.model.skills;
+
+import java.util.List;
+
+/**
+ * Well-known skill entry for the skills CLI.
+ *
+ * @author nacos
+ */
+public class WellKnownSkillEntry {
+
+    private String name;
+
+    private String description;
+
+    private List<String> files;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<String> getFiles() {
+        return files;
+    }
+
+    public void setFiles(List<String> files) {
+        this.files = files;
+    }
+}

--- a/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/model/skills/WellKnownSkillsIndex.java
+++ b/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/model/skills/WellKnownSkillsIndex.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.model.skills;
+
+import java.util.List;
+
+/**
+ * Well-known skills index response for the skills CLI.
+ *
+ * @author nacos
+ */
+public class WellKnownSkillsIndex {
+
+    private List<WellKnownSkillEntry> skills;
+
+    public List<WellKnownSkillEntry> getSkills() {
+        return skills;
+    }
+
+    public void setSkills(List<WellKnownSkillEntry> skills) {
+        this.skills = skills;
+    }
+}

--- a/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/service/NacosSkillsRegistryService.java
+++ b/mcp-registry-adaptor/src/main/java/com/alibaba/nacos/mcpregistry/service/NacosSkillsRegistryService.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.service;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.model.skills.SkillIndexManifest;
+import com.alibaba.nacos.ai.service.skills.SkillIndexManifestService;
+import com.alibaba.nacos.ai.service.skills.SkillOperationService;
+import com.alibaba.nacos.api.ai.model.skills.Skill;
+import com.alibaba.nacos.api.ai.model.skills.SkillResource;
+import com.alibaba.nacos.api.ai.model.skills.SkillSummary;
+import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.mcpregistry.model.skills.SkillsSearchItem;
+import com.alibaba.nacos.mcpregistry.model.skills.SkillsSearchResponse;
+import com.alibaba.nacos.mcpregistry.model.skills.WellKnownSkillEntry;
+import com.alibaba.nacos.mcpregistry.model.skills.WellKnownSkillsIndex;
+import com.alibaba.nacos.plugin.datafilter.constant.DataFilterConstants;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Service for exposing Nacos skills through the well-known protocol expected by the skills CLI.
+ *
+ * @author nacos
+ */
+@Service
+public class NacosSkillsRegistryService {
+
+    private static final int LIST_PAGE_SIZE = 100;
+
+    private static final Set<String> BINARY_EXTENSIONS = new HashSet<>();
+
+    private static final String MARKDOWN_FILE = "SKILL.md";
+
+    private static final String METADATA_ENCODING = "encoding";
+
+    private static final String METADATA_ENCODING_BASE64 = "base64";
+
+    static {
+        Collections.addAll(BINARY_EXTENSIONS, "ttf", "otf", "woff", "woff2", "eot",
+                "png", "jpg", "jpeg", "gif", "webp", "ico", "cur", "pdf", "bin");
+    }
+
+    private final SkillOperationService skillOperationService;
+
+    private final SkillIndexManifestService skillIndexManifestService;
+
+    public NacosSkillsRegistryService(SkillOperationService skillOperationService,
+            SkillIndexManifestService skillIndexManifestService) {
+        this.skillOperationService = skillOperationService;
+        this.skillIndexManifestService = skillIndexManifestService;
+    }
+
+    /**
+     * Build the well-known skill index for a namespace.
+     *
+     * @param namespaceId namespace to query
+     * @return well-known index response
+     * @throws NacosException if query fails
+     */
+    public WellKnownSkillsIndex buildIndex(String namespaceId) throws NacosException {
+        List<ExportableSkill> skills = collectExportableSkills(namespaceId, null, Integer.MAX_VALUE);
+        skills.sort(Comparator.comparing(each -> each.summary().getName()));
+        List<WellKnownSkillEntry> entries = new ArrayList<>(skills.size());
+        for (ExportableSkill each : skills) {
+            entries.add(toWellKnownEntry(each));
+        }
+        WellKnownSkillsIndex result = new WellKnownSkillsIndex();
+        result.setSkills(entries);
+        return result;
+    }
+
+    /**
+     * Search exportable skills for the CLI search endpoint.
+     *
+     * @param namespaceId namespace to query
+     * @param query search keyword
+     * @param limit max result count
+     * @param sourceBaseUrl source URL reported to the CLI
+     * @return CLI-compatible search response
+     * @throws NacosException if query fails
+     */
+    public SkillsSearchResponse search(String namespaceId, String query, int limit, String sourceBaseUrl)
+            throws NacosException {
+        List<ExportableSkill> skills = collectExportableSkills(namespaceId, query, limit);
+        skills.sort(Comparator.comparingLong((ExportableSkill each) -> safeDownloadCount(each.summary())).reversed()
+                .thenComparing(each -> each.summary().getName()));
+        List<SkillsSearchItem> items = new ArrayList<>(Math.min(limit, skills.size()));
+        for (int i = 0; i < skills.size() && i < limit; i++) {
+            SkillSummary summary = skills.get(i).summary();
+            SkillsSearchItem item = new SkillsSearchItem();
+            item.setId(summary.getName());
+            item.setName(summary.getName());
+            item.setInstalls(safeDownloadCount(summary));
+            item.setSource(sourceBaseUrl);
+            items.add(item);
+        }
+        SkillsSearchResponse result = new SkillsSearchResponse();
+        result.setSkills(items);
+        return result;
+    }
+
+    public String getSkillFileContent(String namespaceId, String skillName, String relativePath) throws NacosException {
+        ExportableSkill skill = loadExportableSkill(namespaceId, skillName);
+        if (skill == null) {
+            return null;
+        }
+        if (MARKDOWN_FILE.equals(relativePath)) {
+            return SkillUtils.toMarkdown(skill.skill());
+        }
+        if (skill.skill().getResource() == null) {
+            return null;
+        }
+        for (SkillResource each : skill.skill().getResource().values()) {
+            if (each == null) {
+                continue;
+            }
+            if (relativePath.equals(buildRelativePath(each))) {
+                return each.getContent();
+            }
+        }
+        return null;
+    }
+
+    private List<ExportableSkill> collectExportableSkills(String namespaceId, String query, int limit)
+            throws NacosException {
+        List<ExportableSkill> result = new ArrayList<>();
+        int pageNo = 1;
+        int pagesAvailable = 1;
+        while (pageNo <= pagesAvailable) {
+            Page<SkillSummary> page = skillOperationService.listSkills(namespaceId, query, Constants.Skills.SEARCH_BLUR,
+                    "download_count", pageNo, LIST_PAGE_SIZE);
+            if (page == null || CollectionUtils.isEmpty(page.getPageItems())) {
+                break;
+            }
+            pagesAvailable = page.getPagesAvailable();
+            for (SkillSummary each : page.getPageItems()) {
+                if (!isEligibleSummary(each)) {
+                    continue;
+                }
+                ExportableSkill exportable = loadExportableSkill(namespaceId, each.getName(), each);
+                if (exportable == null) {
+                    continue;
+                }
+                result.add(exportable);
+                if (limit != Integer.MAX_VALUE && result.size() >= limit) {
+                    return result;
+                }
+            }
+            pageNo++;
+        }
+        return result;
+    }
+
+    private ExportableSkill loadExportableSkill(String namespaceId, String skillName) throws NacosException {
+        Page<SkillSummary> page = skillOperationService.listSkills(namespaceId, skillName, Constants.Skills.SEARCH_ACCURATE,
+                "download_count", 1, 1);
+        if (page == null || CollectionUtils.isEmpty(page.getPageItems())) {
+            return null;
+        }
+        SkillSummary summary = page.getPageItems().get(0);
+        if (!isEligibleSummary(summary)) {
+            return null;
+        }
+        return loadExportableSkill(namespaceId, skillName, summary);
+    }
+
+    private ExportableSkill loadExportableSkill(String namespaceId, String skillName, SkillSummary summary)
+            throws NacosException {
+        SkillIndexManifest manifest = skillIndexManifestService.query(namespaceId, skillName);
+        String resolvedVersion = SkillIndexManifestService.resolveVersion(manifest, null, SkillIndexManifest.LABEL_LATEST);
+        if (StringUtils.isBlank(resolvedVersion)) {
+            return null;
+        }
+        Skill skill;
+        try {
+            skill = skillOperationService.getSkillVersionDetail(namespaceId, skillName, resolvedVersion);
+        } catch (NacosException e) {
+            if (e.getErrCode() == NacosException.NOT_FOUND || e.getErrCode() == NacosException.NO_RIGHT) {
+                return null;
+            }
+            throw e;
+        }
+        if (skill == null || StringUtils.isBlank(skill.getName()) || StringUtils.isBlank(skill.getDescription())) {
+            return null;
+        }
+        List<String> files = buildFiles(skill);
+        if (files == null) {
+            return null;
+        }
+        return new ExportableSkill(summary, skill, files);
+    }
+
+    private boolean isEligibleSummary(SkillSummary summary) {
+        return summary != null
+                && summary.isEnable()
+                && DataFilterConstants.SCOPE_PUBLIC.equalsIgnoreCase(summary.getScope())
+                && summary.getOnlineCnt() != null
+                && summary.getOnlineCnt() > 0
+                && StringUtils.isNotBlank(summary.getName())
+                && StringUtils.isNotBlank(summary.getDescription());
+    }
+
+    private List<String> buildFiles(Skill skill) {
+        List<String> result = new ArrayList<>();
+        result.add(MARKDOWN_FILE);
+        if (skill.getResource() == null || skill.getResource().isEmpty()) {
+            return result;
+        }
+        List<String> resourcePaths = new ArrayList<>(skill.getResource().size());
+        for (SkillResource each : skill.getResource().values()) {
+            if (each == null || StringUtils.isBlank(each.getName())) {
+                continue;
+            }
+            if (isBinaryResource(each)) {
+                return null;
+            }
+            resourcePaths.add(buildRelativePath(each));
+        }
+        resourcePaths.sort(String::compareTo);
+        result.addAll(resourcePaths);
+        return result;
+    }
+
+    private boolean isBinaryResource(SkillResource resource) {
+        Map<String, Object> metadata = resource.getMetadata();
+        if (metadata != null && METADATA_ENCODING_BASE64.equals(metadata.get(METADATA_ENCODING))) {
+            return true;
+        }
+        String name = resource.getName();
+        if (StringUtils.isBlank(name)) {
+            return false;
+        }
+        int dot = name.lastIndexOf('.');
+        if (dot < 0 || dot == name.length() - 1) {
+            return false;
+        }
+        String ext = name.substring(dot + 1).toLowerCase(Locale.ENGLISH);
+        return BINARY_EXTENSIONS.contains(ext);
+    }
+
+    private String buildRelativePath(SkillResource resource) {
+        if (StringUtils.isBlank(resource.getType())) {
+            return resource.getName();
+        }
+        return resource.getType() + "/" + resource.getName();
+    }
+
+    private WellKnownSkillEntry toWellKnownEntry(ExportableSkill each) {
+        WellKnownSkillEntry entry = new WellKnownSkillEntry();
+        entry.setName(each.skill().getName());
+        entry.setDescription(each.skill().getDescription());
+        entry.setFiles(each.files());
+        return entry;
+    }
+
+    private long safeDownloadCount(SkillSummary summary) {
+        return summary.getDownloadCount() == null ? 0L : summary.getDownloadCount();
+    }
+
+    private record ExportableSkill(SkillSummary summary, Skill skill, List<String> files) {
+    }
+}

--- a/mcp-registry-adaptor/src/test/java/com/alibaba/nacos/mcpregistry/controller/SkillsRegistryControllerTest.java
+++ b/mcp-registry-adaptor/src/test/java/com/alibaba/nacos/mcpregistry/controller/SkillsRegistryControllerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.controller;
+
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.mcpregistry.model.skills.SkillsSearchItem;
+import com.alibaba.nacos.mcpregistry.model.skills.SkillsSearchResponse;
+import com.alibaba.nacos.mcpregistry.model.skills.WellKnownSkillEntry;
+import com.alibaba.nacos.mcpregistry.model.skills.WellKnownSkillsIndex;
+import com.alibaba.nacos.mcpregistry.service.NacosSkillsRegistryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Unit tests for {@link SkillsRegistryController}.
+ *
+ * @author nacos
+ */
+@ExtendWith(MockitoExtension.class)
+@ContextConfiguration(classes = org.springframework.mock.web.MockServletContext.class)
+@WebAppConfiguration
+class SkillsRegistryControllerTest {
+
+    @InjectMocks
+    private SkillsRegistryController skillsRegistryController;
+
+    @Mock
+    private NacosSkillsRegistryService nacosSkillsRegistryService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(skillsRegistryController).build();
+    }
+
+    @Test
+    void testGetIndex() throws Exception {
+        WellKnownSkillEntry entry = new WellKnownSkillEntry();
+        entry.setName("demo-skill");
+        entry.setDescription("demo");
+        entry.setFiles(List.of("SKILL.md", "docs/guide.md"));
+        WellKnownSkillsIndex index = new WellKnownSkillsIndex();
+        index.setSkills(List.of(entry));
+        when(nacosSkillsRegistryService.buildIndex("public")).thenReturn(index);
+
+        String content = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/registry/public/.well-known/agent-skills/index.json"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        WellKnownSkillsIndex response = JacksonUtils.toObj(content, WellKnownSkillsIndex.class);
+        assertEquals(1, response.getSkills().size());
+        assertEquals("demo-skill", response.getSkills().get(0).getName());
+    }
+
+    @Test
+    void testSearch() throws Exception {
+        SkillsSearchItem item = new SkillsSearchItem();
+        item.setId("demo-skill");
+        item.setName("demo-skill");
+        item.setInstalls(12);
+        item.setSource("http://localhost/registry/public");
+        SkillsSearchResponse response = new SkillsSearchResponse();
+        response.setSkills(List.of(item));
+        when(nacosSkillsRegistryService.search(eq("public"), eq("demo"), eq(10),
+                eq("http://localhost/registry/public"))).thenReturn(response);
+
+        String content = mockMvc.perform(MockMvcRequestBuilders.get("/registry/public/api/search")
+                        .param("q", "demo"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        SkillsSearchResponse actual = JacksonUtils.toObj(content, SkillsSearchResponse.class);
+        assertEquals(1, actual.getSkills().size());
+        assertEquals("demo-skill", actual.getSkills().get(0).getId());
+    }
+
+    @Test
+    void testGetSkillMarkdown() throws Exception {
+        when(nacosSkillsRegistryService.getSkillFileContent("public", "demo-skill", "SKILL.md"))
+                .thenReturn("---\nname: demo-skill\n---\n");
+
+        String content = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/registry/public/.well-known/agent-skills/demo-skill/SKILL.md"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertTrue(content.contains("demo-skill"));
+    }
+
+    @Test
+    void testGetNestedFile() throws Exception {
+        when(nacosSkillsRegistryService.getSkillFileContent("public", "demo-skill", "docs/guide.md"))
+                .thenReturn("guide");
+
+        String content = mockMvc.perform(
+                        MockMvcRequestBuilders.get("/registry/public/.well-known/skills/demo-skill/docs/guide.md"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertEquals("guide", content);
+    }
+
+    @Test
+    void testGetFileNotFound() throws Exception {
+        when(nacosSkillsRegistryService.getSkillFileContent("public", "demo-skill", "docs/missing.md"))
+                .thenReturn(null);
+
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/registry/public/.well-known/agent-skills/demo-skill/docs/missing.md"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/mcp-registry-adaptor/src/test/java/com/alibaba/nacos/mcpregistry/service/NacosSkillsRegistryServiceTest.java
+++ b/mcp-registry-adaptor/src/test/java/com/alibaba/nacos/mcpregistry/service/NacosSkillsRegistryServiceTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.mcpregistry.service;
+
+import com.alibaba.nacos.ai.model.skills.SkillIndexManifest;
+import com.alibaba.nacos.ai.service.skills.SkillIndexManifestService;
+import com.alibaba.nacos.ai.service.skills.SkillOperationService;
+import com.alibaba.nacos.api.ai.model.skills.Skill;
+import com.alibaba.nacos.api.ai.model.skills.SkillResource;
+import com.alibaba.nacos.api.ai.model.skills.SkillSummary;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.mcpregistry.model.skills.SkillsSearchResponse;
+import com.alibaba.nacos.mcpregistry.model.skills.WellKnownSkillsIndex;
+import com.alibaba.nacos.plugin.datafilter.constant.DataFilterConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.alibaba.nacos.ai.constant.Constants.Skills.SEARCH_ACCURATE;
+import static com.alibaba.nacos.ai.constant.Constants.Skills.SEARCH_BLUR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link NacosSkillsRegistryService}.
+ *
+ * @author nacos
+ */
+@ExtendWith(MockitoExtension.class)
+class NacosSkillsRegistryServiceTest {
+
+    @Mock
+    private SkillOperationService skillOperationService;
+
+    @Mock
+    private SkillIndexManifestService skillIndexManifestService;
+
+    private NacosSkillsRegistryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new NacosSkillsRegistryService(skillOperationService, skillIndexManifestService);
+    }
+
+    @Test
+    void testBuildIndexFiltersBinarySkill() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        page.setPageItems(List.of(buildSummary("text-skill", 5L), buildSummary("binary-skill", 10L)));
+        when(skillOperationService.listSkills(eq("public"), eq((String) null), eq(SEARCH_BLUR), eq("download_count"),
+                eq(1), eq(100))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "text-skill")).thenReturn(buildManifest("v1"));
+        when(skillIndexManifestService.query("public", "binary-skill")).thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "text-skill", "v1"))
+                .thenReturn(buildTextSkill("text-skill"));
+        when(skillOperationService.getSkillVersionDetail("public", "binary-skill", "v1"))
+                .thenReturn(buildBinarySkill("binary-skill"));
+
+        WellKnownSkillsIndex result = service.buildIndex("public");
+
+        assertNotNull(result);
+        assertEquals(1, result.getSkills().size());
+        assertEquals("text-skill", result.getSkills().get(0).getName());
+        assertEquals(List.of("SKILL.md", "docs/guide.md"), result.getSkills().get(0).getFiles());
+    }
+
+    @Test
+    void testSearchBuildsCliShape() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        page.setPageItems(List.of(buildSummary("b-skill", 2L), buildSummary("a-skill", 9L)));
+        when(skillOperationService.listSkills(eq("public"), eq("demo"), eq(SEARCH_BLUR), eq("download_count"),
+                eq(1), eq(100))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "a-skill")).thenReturn(buildManifest("v1"));
+        when(skillIndexManifestService.query("public", "b-skill")).thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "a-skill", "v1"))
+                .thenReturn(buildTextSkill("a-skill"));
+        when(skillOperationService.getSkillVersionDetail("public", "b-skill", "v1"))
+                .thenReturn(buildTextSkill("b-skill"));
+
+        SkillsSearchResponse result = service.search("public", "demo", 10, "http://localhost/registry/public");
+
+        assertEquals(2, result.getSkills().size());
+        assertEquals("a-skill", result.getSkills().get(0).getName());
+        assertEquals(9L, result.getSkills().get(0).getInstalls());
+        assertEquals("http://localhost/registry/public", result.getSkills().get(0).getSource());
+    }
+
+    @Test
+    void testGetSkillFileContent() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        page.setPageItems(List.of(buildSummary("demo-skill", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq("demo-skill"), eq(SEARCH_ACCURATE), eq("download_count"),
+                eq(1), eq(1))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "demo-skill")).thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "demo-skill", "v1"))
+                .thenReturn(buildTextSkill("demo-skill"));
+
+        String markdown = service.getSkillFileContent("public", "demo-skill", "SKILL.md");
+        String file = service.getSkillFileContent("public", "demo-skill", "docs/guide.md");
+        String missing = service.getSkillFileContent("public", "demo-skill", "docs/missing.md");
+
+        assertTrue(markdown.contains("name: demo-skill"));
+        assertEquals("guide", file);
+        assertNull(missing);
+    }
+
+    private SkillSummary buildSummary(String name, Long downloadCount) {
+        SkillSummary result = new SkillSummary();
+        result.setNamespaceId("public");
+        result.setName(name);
+        result.setDescription(name + " description");
+        result.setEnable(true);
+        result.setScope(DataFilterConstants.SCOPE_PUBLIC);
+        result.setOnlineCnt(1);
+        result.setDownloadCount(downloadCount);
+        return result;
+    }
+
+    private SkillIndexManifest buildManifest(String version) {
+        SkillIndexManifest manifest = new SkillIndexManifest();
+        manifest.setLabels(Map.of(SkillIndexManifest.LABEL_LATEST, version));
+        manifest.setVersions(Map.of(version, List.of("ignored")));
+        return manifest;
+    }
+
+    private Skill buildTextSkill(String name) {
+        Skill result = new Skill();
+        result.setNamespaceId("public");
+        result.setName(name);
+        result.setDescription(name + " description");
+        result.setInstruction("# " + name);
+        SkillResource resource = new SkillResource();
+        resource.setType("docs");
+        resource.setName("guide.md");
+        resource.setContent("guide");
+        result.setResource(Map.of("docs::guide.md", resource));
+        return result;
+    }
+
+    private Skill buildBinarySkill(String name) {
+        Skill result = buildTextSkill(name);
+        SkillResource binary = new SkillResource();
+        binary.setType("assets");
+        binary.setName("logo.png");
+        binary.setContent("AA==");
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("encoding", "base64");
+        binary.setMetadata(metadata);
+        result.setResource(Map.of("assets::logo.png", binary));
+        return result;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This change updates the Skills CLI compatible registry entrypoint exposed by `mcp-registry-adaptor` to remove the `/skills` path segment from the public URL.

The exported registry base URL is now:

`/registry/{namespaceId}`

instead of:

`/skills/registry/{namespaceId}`

This keeps the Nacos adaptor compatible with the upstream `vercel-labs/skills` CLI while aligning the external route with the latest agreed API shape.

## Brief changelog

- Change `SkillsRegistryController` base path from `/skills/registry` to `/registry`
- Keep the same well-known and search endpoints under the new base path:
  - `GET /registry/{namespaceId}/.well-known/agent-skills/index.json`
  - `GET /registry/{namespaceId}/.well-known/skills/index.json`
  - `GET /registry/{namespaceId}/.well-known/agent-skills/{skillName}/SKILL.md`
  - `GET /registry/{namespaceId}/.well-known/agent-skills/{skillName}/**`
  - `GET /registry/{namespaceId}/.well-known/skills/{skillName}/**`
  - `GET /registry/{namespaceId}/api/search`
- Update controller and service tests to use the new base URL
- Re-verify the new route with the real `skills` CLI against a locally started MCP registry

## Verifying this change

Verified with unit tests:

```bash
mvn -pl mcp-registry-adaptor -am test \
  -Dtest=SkillsRegistryControllerTest,NacosSkillsRegistryServiceTest,McpRegistryControllerTest,NacosMcpRegistryServiceTest \
  -Dsurefire.failIfNoSpecifiedTests=false
```

Verified manually against a local MCP registry instance:

```bash
curl http://127.0.0.1:9080/registry/public/.well-known/agent-skills/index.json
skills add 'http://127.0.0.1:9080/registry/public' --list
SKILLS_API_URL='http://127.0.0.1:9080/registry/public' skills find test
skills add 'http://127.0.0.1:9080/registry/public' --skill test -y
```

Observed results:
- `index.json` returned the published skill list successfully
- `skills add ... --list` discovered skills successfully
- `skills find` returned the expected search result from `/api/search`
- `skills add ... --skill test -y` installed the skill successfully

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
