### PR TITLE
fix: fix HttpURLConnection leak on exception in JdkHttpClientRequest

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
@@ -91,38 +91,43 @@ public class JdkHttpClientRequest implements HttpClientRequest {
         replaceDefaultConfig(requestHttpEntity.getHttpClientConfig());
         
         HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
-        Map<String, String> headerMap = headers.getHeader();
-        if (headerMap != null && headerMap.size() > 0) {
-            for (Map.Entry<String, String> entry : headerMap.entrySet()) {
-                conn.setRequestProperty(entry.getKey(), entry.getValue());
+        try {
+            Map<String, String> headerMap = headers.getHeader();
+            if (headerMap != null && headerMap.size() > 0) {
+                for (Map.Entry<String, String> entry : headerMap.entrySet()) {
+                    conn.setRequestProperty(entry.getKey(), entry.getValue());
+                }
             }
+
+            conn.setConnectTimeout(this.httpClientConfig.getConTimeOutMillis());
+            conn.setReadTimeout(this.httpClientConfig.getReadTimeOutMillis());
+            conn.setRequestMethod(httpMethod);
+            if (body != null && !"".equals(body)) {
+                if (body instanceof File) {
+                    handleFileUpload(conn, (File) body);
+                }
+                String contentType = headers.getValue(HttpHeaderConsts.CONTENT_TYPE);
+                String bodyStr = body instanceof String ? (String) body : JacksonUtils.toJson(body);
+                if (MediaType.APPLICATION_FORM_URLENCODED.equals(contentType)) {
+                    Map<String, String> map = JacksonUtils.toObj(bodyStr, HashMap.class);
+                    bodyStr = HttpUtils.encodingParams(map, headers.getCharset());
+                }
+                if (bodyStr != null) {
+                    conn.setDoOutput(true);
+                    byte[] b = bodyStr.getBytes(StandardCharsets.UTF_8);
+                    conn.setRequestProperty(CONTENT_LENGTH, String.valueOf(b.length));
+                    OutputStream outputStream = conn.getOutputStream();
+                    outputStream.write(b, 0, b.length);
+                    outputStream.flush();
+                    IoUtils.closeQuietly(outputStream);
+                }
+            }
+            conn.connect();
+            return new JdkHttpClientResponse(conn);
+        } catch (Exception e) {
+            conn.disconnect();
+            throw e;
         }
-        
-        conn.setConnectTimeout(this.httpClientConfig.getConTimeOutMillis());
-        conn.setReadTimeout(this.httpClientConfig.getReadTimeOutMillis());
-        conn.setRequestMethod(httpMethod);
-        if (body != null && !"".equals(body)) {
-            if (body instanceof File) {
-                handleFileUpload(conn, (File) body);
-            }
-            String contentType = headers.getValue(HttpHeaderConsts.CONTENT_TYPE);
-            String bodyStr = body instanceof String ? (String) body : JacksonUtils.toJson(body);
-            if (MediaType.APPLICATION_FORM_URLENCODED.equals(contentType)) {
-                Map<String, String> map = JacksonUtils.toObj(bodyStr, HashMap.class);
-                bodyStr = HttpUtils.encodingParams(map, headers.getCharset());
-            }
-            if (bodyStr != null) {
-                conn.setDoOutput(true);
-                byte[] b = bodyStr.getBytes(StandardCharsets.UTF_8);
-                conn.setRequestProperty(CONTENT_LENGTH, String.valueOf(b.length));
-                OutputStream outputStream = conn.getOutputStream();
-                outputStream.write(b, 0, b.length);
-                outputStream.flush();
-                IoUtils.closeQuietly(outputStream);
-            }
-        }
-        conn.connect();
-        return new JdkHttpClientResponse(conn);
     }
     
     private void handleFileUpload(HttpURLConnection conn, File file) throws IOException {

--- a/common/src/test/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequestTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequestTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
@@ -42,9 +43,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -117,6 +120,33 @@ class JdkHttpClientRequestTest {
         verify(outputStream, never()).write(any(), eq(0), anyInt());
         assertEquals(connection, getActualConnection(response));
         
+    }
+    
+    @Test
+    void testExecuteDisconnectsOnOutputStreamException() throws Exception {
+        when(connection.getOutputStream()).thenThrow(new IOException("output stream error"));
+        Header header = Header.newInstance();
+        HttpClientConfig config = HttpClientConfig.builder().build();
+        RequestHttpEntity httpEntity = new RequestHttpEntity(config, header, Query.EMPTY, "body");
+        assertThrows(IOException.class, () -> httpClientRequest.execute(uri, "GET", httpEntity));
+        verify(connection).disconnect();
+    }
+    
+    @Test
+    void testExecuteDisconnectsOnConnectException() throws Exception {
+        doThrow(new IOException("connect error")).when(connection).connect();
+        Header header = Header.newInstance();
+        RequestHttpEntity httpEntity = new RequestHttpEntity(header, Query.EMPTY);
+        assertThrows(IOException.class, () -> httpClientRequest.execute(uri, "GET", httpEntity));
+        verify(connection).disconnect();
+    }
+    
+    @Test
+    void testExecuteNoDisconnectOnSuccess() throws Exception {
+        Header header = Header.newInstance();
+        RequestHttpEntity httpEntity = new RequestHttpEntity(header, Query.EMPTY);
+        httpClientRequest.execute(uri, "GET", httpEntity);
+        verify(connection, never()).disconnect();
     }
     
     private HttpURLConnection getActualConnection(HttpClientResponse actual) throws IllegalAccessException, NoSuchFieldException {


### PR DESCRIPTION
## Summary

- When an exception occurs during request setup in `JdkHttpClientRequest.execute()` (e.g., setting headers, writing body, or calling `connect()`), the `HttpURLConnection` is never disconnected, causing a connection resource leak.
- Wrapped the request logic in a try-catch block to ensure `conn.disconnect()` is called on exception paths before re-throwing.

## Test plan

- [x] Verify that `JdkHttpClientRequest.execute()` properly disconnects the connection when an exception occurs during body writing or connect
- [x] Existing unit tests pass