### PR TITLE
fix: fix InputStream leak in ConfigImportAndExportService.handleEntity()

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/config/ConfigImportAndExportService.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/config/ConfigImportAndExportService.java
@@ -176,8 +176,8 @@ public class ConfigImportAndExportService {
         
         @Override
         public ResponseEntity<byte[]> handleEntity(HttpEntity entity) throws IOException {
-            InputStream inputStream = entity.getContent();
-            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            try (InputStream inputStream = entity.getContent();
+                    ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
                 IoUtils.copy(inputStream, outputStream);
                 byte[] responseBody = outputStream.toByteArray();
                 return ResponseEntity.ok().contentType(MediaType.APPLICATION_OCTET_STREAM)


### PR DESCRIPTION
## Summary

- In `ExportHttpClientResponseHandler.handleEntity()`, the `InputStream` obtained from `HttpEntity.getContent()` is not closed after reading, causing a stream resource leak.
- Included the `InputStream` in the existing try-with-resources block alongside `ByteArrayOutputStream` to ensure proper cleanup.

## Test plan

- [ ] Verify config export handles entity content stream cleanup correctly
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)