### PR TITLE
feat: Enhance AgentSpec controllers and service to support anonymous …

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
@@ -57,6 +57,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 
+import static com.alibaba.nacos.plugin.auth.constant.Constants.Tag.ALLOW_ANONYMOUS;
+
 /**
  * AgentSpec admin controller.
  *
@@ -129,7 +131,8 @@ public class AgentSpecAdminController {
      * @throws NacosException if the agentspec list fails
      */
     @GetMapping("/list")
-    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.ADMIN_API)
+    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.ADMIN_API,
+            tags = {ALLOW_ANONYMOUS})
     public Result<Page<AgentSpecSummary>> listAgentSpecs(AgentSpecListForm agentSpecListForm, PageForm pageForm)
             throws NacosException {
         agentSpecListForm.validate();

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecClientController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecClientController.java
@@ -36,6 +36,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.alibaba.nacos.plugin.auth.constant.Constants.Tag.ALLOW_ANONYMOUS;
+
 /**
  * AgentSpec client controller for runtime read query.
  *
@@ -57,7 +59,7 @@ public class AgentSpecClientController {
      * Search enabled agentspecs for runtime usage.
      */
     @GetMapping("/search")
-    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.OPEN_API)
+    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.OPEN_API, tags = {ALLOW_ANONYMOUS})
     public Result<Page<AgentSpecBasicInfo>> search(AgentSpecSearchForm form, PageForm pageForm) throws NacosException {
         form.validate();
         pageForm.validate();
@@ -69,7 +71,7 @@ public class AgentSpecClientController {
      * Get an online agentspec version by label/version/latest.
      */
     @GetMapping
-    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.OPEN_API)
+    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.OPEN_API, tags = {ALLOW_ANONYMOUS})
     public Result<AgentSpec> get(AgentSpecQueryForm form) throws NacosException {
         form.validate();
         return Result.success(

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecClientController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecClientController.java
@@ -59,7 +59,7 @@ public class AgentSpecClientController {
      * Search enabled agentspecs for runtime usage.
      */
     @GetMapping("/search")
-    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.OPEN_API, tags = {ALLOW_ANONYMOUS})
+    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.OPEN_API)
     public Result<Page<AgentSpecBasicInfo>> search(AgentSpecSearchForm form, PageForm pageForm) throws NacosException {
         form.validate();
         pageForm.validate();

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/VisibilityHelper.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/VisibilityHelper.java
@@ -134,7 +134,7 @@ public class VisibilityHelper {
                         resource);
         if (!result.isAllowed()) {
             throw new NacosApiException(NacosException.NO_RIGHT, ErrorCode.ACCESS_DENIED,
-                    "No permission to modify skill: " + resource.getName());
+                    "No permission to modify " + resource.getType() + ": " + resource.getName());
         }
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -193,8 +193,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
                     "AgentSpec not found: " + agentSpecName);
         }
         AgentSpecVersionInfo versionInfo = requireVersionInfo(meta);
