### PR TITLE
fix(core): fix check-then-act race conditions on ConcurrentHashMap in core module

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/distributed/id/IdGeneratorManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/id/IdGeneratorManager.java
@@ -76,8 +76,9 @@ public class IdGeneratorManager {
      * @return id
      */
     public long nextId(String resource) {
-        if (generatorMap.containsKey(resource)) {
-            return generatorMap.get(resource).nextId();
+        IdGenerator generator = generatorMap.get(resource);
+        if (generator != null) {
+            return generator.nextId();
         }
         throw new NoSuchElementException(
                 "The resource is not registered with the distributed " + "ID resource for the time being.");

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
@@ -341,18 +341,20 @@ public class PluginManager implements PluginStateChecker, PluginStateApplier, Ap
         // Load states
         Map<String, Boolean> states = persistence.loadAllStates();
         states.forEach((pluginId, enabled) -> {
-            if (pluginRegistry.containsKey(pluginId)) {
+            PluginInfo pluginInfo = pluginRegistry.get(pluginId);
+            if (pluginInfo != null) {
                 pluginStates.put(pluginId, enabled);
-                pluginRegistry.get(pluginId).setEnabled(enabled);
+                pluginInfo.setEnabled(enabled);
             }
         });
 
         // Load configs
         Map<String, Map<String, String>> configs = persistence.loadAllConfigs();
         configs.forEach((pluginId, config) -> {
-            if (pluginRegistry.containsKey(pluginId)) {
+            PluginInfo pluginInfoForConfig = pluginRegistry.get(pluginId);
+            if (pluginInfoForConfig != null) {
                 pluginConfigs.put(pluginId, config);
-                pluginRegistry.get(pluginId).setConfig(config);
+                pluginInfoForConfig.setConfig(config);
                 applyConfigToPlugin(pluginId, config);
             }
         });


### PR DESCRIPTION
## Problem

Two classes in the core module use `containsKey()` followed by `get()` on `ConcurrentHashMap` fields. Although each method is individually thread-safe, the **compound operation is not atomic**, creating a check-then-act race condition that can cause `NullPointerException`.

## Race Condition Explained

Take `IdGeneratorManager.nextId()` as an example:

```java
// Before (buggy)
if (generatorMap.containsKey(resource)) {       // Step 1: check key exists
    return generatorMap.get(resource).nextId();  // Step 2: get value and call method
}
```

Between Step 1 and Step 2, another thread may modify the map:

```
Thread A: containsKey("order") -> true
                                          Thread B: generatorMap.remove("order")
Thread A: generatorMap.get("order") -> null
Thread A: null.nextId() -> NullPointerException!
```

`ConcurrentHashMap` guarantees thread-safety for **individual** operations, but NOT for **compound** operations spanning two separate method calls. The time window between `containsKey()` returning `true` and the subsequent `get()` call is a race condition window.

## Root Cause

- `IdGeneratorManager.generatorMap` is a `ConcurrentHashMap<String, IdGenerator>` (line 38), populated via `register()` and accessed from multiple threads in `nextId()`.
- `PluginManager.pluginRegistry` is a `ConcurrentHashMap<String, PluginInfo>` (line 92), modified at runtime by `ApplicationReadyEvent` listener and plugin state synchronizer, while `loadPersistedData()` reads it.

## Fix

Replace the two-step `containsKey()` + `get()` with a single `get()` call and null check:

```java
// After (safe)
IdGenerator generator = generatorMap.get(resource);  // single atomic lookup
if (generator != null) {                              // null check on local variable
    return generator.nextId();                        // safe - local ref cannot be invalidated
}
```

This eliminates the race window because:
1. Only one map access is performed (single `get()`)
2. The result is stored in a local variable, which cannot be affected by other threads
3. The null check and method call operate on the local reference, not the map

### Changes

| Class | Method | Fix Points |
|-------|--------|:----------:|
| `IdGeneratorManager` | `nextId(String resource)` | 1 |
| `PluginManager` | `loadPersistedData()` | 2 (states loop + configs loop) |

## Tests

All existing tests pass (7 `IdGeneratorManagerTest` + 29 `PluginManagerTest`). The fix is behavior-preserving under non-concurrent conditions - it only prevents NPE when concurrent map modifications occur.

## Impact

Prevents potential NPE in ID generation and plugin management paths. No behavioral change under normal single-threaded access.