### PR TITLE
fix(common): use ConcurrentHashMap for fileMd5Map in TlsFileWatcher

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
+++ b/common/src/main/java/com/alibaba/nacos/common/tls/TlsFileWatcher.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -52,7 +51,7 @@ public final class TlsFileWatcher {
     
     private final int checkInterval = TlsSystemConfig.tlsFileCheckInterval;
     
-    private Map<String, String> fileMd5Map = new HashMap<>();
+    private Map<String, String> fileMd5Map = new ConcurrentHashMap<>();
     
     private ConcurrentHashMap<String, FileChangeListener> watchFilesMap = new ConcurrentHashMap<>();
     

--- a/common/src/test/java/com/alibaba/nacos/common/tls/TlsFileWatcherTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/tls/TlsFileWatcherTest.java
@@ -32,12 +32,14 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -172,5 +174,11 @@ class TlsFileWatcherTest {
         TlsFileWatcher.getInstance().start();
         
         verify(executorService, times(1)).scheduleAtFixedRate(any(), anyLong(), anyLong(), any());
+    }
+    
+    @Test
+    void testFileMd5MapIsConcurrentHashMap() throws IllegalAccessException {
+        Map<?, ?> md5Map = (Map<?, ?>) fileMd5MapField.get(TlsFileWatcher.getInstance());
+        assertInstanceOf(ConcurrentHashMap.class, md5Map);
     }
 }


### PR DESCRIPTION
## Problem

`TlsFileWatcher.fileMd5Map` is a plain `HashMap` that is accessed from multiple threads concurrently, which can lead to data races, missed TLS certificate change notifications, or `ConcurrentModificationException`.

## Root Cause

`fileMd5Map` is written by the calling thread in `addFileChangeListener()` (line 87) and read/written by the scheduled executor thread in the periodic file-check task (lines 114, 116). A `HashMap` is not thread-safe — concurrent reads and writes can corrupt its internal structure or produce inconsistent results.

## Fix

Replace `HashMap<String, String>` with `ConcurrentHashMap<String, String>` for `fileMd5Map`, matching the pattern already used for `watchFilesMap` in the same class.

## Tests Added

| Change Point | Test |
|---|---|
| `fileMd5Map` changed from HashMap to ConcurrentHashMap | `testFileMd5MapIsConcurrentHashMap()` — verifies the map instance is ConcurrentHashMap |
| Existing behavior preserved | All 6 existing tests continue to pass (listener registration, change detection, duplicate start guard) |

## Impact

Only affects `TlsFileWatcher` internal state management. No change to public API or behavior — the fix ensures existing thread-safety expectations are met.