-        Page<AiResourceVersion> versionPage = aiResourceVersionPersistService.listAll(namespaceId, agentSpecName, 1,
-                200);
+        Page<AiResourceVersion> versionPage = aiResourceVersionPersistService.list(namespaceId, agentSpecName,
+                RESOURCE_TYPE_AGENTSPEC, null, 1, 200);
         List<AgentSpecMeta.AgentSpecVersionSummary> versionSummaries = new ArrayList<>();
         if (versionPage != null && versionPage.getPageItems() != null) {
             for (AiResourceVersion v : versionPage.getPageItems()) {
@@ -261,7 +261,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         
         aiResourcePersistService.delete(namespaceId, agentSpecName, RESOURCE_TYPE_AGENTSPEC);
         
-        Page<AiResourceVersion> versions = aiResourceVersionPersistService.listAll(namespaceId, agentSpecName, 1, 200);
+        Page<AiResourceVersion> versions = aiResourceVersionPersistService.list(namespaceId, agentSpecName,
+                RESOURCE_TYPE_AGENTSPEC, null, 1, 200);
         aiResourceVersionPersistService.deleteByNameAndType(namespaceId, agentSpecName, RESOURCE_TYPE_AGENTSPEC);
         
         if (versions != null && versions.getPageItems() != null) {
@@ -1099,7 +1100,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     }
     
     private String nextVersion(String namespaceId, String name) {
-        Page<AiResourceVersion> page = aiResourceVersionPersistService.listAll(namespaceId, name, 1, 200);
+        Page<AiResourceVersion> page = aiResourceVersionPersistService.list(namespaceId, name, RESOURCE_TYPE_AGENTSPEC,
+                null, 1, 200);
         int max = 0;
         if (page != null && page.getPageItems() != null) {
             for (AiResourceVersion v : page.getPageItems()) {
@@ -1123,7 +1125,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     }
 
     private String maxVersionByNumber(String namespaceId, String name) {
-        Page<AiResourceVersion> page = aiResourceVersionPersistService.listAll(namespaceId, name, 1, 200);
+        Page<AiResourceVersion> page = aiResourceVersionPersistService.list(namespaceId, name, RESOURCE_TYPE_AGENTSPEC,
+                null, 1, 200);
         int max = 0;
         String resolved = null;
         if (page != null && page.getPageItems() != null) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -28,6 +28,9 @@ import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
 import com.alibaba.nacos.ai.service.VisibilityHelper;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.service.repository.QueryCondition;
+import com.alibaba.nacos.ai.service.visibility.DefaultVisibilityAdvisorConverter;
+import com.alibaba.nacos.ai.service.visibility.VisibilityAdvisorConverter;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.ai.utils.AgentSpecSeedArchiveReader;
 import com.alibaba.nacos.ai.utils.AgentSpecZipParser;
@@ -47,6 +50,9 @@ import com.alibaba.nacos.plugin.ai.pipeline.model.AgentSpecPipelineContext;
 import com.alibaba.nacos.plugin.ai.pipeline.model.ResourceFileContent;
 import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.plugin.visibility.model.BaseVisibilityPredicate;
+import com.alibaba.nacos.plugin.visibility.model.VisibilityQueryContext;
+import com.alibaba.nacos.plugin.visibility.spi.QueryAdvisor;
 import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.slf4j.Logger;
@@ -106,6 +112,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     
     private final PipelineExecutionRepository pipelineExecutionRepository;
     
+    private final VisibilityAdvisorConverter visibilityAdvisorConverter;
+    
     public AgentSpecOperationServiceImpl(AiResourcePersistService aiResourcePersistService,
             AiResourceVersionPersistService aiResourceVersionPersistService,
             PublishPipelineExecutor publishPipelineExecutor,
@@ -115,6 +123,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         this.aiResourceVersionPersistService = aiResourceVersionPersistService;
         this.publishPipelineExecutor = publishPipelineExecutor;
         this.pipelineExecutionRepository = pipelineExecutionRepository;
+        this.visibilityAdvisorConverter = new DefaultVisibilityAdvisorConverter();
     }
     
     private void createDraftWithAgentSpec(String namespaceId, AgentSpec agentSpec, String version,
@@ -192,6 +201,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                     "AgentSpec not found: " + agentSpecName);
         }
+        ensureReadableOrNotFound(meta, "AgentSpec not found: " + agentSpecName);
         AgentSpecVersionInfo versionInfo = requireVersionInfo(meta);
         Page<AiResourceVersion> versionPage = aiResourceVersionPersistService.list(namespaceId, agentSpecName,
                 RESOURCE_TYPE_AGENTSPEC, null, 1, 200);
@@ -239,6 +249,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                     "AgentSpec not found: " + agentSpecName);
         }
+        ensureReadableOrNotFound(meta, "AgentSpec not found: " + agentSpecName);
         if (StringUtils.isBlank(version)) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "Version is required for agentspec version detail");
@@ -258,6 +269,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         if (meta == null) {
             return;
         }
+        VisibilityHelper.checkWritableResource(meta);
         
         aiResourcePersistService.delete(namespaceId, agentSpecName, RESOURCE_TYPE_AGENTSPEC);
         
@@ -288,8 +300,12 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             }
         }
         
