### PR TITLE
fix(client): fix check-then-act race condition in FailoverReactor.isFailoverSwitch

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/backups/FailoverReactor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/backups/FailoverReactor.java
@@ -157,7 +157,8 @@ public class FailoverReactor implements Closeable {
     }
     
     public boolean isFailoverSwitch(String serviceName) {
-        return failoverSwitchEnable && serviceMap.containsKey(serviceName) && serviceMap.get(serviceName).ipCount() > 0;
+        ServiceInfo serviceInfo = serviceMap.get(serviceName);
+        return failoverSwitchEnable && serviceInfo != null && serviceInfo.ipCount() > 0;
     }
     
     public ServiceInfo getService(String key) {

--- a/client/src/test/java/com/alibaba/nacos/client/naming/backups/FailoverReactorTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/backups/FailoverReactorTest.java
@@ -80,7 +80,45 @@ class FailoverReactorTest {
     @Test
     void testIsFailoverSwitch() throws NacosException {
         assertFalse(failoverReactor.isFailoverSwitch());
-        
+    }
+
+    @Test
+    void testIsFailoverSwitchByServiceNameWhenDisabled() {
+        assertFalse(failoverReactor.isFailoverSwitch("non-existent-service"));
+    }
+
+    @Test
+    void testIsFailoverSwitchByServiceNameWhenServiceNotInMap()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = FailoverReactor.class.getDeclaredField("failoverSwitchEnable");
+        field.setAccessible(true);
+        field.set(failoverReactor, true);
+        assertFalse(failoverReactor.isFailoverSwitch("non-existent-service"));
+    }
+
+    @Test
+    void testIsFailoverSwitchByServiceNameWhenServiceHasInstances()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field switchField = FailoverReactor.class.getDeclaredField("failoverSwitchEnable");
+        switchField.setAccessible(true);
+        switchField.set(failoverReactor, true);
+        ServiceInfo serviceInfo = new ServiceInfo("test@@service");
+        serviceInfo.addHost(new Instance());
+        ((Map) ReflectUtils.getFieldValue(failoverReactor, "serviceMap", new HashMap<>())).put("test@@service",
+                serviceInfo);
+        assertTrue(failoverReactor.isFailoverSwitch("test@@service"));
+    }
+
+    @Test
+    void testIsFailoverSwitchByServiceNameWhenServiceHasNoInstances()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field switchField = FailoverReactor.class.getDeclaredField("failoverSwitchEnable");
+        switchField.setAccessible(true);
+        switchField.set(failoverReactor, true);
+        ServiceInfo serviceInfo = new ServiceInfo("test@@empty");
+        ((Map) ReflectUtils.getFieldValue(failoverReactor, "serviceMap", new HashMap<>())).put("test@@empty",
+                serviceInfo);
+        assertFalse(failoverReactor.isFailoverSwitch("test@@empty"));
     }
     
     @Test


### PR DESCRIPTION
## Problem

`FailoverReactor.isFailoverSwitch(String serviceName)` uses a check-then-act pattern on a `ConcurrentHashMap` that can cause `NullPointerException` under concurrent access.

## Race Condition Explained

```java
// Before (buggy)
return failoverSwitchEnable
    && serviceMap.containsKey(serviceName)       // Step 1: check key exists
    && serviceMap.get(serviceName).ipCount() > 0; // Step 2: get value and call method
```

Between Step 1 and Step 2, another thread may modify the map:

```
Thread A: serviceMap.containsKey("order-service") -> true
                                          FailoverSwitchRefresher: serviceMap = new ConcurrentHashMap<>()
Thread A: serviceMap.get("order-service") -> null
Thread A: null.ipCount() -> NullPointerException!
```

`serviceMap` is a `ConcurrentHashMap<String, ServiceInfo>` (line 54), and it is cleared/replaced by the `FailoverSwitchRefresher` scheduled task when failover mode is toggled. The `isFailoverSwitch(String)` method is called from the naming client hot path, making this a practical race condition.

## Fix

Replace the two-step `containsKey()` + `get()` with a single `get()` call and null check:

```java
// After (safe)
ServiceInfo serviceInfo = serviceMap.get(serviceName);  // single atomic lookup
return failoverSwitchEnable && serviceInfo != null && serviceInfo.ipCount() > 0;
```

This eliminates the race window because:
1. Only one map access is performed (single `get()`)
2. The result is stored in a local variable, which cannot be affected by other threads
3. The null check and method call operate on the local reference, not the map
4. It is also more efficient - one hash lookup instead of two

## Tests Added

| Change Point | Test |
|-------------|------|
| Single get() + null check | `testIsFailoverSwitchByServiceNameWhenDisabled()` - returns false when failover disabled |
| Same | `testIsFailoverSwitchByServiceNameWhenServiceNotInMap()` - returns false when service not found (null-safe) |
| Same | `testIsFailoverSwitchByServiceNameWhenServiceHasInstances()` - returns true when service has instances |
| Same | `testIsFailoverSwitchByServiceNameWhenServiceHasNoInstances()` - returns false when no instances |

## Impact

Prevents potential NPE in the naming client failover path. No behavioral change under non-concurrent conditions.