### PR TITLE
fix(core): close CallableStatement in DerbySnapshotOperation to prevent JDBC resource leak

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/persistence/DerbySnapshotOperation.java
+++ b/core/src/main/java/com/alibaba/nacos/core/persistence/DerbySnapshotOperation.java
@@ -159,8 +159,8 @@ public class DerbySnapshotOperation implements SnapshotOperation {
     private void doDerbyBackup(String backupDirectory) throws Exception {
         DataSourceService sourceService = DynamicDataSource.getInstance().getDataSource();
         DataSource dataSource = sourceService.getJdbcTemplate().getDataSource();
-        try (Connection holder = Objects.requireNonNull(dataSource, "dataSource").getConnection()) {
-            CallableStatement cs = holder.prepareCall(backupSql);
+        try (Connection holder = Objects.requireNonNull(dataSource, "dataSource").getConnection();
+             CallableStatement cs = holder.prepareCall(backupSql)) {
             cs.setString(1, backupDirectory);
             cs.execute();
         }

--- a/core/src/test/java/com/alibaba/nacos/core/persistence/DerbySnapshotOperationTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/persistence/DerbySnapshotOperationTest.java
@@ -45,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -140,6 +141,7 @@ class DerbySnapshotOperationTest {
 
         assertTrue(successRef.get());
         assertNull(exRef.get());
+        verify(callableStatement).close();
     }
 
     @Test


### PR DESCRIPTION
## Problem

In `DerbySnapshotOperation.doDerbyBackup()`, the `CallableStatement` is created inside a try-with-resources block that only manages the `Connection`. The statement itself is never closed, causing a JDBC resource leak on each Derby snapshot backup operation.

## Root Cause

The `CallableStatement` was created as a local variable inside the try block rather than being declared in the try-with-resources header:

```java
try (Connection holder = ...) {
    CallableStatement cs = holder.prepareCall(backupSql);  // not auto-closed
    cs.setString(1, backupDirectory);
    cs.execute();
}
```

While closing the `Connection` may implicitly close associated statements in some JDBC drivers, the JDBC specification does not guarantee this behavior, and relying on it is a resource management anti-pattern.

## Fix

- Moved the `CallableStatement` declaration into the try-with-resources header so it is automatically closed after use, consistent with JDBC best practices.

## Tests Added

| Change Point | Test |
|-------------|------|
| CallableStatement now auto-closed via try-with-resources | `testOnSnapshotSaveWithMocks()` — added `verify(callableStatement).close()` to confirm the statement is properly closed after backup execution |

## Impact

Only affects Derby embedded database backup operations. No behavioral change — backups work identically, but the `CallableStatement` is now properly closed after each use.