### PR TITLE
fix(config): add missing ORDER BY to remaining MySQL pagination queries

### DIFF
--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
@@ -55,7 +55,7 @@ public class ConfigInfoMapperByMySql extends AbstractMapperByMysql implements Co
         final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
         final String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
         String sql = "SELECT id,data_id,group_id,tenant_id,app_name,content FROM config_info"
-                + " WHERE tenant_id LIKE ? AND app_name= ?" + " LIMIT " + context.getStartRow() + ","
+                + " WHERE tenant_id LIKE ? AND app_name= ?" + " ORDER BY id LIMIT " + context.getStartRow() + ","
                 + context.getPageSize();
         return new MapperResult(sql, CollectionUtils.list(tenantId, appName));
     }
@@ -63,14 +63,14 @@ public class ConfigInfoMapperByMySql extends AbstractMapperByMysql implements Co
     @Override
     public MapperResult getTenantIdList(MapperContext context) {
         String sql = "SELECT tenant_id FROM config_info WHERE tenant_id != '" + NamespaceUtil.getNamespaceDefaultId()
-                + "' GROUP BY tenant_id LIMIT " + context.getStartRow() + "," + context.getPageSize();
+                + "' GROUP BY tenant_id ORDER BY tenant_id LIMIT " + context.getStartRow() + "," + context.getPageSize();
         return new MapperResult(sql, Collections.emptyList());
     }
     
     @Override
     public MapperResult getGroupIdList(MapperContext context) {
         String sql = "SELECT group_id FROM config_info WHERE tenant_id ='" + NamespaceUtil.getNamespaceDefaultId()
-                + "' GROUP BY group_id LIMIT " + context.getStartRow() + "," + context.getPageSize();
+                + "' GROUP BY group_id ORDER BY group_id LIMIT " + context.getStartRow() + "," + context.getPageSize();
         return new MapperResult(sql, Collections.emptyList());
     }
     
@@ -177,7 +177,7 @@ public class ConfigInfoMapperByMySql extends AbstractMapperByMysql implements Co
             where += " AND content LIKE ? ";
             paramList.add(content);
         }
-        return new MapperResult(sqlFetchRows + where + " LIMIT " + context.getStartRow() + "," + context.getPageSize(),
+        return new MapperResult(sqlFetchRows + where + " ORDER BY id LIMIT " + context.getStartRow() + "," + context.getPageSize(),
                 paramList);
     }
     
@@ -227,7 +227,7 @@ public class ConfigInfoMapperByMySql extends AbstractMapperByMysql implements Co
     
     @Override
     public MapperResult findConfigInfoBaseByGroupFetchRows(MapperContext context) {
-        String sql = "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? AND tenant_id=?" + " LIMIT "
+        String sql = "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? AND tenant_id=?" + " ORDER BY id LIMIT "
                 + context.getStartRow() + "," + context.getPageSize();
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.GROUP_ID),
                 context.getWhereParameter(FieldConstant.TENANT_ID)));

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigTagsRelationMapperByMySql.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigTagsRelationMapperByMySql.java
@@ -85,7 +85,7 @@ public class ConfigTagsRelationMapperByMySql extends AbstractMapperByMysql imple
                 + "SELECT DISTINCT a.id,a.data_id,a.group_id,a.tenant_id,a.app_name,a.content,a.md5,a.type,a.encrypted_data_key,a.c_desc "
                 + "FROM config_info a LEFT JOIN config_tags_relation b ON a.id=b.id"
                 + innerWhere
-                + "LIMIT " + context.getStartRow() + "," + context.getPageSize()
+                + "ORDER BY a.id LIMIT " + context.getStartRow() + "," + context.getPageSize()
                 + ") c LEFT JOIN config_tags_relation d ON c.id=d.id "
                 + "GROUP BY c.id,c.data_id,c.group_id,c.tenant_id,c.app_name,c.content,c.md5,c.type,c.encrypted_data_key,c.c_desc";
         
