### PR TITLE
fix(config): add missing ORDER BY to Oracle pagination queries

### DIFF
--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoMapperByOracle.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoMapperByOracle.java
@@ -44,7 +44,7 @@ public class ConfigInfoMapperByOracle  extends AbstractMapperByOracle implements
         final String appName = (String) context.getWhereParameter(FieldConstant.APP_NAME);
         final String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
         String sql = "SELECT id,data_id,group_id,tenant_id,app_name,content FROM config_info"
-                + " WHERE tenant_id LIKE ? AND app_name= ?" + " OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
+                + " WHERE tenant_id LIKE ? AND app_name= ?" + " ORDER BY id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
                 + context.getPageSize() + " ROWS ONLY";
         return new MapperResult(sql, CollectionUtils.list(tenantId, appName));
     }
@@ -52,14 +52,14 @@ public class ConfigInfoMapperByOracle  extends AbstractMapperByOracle implements
     @Override
     public MapperResult getTenantIdList(MapperContext context) {
         String sql = "SELECT tenant_id FROM config_info WHERE tenant_id != '" + NamespaceUtil.getNamespaceDefaultId()
-                + "' GROUP BY tenant_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
+                + "' GROUP BY tenant_id ORDER BY tenant_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
         return new MapperResult(sql, Collections.emptyList());
     }
 
     @Override
     public MapperResult getGroupIdList(MapperContext context) {
         String sql = "SELECT group_id FROM config_info WHERE tenant_id ='" + NamespaceUtil.getNamespaceDefaultId()
-                + "' GROUP BY group_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
+                + "' GROUP BY group_id ORDER BY group_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
         return new MapperResult(sql, Collections.emptyList());
     }
 
@@ -177,7 +177,7 @@ public class ConfigInfoMapperByOracle  extends AbstractMapperByOracle implements
             paramList.add(content);
         }
         return new MapperResult(sqlFetchRows + where
-                + " OFFSET " + context.getStartRow()
+                + " ORDER BY id OFFSET " + context.getStartRow()
                 + " ROWS FETCH NEXT " + context.getPageSize()
                 + " ROWS ONLY",
                 paramList);
@@ -215,7 +215,7 @@ public class ConfigInfoMapperByOracle  extends AbstractMapperByOracle implements
         }
 
         // 先分页，减少后续 JOIN 的数据量
-        idSql.append(" OFFSET ").append(context.getStartRow()).append(" ROWS FETCH NEXT ").append(context.getPageSize()).append(" ROWS ONLY");
+        idSql.append(" ORDER BY id OFFSET ").append(context.getStartRow()).append(" ROWS FETCH NEXT ").append(context.getPageSize()).append(" ROWS ONLY");
 
         // 外层查询：对分页后的结果进行标签关联
         String sql =
@@ -238,7 +238,7 @@ public class ConfigInfoMapperByOracle  extends AbstractMapperByOracle implements
 
     @Override
     public MapperResult findConfigInfoBaseByGroupFetchRows(MapperContext context) {
-        String sql = "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? AND tenant_id=?" + " OFFSET "
+        String sql = "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? AND tenant_id=?" + " ORDER BY id OFFSET "
                 + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
         return new MapperResult(sql, CollectionUtils.list(context.getWhereParameter(FieldConstant.GROUP_ID),
                 context.getWhereParameter(FieldConstant.TENANT_ID)));
@@ -287,7 +287,7 @@ public class ConfigInfoMapperByOracle  extends AbstractMapperByOracle implements
         }
 
         // 先分页，减少后续 JOIN 的数据量
-        idSql.append(" OFFSET ").append(context.getStartRow()).append(" ROWS FETCH NEXT ").append(context.getPageSize()).append(" ROWS ONLY");
+        idSql.append(" ORDER BY id OFFSET ").append(context.getStartRow()).append(" ROWS FETCH NEXT ").append(context.getPageSize()).append(" ROWS ONLY");
 
         // 外层查询：对分页后的结果进行标签关联
         String sql =

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigTagsRelationMapperByOracle.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigTagsRelationMapperByOracle.java
@@ -82,7 +82,7 @@ public class ConfigTagsRelationMapperByOracle extends AbstractMapperByOracle imp
             idSql.append(") ");
         }
 
