### PR TITLE
fix(ai): eliminate race condition in publish pipeline by pre-generating executionId

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/PublishPipelineExecutor.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/PublishPipelineExecutor.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
 import com.alibaba.nacos.ai.pipeline.model.PipelineNodeResult;
 import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
 import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
 import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResult;
 import com.alibaba.nacos.plugin.ai.pipeline.spi.PublishPipelineService;
 import org.slf4j.Logger;
@@ -79,6 +80,21 @@ public class PublishPipelineExecutor {
      * @return executionId, or null if pipeline is not enabled or no matching nodes
      */
     public String execute(PublishPipelineContext context, PipelineCallback callback) {
+        return execute(context, callback, UUID.randomUUID().toString());
+    }
+    
+    /**
+     * Asynchronously execute the pipeline with a pre-generated executionId.
+     *
+     * <p>Callers who need to write pipeline state (e.g. IN_PROGRESS) before the async task
+     * starts should pre-generate an executionId and use this overload.</p>
+     *
+     * @param context     pipeline context containing resource metadata
+     * @param callback    async callback, invoked exactly once when pipeline execution completes
+     * @param executionId pre-generated execution identifier
+     * @return executionId, or null if pipeline is not enabled or no matching nodes
+     */
+    public String execute(PublishPipelineContext context, PipelineCallback callback, String executionId) {
         // Step 1: Check config
         PipelineConfig config = configProvider.getConfig();
         if (!config.isEnabled()) {
@@ -93,7 +109,6 @@ public class PublishPipelineExecutor {
         }
         
         // Step 3: Create execution record
-        String executionId = UUID.randomUUID().toString();
         long now = System.currentTimeMillis();
         
         PipelineExecution execution = new PipelineExecution();
@@ -191,5 +206,20 @@ public class PublishPipelineExecutor {
         });
         
         return executionId;
+    }
+    
+    /**
+     * Read-only check: whether the pipeline is available for the given resource type.
+     *
+     * @param resourceType the resource type to check
+     * @return true if pipeline is enabled and has matching service nodes
+     */
+    public boolean isPipelineAvailable(PublishPipelineResourceType resourceType) {
+        PipelineConfig config = configProvider.getConfig();
+        if (!config.isEnabled()) {
+            return false;
+        }
+        List<PublishPipelineService> services = pipelineManager.getPipelineServices(resourceType, config.getNodes());
+        return !services.isEmpty();
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -67,6 +67,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * AgentSpec operation service implementation. Mirrors {@code SkillOperationServiceImpl} with AgentSpec types.
@@ -755,15 +756,18 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             }
         });
         
-        String executionId = publishPipelineExecutor.execute(ctx,
-                result -> onPipelineComplete(namespaceId, name, finalTarget, result));
-        if (StringUtils.isBlank(executionId)) {
+        // Check pipeline availability before starting async execution.
+        if (!publishPipelineExecutor.isPipelineAvailable(ctx.getResourceType())) {
             // Pipeline disabled or no matched nodes -> publish directly.
             directPublishWithoutPipeline(namespaceId, meta, info, name, finalTarget, true);
             return finalTarget;
         }
         
-        // Move to reviewing and record pipeline execution id
+        // Pre-generate executionId and write IN_PROGRESS pipelineInfo BEFORE starting async task
+        // to eliminate the race condition where async callback could complete before pipelineInfo is written.
+        String executionId = UUID.randomUUID().toString();
+        
+        // Move to reviewing state
         aiResourceVersionPersistService.updateStatus(namespaceId, name, RESOURCE_TYPE_AGENTSPEC, finalTarget,
                 VERSION_STATUS_REVIEWING);
         info.setEditingVersion(null);
@@ -776,6 +780,17 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         pipelineInfo.setPipeline(new ArrayList<>());
         aiResourceVersionPersistService.updatePublishPipelineInfo(namespaceId, name, RESOURCE_TYPE_AGENTSPEC,
                 finalTarget, JacksonUtils.toJson(pipelineInfo));
+        
+        // Start async pipeline with pre-generated executionId
+        String result = publishPipelineExecutor.execute(ctx,
+                r -> onPipelineComplete(namespaceId, name, finalTarget, r), executionId);
+        if (StringUtils.isBlank(result)) {
+            // Edge case: pipeline became unavailable between isPipelineAvailable check and execute.
+            // Clean up pipelineInfo and publish directly.
+            aiResourceVersionPersistService.updatePublishPipelineInfo(namespaceId, name, RESOURCE_TYPE_AGENTSPEC,
+                    finalTarget, null);
+            directPublishWithoutPipeline(namespaceId, meta, info, name, finalTarget, true);
+        }
         
         return finalTarget;
     }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -73,6 +73,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
