### PR TITLE
fix: fix resource leaks and unsafe array access in multiple modules

### DIFF
--- a/client-basic/src/main/java/com/alibaba/nacos/client/auth/oidc/OidcClientContext.java
+++ b/client-basic/src/main/java/com/alibaba/nacos/client/auth/oidc/OidcClientContext.java
@@ -128,7 +128,10 @@ public class OidcClientContext {
                 return false;
             }
             
-            String responseBody = readInputStreamAsString(connection.getInputStream());
+            String responseBody;
+            try (InputStream responseStream = connection.getInputStream()) {
+                responseBody = readInputStreamAsString(responseStream);
+            }
             
             JsonNode root = OBJECT_MAPPER.readTree(responseBody);
             JsonNode tokenEndpointNode = root.get(OidcProtocolConstants.DISCOVERY_TOKEN_ENDPOINT);

--- a/client-basic/src/main/java/com/alibaba/nacos/client/auth/oidc/OidcTokenHolder.java
+++ b/client-basic/src/main/java/com/alibaba/nacos/client/auth/oidc/OidcTokenHolder.java
@@ -95,15 +95,21 @@ public class OidcTokenHolder {
             
             int responseCode = connection.getResponseCode();
             if (responseCode != OidcProtocolConstants.HTTP_STATUS_OK) {
-                InputStream errorStream = connection.getErrorStream();
-                String errorBody = errorStream != null
-                        ? OidcClientContext.readInputStreamAsString(errorStream) : "";
+                String errorBody = "";
+                try (InputStream errorStream = connection.getErrorStream()) {
+                    if (errorStream != null) {
+                        errorBody = OidcClientContext.readInputStreamAsString(errorStream);
+                    }
+                }
                 LOGGER.error("[OIDC-CLIENT] Token request failed, HTTP status: {}, body: {}",
                         responseCode, errorBody);
                 return false;
             }
-            
-            String responseBody = OidcClientContext.readInputStreamAsString(connection.getInputStream());
+
+            String responseBody;
+            try (InputStream responseStream = connection.getInputStream()) {
+                responseBody = OidcClientContext.readInputStreamAsString(responseStream);
+            }
             
             return parseTokenResponse(responseBody);
             

--- a/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
@@ -91,38 +91,43 @@ public class JdkHttpClientRequest implements HttpClientRequest {
         replaceDefaultConfig(requestHttpEntity.getHttpClientConfig());
         
         HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
-        Map<String, String> headerMap = headers.getHeader();
-        if (headerMap != null && headerMap.size() > 0) {
-            for (Map.Entry<String, String> entry : headerMap.entrySet()) {
-                conn.setRequestProperty(entry.getKey(), entry.getValue());
+        try {
+            Map<String, String> headerMap = headers.getHeader();
+            if (headerMap != null && headerMap.size() > 0) {
+                for (Map.Entry<String, String> entry : headerMap.entrySet()) {
+                    conn.setRequestProperty(entry.getKey(), entry.getValue());
+                }
             }
+
+            conn.setConnectTimeout(this.httpClientConfig.getConTimeOutMillis());
+            conn.setReadTimeout(this.httpClientConfig.getReadTimeOutMillis());
+            conn.setRequestMethod(httpMethod);
+            if (body != null && !"".equals(body)) {
+                if (body instanceof File) {
+                    handleFileUpload(conn, (File) body);
+                }
+                String contentType = headers.getValue(HttpHeaderConsts.CONTENT_TYPE);
+                String bodyStr = body instanceof String ? (String) body : JacksonUtils.toJson(body);
+                if (MediaType.APPLICATION_FORM_URLENCODED.equals(contentType)) {
+                    Map<String, String> map = JacksonUtils.toObj(bodyStr, HashMap.class);
+                    bodyStr = HttpUtils.encodingParams(map, headers.getCharset());
+                }
+                if (bodyStr != null) {
+                    conn.setDoOutput(true);
+                    byte[] b = bodyStr.getBytes(StandardCharsets.UTF_8);
+                    conn.setRequestProperty(CONTENT_LENGTH, String.valueOf(b.length));
+                    OutputStream outputStream = conn.getOutputStream();
+                    outputStream.write(b, 0, b.length);
+                    outputStream.flush();
+                    IoUtils.closeQuietly(outputStream);
+                }
+            }
+            conn.connect();
+            return new JdkHttpClientResponse(conn);
+        } catch (Exception e) {
+            conn.disconnect();
+            throw e;
         }
-        
-        conn.setConnectTimeout(this.httpClientConfig.getConTimeOutMillis());
-        conn.setReadTimeout(this.httpClientConfig.getReadTimeOutMillis());
-        conn.setRequestMethod(httpMethod);
-        if (body != null && !"".equals(body)) {
-            if (body instanceof File) {
-                handleFileUpload(conn, (File) body);
-            }
-            String contentType = headers.getValue(HttpHeaderConsts.CONTENT_TYPE);
-            String bodyStr = body instanceof String ? (String) body : JacksonUtils.toJson(body);
-            if (MediaType.APPLICATION_FORM_URLENCODED.equals(contentType)) {
-                Map<String, String> map = JacksonUtils.toObj(bodyStr, HashMap.class);
-                bodyStr = HttpUtils.encodingParams(map, headers.getCharset());
-            }
-            if (bodyStr != null) {
-                conn.setDoOutput(true);
-                byte[] b = bodyStr.getBytes(StandardCharsets.UTF_8);
-                conn.setRequestProperty(CONTENT_LENGTH, String.valueOf(b.length));
-                OutputStream outputStream = conn.getOutputStream();
-                outputStream.write(b, 0, b.length);
-                outputStream.flush();
-                IoUtils.closeQuietly(outputStream);
-            }
-        }
-        conn.connect();
-        return new JdkHttpClientResponse(conn);
     }
     
     private void handleFileUpload(HttpURLConnection conn, File file) throws IOException {

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/config/ConfigImportAndExportService.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/config/ConfigImportAndExportService.java
@@ -176,8 +176,8 @@ public class ConfigImportAndExportService {
         
         @Override
         public ResponseEntity<byte[]> handleEntity(HttpEntity entity) throws IOException {
-            InputStream inputStream = entity.getContent();
-            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            try (InputStream inputStream = entity.getContent();
+                    ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
                 IoUtils.copy(inputStream, outputStream);
                 byte[] responseBody = outputStream.toByteArray();
                 return ResponseEntity.ok().contentType(MediaType.APPLICATION_OCTET_STREAM)

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
@@ -127,8 +127,13 @@ public class SwitchManager extends RequestProcessor4CP {
             
             if (entry.equals(SwitchEntry.PUSH_VERSION)) {
                 
-                String type = value.split(":")[0];
-                String version = value.split(":")[1];
+                String[] parts = value.split(":");
+                if (parts.length < 2) {
+                    throw new IllegalArgumentException(
+                            "illegal format, must be 'type:version', but got: " + value);
+                }
+                String type = parts[0];
+                String version = parts[1];
                 
                 if (!version.matches(UtilsAndCommons.VERSION_STRING_SYNTAX)) {
                     throw new IllegalArgumentException(


### PR DESCRIPTION
## Summary

- **JdkHttpClientRequest**: `HttpURLConnection` is not disconnected when an exception occurs during request setup (header setting, body writing, or `connect()`), causing connection resource leaks. Added try-catch to ensure `conn.disconnect()` is called on exception paths.
- **OidcClientContext/OidcTokenHolder**: `InputStream` obtained from `HttpURLConnection.getInputStream()` and `getErrorStream()` are never explicitly closed after reading. Wrapped in try-with-resources to ensure proper cleanup.
- **ConfigImportAndExportService**: `InputStream` from `HttpEntity.getContent()` is not closed in `handleEntity()`. Included it in the existing try-with-resources block.
- **SwitchManager**: `value.split(":")[1]` accesses array index without bounds checking, causing `ArrayIndexOutOfBoundsException` when input doesn't contain the expected `:` delimiter. Added length validation before access.

## Test plan

- [ ] Verify `JdkHttpClientRequest.execute()` properly disconnects connection when exception occurs during body writing or connect
- [ ] Verify OIDC token fetch and discovery close all HTTP streams
- [ ] Verify config export handles entity content stream cleanup
- [ ] Verify `SwitchManager` rejects malformed push version values with clear error message
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)