### PR TITLE
fix(config): add ORDER BY to findConfigInfoLike4PageFetchRows for deterministic pagination

### DIFF
--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
@@ -278,8 +278,8 @@ public class ConfigInfoMapperByMySql extends AbstractMapperByMysql implements Co
         }
         
         // 先分页，减少后续 JOIN 的数据量
-        innerSql.append(" LIMIT ").append(context.getStartRow()).append(",").append(context.getPageSize());
-        
+        innerSql.append(" ORDER BY id LIMIT ").append(context.getStartRow()).append(",").append(context.getPageSize());
+
         // 外层查询：对分页后的结果进行标签关联
         final String sql = "SELECT a.id,a.data_id,a.group_id,a.tenant_id,a.app_name,a.content,a.md5,"
                           + "a.encrypted_data_key,a.type,a.c_desc,a.gmt_modified,"

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
@@ -277,7 +277,7 @@ class ConfigInfoMapperByMySqlTest {
         MapperResult mapperResult = configInfoMapperByMySql.findConfigInfoLike4PageFetchRows(context);
         // 验证新的优化后的 SQL 结构：先 LIMIT 再 JOIN
         String expectedInnerSql = "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,encrypted_data_key,type,c_desc,gmt_modified"
-                + " FROM config_info WHERE tenant_id LIKE ? AND app_name = ? LIMIT " + startRow + "," + pageSize;
+                + " FROM config_info WHERE tenant_id LIKE ? AND app_name = ? ORDER BY id LIMIT " + startRow + "," + pageSize;
         String expectedSql = "SELECT a.id,a.data_id,a.group_id,a.tenant_id,a.app_name,a.content,a.md5,a.encrypted_data_key,a.type,a.c_desc"
                 + ",a.gmt_modified,GROUP_CONCAT(b.tag_name SEPARATOR ',') as config_tags "
                 + "FROM (" + expectedInnerSql + ") a "
@@ -420,7 +420,7 @@ class ConfigInfoMapperByMySqlTest {
         assertEquals(true, sql.contains("LIKE"));
         assertEquals(true, sql.contains("IN"));
         assertEquals(true, sql.contains("FROM (SELECT"));
-        assertEquals(true, sql.contains("LIMIT"));
+        assertEquals(true, sql.contains("ORDER BY id LIMIT"));
         
         // 验证参数数量（tenant + dataId + group + appName + content + 2个type）
         assertEquals(7, paramList.size());


### PR DESCRIPTION
## Problem

When using `findConfigInfoLike4PageFetchRows` in the MySQL implementation with `LIMIT/OFFSET` pagination, the result ordering is non-deterministic across pages. This causes duplicate or missing records when paginating through fuzzy query results — for example, page 1 returns results sorted by `dataId` lexicographically, but page 2 returns results sorted by primary key `id`, leading to inconsistent pagination.

## Root Cause

The inner SQL query in `ConfigInfoMapperByMySql.findConfigInfoLike4PageFetchRows()` applies `LIMIT` without an `ORDER BY` clause. Without explicit ordering, MySQL does not guarantee consistent row ordering across paginated queries, especially when the query optimizer chooses different execution plans for different offsets.

## Fix

- Added `ORDER BY id` before `LIMIT` in the inner query of `findConfigInfoLike4PageFetchRows()`, consistent with other paginated methods in the same class (e.g., `findAllConfigKey`, `findAllConfigInfoBaseFetchRows`, `findChangeConfigFetchRows`, `listGroupKeyMd5ByPageFetchRows`, `findAllConfigInfoFetchRows`).

## Tests Added

| Change Point | Test |
|-------------|------|
| Added `ORDER BY id` before `LIMIT` in inner query | `testFindConfigInfoLike4PageFetchRows()` — verifies the exact generated SQL contains `ORDER BY id LIMIT` |
| Same change point | `testFindConfigInfoLike4PageFetchRowsWithDescAndTags()` — verifies ORDER BY is present when all parameters (dataId, group, appName, content, types) are provided |

## Impact

This fix ensures deterministic pagination ordering for fuzzy config queries on MySQL. Only the `findConfigInfoLike4PageFetchRows` method in the MySQL mapper is changed. No behavioral changes for other query methods or other database dialects.

Fixes #14046