### PR TITLE
fix(naming): fix check-then-act race conditions on ConcurrentHashMap in naming module

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/ServiceManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/ServiceManager.java
@@ -100,8 +100,9 @@ public class ServiceManager {
      * @return removed service
      */
     public Service removeSingleton(Service service) {
-        if (namespaceSingletonMaps.containsKey(service.getNamespace())) {
-            namespaceSingletonMaps.get(service.getNamespace()).remove(service);
+        Set<Service> services = namespaceSingletonMaps.get(service.getNamespace());
+        if (services != null) {
+            services.remove(service);
         }
         return singletonRepository.remove(service);
     }

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManager.java
@@ -72,7 +72,8 @@ public class ClientServiceIndexesManager extends SmartSubscriber {
      * @param service The service of the Nacos.
      */
     public void removePublisherIndexesByEmptyService(Service service) {
-        if (publisherIndexes.containsKey(service) && publisherIndexes.get(service).isEmpty()) {
+        Set<String> publishers = publisherIndexes.get(service);
+        if (publishers != null && publishers.isEmpty()) {
             publisherIndexes.remove(service);
         }
     }

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/NamingFuzzyWatchContextService.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/NamingFuzzyWatchContextService.java
@@ -283,8 +283,9 @@ public class NamingFuzzyWatchContextService extends SmartSubscriber {
      * @param clientId        client id.
      */
     public void removeFuzzyWatchContext(String groupKeyPattern, String clientId) {
-        if (watchedClientsMap.containsKey(groupKeyPattern)) {
-            watchedClientsMap.get(groupKeyPattern).remove(clientId);
+        Set<String> clients = watchedClientsMap.get(groupKeyPattern);
+        if (clients != null) {
+            clients.remove(clientId);
         }
     }
     

--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManager.java
@@ -76,7 +76,8 @@ public class NamingMetadataManager extends SmartSubscriber {
      * @return true if contain instance metadata, otherwise false
      */
     public boolean containInstanceMetadata(Service service, String metadataId) {
-        return instanceMetadataMap.containsKey(service) && instanceMetadataMap.get(service).containsKey(metadataId);
+        ConcurrentMap<String, InstanceMetadata> metadataMap = instanceMetadataMap.get(service);
+        return metadataMap != null && metadataMap.containsKey(metadataId);
     }
     
     /**


### PR DESCRIPTION
## Problem

Four methods in the naming module use `containsKey()` followed by `get()` on `ConcurrentHashMap`/`ConcurrentMap` fields. Although each method is individually thread-safe, the **compound operation is not atomic**, creating a check-then-act race condition that can cause `NullPointerException`.

## Race Condition Explained

Take `ServiceManager.removeSingleton()` as an example:

```java
// Before (buggy)
if (namespaceSingletonMaps.containsKey(service.getNamespace())) {       // Step 1: check
    namespaceSingletonMaps.get(service.getNamespace()).remove(service);  // Step 2: get and use
}
```

Between Step 1 and Step 2, another thread may remove the entry:

```
Thread A: containsKey("public") -> true
                                          Thread B: namespaceSingletonMaps.remove("public")
Thread A: get("public") -> null
Thread A: null.remove(service) -> NullPointerException!
```

`ConcurrentHashMap` guarantees thread-safety for **individual** operations, but NOT for **compound** operations spanning two separate method calls.

## Fix

Replace all `containsKey()` + `get()` patterns with a single `get()` call and null check:

```java
// After (safe)
Set<Service> services = namespaceSingletonMaps.get(service.getNamespace());  // single lookup
if (services != null) {                                                       // null check
    services.remove(service);                                                 // safe
}
```

### All 4 Fix Points

| Class | Method | Field Type |
|-------|--------|-----------|
| `ClientServiceIndexesManager` | `removePublisherIndexesByEmptyService` | `ConcurrentMap<Service, Set<String>>` |
| `NamingMetadataManager` | `containInstanceMetadata` | `ConcurrentMap<Service, ConcurrentMap<String, InstanceMetadata>>` |
| `NamingFuzzyWatchContextService` | `removeFuzzyWatchContext` | `ConcurrentMap<String, Set<String>>` |
| `ServiceManager` | `removeSingleton` | `ConcurrentHashMap<String, Set<Service>>` |

All four fields are modified at runtime by event handlers and background tasks, making the race condition window practical.

## Tests

All existing tests pass (31 tests across `ClientServiceIndexesManagerTest`, `NamingMetadataManagerTest`, `NamingFuzzyWatchContextServiceTest`). The fix is behavior-preserving under non-concurrent conditions - it only prevents NPE when concurrent map modifications occur.

## Impact

Prevents potential NPE in naming service operations (service registration, metadata lookup, fuzzy watch, service removal). No behavioral change under normal single-threaded access.