### PR TITLE
fix(naming): include cluster field in InstancePublishInfo equals and hashCode

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/pojo/InstancePublishInfo.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/pojo/InstancePublishInfo.java
@@ -104,13 +104,13 @@ public class InstancePublishInfo implements Serializable {
             return false;
         }
         InstancePublishInfo that = (InstancePublishInfo) o;
-        return port == that.port && healthy == that.healthy && Objects.equals(ip, that.ip) && Objects
-                .equals(extendDatum, that.extendDatum);
+        return port == that.port && healthy == that.healthy && Objects.equals(ip, that.ip)
+                && Objects.equals(cluster, that.cluster) && Objects.equals(extendDatum, that.extendDatum);
     }
-    
+
     @Override
     public int hashCode() {
-        return Objects.hash(ip, port, extendDatum, healthy);
+        return Objects.hash(ip, port, healthy, cluster, extendDatum);
     }
     
     @Override

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/InstancePublishInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/InstancePublishInfoTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.pojo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class InstancePublishInfoTest {
+
+    @Test
+    void testEqualsWithSameCluster() {
+        InstancePublishInfo info1 = new InstancePublishInfo("1.1.1.1", 8080);
+        info1.setCluster("clusterA");
+        InstancePublishInfo info2 = new InstancePublishInfo("1.1.1.1", 8080);
+        info2.setCluster("clusterA");
+        assertEquals(info1, info2);
+        assertEquals(info1.hashCode(), info2.hashCode());
+    }
+
+    @Test
+    void testNotEqualsWithDifferentCluster() {
+        InstancePublishInfo info1 = new InstancePublishInfo("1.1.1.1", 8080);
+        info1.setCluster("clusterA");
+        InstancePublishInfo info2 = new InstancePublishInfo("1.1.1.1", 8080);
+        info2.setCluster("clusterB");
+        assertNotEquals(info1, info2);
+    }
+
+    @Test
+    void testEqualsWithNullCluster() {
+        InstancePublishInfo info1 = new InstancePublishInfo("1.1.1.1", 8080);
+        InstancePublishInfo info2 = new InstancePublishInfo("1.1.1.1", 8080);
+        assertEquals(info1, info2);
+        assertEquals(info1.hashCode(), info2.hashCode());
+    }
+
+    @Test
+    void testNotEqualsWithDifferentPort() {
+        InstancePublishInfo info1 = new InstancePublishInfo("1.1.1.1", 8080);
+        InstancePublishInfo info2 = new InstancePublishInfo("1.1.1.1", 8081);
+        assertNotEquals(info1, info2);
+    }
+
+    @Test
+    void testNotEqualsWithDifferentHealthy() {
+        InstancePublishInfo info1 = new InstancePublishInfo("1.1.1.1", 8080);
+        info1.setHealthy(true);
+        InstancePublishInfo info2 = new InstancePublishInfo("1.1.1.1", 8080);
+        info2.setHealthy(false);
+        assertNotEquals(info1, info2);
+    }
+
+    @Test
+    void testEqualsSameObject() {
+        InstancePublishInfo info = new InstancePublishInfo("1.1.1.1", 8080);
+        assertEquals(info, info);
+    }
+
+    @Test
+    void testNotEqualsNull() {
+        InstancePublishInfo info = new InstancePublishInfo("1.1.1.1", 8080);
+        assertNotEquals(null, info);
+    }
+
+    @Test
+    void testGetMetadataId() {
+        InstancePublishInfo info = new InstancePublishInfo("1.1.1.1", 8080);
+        info.setCluster("clusterA");
+        assertEquals("1.1.1.1:8080:clusterA", info.getMetadataId());
+    }
+}


### PR DESCRIPTION
## Problem

`InstancePublishInfo.equals()` and `hashCode()` do not include the `cluster` field. This means two instances with the same IP and port but in different clusters are considered equal, which can cause Distro data sync to miss cluster changes across Nacos nodes.

## Root Cause

The `cluster` field is part of the instance identity — it is used in `getMetadataId()` to generate the metadata identifier (`ip:port:cluster`). However, it was omitted from `equals()` and `hashCode()`:

```java
// Before: cluster missing
return port == that.port && healthy == that.healthy
    && Objects.equals(ip, that.ip) && Objects.equals(extendDatum, that.extendDatum);
```

In `DistroClientDataProcessor`, `equals()` is used to detect instance changes during cluster sync:
```java
if (!instancePublishInfo.equals(client.getInstancePublishInfo(singleton))) {
```

Without `cluster` in equals, changing an instance's cluster will not be detected as a change, causing data inconsistency between Nacos cluster nodes.

## Fix

Added `cluster` to both `equals()` and `hashCode()`:

```java
// After: cluster included
return port == that.port && healthy == that.healthy
    && Objects.equals(ip, that.ip) && Objects.equals(cluster, that.cluster)
    && Objects.equals(extendDatum, that.extendDatum);
```

## Tests Added

Created `InstancePublishInfoTest` with 8 test cases:

| Change Point | Test |
|-------------|------|
| cluster in equals | `testEqualsWithSameCluster()` — same cluster returns equal |
| cluster in equals | `testNotEqualsWithDifferentCluster()` — different cluster returns not equal |
| null-safety | `testEqualsWithNullCluster()` — null clusters are handled safely |
| hashCode consistency | `testEqualsWithSameCluster()` — equal objects have equal hashCodes |
| existing behavior preserved | `testNotEqualsWithDifferentPort()`, `testNotEqualsWithDifferentHealthy()`, `testEqualsSameObject()`, `testNotEqualsNull()` |
| metadataId uses cluster | `testGetMetadataId()` — verifies cluster is part of metadata identity |

## Impact

Fixes Distro sync detection for cluster changes. `InstancePublishInfo` is used as map VALUES (not keys) in `AbstractClient.publishers`, so this change does not affect HashMap key behavior.