@@ -842,14 +843,16 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         ctx.setVersion(finalTarget);
         ctx.setFiles(buildPipelineFiles(skill));
 
-        // Execute asynchronously via standard pipeline engine.
-        String executionId = publishPipelineExecutor.execute(ctx,
-                result -> onPipelineComplete(namespaceId, name, finalTarget, result));
-        if (StringUtils.isBlank(executionId)) {
+        // Check pipeline availability before starting async execution.
+        if (!publishPipelineExecutor.isPipelineAvailable(ctx.getResourceType())) {
             // Pipeline disabled or no matched nodes -> publish directly.
             publish(namespaceId, name, finalTarget, true);
             return finalTarget;
         }
+        
+        // Pre-generate executionId and write IN_PROGRESS pipelineInfo BEFORE starting async task
+        // to eliminate the race condition where async callback could complete before pipelineInfo is written.
+        String executionId = UUID.randomUUID().toString();
 
         // Record pipeline execution id.
         SkillPublishPipelineInfo pipelineInfo = new SkillPublishPipelineInfo();
@@ -858,6 +861,17 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         pipelineInfo.setPipeline(new ArrayList<>());
         aiResourceVersionPersistService.updatePublishPipelineInfo(namespaceId, name, RESOURCE_TYPE_SKILL, finalTarget,
                 JacksonUtils.toJson(pipelineInfo));
+
+        // Start async pipeline with pre-generated executionId.
+        String result = publishPipelineExecutor.execute(ctx,
+                r -> onPipelineComplete(namespaceId, name, finalTarget, r), executionId);
+        if (StringUtils.isBlank(result)) {
+            // Edge case: pipeline became unavailable between isPipelineAvailable check and execute.
+            // Clean up pipelineInfo and publish directly.
+            aiResourceVersionPersistService.updatePublishPipelineInfo(namespaceId, name, RESOURCE_TYPE_SKILL,
+                    finalTarget, null);
+            publish(namespaceId, name, finalTarget, true);
+        }
 
         return finalTarget;
     }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecPipelineCompletionTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecPipelineCompletionTest.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
 import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -114,10 +115,15 @@ class AgentSpecPipelineCompletionTest {
                     eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), any(Long.class), any()))
                     .thenReturn(true);
 
-            // Capture the callback from execute()
+            // isPipelineAvailable returns true
+            when(publishPipelineExecutor.isPipelineAvailable(any(PublishPipelineResourceType.class)))
+                    .thenReturn(true);
+
+            // Capture the callback from execute() and return caller's executionId
             ArgumentCaptor<PipelineCallback> callbackCaptor = ArgumentCaptor.forClass(PipelineCallback.class);
-            when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), callbackCaptor.capture()))
-                    .thenReturn("exec-" + input.executionId);
+            when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), callbackCaptor.capture(),
+                    any(String.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(2));
 
             // Construct service and call submit to trigger pipeline
             AgentSpecOperationServiceImpl service = new AgentSpecOperationServiceImpl(
@@ -182,10 +188,15 @@ class AgentSpecPipelineCompletionTest {
                     eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), any(Long.class), any()))
                     .thenReturn(true);
 