@@ -135,7 +135,7 @@ public class ConfigTagsRelationMapperByMySql extends AbstractMapperByMysql imple
             innerWhere.and().in("a.type", types);
         }
         
-        innerWhere.limit(context.getStartRow(), context.getPageSize());
+        innerWhere.orderBy("a.id").limit(context.getStartRow(), context.getPageSize());
         MapperResult innerResult = innerWhere.build();
         
         // 构建外层查询：获取筛选出的配置的完整标签信息

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySqlTest.java
@@ -101,7 +101,7 @@ class ConfigInfoMapperByMySqlTest {
     void testFindConfigInfoByAppFetchRows() {
         MapperResult mapperResult = configInfoMapperByMySql.findConfigInfoByAppFetchRows(context);
         assertEquals(mapperResult.getSql(),
-                "SELECT id,data_id,group_id,tenant_id,app_name,content FROM config_info WHERE tenant_id LIKE ? AND app_name= ? LIMIT "
+                "SELECT id,data_id,group_id,tenant_id,app_name,content FROM config_info WHERE tenant_id LIKE ? AND app_name= ? ORDER BY id LIMIT "
                         + startRow + "," + pageSize);
         assertArrayEquals(new Object[] {tenantId, appName}, mapperResult.getParamList().toArray());
     }
@@ -117,7 +117,7 @@ class ConfigInfoMapperByMySqlTest {
     void testGetTenantIdList() {
         MapperResult mapperResult = configInfoMapperByMySql.getTenantIdList(context);
         assertEquals(mapperResult.getSql(), "SELECT tenant_id FROM config_info WHERE tenant_id != '" + NamespaceUtil.getNamespaceDefaultId()
-                + "' GROUP BY tenant_id LIMIT " + startRow + "," + pageSize);
+                + "' GROUP BY tenant_id ORDER BY tenant_id LIMIT " + startRow + "," + pageSize);
         assertArrayEquals(mapperResult.getParamList().toArray(), emptyObjs);
     }
     
@@ -125,7 +125,7 @@ class ConfigInfoMapperByMySqlTest {
     void testGetGroupIdList() {
         MapperResult mapperResult = configInfoMapperByMySql.getGroupIdList(context);
         assertEquals(mapperResult.getSql(),
-                "SELECT group_id FROM config_info WHERE tenant_id ='public' GROUP BY group_id LIMIT " + startRow + "," + pageSize);
+                "SELECT group_id FROM config_info WHERE tenant_id ='public' GROUP BY group_id ORDER BY group_id LIMIT " + startRow + "," + pageSize);
         assertArrayEquals(mapperResult.getParamList().toArray(), emptyObjs);
     }
     
@@ -229,7 +229,7 @@ class ConfigInfoMapperByMySqlTest {
     void testFindConfigInfoBaseLikeFetchRows() {
         MapperResult mapperResult = configInfoMapperByMySql.findConfigInfoBaseLikeFetchRows(context);
         assertEquals(mapperResult.getSql(),
-                "SELECT id,data_id,group_id,tenant_id,content FROM config_info WHERE  1=1 AND tenant_id='public'  LIMIT " + startRow + ","
+                "SELECT id,data_id,group_id,tenant_id,content FROM config_info WHERE  1=1 AND tenant_id='public'  ORDER BY id LIMIT " + startRow + ","
                         + pageSize);
         assertArrayEquals(mapperResult.getParamList().toArray(), emptyObjs);
     }
@@ -261,7 +261,7 @@ class ConfigInfoMapperByMySqlTest {
         context.putWhereParameter(FieldConstant.GROUP_ID, groupId);
         MapperResult mapperResult = configInfoMapperByMySql.findConfigInfoBaseByGroupFetchRows(context);
         assertEquals(mapperResult.getSql(),
-                "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? AND tenant_id=? LIMIT " + startRow + "," + pageSize);
+                "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? AND tenant_id=? ORDER BY id LIMIT " + startRow + "," + pageSize);
         assertArrayEquals(new Object[] {groupId, tenantId}, mapperResult.getParamList().toArray());
     }
     

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigTagsRelationMapperByMySqlTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigTagsRelationMapperByMySqlTest.java
@@ -92,7 +92,8 @@ class ConfigTagsRelationMapperByMySqlTest {
         assertEquals(true, sql.contains("SELECT DISTINCT a.id"));  // 内层查询
         assertEquals(true, sql.contains("LEFT JOIN config_tags_relation d ON c.id=d.id"));  // 外层关联获取所有标签
         assertEquals(true, sql.contains("b.tag_name IN"));  // 内层标签筛选条件
-        
+        assertEquals(true, sql.contains("ORDER BY a.id"));  // 内层排序保证分页确定性
+
         List<Object> list = CollectionUtils.list(tenantId);
         list.add("dataID1");
         list.add("groupID1");
@@ -101,7 +102,7 @@ class ConfigTagsRelationMapperByMySqlTest {
         list.addAll(Arrays.asList(tagArr));
         assertArrayEquals(mapperResult.getParamList().toArray(), list.toArray());
     }
-    
+
     @Test
     void testFindConfigInfoLike4PageCountRowss() {
         context.putWhereParameter(FieldConstant.DATA_ID, "dataID1");
@@ -141,7 +142,8 @@ class ConfigTagsRelationMapperByMySqlTest {
         assertEquals(true, sql.contains("LEFT JOIN config_tags_relation d ON c.id=d.id"));  // 外层关联获取所有标签
         assertEquals(true, sql.contains("b.tag_name LIKE"));  // 内层标签筛选条件
         assertEquals(true, sql.contains("LIKE"));
-        
+        assertEquals(true, sql.contains("ORDER BY a.id"));  // 内层排序保证分页确定性
+
         List<Object> list = CollectionUtils.list(tenantId);
         list.add("dataID1");
         list.add("groupID1");

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
@@ -184,7 +184,18 @@ public final class WhereBuilder {
         where.append(" GROUP BY ").append(fields);
         return this;
     }
-    
+
+    /**
+     * Build ORDER BY.
+     *
+     * @param fields Order by fields
+     * @return Return {@link WhereBuilder}
+     */
+    public WhereBuilder orderBy(String fields) {
+        where.append(" ORDER BY ").append(fields);
+        return this;
+    }
+
     /**
      * Build EXISTS conditional.
      * <p>


### PR DESCRIPTION
## Problem

Several pagination methods in `ConfigInfoMapperByMySql` and `ConfigTagsRelationMapperByMySql` use `LIMIT` without `ORDER BY`, causing non-deterministic results across paginated requests. This is the same class of bug as #14046, affecting additional methods not covered by PRs #14741 and #14742.

## Root Cause

MySQL does not guarantee consistent row ordering without an explicit `ORDER BY` clause. When `LIMIT/OFFSET` is used for pagination, different pages may return overlapping or missing records due to the query optimizer choosing different execution plans.

## Fix

Added `ORDER BY` before `LIMIT` in all affected methods:

**ConfigInfoMapperByMySql (5 methods):**
- `findConfigInfoByAppFetchRows` — added `ORDER BY id`
- `getTenantIdList` — added `ORDER BY tenant_id`
- `getGroupIdList` — added `ORDER BY group_id`
- `findConfigInfoBaseLikeFetchRows` — added `ORDER BY id`
- `findConfigInfoBaseByGroupFetchRows` — added `ORDER BY id`

**ConfigTagsRelationMapperByMySql (2 methods):**
- `findConfigInfo4PageFetchRows` — added `ORDER BY a.id`
- `findConfigInfoLike4PageFetchRows` — added `orderBy("a.id")` via WhereBuilder

Also added `orderBy()` method to `WhereBuilder` for fluent ORDER BY support.

## Tests Added

All 7 corresponding test methods updated to verify the ORDER BY clause is present in the generated SQL.

## Impact

Ensures deterministic pagination ordering for all MySQL config queries. Consistent with existing methods in the same classes that already use `ORDER BY id`.