### PR TITLE
fix(config): make ClientIpWhiteList.isOpen volatile and null-safe

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ClientIpWhiteList.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ClientIpWhiteList.java
@@ -41,7 +41,7 @@ public class ClientIpWhiteList {
     private static final AtomicReference<List<String>> CLIENT_IP_WHITELIST = new AtomicReference<>(
         new ArrayList<>());
     
-    private static Boolean isOpen = false;
+    private static volatile boolean isOpen = false;
     
     /**
      * Judge whether specified client ip includes in the whitelist.
@@ -85,7 +85,7 @@ public class ClientIpWhiteList {
         DEFAULT_LOG.warn("[clientIpWhiteList] {}", content);
         try {
             AclInfo acl = JacksonUtils.toObj(content, AclInfo.class);
-            isOpen = acl.getIsOpen();
+            isOpen = Boolean.TRUE.equals(acl.getIsOpen());
             CLIENT_IP_WHITELIST.set(acl.getIps());
         } catch (Exception ioe) {
             DEFAULT_LOG.error("failed to load clientIpWhiteList, " + ioe.toString(), ioe);

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ClientIpWhiteListTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ClientIpWhiteListTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientIpWhiteListTest {
+    
+    @AfterEach
+    void tearDown() {
+        ClientIpWhiteList.load("");
+    }
+    
+    @Test
+    void testIsOpenFieldIsVolatile() throws NoSuchFieldException {
+        Field isOpenField = ClientIpWhiteList.class.getDeclaredField("isOpen");
+        assertTrue(Modifier.isVolatile(isOpenField.getModifiers()));
+    }
+    
+    @Test
+    void testLoadValidContentEnablesWhitelist() {
+        String content = "{\"isOpen\":true,\"ips\":[\"192.168.1.1\",\"10.0.0.1\"]}";
+        ClientIpWhiteList.load(content);
+        assertTrue(ClientIpWhiteList.isEnableWhitelist());
+        assertTrue(ClientIpWhiteList.isLegalClient("192.168.1.1"));
+        assertTrue(ClientIpWhiteList.isLegalClient("10.0.0.1"));
+        assertFalse(ClientIpWhiteList.isLegalClient("172.16.0.1"));
+    }
+    
+    @Test
+    void testLoadBlankContentDisablesWhitelist() {
+        String content = "{\"isOpen\":true,\"ips\":[\"192.168.1.1\"]}";
+        ClientIpWhiteList.load(content);
+        assertTrue(ClientIpWhiteList.isEnableWhitelist());
+        
+        ClientIpWhiteList.load("");
+        assertFalse(ClientIpWhiteList.isEnableWhitelist());
+    }
+    
+    @Test
+    void testLoadNullIsOpenDoesNotThrowNpe() {
+        String content = "{\"ips\":[\"192.168.1.1\"]}";
+        assertDoesNotThrow(() -> ClientIpWhiteList.load(content));
+        assertFalse(ClientIpWhiteList.isEnableWhitelist());
+    }
+    
+    @Test
+    void testLoadWithIsOpenFalse() {
+        String content = "{\"isOpen\":false,\"ips\":[\"192.168.1.1\"]}";
+        ClientIpWhiteList.load(content);
+        assertFalse(ClientIpWhiteList.isEnableWhitelist());
+    }
+    
+    @Test
+    void testIsLegalClientThrowsOnBlankInput() {
+        assertThrows(IllegalArgumentException.class, () -> ClientIpWhiteList.isLegalClient(""));
+        assertThrows(IllegalArgumentException.class, () -> ClientIpWhiteList.isLegalClient(null));
+    }
+    
+    @Test
+    void testLoadInvalidJsonDoesNotCrash() {
+        assertDoesNotThrow(() -> ClientIpWhiteList.load("not-valid-json"));
+        assertFalse(ClientIpWhiteList.isEnableWhitelist());
+    }
+}


### PR DESCRIPTION
## Problem

`ClientIpWhiteList.isOpen` has two issues:

1. **Visibility bug**: The field is written by the config-load thread (in `load()`) and read by HTTP request threads (in `isEnableWhitelist()`). Without `volatile`, the Java Memory Model does not guarantee cross-thread visibility, so request threads may read a stale value indefinitely.

2. **NullPointerException risk**: `isOpen` is a `Boolean` wrapper, and `acl.getIsOpen()` can return `null` when the JSON field is absent. The `isEnableWhitelist()` method returns primitive `boolean`, so a `null` `isOpen` would cause auto-unboxing NPE.

## Root Cause

- `private static Boolean isOpen = false;` — not `volatile`, not thread-safe for cross-thread reads/writes.
- `isOpen = acl.getIsOpen();` — no null guard, yet downstream returns primitive `boolean`.

## Fix

- Change `Boolean isOpen` to `volatile boolean isOpen` for guaranteed visibility.
- Use `Boolean.TRUE.equals(acl.getIsOpen())` for null-safe assignment — treats `null` as `false`.

## Tests Added

| Change Point | Test |
|---|---|
| `isOpen` field is volatile | `testIsOpenFieldIsVolatile()` — reflection check on field modifiers |
| Valid JSON enables whitelist | `testLoadValidContentEnablesWhitelist()` — verifies isOpen=true and IP matching |
| Blank content disables whitelist | `testLoadBlankContentDisablesWhitelist()` — load then clear |
| Null isOpen does not throw NPE | `testLoadNullIsOpenDoesNotThrowNpe()` — JSON without isOpen field |
| isOpen=false works correctly | `testLoadWithIsOpenFalse()` — explicit false |
| Blank/null client IP validation | `testIsLegalClientThrowsOnBlankInput()` — boundary check |
| Invalid JSON does not crash | `testLoadInvalidJsonDoesNotCrash()` — malformed input |

## Impact

Only affects `ClientIpWhiteList` internal state. No API or behavioral change for correctly-formed inputs — the fix prevents stale reads and NPE on malformed ACL config.