-            // Capture the callback from execute()
+            // isPipelineAvailable returns true
+            when(publishPipelineExecutor.isPipelineAvailable(any(PublishPipelineResourceType.class)))
+                    .thenReturn(true);
+
+            // Capture the callback from execute() and return caller's executionId
             ArgumentCaptor<PipelineCallback> callbackCaptor = ArgumentCaptor.forClass(PipelineCallback.class);
-            when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), callbackCaptor.capture()))
-                    .thenReturn("exec-" + input.executionId);
+            when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), callbackCaptor.capture(),
+                    any(String.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(2));
 
             // After submit(), the meta's reviewingVersion will be set to the version.
             // For the callback's find() call, return meta with reviewingVersion set.

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecSubmitPipelineAvailabilityTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecSubmitPipelineAvailabilityTest.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
 import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -59,12 +60,6 @@ class AgentSpecSubmitPipelineAvailabilityTest {
                 new SubmitInput("ns", "b", "ver"));
     }
 
-    private static java.util.List<SubmitWithPipelineInput> sampleSubmitWithPipelineInputs() {
-        return java.util.Arrays.asList(
-                new SubmitWithPipelineInput("public", "x", "v1", "exec-1"),
-                new SubmitWithPipelineInput("ns", "y", "v2", "pipeline-id-abc"));
-    }
-
     /**
      * When Pipeline is not enabled or has no matching nodes (execute returns null),
      * submit directly publishes and version status becomes online.
@@ -98,9 +93,9 @@ class AgentSpecSubmitPipelineAvailabilityTest {
                     .thenReturn(draftVersion)
                     .thenReturn(reviewingVersion);
 
-            // Pipeline executor returns null -> pipeline disabled / no matching nodes
-            when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), any()))
-                    .thenReturn(null);
+            // isPipelineAvailable returns false -> pipeline disabled / no matching nodes
+            when(publishPipelineExecutor.isPipelineAvailable(any(PublishPipelineResourceType.class)))
+                    .thenReturn(false);
 
             // Mock updateMetaCas to return true
             when(aiResourcePersistService.updateMetaCas(
@@ -123,6 +118,9 @@ class AgentSpecSubmitPipelineAvailabilityTest {
             assertEquals("online", statusCaptor.getValue(),
                     "Version status should become 'online' when pipeline is disabled");
 
+            // Verify: execute was never called
+            verify(publishPipelineExecutor, never()).execute(any(), any(), any(String.class));
+
             // Verify: updatePublishPipelineInfo was NOT called (no pipeline execution)
             verify(aiResourceVersionPersistService, never()).updatePublishPipelineInfo(
                     any(), any(), any(), any(), any());
@@ -137,7 +135,7 @@ class AgentSpecSubmitPipelineAvailabilityTest {
      */
     @Test
     void submitSetsReviewingWhenPipelineEnabled() throws Exception {
-        for (SubmitWithPipelineInput input : sampleSubmitWithPipelineInputs()) {
+        for (SubmitInput input : sampleSubmitInputs()) {
             EnvUtil.setEnvironment(new StandardEnvironment());
 
             // Mock dependencies
@@ -158,9 +156,13 @@ class AgentSpecSubmitPipelineAvailabilityTest {
                     eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version)))
                     .thenReturn(draftVersion);
 
-            // Pipeline executor returns a non-blank executionId -> pipeline enabled with matching nodes
-            when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), any()))
-                    .thenReturn(input.executionId);
+            // isPipelineAvailable returns true -> pipeline enabled with matching nodes
+            when(publishPipelineExecutor.isPipelineAvailable(any(PublishPipelineResourceType.class)))
+                    .thenReturn(true);
+
+            // Pipeline executor returns the caller's pre-generated executionId
+            when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), any(), any(String.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(2));
 
             // Mock updateMetaCas to return true
             when(aiResourcePersistService.updateMetaCas(
@@ -203,8 +205,13 @@ class AgentSpecSubmitPipelineAvailabilityTest {
             String pipelineInfoJson = pipelineInfoCaptor.getValue();
             assertTrue(pipelineInfoJson.contains("IN_PROGRESS"),
                     "publishPipelineInfo should contain IN_PROGRESS status, but was: " + pipelineInfoJson);
-            assertTrue(pipelineInfoJson.contains(input.executionId),
-                    "publishPipelineInfo should contain executionId '" + input.executionId
+
+            // Verify: the executionId in pipelineInfo matches the one passed to execute
+            ArgumentCaptor<String> execIdCaptor = ArgumentCaptor.forClass(String.class);
+            verify(publishPipelineExecutor).execute(any(PublishPipelineContext.class), any(), execIdCaptor.capture());
+            String capturedExecId = execIdCaptor.getValue();
+            assertTrue(pipelineInfoJson.contains(capturedExecId),
+                    "publishPipelineInfo should contain executionId '" + capturedExecId
                             + "', but was: " + pipelineInfoJson);
         }
     }
@@ -254,23 +261,4 @@ class AgentSpecSubmitPipelineAvailabilityTest {
         }
     }
 
-    static class SubmitWithPipelineInput {
-        final String namespaceId;
-        final String name;
-        final String version;
-        final String executionId;
-
-        SubmitWithPipelineInput(String namespaceId, String name, String version, String executionId) {
-            this.namespaceId = namespaceId;
-            this.name = name;
-            this.version = version;
-            this.executionId = executionId;
-        }
-
-        @Override
-        public String toString() {
-            return "SubmitWithPipelineInput{ns='" + namespaceId + "', name='" + name
-                    + "', version='" + version + "', execId='" + executionId + "'}";
-        }
-    }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecSubmitResourceTypeTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecSubmitResourceTypeTest.java
@@ -79,20 +79,26 @@ class AgentSpecSubmitResourceTypeTest {
                     eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), eq(input.version)))
                     .thenReturn(versionRow);
 
