### PR TITLE
fix(naming): do not force clusterName to DEFAULT in v3 HTTP API

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/CatalogServiceV2Impl.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/CatalogServiceV2Impl.java
@@ -113,7 +113,7 @@ public class CatalogServiceV2Impl implements CatalogService {
             throw new NacosException(NacosException.NOT_FOUND,
                     String.format("service %s@@%s is not found!", groupName, serviceName));
         }
-        if (!serviceStorage.getClusters(service).contains(clusterName)) {
+        if (StringUtils.isNotBlank(clusterName) && !serviceStorage.getClusters(service).contains(clusterName)) {
             throw new NacosException(NacosException.NOT_FOUND, "cluster " + clusterName + " is not found!");
         }
         ServiceInfo serviceInfo = serviceStorage.getData(service);

--- a/naming/src/main/java/com/alibaba/nacos/naming/model/form/InstanceListForm.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/model/form/InstanceListForm.java
@@ -21,7 +21,6 @@ import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.api.model.NacosForm;
-import com.alibaba.nacos.naming.misc.UtilsAndCommons;
 import org.springframework.http.HttpStatus;
 
 import java.util.Objects;
@@ -69,7 +68,7 @@ public class InstanceListForm implements NacosForm {
             groupName = Constants.DEFAULT_GROUP;
         }
         if (StringUtils.isBlank(clusterName)) {
-            clusterName = UtilsAndCommons.DEFAULT_CLUSTER_NAME;
+            clusterName = StringUtils.EMPTY;
         }
         if (null == healthyOnly) {
             healthyOnly = false;

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceOpenApiControllerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceOpenApiControllerTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.naming.controllers.v3;
 
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.naming.NamingResponseCode;
@@ -119,7 +120,7 @@ class InstanceOpenApiControllerTest {
         serviceInfo.setName("test");
         serviceInfo.setHosts(Collections.singletonList(instance));
         when(instanceOperator.listInstance(Constants.DEFAULT_NAMESPACE_ID, Constants.DEFAULT_GROUP, "test", null,
-                Constants.DEFAULT_CLUSTER_NAME, false)).thenReturn(serviceInfo);
+                StringUtils.EMPTY, false)).thenReturn(serviceInfo);
         Result<List<Instance>> actual = instanceOpenApiController.list(instanceForm);
         assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
         assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/CatalogServiceV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/CatalogServiceV2ImplTest.java
@@ -131,7 +131,38 @@ class CatalogServiceV2ImplTest {
             catalogServiceV2Impl.listInstances("A", "B", "C", "DD");
         });
     }
-    
+
+    @Test
+    void testListInstancesWithBlankClusterNameReturnsAll() throws NacosException {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setGroupName("B");
+        serviceInfo.setName("C");
+        Instance instance1 = new Instance();
+        instance1.setClusterName("cluster1");
+        instance1.setIp("1.1.1.1");
+        Instance instance2 = new Instance();
+        instance2.setClusterName("cluster2");
+        instance2.setIp("2.2.2.2");
+        serviceInfo.setHosts(List.of(instance1, instance2));
+        Mockito.when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        List<? extends Instance> instances = catalogServiceV2Impl.listInstances("A", "B", "C", "");
+        assertEquals(2, instances.size());
+    }
+
+    @Test
+    void testListInstancesWithNullClusterNameReturnsAll() throws NacosException {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setGroupName("B");
+        serviceInfo.setName("C");
+        Instance instance = new Instance();
+        instance.setClusterName("anyCluster");
+        instance.setIp("1.1.1.1");
+        serviceInfo.setHosts(Collections.singletonList(instance));
+        Mockito.when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        List<? extends Instance> instances = catalogServiceV2Impl.listInstances("A", "B", "C", null);
+        assertEquals(1, instances.size());
+    }
+
     @Test
     void testPageListService() throws NacosException {
         ServiceInfo serviceInfo = new ServiceInfo();

--- a/naming/src/test/java/com/alibaba/nacos/naming/model/form/InstanceListFormTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/model/form/InstanceListFormTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.model.form;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class InstanceListFormTest {
+
+    @Test
+    void testFillDefaultValueWhenClusterNameIsBlank() throws NacosApiException {
+        InstanceListForm form = new InstanceListForm();
+        form.setServiceName("testService");
+        form.validate();
+        assertEquals("", form.getClusterName());
+    }
+
+    @Test
+    void testFillDefaultValueWhenClusterNameIsProvided() throws NacosApiException {
+        InstanceListForm form = new InstanceListForm();
+        form.setServiceName("testService");
+        form.setClusterName("myCluster");
+        form.validate();
+        assertEquals("myCluster", form.getClusterName());
+    }
+
+    @Test
+    void testFillDefaultValueForNamespaceAndGroup() throws NacosApiException {
+        InstanceListForm form = new InstanceListForm();
+        form.setServiceName("testService");
+        form.validate();
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, form.getNamespaceId());
+        assertEquals(Constants.DEFAULT_GROUP, form.getGroupName());
+    }
+
+    @Test
+    void testValidateThrowsExceptionWhenServiceNameIsBlank() {
+        InstanceListForm form = new InstanceListForm();
+        assertThrows(NacosApiException.class, () -> form.validate());
+    }
+}


### PR DESCRIPTION
## Problem

When calling the v3 HTTP API to list instances without specifying a `clusterName`, the API returns `NOT_FOUND` for services that use non-default cluster names (e.g., `cluster-hba`). The same query via gRPC correctly returns all instances.

## Root Cause

`InstanceListForm.fillDefaultValue()` forces an empty `clusterName` to `"DEFAULT"`. Then `CatalogServiceV2Impl.listInstances()` does an exact match — if the service has no cluster named `"DEFAULT"`, it throws `NacosException.NOT_FOUND`.

The gRPC path (`ServiceQueryRequestHandler`) treats empty cluster as an empty string, which flows into `ServiceUtil.doSelectInstances()` where an empty cluster produces an empty `clusterSets`, causing `checkCluster()` to return `true` for all instances.

## Fix

- **`InstanceListForm.fillDefaultValue()`**: Use `StringUtils.EMPTY` instead of `UtilsAndCommons.DEFAULT_CLUSTER_NAME` when `clusterName` is blank, so the v3 HTTP path passes an empty string just like gRPC does.
- **`CatalogServiceV2Impl.listInstances()`**: Skip the cluster-existence check when `clusterName` is blank, letting `ServiceUtil.selectInstances()` handle the empty-cluster case correctly (return all instances).

## Tests Added

| Change Point | Test |
|---|---|
| `InstanceListForm`: blank clusterName → empty string | `InstanceListFormTest.testFillDefaultValueWhenClusterNameIsBlank()` |
| `InstanceListForm`: provided clusterName preserved | `InstanceListFormTest.testFillDefaultValueWhenClusterNameIsProvided()` |
| `InstanceListForm`: default namespace/group | `InstanceListFormTest.testFillDefaultValueForNamespaceAndGroup()` |
| `InstanceListForm`: missing serviceName throws | `InstanceListFormTest.testValidateThrowsExceptionWhenServiceNameIsBlank()` |
| `CatalogServiceV2Impl`: blank cluster returns all instances | `CatalogServiceV2ImplTest.testListInstancesWithBlankClusterNameReturnsAll()` |
| `CatalogServiceV2Impl`: null cluster returns all instances | `CatalogServiceV2ImplTest.testListInstancesWithNullClusterNameReturnsAll()` |

## Impact

Only affects the v3 HTTP instance-list endpoint when `clusterName` is omitted. No change to gRPC behavior or any other API.

Fixes #14650