### PR TITLE
support import data with source

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/config/AgentSpecDataBootstrapInitializer.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/AgentSpecDataBootstrapInitializer.java
@@ -198,7 +198,8 @@ public class AgentSpecDataBootstrapInitializer implements ApplicationListener<Ap
     private ImportTaskResult importBuiltInAgentSpec(AgentSpecSeedArchiveReader.AgentSpecPackage pkg) {
         try {
             LOGGER.info("Import built-in agentspec `{}` from `{}`", pkg.getAgentSpecName(), pkg.getSourcePath());
-            agentSpecOperationService.bootstrapAgentSpecFromZip(Constants.DEFAULT_NAMESPACE_ID, pkg.getZipBytes());
+            agentSpecOperationService.bootstrapAgentSpecFromZip(Constants.DEFAULT_NAMESPACE_ID, pkg.getZipBytes(),
+                    pkg.getFrom());
             return ImportTaskResult.success(pkg.getAgentSpecName());
         } catch (Exception e) {
             LOGGER.error("Failed to bootstrap built-in agentspec `{}` from `{}`", pkg.getAgentSpecName(),

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/SkillDataBootstrapInitializer.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/SkillDataBootstrapInitializer.java
@@ -192,7 +192,8 @@ public class SkillDataBootstrapInitializer implements ApplicationListener<Applic
     private ImportTaskResult importBuiltInSkill(SkillSeedArchiveReader.SkillPackage skillPackage) {
         try {
             LOGGER.info("Import built-in skill `{}` from `{}`", skillPackage.getSkillName(), skillPackage.getSourcePath());
-            skillOperationService.bootstrapSkillFromZip(Constants.DEFAULT_NAMESPACE_ID, skillPackage.getZipBytes());
+            skillOperationService.bootstrapSkillFromZip(Constants.DEFAULT_NAMESPACE_ID, skillPackage.getZipBytes(),
+                    skillPackage.getFrom());
             return ImportTaskResult.success(skillPackage.getSkillName());
         } catch (Exception e) {
             LOGGER.error("Failed to bootstrap built-in skill `{}` from `{}`", skillPackage.getSkillName(),

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationService.java
@@ -124,6 +124,18 @@ public interface AgentSpecOperationService {
      * @throws NacosException if bootstrap failed
      */
     void bootstrapAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
+
+    /**
+     * Bootstrap agentspec from zip file as an online agentspec with source metadata.
+     *
+     * @param namespaceId namespace ID
+     * @param zipBytes zip file bytes
+     * @param from source identifier, e.g. github.com/nacos
+     * @throws NacosException if bootstrap failed
+     */
+    default void bootstrapAgentSpecFromZip(String namespaceId, byte[] zipBytes, String from) throws NacosException {
+        bootstrapAgentSpecFromZip(namespaceId, zipBytes);
+    }
     
     /**
      * Search agentspecs for runtime client usage. Only returns enabled agentspecs that have at least one online

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -402,6 +402,11 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     
     @Override
     public void bootstrapAgentSpecFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        bootstrapAgentSpecFromZip(namespaceId, zipBytes, null);
+    }
+
+    @Override
+    public void bootstrapAgentSpecFromZip(String namespaceId, byte[] zipBytes, String from) throws NacosException {
         AgentSpec agentSpec = AgentSpecZipParser.parseAgentSpecFromZip(zipBytes, namespaceId);
         if (agentSpec == null || StringUtils.isBlank(agentSpec.getName())) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
@@ -447,6 +452,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         meta.setDesc(agentSpec.getDescription());
         meta.setBizTags(agentSpec.getBizTags());
         meta.setOwner(DEFAULT_AUTHOR);
+        meta.setFrom(from);
         meta.setScope(VisibilityConstants.SCOPE_PUBLIC);
         meta.setVersionInfo(JacksonUtils.toJson(versionInfo));
         meta.setMetaVersion(1L);

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationService.java
@@ -84,6 +84,18 @@ public interface SkillOperationService {
     void bootstrapSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException;
 
     /**
+     * Bootstrap skill from zip file as an online skill with source metadata.
+     *
+     * @param namespaceId namespace ID
+     * @param zipBytes zip file bytes
+     * @param from source identifier, e.g. github.com/nacos
+     * @throws NacosException if bootstrap failed
+     */
+    default void bootstrapSkillFromZip(String namespaceId, byte[] zipBytes, String from) throws NacosException {
+        bootstrapSkillFromZip(namespaceId, zipBytes);
+    }
+
+    /**
      * Get skill detail for admin usage. Returns version governance metadata and all version summaries.
      *
      * @param namespaceId namespace ID

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -198,6 +198,11 @@ public class SkillOperationServiceImpl implements SkillOperationService {
 
     @Override
     public void bootstrapSkillFromZip(String namespaceId, byte[] zipBytes) throws NacosException {
+        bootstrapSkillFromZip(namespaceId, zipBytes, null);
+    }
+
+    @Override
+    public void bootstrapSkillFromZip(String namespaceId, byte[] zipBytes, String from) throws NacosException {
         Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, namespaceId);
         if (skill == null || StringUtils.isBlank(skill.getName())) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING, "Skill name is required");
@@ -236,6 +241,7 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         meta.setStatus(META_STATUS_ENABLE);
         meta.setDesc(skill.getDescription());
         meta.setOwner(DEFAULT_AUTHOR);
+        meta.setFrom(from);
         meta.setScope(VisibilityConstants.SCOPE_PUBLIC);
         meta.setVersionInfo(JacksonUtils.toJson(versionInfo));
         meta.setMetaVersion(1L);

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecSeedArchiveReader.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecSeedArchiveReader.java
@@ -87,7 +87,7 @@ public final class AgentSpecSeedArchiveReader {
                 LOGGER.warn("Skip duplicate built-in agentspec name `{}` from archive path `{}`", agentSpecName, root);
                 continue;
             }
-            result.add(new AgentSpecPackage(agentSpecName, root, buildAgentSpecZip(entries, root)));
+            result.add(new AgentSpecPackage(agentSpecName, extractFrom(root), root, buildAgentSpecZip(entries, root)));
         }
         return result;
     }
@@ -198,6 +198,22 @@ public final class AgentSpecSeedArchiveReader {
         return root.isEmpty() ? fileName : root + "/" + fileName;
     }
 
+    private static String extractFrom(String sourcePath) {
+        if (StringUtils.isBlank(sourcePath)) {
+            return null;
+        }
+        String normalized = sourcePath;
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        int idx = normalized.lastIndexOf('/');
+        if (idx <= 0) {
+            return null;
+        }
+        String from = normalized.substring(0, idx).trim();
+        return StringUtils.isBlank(from) ? null : from;
+    }
+
     /**
      * Standalone agentspec package built from the seed archive.
      */
@@ -205,18 +221,25 @@ public final class AgentSpecSeedArchiveReader {
 
         private final String agentSpecName;
 
+        private final String from;
+
         private final String sourcePath;
 
         private final byte[] zipBytes;
 
-        public AgentSpecPackage(String agentSpecName, String sourcePath, byte[] zipBytes) {
+        public AgentSpecPackage(String agentSpecName, String from, String sourcePath, byte[] zipBytes) {
             this.agentSpecName = agentSpecName;
+            this.from = from;
             this.sourcePath = sourcePath;
             this.zipBytes = zipBytes == null ? new byte[0] : zipBytes;
         }
 
         public String getAgentSpecName() {
             return agentSpecName;
+        }
+
+        public String getFrom() {
+            return from;
         }
 
         public String getSourcePath() {

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillSeedArchiveReader.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillSeedArchiveReader.java
@@ -93,7 +93,7 @@ public final class SkillSeedArchiveReader {
                 LOGGER.warn("Skip duplicate built-in skill name `{}` from archive path `{}`", skillName, root);
                 continue;
             }
-            result.add(new SkillPackage(skillName, root, buildSkillZip(entries, root, skillName)));
+            result.add(new SkillPackage(skillName, extractFrom(root), root, buildSkillZip(entries, root, skillName)));
         }
         return result;
     }
@@ -200,6 +200,22 @@ public final class SkillSeedArchiveReader {
         return root.isEmpty() ? fileName : root + "/" + fileName;
     }
 
+    private static String extractFrom(String sourcePath) {
+        if (StringUtils.isBlank(sourcePath)) {
+            return null;
+        }
+        String normalized = sourcePath;
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        int idx = normalized.lastIndexOf('/');
+        if (idx <= 0) {
+            return null;
+        }
+        String from = normalized.substring(0, idx).trim();
+        return StringUtils.isBlank(from) ? null : from;
+    }
+
     /**
      * Standalone skill package built from the seed archive.
      */
@@ -207,18 +223,25 @@ public final class SkillSeedArchiveReader {
 
         private final String skillName;
 
+        private final String from;
+
         private final String sourcePath;
 
         private final byte[] zipBytes;
 
-        public SkillPackage(String skillName, String sourcePath, byte[] zipBytes) {
+        public SkillPackage(String skillName, String from, String sourcePath, byte[] zipBytes) {
             this.skillName = skillName;
+            this.from = from;
             this.sourcePath = sourcePath;
             this.zipBytes = zipBytes == null ? new byte[0] : zipBytes;
         }
 
         public String getSkillName() {
             return skillName;
+        }
+
+        public String getFrom() {
+            return from;
         }
 
         public String getSourcePath() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentSpecSeedArchiveReaderTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentSpecSeedArchiveReaderTest.java
@@ -51,6 +51,7 @@ class AgentSpecSeedArchiveReaderTest {
 
         assertEquals(1, actual.size());
         assertEquals("演示坐席", actual.get(0).getAgentSpecName());
+        assertEquals("vendor", actual.get(0).getFrom());
 
         AgentSpec spec = AgentSpecZipParser.parseAgentSpecFromZip(actual.get(0).getZipBytes(), "public");
         assertEquals("演示坐席", spec.getName());
@@ -71,6 +72,16 @@ class AgentSpecSeedArchiveReaderTest {
 
         assertEquals(1, actual.size());
         assertEquals("同名坐席", actual.get(0).getAgentSpecName());
+    }
+
+    @Test
+    void shouldParseNestedFromPath() throws Exception {
+        String manifest = "{\"version\":\"1.0\",\"worker\":{\"suggested_name\":\"find-agentspec\"}}";
+        byte[] archive = buildArchive(new ArchiveEntry("github.com/nacos/find-agentspec/manifest.json", manifest));
+        List<AgentSpecSeedArchiveReader.AgentSpecPackage> actual =
+                AgentSpecSeedArchiveReader.read(new ByteArrayInputStream(archive));
+        assertEquals(1, actual.size());
+        assertEquals("github.com/nacos", actual.get(0).getFrom());
     }
 
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillSeedArchiveReaderTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillSeedArchiveReaderTest.java
@@ -49,6 +49,7 @@ class SkillSeedArchiveReaderTest {
 
         assertEquals(1, actual.size());
         assertEquals("demo-skill", actual.get(0).getSkillName());
+        assertEquals("vendor", actual.get(0).getFrom());
 
         Skill skill = SkillZipParser.parseSkillFromZip(actual.get(0).getZipBytes(), "public");
         assertEquals("demo-skill", skill.getName());
@@ -66,6 +67,15 @@ class SkillSeedArchiveReaderTest {
 
         assertEquals(1, actual.size());
         assertEquals("same-skill", actual.get(0).getSkillName());
+    }
+
+    @Test
+    void shouldParseNestedFromPath() throws Exception {
+        byte[] archive = buildArchive(new ArchiveEntry("github.com/nacos/find-skills/SKILL.md",
+                buildSkillMarkdown("find-skills")));
+        List<SkillSeedArchiveReader.SkillPackage> actual = SkillSeedArchiveReader.read(new ByteArrayInputStream(archive));
+        assertEquals(1, actual.size());
+        assertEquals("github.com/nacos", actual.get(0).getFrom());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

When bootstrapping built-in agentspecs and skills from seed archives, the `from` metadata (source origin, e.g. `github.com/nacos`) was not being tracked. This makes it impossible to distinguish where a built-in resource was originally sourced from after import.

This change adds a `from` field to the bootstrap pipeline so that the source origin of each bundled agentspec/skill is extracted from the archive directory structure and persisted into the resource metadata.

## Brief changelog

- `AgentSpecSeedArchiveReader` / `SkillSeedArchiveReader`: add `extractFrom(sourcePath)` method that derives the source identifier from the archive directory hierarchy (e.g. `github.com/nacos/find-agentspec/` → `github.com/nacos`). Add `from` field to `AgentSpecPackage` / `SkillPackage`.
- `AgentSpecOperationService` / `SkillOperationService`: add overloaded `bootstrapAgentSpecFromZip(namespaceId, zipBytes, from)` / `bootstrapSkillFromZip(namespaceId, zipBytes, from)` default interface method with backward-compatible delegation.
- `AgentSpecOperationServiceImpl` / `SkillOperationServiceImpl`: implement the new overload, set `meta.setFrom(from)` during bootstrap.
- `AgentSpecDataBootstrapInitializer` / `SkillDataBootstrapInitializer`: pass `pkg.getFrom()` / `skillPackage.getFrom()` when calling the bootstrap method.
- Add unit tests for `extractFrom` path parsing in both `AgentSpecSeedArchiveReaderTest` and `SkillSeedArchiveReaderTest`.

## Verifying this change

- [x] Existing `AgentSpecSeedArchiveReaderTest.shouldParseVendorPrefixedArchive` now also asserts `getFrom()` returns `"vendor"`.
- [x] New test `AgentSpecSeedArchiveReaderTest.shouldParseNestedFromPath` verifies deeply nested paths like `github.com/nacos/find-agentspec/` produce `from = "github.com/nacos"`.
- [x] Existing `SkillSeedArchiveReaderTest.shouldParseVendorPrefixedArchive` now also asserts `getFrom()` returns `"vendor"`.
- [x] New test `SkillSeedArchiveReaderTest.shouldParseNestedFromPath` verifies deeply nested paths produce the correct `from` value.
- [x] The new overloaded interface methods use `default` delegation, so all existing callers remain backward-compatible without changes.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
- [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
