### PR TITLE
fix: fix InputStream leak in OIDC client HTTP operations

### DIFF
--- a/client-basic/src/main/java/com/alibaba/nacos/client/auth/oidc/OidcClientContext.java
+++ b/client-basic/src/main/java/com/alibaba/nacos/client/auth/oidc/OidcClientContext.java
@@ -128,7 +128,10 @@ public class OidcClientContext {
                 return false;
             }
             
-            String responseBody = readInputStreamAsString(connection.getInputStream());
+            String responseBody;
+            try (InputStream responseStream = connection.getInputStream()) {
+                responseBody = readInputStreamAsString(responseStream);
+            }
             
             JsonNode root = OBJECT_MAPPER.readTree(responseBody);
             JsonNode tokenEndpointNode = root.get(OidcProtocolConstants.DISCOVERY_TOKEN_ENDPOINT);

--- a/client-basic/src/main/java/com/alibaba/nacos/client/auth/oidc/OidcTokenHolder.java
+++ b/client-basic/src/main/java/com/alibaba/nacos/client/auth/oidc/OidcTokenHolder.java
@@ -95,15 +95,21 @@ public class OidcTokenHolder {
             
             int responseCode = connection.getResponseCode();
             if (responseCode != OidcProtocolConstants.HTTP_STATUS_OK) {
-                InputStream errorStream = connection.getErrorStream();
-                String errorBody = errorStream != null
-                        ? OidcClientContext.readInputStreamAsString(errorStream) : "";
+                String errorBody = "";
+                try (InputStream errorStream = connection.getErrorStream()) {
+                    if (errorStream != null) {
+                        errorBody = OidcClientContext.readInputStreamAsString(errorStream);
+                    }
+                }
                 LOGGER.error("[OIDC-CLIENT] Token request failed, HTTP status: {}, body: {}",
                         responseCode, errorBody);
                 return false;
             }
-            
-            String responseBody = OidcClientContext.readInputStreamAsString(connection.getInputStream());
+
+            String responseBody;
+            try (InputStream responseStream = connection.getInputStream()) {
+                responseBody = OidcClientContext.readInputStreamAsString(responseStream);
+            }
             
             return parseTokenResponse(responseBody);
             


### PR DESCRIPTION
## Summary

- `OidcClientContext.discover()` obtains an `InputStream` from `HttpURLConnection.getInputStream()` but never closes it after reading the OIDC discovery response.
- `OidcTokenHolder.fetchToken()` obtains `InputStream` from both `getInputStream()` and `getErrorStream()` without closing them after reading.
- Wrapped these streams in try-with-resources to ensure proper cleanup.

## Test plan

- [ ] Verify OIDC discovery properly closes the response input stream
- [ ] Verify OIDC token fetch properly closes both success and error streams
- [ ] Existing unit tests pass