-            when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), any()))
-                    .thenReturn(null);
+            // isPipelineAvailable returns true to enter the pipeline path
+            when(publishPipelineExecutor.isPipelineAvailable(any(PublishPipelineResourceType.class)))
+                    .thenReturn(true);
+
+            // Pipeline executor returns the caller's pre-generated executionId
+            when(publishPipelineExecutor.execute(any(PublishPipelineContext.class), any(), any(String.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(2));
+
+            // Mock updateMetaCas to return true
+            when(aiResourcePersistService.updateMetaCas(
+                    eq(input.namespaceId), eq(input.name), eq(RESOURCE_TYPE_AGENTSPEC), any(Long.class), any()))
+                    .thenReturn(true);
 
             AgentSpecOperationServiceImpl service = new AgentSpecOperationServiceImpl(
                     aiResourcePersistService, aiResourceVersionPersistService,
                     publishPipelineExecutor, pipelineExecutionRepository);
-            try {
-                service.submit(input.namespaceId, input.name, input.version);
-            } catch (Exception e) {
-                // publish() may fail due to unmocked storage, but the context was already captured
-            }
+            service.submit(input.namespaceId, input.name, input.version);
 
             ArgumentCaptor<PublishPipelineContext> captor = ArgumentCaptor.forClass(PublishPipelineContext.class);
-            verify(publishPipelineExecutor).execute(captor.capture(), any());
+            verify(publishPipelineExecutor).execute(captor.capture(), any(), any(String.class));
 
             PublishPipelineContext capturedCtx = captor.getValue();
             assertNotNull(capturedCtx, "PublishPipelineContext should not be null");


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

 eliminate race condition in publish pipeline by pre-generating executionId

## Brief changelog

- Add isPipelineAvailable() to PublishPipelineExecutor for read-only check
- Add execute(ctx, callback, executionId) overload accepting pre-generated ID
- Modify AgentSpec/Skill submit to check pipeline first, write IN_PROGRESS pipelineInfo synchronously before starting async pipeline task
- Update tests to adapt to new isPipelineAvailable + 3-arg execute API

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

