### PR TITLE
fix(config): add missing ORDER BY to Derby pagination queries

### DIFF
--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
@@ -49,7 +49,7 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
         final String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
         
         String sql = "SELECT ID,data_id,group_id,tenant_id,app_name,content FROM config_info WHERE tenant_id LIKE ?"
-                + SQL_DERBY_ESCAPE_BACK_SLASH_FOR_LIKE + "AND app_name = ?" + " OFFSET " + context.getStartRow()
+                + SQL_DERBY_ESCAPE_BACK_SLASH_FOR_LIKE + "AND app_name = ?" + " ORDER BY id OFFSET " + context.getStartRow()
                 + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY";
         
         return new MapperResult(sql, CollectionUtils.list(tenantId, appName));
@@ -60,7 +60,7 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
         
         return new MapperResult(
                 "SELECT tenant_id FROM config_info WHERE tenant_id != '" + NamespaceUtil.getNamespaceDefaultId()
-                        + "' GROUP BY tenant_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
+                        + "' GROUP BY tenant_id ORDER BY tenant_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
                         + context.getPageSize() + " ROWS ONLY", Collections.emptyList());
     }
     
@@ -69,7 +69,7 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
         
         return new MapperResult(
                 "SELECT group_id FROM config_info WHERE tenant_id ='" + NamespaceUtil.getNamespaceDefaultId()
-                        + "' GROUP BY group_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
+                        + "' GROUP BY group_id ORDER BY group_id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT "
                         + context.getPageSize() + " ROWS ONLY", Collections.emptyList());
     }
     
@@ -147,10 +147,10 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
             paramList.add(endTime);
         }
         return new MapperResult(
-                sqlFetchRows + where + " OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize()
+                sqlFetchRows + where + " ORDER BY id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize()
                         + " ROWS ONLY", paramList);
     }
-    
+
     @Override
     public MapperResult listGroupKeyMd5ByPageFetchRows(MapperContext context) {
         
@@ -181,10 +181,10 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
             paramList.add(tenant);
         }
         return new MapperResult(
-                sqlFetchRows + where + " OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize()
+                sqlFetchRows + where + " ORDER BY id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize()
                         + " ROWS ONLY", paramList);
     }
-    
+
     @Override
     public MapperResult findConfigInfo4PageFetchRows(MapperContext context) {
         final String tenantId = (String) context.getWhereParameter(FieldConstant.TENANT_ID);
@@ -221,14 +221,14 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
         
         // Derby 分页语法
         return new MapperResult(
-                sql + where + " OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize()
+                sql + where + " ORDER BY id OFFSET " + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize()
                         + " ROWS ONLY", paramList);
     }
     
     @Override
     public MapperResult findConfigInfoBaseByGroupFetchRows(MapperContext context) {
         return new MapperResult(
-                "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? " + "AND tenant_id=?" + " OFFSET "
+                "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? " + "AND tenant_id=?" + " ORDER BY id OFFSET "
                         + context.getStartRow() + " ROWS FETCH NEXT " + context.getPageSize() + " ROWS ONLY",
                 CollectionUtils.list(context.getWhereParameter(FieldConstant.GROUP_ID),
                         context.getWhereParameter(FieldConstant.TENANT_ID)));
@@ -294,7 +294,7 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
             where.and().in("type", types);
         }
         
