### PR TITLE
fix(config): add ORDER BY to findConfigInfo4PageFetchRows for deterministic pagination

### DIFF
--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
@@ -214,8 +214,8 @@ public class ConfigInfoMapperByMySql extends AbstractMapperByMysql implements Co
         }
         
         // 先分页，减少后续 JOIN 的数据量
-        innerSql.append(" LIMIT ").append(context.getStartRow()).append(",").append(context.getPageSize());
-        
+        innerSql.append(" ORDER BY id LIMIT ").append(context.getStartRow()).append(",").append(context.getPageSize());
+
         // 外层查询：对分页后的结果进行标签关联
         final String sql = "SELECT a.id,a.data_id,a.group_id,a.tenant_id,a.app_name,a.content,a.md5,a.type,a.encrypted_data_key,a.c_desc,"
                           + "GROUP_CONCAT(b.tag_name SEPARATOR ',') as config_tags "

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
@@ -246,7 +246,7 @@ class ConfigInfoMapperByMySqlTest {
         MapperResult mapperResult = configInfoMapperByMySql.findConfigInfo4PageFetchRows(context);
         // 验证新的优化后的 SQL 结构：先 LIMIT 再 JOIN
         String expectedInnerSql = "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,type,encrypted_data_key,c_desc FROM config_info "
-                + "WHERE tenant_id=? AND app_name=? LIMIT " + startRow + "," + pageSize;
+                + "WHERE tenant_id=? AND app_name=? ORDER BY id LIMIT " + startRow + "," + pageSize;
         String expectedSql = "SELECT a.id,a.data_id,a.group_id,a.tenant_id,a.app_name,a.content,a.md5,a.type,a.encrypted_data_key,a.c_desc,"
                 + "GROUP_CONCAT(b.tag_name SEPARATOR ',') as config_tags "
                 + "FROM (" + expectedInnerSql + ") a "
@@ -386,8 +386,8 @@ class ConfigInfoMapperByMySqlTest {
         assertEquals(true, sql.contains("LEFT JOIN config_tags_relation b ON a.id=b.id"));
         assertEquals(true, sql.contains("GROUP BY"));
         assertEquals(true, sql.contains("FROM (SELECT"));
-        assertEquals(true, sql.contains("LIMIT"));
-        
+        assertEquals(true, sql.contains("ORDER BY id LIMIT"));
+
         // 验证参数
         assertEquals(5, paramList.size());
         assertEquals(tenantId, paramList.get(0));


### PR DESCRIPTION
## Problem

The `findConfigInfo4PageFetchRows` method in `ConfigInfoMapperByMySql` uses `LIMIT/OFFSET` pagination in its inner subquery without an `ORDER BY` clause. Without explicit ordering, MySQL does not guarantee consistent row ordering across paginated queries, which can lead to duplicate or missing records when users paginate through config listing results.

## Root Cause

The inner SQL query constructed in `findConfigInfo4PageFetchRows()` applies `LIMIT` directly without `ORDER BY`:

```sql
SELECT ... FROM config_info WHERE tenant_id=? ... LIMIT startRow,pageSize
```

This is the same class of bug as #14046 (which affected `findConfigInfoLike4PageFetchRows`), but in a different method that handles exact-match config queries rather than fuzzy queries.

## Fix

- Added `ORDER BY id` before `LIMIT` in the inner query of `findConfigInfo4PageFetchRows()`, consistent with other paginated methods in the same class (e.g., `findAllConfigKey`, `findAllConfigInfoBaseFetchRows`, `findChangeConfigFetchRows`, `listGroupKeyMd5ByPageFetchRows`, `findAllConfigInfoFetchRows`).

## Tests Added

| Change Point | Test |
|-------------|------|
| Added `ORDER BY id` before `LIMIT` in inner query | `testFindConfigInfo4PageFetchRows()` — verifies the exact generated SQL contains `ORDER BY id LIMIT` |
| Same change point | `testFindConfigInfo4PageFetchRowsWithDescAndTags()` — verifies ORDER BY is present when all parameters (dataId, group, appName, content) are provided |

## Impact

This fix ensures deterministic pagination ordering for exact-match config queries on MySQL. Only the `findConfigInfo4PageFetchRows` method in the MySQL mapper is changed. No behavioral changes for other query methods or other database dialects.