### PR TITLE
fix: fix ArrayIndexOutOfBoundsException in SwitchManager

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
@@ -127,8 +127,13 @@ public class SwitchManager extends RequestProcessor4CP {
             
             if (entry.equals(SwitchEntry.PUSH_VERSION)) {
                 
-                String type = value.split(":")[0];
-                String version = value.split(":")[1];
+                String[] parts = value.split(":");
+                if (parts.length < 2) {
+                    throw new IllegalArgumentException(
+                            "illegal format, must be 'type:version', but got: " + value);
+                }
+                String type = parts[0];
+                String version = parts[1];
                 
                 if (!version.matches(UtilsAndCommons.VERSION_STRING_SYNTAX)) {
                     throw new IllegalArgumentException(

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import com.alibaba.nacos.consistency.cp.CPProtocol;
+import com.alibaba.nacos.core.distributed.ProtocolManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SwitchManagerTest {
+
+    private SwitchManager switchManager;
+
+    private SwitchDomain switchDomain;
+
+    @Mock
+    private ProtocolManager protocolManager;
+
+    @Mock
+    private CPProtocol cpProtocol;
+
+    @BeforeEach
+    void setUp() {
+        switchDomain = new SwitchDomain();
+        when(protocolManager.getCpProtocol()).thenReturn(cpProtocol);
+        switchManager = new SwitchManager(switchDomain, protocolManager);
+    }
+
+    @Test
+    void testUpdatePushVersionWithValidJavaValue() throws Exception {
+        switchManager.update(SwitchEntry.PUSH_VERSION, "java:2.0.0", true);
+        assertEquals("2.0.0", switchDomain.getPushVersionOfJava());
+    }
+
+    @Test
+    void testUpdatePushVersionWithValidPythonValue() throws Exception {
+        switchManager.update(SwitchEntry.PUSH_VERSION, "python:3.1.0", true);
+        assertEquals("3.1.0", switchDomain.getPushVersionOfPython());
+    }
+
+    @Test
+    void testUpdatePushVersionWithMultipleColons() throws Exception {
+        switchManager.update(SwitchEntry.PUSH_VERSION, "java:1.0.0:extra", true);
+        assertEquals("1.0.0", switchDomain.getPushVersionOfJava());
+    }
+
+    @Test
+    void testUpdatePushVersionWithoutDelimiter() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> switchManager.update(SwitchEntry.PUSH_VERSION, "invalidvalue", true));
+        assertEquals("illegal format, must be 'type:version', but got: invalidvalue", exception.getMessage());
+    }
+
+    @Test
+    void testUpdatePushVersionWithEmptyValue() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> switchManager.update(SwitchEntry.PUSH_VERSION, "", true));
+        assertEquals("illegal format, must be 'type:version', but got: ", exception.getMessage());
+    }
+
+    @Test
+    void testUpdatePushVersionWithTrailingColon() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> switchManager.update(SwitchEntry.PUSH_VERSION, "java:", true));
+        assertEquals("illegal format, must be 'type:version', but got: java:", exception.getMessage());
+    }
+
+    @Test
+    void testUpdatePushVersionWithInvalidVersionFormat() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> switchManager.update(SwitchEntry.PUSH_VERSION, "java:abc", true));
+        assertEquals("illegal version, must match: " + UtilsAndCommons.VERSION_STRING_SYNTAX,
+                exception.getMessage());
+    }
+
+    @Test
+    void testUpdatePushVersionWithUnsupportedClientType() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> switchManager.update(SwitchEntry.PUSH_VERSION, "ruby:1.0.0", true));
+        assertEquals("unsupported client type: ruby", exception.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary

- `SwitchManager.update()` splits the push version value by `:` and directly accesses index `[1]` without checking the array length. When the input does not contain a `:` delimiter, this causes `ArrayIndexOutOfBoundsException`.
- Added length validation before accessing the split result, and throws a clear `IllegalArgumentException` with the expected format.

## Test plan

- [x] Verify that a malformed push version value (without `:`) produces a clear error message instead of `ArrayIndexOutOfBoundsException`
- [x] Verify that valid `type:version` format still works correctly
- [x] Existing unit tests pass