-        Page<AiResource> metaPage = aiResourcePersistService.list(namespaceId, RESOURCE_TYPE_AGENTSPEC, nameLike, null,
-                pageNo, pageSize);
+        QueryCondition queryCondition = buildQueryCondition(namespaceId, RESOURCE_TYPE_AGENTSPEC, nameLike, null,
+                VisibilityConstants.ACTION_READ);
+        if (queryCondition.isAlwaysEmpty()) {
+            return buildEmptyPage(pageNo);
+        }
+        Page<AiResource> metaPage = aiResourcePersistService.list(queryCondition, pageNo, pageSize);
         List<AgentSpecSummary> items = new ArrayList<>();
         if (metaPage != null && metaPage.getPageItems() != null) {
             for (AiResource meta : metaPage.getPageItems()) {
@@ -369,6 +385,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             return name;
         }
         
+        VisibilityHelper.checkWritableResource(meta);
         AgentSpecVersionInfo info = requireVersionInfo(meta);
         if (StringUtils.isNotBlank(info.getEditingVersion()) || StringUtils.isNotBlank(info.getReviewingVersion())) {
             throw new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
@@ -484,6 +501,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             return name;
         }
 
+        VisibilityHelper.checkWritableResource(meta);
         AgentSpecVersionInfo info = requireVersionInfo(meta);
         String editing = info.getEditingVersion();
         if (StringUtils.isNotBlank(editing)) {
@@ -525,8 +543,12 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             throws NacosException {
         String nameLike = StringUtils.isBlank(keyword) ? null
                 : aiResourcePersistService.generateLikeArgument(Constants.ALL_PATTERN + keyword + Constants.ALL_PATTERN);
-        Page<AiResource> metaPage = aiResourcePersistService.list(namespaceId, RESOURCE_TYPE_AGENTSPEC, nameLike, null,
-                pageNo, pageSize);
+        QueryCondition queryCondition = buildQueryCondition(namespaceId, RESOURCE_TYPE_AGENTSPEC, nameLike, null,
+                VisibilityConstants.ACTION_READ);
+        if (queryCondition.isAlwaysEmpty()) {
+            return buildEmptyPage(pageNo);
+        }
+        Page<AiResource> metaPage = aiResourcePersistService.list(queryCondition, pageNo, pageSize);
         List<AgentSpecBasicInfo> items = new ArrayList<>();
         if (metaPage != null && metaPage.getPageItems() != null) {
             for (AiResource meta : metaPage.getPageItems()) {
@@ -562,6 +584,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                     "AgentSpec not found: " + name);
         }
+        ensureReadableOrNotFound(meta, "AgentSpec not found: " + name);
         if (!META_STATUS_ENABLE.equalsIgnoreCase(meta.getStatus())) {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                     "AgentSpec disabled: " + name);
@@ -595,6 +618,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             return "v1";
         }
 
+        VisibilityHelper.checkWritableResource(meta);
         AgentSpecVersionInfo info = requireVersionInfo(meta);
         if (StringUtils.isNotBlank(info.getEditingVersion()) || StringUtils.isNotBlank(info.getReviewingVersion())) {
             throw new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
@@ -646,6 +670,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             createDraftWithAgentSpec(namespaceId, draftAgentSpec, "v1", null, true);
             return;
         }
+        VisibilityHelper.checkWritableResource(meta);
         AgentSpecVersionInfo info = requireVersionInfo(meta);
         String editing = info.getEditingVersion();
         if (StringUtils.isBlank(editing)) {
@@ -669,6 +694,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     @Override
     public void deleteDraft(String namespaceId, String name) throws NacosException {
         AiResource meta = requireMeta(namespaceId, name);
+        VisibilityHelper.checkWritableResource(meta);
         AgentSpecVersionInfo info = requireVersionInfo(meta);
         String editing = info.getEditingVersion();
         if (StringUtils.isBlank(editing)) {
@@ -687,6 +713,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     @Override
     public String submit(String namespaceId, String name, String version) throws NacosException {
         AiResource meta = requireMeta(namespaceId, name);
+        VisibilityHelper.checkWritableResource(meta);
         AgentSpecVersionInfo info = requireVersionInfo(meta);
         
         String target = version;
@@ -770,6 +797,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     public void publish(String namespaceId, String name, String version, boolean updateLatestLabel)
             throws NacosException {
         AiResource meta = requireMeta(namespaceId, name);
+        VisibilityHelper.checkWritableResource(meta);
         AgentSpecVersionInfo info = requireVersionInfo(meta);
         
         AiResourceVersion v = aiResourceVersionPersistService.find(namespaceId, name, RESOURCE_TYPE_AGENTSPEC,
@@ -839,6 +867,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     public void changeOnlineStatus(String namespaceId, String name, String scope, String version, boolean online)
             throws NacosException {
         AiResource meta = requireMeta(namespaceId, name);
+        VisibilityHelper.checkWritableResource(meta);
         AgentSpecVersionInfo info = requireVersionInfo(meta);
         
         boolean agentSpecScope = SCOPE_AGENTSPEC.equalsIgnoreCase(scope) || StringUtils.isBlank(version);
@@ -983,6 +1012,44 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         json.put("provider", resolveStorageProvider());
         json.put("scope", namespaceId + ":" + agentSpecName + ":" + version);
         return JacksonUtils.toJson(json);
+    }
+    
+    private QueryCondition buildQueryCondition(String namespaceId, String resourceType, String nameLike,
+            String bizTagsLike, String action) {
+        String identity = VisibilityHelper.resolveCurrentIdentity();
+        String apiType = VisibilityHelper.resolveCurrentApiType();
+        QueryCondition queryCondition = new QueryCondition();
+        queryCondition.setNamespaceId(namespaceId);
+        queryCondition.setType(resourceType);
+        queryCondition.setNameLike(nameLike);
+        queryCondition.setBizTagsLike(bizTagsLike);
+        VisibilityQueryContext context = new VisibilityQueryContext();
+        context.setNamespaceId(namespaceId);
+        context.setResourceType(resourceType);
+        QueryAdvisor advisor = VisibilityHelper.findVisibilityService()
+                .map(service -> service.adviseQuery(identity, action, apiType, context))
+                .orElseGet(() -> {
+                    QueryAdvisor queryAdvisor = new QueryAdvisor();
+                    queryAdvisor.setBasePredicate(BaseVisibilityPredicate.ALL);
+                    return queryAdvisor;
+                });
+        return visibilityAdvisorConverter.convert(queryCondition, identity, advisor, context);
+    }
+    
+    private void ensureReadableOrNotFound(AiResource resource, String notFoundMessage) throws NacosException {
+        if (VisibilityHelper.canReadResource(resource)) {
+            return;
+        }
+        throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND, notFoundMessage);
+    }
+    
+    private static <T> Page<T> buildEmptyPage(int pageNo) {
+        Page<T> page = new Page<>();
+        page.setPageItems(new ArrayList<>());
+        page.setTotalCount(0);
+        page.setPagesAvailable(0);
+        page.setPageNumber(pageNo);
+        return page;
     }
     
     private AiResource requireMeta(String namespaceId, String name) throws NacosException {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
@@ -66,6 +66,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -269,8 +270,8 @@ class AgentSpecOperationServiceImplTest {
 
         com.alibaba.nacos.api.model.Page<AiResourceVersion> emptyPage = new com.alibaba.nacos.api.model.Page<>();
         when(aiResourcePersistService.find(eq(namespaceId), eq(agentSpecName), anyString())).thenReturn(meta);
-        when(aiResourceVersionPersistService.listAll(eq(namespaceId), eq(agentSpecName), anyInt(), anyInt()))
-                .thenReturn(emptyPage);
+        when(aiResourceVersionPersistService.list(eq(namespaceId), eq(agentSpecName), eq("agentspec"), isNull(),
+                anyInt(), anyInt())).thenReturn(emptyPage);
         when(aiResourcePersistService.updateMetaCas(eq(namespaceId), eq(agentSpecName), anyString(), eq(1L), any()))
                 .thenReturn(true);
 
@@ -334,8 +335,8 @@ class AgentSpecOperationServiceImplTest {
         v2.setVersion("v2");
         versions.setPageItems(java.util.List.of(v2));
         when(aiResourcePersistService.find(eq(namespaceId), eq("测试坐席"), anyString())).thenReturn(meta);
-        when(aiResourceVersionPersistService.listAll(eq(namespaceId), eq("测试坐席"), anyInt(), anyInt()))
-                .thenReturn(versions);
+        when(aiResourceVersionPersistService.list(eq(namespaceId), eq("测试坐席"), eq("agentspec"), isNull(),
+                anyInt(), anyInt())).thenReturn(versions);
         when(aiResourcePersistService.updateMetaCas(eq(namespaceId), eq("测试坐席"), anyString(), eq(3L), any()))
                 .thenReturn(true);
 
@@ -442,8 +443,8 @@ class AgentSpecOperationServiceImplTest {
         Page<AiResourceVersion> versions = new Page<>();
         versions.setPageItems(List.of());
         when(aiResourcePersistService.find(eq(namespaceId), eq(agentSpecName), anyString())).thenReturn(meta);
-        when(aiResourceVersionPersistService.listAll(eq(namespaceId), eq(agentSpecName), anyInt(), anyInt()))
-                .thenReturn(versions);
+        when(aiResourceVersionPersistService.list(eq(namespaceId), eq(agentSpecName), eq("agentspec"), isNull(),
+                anyInt(), anyInt())).thenReturn(versions);
 
         AgentSpecMeta result = service.getAgentSpecDetail(namespaceId, agentSpecName);
 

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
@@ -466,7 +466,7 @@ class AgentSpecOperationServiceImplTest {
         metaPage.setTotalCount(1);
         metaPage.setPagesAvailable(1);
         metaPage.setPageNumber(1);
-        when(aiResourcePersistService.list(eq(namespaceId), anyString(), any(), any(), eq(1), eq(10)))
+        when(aiResourcePersistService.list(any(), eq(1), eq(10)))
                 .thenReturn(metaPage);
 
         Page<AgentSpecSummary> result = service.listAgentSpecs(namespaceId, null, null, 1, 10);


### PR DESCRIPTION
## What is the purpose of the change

Fix AgentSpec visibility/scope enforcement to be consistent with Skill behavior. Previously, AgentSpec list, search, and single-resource read operations did not apply scope-based access control, and all write operations lacked ownership checks. This means:

- Any authenticated user could see all AgentSpecs (including other users' `PRIVATE` ones) via list/search
- Any authenticated user with write permissions could modify or delete AgentSpecs owned by others
- `aiResourceVersionPersistService.listAll()` was used without a type filter, potentially causing skill version records to leak into AgentSpec queries
- The admin `/list` and client `GET` endpoints required authentication even when the resource is `PUBLIC`
- The error message in `VisibilityHelper.checkWritableResource()` was hardcoded to "skill" regardless of resource type

## Brief changelog

- **AgentSpec list/search**: Replace raw `aiResourcePersistService.list(namespaceId, type, ...)` calls with `buildQueryCondition()` + `VisibilityAdvisorConverter`, applying the same `PUBLIC_AND_OWNER` predicate as Skill (anonymous → PUBLIC only; authenticated user → PUBLIC + own; admin → ALL)
- **Write operation ownership checks**: Add `VisibilityHelper.checkWritableResource(meta)` before all mutation operations (`createDraft`, `updateDraft`, `deleteDraft`, `submit`, `publish`, `online`, `offline`, `delete`, `updateLabels`, `updateBizTags`, `updateScope`)
- **Single-resource read checks**: Add `ensureReadableOrNotFound()` in `getAgentSpecDetail`, `getAgentSpecVersion`, and client `get` to return 404 for inaccessible resources instead of 200
- **Anonymous access**: Add `tags = {ALLOW_ANONYMOUS}` to admin `GET /list` and client `GET` so public resources are accessible without a token, consistent with Skill
- **Type filter fix**: Replace all `aiResourceVersionPersistService.listAll()` calls with typed `list(namespaceId, name, RESOURCE_TYPE_AGENTSPEC, null, ...)` to prevent skill version records from being included in AgentSpec version queries
- **Error message fix**: Change hardcoded `"No permission to modify skill: "` in `VisibilityHelper` to use `resource.getType()` dynamically

## Verifying this change

Manually verified against a locally running Nacos server using `curl`:

**Visibility filtering on list (anonymous / user / admin)**
- Anonymous `GET /v3/admin/ai/agentspecs/list` → returns only `PUBLIC` AgentSpecs ✅
- Authenticated user → returns own `PRIVATE` + all `PUBLIC` (`PUBLIC_AND_OWNER`) ✅
- Another user's `PRIVATE` AgentSpec is not visible in list results ✅
- Admin (`ROLE_ADMIN`) → returns all records regardless of scope ✅

**Single-resource GET**
- Owner `GET` own `PRIVATE` → 200 ✅
- Non-owner `GET` another user's `PRIVATE` → 404 ✅
- Admin `GET` any `PRIVATE` → 200 ✅

**Write operation isolation**
- Non-owner attempts `updateScope` / `delete` on another user's AgentSpec → 403 `access denied` ✅
- Owner and admin can modify freely ✅

**Client API**
- Anonymous `GET /v3/client/ai/agentspecs?name=...` on `PRIVATE` → 404 ✅
- Anonymous `GET` on `PUBLIC` → 200 ✅
- Authenticated `POST /search` → returns own `PRIVATE` + all `PUBLIC`, excludes other users' `PRIVATE` ✅

**Type filter**
- AgentSpec list contains no Skill records; Skill list contains no AgentSpec records ✅