-        where.offset(context.getStartRow(), context.getPageSize());
+        where.orderBy("id").offset(context.getStartRow(), context.getPageSize());
         return where.build();
     }
     

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerbyTest.java
@@ -99,7 +99,7 @@ class ConfigInfoMapperByDerbyTest {
     void testFindConfigInfoByAppFetchRows() {
         MapperResult mapperResult = configInfoMapperByDerby.findConfigInfoByAppFetchRows(context);
         assertEquals(mapperResult.getSql(), "SELECT ID,data_id,group_id,tenant_id,app_name,content FROM config_info WHERE tenant_id LIKE"
-                + " ? ESCAPE '\\' AND app_name = ? OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
+                + " ? ESCAPE '\\' AND app_name = ? ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
         assertArrayEquals(new Object[] {tenantId, appName}, mapperResult.getParamList().toArray());
     }
     
@@ -114,7 +114,7 @@ class ConfigInfoMapperByDerbyTest {
     void testGetTenantIdList() {
         MapperResult mapperResult = configInfoMapperByDerby.getTenantIdList(context);
         assertEquals(mapperResult.getSql(),
-                "SELECT tenant_id FROM config_info WHERE tenant_id != 'public' GROUP BY tenant_id OFFSET " + startRow + " ROWS FETCH NEXT "
+                "SELECT tenant_id FROM config_info WHERE tenant_id != 'public' GROUP BY tenant_id ORDER BY tenant_id OFFSET " + startRow + " ROWS FETCH NEXT "
                         + pageSize + " ROWS ONLY");
         assertArrayEquals(mapperResult.getParamList().toArray(), emptyObjs);
     }
@@ -123,7 +123,7 @@ class ConfigInfoMapperByDerbyTest {
     void testGetGroupIdList() {
         MapperResult mapperResult = configInfoMapperByDerby.getGroupIdList(context);
         assertEquals(mapperResult.getSql(),
-                "SELECT group_id FROM config_info WHERE tenant_id ='public' GROUP BY group_id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize
+                "SELECT group_id FROM config_info WHERE tenant_id ='public' GROUP BY group_id ORDER BY group_id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize
                         + " ROWS ONLY");
         assertArrayEquals(mapperResult.getParamList().toArray(), emptyObjs);
     }
@@ -185,7 +185,7 @@ class ConfigInfoMapperByDerbyTest {
     void testFindChangeConfigFetchRows() {
         MapperResult mapperResult = configInfoMapperByDerby.findChangeConfigFetchRows(context);
         assertEquals(mapperResult.getSql(), "SELECT id,data_id,group_id,tenant_id,app_name,content,type,md5,gmt_modified FROM config_info "
-                + "WHERE  1=1  AND app_name = ?  AND gmt_modified >=?  AND gmt_modified <=?  OFFSET " + startRow + " ROWS FETCH NEXT "
+                + "WHERE  1=1  AND app_name = ?  AND gmt_modified >=?  AND gmt_modified <=?  ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT "
                 + pageSize + " ROWS ONLY");
         assertArrayEquals(new Object[] {appName, startTime, endTime}, mapperResult.getParamList().toArray());
 
@@ -195,7 +195,7 @@ class ConfigInfoMapperByDerbyTest {
         mapperResult = configInfoMapperByDerby.findChangeConfigFetchRows(context);
         assertEquals(mapperResult.getSql(), "SELECT id,data_id,group_id,tenant_id,app_name,content,type,"
                 + "md5,gmt_modified FROM config_info WHERE  1=1  AND data_id LIKE ? ESCAPE '\\'  AND group_id LIKE ? ESCAPE '\\' "
-                + " AND app_name = ?  AND gmt_modified >=?  AND gmt_modified <=?  OFFSET "
+                + " AND app_name = ?  AND gmt_modified >=?  AND gmt_modified <=?  ORDER BY id OFFSET "
                 + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
         assertArrayEquals(new Object[] {"test_data", "test_group", appName, startTime, endTime}, mapperResult.getParamList().toArray());
     }
@@ -239,7 +239,7 @@ class ConfigInfoMapperByDerbyTest {
     void testFindConfigInfoBaseLikeFetchRows() {
         MapperResult mapperResult = configInfoMapperByDerby.findConfigInfoBaseLikeFetchRows(context);
         assertEquals(mapperResult.getSql(),
-                "SELECT id,data_id,group_id,tenant_id,content FROM config_info WHERE  1=1 AND tenant_id='public'  " + "OFFSET " + startRow
+                "SELECT id,data_id,group_id,tenant_id,content FROM config_info WHERE  1=1 AND tenant_id='public'  " + "ORDER BY id OFFSET " + startRow
                         + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
         assertArrayEquals(mapperResult.getParamList().toArray(), emptyObjs);
 
@@ -251,7 +251,7 @@ class ConfigInfoMapperByDerbyTest {
         assertEquals(mapperResult.getSql(),
                 "SELECT id,data_id,group_id,tenant_id,content FROM config_info WHERE  1=1 AND tenant_id='public' "
                         + " AND data_id LIKE ? ESCAPE '\\'  AND group_id LIKE ? ESCAPE '\\'  AND content LIKE ? ESCAPE '\\' "
-                        + " OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
+                        + " ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
         assertArrayEquals(new Object[] {"test_data", "test_group", "test_content"}, mapperResult.getParamList().toArray());
     }
     
@@ -268,7 +268,7 @@ class ConfigInfoMapperByDerbyTest {
         assertEquals(mapperResult.getSql(),
                 "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,type,encrypted_data_key,c_desc "
                         + "FROM config_info WHERE  tenant_id=?  AND app_name=? "
-                        + " OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
+                        + " ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
         assertArrayEquals(new Object[] {tenantId, appName}, mapperResult.getParamList().toArray());
 
         // Test with content to verify LIKE ESCAPE
@@ -277,7 +277,7 @@ class ConfigInfoMapperByDerbyTest {
         assertEquals(mapperResult.getSql(),
                 "SELECT id,data_id,group_id,tenant_id,app_name,content,md5,type,encrypted_data_key,c_desc "
                         + "FROM config_info WHERE  tenant_id=?  AND app_name=?  AND content LIKE ? ESCAPE '\\' "
-                        + " OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
+                        + " ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
         assertArrayEquals(new Object[] {tenantId, appName, "test_content"}, mapperResult.getParamList().toArray());
     }
     
@@ -286,7 +286,7 @@ class ConfigInfoMapperByDerbyTest {
         context.putWhereParameter(FieldConstant.GROUP_ID, groupId);
         MapperResult mapperResult = configInfoMapperByDerby.findConfigInfoBaseByGroupFetchRows(context);
         assertEquals(mapperResult.getSql(),
-                "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? AND tenant_id=? " + "OFFSET " + startRow
+                "SELECT id,data_id,group_id,content FROM config_info WHERE group_id=? AND tenant_id=? " + "ORDER BY id OFFSET " + startRow
                         + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
         assertArrayEquals(new Object[] {groupId, tenantId}, mapperResult.getParamList().toArray());
     }
@@ -315,7 +315,7 @@ class ConfigInfoMapperByDerbyTest {
         // Verify LIKE ESCAPE is used for tenant_id
         assertEquals(mapperResult.getSql(), "SELECT id,data_id,group_id,tenant_id,app_name,content,"
                 + "md5,encrypted_data_key,type,c_desc,gmt_modified FROM config_info "
-                + "WHERE tenant_id LIKE ? ESCAPE '\\'  AND app_name = ?  OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
+                + "WHERE tenant_id LIKE ? ESCAPE '\\'  AND app_name = ?  ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
         assertArrayEquals(new Object[] {tenantId, appName}, mapperResult.getParamList().toArray());
 
         // Test with dataId, group, and content to verify LIKE ESCAPE
@@ -327,7 +327,7 @@ class ConfigInfoMapperByDerbyTest {
                 + "md5,encrypted_data_key,type,c_desc,gmt_modified FROM config_info WHERE tenant_id LIKE ? ESCAPE '\\' "
                 + " AND data_id LIKE ? ESCAPE '\\'  AND group_id LIKE ? ESCAPE '\\'  AND app_name = ? "
                 + " AND content LIKE ? ESCAPE '\\' "
-                + " OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
+                + " ORDER BY id OFFSET " + startRow + " ROWS FETCH NEXT " + pageSize + " ROWS ONLY");
         assertArrayEquals(new Object[] {tenantId, "test_data", "test_group", appName, "test_content"}, mapperResult.getParamList().toArray());
     }
     

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
@@ -184,7 +184,18 @@ public final class WhereBuilder {
         where.append(" GROUP BY ").append(fields);
         return this;
     }
-    
+
+    /**
+     * Build ORDER BY.
+     *
+     * @param fields Order by fields
+     * @return Return {@link WhereBuilder}
+     */
+    public WhereBuilder orderBy(String fields) {
+        where.append(" ORDER BY ").append(fields);
+        return this;
+    }
+
     /**
      * Build EXISTS conditional.
      * <p>


### PR DESCRIPTION
## Problem

Several pagination methods in `ConfigInfoMapperByDerby` use `OFFSET/FETCH NEXT` without `ORDER BY`, causing non-deterministic results across paginated requests. This is the Derby dialect equivalent of the MySQL bug reported in #14046.

## Root Cause

Derby does not guarantee consistent row ordering without an explicit `ORDER BY` clause. When `OFFSET/FETCH NEXT` is used for pagination, different pages may return overlapping or missing records.

## Fix

Added `ORDER BY` before `OFFSET` in all affected methods:

**ConfigInfoMapperByDerby (8 methods):**
- `findConfigInfoByAppFetchRows` — added `ORDER BY id`
- `getTenantIdList` — added `ORDER BY tenant_id`
- `getGroupIdList` — added `ORDER BY group_id`
- `findChangeConfigFetchRows` — added `ORDER BY id`
- `findConfigInfoBaseLikeFetchRows` — added `ORDER BY id`
- `findConfigInfo4PageFetchRows` — added `ORDER BY id`
- `findConfigInfoBaseByGroupFetchRows` — added `ORDER BY id`
- `findConfigInfoLike4PageFetchRows` — added `orderBy("id")` via WhereBuilder

Also added `orderBy()` method to `WhereBuilder` for fluent ORDER BY support.

## Tests Added

All 8 corresponding test methods updated to verify the ORDER BY clause is present in the generated SQL.

## Impact

Ensures deterministic pagination ordering for all Derby config queries. Consistent with existing methods in the same class that already use `ORDER BY id`.