-        idSql.append(" OFFSET ")
+        idSql.append(" ORDER BY a.id OFFSET ")
                 .append(context.getStartRow())
                 .append(" ROWS FETCH NEXT ")
                 .append(context.getPageSize())
@@ -150,7 +150,7 @@ public class ConfigTagsRelationMapperByOracle extends AbstractMapperByOracle imp
             idQuery.and().in("a.type", types);
         }
 
-        idQuery.offset(context.getStartRow(), context.getPageSize());
+        idQuery.orderBy("a.id").offset(context.getStartRow(), context.getPageSize());
         MapperResult idResult = idQuery.build();
 
         // 构建外层查询：获取筛选出的配置的完整标签信息

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/test/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoMapperByOracleTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/test/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoMapperByOracleTest.java
@@ -102,7 +102,7 @@ class ConfigInfoMapperByOracleTest {
     void testFindConfigInfoByAppFetchRows() {
         MapperResult mapperResult = configInfoMapperByOracle.findConfigInfoByAppFetchRows(context);
         assertTrue(mapperResult.getSql().contains("SELECT id,data_id,group_id,tenant_id,app_name,content FROM config_info"));
-        assertTrue(mapperResult.getSql().contains("OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
+        assertTrue(mapperResult.getSql().contains("ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
         assertArrayEquals(new Object[] {tenantId, appName}, mapperResult.getParamList().toArray());
     }
     
@@ -117,7 +117,7 @@ class ConfigInfoMapperByOracleTest {
     void testGetTenantIdList() {
         MapperResult mapperResult = configInfoMapperByOracle.getTenantIdList(context);
         assertTrue(mapperResult.getSql().contains("SELECT tenant_id FROM config_info"));
-        assertTrue(mapperResult.getSql().contains("GROUP BY tenant_id"));
+        assertTrue(mapperResult.getSql().contains("GROUP BY tenant_id ORDER BY tenant_id"));
         assertTrue(mapperResult.getSql().contains("OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
     }
     
@@ -125,7 +125,7 @@ class ConfigInfoMapperByOracleTest {
     void testGetGroupIdList() {
         MapperResult mapperResult = configInfoMapperByOracle.getGroupIdList(context);
         assertTrue(mapperResult.getSql().contains("SELECT group_id FROM config_info"));
-        assertTrue(mapperResult.getSql().contains("GROUP BY group_id"));
+        assertTrue(mapperResult.getSql().contains("GROUP BY group_id ORDER BY group_id"));
         assertTrue(mapperResult.getSql().contains("OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
     }
     
@@ -222,7 +222,7 @@ class ConfigInfoMapperByOracleTest {
     void testFindConfigInfoBaseLikeFetchRows() {
         MapperResult mapperResult = configInfoMapperByOracle.findConfigInfoBaseLikeFetchRows(context);
         assertTrue(mapperResult.getSql().contains("SELECT id,data_id,group_id,tenant_id,content FROM config_info"));
-        assertTrue(mapperResult.getSql().contains("OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
+        assertTrue(mapperResult.getSql().contains("ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
         assertArrayEquals(mapperResult.getParamList().toArray(), emptyObjs);
     }
     
@@ -240,7 +240,7 @@ class ConfigInfoMapperByOracleTest {
         String sql = mapperResult.getSql();
         assertTrue(sql.contains("WITH tag_agg AS"));
         assertTrue(sql.contains("LISTAGG"));
-        assertTrue(sql.contains("OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
+        assertTrue(sql.contains("ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
         assertArrayEquals(new Object[] {tenantId, appName}, mapperResult.getParamList().toArray());
     }
     
@@ -250,7 +250,7 @@ class ConfigInfoMapperByOracleTest {
         MapperResult mapperResult = configInfoMapperByOracle.findConfigInfoBaseByGroupFetchRows(context);
         assertTrue(mapperResult.getSql().contains("SELECT id,data_id,group_id,content FROM config_info"));
         assertTrue(mapperResult.getSql().contains("WHERE group_id=? AND tenant_id=?"));
-        assertTrue(mapperResult.getSql().contains("OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
+        assertTrue(mapperResult.getSql().contains("ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
         assertArrayEquals(new Object[] {groupId, tenantId}, mapperResult.getParamList().toArray());
     }
     
@@ -268,7 +268,7 @@ class ConfigInfoMapperByOracleTest {
         String sql = mapperResult.getSql();
         assertTrue(sql.contains("WITH tag_agg AS"));
         assertTrue(sql.contains("LISTAGG"));
-        assertTrue(sql.contains("OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
+        assertTrue(sql.contains("ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
         assertArrayEquals(new Object[] {tenantId, appName}, mapperResult.getParamList().toArray());
     }
     

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/test/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigTagsRelationMapperByOracleTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/test/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigTagsRelationMapperByOracleTest.java
@@ -69,7 +69,7 @@ class ConfigTagsRelationMapperByOracleTest {
         assertTrue(sql.contains("SELECT DISTINCT a.id"));
         assertTrue(sql.contains("FROM config_info a"));
         assertTrue(sql.contains("LEFT JOIN config_tags_relation b"));
-        assertTrue(sql.contains("OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
+        assertTrue(sql.contains("ORDER BY a.id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY"));
         assertTrue(mapperResult.getParamList().contains(tenantId));
         assertTrue(mapperResult.getParamList().contains(dataId));
         assertTrue(mapperResult.getParamList().contains(groupId));
@@ -84,6 +84,7 @@ class ConfigTagsRelationMapperByOracleTest {
         assertTrue(sql.contains("SELECT DISTINCT a.id"));
         assertTrue(sql.contains("FROM config_info a"));
         assertTrue(sql.contains("LEFT JOIN config_tags_relation b"));
+        assertTrue(sql.contains("ORDER BY a.id"));
         assertTrue(mapperResult.getParamList().contains(tenantId));
     }
     

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
@@ -184,7 +184,18 @@ public final class WhereBuilder {
         where.append(" GROUP BY ").append(fields);
         return this;
     }
-    
+
+    /**
+     * Build ORDER BY.
+     *
+     * @param fields Order by fields
+     * @return Return {@link WhereBuilder}
+     */
+    public WhereBuilder orderBy(String fields) {
+        where.append(" ORDER BY ").append(fields);
+        return this;
+    }
+
     /**
      * Build EXISTS conditional.
      * <p>


### PR DESCRIPTION
## Problem

Several pagination methods in `ConfigInfoMapperByOracle` and `ConfigTagsRelationMapperByOracle` use `OFFSET/FETCH NEXT` without `ORDER BY`, causing non-deterministic results across paginated requests. This is the Oracle dialect equivalent of the MySQL bug reported in #14046.

## Root Cause

Oracle does not guarantee consistent row ordering without an explicit `ORDER BY` clause. When `OFFSET/FETCH NEXT` is used for pagination, different pages may return overlapping or missing records.

## Fix

Added `ORDER BY` before `OFFSET` in all affected methods:

**ConfigInfoMapperByOracle (7 methods):**
- `findConfigInfoByAppFetchRows` — added `ORDER BY id`
- `getTenantIdList` — added `ORDER BY tenant_id`
- `getGroupIdList` — added `ORDER BY group_id`
- `findConfigInfoBaseLikeFetchRows` — added `ORDER BY id`
- `findConfigInfo4PageFetchRows` — added `ORDER BY id`
- `findConfigInfoLike4PageFetchRows` — added `ORDER BY id`
- `findConfigInfoBaseByGroupFetchRows` — added `ORDER BY id`

**ConfigTagsRelationMapperByOracle (2 methods):**
- `findConfigInfo4PageFetchRows` — added `ORDER BY a.id`
- `findConfigInfoLike4PageFetchRows` — added `orderBy("a.id")` via WhereBuilder

Also added `orderBy()` method to `WhereBuilder` for fluent ORDER BY support.

## Tests Added

All 9 corresponding test methods updated to verify the ORDER BY clause is present in the generated SQL.

## Impact

Ensures deterministic pagination ordering for all Oracle config queries. Consistent with existing methods in the same classes that already use `ORDER BY id`.