### PR TITLE
fix(console-ui-next): use customNamespaceId when creating namespace

### DIFF
--- a/console-ui-next/src/api/namespace.ts
+++ b/console-ui-next/src/api/namespace.ts
@@ -15,7 +15,8 @@ export interface NamespaceListResponse {
 }
 
 export interface NamespaceCreateData {
-  namespaceId: string;
+  customNamespaceId?: string;
+  namespaceId?: string;
   namespaceName: string;
   namespaceDesc?: string;
 }
@@ -33,8 +34,14 @@ export const namespaceApi = {
   detail: (namespaceId: string): AxiosPromise<Namespace> =>
     client.get('v3/console/core/namespace', { params: { namespaceId } }),
 
-  create: (data: NamespaceCreateData): AxiosPromise<void> =>
-    client.post('v3/console/core/namespace', data),
+  create: (data: NamespaceCreateData): AxiosPromise<void> => {
+    const customNamespaceId = data.customNamespaceId ?? data.namespaceId ?? '';
+    return client.post('v3/console/core/namespace', {
+      customNamespaceId,
+      namespaceName: data.namespaceName,
+      namespaceDesc: data.namespaceDesc,
+    });
+  },
   
   update: (data: NamespaceUpdateData): AxiosPromise<void> =>
     client.put('v3/console/core/namespace', data),

--- a/console-ui-next/src/pages/namespace/index.tsx
+++ b/console-ui-next/src/pages/namespace/index.tsx
@@ -76,7 +76,7 @@ export default function NamespacePage() {
     setSaving(true);
     try {
       await namespaceApi.create({
-        namespaceId: formId.trim(),
+        customNamespaceId: formId.trim(),
         namespaceName: formName.trim(),
         namespaceDesc: formDesc.trim(),
       });


### PR DESCRIPTION

Fix new UI namespace creation to send customNamespaceId (with backward-compatible mapping from namespaceId) so custom namespace IDs are preserved instead of being auto-generated as UUIDs.


