### PR TITLE
feat: 添加 MCP 服务器资源规范支持

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -121,6 +121,7 @@ public class Constants {
         public static final String CONSOLE_PATH = "/v3/console/ai/skills";
         
         public static final String ADMIN_PATH = "/v3/admin/ai/skills";
+
         public static final String CLIENT_PATH = "/v3/client/ai/skills";
         
         public static final String SKILL_GROUP = "skill";

--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -115,6 +115,7 @@ public class Constants {
 
         public static final String NACOS_AGENT_ENDPOINT_QUERY_KEY = "__nacos.agent.endpoint.query__";
     }
+
     public static class Skills {
 
         public static final String CONSOLE_PATH = "/v3/console/ai/skills";
@@ -172,6 +173,7 @@ public class Constants {
 
         public static final String CONSOLE_PATH = "/v3/console/ai/pipelines";
     }
+
     public static class Prompt {
 
         public static final String CONSOLE_PATH = "/v3/console/ai/prompt";

--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -22,110 +22,114 @@ package com.alibaba.nacos.ai.constant;
  * @author xiweng.yy
  */
 public class Constants {
-    
+
     public static final String MCP_PATH = "/ai/mcp";
-    
+
     public static final String MCP_ADMIN_PATH = "/v3/admin" + MCP_PATH;
-    
+
     public static final String MCP_CONSOLE_PATH = "/v3/console" + MCP_PATH;
-    
+
     public static final String MCP_LIST_SEARCH_ACCURATE = "accurate";
-    
+
     public static final String MCP_LIST_SEARCH_BLUR = "blur";
-    
+
     public static final String ALL_PATTERN = com.alibaba.nacos.api.common.Constants.ALL_PATTERN;
-    
+
     public static final String MCP_SERVER_VERSIONS_GROUP = "mcp-server-versions";
-    
+
     public static final String MCP_SERVER_GROUP = "mcp-server";
-    
+
     public static final String MCP_SERVER_TOOL_GROUP = "mcp-tools";
-    
+
+    public static final String MCP_SERVER_RESOURCE_GROUP = "mcp-resources";
+
     public static final String MCP_SERVER_SPEC_DATA_ID_SUFFIX = "-mcp-server.json";
-    
+
     public static final String MCP_SERVER_VERSION_DATA_ID_SUFFIX = "-mcp-versions.json";
-    
+
     public static final String MCP_SERVER_TOOL_DATA_ID_SUFFIX = "-mcp-tools.json";
-    
+
+    public static final String MCP_SERVER_RESOURCE_DATA_ID_SUFFIX = "-mcp-resources.json";
+
     public static final String MCP_SERVER_ENDPOINT_GROUP = "mcp-endpoints";
-    
+
     public static final String MCP_SERVER_ENDPOINT_CLUSTER = com.alibaba.nacos.api.common.Constants.DEFAULT_CLUSTER_NAME;
-    
+
     public static final String MCP_BACKEND_INSTANCE_PROTOCOL_KEY = "transportProtocol";
 
     public static final String MCP_SERVER_ENDPOINT_ADDRESS = "address";
-    
+
     public static final String MCP_SERVER_ENDPOINT_PORT = "port";
-    
+
     public static final String MCP_SERVER_ENDPOINT_METADATA_MARK = "__nacos.ai.mcp.service__";
-    
+
     public static final String MCP_SERVER_CONFIG_MARK = "nacos.internal.config=mcp";
-    
+
     public static final String PROTOCOL_TYPE_HTTP = "http";
-    
+
     public static final String PROTOCOL_TYPE_HTTPS = "https";
-    
+
     public static final String SERVER_EXPORT_PATH_KEY = "exportPath";
-    
+
     public static final String MCP_SERVER_NAME_TAG_KEY_PREFIX = "mcpServerName=";
-    
+
     public static final int MAX_LIST_SIZE = 100;
-    
+
     public static final String RELEASE_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-    
+
     public static final String CONFIG_TAGS_NAME = "config_tags";
-    
+
     public static final String META_PATH = "path";
-    
+
     public static final String SERVER_VERSION_CONFIG_DATA_ID_TEMPLATE = "%s" + MCP_SERVER_VERSION_DATA_ID_SUFFIX;
-    
+
     public static final String SERVER_SPECIFICATION_CONFIG_DATA_ID_TEMPLATE = "%s-%s" + MCP_SERVER_SPEC_DATA_ID_SUFFIX;
-    
+
     public static final String SERVER_TOOLS_SPEC_CONFIG_DATA_ID_TEMPLATE = "%s-%s" + MCP_SERVER_TOOL_DATA_ID_SUFFIX;
-    
+
+    public static final String SERVER_RESOURCE_SPEC_CONFIG_DATA_ID_TEMPLATE = "%s-%s" + MCP_SERVER_RESOURCE_DATA_ID_SUFFIX;
+
     public static class A2A {
-        
+
         public static final String CONSOLE_PATH = "/v3/console/ai/a2a";
-        
+
         public static final String ADMIN_PATH = "/v3/admin/ai/a2a";
-        
+
         public static final String AGENT_GROUP = "agent";
-        
+
         public static final String AGENT_VERSION_GROUP = "agent-version";
-        
+
         public static final String SEARCH_BLUR = "blur";
-        
+
         public static final String SEARCH_ACCURATE = "accurate";
-        
+
         public static final String AGENT_ENDPOINT_GROUP = "agent-endpoints";
-        
+
         public static final String AGENT_ENDPOINT_PATH_KEY = "__nacos.agent.endpoint.path__";
-        
+
         public static final String AGENT_ENDPOINT_TRANSPORT_KEY = "__nacos.agent.endpoint.transport__";
-        
+
         public static final String NACOS_AGENT_ENDPOINT_SUPPORT_TLS = "__nacos.agent.endpoint.supportTls__";
-        
+
         public static final String NACOS_AGENT_ENDPOINT_PROTOCOL_KEY = "__nacos.agent.endpoint.protocol__";
-        
+
         public static final String NACOS_AGENT_ENDPOINT_QUERY_KEY = "__nacos.agent.endpoint.query__";
     }
-    
     public static class Skills {
-        
-        public static final String CONSOLE_PATH = "/v3/console/ai/skills";
-        
-        public static final String ADMIN_PATH = "/v3/admin/ai/skills";
 
+        public static final String CONSOLE_PATH = "/v3/console/ai/skills";
+
+        public static final String ADMIN_PATH = "/v3/admin/ai/skills";
         public static final String CLIENT_PATH = "/v3/client/ai/skills";
-        
+
         public static final String SKILL_GROUP = "skill";
-        
+
         public static final String SKILL_VERSION_GROUP = "skill-version";
-        
+
         public static final String SEARCH_BLUR = "blur";
-        
+
         public static final String SEARCH_ACCURATE = "accurate";
-        
+
         public static final String SKILL_DEFAULT_NAMESPACE = "public";
 
         /**
@@ -133,115 +137,114 @@ public class Constants {
          */
         public static final long MAX_UPLOAD_ZIP_BYTES = 10L * 1024 * 1024;
     }
-    
+
     public static class AgentSpecs {
-        
+
         public static final String ADMIN_PATH = "/v3/admin/ai/agentspecs";
-        
+
         public static final String CLIENT_PATH = "/v3/client/ai/agentspecs";
-        
+
         public static final String CONSOLE_PATH = "/v3/console/ai/agentspecs";
-        
+
         public static final String AGENTSPEC_GROUP_PREFIX = "agentspec_";
-        
+
         public static final String RESOURCE_TYPE_AGENTSPEC = "agentspec";
-        
+
         public static final String AGENTSPEC_MAIN_DATA_ID = "manifest.json";
-        
+
         /**
          * Max allowed size for agentspec zip upload (50MB). Exceeding this will result in a clear error.
          */
         public static final long MAX_UPLOAD_ZIP_BYTES = 50L * 1024 * 1024;
-        
+
         public static final String AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY = "nacos.ai.agentspec.storage.provider";
-        
+
         public static final String SEARCH_BLUR = "blur";
-        
+
         public static final String SEARCH_ACCURATE = "accurate";
-        
+
         public static final String AGENTSPEC_DEFAULT_NAMESPACE = "public";
     }
-    
+
     public static class Pipeline {
-        
+
         public static final String ADMIN_PATH = "/v3/admin/ai/pipelines";
-        
+
         public static final String CONSOLE_PATH = "/v3/console/ai/pipelines";
     }
-    
     public static class Prompt {
-        
+
         public static final String CONSOLE_PATH = "/v3/console/ai/prompt";
-        
+
         public static final String ADMIN_PATH = "/v3/admin/ai/prompt";
-        
+
         public static final String CLIENT_PATH = "/v3/client/ai/prompt";
-        
+
         /**
          * Fixed group for all prompt configurations.
          */
         public static final String PROMPT_GROUP = "nacos-ai-prompt";
-        
+
         /**
          * DataId suffix for prompt configurations.
          */
         public static final String PROMPT_DATA_ID_SUFFIX = ".json";
-        
+
         /**
          * DataId suffix for descriptor side prompt metadata.
          */
         public static final String DESCRIPTOR_DATA_ID_SUFFIX = ".descriptor" + PROMPT_DATA_ID_SUFFIX;
-        
+
         /**
          * DataId suffix for runtime label/version mapping.
          */
         public static final String LABEL_VERSION_MAPPING_DATA_ID_SUFFIX = ".label-version-mapping" + PROMPT_DATA_ID_SUFFIX;
-        
+
         /**
          * Key for prompt version in extInfo.
          */
         public static final String EXT_PROMPT_VERSION = "prompt_version";
-        
+
         /**
          * Key for prompt commit message in extInfo.
          */
         public static final String EXT_PROMPT_COMMIT_MSG = "prompt_commit_msg";
-        
+
         /**
          * Search mode: blur search.
          */
         public static final String SEARCH_BLUR = "blur";
-        
+
         /**
          * Search mode: accurate search.
          */
         public static final String SEARCH_ACCURATE = "accurate";
-        
+
         /**
          * Default namespace for prompt.
          */
         public static final String PROMPT_DEFAULT_NAMESPACE = "public";
-        
+
         /**
          * Config type for prompt.
          */
         public static final String PROMPT_CONFIG_TYPE = "json";
-        
+
         /**
          * JSON field: promptKey.
          */
         public static final String FIELD_PROMPT_KEY = "promptKey";
-        
+
         /**
          * JSON field: version.
          */
         public static final String FIELD_VERSION = "version";
-        
+
         /**
          * JSON field: template.
          */
         public static final String FIELD_TEMPLATE = "template";
-        
+
         /**
          * JSON field: commitMsg.
          */

--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -22,115 +22,115 @@ package com.alibaba.nacos.ai.constant;
  * @author xiweng.yy
  */
 public class Constants {
-
+    
     public static final String MCP_PATH = "/ai/mcp";
-
+    
     public static final String MCP_ADMIN_PATH = "/v3/admin" + MCP_PATH;
-
+    
     public static final String MCP_CONSOLE_PATH = "/v3/console" + MCP_PATH;
-
+    
     public static final String MCP_LIST_SEARCH_ACCURATE = "accurate";
-
+    
     public static final String MCP_LIST_SEARCH_BLUR = "blur";
-
+    
     public static final String ALL_PATTERN = com.alibaba.nacos.api.common.Constants.ALL_PATTERN;
-
+    
     public static final String MCP_SERVER_VERSIONS_GROUP = "mcp-server-versions";
-
+    
     public static final String MCP_SERVER_GROUP = "mcp-server";
-
+    
     public static final String MCP_SERVER_TOOL_GROUP = "mcp-tools";
-
+    
     public static final String MCP_SERVER_RESOURCE_GROUP = "mcp-resources";
 
     public static final String MCP_SERVER_SPEC_DATA_ID_SUFFIX = "-mcp-server.json";
-
+    
     public static final String MCP_SERVER_VERSION_DATA_ID_SUFFIX = "-mcp-versions.json";
-
+    
     public static final String MCP_SERVER_TOOL_DATA_ID_SUFFIX = "-mcp-tools.json";
-
+    
     public static final String MCP_SERVER_RESOURCE_DATA_ID_SUFFIX = "-mcp-resources.json";
 
     public static final String MCP_SERVER_ENDPOINT_GROUP = "mcp-endpoints";
-
+    
     public static final String MCP_SERVER_ENDPOINT_CLUSTER = com.alibaba.nacos.api.common.Constants.DEFAULT_CLUSTER_NAME;
-
+    
     public static final String MCP_BACKEND_INSTANCE_PROTOCOL_KEY = "transportProtocol";
 
     public static final String MCP_SERVER_ENDPOINT_ADDRESS = "address";
-
+    
     public static final String MCP_SERVER_ENDPOINT_PORT = "port";
-
+    
     public static final String MCP_SERVER_ENDPOINT_METADATA_MARK = "__nacos.ai.mcp.service__";
-
+    
     public static final String MCP_SERVER_CONFIG_MARK = "nacos.internal.config=mcp";
-
+    
     public static final String PROTOCOL_TYPE_HTTP = "http";
-
+    
     public static final String PROTOCOL_TYPE_HTTPS = "https";
-
+    
     public static final String SERVER_EXPORT_PATH_KEY = "exportPath";
-
+    
     public static final String MCP_SERVER_NAME_TAG_KEY_PREFIX = "mcpServerName=";
-
+    
     public static final int MAX_LIST_SIZE = 100;
-
+    
     public static final String RELEASE_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-
+    
     public static final String CONFIG_TAGS_NAME = "config_tags";
-
+    
     public static final String META_PATH = "path";
-
+    
     public static final String SERVER_VERSION_CONFIG_DATA_ID_TEMPLATE = "%s" + MCP_SERVER_VERSION_DATA_ID_SUFFIX;
-
+    
     public static final String SERVER_SPECIFICATION_CONFIG_DATA_ID_TEMPLATE = "%s-%s" + MCP_SERVER_SPEC_DATA_ID_SUFFIX;
-
+    
     public static final String SERVER_TOOLS_SPEC_CONFIG_DATA_ID_TEMPLATE = "%s-%s" + MCP_SERVER_TOOL_DATA_ID_SUFFIX;
-
+    
     public static final String SERVER_RESOURCE_SPEC_CONFIG_DATA_ID_TEMPLATE = "%s-%s" + MCP_SERVER_RESOURCE_DATA_ID_SUFFIX;
 
     public static class A2A {
-
+        
         public static final String CONSOLE_PATH = "/v3/console/ai/a2a";
-
+        
         public static final String ADMIN_PATH = "/v3/admin/ai/a2a";
-
+        
         public static final String AGENT_GROUP = "agent";
-
+        
         public static final String AGENT_VERSION_GROUP = "agent-version";
-
+        
         public static final String SEARCH_BLUR = "blur";
-
+        
         public static final String SEARCH_ACCURATE = "accurate";
-
+        
         public static final String AGENT_ENDPOINT_GROUP = "agent-endpoints";
-
+        
         public static final String AGENT_ENDPOINT_PATH_KEY = "__nacos.agent.endpoint.path__";
-
+        
         public static final String AGENT_ENDPOINT_TRANSPORT_KEY = "__nacos.agent.endpoint.transport__";
-
+        
         public static final String NACOS_AGENT_ENDPOINT_SUPPORT_TLS = "__nacos.agent.endpoint.supportTls__";
-
+        
         public static final String NACOS_AGENT_ENDPOINT_PROTOCOL_KEY = "__nacos.agent.endpoint.protocol__";
-
+        
         public static final String NACOS_AGENT_ENDPOINT_QUERY_KEY = "__nacos.agent.endpoint.query__";
     }
-
+    
     public static class Skills {
-
+        
         public static final String CONSOLE_PATH = "/v3/console/ai/skills";
-
+        
         public static final String ADMIN_PATH = "/v3/admin/ai/skills";
         public static final String CLIENT_PATH = "/v3/client/ai/skills";
-
+        
         public static final String SKILL_GROUP = "skill";
-
+        
         public static final String SKILL_VERSION_GROUP = "skill-version";
-
+        
         public static final String SEARCH_BLUR = "blur";
-
+        
         public static final String SEARCH_ACCURATE = "accurate";
-
+        
         public static final String SKILL_DEFAULT_NAMESPACE = "public";
 
         /**
@@ -138,115 +138,115 @@ public class Constants {
          */
         public static final long MAX_UPLOAD_ZIP_BYTES = 10L * 1024 * 1024;
     }
-
+    
     public static class AgentSpecs {
-
+        
         public static final String ADMIN_PATH = "/v3/admin/ai/agentspecs";
-
+        
         public static final String CLIENT_PATH = "/v3/client/ai/agentspecs";
-
+        
         public static final String CONSOLE_PATH = "/v3/console/ai/agentspecs";
-
+        
         public static final String AGENTSPEC_GROUP_PREFIX = "agentspec_";
-
+        
         public static final String RESOURCE_TYPE_AGENTSPEC = "agentspec";
-
+        
         public static final String AGENTSPEC_MAIN_DATA_ID = "manifest.json";
-
+        
         /**
          * Max allowed size for agentspec zip upload (50MB). Exceeding this will result in a clear error.
          */
         public static final long MAX_UPLOAD_ZIP_BYTES = 50L * 1024 * 1024;
-
+        
         public static final String AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY = "nacos.ai.agentspec.storage.provider";
-
+        
         public static final String SEARCH_BLUR = "blur";
-
+        
         public static final String SEARCH_ACCURATE = "accurate";
-
+        
         public static final String AGENTSPEC_DEFAULT_NAMESPACE = "public";
     }
-
+    
     public static class Pipeline {
-
+        
         public static final String ADMIN_PATH = "/v3/admin/ai/pipelines";
-
+        
         public static final String CONSOLE_PATH = "/v3/console/ai/pipelines";
     }
-
+    
     public static class Prompt {
-
+        
         public static final String CONSOLE_PATH = "/v3/console/ai/prompt";
-
+        
         public static final String ADMIN_PATH = "/v3/admin/ai/prompt";
-
+        
         public static final String CLIENT_PATH = "/v3/client/ai/prompt";
-
+        
         /**
          * Fixed group for all prompt configurations.
          */
         public static final String PROMPT_GROUP = "nacos-ai-prompt";
-
+        
         /**
          * DataId suffix for prompt configurations.
          */
         public static final String PROMPT_DATA_ID_SUFFIX = ".json";
-
+        
         /**
          * DataId suffix for descriptor side prompt metadata.
          */
         public static final String DESCRIPTOR_DATA_ID_SUFFIX = ".descriptor" + PROMPT_DATA_ID_SUFFIX;
-
+        
         /**
          * DataId suffix for runtime label/version mapping.
          */
         public static final String LABEL_VERSION_MAPPING_DATA_ID_SUFFIX = ".label-version-mapping" + PROMPT_DATA_ID_SUFFIX;
-
+        
         /**
          * Key for prompt version in extInfo.
          */
         public static final String EXT_PROMPT_VERSION = "prompt_version";
-
+        
         /**
          * Key for prompt commit message in extInfo.
          */
         public static final String EXT_PROMPT_COMMIT_MSG = "prompt_commit_msg";
-
+        
         /**
          * Search mode: blur search.
          */
         public static final String SEARCH_BLUR = "blur";
-
+        
         /**
          * Search mode: accurate search.
          */
         public static final String SEARCH_ACCURATE = "accurate";
-
+        
         /**
          * Default namespace for prompt.
          */
         public static final String PROMPT_DEFAULT_NAMESPACE = "public";
-
+        
         /**
          * Config type for prompt.
          */
         public static final String PROMPT_CONFIG_TYPE = "json";
-
+        
         /**
          * JSON field: promptKey.
          */
         public static final String FIELD_PROMPT_KEY = "promptKey";
-
+        
         /**
          * JSON field: version.
          */
         public static final String FIELD_VERSION = "version";
-
+        
         /**
          * JSON field: template.
          */
         public static final String FIELD_TEMPLATE = "template";
-
+        
         /**
          * JSON field: commitMsg.
          */

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/McpAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/McpAdminController.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.ai.param.McpHttpParamExtractor;
 import com.alibaba.nacos.ai.service.McpServerOperationService;
 import com.alibaba.nacos.ai.utils.McpRequestUtil;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
@@ -109,9 +110,10 @@ public class McpAdminController {
         mcpForm.validate();
         McpServerBasicInfo basicInfo = McpRequestUtil.parseMcpServerBasicInfo(mcpForm);
         McpToolSpecification mcpTools = McpRequestUtil.parseMcpTools(mcpForm);
+        McpResourceSpecification mcpResources = McpRequestUtil.parseMcpResources(mcpForm);
         McpEndpointSpec endpointSpec = McpRequestUtil.parseMcpEndpointSpec(basicInfo, mcpForm);
         String mcpId = mcpServerOperationService.createMcpServer(mcpForm.getNamespaceId(), basicInfo, mcpTools,
-                endpointSpec);
+                mcpResources, endpointSpec);
         return Result.success(mcpId);
     }
     
@@ -131,9 +133,10 @@ public class McpAdminController {
         mcpForm.validate();
         McpServerBasicInfo basicInfo = McpRequestUtil.parseMcpServerBasicInfo(mcpForm);
         McpToolSpecification mcpTools = McpRequestUtil.parseMcpTools(mcpForm);
+        McpResourceSpecification mcpResources = McpRequestUtil.parseMcpResources(mcpForm);
         McpEndpointSpec endpointSpec = McpRequestUtil.parseMcpEndpointSpec(basicInfo, mcpForm);
         mcpServerOperationService.updateMcpServer(mcpForm.getNamespaceId(), mcpForm.getLatest(), basicInfo, mcpTools,
-                endpointSpec, mcpForm.isOverrideExisting());
+                mcpResources, endpointSpec, mcpForm.isOverrideExisting());
         return Result.success("ok");
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/McpAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/McpAdminController.java
@@ -57,13 +57,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(Constants.MCP_ADMIN_PATH)
 @ExtractorManager.Extractor(httpExtractor = McpHttpParamExtractor.class)
 public class McpAdminController {
-    
+
     private final McpServerOperationService mcpServerOperationService;
-    
+
     public McpAdminController(McpServerOperationService mcpServerOperationService) {
         this.mcpServerOperationService = mcpServerOperationService;
     }
-    
+
     /**
      * List mcp server.
      *
@@ -82,7 +82,7 @@ public class McpAdminController {
                 mcpServerOperationService.listMcpServerWithPage(mcpListForm.getNamespaceId(), mcpListForm.getMcpName(),
                         mcpListForm.getSearch(), pageForm.getPageNo(), pageForm.getPageSize()));
     }
-    
+
     /**
      * Get specified mcp server detail info.
      *
@@ -97,7 +97,7 @@ public class McpAdminController {
         return Result.success(mcpServerOperationService.getMcpServerDetail(mcpForm.getNamespaceId(), mcpForm.getMcpId(),
                 mcpForm.getMcpName(), mcpForm.getVersion()));
     }
-    
+
     /**
      * Create new mcp server.
      *
@@ -116,7 +116,7 @@ public class McpAdminController {
                 mcpResources, endpointSpec);
         return Result.success(mcpId);
     }
-    
+
     /**
      * Update existed mcp server.
      *
@@ -139,7 +139,7 @@ public class McpAdminController {
                 mcpResources, endpointSpec, mcpForm.isOverrideExisting());
         return Result.success("ok");
     }
-    
+
     /**
      * Delete existed mcp server.
      *

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/McpAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/McpAdminController.java
@@ -57,13 +57,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(Constants.MCP_ADMIN_PATH)
 @ExtractorManager.Extractor(httpExtractor = McpHttpParamExtractor.class)
 public class McpAdminController {
-
+    
     private final McpServerOperationService mcpServerOperationService;
-
+    
     public McpAdminController(McpServerOperationService mcpServerOperationService) {
         this.mcpServerOperationService = mcpServerOperationService;
     }
-
+    
     /**
      * List mcp server.
      *
@@ -82,7 +82,7 @@ public class McpAdminController {
                 mcpServerOperationService.listMcpServerWithPage(mcpListForm.getNamespaceId(), mcpListForm.getMcpName(),
                         mcpListForm.getSearch(), pageForm.getPageNo(), pageForm.getPageSize()));
     }
-
+    
     /**
      * Get specified mcp server detail info.
      *
@@ -97,7 +97,7 @@ public class McpAdminController {
         return Result.success(mcpServerOperationService.getMcpServerDetail(mcpForm.getNamespaceId(), mcpForm.getMcpId(),
                 mcpForm.getMcpName(), mcpForm.getVersion()));
     }
-
+    
     /**
      * Create new mcp server.
      *
@@ -116,7 +116,7 @@ public class McpAdminController {
                 mcpResources, endpointSpec);
         return Result.success(mcpId);
     }
-
+    
     /**
      * Update existed mcp server.
      *
@@ -139,7 +139,7 @@ public class McpAdminController {
                 mcpResources, endpointSpec, mcpForm.isOverrideExisting());
         return Result.success("ok");
     }
-
+    
     /**
      * Delete existed mcp server.
      *

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/mcp/admin/McpDetailForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/mcp/admin/McpDetailForm.java
@@ -29,18 +29,18 @@ import java.io.Serial;
  * @author xiweng.yy
  */
 public class McpDetailForm extends McpForm {
-
+    
     @Serial
     private static final long serialVersionUID = 8016131725604983670L;
-
+    
     private String serverSpecification;
-
+    
     private String toolSpecification;
-
+    
     private String resourceSpecification;
 
     private String endpointSpecification;
-
+    
     @Override
     public void validate() throws NacosApiException {
         fillDefaultValue();
@@ -49,23 +49,23 @@ public class McpDetailForm extends McpForm {
                     "Required parameter 'serverSpecification' type McpServerBasicInfo is not present");
         }
     }
-
+    
     public String getServerSpecification() {
         return serverSpecification;
     }
-
+    
     public void setServerSpecification(String serverSpecification) {
         this.serverSpecification = serverSpecification;
     }
-
+    
     public String getToolSpecification() {
         return toolSpecification;
     }
-
+    
     public void setToolSpecification(String toolSpecification) {
         this.toolSpecification = toolSpecification;
     }
-
+    
     public String getResourceSpecification() {
         return resourceSpecification;
     }
@@ -77,9 +77,9 @@ public class McpDetailForm extends McpForm {
     public String getEndpointSpecification() {
         return endpointSpecification;
     }
-
+    
     public void setEndpointSpecification(String endpointSpecification) {
         this.endpointSpecification = endpointSpecification;
     }
-
+    
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/mcp/admin/McpDetailForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/mcp/admin/McpDetailForm.java
@@ -37,6 +37,8 @@ public class McpDetailForm extends McpForm {
     
     private String toolSpecification;
     
+    private String resourceSpecification;
+    
     private String endpointSpecification;
     
     @Override
@@ -62,6 +64,14 @@ public class McpDetailForm extends McpForm {
     
     public void setToolSpecification(String toolSpecification) {
         this.toolSpecification = toolSpecification;
+    }
+    
+    public String getResourceSpecification() {
+        return resourceSpecification;
+    }
+    
+    public void setResourceSpecification(String resourceSpecification) {
+        this.resourceSpecification = resourceSpecification;
     }
     
     public String getEndpointSpecification() {

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/mcp/admin/McpDetailForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/mcp/admin/McpDetailForm.java
@@ -29,18 +29,18 @@ import java.io.Serial;
  * @author xiweng.yy
  */
 public class McpDetailForm extends McpForm {
-    
+
     @Serial
     private static final long serialVersionUID = 8016131725604983670L;
-    
+
     private String serverSpecification;
-    
+
     private String toolSpecification;
-    
+
     private String resourceSpecification;
-    
+
     private String endpointSpecification;
-    
+
     @Override
     public void validate() throws NacosApiException {
         fillDefaultValue();
@@ -49,37 +49,37 @@ public class McpDetailForm extends McpForm {
                     "Required parameter 'serverSpecification' type McpServerBasicInfo is not present");
         }
     }
-    
+
     public String getServerSpecification() {
         return serverSpecification;
     }
-    
+
     public void setServerSpecification(String serverSpecification) {
         this.serverSpecification = serverSpecification;
     }
-    
+
     public String getToolSpecification() {
         return toolSpecification;
     }
-    
+
     public void setToolSpecification(String toolSpecification) {
         this.toolSpecification = toolSpecification;
     }
-    
+
     public String getResourceSpecification() {
         return resourceSpecification;
     }
-    
+
     public void setResourceSpecification(String resourceSpecification) {
         this.resourceSpecification = resourceSpecification;
     }
-    
+
     public String getEndpointSpecification() {
         return endpointSpecification;
     }
-    
+
     public void setEndpointSpecification(String endpointSpecification) {
         this.endpointSpecification = endpointSpecification;
     }
-    
+
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.ai.service.McpServerOperationService;
 import com.alibaba.nacos.ai.utils.McpRequestUtil;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
 import com.alibaba.nacos.api.ai.remote.request.ReleaseMcpServerRequest;
@@ -145,23 +146,25 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
     private String createNewMcpServer(String namespaceId, ReleaseMcpServerRequest request) throws NacosException {
         McpServerBasicInfo mcpServerBasicInfo = request.getServerSpecification();
         McpToolSpecification toolSpecification = request.getToolSpecification();
+        McpResourceSpecification resourceSpecification = request.getResourceSpecification();
         McpEndpointSpec endpointSpecification =
                 null == request.getEndpointSpecification() ? autoBuildMcpEndpointSpecification(namespaceId,
                         mcpServerBasicInfo) : request.getEndpointSpecification();
         return mcpServerOperationService.createMcpServer(namespaceId, mcpServerBasicInfo, toolSpecification,
-                endpointSpecification);
+                resourceSpecification, endpointSpecification);
     }
     
     private void createNewVersionMcpServer(String namespaceId, ReleaseMcpServerRequest request) throws NacosException {
         McpServerBasicInfo mcpServerBasicInfo = request.getServerSpecification();
         McpToolSpecification toolSpecification = request.getToolSpecification();
+        McpResourceSpecification resourceSpecification = request.getResourceSpecification();
         McpEndpointSpec endpointSpecification =
                 null == request.getEndpointSpecification() ? autoBuildMcpEndpointSpecification(namespaceId,
                         mcpServerBasicInfo) : request.getEndpointSpecification();
         Boolean isLatest = mcpServerBasicInfo.getVersionDetail().getIs_latest();
         boolean isPublish = isLatest != null && isLatest;
         mcpServerOperationService.updateMcpServer(namespaceId, isPublish, mcpServerBasicInfo, toolSpecification,
-                endpointSpecification, Boolean.FALSE);
+                resourceSpecification, endpointSpecification, Boolean.FALSE);
         
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
@@ -53,22 +53,22 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpServerRequest, ReleaseMcpServerResponse> {
-
+    
     private static final Logger LOGGER = LoggerFactory.getLogger(ReleaseMcpServerRequest.class);
-
+    
     private final McpServerOperationService mcpServerOperationService;
-
+    
     private final McpEndpointOperationService endpointOperationService;
-
+    
     private final McpServerIndex mcpServerIndex;
-
+    
     public ReleaseMcpServerRequestHandler(McpServerOperationService mcpServerOperationService,
             McpEndpointOperationService endpointOperationService, McpServerIndex mcpServerIndex) {
         this.mcpServerOperationService = mcpServerOperationService;
         this.endpointOperationService = endpointOperationService;
         this.mcpServerIndex = mcpServerIndex;
     }
-
+    
     @Override
     @NamespaceValidation
     @ExtractorManager.Extractor(rpcExtractor = McpServerRequestParamExtractor.class)
@@ -84,7 +84,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
             return response;
         }
     }
-
+    
     private void checkParameters(ReleaseMcpServerRequest request) throws NacosException {
         McpServerBasicInfo serverSpecification = request.getServerSpecification();
         if (null == serverSpecification) {
@@ -102,7 +102,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
                     "Required parameter `serverSpecification.versionDetail.version` not present");
         }
     }
-
+    
     private ReleaseMcpServerResponse doHandler(ReleaseMcpServerRequest request, RequestMeta meta)
             throws NacosException {
         String namespaceId = request.getNamespaceId();
@@ -142,7 +142,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
         }
         return response;
     }
-
+    
     private String createNewMcpServer(String namespaceId, ReleaseMcpServerRequest request) throws NacosException {
         McpServerBasicInfo mcpServerBasicInfo = request.getServerSpecification();
         McpToolSpecification toolSpecification = request.getToolSpecification();
@@ -153,7 +153,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
         return mcpServerOperationService.createMcpServer(namespaceId, mcpServerBasicInfo, toolSpecification,
                 resourceSpecification, endpointSpecification);
     }
-
+    
     private void createNewVersionMcpServer(String namespaceId, ReleaseMcpServerRequest request) throws NacosException {
         McpServerBasicInfo mcpServerBasicInfo = request.getServerSpecification();
         McpToolSpecification toolSpecification = request.getToolSpecification();
@@ -165,9 +165,9 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
         boolean isPublish = isLatest != null && isLatest;
         mcpServerOperationService.updateMcpServer(namespaceId, isPublish, mcpServerBasicInfo, toolSpecification,
                 resourceSpecification, endpointSpecification, Boolean.FALSE);
-
+        
     }
-
+    
     private McpEndpointSpec autoBuildMcpEndpointSpecification(String namespaceId,
             McpServerBasicInfo mcpServerBasicInfo) {
         if (AiConstants.Mcp.MCP_PROTOCOL_STDIO.equals(mcpServerBasicInfo.getProtocol())) {
@@ -177,7 +177,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
         return autoBuildMcpEndpointSpecification(namespaceId, mcpServerBasicInfo.getName(),
                 mcpServerBasicInfo.getVersionDetail().getVersion());
     }
-
+    
     private McpEndpointSpec autoBuildMcpEndpointSpecification(String namespaceId, String mcpName, String version) {
         String versionMcpName = mcpName + "::" + version;
         Service service = endpointOperationService.generateService(namespaceId, versionMcpName);

--- a/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
@@ -53,22 +53,22 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpServerRequest, ReleaseMcpServerResponse> {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ReleaseMcpServerRequest.class);
-    
+
     private final McpServerOperationService mcpServerOperationService;
-    
+
     private final McpEndpointOperationService endpointOperationService;
-    
+
     private final McpServerIndex mcpServerIndex;
-    
+
     public ReleaseMcpServerRequestHandler(McpServerOperationService mcpServerOperationService,
             McpEndpointOperationService endpointOperationService, McpServerIndex mcpServerIndex) {
         this.mcpServerOperationService = mcpServerOperationService;
         this.endpointOperationService = endpointOperationService;
         this.mcpServerIndex = mcpServerIndex;
     }
-    
+
     @Override
     @NamespaceValidation
     @ExtractorManager.Extractor(rpcExtractor = McpServerRequestParamExtractor.class)
@@ -84,7 +84,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
             return response;
         }
     }
-    
+
     private void checkParameters(ReleaseMcpServerRequest request) throws NacosException {
         McpServerBasicInfo serverSpecification = request.getServerSpecification();
         if (null == serverSpecification) {
@@ -102,7 +102,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
                     "Required parameter `serverSpecification.versionDetail.version` not present");
         }
     }
-    
+
     private ReleaseMcpServerResponse doHandler(ReleaseMcpServerRequest request, RequestMeta meta)
             throws NacosException {
         String namespaceId = request.getNamespaceId();
@@ -142,7 +142,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
         }
         return response;
     }
-    
+
     private String createNewMcpServer(String namespaceId, ReleaseMcpServerRequest request) throws NacosException {
         McpServerBasicInfo mcpServerBasicInfo = request.getServerSpecification();
         McpToolSpecification toolSpecification = request.getToolSpecification();
@@ -153,7 +153,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
         return mcpServerOperationService.createMcpServer(namespaceId, mcpServerBasicInfo, toolSpecification,
                 resourceSpecification, endpointSpecification);
     }
-    
+
     private void createNewVersionMcpServer(String namespaceId, ReleaseMcpServerRequest request) throws NacosException {
         McpServerBasicInfo mcpServerBasicInfo = request.getServerSpecification();
         McpToolSpecification toolSpecification = request.getToolSpecification();
@@ -165,9 +165,9 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
         boolean isPublish = isLatest != null && isLatest;
         mcpServerOperationService.updateMcpServer(namespaceId, isPublish, mcpServerBasicInfo, toolSpecification,
                 resourceSpecification, endpointSpecification, Boolean.FALSE);
-        
+
     }
-    
+
     private McpEndpointSpec autoBuildMcpEndpointSpecification(String namespaceId,
             McpServerBasicInfo mcpServerBasicInfo) {
         if (AiConstants.Mcp.MCP_PROTOCOL_STDIO.equals(mcpServerBasicInfo.getProtocol())) {
@@ -177,7 +177,7 @@ public class ReleaseMcpServerRequestHandler extends RequestHandler<ReleaseMcpSer
         return autoBuildMcpEndpointSpecification(namespaceId, mcpServerBasicInfo.getName(),
                 mcpServerBasicInfo.getVersionDetail().getVersion());
     }
-    
+
     private McpEndpointSpec autoBuildMcpEndpointSpecification(String namespaceId, String mcpName, String version) {
         String versionMcpName = mcpName + "::" + version;
         Service service = endpointOperationService.generateService(namespaceId, versionMcpName);

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpResourceOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpResourceOperationService.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.utils.McpConfigUtils;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
+import com.alibaba.nacos.config.server.model.form.ConfigFormV3;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.springframework.stereotype.Service;
+
+/**
+ * Nacos AI MCP resource operation service.
+ *
+ * @author xiweng.yy
+ */
+@Service
+public class McpResourceOperationService {
+    
+    private final ConfigQueryChainService configQueryChainService;
+    
+    private final ConfigOperationService configOperationService;
+    
+    public McpResourceOperationService(ConfigQueryChainService configQueryChainService,
+            ConfigOperationService configOperationService) {
+        this.configQueryChainService = configQueryChainService;
+        this.configOperationService = configOperationService;
+    }
+    
+    /**
+     * Create or update mcp server resources. If mcp server resources already exist, will fully replace it.
+     *
+     * @param namespaceId namespace id of mcp server
+     * @param serverBasicInfo mcp server basic info
+     * @param resourceSpecification mcp server resource specification
+     * @throws NacosException any exception during handling
+     */
+    public void refreshMcpResource(String namespaceId, McpServerBasicInfo serverBasicInfo,
+            McpResourceSpecification resourceSpecification) throws NacosException {
+        ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
+        ConfigFormV3 resourceConfigForm = buildMcpResourceConfigForm(namespaceId, serverBasicInfo, resourceSpecification);
+        configOperationService.publishConfig(resourceConfigForm, configRequestInfo, null);
+    }
+    
+    public McpResourceSpecification getMcpResource(String namespaceId, String resourceDescriptionRef) {
+        ConfigQueryChainRequest request = buildQueryMcpResourceRequest(namespaceId, resourceDescriptionRef);
+        ConfigQueryChainResponse response = configQueryChainService.handle(request);
+        if (ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND == response.getStatus()) {
+            return null;
+        }
+        return transferToMcpServerResource(response);
+    }
+    
+    public void deleteMcpResource(String namespaceId, String mcpServerId, String version) throws NacosException {
+        configOperationService.deleteConfig(McpConfigUtils.formatServerResourceSpecDataId(mcpServerId, version),
+                Constants.MCP_SERVER_RESOURCE_GROUP, namespaceId, null, null, "nacos", null);
+    }
+    
+    private ConfigFormV3 buildMcpResourceConfigForm(String namespaceId, McpServerBasicInfo mcpServerBasicInfo,
+            McpResourceSpecification resourceSpecification) {
+        ConfigFormV3 configFormV3 = new ConfigFormV3();
+        configFormV3.setGroupName(Constants.MCP_SERVER_RESOURCE_GROUP);
+        configFormV3.setGroup(Constants.MCP_SERVER_RESOURCE_GROUP);
+        configFormV3.setNamespaceId(namespaceId);
+        String resourceSpecDataId = McpConfigUtils.formatServerResourceSpecDataId(mcpServerBasicInfo.getId(),
+                mcpServerBasicInfo.getVersionDetail().getVersion());
+        configFormV3.setDataId(resourceSpecDataId);
+        configFormV3.setContent(JacksonUtils.toJson(resourceSpecification));
+        configFormV3.setType(ConfigType.JSON.getType());
+        configFormV3.setAppName(mcpServerBasicInfo.getName());
+        configFormV3.setSrcUser("nacos");
+        configFormV3.setConfigTags(Constants.MCP_SERVER_CONFIG_MARK);
+        return configFormV3;
+    }
+    
+    private ConfigQueryChainRequest buildQueryMcpResourceRequest(String namespaceId, String resourceDescriptionRef) {
+        ConfigQueryChainRequest request = new ConfigQueryChainRequest();
+        request.setDataId(resourceDescriptionRef);
+        request.setGroup(Constants.MCP_SERVER_RESOURCE_GROUP);
+        request.setTenant(namespaceId);
+        return request;
+    }
+    
+    private McpResourceSpecification transferToMcpServerResource(ConfigQueryChainResponse response) {
+        return JacksonUtils.toObj(response.getContent(), new TypeReference<>() {
+        });
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpResourceOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpResourceOperationService.java
@@ -39,17 +39,17 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class McpResourceOperationService {
-    
+
     private final ConfigQueryChainService configQueryChainService;
-    
+
     private final ConfigOperationService configOperationService;
-    
+
     public McpResourceOperationService(ConfigQueryChainService configQueryChainService,
             ConfigOperationService configOperationService) {
         this.configQueryChainService = configQueryChainService;
         this.configOperationService = configOperationService;
     }
-    
+
     /**
      * Create or update mcp server resources. If mcp server resources already exist, will fully replace it.
      *
@@ -64,7 +64,7 @@ public class McpResourceOperationService {
         ConfigFormV3 resourceConfigForm = buildMcpResourceConfigForm(namespaceId, serverBasicInfo, resourceSpecification);
         configOperationService.publishConfig(resourceConfigForm, configRequestInfo, null);
     }
-    
+
     public McpResourceSpecification getMcpResource(String namespaceId, String resourceDescriptionRef) {
         ConfigQueryChainRequest request = buildQueryMcpResourceRequest(namespaceId, resourceDescriptionRef);
         ConfigQueryChainResponse response = configQueryChainService.handle(request);
@@ -73,12 +73,12 @@ public class McpResourceOperationService {
         }
         return transferToMcpServerResource(response);
     }
-    
+
     public void deleteMcpResource(String namespaceId, String mcpServerId, String version) throws NacosException {
         configOperationService.deleteConfig(McpConfigUtils.formatServerResourceSpecDataId(mcpServerId, version),
                 Constants.MCP_SERVER_RESOURCE_GROUP, namespaceId, null, null, "nacos", null);
     }
-    
+
     private ConfigFormV3 buildMcpResourceConfigForm(String namespaceId, McpServerBasicInfo mcpServerBasicInfo,
             McpResourceSpecification resourceSpecification) {
         ConfigFormV3 configFormV3 = new ConfigFormV3();
@@ -95,7 +95,7 @@ public class McpResourceOperationService {
         configFormV3.setConfigTags(Constants.MCP_SERVER_CONFIG_MARK);
         return configFormV3;
     }
-    
+
     private ConfigQueryChainRequest buildQueryMcpResourceRequest(String namespaceId, String resourceDescriptionRef) {
         ConfigQueryChainRequest request = new ConfigQueryChainRequest();
         request.setDataId(resourceDescriptionRef);
@@ -103,7 +103,7 @@ public class McpResourceOperationService {
         request.setTenant(namespaceId);
         return request;
     }
-    
+
     private McpResourceSpecification transferToMcpServerResource(ConfigQueryChainResponse response) {
         return JacksonUtils.toObj(response.getContent(), new TypeReference<>() {
         });

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.ai.utils.McpConfigUtils;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.FrontEndpointConfig;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerImportRequest;
@@ -213,13 +214,15 @@ public class McpServerImportService {
 
             McpServerDetailInfo server = item.getServer();
             McpToolSpecification toolSpec = server.getToolSpec();
+            McpResourceSpecification resourceSpec = server.getResourceSpec();
             McpServerBasicInfo basicInfo = generateMcpBasicInfo(server);
             McpEndpointSpec endpointSpec = generateEndpointSpec(server);
             McpServerIndexData exist = mcpCacheIndex.getMcpServerByName(namespaceId, item.getServerName());
             if (exist != null && overrideExisting) {
-                operationService.updateMcpServer(namespaceId, true, basicInfo, toolSpec, endpointSpec, true);
+                operationService.updateMcpServer(namespaceId, true, basicInfo, toolSpec, resourceSpec, endpointSpec,
+                        true);
             } else {
-                operationService.createMcpServer(namespaceId, basicInfo, toolSpec, endpointSpec);
+                operationService.createMcpServer(namespaceId, basicInfo, toolSpec, resourceSpec, endpointSpec);
             }
             result.setStatus(McpImportResultStatusEnum.SUCCESS.getName());
         } catch (Exception e) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
@@ -69,7 +69,7 @@ public class McpServerImportService {
 
     public McpServerImportService(McpExternalDataAdaptor transformService,
                                   McpServerValidationService validationService,
-                                  McpServerOperationService operationService,
+                                  McpServerOperationService operationService, 
                                   McpCacheIndex mcpCacheIndex) {
         this.transformService = transformService;
         this.validationService = validationService;

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
@@ -69,7 +69,7 @@ public class McpServerImportService {
 
     public McpServerImportService(McpExternalDataAdaptor transformService,
                                   McpServerValidationService validationService,
-                                  McpServerOperationService operationService, 
+                                  McpServerOperationService operationService,
                                   McpCacheIndex mcpCacheIndex) {
         this.transformService = transformService;
         this.validationService = validationService;

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
@@ -30,6 +30,7 @@ import com.alibaba.nacos.api.ai.model.mcp.McpEndpointInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerVersionInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServiceRef;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
@@ -83,33 +84,36 @@ import static com.alibaba.nacos.ai.utils.McpConfigUtils.buildMcpServerVersionCon
  */
 @org.springframework.stereotype.Service
 public class McpServerOperationService {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(McpServerOperationService.class);
-    
+
     private final ConfigQueryChainService configQueryChainService;
-    
+
     private final ConfigOperationService configOperationService;
-    
+
     private final McpToolOperationService toolOperationService;
-    
+
+    private final McpResourceOperationService resourceOperationService;
+
     private final McpEndpointOperationService endpointOperationService;
-    
+
     private final McpServerIndex mcpServerIndex;
-    
+
     private final SyncEffectService syncEffectService;
-    
+
     public McpServerOperationService(ConfigQueryChainService configQueryChainService,
             ConfigOperationService configOperationService, McpToolOperationService toolOperationService,
-            McpEndpointOperationService endpointOperationService, McpServerIndex mcpServerIndex,
-            SyncEffectService syncEffectService) {
+            McpResourceOperationService resourceOperationService, McpEndpointOperationService endpointOperationService,
+            McpServerIndex mcpServerIndex, SyncEffectService syncEffectService) {
         this.configQueryChainService = configQueryChainService;
         this.configOperationService = configOperationService;
         this.toolOperationService = toolOperationService;
+        this.resourceOperationService = resourceOperationService;
         this.endpointOperationService = endpointOperationService;
         this.mcpServerIndex = mcpServerIndex;
         this.syncEffectService = syncEffectService;
     }
-    
+
     /**
      * List mcp server.
      *
@@ -143,7 +147,7 @@ public class McpServerOperationService {
         }
         return finalResult;
     }
-    
+
     private Page<McpServerBasicInfo> mapIndexPageToBasicServerPage(Page<McpServerIndexData> indexData) {
         Page<McpServerBasicInfo> result = new Page<>();
         result.setTotalCount(indexData.getTotalCount());
@@ -152,7 +156,7 @@ public class McpServerOperationService {
         result.setPageItems(mapIndexListToServerList(indexData.getPageItems()));
         return result;
     }
-    
+
     /**
      * Get specified mcp server detail info. mcpServerId or namespaceId + mcpServerName is needed.
      *
@@ -164,52 +168,57 @@ public class McpServerOperationService {
     public McpServerDetailInfo getMcpServerDetail(String namespaceId, String mcpServerId, String mcpServerName,
             String version) throws NacosException {
         mcpServerId = resolveMcpServerId(namespaceId, mcpServerName, mcpServerId);
-        
+
         McpServerVersionInfo mcpServerVersionInfo = getMcpServerVersionInfo(namespaceId, mcpServerId);
         if (StringUtils.isEmpty(version)) {
             int size = mcpServerVersionInfo.getVersionDetails().size();
             ServerVersionDetail last = mcpServerVersionInfo.getVersionDetails().get(size - 1);
             version = last.getVersion();
         }
-        
+
         ConfigQueryChainRequest request = buildQueryMcpServerRequest(namespaceId, mcpServerId, version);
         ConfigQueryChainResponse response = configQueryChainService.handle(request);
         if (McpConfigUtils.isConfigNotFound(response.getStatus())) {
             throw new NacosApiException(NacosApiException.NOT_FOUND, ErrorCode.MCP_SEVER_VERSION_NOT_FOUND,
                     String.format("mcp server `%s` for version `%s` not found", mcpServerId, version));
         }
-        
+
         McpServerStorageInfo serverSpecification = JacksonUtils.toObj(response.getContent(),
                 McpServerStorageInfo.class);
-        
+
         McpServerDetailInfo result = new McpServerDetailInfo();
         result.setId(mcpServerId);
-        result.setNamespaceId(namespaceId);
         BeanUtils.copyProperties(serverSpecification, result);
-        
+        result.setNamespaceId(namespaceId);
+
         List<ServerVersionDetail> versionDetails = mcpServerVersionInfo.getVersionDetails();
         String latestVersion = mcpServerVersionInfo.getLatestPublishedVersion();
         for (ServerVersionDetail versionDetail : versionDetails) {
             versionDetail.setIs_latest(versionDetail.getVersion().equals(latestVersion));
         }
         result.setAllVersions(mcpServerVersionInfo.getVersionDetails());
-        
+
         ServerVersionDetail versionDetail = result.getVersionDetail();
         versionDetail.setIs_latest(versionDetail.getVersion().equals(latestVersion));
         result.setVersion(versionDetail.getVersion());
-        
+
         if (Objects.nonNull(serverSpecification.getToolsDescriptionRef())) {
             McpToolSpecification toolSpec = toolOperationService.getMcpTool(namespaceId,
                     serverSpecification.getToolsDescriptionRef());
             result.setToolSpec(toolSpec);
         }
-        
+        if (Objects.nonNull(serverSpecification.getResourceDescriptionRef())) {
+            McpResourceSpecification resourceSpec = resourceOperationService.getMcpResource(namespaceId,
+                    serverSpecification.getResourceDescriptionRef());
+            result.setResourceSpec(resourceSpec);
+        }
+
         if (!AiConstants.Mcp.MCP_PROTOCOL_STDIO.equalsIgnoreCase(serverSpecification.getProtocol())) {
             injectEndpoint(result);
         }
         return result;
     }
-    
+
     private McpServerVersionInfo getMcpServerVersionInfo(String namespaceId, String mcpServerId)
             throws NacosApiException {
         ConfigQueryChainRequest request = buildQueryMcpServerVersionInfoRequest(namespaceId, mcpServerId);
@@ -219,28 +228,28 @@ public class McpServerOperationService {
                     String.format("Mcp server [ID: %s] not found in namespace [%s]. Response: %s", mcpServerId,
                             namespaceId, response.getMessage()));
         }
-        
+
         return JacksonUtils.toObj(response.getContent(), McpServerVersionInfo.class);
     }
-    
+
     private void injectEndpoint(McpServerDetailInfo detailInfo) throws NacosException {
         injectBackendEndpointRef(detailInfo);
         injectFrontendEndpointRef(detailInfo);
     }
-    
+
     private void injectBackendEndpointRef(McpServerDetailInfo detailInfo) throws NacosException {
         List<Instance> instances;
-        
+
         instances = endpointOperationService.getMcpServerEndpointInstances(
                 detailInfo.getRemoteServerConfig().getServiceRef());
-        
+
         String protocol = null;
         McpServiceRef serviceRef = detailInfo.getRemoteServerConfig().getServiceRef();
         if (Objects.nonNull(serviceRef)) {
             protocol = serviceRef.getTransportProtocol();
         }
         List<McpEndpointInfo> backendEndpoints = transferToMcpEndpointInfo(instances,
-                detailInfo.getRemoteServerConfig().getExportPath(), 
+                detailInfo.getRemoteServerConfig().getExportPath(),
                 protocol);
         detailInfo.setBackendEndpoints(backendEndpoints);
     }
@@ -259,12 +268,12 @@ public class McpServerOperationService {
         }
         return endpointInfos;
     }
-    
+
     private List<McpEndpointInfo> transferToMcpEndpointInfo(List<Instance> instances, String exportPath,
             String protocol) {
         return transferToMcpEndpointInfoWithHeaders(instances, exportPath, protocol, null);
     }
-    
+
     private void injectFrontendEndpointRef(McpServerDetailInfo detailInfo) throws NacosException {
         List<FrontEndpointConfig> frontEndpointConfigs = detailInfo.getRemoteServerConfig()
                 .getFrontEndpointConfigList();
@@ -311,7 +320,7 @@ public class McpServerOperationService {
             detailInfo.setFrontendEndpoints(frontendEndpoints);
         }
     }
-    
+
     /**
      * Create new mcp server.
      *
@@ -323,14 +332,31 @@ public class McpServerOperationService {
      */
     public String createMcpServer(String namespaceId, McpServerBasicInfo serverSpecification,
             McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException {
-        
+        return createMcpServer(namespaceId, serverSpecification, toolSpecification, null, endpointSpecification);
+    }
+
+    /**
+     * Create new mcp server with resource specification.
+     *
+     * @param namespaceId namespace id of mcp server
+     * @param serverSpecification mcp server specification
+     * @param toolSpecification mcp server tool specification
+     * @param resourceSpecification mcp server resource specification
+     * @param endpointSpecification mcp server endpoint specification
+     * @return mcp server id
+     * @throws NacosException any exception during handling
+     */
+    public String createMcpServer(String namespaceId, McpServerBasicInfo serverSpecification,
+            McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification,
+            McpEndpointSpec endpointSpecification) throws NacosException {
+
         String existId = resolveMcpServerId(namespaceId, serverSpecification.getName(), StringUtils.EMPTY);
         if (StringUtils.isNotEmpty(existId)) {
             throw new NacosApiException(NacosApiException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
                     String.format("mcp server `%s` has existed, please update it rather than create.",
                             serverSpecification.getName()));
         }
-        
+
         ServerVersionDetail versionDetail = serverSpecification.getVersionDetail();
         if (null == versionDetail && StringUtils.isNotBlank(serverSpecification.getVersion())) {
             versionDetail = new ServerVersionDetail();
@@ -343,7 +369,7 @@ public class McpServerOperationService {
         }
         String id;
         String customMcpId = serverSpecification.getId();
-        
+
         if (StringUtils.isEmpty(customMcpId)) {
             id = UUID.randomUUID().toString();
         } else {
@@ -355,43 +381,43 @@ public class McpServerOperationService {
                 throw new NacosApiException(NacosApiException.INVALID_PARAM, ErrorCode.PARAMETER_VALIDATE_ERROR,
                         "parameter `serverSpecification.id` conflict with exist mcp server id");
             }
-            
+
             id = customMcpId;
         }
-        
+
         serverSpecification.setId(id);
         ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(Constants.RELEASE_DATE_FORMAT);
         String formattedCurrentTime = currentTime.format(formatter);
         versionDetail.setRelease_date(formattedCurrentTime);
-        
+
         McpServerStorageInfo newSpecification = new McpServerStorageInfo();
         BeanUtils.copyProperties(serverSpecification, newSpecification);
-        injectToolAndEndpoint(namespaceId, serverSpecification.getId(), newSpecification, toolSpecification,
-                endpointSpecification, Boolean.FALSE);
-        
+        injectMcpDescriptionsAndEndpoint(namespaceId, serverSpecification.getId(), newSpecification,
+                toolSpecification, resourceSpecification, endpointSpecification, false, null);
+
         McpServerVersionInfo versionInfo = buildServerVersionInfo(newSpecification, id, versionDetail);
-        
+
         ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
         configRequestInfo.setUpdateForExist(Boolean.FALSE);
-        
+
         ConfigFormV3 mcpServerVersionForm = buildMcpServerVersionForm(namespaceId, versionInfo);
         configOperationService.publishConfig(mcpServerVersionForm, configRequestInfo, null);
-        
+
         ConfigForm configForm = buildMcpConfigForm(namespaceId, id, versionDetail.getVersion(), newSpecification);
         long startOperationTime = System.currentTimeMillis();
         configOperationService.publishConfig(configForm, configRequestInfo, null);
         syncEffectService.toSync(configForm, startOperationTime);
-        
+
         // Delete the relevant cache after a successful database operation
         invalidateCacheAfterDbOperation(namespaceId, serverSpecification.getName(), id);
         AiResourceTraceService.logSuccess("mcp", serverSpecification.getName(),
                 versionDetail.getVersion(), AiResourceTraceService.OP_CREATE_DRAFT,
                 VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
-        
+
         return id;
     }
-    
+
     private static McpServerVersionInfo buildServerVersionInfo(McpServerBasicInfo serverSpecification, String id,
             ServerVersionDetail versionDetail) {
         McpServerVersionInfo versionInfo = new McpServerVersionInfo();
@@ -406,7 +432,7 @@ public class McpServerOperationService {
         versionInfo.setVersions(Collections.singletonList(versionDetail));
         return versionInfo;
     }
-    
+
     /**
      * Update existed mcp server.
      *
@@ -422,14 +448,22 @@ public class McpServerOperationService {
      * @throws NacosException any exception during handling
      */
     public void updateMcpServer(String namespaceId, boolean isPublish, McpServerBasicInfo serverSpecification,
-            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException {
-        
+            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification, boolean overrideExisting)
+            throws NacosException {
+        updateMcpServer(namespaceId, isPublish, serverSpecification, toolSpecification, null, endpointSpecification,
+                overrideExisting);
+    }
+
+    public void updateMcpServer(String namespaceId, boolean isPublish, McpServerBasicInfo serverSpecification,
+            McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification,
+            McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException {
+
         String mcpServerId = serverSpecification.getId();
         mcpServerId = resolveMcpServerId(namespaceId, serverSpecification.getName(), mcpServerId);
         if (StringUtils.isEmpty(serverSpecification.getId())) {
             serverSpecification.setId(mcpServerId);
         }
-        
+
         ServerVersionDetail versionDetail = serverSpecification.getVersionDetail();
         if (null == versionDetail && StringUtils.isNotBlank(serverSpecification.getVersion())) {
             versionDetail = new ServerVersionDetail();
@@ -441,15 +475,17 @@ public class McpServerOperationService {
                     "Version must be specified in parameter `serverSpecification`");
         }
         final McpServerVersionInfo mcpServerVersionInfo = getMcpServerVersionInfo(namespaceId, mcpServerId);
-        
+
         String updateVersion = versionDetail.getVersion();
+        McpServerStorageInfo oldSpecification = getMcpServerStorageInfoIfPresent(namespaceId, mcpServerId, updateVersion);
         McpServerStorageInfo newSpecification = new McpServerStorageInfo();
         BeanUtils.copyProperties(serverSpecification, newSpecification);
-        injectToolAndEndpoint(namespaceId, mcpServerId, newSpecification, toolSpecification, endpointSpecification, overrideExisting);
-        
+        injectMcpDescriptionsAndEndpoint(namespaceId, mcpServerId, newSpecification, toolSpecification,
+                resourceSpecification, endpointSpecification, overrideExisting, oldSpecification);
+
         ConfigForm configForm = buildMcpConfigForm(namespaceId, mcpServerId, updateVersion, newSpecification);
         configOperationService.publishConfig(configForm, new ConfigRequestInfo(), null);
-        
+
         List<ServerVersionDetail> versionDetails = mcpServerVersionInfo.getVersionDetails();
         Set<String> versionSet = versionDetails.stream().map(ServerVersionDetail::getVersion)
                 .collect(Collectors.toSet());
@@ -459,7 +495,7 @@ public class McpServerOperationService {
             versionDetails.add(version);
             mcpServerVersionInfo.setVersions(versionDetails);
         }
-        
+
         if (isPublish) {
             mcpServerVersionInfo.setName(newSpecification.getName());
             mcpServerVersionInfo.setDescription(newSpecification.getDescription());
@@ -468,7 +504,7 @@ public class McpServerOperationService {
             mcpServerVersionInfo.setFrontProtocol(newSpecification.getFrontProtocol());
             mcpServerVersionInfo.setCapabilities(newSpecification.getCapabilities());
             mcpServerVersionInfo.setLatestPublishedVersion(updateVersion);
-            
+
             for (ServerVersionDetail detail : versionDetails) {
                 if (detail.getVersion().equals(updateVersion)) {
                     ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
@@ -484,12 +520,12 @@ public class McpServerOperationService {
             mcpServerVersionInfo.setVersions(versionDetails);
             mcpServerVersionInfo.setEnabled(newSpecification.isEnabled());
         }
-        
+
         ConfigFormV3 mcpServerVersionForm = buildMcpServerVersionForm(namespaceId, mcpServerVersionInfo);
         long startOperationTime = System.currentTimeMillis();
         configOperationService.publishConfig(mcpServerVersionForm, new ConfigRequestInfo(), null);
         syncEffectService.toSync(mcpServerVersionForm, startOperationTime);
-        
+
         // Delete the relevant cache after a successful database operation
         invalidateCacheAfterDbUpdateOperation(namespaceId, mcpServerVersionInfo.getName(),
                 serverSpecification.getName(), mcpServerId);
@@ -497,7 +533,7 @@ public class McpServerOperationService {
                 updateVersion, isPublish ? AiResourceTraceService.OP_PUBLISH : AiResourceTraceService.OP_UPDATE_DRAFT,
                 VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
-    
+
     /**
      * Delete existed mcp server.
      *
@@ -516,9 +552,10 @@ public class McpServerOperationService {
             versionsNeedDelete = mcpServerVersionInfo.getVersionDetails().stream().map(ServerVersionDetail::getVersion)
                     .collect(Collectors.toList());
         }
-        
+
         for (String versionNeedDelete : versionsNeedDelete) {
             toolOperationService.deleteMcpTool(namespaceId, mcpServerId, versionNeedDelete);
+            resourceOperationService.deleteMcpResource(namespaceId, mcpServerId, versionNeedDelete);
             endpointOperationService.deleteMcpServerEndpointService(namespaceId, mcpServerVersionInfo.getName() + "::" + versionNeedDelete);
             String serverSpecDataId = McpConfigUtils.formatServerSpecInfoDataId(mcpServerId, versionNeedDelete);
             configOperationService.deleteConfig(serverSpecDataId, Constants.MCP_SERVER_GROUP, namespaceId, null, null,
@@ -527,7 +564,7 @@ public class McpServerOperationService {
             configOperationService.deleteConfig(serverVersionDataId, Constants.MCP_SERVER_VERSIONS_GROUP, namespaceId,
                     null, null, "nacos", null);
         }
-        
+
         // Delete the relevant cache after a successful database operation
         invalidateCacheAfterDbOperation(namespaceId, mcpName, mcpServerId);
         AiResourceTraceService.logSuccess("mcp", mcpName, version,
@@ -535,9 +572,11 @@ public class McpServerOperationService {
                         : AiResourceTraceService.OP_DELETE_RESOURCE,
                 VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
-    
-    private void injectToolAndEndpoint(String namespaceId, String mcpServerId, McpServerStorageInfo serverSpecification,
-            McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException {
+
+    private void injectMcpDescriptionsAndEndpoint(String namespaceId, String mcpServerId,
+            McpServerStorageInfo serverSpecification, McpToolSpecification toolSpecification,
+            McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification,
+            boolean overrideExisting, McpServerStorageInfo oldSpecification) throws NacosException {
         serverSpecification.setCapabilities(new LinkedList<>());
         boolean hasToolSpec = toolSpecification != null;
         boolean hasTools = hasToolSpec && toolSpecification.getTools() != null;
@@ -551,6 +590,18 @@ public class McpServerOperationService {
             String toolSpecDataId = McpConfigUtils.formatServerToolSpecDataId(mcpServerId, version);
             serverSpecification.setToolsDescriptionRef(toolSpecDataId);
         }
+        boolean hasResourceSpec = hasResourceSpecification(resourceSpecification);
+        if (hasResourceSpec) {
+            resourceOperationService.refreshMcpResource(namespaceId, serverSpecification, resourceSpecification);
+            serverSpecification.getCapabilities().add(McpCapability.RESOURCE);
+            String version = serverSpecification.getVersionDetail().getVersion();
+            String resourceSpecDataId = McpConfigUtils.formatServerResourceSpecDataId(mcpServerId, version);
+            serverSpecification.setResourceDescriptionRef(resourceSpecDataId);
+        } else if (Objects.nonNull(oldSpecification) && StringUtils.isNotBlank(oldSpecification.getResourceDescriptionRef())) {
+            resourceOperationService.deleteMcpResource(namespaceId, mcpServerId,
+                    serverSpecification.getVersionDetail().getVersion());
+            serverSpecification.setResourceDescriptionRef(null);
+        }
         if (null != endpointSpecification) {
             Service service = endpointOperationService.createMcpServerEndpointServiceIfNecessary(namespaceId,
                     serverSpecification.getName(), serverSpecification.getVersionDetail().getVersion(), endpointSpecification, overrideExisting);
@@ -563,7 +614,25 @@ public class McpServerOperationService {
             serverSpecification.getRemoteServerConfig().setServiceRef(serviceRef);
         }
     }
-    
+
+    private boolean hasResourceSpecification(McpResourceSpecification resourceSpecification) {
+        if (null == resourceSpecification) {
+            return false;
+        }
+        return CollectionUtils.isNotEmpty(resourceSpecification.getResources())
+                || CollectionUtils.isNotEmpty(resourceSpecification.getResourceTemplates())
+                || Objects.nonNull(resourceSpecification.getEncryptData());
+    }
+
+    private McpServerStorageInfo getMcpServerStorageInfoIfPresent(String namespaceId, String mcpServerId, String version) {
+        ConfigQueryChainRequest request = buildQueryMcpServerRequest(namespaceId, mcpServerId, version);
+        ConfigQueryChainResponse response = configQueryChainService.handle(request);
+        if (McpConfigUtils.isConfigNotFound(response.getStatus())) {
+            return null;
+        }
+        return JacksonUtils.toObj(response.getContent(), McpServerStorageInfo.class);
+    }
+
     private ConfigFormV3 buildMcpServerVersionForm(String namespaceId, McpServerVersionInfo mcpServerVersionInfo) {
         ConfigFormV3 configFormV3 = new ConfigFormV3();
         configFormV3.setGroupName(Constants.MCP_SERVER_VERSIONS_GROUP);
@@ -578,7 +647,7 @@ public class McpServerOperationService {
         configFormV3.setConfigTags(configTags);
         return configFormV3;
     }
-    
+
     private ConfigFormV3 buildMcpConfigForm(String namespaceId, String mcpServerId, String version,
             McpServerBasicInfo serverSpecification) {
         ConfigFormV3 configFormV3 = new ConfigFormV3();
@@ -593,7 +662,7 @@ public class McpServerOperationService {
         configFormV3.setConfigTags(MCP_SERVER_CONFIG_MARK);
         return configFormV3;
     }
-    
+
     private ConfigQueryChainRequest buildQueryMcpServerRequest(String namespaceId, String mcpServerId, String version) {
         ConfigQueryChainRequest request = new ConfigQueryChainRequest();
         request.setDataId(McpConfigUtils.formatServerSpecInfoDataId(mcpServerId, version));
@@ -601,7 +670,7 @@ public class McpServerOperationService {
         request.setTenant(namespaceId);
         return request;
     }
-    
+
     private ConfigQueryChainRequest buildQueryMcpServerVersionInfoRequest(String namespaceId, String mcpServerId) {
         ConfigQueryChainRequest request = new ConfigQueryChainRequest();
         request.setDataId(McpConfigUtils.formatServerVersionInfoDataId(mcpServerId));
@@ -609,7 +678,7 @@ public class McpServerOperationService {
         request.setTenant(namespaceId);
         return request;
     }
-    
+
     private McpServerVersionInfo transferToMcpServerVersionInfo(String content) {
         McpServerVersionInfo versionInfo = JacksonUtils.toObj(content, McpServerVersionInfo.class);
         String latestPublishedVersion = versionInfo.getLatestPublishedVersion();
@@ -625,20 +694,20 @@ public class McpServerOperationService {
         versionInfo.setVersion(latestPublishedVersion);
         return versionInfo;
     }
-    
+
     private String resolveMcpServerId(String namespaceId, String serverName, String serverId) {
         if (StringUtils.isNotEmpty(serverId)) {
             return serverId;
         }
-        
+
         McpServerIndexData indexData = mcpServerIndex.getMcpServerByName(namespaceId, serverName);
         if (Objects.nonNull(indexData)) {
             return indexData.getId();
         }
-        
+
         return null;
     }
-    
+
     /**
      * Invalidate cache after update mcp server operation.
      *
@@ -667,7 +736,7 @@ public class McpServerOperationService {
                     namespaceId, oldMcpName, newMcpName, mcpServerId, e.getMessage());
         }
     }
-    
+
     /**
      * Unified cache invalidation method.
      *

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
@@ -84,23 +84,23 @@ import static com.alibaba.nacos.ai.utils.McpConfigUtils.buildMcpServerVersionCon
  */
 @org.springframework.stereotype.Service
 public class McpServerOperationService {
-
+    
     private static final Logger LOGGER = LoggerFactory.getLogger(McpServerOperationService.class);
-
+    
     private final ConfigQueryChainService configQueryChainService;
-
+    
     private final ConfigOperationService configOperationService;
-
+    
     private final McpToolOperationService toolOperationService;
-
+    
     private final McpResourceOperationService resourceOperationService;
 
     private final McpEndpointOperationService endpointOperationService;
-
+    
     private final McpServerIndex mcpServerIndex;
-
+    
     private final SyncEffectService syncEffectService;
-
+    
     public McpServerOperationService(ConfigQueryChainService configQueryChainService,
             ConfigOperationService configOperationService, McpToolOperationService toolOperationService,
             McpResourceOperationService resourceOperationService, McpEndpointOperationService endpointOperationService,
@@ -113,7 +113,7 @@ public class McpServerOperationService {
         this.mcpServerIndex = mcpServerIndex;
         this.syncEffectService = syncEffectService;
     }
-
+    
     /**
      * List mcp server.
      *
@@ -147,7 +147,7 @@ public class McpServerOperationService {
         }
         return finalResult;
     }
-
+    
     private Page<McpServerBasicInfo> mapIndexPageToBasicServerPage(Page<McpServerIndexData> indexData) {
         Page<McpServerBasicInfo> result = new Page<>();
         result.setTotalCount(indexData.getTotalCount());
@@ -156,7 +156,7 @@ public class McpServerOperationService {
         result.setPageItems(mapIndexListToServerList(indexData.getPageItems()));
         return result;
     }
-
+    
     /**
      * Get specified mcp server detail info. mcpServerId or namespaceId + mcpServerName is needed.
      *
@@ -168,40 +168,40 @@ public class McpServerOperationService {
     public McpServerDetailInfo getMcpServerDetail(String namespaceId, String mcpServerId, String mcpServerName,
             String version) throws NacosException {
         mcpServerId = resolveMcpServerId(namespaceId, mcpServerName, mcpServerId);
-
+        
         McpServerVersionInfo mcpServerVersionInfo = getMcpServerVersionInfo(namespaceId, mcpServerId);
         if (StringUtils.isEmpty(version)) {
             int size = mcpServerVersionInfo.getVersionDetails().size();
             ServerVersionDetail last = mcpServerVersionInfo.getVersionDetails().get(size - 1);
             version = last.getVersion();
         }
-
+        
         ConfigQueryChainRequest request = buildQueryMcpServerRequest(namespaceId, mcpServerId, version);
         ConfigQueryChainResponse response = configQueryChainService.handle(request);
         if (McpConfigUtils.isConfigNotFound(response.getStatus())) {
             throw new NacosApiException(NacosApiException.NOT_FOUND, ErrorCode.MCP_SEVER_VERSION_NOT_FOUND,
                     String.format("mcp server `%s` for version `%s` not found", mcpServerId, version));
         }
-
+        
         McpServerStorageInfo serverSpecification = JacksonUtils.toObj(response.getContent(),
                 McpServerStorageInfo.class);
-
+        
         McpServerDetailInfo result = new McpServerDetailInfo();
         result.setId(mcpServerId);
         BeanUtils.copyProperties(serverSpecification, result);
         result.setNamespaceId(namespaceId);
-
+        
         List<ServerVersionDetail> versionDetails = mcpServerVersionInfo.getVersionDetails();
         String latestVersion = mcpServerVersionInfo.getLatestPublishedVersion();
         for (ServerVersionDetail versionDetail : versionDetails) {
             versionDetail.setIs_latest(versionDetail.getVersion().equals(latestVersion));
         }
         result.setAllVersions(mcpServerVersionInfo.getVersionDetails());
-
+        
         ServerVersionDetail versionDetail = result.getVersionDetail();
         versionDetail.setIs_latest(versionDetail.getVersion().equals(latestVersion));
         result.setVersion(versionDetail.getVersion());
-
+        
         if (Objects.nonNull(serverSpecification.getToolsDescriptionRef())) {
             McpToolSpecification toolSpec = toolOperationService.getMcpTool(namespaceId,
                     serverSpecification.getToolsDescriptionRef());
@@ -212,13 +212,13 @@ public class McpServerOperationService {
                     serverSpecification.getResourceDescriptionRef());
             result.setResourceSpec(resourceSpec);
         }
-
+        
         if (!AiConstants.Mcp.MCP_PROTOCOL_STDIO.equalsIgnoreCase(serverSpecification.getProtocol())) {
             injectEndpoint(result);
         }
         return result;
     }
-
+    
     private McpServerVersionInfo getMcpServerVersionInfo(String namespaceId, String mcpServerId)
             throws NacosApiException {
         ConfigQueryChainRequest request = buildQueryMcpServerVersionInfoRequest(namespaceId, mcpServerId);
@@ -228,28 +228,28 @@ public class McpServerOperationService {
                     String.format("Mcp server [ID: %s] not found in namespace [%s]. Response: %s", mcpServerId,
                             namespaceId, response.getMessage()));
         }
-
+        
         return JacksonUtils.toObj(response.getContent(), McpServerVersionInfo.class);
     }
-
+    
     private void injectEndpoint(McpServerDetailInfo detailInfo) throws NacosException {
         injectBackendEndpointRef(detailInfo);
         injectFrontendEndpointRef(detailInfo);
     }
-
+    
     private void injectBackendEndpointRef(McpServerDetailInfo detailInfo) throws NacosException {
         List<Instance> instances;
-
+        
         instances = endpointOperationService.getMcpServerEndpointInstances(
                 detailInfo.getRemoteServerConfig().getServiceRef());
-
+        
         String protocol = null;
         McpServiceRef serviceRef = detailInfo.getRemoteServerConfig().getServiceRef();
         if (Objects.nonNull(serviceRef)) {
             protocol = serviceRef.getTransportProtocol();
         }
         List<McpEndpointInfo> backendEndpoints = transferToMcpEndpointInfo(instances,
-                detailInfo.getRemoteServerConfig().getExportPath(),
+                detailInfo.getRemoteServerConfig().getExportPath(), 
                 protocol);
         detailInfo.setBackendEndpoints(backendEndpoints);
     }
@@ -268,12 +268,12 @@ public class McpServerOperationService {
         }
         return endpointInfos;
     }
-
+    
     private List<McpEndpointInfo> transferToMcpEndpointInfo(List<Instance> instances, String exportPath,
             String protocol) {
         return transferToMcpEndpointInfoWithHeaders(instances, exportPath, protocol, null);
     }
-
+    
     private void injectFrontendEndpointRef(McpServerDetailInfo detailInfo) throws NacosException {
         List<FrontEndpointConfig> frontEndpointConfigs = detailInfo.getRemoteServerConfig()
                 .getFrontEndpointConfigList();
@@ -320,7 +320,7 @@ public class McpServerOperationService {
             detailInfo.setFrontendEndpoints(frontendEndpoints);
         }
     }
-
+    
     /**
      * Create new mcp server.
      *
@@ -349,14 +349,14 @@ public class McpServerOperationService {
     public String createMcpServer(String namespaceId, McpServerBasicInfo serverSpecification,
             McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException {
-
+        
         String existId = resolveMcpServerId(namespaceId, serverSpecification.getName(), StringUtils.EMPTY);
         if (StringUtils.isNotEmpty(existId)) {
             throw new NacosApiException(NacosApiException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
                     String.format("mcp server `%s` has existed, please update it rather than create.",
                             serverSpecification.getName()));
         }
-
+        
         ServerVersionDetail versionDetail = serverSpecification.getVersionDetail();
         if (null == versionDetail && StringUtils.isNotBlank(serverSpecification.getVersion())) {
             versionDetail = new ServerVersionDetail();
@@ -369,7 +369,7 @@ public class McpServerOperationService {
         }
         String id;
         String customMcpId = serverSpecification.getId();
-
+        
         if (StringUtils.isEmpty(customMcpId)) {
             id = UUID.randomUUID().toString();
         } else {
@@ -381,43 +381,43 @@ public class McpServerOperationService {
                 throw new NacosApiException(NacosApiException.INVALID_PARAM, ErrorCode.PARAMETER_VALIDATE_ERROR,
                         "parameter `serverSpecification.id` conflict with exist mcp server id");
             }
-
+            
             id = customMcpId;
         }
-
+        
         serverSpecification.setId(id);
         ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(Constants.RELEASE_DATE_FORMAT);
         String formattedCurrentTime = currentTime.format(formatter);
         versionDetail.setRelease_date(formattedCurrentTime);
-
+        
         McpServerStorageInfo newSpecification = new McpServerStorageInfo();
         BeanUtils.copyProperties(serverSpecification, newSpecification);
         injectMcpDescriptionsAndEndpoint(namespaceId, serverSpecification.getId(), newSpecification,
                 toolSpecification, resourceSpecification, endpointSpecification, false, null);
-
+        
         McpServerVersionInfo versionInfo = buildServerVersionInfo(newSpecification, id, versionDetail);
-
+        
         ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
         configRequestInfo.setUpdateForExist(Boolean.FALSE);
-
+        
         ConfigFormV3 mcpServerVersionForm = buildMcpServerVersionForm(namespaceId, versionInfo);
         configOperationService.publishConfig(mcpServerVersionForm, configRequestInfo, null);
-
+        
         ConfigForm configForm = buildMcpConfigForm(namespaceId, id, versionDetail.getVersion(), newSpecification);
         long startOperationTime = System.currentTimeMillis();
         configOperationService.publishConfig(configForm, configRequestInfo, null);
         syncEffectService.toSync(configForm, startOperationTime);
-
+        
         // Delete the relevant cache after a successful database operation
         invalidateCacheAfterDbOperation(namespaceId, serverSpecification.getName(), id);
         AiResourceTraceService.logSuccess("mcp", serverSpecification.getName(),
                 versionDetail.getVersion(), AiResourceTraceService.OP_CREATE_DRAFT,
                 VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
-
+        
         return id;
     }
-
+    
     private static McpServerVersionInfo buildServerVersionInfo(McpServerBasicInfo serverSpecification, String id,
             ServerVersionDetail versionDetail) {
         McpServerVersionInfo versionInfo = new McpServerVersionInfo();
@@ -432,7 +432,7 @@ public class McpServerOperationService {
         versionInfo.setVersions(Collections.singletonList(versionDetail));
         return versionInfo;
     }
-
+    
     /**
      * Update existed mcp server.
      *
@@ -469,13 +469,13 @@ public class McpServerOperationService {
     public void updateMcpServer(String namespaceId, boolean isPublish, McpServerBasicInfo serverSpecification,
             McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification,
             McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException {
-
+        
         String mcpServerId = serverSpecification.getId();
         mcpServerId = resolveMcpServerId(namespaceId, serverSpecification.getName(), mcpServerId);
         if (StringUtils.isEmpty(serverSpecification.getId())) {
             serverSpecification.setId(mcpServerId);
         }
-
+        
         ServerVersionDetail versionDetail = serverSpecification.getVersionDetail();
         if (null == versionDetail && StringUtils.isNotBlank(serverSpecification.getVersion())) {
             versionDetail = new ServerVersionDetail();
@@ -487,17 +487,17 @@ public class McpServerOperationService {
                     "Version must be specified in parameter `serverSpecification`");
         }
         final McpServerVersionInfo mcpServerVersionInfo = getMcpServerVersionInfo(namespaceId, mcpServerId);
-
+        
         String updateVersion = versionDetail.getVersion();
         McpServerStorageInfo oldSpecification = getMcpServerStorageInfoIfPresent(namespaceId, mcpServerId, updateVersion);
         McpServerStorageInfo newSpecification = new McpServerStorageInfo();
         BeanUtils.copyProperties(serverSpecification, newSpecification);
         injectMcpDescriptionsAndEndpoint(namespaceId, mcpServerId, newSpecification, toolSpecification,
                 resourceSpecification, endpointSpecification, overrideExisting, oldSpecification);
-
+        
         ConfigForm configForm = buildMcpConfigForm(namespaceId, mcpServerId, updateVersion, newSpecification);
         configOperationService.publishConfig(configForm, new ConfigRequestInfo(), null);
-
+        
         List<ServerVersionDetail> versionDetails = mcpServerVersionInfo.getVersionDetails();
         Set<String> versionSet = versionDetails.stream().map(ServerVersionDetail::getVersion)
                 .collect(Collectors.toSet());
@@ -507,7 +507,7 @@ public class McpServerOperationService {
             versionDetails.add(version);
             mcpServerVersionInfo.setVersions(versionDetails);
         }
-
+        
         if (isPublish) {
             mcpServerVersionInfo.setName(newSpecification.getName());
             mcpServerVersionInfo.setDescription(newSpecification.getDescription());
@@ -516,7 +516,7 @@ public class McpServerOperationService {
             mcpServerVersionInfo.setFrontProtocol(newSpecification.getFrontProtocol());
             mcpServerVersionInfo.setCapabilities(newSpecification.getCapabilities());
             mcpServerVersionInfo.setLatestPublishedVersion(updateVersion);
-
+            
             for (ServerVersionDetail detail : versionDetails) {
                 if (detail.getVersion().equals(updateVersion)) {
                     ZonedDateTime currentTime = ZonedDateTime.now(ZoneOffset.UTC);
@@ -532,12 +532,12 @@ public class McpServerOperationService {
             mcpServerVersionInfo.setVersions(versionDetails);
             mcpServerVersionInfo.setEnabled(newSpecification.isEnabled());
         }
-
+        
         ConfigFormV3 mcpServerVersionForm = buildMcpServerVersionForm(namespaceId, mcpServerVersionInfo);
         long startOperationTime = System.currentTimeMillis();
         configOperationService.publishConfig(mcpServerVersionForm, new ConfigRequestInfo(), null);
         syncEffectService.toSync(mcpServerVersionForm, startOperationTime);
-
+        
         // Delete the relevant cache after a successful database operation
         invalidateCacheAfterDbUpdateOperation(namespaceId, mcpServerVersionInfo.getName(),
                 serverSpecification.getName(), mcpServerId);
@@ -545,7 +545,7 @@ public class McpServerOperationService {
                 updateVersion, isPublish ? AiResourceTraceService.OP_PUBLISH : AiResourceTraceService.OP_UPDATE_DRAFT,
                 VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
-
+    
     /**
      * Delete existed mcp server.
      *
@@ -564,7 +564,7 @@ public class McpServerOperationService {
             versionsNeedDelete = mcpServerVersionInfo.getVersionDetails().stream().map(ServerVersionDetail::getVersion)
                     .collect(Collectors.toList());
         }
-
+        
         for (String versionNeedDelete : versionsNeedDelete) {
             toolOperationService.deleteMcpTool(namespaceId, mcpServerId, versionNeedDelete);
             resourceOperationService.deleteMcpResource(namespaceId, mcpServerId, versionNeedDelete);
@@ -576,7 +576,7 @@ public class McpServerOperationService {
             configOperationService.deleteConfig(serverVersionDataId, Constants.MCP_SERVER_VERSIONS_GROUP, namespaceId,
                     null, null, "nacos", null);
         }
-
+        
         // Delete the relevant cache after a successful database operation
         invalidateCacheAfterDbOperation(namespaceId, mcpName, mcpServerId);
         AiResourceTraceService.logSuccess("mcp", mcpName, version,
@@ -584,7 +584,7 @@ public class McpServerOperationService {
                         : AiResourceTraceService.OP_DELETE_RESOURCE,
                 VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
-
+    
     private void injectMcpDescriptionsAndEndpoint(String namespaceId, String mcpServerId,
             McpServerStorageInfo serverSpecification, McpToolSpecification toolSpecification,
             McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification,
@@ -626,7 +626,7 @@ public class McpServerOperationService {
             serverSpecification.getRemoteServerConfig().setServiceRef(serviceRef);
         }
     }
-
+    
     private boolean hasResourceSpecification(McpResourceSpecification resourceSpecification) {
         if (null == resourceSpecification) {
             return false;
@@ -659,7 +659,7 @@ public class McpServerOperationService {
         configFormV3.setConfigTags(configTags);
         return configFormV3;
     }
-
+    
     private ConfigFormV3 buildMcpConfigForm(String namespaceId, String mcpServerId, String version,
             McpServerBasicInfo serverSpecification) {
         ConfigFormV3 configFormV3 = new ConfigFormV3();
@@ -674,7 +674,7 @@ public class McpServerOperationService {
         configFormV3.setConfigTags(MCP_SERVER_CONFIG_MARK);
         return configFormV3;
     }
-
+    
     private ConfigQueryChainRequest buildQueryMcpServerRequest(String namespaceId, String mcpServerId, String version) {
         ConfigQueryChainRequest request = new ConfigQueryChainRequest();
         request.setDataId(McpConfigUtils.formatServerSpecInfoDataId(mcpServerId, version));
@@ -682,7 +682,7 @@ public class McpServerOperationService {
         request.setTenant(namespaceId);
         return request;
     }
-
+    
     private ConfigQueryChainRequest buildQueryMcpServerVersionInfoRequest(String namespaceId, String mcpServerId) {
         ConfigQueryChainRequest request = new ConfigQueryChainRequest();
         request.setDataId(McpConfigUtils.formatServerVersionInfoDataId(mcpServerId));
@@ -690,7 +690,7 @@ public class McpServerOperationService {
         request.setTenant(namespaceId);
         return request;
     }
-
+    
     private McpServerVersionInfo transferToMcpServerVersionInfo(String content) {
         McpServerVersionInfo versionInfo = JacksonUtils.toObj(content, McpServerVersionInfo.class);
         String latestPublishedVersion = versionInfo.getLatestPublishedVersion();
@@ -706,20 +706,20 @@ public class McpServerOperationService {
         versionInfo.setVersion(latestPublishedVersion);
         return versionInfo;
     }
-
+    
     private String resolveMcpServerId(String namespaceId, String serverName, String serverId) {
         if (StringUtils.isNotEmpty(serverId)) {
             return serverId;
         }
-
+        
         McpServerIndexData indexData = mcpServerIndex.getMcpServerByName(namespaceId, serverName);
         if (Objects.nonNull(indexData)) {
             return indexData.getId();
         }
-
+        
         return null;
     }
-
+    
     /**
      * Invalidate cache after update mcp server operation.
      *
@@ -748,7 +748,7 @@ public class McpServerOperationService {
                     namespaceId, oldMcpName, newMcpName, mcpServerId, e.getMessage());
         }
     }
-
+    
     /**
      * Unified cache invalidation method.
      *

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
@@ -454,6 +454,18 @@ public class McpServerOperationService {
                 overrideExisting);
     }
 
+    /**
+     * Update current mcp server specification, tools, resources and endpoint information.
+     *
+     * @param namespaceId           namespace id of mcp server, used to mark which mcp server to update
+     * @param isPublish             whether publish latest version after update
+     * @param serverSpecification   mcp server basic specification
+     * @param toolSpecification     mcp server included tools, optional
+     * @param resourceSpecification mcp server included resources, optional
+     * @param endpointSpecification mcp server endpoint specification, optional
+     * @param overrideExisting      if replace all the instances when update the mcp server
+     * @throws NacosException any exception during handling
+     */
     public void updateMcpServer(String namespaceId, boolean isPublish, McpServerBasicInfo serverSpecification,
             McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification,
             McpEndpointSpec endpointSpecification, boolean overrideExisting) throws NacosException {

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/McpConfigUtils.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/McpConfigUtils.java
@@ -49,31 +49,31 @@ public class McpConfigUtils {
     public static String formatServerVersionInfoDataId(String id) {
         return String.format(Constants.SERVER_VERSION_CONFIG_DATA_ID_TEMPLATE, id);
     }
-    
+
     public static String formatServerSpecInfoDataId(String id, String version) {
         return String.format(Constants.SERVER_SPECIFICATION_CONFIG_DATA_ID_TEMPLATE, id, version);
     }
-    
+
     public static String formatServerToolSpecDataId(String id, String version) {
         return String.format(Constants.SERVER_TOOLS_SPEC_CONFIG_DATA_ID_TEMPLATE, id, version);
     }
-    
+
     public static String formatServerResourceSpecDataId(String id, String version) {
         return String.format(Constants.SERVER_RESOURCE_SPEC_CONFIG_DATA_ID_TEMPLATE, id, version);
     }
-    
+
     public static String formatServerNameTagBlurSearchValue(String serverName) {
         return Constants.MCP_SERVER_NAME_TAG_KEY_PREFIX + Constants.ALL_PATTERN + serverName + Constants.ALL_PATTERN;
     }
-    
+
     public static String formatServerNameTagAccurateSearchValue(String serverName) {
         return Constants.MCP_SERVER_NAME_TAG_KEY_PREFIX +  serverName;
     }
-    
+
     public static boolean isConfigFound(ConfigQueryChainResponse.ConfigQueryStatus status) {
         return ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL.equals(status);
     }
-    
+
     public static boolean isConfigNotFound(ConfigQueryChainResponse.ConfigQueryStatus status) {
         return ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND.equals(status);
     }

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/McpConfigUtils.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/McpConfigUtils.java
@@ -49,15 +49,15 @@ public class McpConfigUtils {
     public static String formatServerVersionInfoDataId(String id) {
         return String.format(Constants.SERVER_VERSION_CONFIG_DATA_ID_TEMPLATE, id);
     }
-
+    
     public static String formatServerSpecInfoDataId(String id, String version) {
         return String.format(Constants.SERVER_SPECIFICATION_CONFIG_DATA_ID_TEMPLATE, id, version);
     }
-
+    
     public static String formatServerToolSpecDataId(String id, String version) {
         return String.format(Constants.SERVER_TOOLS_SPEC_CONFIG_DATA_ID_TEMPLATE, id, version);
     }
-
+    
     public static String formatServerResourceSpecDataId(String id, String version) {
         return String.format(Constants.SERVER_RESOURCE_SPEC_CONFIG_DATA_ID_TEMPLATE, id, version);
     }
@@ -65,15 +65,15 @@ public class McpConfigUtils {
     public static String formatServerNameTagBlurSearchValue(String serverName) {
         return Constants.MCP_SERVER_NAME_TAG_KEY_PREFIX + Constants.ALL_PATTERN + serverName + Constants.ALL_PATTERN;
     }
-
+    
     public static String formatServerNameTagAccurateSearchValue(String serverName) {
         return Constants.MCP_SERVER_NAME_TAG_KEY_PREFIX +  serverName;
     }
-
+    
     public static boolean isConfigFound(ConfigQueryChainResponse.ConfigQueryStatus status) {
         return ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL.equals(status);
     }
-
+    
     public static boolean isConfigNotFound(ConfigQueryChainResponse.ConfigQueryStatus status) {
         return ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND.equals(status);
     }

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/McpConfigUtils.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/McpConfigUtils.java
@@ -58,6 +58,10 @@ public class McpConfigUtils {
         return String.format(Constants.SERVER_TOOLS_SPEC_CONFIG_DATA_ID_TEMPLATE, id, version);
     }
     
+    public static String formatServerResourceSpecDataId(String id, String version) {
+        return String.format(Constants.SERVER_RESOURCE_SPEC_CONFIG_DATA_ID_TEMPLATE, id, version);
+    }
+    
     public static String formatServerNameTagBlurSearchValue(String serverName) {
         return Constants.MCP_SERVER_NAME_TAG_KEY_PREFIX + Constants.ALL_PATTERN + serverName + Constants.ALL_PATTERN;
     }

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/McpRequestUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/McpRequestUtil.java
@@ -42,9 +42,9 @@ import java.util.Map;
  * @author xiweng.yy
  */
 public class McpRequestUtil {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(McpRequestUtil.class);
-    
+
     /**
      * Parse Mcp detail request form to {@link McpServerBasicInfo}.
      *
@@ -61,7 +61,7 @@ public class McpRequestUtil {
         }
         return result;
     }
-    
+
     /**
      * Parse Mcp tools request form to {@link McpTool}.
      *
@@ -76,7 +76,7 @@ public class McpRequestUtil {
         return McpRequestUtil.deserializeSpec(mcpForm.getToolSpecification(), new TypeReference<>() {
         });
     }
-    
+
     /**
      * Parse Mcp resources request form to {@link McpResourceSpecification}.
      *
@@ -91,7 +91,7 @@ public class McpRequestUtil {
         return McpRequestUtil.deserializeSpec(mcpForm.getResourceSpecification(), new TypeReference<>() {
         });
     }
-    
+
     /**
      * Parse Mcp endpoint request form to {@link McpEndpointSpec}.
      *
@@ -112,7 +112,7 @@ public class McpRequestUtil {
         return McpRequestUtil.deserializeSpec(mcpForm.getEndpointSpecification(), new TypeReference<>() {
         });
     }
-    
+
     /**
      * Deserialize spec from json request.
      *
@@ -125,7 +125,7 @@ public class McpRequestUtil {
     public static <T> T deserializeSpec(String spec, TypeReference<T> typeReference) throws NacosApiException {
         return deserializeSpec(spec, typeReference, LOGGER);
     }
-    
+
     /**
      * Deserialize spec from json request.
      *
@@ -147,7 +147,7 @@ public class McpRequestUtil {
                     "serverSpecification or toolSpecification is invalid. Can't be parsed.");
         }
     }
-    
+
     /**
      * Transfer input to McpServiceRef.
      *
@@ -163,7 +163,7 @@ public class McpRequestUtil {
         }
         throw new IllegalArgumentException("input must be instance of McpServiceRef or Map");
     }
-    
+
     /**
      * If request contains valid namespaceId, do nothing. If not, fill default namespaceId.
      *

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/McpRequestUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/McpRequestUtil.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.ai.utils;
 import com.alibaba.nacos.ai.form.mcp.admin.McpDetailForm;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServiceRef;
 import com.alibaba.nacos.api.ai.model.mcp.McpTool;
@@ -73,6 +74,21 @@ public class McpRequestUtil {
             return null;
         }
         return McpRequestUtil.deserializeSpec(mcpForm.getToolSpecification(), new TypeReference<>() {
+        });
+    }
+    
+    /**
+     * Parse Mcp resources request form to {@link McpResourceSpecification}.
+     *
+     * @param mcpForm mcp detail request.
+     * @return mcp server resource info
+     * @throws NacosApiException if parse failed.
+     */
+    public static McpResourceSpecification parseMcpResources(McpDetailForm mcpForm) throws NacosApiException {
+        if (StringUtils.isBlank(mcpForm.getResourceSpecification())) {
+            return null;
+        }
+        return McpRequestUtil.deserializeSpec(mcpForm.getResourceSpecification(), new TypeReference<>() {
         });
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/McpRequestUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/McpRequestUtil.java
@@ -42,9 +42,9 @@ import java.util.Map;
  * @author xiweng.yy
  */
 public class McpRequestUtil {
-
+    
     private static final Logger LOGGER = LoggerFactory.getLogger(McpRequestUtil.class);
-
+    
     /**
      * Parse Mcp detail request form to {@link McpServerBasicInfo}.
      *
@@ -61,7 +61,7 @@ public class McpRequestUtil {
         }
         return result;
     }
-
+    
     /**
      * Parse Mcp tools request form to {@link McpTool}.
      *
@@ -76,7 +76,7 @@ public class McpRequestUtil {
         return McpRequestUtil.deserializeSpec(mcpForm.getToolSpecification(), new TypeReference<>() {
         });
     }
-
+    
     /**
      * Parse Mcp resources request form to {@link McpResourceSpecification}.
      *
@@ -112,7 +112,7 @@ public class McpRequestUtil {
         return McpRequestUtil.deserializeSpec(mcpForm.getEndpointSpecification(), new TypeReference<>() {
         });
     }
-
+    
     /**
      * Deserialize spec from json request.
      *
@@ -125,7 +125,7 @@ public class McpRequestUtil {
     public static <T> T deserializeSpec(String spec, TypeReference<T> typeReference) throws NacosApiException {
         return deserializeSpec(spec, typeReference, LOGGER);
     }
-
+    
     /**
      * Deserialize spec from json request.
      *
@@ -147,7 +147,7 @@ public class McpRequestUtil {
                     "serverSpecification or toolSpecification is invalid. Can't be parsed.");
         }
     }
-
+    
     /**
      * Transfer input to McpServiceRef.
      *
@@ -163,7 +163,7 @@ public class McpRequestUtil {
         }
         throw new IllegalArgumentException("input must be instance of McpServiceRef or Map");
     }
-
+    
     /**
      * If request contains valid namespaceId, do nothing. If not, fill default namespaceId.
      *

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/McpAdminControllerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/McpAdminControllerTest.java
@@ -61,24 +61,24 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = MockServletContext.class)
 @WebAppConfiguration
 class McpAdminControllerTest {
-
+    
     private static final String MCP_SERVER_SPEC =
             "{\"protocol\":\"stdio\",\"frontProtocol\":\"stdio\",\"name\":\"nacos-mcp-server\","
                     + "\"id\":\"\",\"description\":\"nacos local mcp server(test version)\",\"versionDetail\":{\"version\":\"1.0.0\"},"
                     + "\"enabled\":true,\"localServerConfig\":{}}'";
-
+    
     private static final String MCP_RESOURCE_SPEC =
             "{\"resources\":[{\"name\":\"readme\",\"uri\":\"file:///README.md\",\"description\":\"test resource\"}]}";
 
     private McpAdminController mcpAdminController;
-
+    
     private MockMvc mockMvc;
-
+    
     private ConfigurableEnvironment cachedEnvironment;
-
+    
     @Mock
     private McpServerOperationService mcpServerOperationService;
-
+    
     @BeforeEach
     void setUp() {
         cachedEnvironment = EnvUtil.getEnvironment();
@@ -86,12 +86,12 @@ class McpAdminControllerTest {
         mcpAdminController = new McpAdminController(mcpServerOperationService);
         mockMvc = MockMvcBuilders.standaloneSetup(mcpAdminController).build();
     }
-
+    
     @AfterEach
     void tearDown() {
         EnvUtil.setEnvironment(cachedEnvironment);
     }
-
+    
     @Test
     void listMcpServersWithIllegalSearch() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(Constants.MCP_ADMIN_PATH + "/list")
@@ -99,7 +99,7 @@ class McpAdminControllerTest {
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Request parameter `search` should be `accurate` or `blur`.");
     }
-
+    
     @Test
     void listMcpServersWithIllegalPage() throws Throwable {
         final MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(Constants.MCP_ADMIN_PATH + "/list")
@@ -111,7 +111,7 @@ class McpAdminControllerTest {
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder2).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'pageSize' should be positive integer, current is 0");
     }
-
+    
     @Test
     void listMcpServersSuccess() throws Throwable {
         when(mcpServerOperationService.listMcpServerWithPage(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null,
@@ -126,14 +126,14 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertInstanceOf(Page.class, result.getData());
     }
-
+    
     @Test
     void getMcpServerWithoutMcpIdAndMcpName() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(Constants.MCP_ADMIN_PATH);
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'mcpId' or 'mcpName' type String at lease one is not present");
     }
-
+    
     @Test
     void getMcpServerWithMcpName() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(Constants.MCP_ADMIN_PATH)
@@ -147,7 +147,7 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertInstanceOf(McpServerDetailInfo.class, result.getData());
     }
-
+    
     @Test
     void getMcpServerWithMcpId() throws Exception {
         String id = UUID.randomUUID().toString();
@@ -161,7 +161,7 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertInstanceOf(McpServerDetailInfo.class, result.getData());
     }
-
+    
     @Test
     void getMcpServerWithVersion() throws Exception {
         String id = UUID.randomUUID().toString();
@@ -176,14 +176,14 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertInstanceOf(McpServerDetailInfo.class, result.getData());
     }
-
+    
     @Test
     void createMcpServerWithoutSpec() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.post(Constants.MCP_ADMIN_PATH);
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'serverSpecification' type McpServerBasicInfo is not present");
     }
-
+    
     @Test
     void createMcpServerWithSpec() throws Exception {
         String mcpId = UUID.randomUUID().toString();
@@ -215,14 +215,14 @@ class McpAdminControllerTest {
         verify(mcpServerOperationService).createMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
                 any(McpServerBasicInfo.class), isNull(), any(), isNull());
     }
-
+    
     @Test
     void updateMcpServerWithoutSpec() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.put(Constants.MCP_ADMIN_PATH);
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'serverSpecification' type McpServerBasicInfo is not present");
     }
-
+    
     @Test
     void updateMcpServerWithSpec() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.put(Constants.MCP_ADMIN_PATH)
@@ -250,7 +250,7 @@ class McpAdminControllerTest {
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
                 any(McpServerBasicInfo.class), isNull(), isNull(), isNull(), eq(true));
     }
-
+    
     @Test
     void updateMcpServerWithoutLatest() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.put(Constants.MCP_ADMIN_PATH)
@@ -264,14 +264,14 @@ class McpAdminControllerTest {
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
                 any(McpServerBasicInfo.class), isNull(), isNull(), isNull(), eq(false));
     }
-
+    
     @Test
     void deleteMcpServerWithoutMcpIdAndMcpName() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.delete(Constants.MCP_ADMIN_PATH);
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'mcpId' or 'mcpName' type String at lease one is not present");
     }
-
+    
     @Test
     void deleteMcpServerWithMcpName() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.delete(Constants.MCP_ADMIN_PATH)
@@ -285,7 +285,7 @@ class McpAdminControllerTest {
         verify(mcpServerOperationService).deleteMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "testName", null,
                 null);
     }
-
+    
     @Test
     void deleteMcpServerWithMcpId() throws Exception {
         String id = UUID.randomUUID().toString();
@@ -299,7 +299,7 @@ class McpAdminControllerTest {
         assertEquals("ok", result.getData());
         verify(mcpServerOperationService).deleteMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, id, null);
     }
-
+    
     @Test
     void deleteMcpServerWithVersion() throws Exception {
         String id = UUID.randomUUID().toString();
@@ -313,7 +313,7 @@ class McpAdminControllerTest {
         assertEquals("ok", result.getData());
         verify(mcpServerOperationService).deleteMcpServer("testNs", null, id, "1.0.0");
     }
-
+    
     private static <T extends Throwable> void assertServletException(Class<T> expectedCause, Executable executable,
             String expectedMsg) throws Throwable {
         try {

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/McpAdminControllerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/McpAdminControllerTest.java
@@ -61,21 +61,24 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = MockServletContext.class)
 @WebAppConfiguration
 class McpAdminControllerTest {
-    
+
     private static final String MCP_SERVER_SPEC =
             "{\"protocol\":\"stdio\",\"frontProtocol\":\"stdio\",\"name\":\"nacos-mcp-server\","
                     + "\"id\":\"\",\"description\":\"nacos local mcp server(test version)\",\"versionDetail\":{\"version\":\"1.0.0\"},"
                     + "\"enabled\":true,\"localServerConfig\":{}}'";
-    
+
+    private static final String MCP_RESOURCE_SPEC =
+            "{\"resources\":[{\"name\":\"readme\",\"uri\":\"file:///README.md\",\"description\":\"test resource\"}]}";
+
     private McpAdminController mcpAdminController;
-    
+
     private MockMvc mockMvc;
-    
+
     private ConfigurableEnvironment cachedEnvironment;
-    
+
     @Mock
     private McpServerOperationService mcpServerOperationService;
-    
+
     @BeforeEach
     void setUp() {
         cachedEnvironment = EnvUtil.getEnvironment();
@@ -83,12 +86,12 @@ class McpAdminControllerTest {
         mcpAdminController = new McpAdminController(mcpServerOperationService);
         mockMvc = MockMvcBuilders.standaloneSetup(mcpAdminController).build();
     }
-    
+
     @AfterEach
     void tearDown() {
         EnvUtil.setEnvironment(cachedEnvironment);
     }
-    
+
     @Test
     void listMcpServersWithIllegalSearch() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(Constants.MCP_ADMIN_PATH + "/list")
@@ -96,7 +99,7 @@ class McpAdminControllerTest {
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Request parameter `search` should be `accurate` or `blur`.");
     }
-    
+
     @Test
     void listMcpServersWithIllegalPage() throws Throwable {
         final MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(Constants.MCP_ADMIN_PATH + "/list")
@@ -108,7 +111,7 @@ class McpAdminControllerTest {
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder2).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'pageSize' should be positive integer, current is 0");
     }
-    
+
     @Test
     void listMcpServersSuccess() throws Throwable {
         when(mcpServerOperationService.listMcpServerWithPage(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null,
@@ -123,14 +126,14 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertInstanceOf(Page.class, result.getData());
     }
-    
+
     @Test
     void getMcpServerWithoutMcpIdAndMcpName() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(Constants.MCP_ADMIN_PATH);
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'mcpId' or 'mcpName' type String at lease one is not present");
     }
-    
+
     @Test
     void getMcpServerWithMcpName() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(Constants.MCP_ADMIN_PATH)
@@ -144,7 +147,7 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertInstanceOf(McpServerDetailInfo.class, result.getData());
     }
-    
+
     @Test
     void getMcpServerWithMcpId() throws Exception {
         String id = UUID.randomUUID().toString();
@@ -158,7 +161,7 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertInstanceOf(McpServerDetailInfo.class, result.getData());
     }
-    
+
     @Test
     void getMcpServerWithVersion() throws Exception {
         String id = UUID.randomUUID().toString();
@@ -173,21 +176,21 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertInstanceOf(McpServerDetailInfo.class, result.getData());
     }
-    
+
     @Test
     void createMcpServerWithoutSpec() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.post(Constants.MCP_ADMIN_PATH);
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'serverSpecification' type McpServerBasicInfo is not present");
     }
-    
+
     @Test
     void createMcpServerWithSpec() throws Exception {
         String mcpId = UUID.randomUUID().toString();
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.post(Constants.MCP_ADMIN_PATH)
                 .param("serverSpecification", MCP_SERVER_SPEC);
         when(mcpServerOperationService.createMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
-                any(McpServerBasicInfo.class), any(), any())).thenReturn(mcpId);
+                any(McpServerBasicInfo.class), any(), any(), any())).thenReturn(mcpId);
         MockHttpServletResponse response = mockMvc.perform(builder).andReturn().getResponse();
         assertEquals(200, response.getStatus());
 
@@ -197,16 +200,29 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals(mcpId, result.getData());
         verify(mcpServerOperationService).createMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
-                any(McpServerBasicInfo.class), isNull(), isNull());
+                any(McpServerBasicInfo.class), isNull(), isNull(), isNull());
     }
-    
+
+    @Test
+    void createMcpServerWithResourceSpec() throws Exception {
+        String mcpId = UUID.randomUUID().toString();
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.post(Constants.MCP_ADMIN_PATH)
+                .param("serverSpecification", MCP_SERVER_SPEC).param("resourceSpecification", MCP_RESOURCE_SPEC);
+        when(mcpServerOperationService.createMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
+                any(McpServerBasicInfo.class), any(), any(), any())).thenReturn(mcpId);
+        MockHttpServletResponse response = mockMvc.perform(builder).andReturn().getResponse();
+        assertEquals(200, response.getStatus());
+        verify(mcpServerOperationService).createMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
+                any(McpServerBasicInfo.class), isNull(), any(), isNull());
+    }
+
     @Test
     void updateMcpServerWithoutSpec() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.put(Constants.MCP_ADMIN_PATH);
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'serverSpecification' type McpServerBasicInfo is not present");
     }
-    
+
     @Test
     void updateMcpServerWithSpec() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.put(Constants.MCP_ADMIN_PATH)
@@ -218,7 +234,7 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("ok", result.getData());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
-                any(McpServerBasicInfo.class), isNull(), isNull(), eq(false));
+                any(McpServerBasicInfo.class), isNull(), isNull(), isNull(), eq(false));
     }
 
     @Test
@@ -232,9 +248,9 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("ok", result.getData());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
-                any(McpServerBasicInfo.class), isNull(), isNull(), eq(true));
+                any(McpServerBasicInfo.class), isNull(), isNull(), isNull(), eq(true));
     }
-    
+
     @Test
     void updateMcpServerWithoutLatest() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.put(Constants.MCP_ADMIN_PATH)
@@ -246,16 +262,16 @@ class McpAdminControllerTest {
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("ok", result.getData());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
-                any(McpServerBasicInfo.class), isNull(), isNull(), eq(false));
+                any(McpServerBasicInfo.class), isNull(), isNull(), isNull(), eq(false));
     }
-    
+
     @Test
     void deleteMcpServerWithoutMcpIdAndMcpName() throws Throwable {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.delete(Constants.MCP_ADMIN_PATH);
         assertServletException(NacosApiException.class, () -> mockMvc.perform(builder).andReturn(),
                 "ErrCode:400, ErrMsg:Required parameter 'mcpId' or 'mcpName' type String at lease one is not present");
     }
-    
+
     @Test
     void deleteMcpServerWithMcpName() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.delete(Constants.MCP_ADMIN_PATH)
@@ -269,7 +285,7 @@ class McpAdminControllerTest {
         verify(mcpServerOperationService).deleteMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "testName", null,
                 null);
     }
-    
+
     @Test
     void deleteMcpServerWithMcpId() throws Exception {
         String id = UUID.randomUUID().toString();
@@ -283,7 +299,7 @@ class McpAdminControllerTest {
         assertEquals("ok", result.getData());
         verify(mcpServerOperationService).deleteMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, id, null);
     }
-    
+
     @Test
     void deleteMcpServerWithVersion() throws Exception {
         String id = UUID.randomUUID().toString();
@@ -297,7 +313,7 @@ class McpAdminControllerTest {
         assertEquals("ok", result.getData());
         verify(mcpServerOperationService).deleteMcpServer("testNs", null, id, "1.0.0");
     }
-    
+
     private static <T extends Throwable> void assertServletException(Class<T> expectedCause, Executable executable,
             String expectedMsg) throws Throwable {
         try {

--- a/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
@@ -125,7 +125,7 @@ class ReleaseMcpServerRequestHandlerTest {
         when(endpointOperationService.generateService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "test::1.0.0")).thenReturn(
                 Service.newService(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, Constants.MCP_SERVER_ENDPOINT_GROUP, "test"));
         when(mcpServerOperationService.createMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
-                eq(request.getServerSpecification()), isNull(), isNotNull())).thenReturn(id);
+                eq(request.getServerSpecification()), isNull(), isNull(), isNotNull())).thenReturn(id);
         when(meta.getConnectionId()).thenReturn("111");
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
@@ -141,7 +141,7 @@ class ReleaseMcpServerRequestHandlerTest {
                 "1.0.0")).thenThrow(
                     new NacosApiException(NacosException.NOT_FOUND, ErrorCode.MCP_SERVER_NOT_FOUND, ""));
         when(mcpServerOperationService.createMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
-                eq(request.getServerSpecification()), isNull(), isNotNull())).thenReturn(id);
+                eq(request.getServerSpecification()), isNull(), isNull(), isNotNull())).thenReturn(id);
         when(meta.getConnectionId()).thenReturn("111");
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
@@ -157,7 +157,7 @@ class ReleaseMcpServerRequestHandlerTest {
                 "1.0.0")).thenThrow(
                     new NacosApiException(NacosException.NOT_FOUND, ErrorCode.MCP_SERVER_NOT_FOUND, ""));
         when(mcpServerOperationService.createMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
-                eq(request.getServerSpecification()), isNull(), isNull())).thenReturn(id);
+                eq(request.getServerSpecification()), isNull(), isNull(), isNull())).thenReturn(id);
         when(meta.getConnectionId()).thenReturn("111");
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
@@ -179,7 +179,7 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
-                eq(request.getServerSpecification()), isNull(), isNotNull(), eq(false));
+                eq(request.getServerSpecification()), isNull(), isNull(), isNotNull(), eq(false));
     }
     
     @Test
@@ -197,7 +197,7 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
-                eq(request.getServerSpecification()), isNull(), isNotNull(), eq(false));
+                eq(request.getServerSpecification()), isNull(), isNull(), isNotNull(), eq(false));
         verify(endpointOperationService, never()).generateService(anyString(), anyString());
     }
     
@@ -217,7 +217,7 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
-                eq(request.getServerSpecification()), isNull(), isNotNull(), eq(false));
+                eq(request.getServerSpecification()), isNull(), isNull(), isNotNull(), eq(false));
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
@@ -54,31 +54,31 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ReleaseMcpServerRequestHandlerTest {
-
+    
     @Mock
     private McpServerOperationService mcpServerOperationService;
-
+    
     @Mock
     private McpEndpointOperationService endpointOperationService;
-
+    
     @Mock
     private McpServerIndex mcpServerIndex;
-
+    
     @Mock
     private RequestMeta meta;
-
+    
     ReleaseMcpServerRequestHandler requestHandler;
-
+    
     @BeforeEach
     void setUp() {
         requestHandler = new ReleaseMcpServerRequestHandler(mcpServerOperationService, endpointOperationService,
                 mcpServerIndex);
     }
-
+    
     @AfterEach
     void tearDown() {
     }
-
+    
     @Test
     void handleWithInvalidParameter() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -100,7 +100,7 @@ class ReleaseMcpServerRequestHandlerTest {
         assertErrorResponse(response, NacosException.INVALID_PARAM,
                 "Required parameter `serverSpecification.versionDetail.version` not present");
     }
-
+    
     @Test
     void handleReleaseExistedServerAndVersion() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -113,7 +113,7 @@ class ReleaseMcpServerRequestHandlerTest {
         assertErrorResponse(response, NacosException.CONFLICT,
                 "Mcp Server test and target version 1.0.0 already exist, do not do release");
     }
-
+    
     @Test
     void handleReleaseNewServerForSse() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -130,7 +130,7 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
     }
-
+    
     @Test
     void handleReleaseNewServerForSseWithSpecifiedEndpoint() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -147,7 +147,7 @@ class ReleaseMcpServerRequestHandlerTest {
         assertEquals(id, response.getMcpId());
         verify(endpointOperationService, never()).generateService(anyString(), anyString());
     }
-
+    
     @Test
     void handleReleaseNewServerForStdio() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -162,7 +162,7 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
     }
-
+    
     @Test
     void handleReleaseNewVersionWithoutLatest() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -181,7 +181,7 @@ class ReleaseMcpServerRequestHandlerTest {
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
                 eq(request.getServerSpecification()), isNull(), isNull(), isNotNull(), eq(false));
     }
-
+    
     @Test
     void handleReleaseNewVersionWithoutLatestWithSpecifiedEndpoint() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -200,7 +200,7 @@ class ReleaseMcpServerRequestHandlerTest {
                 eq(request.getServerSpecification()), isNull(), isNull(), isNotNull(), eq(false));
         verify(endpointOperationService, never()).generateService(anyString(), anyString());
     }
-
+    
     @Test
     void handleReleaseNewVersionWithLatest() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -219,7 +219,7 @@ class ReleaseMcpServerRequestHandlerTest {
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
                 eq(request.getServerSpecification()), isNull(), isNull(), isNotNull(), eq(false));
     }
-
+    
     @Test
     void handleReleaseWithException() throws NacosException {
         NacosApiException exceptedException = new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.SERVER_ERROR,
@@ -234,7 +234,7 @@ class ReleaseMcpServerRequestHandlerTest {
             assertEquals(exceptedException, e);
         }
     }
-
+    
     private McpServerBasicInfo buildMockServerSpecification(boolean isStdio, boolean isLatest) {
         McpServerBasicInfo result = new McpServerBasicInfo();
         result.setName("test");
@@ -253,7 +253,7 @@ class ReleaseMcpServerRequestHandlerTest {
         }
         return result;
     }
-
+    
     private McpServerDetailInfo buildMockServerDetail() {
         McpServerDetailInfo result = new McpServerDetailInfo();
         result.setName("test");
@@ -263,7 +263,7 @@ class ReleaseMcpServerRequestHandlerTest {
         result.setId(UUID.randomUUID().toString());
         return result;
     }
-
+    
     private void assertErrorResponse(ReleaseMcpServerResponse response, int code, String message) {
         assertEquals(ResponseCode.FAIL.getCode(), response.getResultCode());
         assertEquals(code, response.getErrorCode());

--- a/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandlerTest.java
@@ -54,31 +54,31 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ReleaseMcpServerRequestHandlerTest {
-    
+
     @Mock
     private McpServerOperationService mcpServerOperationService;
-    
+
     @Mock
     private McpEndpointOperationService endpointOperationService;
-    
+
     @Mock
     private McpServerIndex mcpServerIndex;
-    
+
     @Mock
     private RequestMeta meta;
-    
+
     ReleaseMcpServerRequestHandler requestHandler;
-    
+
     @BeforeEach
     void setUp() {
         requestHandler = new ReleaseMcpServerRequestHandler(mcpServerOperationService, endpointOperationService,
                 mcpServerIndex);
     }
-    
+
     @AfterEach
     void tearDown() {
     }
-    
+
     @Test
     void handleWithInvalidParameter() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -100,7 +100,7 @@ class ReleaseMcpServerRequestHandlerTest {
         assertErrorResponse(response, NacosException.INVALID_PARAM,
                 "Required parameter `serverSpecification.versionDetail.version` not present");
     }
-    
+
     @Test
     void handleReleaseExistedServerAndVersion() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -113,7 +113,7 @@ class ReleaseMcpServerRequestHandlerTest {
         assertErrorResponse(response, NacosException.CONFLICT,
                 "Mcp Server test and target version 1.0.0 already exist, do not do release");
     }
-    
+
     @Test
     void handleReleaseNewServerForSse() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -130,7 +130,7 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
     }
-    
+
     @Test
     void handleReleaseNewServerForSseWithSpecifiedEndpoint() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -147,7 +147,7 @@ class ReleaseMcpServerRequestHandlerTest {
         assertEquals(id, response.getMcpId());
         verify(endpointOperationService, never()).generateService(anyString(), anyString());
     }
-    
+
     @Test
     void handleReleaseNewServerForStdio() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -162,7 +162,7 @@ class ReleaseMcpServerRequestHandlerTest {
         ReleaseMcpServerResponse response = requestHandler.handle(request, meta);
         assertEquals(id, response.getMcpId());
     }
-    
+
     @Test
     void handleReleaseNewVersionWithoutLatest() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -181,7 +181,7 @@ class ReleaseMcpServerRequestHandlerTest {
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(false),
                 eq(request.getServerSpecification()), isNull(), isNull(), isNotNull(), eq(false));
     }
-    
+
     @Test
     void handleReleaseNewVersionWithoutLatestWithSpecifiedEndpoint() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -200,7 +200,7 @@ class ReleaseMcpServerRequestHandlerTest {
                 eq(request.getServerSpecification()), isNull(), isNull(), isNotNull(), eq(false));
         verify(endpointOperationService, never()).generateService(anyString(), anyString());
     }
-    
+
     @Test
     void handleReleaseNewVersionWithLatest() throws NacosException {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -219,7 +219,7 @@ class ReleaseMcpServerRequestHandlerTest {
         verify(mcpServerOperationService).updateMcpServer(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), eq(true),
                 eq(request.getServerSpecification()), isNull(), isNull(), isNotNull(), eq(false));
     }
-    
+
     @Test
     void handleReleaseWithException() throws NacosException {
         NacosApiException exceptedException = new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.SERVER_ERROR,
@@ -234,7 +234,7 @@ class ReleaseMcpServerRequestHandlerTest {
             assertEquals(exceptedException, e);
         }
     }
-    
+
     private McpServerBasicInfo buildMockServerSpecification(boolean isStdio, boolean isLatest) {
         McpServerBasicInfo result = new McpServerBasicInfo();
         result.setName("test");
@@ -253,7 +253,7 @@ class ReleaseMcpServerRequestHandlerTest {
         }
         return result;
     }
-    
+
     private McpServerDetailInfo buildMockServerDetail() {
         McpServerDetailInfo result = new McpServerDetailInfo();
         result.setName("test");
@@ -263,7 +263,7 @@ class ReleaseMcpServerRequestHandlerTest {
         result.setId(UUID.randomUUID().toString());
         return result;
     }
-    
+
     private void assertErrorResponse(ReleaseMcpServerResponse response, int code, String message) {
         assertEquals(ResponseCode.FAIL.getCode(), response.getResultCode());
         assertEquals(code, response.getErrorCode());

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpResourceOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpResourceOperationServiceTest.java
@@ -48,20 +48,20 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class McpResourceOperationServiceTest {
-    
+
     @Mock
     private ConfigQueryChainService configQueryChainService;
-    
+
     @Mock
     private ConfigOperationService configOperationService;
-    
+
     private McpResourceOperationService resourceOperationService;
-    
+
     @BeforeEach
     void setUp() {
         resourceOperationService = new McpResourceOperationService(configQueryChainService, configOperationService);
     }
-    
+
     @Test
     void refreshMcpResource() throws NacosException {
         McpServerBasicInfo serverBasicInfo = getMcpServerBasicInfo();
@@ -70,7 +70,7 @@ class McpResourceOperationServiceTest {
                 resourceSpecification);
         verify(configOperationService).publishConfig(any(ConfigFormV3.class), any(ConfigRequestInfo.class), isNull());
     }
-    
+
     @Test
     void getMcpResource() {
         ConfigQueryChainResponse response = new ConfigQueryChainResponse();
@@ -84,7 +84,7 @@ class McpResourceOperationServiceTest {
                 AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, resourceRef);
         assertNotNull(actual);
     }
-    
+
     @Test
     void getMcpResourceNotFound() {
         ConfigQueryChainResponse response = new ConfigQueryChainResponse();
@@ -97,7 +97,7 @@ class McpResourceOperationServiceTest {
                 AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, resourceRef);
         assertNull(actual);
     }
-    
+
     @Test
     void deleteMcpResource() throws NacosException {
         String id = UUID.randomUUID().toString();
@@ -106,7 +106,7 @@ class McpResourceOperationServiceTest {
                 Constants.MCP_SERVER_RESOURCE_GROUP, AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos",
                 null);
     }
-    
+
     private McpServerBasicInfo getMcpServerBasicInfo() {
         String id = UUID.randomUUID().toString();
         McpServerBasicInfo serverBasicInfo = new McpServerBasicInfo();
@@ -121,7 +121,7 @@ class McpResourceOperationServiceTest {
         serverBasicInfo.setVersionDetail(serverVersionDetail);
         return serverBasicInfo;
     }
-    
+
     private McpResourceSpecification getMcpResourceSpecification() {
         McpResourceSpecification resourceSpecification = new McpResourceSpecification();
         HashMap<String, Object> resource = new HashMap<>();

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpResourceOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpResourceOperationServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.utils.McpConfigUtils;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
+import com.alibaba.nacos.config.server.model.form.ConfigFormV3;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpResourceOperationServiceTest {
+    
+    @Mock
+    private ConfigQueryChainService configQueryChainService;
+    
+    @Mock
+    private ConfigOperationService configOperationService;
+    
+    private McpResourceOperationService resourceOperationService;
+    
+    @BeforeEach
+    void setUp() {
+        resourceOperationService = new McpResourceOperationService(configQueryChainService, configOperationService);
+    }
+    
+    @Test
+    void refreshMcpResource() throws NacosException {
+        McpServerBasicInfo serverBasicInfo = getMcpServerBasicInfo();
+        McpResourceSpecification resourceSpecification = getMcpResourceSpecification();
+        resourceOperationService.refreshMcpResource(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, serverBasicInfo,
+                resourceSpecification);
+        verify(configOperationService).publishConfig(any(ConfigFormV3.class), any(ConfigRequestInfo.class), isNull());
+    }
+    
+    @Test
+    void getMcpResource() {
+        ConfigQueryChainResponse response = new ConfigQueryChainResponse();
+        response.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        response.setContent(JacksonUtils.toJson(getMcpResourceSpecification()));
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(response);
+        String id = UUID.randomUUID().toString();
+        String version = "1.0.0";
+        String resourceRef = McpConfigUtils.formatServerResourceSpecDataId(id, version);
+        McpResourceSpecification actual = resourceOperationService.getMcpResource(
+                AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, resourceRef);
+        assertNotNull(actual);
+    }
+    
+    @Test
+    void getMcpResourceNotFound() {
+        ConfigQueryChainResponse response = new ConfigQueryChainResponse();
+        response.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND);
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(response);
+        String id = UUID.randomUUID().toString();
+        String version = "1.0.0";
+        String resourceRef = McpConfigUtils.formatServerResourceSpecDataId(id, version);
+        McpResourceSpecification actual = resourceOperationService.getMcpResource(
+                AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, resourceRef);
+        assertNull(actual);
+    }
+    
+    @Test
+    void deleteMcpResource() throws NacosException {
+        String id = UUID.randomUUID().toString();
+        resourceOperationService.deleteMcpResource(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id, "1.0.0");
+        verify(configOperationService).deleteConfig(McpConfigUtils.formatServerResourceSpecDataId(id, "1.0.0"),
+                Constants.MCP_SERVER_RESOURCE_GROUP, AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos",
+                null);
+    }
+    
+    private McpServerBasicInfo getMcpServerBasicInfo() {
+        String id = UUID.randomUUID().toString();
+        McpServerBasicInfo serverBasicInfo = new McpServerBasicInfo();
+        serverBasicInfo.setId(id);
+        serverBasicInfo.setName("mcpName");
+        serverBasicInfo.setProtocol(AiConstants.Mcp.MCP_PROTOCOL_STDIO);
+        serverBasicInfo.setDescription("Mock Mcp Server");
+        serverBasicInfo.setEnabled(true);
+        serverBasicInfo.setFrontProtocol(AiConstants.Mcp.MCP_PROTOCOL_STDIO);
+        ServerVersionDetail serverVersionDetail = new ServerVersionDetail();
+        serverVersionDetail.setVersion("1.0.0");
+        serverBasicInfo.setVersionDetail(serverVersionDetail);
+        return serverBasicInfo;
+    }
+    
+    private McpResourceSpecification getMcpResourceSpecification() {
+        McpResourceSpecification resourceSpecification = new McpResourceSpecification();
+        HashMap<String, Object> resource = new HashMap<>();
+        resource.put("name", "readme");
+        resource.put("uri", "file:///README.md");
+        resourceSpecification.getResources().add(resource);
+        return resourceSpecification;
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerImportServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerImportServiceTest.java
@@ -46,6 +46,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -471,8 +472,9 @@ class McpServerImportServiceTest {
         assertEquals(1, response.getSuccessCount());
         assertEquals(0, response.getFailedCount());
         assertEquals(0, response.getSkippedCount());
-        verify(operationService).updateMcpServer(eq("test-namespace"), eq(true), any(), any(), any(), anyBoolean());
-        verify(operationService, never()).createMcpServer(anyString(), any(), any(), any());
+        verify(operationService).updateMcpServer(eq("test-namespace"), eq(true), any(), any(), isNull(), any(),
+                anyBoolean());
+        verify(operationService, never()).createMcpServer(anyString(), any(), any(), any(), any());
     }
 
     @Test
@@ -517,8 +519,9 @@ class McpServerImportServiceTest {
         assertEquals(1, response.getSuccessCount());
         assertEquals(0, response.getFailedCount());
         assertEquals(0, response.getSkippedCount());
-        verify(operationService).createMcpServer(eq("test-namespace"), any(), any(), any());
-        verify(operationService, never()).updateMcpServer(anyString(), anyBoolean(), any(), any(), any(), anyBoolean());
+        verify(operationService).createMcpServer(eq("test-namespace"), any(), any(), isNull(), any());
+        verify(operationService, never()).updateMcpServer(anyString(), anyBoolean(), any(), any(), any(), any(),
+                anyBoolean());
     }
 
     @Test
@@ -571,7 +574,7 @@ class McpServerImportServiceTest {
         assertTrue(response.isSuccess());
         assertEquals(1, response.getTotalCount());
         assertEquals(1, response.getSuccessCount());
-        verify(operationService).createMcpServer(eq("test-namespace"), any(), any(), any());
+        verify(operationService).createMcpServer(eq("test-namespace"), any(), any(), isNull(), any());
     }
 
     @Test
@@ -617,7 +620,7 @@ class McpServerImportServiceTest {
         assertTrue(response.isSuccess());
         assertEquals(1, response.getTotalCount());
         assertEquals(1, response.getSuccessCount());
-        verify(operationService).createMcpServer(eq("test-namespace"), any(), any(), any());
+        verify(operationService).createMcpServer(eq("test-namespace"), any(), any(), isNull(), any());
     }
 
     @Test
@@ -655,7 +658,7 @@ class McpServerImportServiceTest {
 
         // Mock operation service to throw exception
         doThrow(new NacosException(500, "Failed to create server")).when(operationService)
-                .createMcpServer(anyString(), any(), any(), any());
+                .createMcpServer(anyString(), any(), any(), any(), any());
 
         // When
         McpServerImportResponse response = importService.executeImport("test-namespace", request);
@@ -729,6 +732,6 @@ class McpServerImportServiceTest {
         assertEquals(1, response.getTotalCount());
         assertEquals(0, response.getSuccessCount());
         assertEquals(1, response.getFailedCount());
-        verify(operationService, never()).createMcpServer(eq("test-namespace"), any(), any(), any());
+        verify(operationService, never()).createMcpServer(eq("test-namespace"), any(), any(), any(), any());
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerImportServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerImportServiceTest.java
@@ -438,7 +438,7 @@ class McpServerImportServiceTest {
         List<McpServerDetailInfo> servers = new ArrayList<>();
         when(transformService.adaptExternalDataToNacosMcpServerFormat(any())).thenReturn(
                 servers);
-
+        
         // Mock existing server in cache index
         McpServerIndexData data = new McpServerIndexData();
         when(mcpCacheIndex.getMcpServerByName(eq("test-namespace"), eq("Test Server"))).thenReturn(data);

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerImportServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerImportServiceTest.java
@@ -438,7 +438,7 @@ class McpServerImportServiceTest {
         List<McpServerDetailInfo> servers = new ArrayList<>();
         when(transformService.adaptExternalDataToNacosMcpServerFormat(any())).thenReturn(
                 servers);
-        
+
         // Mock existing server in cache index
         McpServerIndexData data = new McpServerIndexData();
         when(mcpCacheIndex.getMcpServerByName(eq("test-namespace"), eq("Test Server"))).thenReturn(data);

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
@@ -646,31 +646,6 @@ class McpServerOperationServiceTest {
     }
 
     @Test
-    void createMcpServerWithEncryptedToolSpecOnly() throws NacosException {
-        McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
-        mockServerBasicInfo.setVersionDetail(mockVersion("1.0.0"));
-
-        McpToolSpecification toolSpecification = new McpToolSpecification();
-        toolSpecification.setSpecificationType("encrypted");
-        EncryptObject encryptObject = new EncryptObject();
-        encryptObject.setData("ciphertext");
-        toolSpecification.setEncryptData(encryptObject);
-
-        String id = serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
-                toolSpecification, null);
-        assertNotNull(id);
-
-        // should trigger tool refresh even when tools/securitySchemes are empty
-        verify(toolOperationService, times(1)).refreshMcpTool(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
-                any(McpServerStorageInfo.class), eq(toolSpecification));
-        verify(configOperationService, times(2)).publishConfig(any(ConfigFormV3.class), any(ConfigRequestInfo.class),
-                isNull());
-        verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
-                mockServerBasicInfo.getName());
-        verify(mcpServerIndex, times(1)).removeMcpServerById(id);
-    }
-
-    @Test
     void createMcpServerWithEndpointSpec() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
         mockServerBasicInfo.setVersionDetail(mockVersion("1.0.0"));

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.FrontEndpointConfig;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
 import com.alibaba.nacos.api.ai.model.mcp.EncryptObject;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerRemoteServiceConfig;
@@ -77,37 +78,41 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class McpServerOperationServiceTest {
-    
+
     @Mock
     private ConfigQueryChainService configQueryChainService;
-    
+
     @Mock
     private ConfigOperationService configOperationService;
-    
+
     @Mock
     private McpToolOperationService toolOperationService;
-    
+
+    @Mock
+    private McpResourceOperationService resourceOperationService;
+
     @Mock
     private McpEndpointOperationService endpointOperationService;
-    
+
     @Mock
     private McpServerIndex mcpServerIndex;
-    
+
     @Mock
     private SyncEffectService syncEffectService;
-    
+
     McpServerOperationService serverOperationService;
-    
+
     @BeforeEach
     void setUp() {
         serverOperationService = new McpServerOperationService(configQueryChainService, configOperationService,
-                toolOperationService, endpointOperationService, mcpServerIndex, syncEffectService);
+                toolOperationService, resourceOperationService, endpointOperationService, mcpServerIndex,
+                syncEffectService);
     }
-    
+
     @AfterEach
     void tearDown() {
     }
-    
+
     @Test
     void listMcpServerWithPage() {
         String id = mockId();
@@ -127,7 +132,7 @@ class McpServerOperationServiceTest {
         assertEquals("mcpName", result.getPageItems().get(0).getName());
         assertEquals("9.9.9", result.getPageItems().get(0).getVersion());
     }
-    
+
     @Test
     void listMcpServerWithOverPageNo() {
         Page<McpServerIndexData> mockIndexData = new Page<>();
@@ -144,7 +149,7 @@ class McpServerOperationServiceTest {
         assertEquals(1, result.getTotalCount());
         assertEquals(0, result.getPageItems().size());
     }
-    
+
     @Test
     void getMcpServerDetailByIdFoundStdioTypeWithToolsWithNamespace() throws NacosException {
         String id = mockId();
@@ -163,8 +168,26 @@ class McpServerOperationServiceTest {
         assertEquals("9.9.9", actual.getVersionDetail().getVersion());
         assertTrue(actual.getVersionDetail().getIs_latest());
         assertNotNull(actual.getToolSpec());
+        assertEquals(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, actual.getNamespaceId());
     }
-    
+
+    @Test
+    void getMcpServerDetailByIdFoundStdioTypeWithResourcesWithNamespace() throws NacosException {
+        String id = mockId();
+        ConfigQueryChainResponse versionDataResponse = mockConfigQueryChainResponse(mockServerVersionInfo(id));
+        McpServerStorageInfo storageInfo = mockStorageInfo(id, true, false, AiConstants.Mcp.MCP_PROTOCOL_STDIO);
+        storageInfo.setResourceDescriptionRef(McpConfigUtils.formatServerResourceSpecDataId(id, "9.9.9"));
+        ConfigQueryChainResponse storageDataResponse = mockConfigQueryChainResponse(storageInfo);
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(versionDataResponse,
+                storageDataResponse);
+        when(resourceOperationService.getMcpResource(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
+                McpConfigUtils.formatServerResourceSpecDataId(id, "9.9.9"))).thenReturn(mockResourceSpecification());
+        McpServerDetailInfo actual = serverOperationService.getMcpServerDetail(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
+                id, null, null);
+        assertNotNull(actual.getResourceSpec());
+        assertEquals(1, actual.getResourceSpec().getResources().size());
+    }
+
     @Test
     void getMcpServerDetailByIdFoundSseTypeWithoutToolsWithNamespace() throws NacosException {
         String id = mockId();
@@ -198,7 +221,7 @@ class McpServerOperationServiceTest {
         assertEquals("127.0.0.1", actual.getBackendEndpoints().get(0).getAddress());
         assertEquals(8848, actual.getBackendEndpoints().get(0).getPort());
     }
-    
+
     @Test
     void getMcpServerDetailByIdFoundHttpTypeWithoutToolsWithNamespace() throws NacosException {
         String id = mockId();
@@ -235,7 +258,7 @@ class McpServerOperationServiceTest {
         assertEquals(8848, actual.getBackendEndpoints().get(0).getPort());
         assertEquals("/nacos", actual.getBackendEndpoints().get(0).getPath());
     }
-    
+
     @Test
     void getMcpServerDetailByIdWithServiceRefFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -279,7 +302,7 @@ class McpServerOperationServiceTest {
         assertEquals(8848, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/sse", actual.getFrontendEndpoints().get(0).getPath());
     }
-    
+
     @Test
     void getMcpServerDetailByIdWithDirectFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -314,7 +337,7 @@ class McpServerOperationServiceTest {
         assertEquals(8848, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/sse", actual.getFrontendEndpoints().get(0).getPath());
     }
-    
+
     @Test
     void getMcpServerDetailByIdWithDirectNoPortFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -349,7 +372,7 @@ class McpServerOperationServiceTest {
         assertEquals(80, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/sse", actual.getFrontendEndpoints().get(0).getPath());
     }
-    
+
     @Test
     void getMcpServerDetailByIdWithDirectNoPortForHttpsFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -384,7 +407,7 @@ class McpServerOperationServiceTest {
         assertEquals(443, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/sse", actual.getFrontendEndpoints().get(0).getPath());
     }
-    
+
     @Test
     void getMcpServerDetailByIdWithToBackendFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -429,7 +452,7 @@ class McpServerOperationServiceTest {
         assertEquals(8848, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/nacos", actual.getFrontendEndpoints().get(0).getPath());
     }
-    
+
     @Test
     void getMcpServerDetailByIdNotFoundWithNamespace() throws NacosException {
         String id = mockId();
@@ -438,7 +461,7 @@ class McpServerOperationServiceTest {
         assertThrows(NacosApiException.class,
                 () -> serverOperationService.getMcpServerDetail(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id, null, null));
     }
-    
+
     @Test
     void getMcpServerDetailByIdFoundWithNamespace() throws NacosException {
         String id = mockId();
@@ -456,7 +479,7 @@ class McpServerOperationServiceTest {
         assertTrue(actual.getVersionDetail().getIs_latest());
         assertNull(actual.getToolSpec());
     }
-    
+
     @Test
     void getMcpServerDetailByIdNotFoundWithVersion() throws NacosException {
         String id = mockId();
@@ -468,7 +491,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.getMcpServerDetail(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id, null,
                         "non-exist"));
     }
-    
+
     @Test
     void getMcpServerDetailByIdFoundWithVersion() throws NacosException {
         String id = mockId();
@@ -486,7 +509,7 @@ class McpServerOperationServiceTest {
         assertFalse(actual.getVersionDetail().getIs_latest());
         assertNull(actual.getToolSpec());
     }
-    
+
     @Test
     void getMcpServerDetailByNameNotFound() throws NacosException {
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(
@@ -495,7 +518,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.getMcpServerDetail(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, "mcpName",
                         null));
     }
-    
+
     @Test
     void getMcpServerDetailByNameFound() throws NacosException {
         String id = mockId();
@@ -515,7 +538,7 @@ class McpServerOperationServiceTest {
         assertTrue(actual.getVersionDetail().getIs_latest());
         assertNull(actual.getToolSpec());
     }
-    
+
     @Test
     void createMcpServerExistedName() {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -525,7 +548,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
                         null, null));
     }
-    
+
     @Test
     void createMcpServerWithoutVersion() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -534,7 +557,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
                         null, null));
     }
-    
+
     @Test
     void createMcpServerWithOldSpec() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -549,7 +572,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-    
+
     @Test
     void createMcpServerWithNewSpec() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -564,7 +587,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-    
+
     @Test
     void createMcpServerWithToolSpec() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -581,6 +604,45 @@ class McpServerOperationServiceTest {
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
+    }
+
+    @Test
+    void createMcpServerWithEncryptedToolSpecOnly() throws NacosException {
+        McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
+        mockServerBasicInfo.setVersionDetail(mockVersion("1.0.0"));
+
+        McpToolSpecification toolSpecification = new McpToolSpecification();
+        toolSpecification.setSpecificationType("encrypted");
+        EncryptObject encryptObject = new EncryptObject();
+        encryptObject.setData("ciphertext");
+        toolSpecification.setEncryptData(encryptObject);
+
+        String id = serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
+                toolSpecification, null);
+        assertNotNull(id);
+
+        // should trigger tool refresh even when tools/securitySchemes are empty
+        verify(toolOperationService, times(1)).refreshMcpTool(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
+                any(McpServerStorageInfo.class), eq(toolSpecification));
+        verify(configOperationService, times(2)).publishConfig(any(ConfigFormV3.class), any(ConfigRequestInfo.class),
+                isNull());
+        verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
+                mockServerBasicInfo.getName());
+        verify(mcpServerIndex, times(1)).removeMcpServerById(id);
+    }
+
+    @Test
+    void createMcpServerWithResourceSpec() throws NacosException {
+        McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
+        mockServerBasicInfo.setVersionDetail(mockVersion("1.0.0"));
+        McpResourceSpecification resourceSpecification = mockResourceSpecification();
+        String id = serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
+                null, resourceSpecification, null);
+        assertNotNull(id);
+        verify(resourceOperationService).refreshMcpResource(eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE),
+                any(McpServerStorageInfo.class), eq(resourceSpecification));
+        verify(configOperationService, times(2)).publishConfig(any(ConfigFormV3.class), any(ConfigRequestInfo.class),
+                isNull());
     }
 
     @Test
@@ -630,7 +692,7 @@ class McpServerOperationServiceTest {
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName");
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-    
+
     @Test
     void createMcpServerByCustomIdWithException() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -646,7 +708,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
                         null, null));
     }
-    
+
     @Test
     void createMcpServerByCustomIdWithExistedId() throws NacosException {
         String id = UUID.randomUUID().toString();
@@ -664,7 +726,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
                         null, null));
     }
-    
+
     @Test
     void createMcpServerByCustomId() throws NacosException {
         String id = UUID.randomUUID().toString();
@@ -690,7 +752,7 @@ class McpServerOperationServiceTest {
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName");
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-    
+
     @Test
     void updateMcpServerByIdNotFound() {
         String id = mockId();
@@ -699,7 +761,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true,
                         mockServerBasicInfo, null, null, false));
     }
-    
+
     @Test
     void updateMcpServerByIdWithoutVersion() {
         String id = mockId();
@@ -710,7 +772,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true,
                         mockServerBasicInfo, null, null, false));
     }
-    
+
     @Test
     void updateMcpServerByIdWithOldSpec() throws NacosException {
         String id = mockId();
@@ -727,7 +789,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-    
+
     @Test
     void updateMcpServerByIdWithNewSpec() throws NacosException {
         String id = mockId();
@@ -744,7 +806,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-    
+
     @Test
     void updateMcpServerByIdNewVersion() throws NacosException {
         String id = mockId();
@@ -761,7 +823,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-    
+
     @Test
     void updateMcpServerByNameNotFound() {
         McpServerVersionInfo mockServerBasicInfo = mockServerVersionInfo(null);
@@ -769,7 +831,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true,
                         mockServerBasicInfo, null, null, false));
     }
-    
+
     @Test
     void updateMcpServerByNameFound() throws NacosException {
         String id = mockId();
@@ -814,7 +876,7 @@ class McpServerOperationServiceTest {
                 updateSpec.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-    
+
     @Test
     void deleteMcpServerByIdNotFound() {
         String id = mockId();
@@ -823,7 +885,7 @@ class McpServerOperationServiceTest {
         assertThrows(NacosApiException.class,
                 () -> serverOperationService.deleteMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, id, null));
     }
-    
+
     @Test
     void deleteMcpServerById() throws NacosException {
         String id = mockId();
@@ -846,12 +908,14 @@ class McpServerOperationServiceTest {
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
         for (ServerVersionDetail each : mockServerVersionInfo(id).getVersionDetails()) {
             verify(toolOperationService).deleteMcpTool(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id, each.getVersion());
+            verify(resourceOperationService).deleteMcpResource(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id,
+                    each.getVersion());
             String serverSpecDataId = McpConfigUtils.formatServerSpecInfoDataId(id, each.getVersion());
             verify(configOperationService).deleteConfig(serverSpecDataId, Constants.MCP_SERVER_GROUP,
                     AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
         }
     }
-    
+
     @Test
     void deleteMcpServerByName() throws NacosException {
         String id = mockId();
@@ -877,12 +941,14 @@ class McpServerOperationServiceTest {
                 AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
         for (ServerVersionDetail each : mockServerVersionInfo(id).getVersionDetails()) {
             verify(toolOperationService).deleteMcpTool(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id, each.getVersion());
+            verify(resourceOperationService).deleteMcpResource(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id,
+                    each.getVersion());
             String serverSpecDataId = McpConfigUtils.formatServerSpecInfoDataId(id, each.getVersion());
             verify(configOperationService).deleteConfig(serverSpecDataId, Constants.MCP_SERVER_GROUP,
                     AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
         }
     }
-    
+
     @Test
     void deleteMcpServerForTargetVersion() throws NacosException {
         String id = mockId();
@@ -897,25 +963,26 @@ class McpServerOperationServiceTest {
         verify(configOperationService).deleteConfig(serverVersionDataId, Constants.MCP_SERVER_VERSIONS_GROUP,
                 AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
         verify(toolOperationService).deleteMcpTool(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id, "1.0.0");
+        verify(resourceOperationService).deleteMcpResource(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id, "1.0.0");
         String serverSpecDataId = McpConfigUtils.formatServerSpecInfoDataId(id, "1.0.0");
         verify(configOperationService).deleteConfig(serverSpecDataId, Constants.MCP_SERVER_GROUP,
                 AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
     }
-    
+
     @Test
     void invalidateCacheAfterDbUpdateOperationWithDifferentNames() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String oldMcpName = "oldName";
         String newMcpName = "newName";
         String mcpServerId = mockId();
-        
+
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbUpdateOperation", String.class, String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, oldMcpName, newMcpName, mcpServerId);
-            
+
             // 验证方法调用
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, oldMcpName);
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, newMcpName);
@@ -924,21 +991,21 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     void invalidateCacheAfterDbUpdateOperationWithSameNames() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String oldMcpName = "sameName";
         String newMcpName = "sameName";
         String mcpServerId = mockId();
-        
+
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbUpdateOperation", String.class, String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, oldMcpName, newMcpName, mcpServerId);
-            
+
             // 验证方法调用
             // 当名称相同时，只调用一次removeMcpServerByName
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, newMcpName);
@@ -947,21 +1014,21 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     void invalidateCacheAfterDbUpdateOperationWithEmptyNames() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String oldMcpName = "";
         String newMcpName = "";
         String mcpServerId = mockId();
-        
+
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbUpdateOperation", String.class, String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, oldMcpName, newMcpName, mcpServerId);
-            
+
             // 验证方法调用
             // 当名称为空时，不调用removeMcpServerByName
             verify(mcpServerIndex, never()).removeMcpServerByName(anyString(), anyString());
@@ -970,20 +1037,20 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     void invalidateCacheAfterDbOperation() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String mcpName = "testName";
         String mcpServerId = mockId();
-        
+
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbOperation", String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, mcpName, mcpServerId);
-            
+
             // 验证方法调用
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, mcpName);
             verify(mcpServerIndex, times(1)).removeMcpServerById(mcpServerId);
@@ -991,20 +1058,20 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     void invalidateCacheAfterDbOperationWithEmptyName() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String mcpName = "";
         String mcpServerId = mockId();
-        
+
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbOperation", String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, mcpName, mcpServerId);
-            
+
             // 验证方法调用
             // 当名称为空时，不调用removeMcpServerByName
             verify(mcpServerIndex, never()).removeMcpServerByName(anyString(), anyString());
@@ -1013,20 +1080,20 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     void invalidateCacheAfterDbOperationWithEmptyId() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String mcpName = "testName";
         String mcpServerId = "";
-        
+
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbOperation", String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, mcpName, mcpServerId);
-            
+
             // 验证方法调用
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, mcpName);
             // 当ID为空时，不调用removeMcpServerById
@@ -1035,43 +1102,43 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Test
     void invalidateCacheAfterDbOperationWithException() throws Exception {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String mcpName = "testName";
         String mcpServerId = mockId();
-        
+
         // 模拟mcpServerIndex抛出异常
         doThrow(new RuntimeException("Test exception")).when(mcpServerIndex).removeMcpServerByName(namespaceId, mcpName);
-        
+
         // 使用反射调用私有方法
         java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                 "invalidateCacheAfterDbOperation", String.class, String.class, String.class);
         method.setAccessible(true);
         method.invoke(serverOperationService, namespaceId, mcpName, mcpServerId);
-        
+
         // 验证方法被调用，即使有异常
         verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, mcpName);
         verify(mcpServerIndex, never()).removeMcpServerById(mcpServerId);
     }
-    
+
     @Test
     void invalidateCacheAfterDbUpdateOperationWithException() throws Exception {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String oldMcpName = "oldName";
         String newMcpName = "newName";
         String mcpServerId = mockId();
-        
+
         // 模拟mcpServerIndex抛出异常
         doThrow(new RuntimeException("Test exception")).when(mcpServerIndex).removeMcpServerByName(namespaceId, oldMcpName);
-        
+
         // 使用反射调用私有方法
         java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                 "invalidateCacheAfterDbUpdateOperation", String.class, String.class, String.class, String.class);
         method.setAccessible(true);
         method.invoke(serverOperationService, namespaceId, oldMcpName, newMcpName, mcpServerId);
-        
+
         verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, oldMcpName);
         verify(mcpServerIndex, never()).removeMcpServerByName(namespaceId, newMcpName);
         verify(mcpServerIndex, never()).removeMcpServerById(mcpServerId);
@@ -1087,7 +1154,7 @@ class McpServerOperationServiceTest {
         indexDataPage.getPageItems().get(0).setNamespaceId(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE);
         return indexDataPage;
     }
-    
+
     private ConfigQueryChainResponse mockConfigQueryChainResponse(Object obj) {
         ConfigQueryChainResponse mockResponse = new ConfigQueryChainResponse();
         if (null != obj) {
@@ -1098,7 +1165,7 @@ class McpServerOperationServiceTest {
         }
         return mockResponse;
     }
-    
+
     private McpServerVersionInfo mockServerVersionInfo(String id) {
         McpServerVersionInfo serverVersionInfo = new McpServerVersionInfo();
         serverVersionInfo.setId(id);
@@ -1110,13 +1177,13 @@ class McpServerOperationServiceTest {
         serverVersionInfo.setVersions(versionDetails);
         return serverVersionInfo;
     }
-    
+
     private ServerVersionDetail mockVersion(String version) {
         ServerVersionDetail versionDetail = new ServerVersionDetail();
         versionDetail.setVersion(version);
         return versionDetail;
     }
-    
+
     private McpServerStorageInfo mockStorageInfo(String id, boolean isLatest, boolean withTools, String protocol) {
         McpServerStorageInfo storageInfo = new McpServerStorageInfo();
         storageInfo.setId(id);
@@ -1128,8 +1195,17 @@ class McpServerOperationServiceTest {
         storageInfo.setToolsDescriptionRef(withTools ? McpConfigUtils.formatServerToolSpecDataId(id, version) : null);
         return storageInfo;
     }
-    
+
     private String mockId() {
         return UUID.randomUUID().toString();
+    }
+
+    private McpResourceSpecification mockResourceSpecification() {
+        McpResourceSpecification result = new McpResourceSpecification();
+        HashMap<String, Object> resource = new HashMap<>();
+        resource.put("name", "readme");
+        resource.put("uri", "file:///README.md");
+        result.getResources().add(resource);
+        return result;
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
@@ -78,41 +78,41 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class McpServerOperationServiceTest {
-
+    
     @Mock
     private ConfigQueryChainService configQueryChainService;
-
+    
     @Mock
     private ConfigOperationService configOperationService;
-
+    
     @Mock
     private McpToolOperationService toolOperationService;
-
+    
     @Mock
     private McpResourceOperationService resourceOperationService;
 
     @Mock
     private McpEndpointOperationService endpointOperationService;
-
+    
     @Mock
     private McpServerIndex mcpServerIndex;
-
+    
     @Mock
     private SyncEffectService syncEffectService;
-
+    
     McpServerOperationService serverOperationService;
-
+    
     @BeforeEach
     void setUp() {
         serverOperationService = new McpServerOperationService(configQueryChainService, configOperationService,
                 toolOperationService, resourceOperationService, endpointOperationService, mcpServerIndex,
                 syncEffectService);
     }
-
+    
     @AfterEach
     void tearDown() {
     }
-
+    
     @Test
     void listMcpServerWithPage() {
         String id = mockId();
@@ -132,7 +132,7 @@ class McpServerOperationServiceTest {
         assertEquals("mcpName", result.getPageItems().get(0).getName());
         assertEquals("9.9.9", result.getPageItems().get(0).getVersion());
     }
-
+    
     @Test
     void listMcpServerWithOverPageNo() {
         Page<McpServerIndexData> mockIndexData = new Page<>();
@@ -149,7 +149,7 @@ class McpServerOperationServiceTest {
         assertEquals(1, result.getTotalCount());
         assertEquals(0, result.getPageItems().size());
     }
-
+    
     @Test
     void getMcpServerDetailByIdFoundStdioTypeWithToolsWithNamespace() throws NacosException {
         String id = mockId();
@@ -187,7 +187,7 @@ class McpServerOperationServiceTest {
         assertNotNull(actual.getResourceSpec());
         assertEquals(1, actual.getResourceSpec().getResources().size());
     }
-
+    
     @Test
     void getMcpServerDetailByIdFoundSseTypeWithoutToolsWithNamespace() throws NacosException {
         String id = mockId();
@@ -221,7 +221,7 @@ class McpServerOperationServiceTest {
         assertEquals("127.0.0.1", actual.getBackendEndpoints().get(0).getAddress());
         assertEquals(8848, actual.getBackendEndpoints().get(0).getPort());
     }
-
+    
     @Test
     void getMcpServerDetailByIdFoundHttpTypeWithoutToolsWithNamespace() throws NacosException {
         String id = mockId();
@@ -258,7 +258,7 @@ class McpServerOperationServiceTest {
         assertEquals(8848, actual.getBackendEndpoints().get(0).getPort());
         assertEquals("/nacos", actual.getBackendEndpoints().get(0).getPath());
     }
-
+    
     @Test
     void getMcpServerDetailByIdWithServiceRefFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -302,7 +302,7 @@ class McpServerOperationServiceTest {
         assertEquals(8848, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/sse", actual.getFrontendEndpoints().get(0).getPath());
     }
-
+    
     @Test
     void getMcpServerDetailByIdWithDirectFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -337,7 +337,7 @@ class McpServerOperationServiceTest {
         assertEquals(8848, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/sse", actual.getFrontendEndpoints().get(0).getPath());
     }
-
+    
     @Test
     void getMcpServerDetailByIdWithDirectNoPortFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -372,7 +372,7 @@ class McpServerOperationServiceTest {
         assertEquals(80, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/sse", actual.getFrontendEndpoints().get(0).getPath());
     }
-
+    
     @Test
     void getMcpServerDetailByIdWithDirectNoPortForHttpsFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -407,7 +407,7 @@ class McpServerOperationServiceTest {
         assertEquals(443, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/sse", actual.getFrontendEndpoints().get(0).getPath());
     }
-
+    
     @Test
     void getMcpServerDetailByIdWithToBackendFrontEndpoint() throws NacosException {
         String id = mockId();
@@ -452,7 +452,7 @@ class McpServerOperationServiceTest {
         assertEquals(8848, actual.getFrontendEndpoints().get(0).getPort());
         assertEquals("/nacos", actual.getFrontendEndpoints().get(0).getPath());
     }
-
+    
     @Test
     void getMcpServerDetailByIdNotFoundWithNamespace() throws NacosException {
         String id = mockId();
@@ -461,7 +461,7 @@ class McpServerOperationServiceTest {
         assertThrows(NacosApiException.class,
                 () -> serverOperationService.getMcpServerDetail(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id, null, null));
     }
-
+    
     @Test
     void getMcpServerDetailByIdFoundWithNamespace() throws NacosException {
         String id = mockId();
@@ -479,7 +479,7 @@ class McpServerOperationServiceTest {
         assertTrue(actual.getVersionDetail().getIs_latest());
         assertNull(actual.getToolSpec());
     }
-
+    
     @Test
     void getMcpServerDetailByIdNotFoundWithVersion() throws NacosException {
         String id = mockId();
@@ -491,7 +491,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.getMcpServerDetail(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id, null,
                         "non-exist"));
     }
-
+    
     @Test
     void getMcpServerDetailByIdFoundWithVersion() throws NacosException {
         String id = mockId();
@@ -509,7 +509,7 @@ class McpServerOperationServiceTest {
         assertFalse(actual.getVersionDetail().getIs_latest());
         assertNull(actual.getToolSpec());
     }
-
+    
     @Test
     void getMcpServerDetailByNameNotFound() throws NacosException {
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class))).thenReturn(
@@ -518,7 +518,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.getMcpServerDetail(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, "mcpName",
                         null));
     }
-
+    
     @Test
     void getMcpServerDetailByNameFound() throws NacosException {
         String id = mockId();
@@ -538,7 +538,7 @@ class McpServerOperationServiceTest {
         assertTrue(actual.getVersionDetail().getIs_latest());
         assertNull(actual.getToolSpec());
     }
-
+    
     @Test
     void createMcpServerExistedName() {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -548,7 +548,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
                         null, null));
     }
-
+    
     @Test
     void createMcpServerWithoutVersion() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -557,7 +557,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
                         null, null));
     }
-
+    
     @Test
     void createMcpServerWithOldSpec() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -572,7 +572,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-
+    
     @Test
     void createMcpServerWithNewSpec() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -587,7 +587,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-
+    
     @Test
     void createMcpServerWithToolSpec() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -667,7 +667,7 @@ class McpServerOperationServiceTest {
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName");
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-
+    
     @Test
     void createMcpServerByCustomIdWithException() throws NacosException {
         McpServerBasicInfo mockServerBasicInfo = mockServerVersionInfo("");
@@ -683,7 +683,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
                         null, null));
     }
-
+    
     @Test
     void createMcpServerByCustomIdWithExistedId() throws NacosException {
         String id = UUID.randomUUID().toString();
@@ -701,7 +701,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.createMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, mockServerBasicInfo,
                         null, null));
     }
-
+    
     @Test
     void createMcpServerByCustomId() throws NacosException {
         String id = UUID.randomUUID().toString();
@@ -727,7 +727,7 @@ class McpServerOperationServiceTest {
         verify(mcpServerIndex, times(1)).removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName");
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-
+    
     @Test
     void updateMcpServerByIdNotFound() {
         String id = mockId();
@@ -736,7 +736,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true,
                         mockServerBasicInfo, null, null, false));
     }
-
+    
     @Test
     void updateMcpServerByIdWithoutVersion() {
         String id = mockId();
@@ -747,7 +747,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true,
                         mockServerBasicInfo, null, null, false));
     }
-
+    
     @Test
     void updateMcpServerByIdWithOldSpec() throws NacosException {
         String id = mockId();
@@ -764,7 +764,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-
+    
     @Test
     void updateMcpServerByIdWithNewSpec() throws NacosException {
         String id = mockId();
@@ -781,7 +781,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-
+    
     @Test
     void updateMcpServerByIdNewVersion() throws NacosException {
         String id = mockId();
@@ -798,7 +798,7 @@ class McpServerOperationServiceTest {
                 mockServerBasicInfo.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-
+    
     @Test
     void updateMcpServerByNameNotFound() {
         McpServerVersionInfo mockServerBasicInfo = mockServerVersionInfo(null);
@@ -806,7 +806,7 @@ class McpServerOperationServiceTest {
                 () -> serverOperationService.updateMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, true,
                         mockServerBasicInfo, null, null, false));
     }
-
+    
     @Test
     void updateMcpServerByNameFound() throws NacosException {
         String id = mockId();
@@ -851,7 +851,7 @@ class McpServerOperationServiceTest {
                 updateSpec.getName());
         verify(mcpServerIndex, times(1)).removeMcpServerById(id);
     }
-
+    
     @Test
     void deleteMcpServerByIdNotFound() {
         String id = mockId();
@@ -860,7 +860,7 @@ class McpServerOperationServiceTest {
         assertThrows(NacosApiException.class,
                 () -> serverOperationService.deleteMcpServer(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, id, null));
     }
-
+    
     @Test
     void deleteMcpServerById() throws NacosException {
         String id = mockId();
@@ -890,7 +890,7 @@ class McpServerOperationServiceTest {
                     AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
         }
     }
-
+    
     @Test
     void deleteMcpServerByName() throws NacosException {
         String id = mockId();
@@ -923,7 +923,7 @@ class McpServerOperationServiceTest {
                     AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
         }
     }
-
+    
     @Test
     void deleteMcpServerForTargetVersion() throws NacosException {
         String id = mockId();
@@ -943,21 +943,21 @@ class McpServerOperationServiceTest {
         verify(configOperationService).deleteConfig(serverSpecDataId, Constants.MCP_SERVER_GROUP,
                 AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
     }
-
+    
     @Test
     void invalidateCacheAfterDbUpdateOperationWithDifferentNames() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String oldMcpName = "oldName";
         String newMcpName = "newName";
         String mcpServerId = mockId();
-
+        
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbUpdateOperation", String.class, String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, oldMcpName, newMcpName, mcpServerId);
-
+            
             // 验证方法调用
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, oldMcpName);
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, newMcpName);
@@ -966,21 +966,21 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-
+    
     @Test
     void invalidateCacheAfterDbUpdateOperationWithSameNames() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String oldMcpName = "sameName";
         String newMcpName = "sameName";
         String mcpServerId = mockId();
-
+        
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbUpdateOperation", String.class, String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, oldMcpName, newMcpName, mcpServerId);
-
+            
             // 验证方法调用
             // 当名称相同时，只调用一次removeMcpServerByName
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, newMcpName);
@@ -989,21 +989,21 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-
+    
     @Test
     void invalidateCacheAfterDbUpdateOperationWithEmptyNames() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String oldMcpName = "";
         String newMcpName = "";
         String mcpServerId = mockId();
-
+        
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbUpdateOperation", String.class, String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, oldMcpName, newMcpName, mcpServerId);
-
+            
             // 验证方法调用
             // 当名称为空时，不调用removeMcpServerByName
             verify(mcpServerIndex, never()).removeMcpServerByName(anyString(), anyString());
@@ -1012,20 +1012,20 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-
+    
     @Test
     void invalidateCacheAfterDbOperation() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String mcpName = "testName";
         String mcpServerId = mockId();
-
+        
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbOperation", String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, mcpName, mcpServerId);
-
+            
             // 验证方法调用
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, mcpName);
             verify(mcpServerIndex, times(1)).removeMcpServerById(mcpServerId);
@@ -1033,20 +1033,20 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-
+    
     @Test
     void invalidateCacheAfterDbOperationWithEmptyName() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String mcpName = "";
         String mcpServerId = mockId();
-
+        
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbOperation", String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, mcpName, mcpServerId);
-
+            
             // 验证方法调用
             // 当名称为空时，不调用removeMcpServerByName
             verify(mcpServerIndex, never()).removeMcpServerByName(anyString(), anyString());
@@ -1055,20 +1055,20 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-
+    
     @Test
     void invalidateCacheAfterDbOperationWithEmptyId() {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String mcpName = "testName";
         String mcpServerId = "";
-
+        
         // 使用反射调用私有方法
         try {
             java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                     "invalidateCacheAfterDbOperation", String.class, String.class, String.class);
             method.setAccessible(true);
             method.invoke(serverOperationService, namespaceId, mcpName, mcpServerId);
-
+            
             // 验证方法调用
             verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, mcpName);
             // 当ID为空时，不调用removeMcpServerById
@@ -1077,43 +1077,43 @@ class McpServerOperationServiceTest {
             throw new RuntimeException(e);
         }
     }
-
+    
     @Test
     void invalidateCacheAfterDbOperationWithException() throws Exception {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String mcpName = "testName";
         String mcpServerId = mockId();
-
+        
         // 模拟mcpServerIndex抛出异常
         doThrow(new RuntimeException("Test exception")).when(mcpServerIndex).removeMcpServerByName(namespaceId, mcpName);
-
+        
         // 使用反射调用私有方法
         java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                 "invalidateCacheAfterDbOperation", String.class, String.class, String.class);
         method.setAccessible(true);
         method.invoke(serverOperationService, namespaceId, mcpName, mcpServerId);
-
+        
         // 验证方法被调用，即使有异常
         verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, mcpName);
         verify(mcpServerIndex, never()).removeMcpServerById(mcpServerId);
     }
-
+    
     @Test
     void invalidateCacheAfterDbUpdateOperationWithException() throws Exception {
         String namespaceId = AiConstants.Mcp.MCP_DEFAULT_NAMESPACE;
         String oldMcpName = "oldName";
         String newMcpName = "newName";
         String mcpServerId = mockId();
-
+        
         // 模拟mcpServerIndex抛出异常
         doThrow(new RuntimeException("Test exception")).when(mcpServerIndex).removeMcpServerByName(namespaceId, oldMcpName);
-
+        
         // 使用反射调用私有方法
         java.lang.reflect.Method method = McpServerOperationService.class.getDeclaredMethod(
                 "invalidateCacheAfterDbUpdateOperation", String.class, String.class, String.class, String.class);
         method.setAccessible(true);
         method.invoke(serverOperationService, namespaceId, oldMcpName, newMcpName, mcpServerId);
-
+        
         verify(mcpServerIndex, times(1)).removeMcpServerByName(namespaceId, oldMcpName);
         verify(mcpServerIndex, never()).removeMcpServerByName(namespaceId, newMcpName);
         verify(mcpServerIndex, never()).removeMcpServerById(mcpServerId);
@@ -1129,7 +1129,7 @@ class McpServerOperationServiceTest {
         indexDataPage.getPageItems().get(0).setNamespaceId(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE);
         return indexDataPage;
     }
-
+    
     private ConfigQueryChainResponse mockConfigQueryChainResponse(Object obj) {
         ConfigQueryChainResponse mockResponse = new ConfigQueryChainResponse();
         if (null != obj) {
@@ -1140,7 +1140,7 @@ class McpServerOperationServiceTest {
         }
         return mockResponse;
     }
-
+    
     private McpServerVersionInfo mockServerVersionInfo(String id) {
         McpServerVersionInfo serverVersionInfo = new McpServerVersionInfo();
         serverVersionInfo.setId(id);
@@ -1152,13 +1152,13 @@ class McpServerOperationServiceTest {
         serverVersionInfo.setVersions(versionDetails);
         return serverVersionInfo;
     }
-
+    
     private ServerVersionDetail mockVersion(String version) {
         ServerVersionDetail versionDetail = new ServerVersionDetail();
         versionDetail.setVersion(version);
         return versionDetail;
     }
-
+    
     private McpServerStorageInfo mockStorageInfo(String id, boolean isLatest, boolean withTools, String protocol) {
         McpServerStorageInfo storageInfo = new McpServerStorageInfo();
         storageInfo.setId(id);
@@ -1170,7 +1170,7 @@ class McpServerOperationServiceTest {
         storageInfo.setToolsDescriptionRef(withTools ? McpConfigUtils.formatServerToolSpecDataId(id, version) : null);
         return storageInfo;
     }
-
+    
     private String mockId() {
         return UUID.randomUUID().toString();
     }

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/McpRequestUtilTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/McpRequestUtilTest.java
@@ -36,15 +36,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class McpRequestUtilTest {
-
+    
     private static final String MCP_SERVER_SPEC_OLD = "{\"protocol\":\"stdio\",\"name\":\"nacos-mcp-server\","
             + "\"description\":\"nacos local mcp server(test version)\",\"version\":\"0.1.0\",\"enabled\":true,\"localServerConfig\":{}}";
-
+    
     private static final String MCP_SERVER_SPEC_NEW =
             "{\"protocol\":\"stdio\",\"frontProtocol\":\"stdio\",\"name\":\"nacos-mcp-server\","
                     + "\"id\":\"\",\"description\":\"nacos local mcp server(test version)\",\"versionDetail\":{\"version\":\"1.0.0\"},"
                     + "\"enabled\":true,\"localServerConfig\":{}}'";
-
+    
     private static final String MCP_TOOL_SPEC =
             "{\"tools\":[{\"name\":\"list_namespace\",\"description\":\"list namespace in nacos\","
                 + "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"string\",\"description\":\"aaa\"}}},"
@@ -53,9 +53,9 @@ class McpRequestUtilTest {
                     + "\"templates\":{\"json-go-tamplate\":{\"templateType\":\"string\",\"requestTemplate\":{\"url\":\"\",\"method\":\"GET\","
                     + "\"headers\":[],\"argsToJsonBody\":false,\"argsToUrlParam\":true,\"argsToFormBody\":true,\"body\":\"string\"},"
                     + "\"responseTemplate\":{\"body\":\"string\"}}}}}}";
-
+    
     private static final String MCP_ENDPOINT_SPEC = "{\"type\":\"DIRECT\",\"data\":{\"address\":\"127.0.0.1\",\"port\":8848}}";
-
+    
     private static final String MCP_RESOURCE_SPEC =
             "{\"resources\":[{\"name\":\"readme\",\"uri\":\"file:///README.md\",\"description\":\"test resource\"}]}";
 
@@ -72,7 +72,7 @@ class McpRequestUtilTest {
         assertTrue(actual.isEnabled());
         assertTrue(actual.getLocalServerConfig().isEmpty());
     }
-
+    
     @Test
     void parseMcpServerBasicInfoWithNewData() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -87,7 +87,7 @@ class McpRequestUtilTest {
         assertTrue(actual.isEnabled());
         assertTrue(actual.getLocalServerConfig().isEmpty());
     }
-
+    
     @Test
     void parseMcpServerBasicInfoWithNewDataNoName() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -103,7 +103,7 @@ class McpRequestUtilTest {
         assertTrue(actual.isEnabled());
         assertTrue(actual.getLocalServerConfig().isEmpty());
     }
-
+    
     @Test
     void parseMcpServerBasicInfoWithWrongData() {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -111,13 +111,13 @@ class McpRequestUtilTest {
         assertThrows(NacosApiException.class, () -> McpRequestUtil.parseMcpServerBasicInfo(mcpForm),
                 "serverSpecification or toolSpecification is invalid. Can't be parsed.");
     }
-
+    
     @Test
     void parseMcpToolsWithoutToolSpec() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
         assertNull(McpRequestUtil.parseMcpTools(mcpForm));
     }
-
+    
     @Test
     void parseMcpToolsWithWrongData() {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -125,7 +125,7 @@ class McpRequestUtilTest {
         assertThrows(NacosApiException.class, () -> McpRequestUtil.parseMcpTools(mcpForm),
                 "serverSpecification or toolSpecification is invalid. Can't be parsed.");
     }
-
+    
     @Test
     void parseMcpToolsSuccess() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -143,7 +143,7 @@ class McpRequestUtilTest {
         assertTrue(actual.getToolsMeta().get("list_namespace").isEnabled());
         assertNotNull(actual.getToolsMeta().get("list_namespace").getTemplates());
     }
-
+    
     @Test
     void parseMcpResourcesWithoutResourceSpec() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -168,7 +168,7 @@ class McpRequestUtilTest {
         mcpForm.setEndpointSpecification(MCP_ENDPOINT_SPEC);
         assertNull(McpRequestUtil.parseMcpEndpointSpec(mcpServerBasicInfo, mcpForm));
     }
-
+    
     @Test
     void parseMcpEndpointSpecWithoutSpec() {
         McpServerBasicInfo mcpServerBasicInfo = new McpServerBasicInfo();
@@ -177,7 +177,7 @@ class McpRequestUtilTest {
                 () -> McpRequestUtil.parseMcpEndpointSpec(mcpServerBasicInfo, new McpDetailForm()),
                 "request parameter `endpointSpecification` is required if mcp server type not `local`.");
     }
-
+    
     @Test
     void parseMcpEndpointSpecSuccess() throws NacosApiException {
         McpServerBasicInfo mcpServerBasicInfo = new McpServerBasicInfo();
@@ -190,14 +190,14 @@ class McpRequestUtilTest {
         assertEquals("127.0.0.1", actual.getData().get("address"));
         assertEquals("8848", actual.getData().get("port"));
     }
-
+    
     @Test
     void transferToMcpServiceRefForMcpServiceRef() {
         McpServiceRef mcpServiceRef = new McpServiceRef();
         McpServiceRef actual = McpRequestUtil.transferToMcpServiceRef(mcpServiceRef);
         assertEquals(mcpServiceRef, actual);
     }
-
+    
     @Test
     void transferToMcpServiceRefForMap() {
         Map<String, String> input = new HashMap<>();
@@ -209,7 +209,7 @@ class McpRequestUtilTest {
         assertEquals("testGroup", actual.getGroupName());
         assertEquals("testService", actual.getServiceName());
     }
-
+    
     @Test
     void transferToMcpServiceRefForOther() {
         assertThrows(IllegalArgumentException.class, () -> McpRequestUtil.transferToMcpServiceRef(new Object()));

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/McpRequestUtilTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/McpRequestUtilTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.ai.utils;
 import com.alibaba.nacos.ai.form.mcp.admin.McpDetailForm;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServiceRef;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
@@ -54,6 +55,9 @@ class McpRequestUtilTest {
                     + "\"responseTemplate\":{\"body\":\"string\"}}}}}}";
     
     private static final String MCP_ENDPOINT_SPEC = "{\"type\":\"DIRECT\",\"data\":{\"address\":\"127.0.0.1\",\"port\":8848}}";
+    
+    private static final String MCP_RESOURCE_SPEC =
+            "{\"resources\":[{\"name\":\"readme\",\"uri\":\"file:///README.md\",\"description\":\"test resource\"}]}";
     
     @Test
     void parseMcpServerBasicInfoWithOldData() throws NacosApiException {
@@ -138,6 +142,22 @@ class McpRequestUtilTest {
         assertNotNull(actual.getToolsMeta().get("list_namespace").getInvokeContext());
         assertTrue(actual.getToolsMeta().get("list_namespace").isEnabled());
         assertNotNull(actual.getToolsMeta().get("list_namespace").getTemplates());
+    }
+    
+    @Test
+    void parseMcpResourcesWithoutResourceSpec() throws NacosApiException {
+        McpDetailForm mcpForm = new McpDetailForm();
+        assertNull(McpRequestUtil.parseMcpResources(mcpForm));
+    }
+    
+    @Test
+    void parseMcpResourcesSuccess() throws NacosApiException {
+        McpDetailForm mcpForm = new McpDetailForm();
+        mcpForm.setResourceSpecification(MCP_RESOURCE_SPEC);
+        McpResourceSpecification actual = McpRequestUtil.parseMcpResources(mcpForm);
+        assertEquals(1, actual.getResources().size());
+        assertEquals("readme", actual.getResources().get(0).get("name"));
+        assertEquals("file:///README.md", actual.getResources().get(0).get("uri"));
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/McpRequestUtilTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/McpRequestUtilTest.java
@@ -36,15 +36,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class McpRequestUtilTest {
-    
+
     private static final String MCP_SERVER_SPEC_OLD = "{\"protocol\":\"stdio\",\"name\":\"nacos-mcp-server\","
             + "\"description\":\"nacos local mcp server(test version)\",\"version\":\"0.1.0\",\"enabled\":true,\"localServerConfig\":{}}";
-    
+
     private static final String MCP_SERVER_SPEC_NEW =
             "{\"protocol\":\"stdio\",\"frontProtocol\":\"stdio\",\"name\":\"nacos-mcp-server\","
                     + "\"id\":\"\",\"description\":\"nacos local mcp server(test version)\",\"versionDetail\":{\"version\":\"1.0.0\"},"
                     + "\"enabled\":true,\"localServerConfig\":{}}'";
-    
+
     private static final String MCP_TOOL_SPEC =
             "{\"tools\":[{\"name\":\"list_namespace\",\"description\":\"list namespace in nacos\","
                 + "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"string\",\"description\":\"aaa\"}}},"
@@ -53,12 +53,12 @@ class McpRequestUtilTest {
                     + "\"templates\":{\"json-go-tamplate\":{\"templateType\":\"string\",\"requestTemplate\":{\"url\":\"\",\"method\":\"GET\","
                     + "\"headers\":[],\"argsToJsonBody\":false,\"argsToUrlParam\":true,\"argsToFormBody\":true,\"body\":\"string\"},"
                     + "\"responseTemplate\":{\"body\":\"string\"}}}}}}";
-    
+
     private static final String MCP_ENDPOINT_SPEC = "{\"type\":\"DIRECT\",\"data\":{\"address\":\"127.0.0.1\",\"port\":8848}}";
-    
+
     private static final String MCP_RESOURCE_SPEC =
             "{\"resources\":[{\"name\":\"readme\",\"uri\":\"file:///README.md\",\"description\":\"test resource\"}]}";
-    
+
     @Test
     void parseMcpServerBasicInfoWithOldData() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -72,7 +72,7 @@ class McpRequestUtilTest {
         assertTrue(actual.isEnabled());
         assertTrue(actual.getLocalServerConfig().isEmpty());
     }
-    
+
     @Test
     void parseMcpServerBasicInfoWithNewData() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -87,7 +87,7 @@ class McpRequestUtilTest {
         assertTrue(actual.isEnabled());
         assertTrue(actual.getLocalServerConfig().isEmpty());
     }
-    
+
     @Test
     void parseMcpServerBasicInfoWithNewDataNoName() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -103,7 +103,7 @@ class McpRequestUtilTest {
         assertTrue(actual.isEnabled());
         assertTrue(actual.getLocalServerConfig().isEmpty());
     }
-    
+
     @Test
     void parseMcpServerBasicInfoWithWrongData() {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -111,13 +111,13 @@ class McpRequestUtilTest {
         assertThrows(NacosApiException.class, () -> McpRequestUtil.parseMcpServerBasicInfo(mcpForm),
                 "serverSpecification or toolSpecification is invalid. Can't be parsed.");
     }
-    
+
     @Test
     void parseMcpToolsWithoutToolSpec() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
         assertNull(McpRequestUtil.parseMcpTools(mcpForm));
     }
-    
+
     @Test
     void parseMcpToolsWithWrongData() {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -125,7 +125,7 @@ class McpRequestUtilTest {
         assertThrows(NacosApiException.class, () -> McpRequestUtil.parseMcpTools(mcpForm),
                 "serverSpecification or toolSpecification is invalid. Can't be parsed.");
     }
-    
+
     @Test
     void parseMcpToolsSuccess() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -143,13 +143,13 @@ class McpRequestUtilTest {
         assertTrue(actual.getToolsMeta().get("list_namespace").isEnabled());
         assertNotNull(actual.getToolsMeta().get("list_namespace").getTemplates());
     }
-    
+
     @Test
     void parseMcpResourcesWithoutResourceSpec() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
         assertNull(McpRequestUtil.parseMcpResources(mcpForm));
     }
-    
+
     @Test
     void parseMcpResourcesSuccess() throws NacosApiException {
         McpDetailForm mcpForm = new McpDetailForm();
@@ -159,7 +159,7 @@ class McpRequestUtilTest {
         assertEquals("readme", actual.getResources().get(0).get("name"));
         assertEquals("file:///README.md", actual.getResources().get(0).get("uri"));
     }
-    
+
     @Test
     void parseMcpEndpointSpecForStdioType() throws NacosApiException {
         McpServerBasicInfo mcpServerBasicInfo = new McpServerBasicInfo();
@@ -168,7 +168,7 @@ class McpRequestUtilTest {
         mcpForm.setEndpointSpecification(MCP_ENDPOINT_SPEC);
         assertNull(McpRequestUtil.parseMcpEndpointSpec(mcpServerBasicInfo, mcpForm));
     }
-    
+
     @Test
     void parseMcpEndpointSpecWithoutSpec() {
         McpServerBasicInfo mcpServerBasicInfo = new McpServerBasicInfo();
@@ -177,7 +177,7 @@ class McpRequestUtilTest {
                 () -> McpRequestUtil.parseMcpEndpointSpec(mcpServerBasicInfo, new McpDetailForm()),
                 "request parameter `endpointSpecification` is required if mcp server type not `local`.");
     }
-    
+
     @Test
     void parseMcpEndpointSpecSuccess() throws NacosApiException {
         McpServerBasicInfo mcpServerBasicInfo = new McpServerBasicInfo();
@@ -190,14 +190,14 @@ class McpRequestUtilTest {
         assertEquals("127.0.0.1", actual.getData().get("address"));
         assertEquals("8848", actual.getData().get("port"));
     }
-    
+
     @Test
     void transferToMcpServiceRefForMcpServiceRef() {
         McpServiceRef mcpServiceRef = new McpServiceRef();
         McpServiceRef actual = McpRequestUtil.transferToMcpServiceRef(mcpServiceRef);
         assertEquals(mcpServiceRef, actual);
     }
-    
+
     @Test
     void transferToMcpServiceRefForMap() {
         Map<String, String> input = new HashMap<>();
@@ -209,7 +209,7 @@ class McpRequestUtilTest {
         assertEquals("testGroup", actual.getGroupName());
         assertEquals("testService", actual.getServiceName());
     }
-    
+
     @Test
     void transferToMcpServiceRefForOther() {
         assertThrows(IllegalArgumentException.class, () -> McpRequestUtil.transferToMcpServiceRef(new Object()));

--- a/api/src/main/java/com/alibaba/nacos/api/ai/AiService.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/AiService.java
@@ -34,7 +34,7 @@ import com.alibaba.nacos.api.exception.NacosException;
  * @author xiweng.yy
  */
 public interface AiService extends A2aService {
-    
+
     /**
      * Get mcp server detail info for latest version.
      *
@@ -45,7 +45,7 @@ public interface AiService extends A2aService {
     default McpServerDetailInfo getMcpServer(String mcpName) throws NacosException {
         return getMcpServer(mcpName, null);
     }
-    
+
     /**
      * Get mcp server detail info.
      *
@@ -55,7 +55,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if request parameter is invalid or mcp server not found or handle error
      */
     McpServerDetailInfo getMcpServer(String mcpName, String version) throws NacosException;
-    
+
     /**
      * Release new mcp server or release new version of exist mcp server request.
      *
@@ -74,7 +74,7 @@ public interface AiService extends A2aService {
             throws NacosException {
         return releaseMcpServer(serverSpecification, toolSpecification, (McpEndpointSpec) null);
     }
-    
+
     /**
      * Release new mcp server or release new version of exist mcp server request.
      *
@@ -88,7 +88,7 @@ public interface AiService extends A2aService {
             McpResourceSpecification resourceSpecification) throws NacosException {
         return releaseMcpServer(serverSpecification, toolSpecification, resourceSpecification, null);
     }
-    
+
     /**
      * Release new mcp server or release new version of exist mcp server request.
      *
@@ -106,7 +106,7 @@ public interface AiService extends A2aService {
      */
     String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException;
-    
+
     /**
      * Release new mcp server or release new version of exist mcp server request.
      *
@@ -120,7 +120,7 @@ public interface AiService extends A2aService {
     String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification)
             throws NacosException;
-    
+
     /**
      * Register an endpoint into target mcp server for all version.
      *
@@ -132,7 +132,7 @@ public interface AiService extends A2aService {
     default void registerMcpServerEndpoint(String mcpName, String address, int port) throws NacosException {
         registerMcpServerEndpoint(mcpName, address, port, null);
     }
-    
+
     /**
      * Register an endpoint into target mcp server for target version.
      *
@@ -143,7 +143,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if request parameter is invalid or handle error
      */
     void registerMcpServerEndpoint(String mcpName, String address, int port, String version) throws NacosException;
-    
+
     /**
      * Deregister an endpoint from target mcp server for any version.
      *
@@ -158,7 +158,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if request parameter is invalid or handle error
      */
     void deregisterMcpServerEndpoint(String mcpName, String address, int port) throws NacosException;
-    
+
     /**
      * Subscribe mcp server.
      *
@@ -171,7 +171,7 @@ public interface AiService extends A2aService {
             throws NacosException {
         return subscribeMcpServer(mcpName, null, mcpServerListener);
     }
-    
+
     /**
      * Subscribe mcp server.
      *
@@ -183,7 +183,7 @@ public interface AiService extends A2aService {
      */
     McpServerDetailInfo subscribeMcpServer(String mcpName, String version,
             AbstractNacosMcpServerListener mcpServerListener) throws NacosException;
-    
+
     /**
      * Un-subscribe mcp server.
      *
@@ -195,7 +195,7 @@ public interface AiService extends A2aService {
             throws NacosException {
         unsubscribeMcpServer(mcpName, null, mcpServerListener);
     }
-    
+
     /**
      * Un-subscribe mcp server.
      *
@@ -206,7 +206,7 @@ public interface AiService extends A2aService {
      */
     void unsubscribeMcpServer(String mcpName, String version, AbstractNacosMcpServerListener mcpServerListener)
             throws NacosException;
-    
+
     /**
      * Download skill as ZIP byte array by skill name. Defaults to latest version.
      *
@@ -238,9 +238,9 @@ public interface AiService extends A2aService {
      * @throws NacosException if skill not found or query error
      */
     byte[] downloadSkillZipByLabel(String skillName, String label) throws NacosException;
-    
+
     // ==================== AgentSpec Management APIs ====================
-    
+
     /**
      * Load agent spec by agent spec name.
      *
@@ -254,7 +254,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if agent spec not found or query error
      */
     AgentSpec loadAgentSpec(String agentSpecName) throws NacosException;
-    
+
     /**
      * Subscribe agent spec.
      *
@@ -265,7 +265,7 @@ public interface AiService extends A2aService {
      */
     AgentSpec subscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException;
-    
+
     /**
      * Un-subscribe agent spec.
      *
@@ -275,9 +275,9 @@ public interface AiService extends A2aService {
      */
     void unsubscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException;
-    
+
     // ==================== Prompt Management APIs ====================
-    
+
     /**
      * Get prompt by prompt key.
      *
@@ -286,7 +286,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if prompt not found or query error
      */
     Prompt getPrompt(String promptKey) throws NacosException;
-    
+
     /**
      * Get prompt by prompt key and target version.
      *
@@ -296,7 +296,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if prompt not found or query error
      */
     Prompt getPromptByVersion(String promptKey, String version) throws NacosException;
-    
+
     /**
      * Get prompt by prompt key and target label.
      *
@@ -306,7 +306,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if prompt not found or query error
      */
     Prompt getPromptByLabel(String promptKey, String label) throws NacosException;
-    
+
     /**
      * Subscribe prompt changes.
      *
@@ -319,7 +319,7 @@ public interface AiService extends A2aService {
      */
     Prompt subscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException;
-    
+
     /**
      * Un-subscribe prompt changes.
      *
@@ -331,12 +331,12 @@ public interface AiService extends A2aService {
      */
     void unsubscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException;
-    
+
     /**
      * Shutdown the AI service and close resources.
      *
      * @throws NacosException exception.
      */
     void shutdown() throws NacosException;
-    
+
 }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/AiService.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/AiService.java
@@ -34,7 +34,7 @@ import com.alibaba.nacos.api.exception.NacosException;
  * @author xiweng.yy
  */
 public interface AiService extends A2aService {
-
+    
     /**
      * Get mcp server detail info for latest version.
      *
@@ -45,7 +45,7 @@ public interface AiService extends A2aService {
     default McpServerDetailInfo getMcpServer(String mcpName) throws NacosException {
         return getMcpServer(mcpName, null);
     }
-
+    
     /**
      * Get mcp server detail info.
      *
@@ -55,7 +55,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if request parameter is invalid or mcp server not found or handle error
      */
     McpServerDetailInfo getMcpServer(String mcpName, String version) throws NacosException;
-
+    
     /**
      * Release new mcp server or release new version of exist mcp server request.
      *
@@ -88,7 +88,7 @@ public interface AiService extends A2aService {
             McpResourceSpecification resourceSpecification) throws NacosException {
         return releaseMcpServer(serverSpecification, toolSpecification, resourceSpecification, null);
     }
-
+    
     /**
      * Release new mcp server or release new version of exist mcp server request.
      *
@@ -106,7 +106,7 @@ public interface AiService extends A2aService {
      */
     String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException;
-
+    
     /**
      * Release new mcp server or release new version of exist mcp server request.
      *
@@ -132,7 +132,7 @@ public interface AiService extends A2aService {
     default void registerMcpServerEndpoint(String mcpName, String address, int port) throws NacosException {
         registerMcpServerEndpoint(mcpName, address, port, null);
     }
-
+    
     /**
      * Register an endpoint into target mcp server for target version.
      *
@@ -143,7 +143,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if request parameter is invalid or handle error
      */
     void registerMcpServerEndpoint(String mcpName, String address, int port, String version) throws NacosException;
-
+    
     /**
      * Deregister an endpoint from target mcp server for any version.
      *
@@ -158,7 +158,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if request parameter is invalid or handle error
      */
     void deregisterMcpServerEndpoint(String mcpName, String address, int port) throws NacosException;
-
+    
     /**
      * Subscribe mcp server.
      *
@@ -171,7 +171,7 @@ public interface AiService extends A2aService {
             throws NacosException {
         return subscribeMcpServer(mcpName, null, mcpServerListener);
     }
-
+    
     /**
      * Subscribe mcp server.
      *
@@ -183,7 +183,7 @@ public interface AiService extends A2aService {
      */
     McpServerDetailInfo subscribeMcpServer(String mcpName, String version,
             AbstractNacosMcpServerListener mcpServerListener) throws NacosException;
-
+    
     /**
      * Un-subscribe mcp server.
      *
@@ -195,7 +195,7 @@ public interface AiService extends A2aService {
             throws NacosException {
         unsubscribeMcpServer(mcpName, null, mcpServerListener);
     }
-
+    
     /**
      * Un-subscribe mcp server.
      *
@@ -206,7 +206,7 @@ public interface AiService extends A2aService {
      */
     void unsubscribeMcpServer(String mcpName, String version, AbstractNacosMcpServerListener mcpServerListener)
             throws NacosException;
-
+    
     /**
      * Download skill as ZIP byte array by skill name. Defaults to latest version.
      *
@@ -238,9 +238,9 @@ public interface AiService extends A2aService {
      * @throws NacosException if skill not found or query error
      */
     byte[] downloadSkillZipByLabel(String skillName, String label) throws NacosException;
-
+    
     // ==================== AgentSpec Management APIs ====================
-
+    
     /**
      * Load agent spec by agent spec name.
      *
@@ -254,7 +254,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if agent spec not found or query error
      */
     AgentSpec loadAgentSpec(String agentSpecName) throws NacosException;
-
+    
     /**
      * Subscribe agent spec.
      *
@@ -265,7 +265,7 @@ public interface AiService extends A2aService {
      */
     AgentSpec subscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException;
-
+    
     /**
      * Un-subscribe agent spec.
      *
@@ -275,9 +275,9 @@ public interface AiService extends A2aService {
      */
     void unsubscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException;
-
+    
     // ==================== Prompt Management APIs ====================
-
+    
     /**
      * Get prompt by prompt key.
      *
@@ -286,7 +286,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if prompt not found or query error
      */
     Prompt getPrompt(String promptKey) throws NacosException;
-
+    
     /**
      * Get prompt by prompt key and target version.
      *
@@ -296,7 +296,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if prompt not found or query error
      */
     Prompt getPromptByVersion(String promptKey, String version) throws NacosException;
-
+    
     /**
      * Get prompt by prompt key and target label.
      *
@@ -306,7 +306,7 @@ public interface AiService extends A2aService {
      * @throws NacosException if prompt not found or query error
      */
     Prompt getPromptByLabel(String promptKey, String label) throws NacosException;
-
+    
     /**
      * Subscribe prompt changes.
      *
@@ -319,7 +319,7 @@ public interface AiService extends A2aService {
      */
     Prompt subscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException;
-
+    
     /**
      * Un-subscribe prompt changes.
      *
@@ -331,12 +331,12 @@ public interface AiService extends A2aService {
      */
     void unsubscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException;
-
+    
     /**
      * Shutdown the AI service and close resources.
      *
      * @throws NacosException exception.
      */
     void shutdown() throws NacosException;
-
+    
 }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/AiService.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/AiService.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.api.ai.listener.AbstractNacosMcpServerListener;
 import com.alibaba.nacos.api.ai.listener.AbstractNacosPromptListener;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
@@ -71,7 +72,21 @@ public interface AiService extends A2aService {
      */
     default String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification)
             throws NacosException {
-        return releaseMcpServer(serverSpecification, toolSpecification, null);
+        return releaseMcpServer(serverSpecification, toolSpecification, (McpEndpointSpec) null);
+    }
+    
+    /**
+     * Release new mcp server or release new version of exist mcp server request.
+     *
+     * @param serverSpecification mcp server specification
+     * @param toolSpecification mcp server tool specification
+     * @param resourceSpecification mcp server resource specification
+     * @return mcp id
+     * @throws NacosException if request parameter is invalid or handle error
+     */
+    default String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
+            McpResourceSpecification resourceSpecification) throws NacosException {
+        return releaseMcpServer(serverSpecification, toolSpecification, resourceSpecification, null);
     }
     
     /**
@@ -91,6 +106,20 @@ public interface AiService extends A2aService {
      */
     String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException;
+    
+    /**
+     * Release new mcp server or release new version of exist mcp server request.
+     *
+     * @param serverSpecification mcp server specification
+     * @param toolSpecification mcp server tool specification
+     * @param resourceSpecification mcp server resource specification
+     * @param endpointSpecification mcp server endpoint specification, optional, if null, will create ref service auto.
+     * @return mcp id
+     * @throws NacosException if request parameter is invalid or handle error
+     */
+    String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
+            McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification)
+            throws NacosException;
     
     /**
      * Register an endpoint into target mcp server for all version.

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpResourceSpecification.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpResourceSpecification.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.ai.model.mcp;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mcp resource specification.
+ *
+ * @author xiweng.yy
+ */
+public class McpResourceSpecification {
+    
+    /**
+     * Resource specification storage type. Defaults to "normal" (plaintext storage).
+     * When set to "encrypted" (or vendor-specific like "encrypt-kms"), server will persist encryptData as-is
+     * and skip parsing resources/resourceTemplates.
+     */
+    private String specificationType;
+    
+    /**
+     * Encrypted payload and metadata when specificationType indicates encryption.
+     */
+    private EncryptObject encryptData;
+    
+    private List<Map<String, Object>> resources = new LinkedList<>();
+    
+    private List<Map<String, Object>> resourceTemplates = new LinkedList<>();
+    
+    private Map<String, Object> extensions = new HashMap<>(1);
+    
+    public String getSpecificationType() {
+        return specificationType;
+    }
+    
+    public void setSpecificationType(String specificationType) {
+        this.specificationType = specificationType;
+    }
+    
+    public EncryptObject getEncryptData() {
+        return encryptData;
+    }
+    
+    public void setEncryptData(EncryptObject encryptData) {
+        this.encryptData = encryptData;
+    }
+    
+    public List<Map<String, Object>> getResources() {
+        return resources;
+    }
+    
+    public void setResources(List<Map<String, Object>> resources) {
+        this.resources = resources;
+    }
+    
+    public List<Map<String, Object>> getResourceTemplates() {
+        return resourceTemplates;
+    }
+    
+    public void setResourceTemplates(List<Map<String, Object>> resourceTemplates) {
+        this.resourceTemplates = resourceTemplates;
+    }
+    
+    public Map<String, Object> getExtensions() {
+        return extensions;
+    }
+    
+    public void setExtensions(Map<String, Object> extensions) {
+        this.extensions = extensions;
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpResourceSpecification.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpResourceSpecification.java
@@ -27,61 +27,61 @@ import java.util.Map;
  * @author xiweng.yy
  */
 public class McpResourceSpecification {
-    
+
     /**
      * Resource specification storage type. Defaults to "normal" (plaintext storage).
      * When set to "encrypted" (or vendor-specific like "encrypt-kms"), server will persist encryptData as-is
      * and skip parsing resources/resourceTemplates.
      */
     private String specificationType;
-    
+
     /**
      * Encrypted payload and metadata when specificationType indicates encryption.
      */
     private EncryptObject encryptData;
-    
+
     private List<Map<String, Object>> resources = new LinkedList<>();
-    
+
     private List<Map<String, Object>> resourceTemplates = new LinkedList<>();
-    
+
     private Map<String, Object> extensions = new HashMap<>(1);
-    
+
     public String getSpecificationType() {
         return specificationType;
     }
-    
+
     public void setSpecificationType(String specificationType) {
         this.specificationType = specificationType;
     }
-    
+
     public EncryptObject getEncryptData() {
         return encryptData;
     }
-    
+
     public void setEncryptData(EncryptObject encryptData) {
         this.encryptData = encryptData;
     }
-    
+
     public List<Map<String, Object>> getResources() {
         return resources;
     }
-    
+
     public void setResources(List<Map<String, Object>> resources) {
         this.resources = resources;
     }
-    
+
     public List<Map<String, Object>> getResourceTemplates() {
         return resourceTemplates;
     }
-    
+
     public void setResourceTemplates(List<Map<String, Object>> resourceTemplates) {
         this.resourceTemplates = resourceTemplates;
     }
-    
+
     public Map<String, Object> getExtensions() {
         return extensions;
     }
-    
+
     public void setExtensions(Map<String, Object> extensions) {
         this.extensions = extensions;
     }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpServerDetailInfo.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpServerDetailInfo.java
@@ -26,45 +26,45 @@ import java.util.List;
  * @author xiweng.yy
  */
 public class McpServerDetailInfo extends McpServerBasicInfo {
-    
+
     private List<McpEndpointInfo> backendEndpoints;
-    
+
     private List<McpEndpointInfo> frontendEndpoints;
-    
+
     private McpToolSpecification toolSpec;
-    
+
     private McpResourceSpecification resourceSpec;
-    
+
     private List<ServerVersionDetail> allVersions;
-    
+
     public List<McpEndpointInfo> getBackendEndpoints() {
         return backendEndpoints;
     }
-    
+
     public void setBackendEndpoints(List<McpEndpointInfo> backendEndpoints) {
         this.backendEndpoints = backendEndpoints;
     }
-    
+
     public List<McpEndpointInfo> getFrontendEndpoints() {
         return frontendEndpoints;
     }
-    
+
     public void setFrontendEndpoints(List<McpEndpointInfo> frontendEndpoints) {
         this.frontendEndpoints = frontendEndpoints;
     }
-    
+
     public McpToolSpecification getToolSpec() {
         return toolSpec;
     }
-    
+
     public void setToolSpec(McpToolSpecification toolSpec) {
         this.toolSpec = toolSpec;
     }
-    
+
     public McpResourceSpecification getResourceSpec() {
         return resourceSpec;
     }
-    
+
     public void setResourceSpec(McpResourceSpecification resourceSpec) {
         this.resourceSpec = resourceSpec;
     }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpServerDetailInfo.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpServerDetailInfo.java
@@ -33,6 +33,8 @@ public class McpServerDetailInfo extends McpServerBasicInfo {
     
     private McpToolSpecification toolSpec;
     
+    private McpResourceSpecification resourceSpec;
+    
     private List<ServerVersionDetail> allVersions;
     
     public List<McpEndpointInfo> getBackendEndpoints() {
@@ -57,6 +59,14 @@ public class McpServerDetailInfo extends McpServerBasicInfo {
     
     public void setToolSpec(McpToolSpecification toolSpec) {
         this.toolSpec = toolSpec;
+    }
+    
+    public McpResourceSpecification getResourceSpec() {
+        return resourceSpec;
+    }
+    
+    public void setResourceSpec(McpResourceSpecification resourceSpec) {
+        this.resourceSpec = resourceSpec;
     }
 
     public List<ServerVersionDetail> getAllVersions() {

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpServerDetailInfo.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/mcp/McpServerDetailInfo.java
@@ -26,37 +26,37 @@ import java.util.List;
  * @author xiweng.yy
  */
 public class McpServerDetailInfo extends McpServerBasicInfo {
-
+    
     private List<McpEndpointInfo> backendEndpoints;
-
+    
     private List<McpEndpointInfo> frontendEndpoints;
-
+    
     private McpToolSpecification toolSpec;
-
+    
     private McpResourceSpecification resourceSpec;
 
     private List<ServerVersionDetail> allVersions;
-
+    
     public List<McpEndpointInfo> getBackendEndpoints() {
         return backendEndpoints;
     }
-
+    
     public void setBackendEndpoints(List<McpEndpointInfo> backendEndpoints) {
         this.backendEndpoints = backendEndpoints;
     }
-
+    
     public List<McpEndpointInfo> getFrontendEndpoints() {
         return frontendEndpoints;
     }
-
+    
     public void setFrontendEndpoints(List<McpEndpointInfo> frontendEndpoints) {
         this.frontendEndpoints = frontendEndpoints;
     }
-
+    
     public McpToolSpecification getToolSpec() {
         return toolSpec;
     }
-
+    
     public void setToolSpec(McpToolSpecification toolSpec) {
         this.toolSpec = toolSpec;
     }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.api.ai.remote.request;
 
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
 
@@ -37,6 +38,8 @@ public class ReleaseMcpServerRequest extends AbstractMcpRequest {
     
     private McpToolSpecification toolSpecification;
     
+    private McpResourceSpecification resourceSpecification;
+    
     private McpEndpointSpec endpointSpecification;
     
     public McpServerBasicInfo getServerSpecification() {
@@ -53,6 +56,14 @@ public class ReleaseMcpServerRequest extends AbstractMcpRequest {
     
     public void setToolSpecification(McpToolSpecification toolSpecification) {
         this.toolSpecification = toolSpecification;
+    }
+    
+    public McpResourceSpecification getResourceSpecification() {
+        return resourceSpecification;
+    }
+    
+    public void setResourceSpecification(McpResourceSpecification resourceSpecification) {
+        this.resourceSpecification = resourceSpecification;
     }
     
     public McpEndpointSpec getEndpointSpecification() {

--- a/api/src/main/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequest.java
@@ -33,43 +33,43 @@ import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
  * @author xiweng.yy
  */
 public class ReleaseMcpServerRequest extends AbstractMcpRequest {
-    
+
     private McpServerBasicInfo serverSpecification;
-    
+
     private McpToolSpecification toolSpecification;
-    
+
     private McpResourceSpecification resourceSpecification;
-    
+
     private McpEndpointSpec endpointSpecification;
-    
+
     public McpServerBasicInfo getServerSpecification() {
         return serverSpecification;
     }
-    
+
     public void setServerSpecification(McpServerBasicInfo serverSpecification) {
         this.serverSpecification = serverSpecification;
     }
-    
+
     public McpToolSpecification getToolSpecification() {
         return toolSpecification;
     }
-    
+
     public void setToolSpecification(McpToolSpecification toolSpecification) {
         this.toolSpecification = toolSpecification;
     }
-    
+
     public McpResourceSpecification getResourceSpecification() {
         return resourceSpecification;
     }
-    
+
     public void setResourceSpecification(McpResourceSpecification resourceSpecification) {
         this.resourceSpecification = resourceSpecification;
     }
-    
+
     public McpEndpointSpec getEndpointSpecification() {
         return endpointSpecification;
     }
-    
+
     public void setEndpointSpecification(McpEndpointSpec endpointSpecification) {
         this.endpointSpecification = endpointSpecification;
     }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequest.java
@@ -33,31 +33,31 @@ import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
  * @author xiweng.yy
  */
 public class ReleaseMcpServerRequest extends AbstractMcpRequest {
-
+    
     private McpServerBasicInfo serverSpecification;
-
+    
     private McpToolSpecification toolSpecification;
-
+    
     private McpResourceSpecification resourceSpecification;
 
     private McpEndpointSpec endpointSpecification;
-
+    
     public McpServerBasicInfo getServerSpecification() {
         return serverSpecification;
     }
-
+    
     public void setServerSpecification(McpServerBasicInfo serverSpecification) {
         this.serverSpecification = serverSpecification;
     }
-
+    
     public McpToolSpecification getToolSpecification() {
         return toolSpecification;
     }
-
+    
     public void setToolSpecification(McpToolSpecification toolSpecification) {
         this.toolSpecification = toolSpecification;
     }
-
+    
     public McpResourceSpecification getResourceSpecification() {
         return resourceSpecification;
     }
@@ -69,7 +69,7 @@ public class ReleaseMcpServerRequest extends AbstractMcpRequest {
     public McpEndpointSpec getEndpointSpecification() {
         return endpointSpecification;
     }
-
+    
     public void setEndpointSpecification(McpEndpointSpec endpointSpecification) {
         this.endpointSpecification = endpointSpecification;
     }

--- a/api/src/test/java/com/alibaba/nacos/api/ai/AiFactoryTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/AiFactoryTest.java
@@ -31,10 +31,12 @@ class AiFactoryTest {
     
     @BeforeEach
     void setUp() {
+        NacosAiService.IS_THROW_EXCEPTION.set(false);
     }
     
     @AfterEach
     void tearDown() {
+        NacosAiService.IS_THROW_EXCEPTION.set(false);
     }
     
     @Test

--- a/api/src/test/java/com/alibaba/nacos/api/ai/AiFactoryTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/AiFactoryTest.java
@@ -28,23 +28,23 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AiFactoryTest {
-
+    
     @BeforeEach
     void setUp() {
         NacosAiService.IS_THROW_EXCEPTION.set(false);
     }
-
+    
     @AfterEach
     void tearDown() {
         NacosAiService.IS_THROW_EXCEPTION.set(false);
     }
-
+    
     @Test
     void createAiServiceWithException() {
         NacosAiService.IS_THROW_EXCEPTION.set(true);
         assertThrows(NacosException.class, () -> AiFactory.createAiService(new Properties()));
     }
-
+    
     @Test
     void createAiServiceSuccess() throws NacosException {
         NacosAiService.IS_THROW_EXCEPTION.set(false);

--- a/api/src/test/java/com/alibaba/nacos/api/ai/AiFactoryTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/AiFactoryTest.java
@@ -28,23 +28,23 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AiFactoryTest {
-    
+
     @BeforeEach
     void setUp() {
         NacosAiService.IS_THROW_EXCEPTION.set(false);
     }
-    
+
     @AfterEach
     void tearDown() {
         NacosAiService.IS_THROW_EXCEPTION.set(false);
     }
-    
+
     @Test
     void createAiServiceWithException() {
         NacosAiService.IS_THROW_EXCEPTION.set(true);
         assertThrows(NacosException.class, () -> AiFactory.createAiService(new Properties()));
     }
-    
+
     @Test
     void createAiServiceSuccess() throws NacosException {
         NacosAiService.IS_THROW_EXCEPTION.set(false);

--- a/api/src/test/java/com/alibaba/nacos/api/ai/AiServiceDefaultMethodTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/AiServiceDefaultMethodTest.java
@@ -22,10 +22,12 @@ import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
+import com.alibaba.nacos.client.ai.NacosAiService;
 import com.alibaba.nacos.api.exception.NacosException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,9 +39,9 @@ class AiServiceDefaultMethodTest {
     AiService aiService;
     
     @BeforeEach
-    void setUp() {
+    void setUp() throws NacosException {
         invokeMark = new AtomicBoolean(false);
-        aiService = new AiService() {
+        aiService = new NacosAiService(new Properties()) {
             @Override
             public McpServerDetailInfo getMcpServer(String mcpName, String version) throws NacosException {
                 invokeMark.set(true);
@@ -82,10 +84,6 @@ class AiServiceDefaultMethodTest {
             public void unsubscribeMcpServer(String mcpName, String version,
                     AbstractNacosMcpServerListener mcpServerListener) throws NacosException {
                 invokeMark.set(true);
-            }
-            
-            @Override
-            public void shutdown() throws NacosException {
             }
         };
     }

--- a/api/src/test/java/com/alibaba/nacos/api/ai/AiServiceDefaultMethodTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/AiServiceDefaultMethodTest.java
@@ -33,11 +33,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AiServiceDefaultMethodTest {
-    
+
     private AtomicBoolean invokeMark;
-    
+
     AiService aiService;
-    
+
     @BeforeEach
     void setUp() throws NacosException {
         invokeMark = new AtomicBoolean(false);
@@ -48,14 +48,14 @@ class AiServiceDefaultMethodTest {
                 invokeMark.set(true);
                 return null;
             }
-            
+
             @Override
             public String releaseMcpServer(McpServerBasicInfo serverSpecification,
                     McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException {
                 invokeMark.set(true);
                 return "";
             }
-            
+
             @Override
             public String releaseMcpServer(McpServerBasicInfo serverSpecification,
                     McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification,
@@ -63,24 +63,24 @@ class AiServiceDefaultMethodTest {
                 invokeMark.set(true);
                 return "";
             }
-            
+
             @Override
             public void registerMcpServerEndpoint(String mcpName, String address, int port, String version)
                     throws NacosException {
                 invokeMark.set(true);
             }
-            
+
             @Override
             public void deregisterMcpServerEndpoint(String mcpName, String address, int port) throws NacosException {
             }
-            
+
             @Override
             public McpServerDetailInfo subscribeMcpServer(String mcpName, String version,
                     AbstractNacosMcpServerListener mcpServerListener) throws NacosException {
                 invokeMark.set(true);
                 return null;
             }
-            
+
             @Override
             public void unsubscribeMcpServer(String mcpName, String version,
                     AbstractNacosMcpServerListener mcpServerListener) throws NacosException {
@@ -88,19 +88,19 @@ class AiServiceDefaultMethodTest {
             }
         };
     }
-    
+
     @Test
     void getMcpServer() throws NacosException {
         aiService.getMcpServer("");
         assertTrue(invokeMark.get());
     }
-    
+
     @Test
     void registerMcpServerEndpoint() throws NacosException {
         aiService.registerMcpServerEndpoint("", "", 0);
         assertTrue(invokeMark.get());
     }
-    
+
     @Test
     void releaseMcpServer() throws NacosException {
         McpServerBasicInfo serverSpecification = new McpServerBasicInfo();
@@ -114,12 +114,12 @@ class AiServiceDefaultMethodTest {
         aiService.releaseMcpServer(serverSpecification, null, new McpResourceSpecification());
         assertTrue(invokeMark.get());
     }
-    
+
     @Test
     void subscribeMcpServer() throws NacosException {
         aiService.subscribeMcpServer("", null);
     }
-    
+
     @Test
     void unsubscribeMcpServer() throws NacosException {
         aiService.unsubscribeMcpServer("", null);

--- a/api/src/test/java/com/alibaba/nacos/api/ai/AiServiceDefaultMethodTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/AiServiceDefaultMethodTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.ai;
+
+import com.alibaba.nacos.api.ai.listener.AbstractNacosMcpServerListener;
+import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
+import com.alibaba.nacos.api.exception.NacosException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiServiceDefaultMethodTest {
+    
+    private AtomicBoolean invokeMark;
+    
+    AiService aiService;
+    
+    @BeforeEach
+    void setUp() {
+        invokeMark = new AtomicBoolean(false);
+        aiService = new AiService() {
+            @Override
+            public McpServerDetailInfo getMcpServer(String mcpName, String version) throws NacosException {
+                invokeMark.set(true);
+                return null;
+            }
+            
+            @Override
+            public String releaseMcpServer(McpServerBasicInfo serverSpecification,
+                    McpToolSpecification toolSpecification, McpEndpointSpec endpointSpecification) throws NacosException {
+                invokeMark.set(true);
+                return "";
+            }
+            
+            @Override
+            public String releaseMcpServer(McpServerBasicInfo serverSpecification,
+                    McpToolSpecification toolSpecification, McpResourceSpecification resourceSpecification,
+                    McpEndpointSpec endpointSpecification) throws NacosException {
+                invokeMark.set(true);
+                return "";
+            }
+            
+            @Override
+            public void registerMcpServerEndpoint(String mcpName, String address, int port, String version)
+                    throws NacosException {
+                invokeMark.set(true);
+            }
+            
+            @Override
+            public void deregisterMcpServerEndpoint(String mcpName, String address, int port) throws NacosException {
+            }
+            
+            @Override
+            public McpServerDetailInfo subscribeMcpServer(String mcpName, String version,
+                    AbstractNacosMcpServerListener mcpServerListener) throws NacosException {
+                invokeMark.set(true);
+                return null;
+            }
+            
+            @Override
+            public void unsubscribeMcpServer(String mcpName, String version,
+                    AbstractNacosMcpServerListener mcpServerListener) throws NacosException {
+                invokeMark.set(true);
+            }
+            
+            @Override
+            public void shutdown() throws NacosException {
+            }
+        };
+    }
+    
+    @Test
+    void getMcpServer() throws NacosException {
+        aiService.getMcpServer("");
+        assertTrue(invokeMark.get());
+    }
+    
+    @Test
+    void registerMcpServerEndpoint() throws NacosException {
+        aiService.registerMcpServerEndpoint("", "", 0);
+        assertTrue(invokeMark.get());
+    }
+    
+    @Test
+    void releaseMcpServer() throws NacosException {
+        McpServerBasicInfo serverSpecification = new McpServerBasicInfo();
+        aiService.releaseMcpServer(serverSpecification, null);
+        assertTrue(invokeMark.get());
+    }
+
+    @Test
+    void releaseMcpServerWithResourceSpecification() throws NacosException {
+        McpServerBasicInfo serverSpecification = new McpServerBasicInfo();
+        aiService.releaseMcpServer(serverSpecification, null, new McpResourceSpecification());
+        assertTrue(invokeMark.get());
+    }
+    
+    @Test
+    void subscribeMcpServer() throws NacosException {
+        aiService.subscribeMcpServer("", null);
+    }
+    
+    @Test
+    void unsubscribeMcpServer() throws NacosException {
+        aiService.unsubscribeMcpServer("", null);
+    }
+}

--- a/api/src/test/java/com/alibaba/nacos/api/ai/AiServiceDefaultMethodTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/AiServiceDefaultMethodTest.java
@@ -41,6 +41,7 @@ class AiServiceDefaultMethodTest {
     @BeforeEach
     void setUp() throws NacosException {
         invokeMark = new AtomicBoolean(false);
+        NacosAiService.IS_THROW_EXCEPTION.set(false);
         aiService = new NacosAiService(new Properties()) {
             @Override
             public McpServerDetailInfo getMcpServer(String mcpName, String version) throws NacosException {

--- a/api/src/test/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequestTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequestTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.api.ai.remote.request;
 
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
 import com.alibaba.nacos.api.remote.request.BasicRequestTest;
@@ -47,6 +48,9 @@ class ReleaseMcpServerRequestTest extends BasicRequestTest {
         request.setServerSpecification(serverSpecification);
         McpToolSpecification toolSpecification = new McpToolSpecification();
         request.setToolSpecification(toolSpecification);
+        McpResourceSpecification resourceSpecification = new McpResourceSpecification();
+        resourceSpecification.getResources().add(new HashMap<>());
+        request.setResourceSpecification(resourceSpecification);
         request.setEndpointSpecification(new McpEndpointSpec());
         request.getEndpointSpecification().setType(AiConstants.Mcp.MCP_ENDPOINT_TYPE_DIRECT);
         request.getEndpointSpecification().setData(new HashMap<>());
@@ -61,6 +65,8 @@ class ReleaseMcpServerRequestTest extends BasicRequestTest {
         assertTrue(json.contains("\"toolSpecification\":{"));
         assertTrue(json.contains("\"tools\":[]"));
         assertTrue(json.contains("\"toolsMeta\":{}"));
+        assertTrue(json.contains("\"resourceSpecification\":{"));
+        assertTrue(json.contains("\"resources\":[{}]"));
         assertTrue(json.contains("\"endpointSpecification\":{"));
         assertTrue(json.contains("\"type\":\"DIRECT\""));
         assertTrue(json.contains(String.format("\"mcpId\":\"%s\"", id)));
@@ -74,7 +80,8 @@ class ReleaseMcpServerRequestTest extends BasicRequestTest {
                 "{\"headers\":{},\"requestId\":\"1\",\"namespaceId\":\"public\",\"mcpId\":\"bbd8036e-4f17-4ed8-befc-a08b6fd5978d\","
                         + "\"mcpName\":\"testMcpName\",\"serverSpecification\":{\"name\":\"testServerName\",\"protocol\":\"stdio\","
                         + "\"frontProtocol\":\"stdio\",\"enabled\":true},\"toolSpecification\":{\"tools\":[],\"toolsMeta\":{},"
-                        + "\"securitySchemes\":[]},\"endpointSpecification\":{\"type\":\"DIRECT\",\"data\":{\"address\":\"127.0.0.1\","
+                        + "\"securitySchemes\":[]},\"resourceSpecification\":{\"resources\":[{}],\"resourceTemplates\":[],\"extensions\":{}},"
+                        + "\"endpointSpecification\":{\"type\":\"DIRECT\",\"data\":{\"address\":\"127.0.0.1\","
                         + "\"port\":\"8848\"}},\"module\":\"ai\"}";
         ReleaseMcpServerRequest result = mapper.readValue(json, ReleaseMcpServerRequest.class);
         assertNotNull(result);
@@ -88,6 +95,9 @@ class ReleaseMcpServerRequestTest extends BasicRequestTest {
         assertEquals(AiConstants.Mcp.MCP_PROTOCOL_STDIO, serverSpecification.getFrontProtocol());
         McpToolSpecification toolSpec = result.getToolSpecification();
         assertNotNull(toolSpec);
+        McpResourceSpecification resourceSpec = result.getResourceSpecification();
+        assertNotNull(resourceSpec);
+        assertEquals(1, resourceSpec.getResources().size());
         McpEndpointSpec endpointSpec = result.getEndpointSpecification();
         assertNotNull(endpointSpec);
         assertEquals(AiConstants.Mcp.MCP_ENDPOINT_TYPE_DIRECT, endpointSpec.getType());

--- a/api/src/test/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequestTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequestTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReleaseMcpServerRequestTest extends BasicRequestTest {
-    
+
     @Test
     void testSerialize() throws Exception {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -73,7 +73,7 @@ class ReleaseMcpServerRequestTest extends BasicRequestTest {
         assertTrue(json.contains(String.format("\"protocol\":\"%s\"", AiConstants.Mcp.MCP_PROTOCOL_STDIO)));
         assertTrue(json.contains(String.format("\"frontProtocol\":\"%s\"", AiConstants.Mcp.MCP_PROTOCOL_STDIO)));
     }
-    
+
     @Test
     void testDeserialize() throws Exception {
         String json =

--- a/api/src/test/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequestTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/remote/request/ReleaseMcpServerRequestTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ReleaseMcpServerRequestTest extends BasicRequestTest {
-
+    
     @Test
     void testSerialize() throws Exception {
         ReleaseMcpServerRequest request = new ReleaseMcpServerRequest();
@@ -73,7 +73,7 @@ class ReleaseMcpServerRequestTest extends BasicRequestTest {
         assertTrue(json.contains(String.format("\"protocol\":\"%s\"", AiConstants.Mcp.MCP_PROTOCOL_STDIO)));
         assertTrue(json.contains(String.format("\"frontProtocol\":\"%s\"", AiConstants.Mcp.MCP_PROTOCOL_STDIO)));
     }
-
+    
     @Test
     void testDeserialize() throws Exception {
         String json =

--- a/api/src/test/java/com/alibaba/nacos/client/ai/NacosAiService.java
+++ b/api/src/test/java/com/alibaba/nacos/client/ai/NacosAiService.java
@@ -27,7 +27,6 @@ import com.alibaba.nacos.api.ai.model.a2a.AgentEndpoint;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
-import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;

--- a/api/src/test/java/com/alibaba/nacos/client/ai/NacosAiService.java
+++ b/api/src/test/java/com/alibaba/nacos/client/ai/NacosAiService.java
@@ -43,26 +43,26 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author xiweng.yy
  */
 public class NacosAiService implements AiService {
-
+    
     public static final AtomicBoolean IS_THROW_EXCEPTION = new AtomicBoolean(false);
-
+    
     public NacosAiService(Properties properties) throws NacosException {
         if (IS_THROW_EXCEPTION.get()) {
             throw new NacosException(NacosException.CLIENT_INVALID_PARAM, "mock exception");
         }
     }
-
+    
     @Override
     public McpServerDetailInfo getMcpServer(String mcpName, String version) throws NacosException {
         return null;
     }
-
+    
     @Override
     public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException {
         return "";
     }
-
+    
     @Override
     public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification)
@@ -73,122 +73,122 @@ public class NacosAiService implements AiService {
     @Override
     public void registerMcpServerEndpoint(String mcpName, String address, int port, String version)
             throws NacosException {
-
+        
     }
-
+    
     @Override
     public void deregisterMcpServerEndpoint(String mcpName, String address, int port) throws NacosException {
-
+    
     }
-
+    
     @Override
     public McpServerDetailInfo subscribeMcpServer(String mcpName, String version,
             AbstractNacosMcpServerListener mcpServerListener) throws NacosException {
         return null;
     }
-
+    
     @Override
     public void unsubscribeMcpServer(String mcpName, String version, AbstractNacosMcpServerListener mcpServerListener)
             throws NacosException {
-
+        
     }
-
+    
     @Override
     public void shutdown() throws NacosException {
-
+    
     }
-
+    
     @Override
     public AgentCardDetailInfo getAgentCard(String agentName, String version, String registrationType)
             throws NacosException {
         return null;
     }
-
+    
     @Override
     public void releaseAgentCard(AgentCard agentCard, String registrationType, boolean setAsLatest)
             throws NacosException {
-
+        
     }
-
+    
     @Override
     public void registerAgentEndpoint(String agentName, AgentEndpoint endpoint) throws NacosException {
-
+    
     }
-
+    
     @Override
     public void registerAgentEndpoint(String agentName, Collection<AgentEndpoint> endpoints) throws NacosException {
-
+    
     }
-
+    
     @Override
     public void deregisterAgentEndpoint(String agentName, AgentEndpoint endpoint) throws NacosException {
-
+    
     }
-
+    
     @Override
     public AgentCardDetailInfo subscribeAgentCard(String agentName, String version,
             AbstractNacosAgentCardListener agentCardListener) throws NacosException {
         return null;
     }
-
+    
     @Override
     public void unsubscribeAgentCard(String agentName, String version, AbstractNacosAgentCardListener agentCardListener)
             throws NacosException {
-
+        
     }
-
+    
     @Override
     public byte[] downloadSkillZip(String skillName) throws NacosException {
         return new byte[0];
     }
-
+    
     @Override
     public byte[] downloadSkillZipByVersion(String skillName, String version) throws NacosException {
         return new byte[0];
     }
-
+    
     @Override
     public byte[] downloadSkillZipByLabel(String skillName, String label) throws NacosException {
         return new byte[0];
     }
-
+    
     @Override
     public AgentSpec loadAgentSpec(String agentSpecName) throws NacosException {
         return null;
     }
-
+    
     @Override
     public AgentSpec subscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException {
         return null;
     }
-
+    
     @Override
     public void unsubscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException {
     }
-
+    
     @Override
     public Prompt getPrompt(String promptKey) throws NacosException {
         return null;
     }
-
+    
     @Override
     public Prompt getPromptByVersion(String promptKey, String version) throws NacosException {
         return null;
     }
-
+    
     @Override
     public Prompt getPromptByLabel(String promptKey, String label) throws NacosException {
         return null;
     }
-
+    
     @Override
     public Prompt subscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException {
         return null;
     }
-
+    
     @Override
     public void unsubscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException {

--- a/api/src/test/java/com/alibaba/nacos/client/ai/NacosAiService.java
+++ b/api/src/test/java/com/alibaba/nacos/client/ai/NacosAiService.java
@@ -26,6 +26,8 @@ import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
 import com.alibaba.nacos.api.ai.model.a2a.AgentEndpoint;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
@@ -42,145 +44,152 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author xiweng.yy
  */
 public class NacosAiService implements AiService {
-    
+
     public static final AtomicBoolean IS_THROW_EXCEPTION = new AtomicBoolean(false);
-    
+
     public NacosAiService(Properties properties) throws NacosException {
         if (IS_THROW_EXCEPTION.get()) {
             throw new NacosException(NacosException.CLIENT_INVALID_PARAM, "mock exception");
         }
     }
-    
+
     @Override
     public McpServerDetailInfo getMcpServer(String mcpName, String version) throws NacosException {
         return null;
     }
-    
+
     @Override
     public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException {
         return "";
     }
-    
+
+    @Override
+    public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
+            McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification)
+            throws NacosException {
+        return "";
+    }
+
     @Override
     public void registerMcpServerEndpoint(String mcpName, String address, int port, String version)
             throws NacosException {
-        
+
     }
-    
+
     @Override
     public void deregisterMcpServerEndpoint(String mcpName, String address, int port) throws NacosException {
-    
+
     }
-    
+
     @Override
     public McpServerDetailInfo subscribeMcpServer(String mcpName, String version,
             AbstractNacosMcpServerListener mcpServerListener) throws NacosException {
         return null;
     }
-    
+
     @Override
     public void unsubscribeMcpServer(String mcpName, String version, AbstractNacosMcpServerListener mcpServerListener)
             throws NacosException {
-        
+
     }
-    
+
     @Override
     public void shutdown() throws NacosException {
-    
+
     }
-    
+
     @Override
     public AgentCardDetailInfo getAgentCard(String agentName, String version, String registrationType)
             throws NacosException {
         return null;
     }
-    
+
     @Override
     public void releaseAgentCard(AgentCard agentCard, String registrationType, boolean setAsLatest)
             throws NacosException {
-        
+
     }
-    
+
     @Override
     public void registerAgentEndpoint(String agentName, AgentEndpoint endpoint) throws NacosException {
-    
+
     }
-    
+
     @Override
     public void registerAgentEndpoint(String agentName, Collection<AgentEndpoint> endpoints) throws NacosException {
-    
+
     }
-    
+
     @Override
     public void deregisterAgentEndpoint(String agentName, AgentEndpoint endpoint) throws NacosException {
-    
+
     }
-    
+
     @Override
     public AgentCardDetailInfo subscribeAgentCard(String agentName, String version,
             AbstractNacosAgentCardListener agentCardListener) throws NacosException {
         return null;
     }
-    
+
     @Override
     public void unsubscribeAgentCard(String agentName, String version, AbstractNacosAgentCardListener agentCardListener)
             throws NacosException {
-        
+
     }
-    
+
     @Override
     public byte[] downloadSkillZip(String skillName) throws NacosException {
         return new byte[0];
     }
-    
+
     @Override
     public byte[] downloadSkillZipByVersion(String skillName, String version) throws NacosException {
         return new byte[0];
     }
-    
+
     @Override
     public byte[] downloadSkillZipByLabel(String skillName, String label) throws NacosException {
         return new byte[0];
     }
-    
+
     @Override
     public AgentSpec loadAgentSpec(String agentSpecName) throws NacosException {
         return null;
     }
-    
+
     @Override
     public AgentSpec subscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException {
         return null;
     }
-    
+
     @Override
     public void unsubscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException {
     }
-    
+
     @Override
     public Prompt getPrompt(String promptKey) throws NacosException {
         return null;
     }
-    
+
     @Override
     public Prompt getPromptByVersion(String promptKey, String version) throws NacosException {
         return null;
     }
-    
+
     @Override
     public Prompt getPromptByLabel(String promptKey, String label) throws NacosException {
         return null;
     }
-    
+
     @Override
     public Prompt subscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException {
         return null;
     }
-    
+
     @Override
     public void unsubscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException {

--- a/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
@@ -77,29 +77,29 @@ import java.util.Set;
  * @author xiweng.yy
  */
 public class NacosAiService implements AiService {
-
+    
     private static final Logger LOGGER = LogUtils.logger(NacosAiService.class);
-
+    
     private final String namespaceId;
-
+    
     private final AiGrpcClient grpcClient;
-
+    
     private final AiHttpClientProxy httpProxy;
-
+    
     private final AiClientProxy aiClientProxy;
-
+    
     private final NacosMcpServerCacheHolder mcpServerCacheHolder;
-
+    
     private final NacosAgentCardCacheHolder agentCardCacheHolder;
-
+    
     private final NacosPromptCacheHolder promptCacheHolder;
-
+    
     private final NacosAgentSpecCacheHolder agentSpecCacheHolder;
-
+    
     private final AiChangeNotifier aiChangeNotifier;
 
     private final ConfigService skillConfigService;
-
+    
     public NacosAiService(Properties properties) throws NacosException {
         NacosClientProperties clientProperties = NacosClientProperties.PROTOTYPE.derive(properties);
         LOGGER.info(ClientBasicParamUtil.getInputParameters(clientProperties.asProperties()));
@@ -122,7 +122,7 @@ public class NacosAiService implements AiService {
         this.aiChangeNotifier = new AiChangeNotifier();
         start();
     }
-
+    
     private String initNamespace(NacosClientProperties properties) {
         String tempNamespace = properties.getProperty(PropertyKeyConst.NAMESPACE);
         if (StringUtils.isBlank(tempNamespace)) {
@@ -130,7 +130,7 @@ public class NacosAiService implements AiService {
         }
         return tempNamespace;
     }
-
+    
     private void start() throws NacosException {
         this.grpcClient.start(this.mcpServerCacheHolder, this.agentCardCacheHolder);
         NotifyCenter.registerToPublisher(McpServerChangedEvent.class, 16384);
@@ -138,7 +138,7 @@ public class NacosAiService implements AiService {
         NotifyCenter.registerToPublisher(AgentSpecChangedEvent.class, 16384);
         NotifyCenter.registerSubscriber(this.aiChangeNotifier);
     }
-
+    
     @Override
     public McpServerDetailInfo getMcpServer(String mcpName, String version) throws NacosException {
         if (StringUtils.isBlank(mcpName)) {
@@ -147,7 +147,7 @@ public class NacosAiService implements AiService {
         }
         return grpcClient.queryMcpServer(mcpName, version);
     }
-
+    
     @Override
     public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException {
@@ -174,7 +174,7 @@ public class NacosAiService implements AiService {
         return grpcClient.releaseMcpServer(serverSpecification, toolSpecification, resourceSpecification,
                 endpointSpecification);
     }
-
+    
     @Override
     public void registerMcpServerEndpoint(String mcpName, String address, int port, String version)
             throws NacosException {
@@ -188,7 +188,7 @@ public class NacosAiService implements AiService {
         instance.validate();
         grpcClient.registerMcpServerEndpoint(mcpName, address, port, version);
     }
-
+    
     @Override
     public void deregisterMcpServerEndpoint(String mcpName, String address, int port) throws NacosException {
         if (StringUtils.isBlank(mcpName)) {
@@ -201,7 +201,7 @@ public class NacosAiService implements AiService {
         instance.validate();
         grpcClient.deregisterMcpServerEndpoint(mcpName, address, port);
     }
-
+    
     @Override
     public McpServerDetailInfo subscribeMcpServer(String mcpName, String version,
             AbstractNacosMcpServerListener mcpServerListener) throws NacosException {
@@ -221,7 +221,7 @@ public class NacosAiService implements AiService {
         }
         return result;
     }
-
+    
     @Override
     public void unsubscribeMcpServer(String mcpName, String version, AbstractNacosMcpServerListener mcpServerListener)
             throws NacosException {
@@ -238,7 +238,7 @@ public class NacosAiService implements AiService {
             grpcClient.unsubscribeMcpServer(mcpName, version);
         }
     }
-
+    
     @Override
     public AgentCardDetailInfo getAgentCard(String agentName, String version, String registrationType)
             throws NacosException {
@@ -248,7 +248,7 @@ public class NacosAiService implements AiService {
         }
         return grpcClient.getAgentCard(agentName, version, registrationType);
     }
-
+    
     @Override
     public void releaseAgentCard(AgentCard agentCard, String registrationType, boolean setAsLatest)
             throws NacosException {
@@ -264,7 +264,7 @@ public class NacosAiService implements AiService {
         }
         grpcClient.releaseAgentCard(agentCard, registrationType, setAsLatest);
     }
-
+    
     @Override
     public void registerAgentEndpoint(String agentName, AgentEndpoint endpoint) throws NacosException {
         if (StringUtils.isBlank(agentName)) {
@@ -274,7 +274,7 @@ public class NacosAiService implements AiService {
         validateAgentEndpoint(endpoint);
         grpcClient.registerAgentEndpoint(agentName, endpoint);
     }
-
+    
     @Override
     public void registerAgentEndpoint(String agentName, Collection<AgentEndpoint> endpoints) throws NacosException {
         if (StringUtils.isBlank(agentName)) {
@@ -284,7 +284,7 @@ public class NacosAiService implements AiService {
         validateAgentEndpoint(endpoints);
         grpcClient.registerAgentEndpoints(agentName, endpoints);
     }
-
+    
     @Override
     public void deregisterAgentEndpoint(String agentName, AgentEndpoint endpoint) throws NacosException {
         if (StringUtils.isBlank(agentName)) {
@@ -294,7 +294,7 @@ public class NacosAiService implements AiService {
         validateAgentEndpoint(endpoint);
         grpcClient.deregisterAgentEndpoint(agentName, endpoint);
     }
-
+    
     @Override
     public AgentCardDetailInfo subscribeAgentCard(String agentName, String version,
             AbstractNacosAgentCardListener agentCardListener) throws NacosException {
@@ -314,7 +314,7 @@ public class NacosAiService implements AiService {
         }
         return result;
     }
-
+    
     @Override
     public void unsubscribeAgentCard(String agentName, String version, AbstractNacosAgentCardListener agentCardListener)
             throws NacosException {
@@ -331,7 +331,7 @@ public class NacosAiService implements AiService {
             grpcClient.unsubscribeAgentCard(agentName, version);
         }
     }
-
+    
     private void validateAgentEndpoint(Collection<AgentEndpoint> endpoints) throws NacosApiException {
         if (null == endpoints || endpoints.isEmpty()) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
@@ -348,7 +348,7 @@ public class NacosAiService implements AiService {
                             String.join(",", versions)));
         }
     }
-
+    
     private void validateAgentEndpoint(AgentEndpoint endpoint) throws NacosApiException {
         if (null == endpoint) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
@@ -363,14 +363,14 @@ public class NacosAiService implements AiService {
         instance.setPort(endpoint.getPort());
         instance.validate();
     }
-
+    
     private static void validateAgentCardField(String fieldName, String fieldValue) throws NacosApiException {
         if (StringUtils.isEmpty(fieldValue)) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "Required parameter `agentCard." + fieldName + "` not present");
         }
     }
-
+    
     @Override
     public byte[] downloadSkillZip(String skillName) throws NacosException {
         if (StringUtils.isBlank(skillName)) {
@@ -379,7 +379,7 @@ public class NacosAiService implements AiService {
         }
         return httpProxy.downloadSkillZip(skillName, null, null);
     }
-
+    
     @Override
     public byte[] downloadSkillZipByVersion(String skillName, String version) throws NacosException {
         if (StringUtils.isBlank(skillName)) {
@@ -388,7 +388,7 @@ public class NacosAiService implements AiService {
         }
         return httpProxy.downloadSkillZip(skillName, version, null);
     }
-
+    
     @Override
     public byte[] downloadSkillZipByLabel(String skillName, String label) throws NacosException {
         if (StringUtils.isBlank(skillName)) {
@@ -397,9 +397,9 @@ public class NacosAiService implements AiService {
         }
         return httpProxy.downloadSkillZip(skillName, null, label);
     }
-
+    
     // ==================== AgentSpec Methods ====================
-
+    
     @Override
     public AgentSpec loadAgentSpec(String agentSpecName) throws NacosException {
         if (StringUtils.isBlank(agentSpecName)) {
@@ -408,7 +408,7 @@ public class NacosAiService implements AiService {
         }
         return agentSpecCacheHolder.queryAgentSpec(agentSpecName);
     }
-
+    
     @Override
     public AgentSpec subscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException {
@@ -420,7 +420,7 @@ public class NacosAiService implements AiService {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "parameters `agentSpecListener` can't be empty or null");
         }
-
+        
         AgentSpecListenerInvoker listenerInvoker = new AgentSpecListenerInvoker(agentSpecListener);
         aiChangeNotifier.registerListener(agentSpecName, listenerInvoker);
         AgentSpec result = agentSpecCacheHolder.subscribeAgentSpec(agentSpecName);
@@ -429,7 +429,7 @@ public class NacosAiService implements AiService {
         }
         return result;
     }
-
+    
     @Override
     public void unsubscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException {
@@ -446,9 +446,9 @@ public class NacosAiService implements AiService {
             agentSpecCacheHolder.unsubscribeAgentSpec(agentSpecName);
         }
     }
-
+    
     // ==================== Prompt Methods ====================
-
+    
     @Override
     public Prompt getPrompt(String promptKey) throws NacosException {
         if (StringUtils.isBlank(promptKey)) {
@@ -457,7 +457,7 @@ public class NacosAiService implements AiService {
         }
         return getPromptByVersion(promptKey, null);
     }
-
+    
     @Override
     public Prompt getPromptByVersion(String promptKey, String version) throws NacosException {
         if (StringUtils.isBlank(promptKey)) {
@@ -469,7 +469,7 @@ public class NacosAiService implements AiService {
         }
         return aiClientProxy.queryPrompt(promptKey, version, null, null);
     }
-
+    
     @Override
     public Prompt getPromptByLabel(String promptKey, String label) throws NacosException {
         if (StringUtils.isBlank(promptKey)) {
@@ -482,7 +482,7 @@ public class NacosAiService implements AiService {
         }
         return aiClientProxy.queryPrompt(promptKey, null, label, null);
     }
-
+    
     @Override
     public Prompt subscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException {
@@ -494,7 +494,7 @@ public class NacosAiService implements AiService {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "parameters `promptListener` can't be null");
         }
-
+        
         PromptListenerInvoker listenerInvoker = new PromptListenerInvoker(promptListener);
         aiChangeNotifier.registerListener(promptKey, version, label, listenerInvoker);
         Prompt result = promptCacheHolder.subscribePrompt(promptKey, version, label);
@@ -503,7 +503,7 @@ public class NacosAiService implements AiService {
         }
         return result;
     }
-
+    
     @Override
     public void unsubscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException {
@@ -520,7 +520,7 @@ public class NacosAiService implements AiService {
             promptCacheHolder.unsubscribePrompt(promptKey, version, label);
         }
     }
-
+    
     @Override
     public void shutdown() throws NacosException {
         this.grpcClient.shutdown();

--- a/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
@@ -77,29 +77,29 @@ import java.util.Set;
  * @author xiweng.yy
  */
 public class NacosAiService implements AiService {
-    
+
     private static final Logger LOGGER = LogUtils.logger(NacosAiService.class);
-    
+
     private final String namespaceId;
-    
+
     private final AiGrpcClient grpcClient;
-    
+
     private final AiHttpClientProxy httpProxy;
-    
+
     private final AiClientProxy aiClientProxy;
-    
+
     private final NacosMcpServerCacheHolder mcpServerCacheHolder;
-    
+
     private final NacosAgentCardCacheHolder agentCardCacheHolder;
-    
+
     private final NacosPromptCacheHolder promptCacheHolder;
-    
+
     private final NacosAgentSpecCacheHolder agentSpecCacheHolder;
-    
+
     private final AiChangeNotifier aiChangeNotifier;
 
     private final ConfigService skillConfigService;
-    
+
     public NacosAiService(Properties properties) throws NacosException {
         NacosClientProperties clientProperties = NacosClientProperties.PROTOTYPE.derive(properties);
         LOGGER.info(ClientBasicParamUtil.getInputParameters(clientProperties.asProperties()));
@@ -122,7 +122,7 @@ public class NacosAiService implements AiService {
         this.aiChangeNotifier = new AiChangeNotifier();
         start();
     }
-    
+
     private String initNamespace(NacosClientProperties properties) {
         String tempNamespace = properties.getProperty(PropertyKeyConst.NAMESPACE);
         if (StringUtils.isBlank(tempNamespace)) {
@@ -130,7 +130,7 @@ public class NacosAiService implements AiService {
         }
         return tempNamespace;
     }
-    
+
     private void start() throws NacosException {
         this.grpcClient.start(this.mcpServerCacheHolder, this.agentCardCacheHolder);
         NotifyCenter.registerToPublisher(McpServerChangedEvent.class, 16384);
@@ -138,7 +138,7 @@ public class NacosAiService implements AiService {
         NotifyCenter.registerToPublisher(AgentSpecChangedEvent.class, 16384);
         NotifyCenter.registerSubscriber(this.aiChangeNotifier);
     }
-    
+
     @Override
     public McpServerDetailInfo getMcpServer(String mcpName, String version) throws NacosException {
         if (StringUtils.isBlank(mcpName)) {
@@ -147,13 +147,13 @@ public class NacosAiService implements AiService {
         }
         return grpcClient.queryMcpServer(mcpName, version);
     }
-    
+
     @Override
     public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException {
         return releaseMcpServer(serverSpecification, toolSpecification, null, endpointSpecification);
     }
-    
+
     @Override
     public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification)
@@ -174,7 +174,7 @@ public class NacosAiService implements AiService {
         return grpcClient.releaseMcpServer(serverSpecification, toolSpecification, resourceSpecification,
                 endpointSpecification);
     }
-    
+
     @Override
     public void registerMcpServerEndpoint(String mcpName, String address, int port, String version)
             throws NacosException {
@@ -188,7 +188,7 @@ public class NacosAiService implements AiService {
         instance.validate();
         grpcClient.registerMcpServerEndpoint(mcpName, address, port, version);
     }
-    
+
     @Override
     public void deregisterMcpServerEndpoint(String mcpName, String address, int port) throws NacosException {
         if (StringUtils.isBlank(mcpName)) {
@@ -201,7 +201,7 @@ public class NacosAiService implements AiService {
         instance.validate();
         grpcClient.deregisterMcpServerEndpoint(mcpName, address, port);
     }
-    
+
     @Override
     public McpServerDetailInfo subscribeMcpServer(String mcpName, String version,
             AbstractNacosMcpServerListener mcpServerListener) throws NacosException {
@@ -221,7 +221,7 @@ public class NacosAiService implements AiService {
         }
         return result;
     }
-    
+
     @Override
     public void unsubscribeMcpServer(String mcpName, String version, AbstractNacosMcpServerListener mcpServerListener)
             throws NacosException {
@@ -238,7 +238,7 @@ public class NacosAiService implements AiService {
             grpcClient.unsubscribeMcpServer(mcpName, version);
         }
     }
-    
+
     @Override
     public AgentCardDetailInfo getAgentCard(String agentName, String version, String registrationType)
             throws NacosException {
@@ -248,7 +248,7 @@ public class NacosAiService implements AiService {
         }
         return grpcClient.getAgentCard(agentName, version, registrationType);
     }
-    
+
     @Override
     public void releaseAgentCard(AgentCard agentCard, String registrationType, boolean setAsLatest)
             throws NacosException {
@@ -264,7 +264,7 @@ public class NacosAiService implements AiService {
         }
         grpcClient.releaseAgentCard(agentCard, registrationType, setAsLatest);
     }
-    
+
     @Override
     public void registerAgentEndpoint(String agentName, AgentEndpoint endpoint) throws NacosException {
         if (StringUtils.isBlank(agentName)) {
@@ -274,7 +274,7 @@ public class NacosAiService implements AiService {
         validateAgentEndpoint(endpoint);
         grpcClient.registerAgentEndpoint(agentName, endpoint);
     }
-    
+
     @Override
     public void registerAgentEndpoint(String agentName, Collection<AgentEndpoint> endpoints) throws NacosException {
         if (StringUtils.isBlank(agentName)) {
@@ -284,7 +284,7 @@ public class NacosAiService implements AiService {
         validateAgentEndpoint(endpoints);
         grpcClient.registerAgentEndpoints(agentName, endpoints);
     }
-    
+
     @Override
     public void deregisterAgentEndpoint(String agentName, AgentEndpoint endpoint) throws NacosException {
         if (StringUtils.isBlank(agentName)) {
@@ -294,7 +294,7 @@ public class NacosAiService implements AiService {
         validateAgentEndpoint(endpoint);
         grpcClient.deregisterAgentEndpoint(agentName, endpoint);
     }
-    
+
     @Override
     public AgentCardDetailInfo subscribeAgentCard(String agentName, String version,
             AbstractNacosAgentCardListener agentCardListener) throws NacosException {
@@ -314,7 +314,7 @@ public class NacosAiService implements AiService {
         }
         return result;
     }
-    
+
     @Override
     public void unsubscribeAgentCard(String agentName, String version, AbstractNacosAgentCardListener agentCardListener)
             throws NacosException {
@@ -331,7 +331,7 @@ public class NacosAiService implements AiService {
             grpcClient.unsubscribeAgentCard(agentName, version);
         }
     }
-    
+
     private void validateAgentEndpoint(Collection<AgentEndpoint> endpoints) throws NacosApiException {
         if (null == endpoints || endpoints.isEmpty()) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
@@ -348,7 +348,7 @@ public class NacosAiService implements AiService {
                             String.join(",", versions)));
         }
     }
-    
+
     private void validateAgentEndpoint(AgentEndpoint endpoint) throws NacosApiException {
         if (null == endpoint) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
@@ -363,14 +363,14 @@ public class NacosAiService implements AiService {
         instance.setPort(endpoint.getPort());
         instance.validate();
     }
-    
+
     private static void validateAgentCardField(String fieldName, String fieldValue) throws NacosApiException {
         if (StringUtils.isEmpty(fieldValue)) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "Required parameter `agentCard." + fieldName + "` not present");
         }
     }
-    
+
     @Override
     public byte[] downloadSkillZip(String skillName) throws NacosException {
         if (StringUtils.isBlank(skillName)) {
@@ -379,7 +379,7 @@ public class NacosAiService implements AiService {
         }
         return httpProxy.downloadSkillZip(skillName, null, null);
     }
-    
+
     @Override
     public byte[] downloadSkillZipByVersion(String skillName, String version) throws NacosException {
         if (StringUtils.isBlank(skillName)) {
@@ -388,7 +388,7 @@ public class NacosAiService implements AiService {
         }
         return httpProxy.downloadSkillZip(skillName, version, null);
     }
-    
+
     @Override
     public byte[] downloadSkillZipByLabel(String skillName, String label) throws NacosException {
         if (StringUtils.isBlank(skillName)) {
@@ -397,9 +397,9 @@ public class NacosAiService implements AiService {
         }
         return httpProxy.downloadSkillZip(skillName, null, label);
     }
-    
+
     // ==================== AgentSpec Methods ====================
-    
+
     @Override
     public AgentSpec loadAgentSpec(String agentSpecName) throws NacosException {
         if (StringUtils.isBlank(agentSpecName)) {
@@ -408,7 +408,7 @@ public class NacosAiService implements AiService {
         }
         return agentSpecCacheHolder.queryAgentSpec(agentSpecName);
     }
-    
+
     @Override
     public AgentSpec subscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException {
@@ -420,7 +420,7 @@ public class NacosAiService implements AiService {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "parameters `agentSpecListener` can't be empty or null");
         }
-        
+
         AgentSpecListenerInvoker listenerInvoker = new AgentSpecListenerInvoker(agentSpecListener);
         aiChangeNotifier.registerListener(agentSpecName, listenerInvoker);
         AgentSpec result = agentSpecCacheHolder.subscribeAgentSpec(agentSpecName);
@@ -429,7 +429,7 @@ public class NacosAiService implements AiService {
         }
         return result;
     }
-    
+
     @Override
     public void unsubscribeAgentSpec(String agentSpecName, AbstractNacosAgentSpecListener agentSpecListener)
             throws NacosException {
@@ -446,9 +446,9 @@ public class NacosAiService implements AiService {
             agentSpecCacheHolder.unsubscribeAgentSpec(agentSpecName);
         }
     }
-    
+
     // ==================== Prompt Methods ====================
-    
+
     @Override
     public Prompt getPrompt(String promptKey) throws NacosException {
         if (StringUtils.isBlank(promptKey)) {
@@ -457,7 +457,7 @@ public class NacosAiService implements AiService {
         }
         return getPromptByVersion(promptKey, null);
     }
-    
+
     @Override
     public Prompt getPromptByVersion(String promptKey, String version) throws NacosException {
         if (StringUtils.isBlank(promptKey)) {
@@ -469,7 +469,7 @@ public class NacosAiService implements AiService {
         }
         return aiClientProxy.queryPrompt(promptKey, version, null, null);
     }
-    
+
     @Override
     public Prompt getPromptByLabel(String promptKey, String label) throws NacosException {
         if (StringUtils.isBlank(promptKey)) {
@@ -482,7 +482,7 @@ public class NacosAiService implements AiService {
         }
         return aiClientProxy.queryPrompt(promptKey, null, label, null);
     }
-    
+
     @Override
     public Prompt subscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException {
@@ -494,7 +494,7 @@ public class NacosAiService implements AiService {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "parameters `promptListener` can't be null");
         }
-        
+
         PromptListenerInvoker listenerInvoker = new PromptListenerInvoker(promptListener);
         aiChangeNotifier.registerListener(promptKey, version, label, listenerInvoker);
         Prompt result = promptCacheHolder.subscribePrompt(promptKey, version, label);
@@ -503,7 +503,7 @@ public class NacosAiService implements AiService {
         }
         return result;
     }
-    
+
     @Override
     public void unsubscribePrompt(String promptKey, String version, String label,
             AbstractNacosPromptListener promptListener) throws NacosException {
@@ -520,7 +520,7 @@ public class NacosAiService implements AiService {
             promptCacheHolder.unsubscribePrompt(promptKey, version, label);
         }
     }
-    
+
     @Override
     public void shutdown() throws NacosException {
         this.grpcClient.shutdown();

--- a/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/NacosAiService.java
@@ -32,6 +32,7 @@ import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
 import com.alibaba.nacos.api.ai.model.a2a.AgentEndpoint;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
@@ -150,6 +151,13 @@ public class NacosAiService implements AiService {
     @Override
     public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException {
+        return releaseMcpServer(serverSpecification, toolSpecification, null, endpointSpecification);
+    }
+    
+    @Override
+    public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
+            McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification)
+            throws NacosException {
         if (null == serverSpecification) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "Required parameter `serverSpecification` not present");
@@ -163,7 +171,8 @@ public class NacosAiService implements AiService {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                     "Required parameter `serverSpecification.versionDetail.version` not present");
         }
-        return grpcClient.releaseMcpServer(serverSpecification, toolSpecification, endpointSpecification);
+        return grpcClient.releaseMcpServer(serverSpecification, toolSpecification, resourceSpecification,
+                endpointSpecification);
     }
     
     @Override

--- a/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiGrpcClient.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiGrpcClient.java
@@ -92,27 +92,27 @@ import static com.alibaba.nacos.client.constant.Constants.Security.SECURITY_INFO
  * @author xiweng.yy
  */
 public class AiGrpcClient implements AiClientProxy {
-
+    
     private static final Logger LOGGER = LoggerFactory.getLogger(AiGrpcClient.class);
-
+    
     private final String namespaceId;
-
+    
     private final String uuid;
-
+    
     private final Long requestTimeout;
-
+    
     private final RpcClient rpcClient;
-
+    
     private final AbstractServerListManager serverListManager;
-
+    
     private final AiGrpcRedoService redoService;
 
     private final NacosClientProperties properties;
 
     private SecurityProxy securityProxy;
-
+    
     private NacosMcpServerCacheHolder mcpServerCacheHolder;
-
+    
     private NacosAgentCardCacheHolder agentCardCacheHolder;
 
     private ScheduledThreadPoolExecutor executorService;
@@ -126,7 +126,7 @@ public class AiGrpcClient implements AiClientProxy {
         this.redoService = new AiGrpcRedoService(properties, this);
         this.properties = properties;
     }
-
+    
     private RpcClient buildRpcClient(NacosClientProperties properties) {
         Map<String, String> labels = new HashMap<>(3);
         labels.put(RemoteConstants.LABEL_SOURCE, RemoteConstants.LABEL_SOURCE_SDK);
@@ -136,7 +136,7 @@ public class AiGrpcClient implements AiClientProxy {
                 .createGrpcClientConfig(properties.asProperties(), labels);
         return RpcClientFactory.createClient(uuid, ConnectionType.GRPC, grpcClientConfig);
     }
-
+    
     /**
      * Start the grpc client.
      *
@@ -163,7 +163,7 @@ public class AiGrpcClient implements AiClientProxy {
         this.executorService.scheduleWithFixedDelay(() -> securityProxy.login(nacosClientPropertiesView), 0,
                 SECURITY_INFO_REFRESH_INTERVAL_MILLS, TimeUnit.MILLISECONDS);
     }
-
+    
     /**
      * Do query mcp server by mcpId and version.
      *
@@ -184,7 +184,7 @@ public class AiGrpcClient implements AiClientProxy {
         QueryMcpServerResponse response = requestToServer(request, QueryMcpServerResponse.class);
         return response.getMcpServerDetailInfo();
     }
-
+    
     /**
      * Query prompt by version/label/latest.
      *
@@ -197,7 +197,7 @@ public class AiGrpcClient implements AiClientProxy {
     public Prompt queryPrompt(String promptKey, String version, String label) throws NacosException {
         return queryPrompt(promptKey, version, label, null);
     }
-
+    
     /**
      * Query prompt by version/label/latest with optional md5.
      *
@@ -261,7 +261,7 @@ public class AiGrpcClient implements AiClientProxy {
         ReleaseMcpServerResponse response = requestToServer(request, ReleaseMcpServerResponse.class);
         return response.getMcpId();
     }
-
+    
     /**
      * Register endpoint to target mcp server and cached to redo service.
      *
@@ -282,7 +282,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.cachedMcpServerEndpointForRedo(mcpName, address, port, version);
         doRegisterMcpServerEndpoint(mcpName, address, port, version);
     }
-
+    
     /**
      * Actual do Register endpoint to target mcp server.
      *
@@ -304,7 +304,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, McpServerEndpointResponse.class);
         redoService.mcpServerEndpointRegistered(mcpName);
     }
-
+    
     /**
      * Deregister endpoint from target mcp server and cached to redo service.
      *
@@ -322,7 +322,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.mcpServerEndpointDeregister(mcpName);
         doDeregisterMcpServerEndpoint(mcpName, address, port);
     }
-
+    
     /**
      * Actual do deregister endpoint from target mcp server.
      *
@@ -341,7 +341,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, McpServerEndpointResponse.class);
         redoService.mcpServerEndpointDeregistered(mcpName);
     }
-
+    
     /**
      * Subscribe mcp server latest version.
      *
@@ -369,7 +369,7 @@ public class AiGrpcClient implements AiClientProxy {
         }
         return cachedServer;
     }
-
+    
     /**
      * Un-subscribe mcp server.
      *
@@ -384,7 +384,7 @@ public class AiGrpcClient implements AiClientProxy {
         }
         mcpServerCacheHolder.removeMcpServerUpdateTask(mcpName, version);
     }
-
+    
     /**
      * Get agent card with nacos extension detail with target version.
      *
@@ -408,7 +408,7 @@ public class AiGrpcClient implements AiClientProxy {
         QueryAgentCardResponse response = requestToServer(request, QueryAgentCardResponse.class);
         return response.getAgentCardDetailInfo();
     }
-
+    
     /**
      * Release new agent card or new version.
      *
@@ -440,7 +440,7 @@ public class AiGrpcClient implements AiClientProxy {
         request.setSetAsLatest(setAsLatest);
         requestToServer(request, ReleaseAgentCardResponse.class);
     }
-
+    
     /**
      * Register agent endpoint into agent.
      *
@@ -457,7 +457,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.cachedAgentEndpointForRedo(agentName, AgentEndpointWrapper.wrap(endpoint));
         doRegisterAgentEndpoint(agentName, endpoint);
     }
-
+    
     /**
      * Batch Register agent endpoint into agent.
      *
@@ -474,7 +474,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.cachedAgentEndpointForRedo(agentName, AgentEndpointWrapper.wrap(endpoints));
         doRegisterAgentEndpoint(agentName, endpoints);
     }
-
+    
     /**
      * Actual do register agent endpoint into agent.
      *
@@ -491,7 +491,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, AgentEndpointResponse.class);
         redoService.agentEndpointRegistered(agentName);
     }
-
+    
     /**
      * Actual do batch register agent endpoint into agent.
      *
@@ -507,7 +507,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, AgentEndpointResponse.class);
         redoService.agentEndpointRegistered(agentName);
     }
-
+    
     /**
      * Deregister agent endpoint from agent.
      *
@@ -524,7 +524,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.agentEndpointDeregister(agentName);
         doDeregisterAgentEndpoint(agentName, endpoint);
     }
-
+    
     /**
      * Actual do deregister agent endpoint from agent.
      *
@@ -541,7 +541,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, AgentEndpointResponse.class);
         redoService.agentEndpointDeregistered(agentName);
     }
-
+    
     /**
      * Subscribe agent card.
      *
@@ -569,7 +569,7 @@ public class AiGrpcClient implements AiClientProxy {
         }
         return cachedAgentCard;
     }
-
+    
     /**
      * Un-subscribe agent card.
      *
@@ -584,11 +584,11 @@ public class AiGrpcClient implements AiClientProxy {
         }
         agentCardCacheHolder.removeAgentCardUpdateTask(agentName, version);
     }
-
+    
     public boolean isEnable() {
         return rpcClient.isRunning();
     }
-
+    
     /**
      * Determine whether nacos-server supports the capability.
      *
@@ -598,7 +598,7 @@ public class AiGrpcClient implements AiClientProxy {
     public boolean isAbilitySupportedByServer(AbilityKey abilityKey) {
         return rpcClient.getConnectionAbility(abilityKey) == AbilityStatus.SUPPORTED;
     }
-
+    
     private <T extends Response> T requestToServer(Request request, Class<T> responseClass) throws NacosException {
         Response response = null;
         try {
@@ -615,7 +615,7 @@ public class AiGrpcClient implements AiClientProxy {
                 throw new NacosException(400,
                         String.format("Unknown AI request type: %s", request.getClass().getSimpleName()));
             }
-
+            
             response = requestTimeout < 0 ? rpcClient.request(request) : rpcClient.request(request, requestTimeout);
             if (ResponseCode.SUCCESS.getCode() != response.getResultCode()) {
                 // If the 403 login operation is triggered, refresh the accessToken of the client
@@ -637,12 +637,12 @@ public class AiGrpcClient implements AiClientProxy {
             throw new NacosException(NacosException.SERVER_ERROR, "Request nacos server failed: ", e);
         }
     }
-
+    
     private Map<String, String> getSecurityHeaders(String namespace, String mcpName) {
         RequestResource resource = buildRequestResource(namespace, mcpName);
         return securityProxy.getIdentityContext(resource);
     }
-
+    
     private RequestResource buildRequestResource(String namespaceId, String mcpName) {
         RequestResource.Builder builder = RequestResource.aiBuilder();
         builder.setNamespace(namespaceId);
@@ -650,7 +650,7 @@ public class AiGrpcClient implements AiClientProxy {
         builder.setResource(null == mcpName ? StringUtils.EMPTY : mcpName);
         return builder.build();
     }
-
+    
     @Override
     public void shutdown() throws NacosException {
         rpcClient.shutdown();

--- a/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiGrpcClient.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiGrpcClient.java
@@ -92,27 +92,27 @@ import static com.alibaba.nacos.client.constant.Constants.Security.SECURITY_INFO
  * @author xiweng.yy
  */
 public class AiGrpcClient implements AiClientProxy {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AiGrpcClient.class);
-    
+
     private final String namespaceId;
-    
+
     private final String uuid;
-    
+
     private final Long requestTimeout;
-    
+
     private final RpcClient rpcClient;
-    
+
     private final AbstractServerListManager serverListManager;
-    
+
     private final AiGrpcRedoService redoService;
 
     private final NacosClientProperties properties;
 
     private SecurityProxy securityProxy;
-    
+
     private NacosMcpServerCacheHolder mcpServerCacheHolder;
-    
+
     private NacosAgentCardCacheHolder agentCardCacheHolder;
 
     private ScheduledThreadPoolExecutor executorService;
@@ -126,7 +126,7 @@ public class AiGrpcClient implements AiClientProxy {
         this.redoService = new AiGrpcRedoService(properties, this);
         this.properties = properties;
     }
-    
+
     private RpcClient buildRpcClient(NacosClientProperties properties) {
         Map<String, String> labels = new HashMap<>(3);
         labels.put(RemoteConstants.LABEL_SOURCE, RemoteConstants.LABEL_SOURCE_SDK);
@@ -136,7 +136,7 @@ public class AiGrpcClient implements AiClientProxy {
                 .createGrpcClientConfig(properties.asProperties(), labels);
         return RpcClientFactory.createClient(uuid, ConnectionType.GRPC, grpcClientConfig);
     }
-    
+
     /**
      * Start the grpc client.
      *
@@ -163,7 +163,7 @@ public class AiGrpcClient implements AiClientProxy {
         this.executorService.scheduleWithFixedDelay(() -> securityProxy.login(nacosClientPropertiesView), 0,
                 SECURITY_INFO_REFRESH_INTERVAL_MILLS, TimeUnit.MILLISECONDS);
     }
-    
+
     /**
      * Do query mcp server by mcpId and version.
      *
@@ -184,7 +184,7 @@ public class AiGrpcClient implements AiClientProxy {
         QueryMcpServerResponse response = requestToServer(request, QueryMcpServerResponse.class);
         return response.getMcpServerDetailInfo();
     }
-    
+
     /**
      * Query prompt by version/label/latest.
      *
@@ -197,7 +197,7 @@ public class AiGrpcClient implements AiClientProxy {
     public Prompt queryPrompt(String promptKey, String version, String label) throws NacosException {
         return queryPrompt(promptKey, version, label, null);
     }
-    
+
     /**
      * Query prompt by version/label/latest with optional md5.
      *
@@ -231,7 +231,7 @@ public class AiGrpcClient implements AiClientProxy {
             McpEndpointSpec endpointSpecification) throws NacosException {
         return releaseMcpServer(serverSpecification, toolSpecification, null, endpointSpecification);
     }
-    
+
     /**
      * Release mcp server with explicit resource specification.
      *
@@ -261,7 +261,7 @@ public class AiGrpcClient implements AiClientProxy {
         ReleaseMcpServerResponse response = requestToServer(request, ReleaseMcpServerResponse.class);
         return response.getMcpId();
     }
-    
+
     /**
      * Register endpoint to target mcp server and cached to redo service.
      *
@@ -282,7 +282,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.cachedMcpServerEndpointForRedo(mcpName, address, port, version);
         doRegisterMcpServerEndpoint(mcpName, address, port, version);
     }
-    
+
     /**
      * Actual do Register endpoint to target mcp server.
      *
@@ -304,7 +304,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, McpServerEndpointResponse.class);
         redoService.mcpServerEndpointRegistered(mcpName);
     }
-    
+
     /**
      * Deregister endpoint from target mcp server and cached to redo service.
      *
@@ -322,7 +322,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.mcpServerEndpointDeregister(mcpName);
         doDeregisterMcpServerEndpoint(mcpName, address, port);
     }
-    
+
     /**
      * Actual do deregister endpoint from target mcp server.
      *
@@ -341,7 +341,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, McpServerEndpointResponse.class);
         redoService.mcpServerEndpointDeregistered(mcpName);
     }
-    
+
     /**
      * Subscribe mcp server latest version.
      *
@@ -369,7 +369,7 @@ public class AiGrpcClient implements AiClientProxy {
         }
         return cachedServer;
     }
-    
+
     /**
      * Un-subscribe mcp server.
      *
@@ -384,7 +384,7 @@ public class AiGrpcClient implements AiClientProxy {
         }
         mcpServerCacheHolder.removeMcpServerUpdateTask(mcpName, version);
     }
-    
+
     /**
      * Get agent card with nacos extension detail with target version.
      *
@@ -408,7 +408,7 @@ public class AiGrpcClient implements AiClientProxy {
         QueryAgentCardResponse response = requestToServer(request, QueryAgentCardResponse.class);
         return response.getAgentCardDetailInfo();
     }
-    
+
     /**
      * Release new agent card or new version.
      *
@@ -440,7 +440,7 @@ public class AiGrpcClient implements AiClientProxy {
         request.setSetAsLatest(setAsLatest);
         requestToServer(request, ReleaseAgentCardResponse.class);
     }
-    
+
     /**
      * Register agent endpoint into agent.
      *
@@ -457,7 +457,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.cachedAgentEndpointForRedo(agentName, AgentEndpointWrapper.wrap(endpoint));
         doRegisterAgentEndpoint(agentName, endpoint);
     }
-    
+
     /**
      * Batch Register agent endpoint into agent.
      *
@@ -474,7 +474,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.cachedAgentEndpointForRedo(agentName, AgentEndpointWrapper.wrap(endpoints));
         doRegisterAgentEndpoint(agentName, endpoints);
     }
-    
+
     /**
      * Actual do register agent endpoint into agent.
      *
@@ -491,7 +491,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, AgentEndpointResponse.class);
         redoService.agentEndpointRegistered(agentName);
     }
-    
+
     /**
      * Actual do batch register agent endpoint into agent.
      *
@@ -507,7 +507,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, AgentEndpointResponse.class);
         redoService.agentEndpointRegistered(agentName);
     }
-    
+
     /**
      * Deregister agent endpoint from agent.
      *
@@ -524,7 +524,7 @@ public class AiGrpcClient implements AiClientProxy {
         redoService.agentEndpointDeregister(agentName);
         doDeregisterAgentEndpoint(agentName, endpoint);
     }
-    
+
     /**
      * Actual do deregister agent endpoint from agent.
      *
@@ -541,7 +541,7 @@ public class AiGrpcClient implements AiClientProxy {
         requestToServer(request, AgentEndpointResponse.class);
         redoService.agentEndpointDeregistered(agentName);
     }
-    
+
     /**
      * Subscribe agent card.
      *
@@ -569,7 +569,7 @@ public class AiGrpcClient implements AiClientProxy {
         }
         return cachedAgentCard;
     }
-    
+
     /**
      * Un-subscribe agent card.
      *
@@ -584,11 +584,11 @@ public class AiGrpcClient implements AiClientProxy {
         }
         agentCardCacheHolder.removeAgentCardUpdateTask(agentName, version);
     }
-    
+
     public boolean isEnable() {
         return rpcClient.isRunning();
     }
-    
+
     /**
      * Determine whether nacos-server supports the capability.
      *
@@ -598,7 +598,7 @@ public class AiGrpcClient implements AiClientProxy {
     public boolean isAbilitySupportedByServer(AbilityKey abilityKey) {
         return rpcClient.getConnectionAbility(abilityKey) == AbilityStatus.SUPPORTED;
     }
-    
+
     private <T extends Response> T requestToServer(Request request, Class<T> responseClass) throws NacosException {
         Response response = null;
         try {
@@ -615,7 +615,7 @@ public class AiGrpcClient implements AiClientProxy {
                 throw new NacosException(400,
                         String.format("Unknown AI request type: %s", request.getClass().getSimpleName()));
             }
-            
+
             response = requestTimeout < 0 ? rpcClient.request(request) : rpcClient.request(request, requestTimeout);
             if (ResponseCode.SUCCESS.getCode() != response.getResultCode()) {
                 // If the 403 login operation is triggered, refresh the accessToken of the client
@@ -637,12 +637,12 @@ public class AiGrpcClient implements AiClientProxy {
             throw new NacosException(NacosException.SERVER_ERROR, "Request nacos server failed: ", e);
         }
     }
-    
+
     private Map<String, String> getSecurityHeaders(String namespace, String mcpName) {
         RequestResource resource = buildRequestResource(namespace, mcpName);
         return securityProxy.getIdentityContext(resource);
     }
-    
+
     private RequestResource buildRequestResource(String namespaceId, String mcpName) {
         RequestResource.Builder builder = RequestResource.aiBuilder();
         builder.setNamespace(namespaceId);
@@ -650,7 +650,7 @@ public class AiGrpcClient implements AiClientProxy {
         builder.setResource(null == mcpName ? StringUtils.EMPTY : mcpName);
         return builder.build();
     }
-    
+
     @Override
     public void shutdown() throws NacosException {
         rpcClient.shutdown();

--- a/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiGrpcClient.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiGrpcClient.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.api.ai.model.a2a.AgentCard;
 import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
 import com.alibaba.nacos.api.ai.model.a2a.AgentEndpoint;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
@@ -228,6 +229,22 @@ public class AiGrpcClient implements AiClientProxy {
      */
     public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
             McpEndpointSpec endpointSpecification) throws NacosException {
+        return releaseMcpServer(serverSpecification, toolSpecification, null, endpointSpecification);
+    }
+    
+    /**
+     * Release mcp server with explicit resource specification.
+     *
+     * @param serverSpecification mcp server specification
+     * @param toolSpecification mcp server tool specification, optional
+     * @param resourceSpecification mcp server resource specification, optional
+     * @param endpointSpecification mcp server endpoint specification, optional
+     * @return mcp id
+     * @throws NacosException if request parameter is invalid or handle error
+     */
+    public String releaseMcpServer(McpServerBasicInfo serverSpecification, McpToolSpecification toolSpecification,
+            McpResourceSpecification resourceSpecification, McpEndpointSpec endpointSpecification)
+            throws NacosException {
         LOGGER.info("[{}] RELEASE Mcp server {}, version {}", uuid, serverSpecification.getName(),
                 serverSpecification.getVersionDetail().getVersion());
         if (!isAbilitySupportedByServer(AbilityKey.SERVER_MCP_REGISTRY)) {
@@ -239,6 +256,7 @@ public class AiGrpcClient implements AiClientProxy {
         request.setMcpName(serverSpecification.getName());
         request.setServerSpecification(serverSpecification);
         request.setToolSpecification(toolSpecification);
+        request.setResourceSpecification(resourceSpecification);
         request.setEndpointSpecification(endpointSpecification);
         ReleaseMcpServerResponse response = requestToServer(request, ReleaseMcpServerResponse.class);
         return response.getMcpId();

--- a/client/src/test/java/com/alibaba/nacos/client/ai/NacosAiServiceTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/NacosAiServiceTest.java
@@ -59,35 +59,35 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NacosAiServiceTest {
-
+    
     @Mock
     private AiGrpcClient grpcClient;
-
+    
     @Mock
     private NacosMcpServerCacheHolder mcpServerCacheHolder;
-
+    
     @Mock
     private NacosAgentCardCacheHolder agentCardCacheHolder;
-
+    
     @Mock
     private AiChangeNotifier aiChangeNotifier;
-
+    
     NacosAiService nacosAiService;
-
+    
     @BeforeEach
     void setUp() throws NacosException {
         Properties properties = new Properties();
         properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1");
         nacosAiService = new NacosAiService(properties);
     }
-
+    
     @AfterEach
     void tearDown() throws NacosException {
         if (null != nacosAiService) {
             nacosAiService.shutdown();
         }
     }
-
+    
     @Test
     void testConstructorWithNamespace() throws NoSuchFieldException, IllegalAccessException, NacosException {
         Field field = NacosAiService.class.getDeclaredField("namespaceId");
@@ -106,19 +106,19 @@ class NacosAiServiceTest {
             }
         }
     }
-
+    
     @Test
     void getMcpServer() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
         when(grpcClient.queryMcpServer("testMcpName", "1.0.0")).thenReturn(new McpServerDetailInfo());
         assertNotNull(nacosAiService.getMcpServer("testMcpName", "1.0.0"));
     }
-
+    
     @Test
     void getMcpServerWithInvalidMcpName() throws NoSuchFieldException, IllegalAccessException, NacosException {
         assertThrows(NacosApiException.class, () -> nacosAiService.getMcpServer("", "1.0.0"));
     }
-
+    
     @Test
     void releaseMcpServer() throws NacosException, NoSuchFieldException, IllegalAccessException {
         injectMocks();
@@ -130,7 +130,7 @@ class NacosAiServiceTest {
         when(grpcClient.releaseMcpServer(serverSpecification, null, null, null)).thenReturn(id);
         assertEquals(id, nacosAiService.releaseMcpServer(serverSpecification, null));
     }
-
+    
     @Test
     void releaseMcpServerWithInvalidParameters() throws NacosException {
         assertThrows(NacosApiException.class, () -> nacosAiService.releaseMcpServer(null, null));
@@ -141,14 +141,14 @@ class NacosAiServiceTest {
         serverSpecification.setVersionDetail(new ServerVersionDetail());
         assertThrows(NacosApiException.class, () -> nacosAiService.releaseMcpServer(serverSpecification, null));
     }
-
+    
     @Test
     void registerMcpServerEndpoint() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
         nacosAiService.registerMcpServerEndpoint("testMcpName", "1.1.1.1", 8848, "1.0.0");
         verify(grpcClient).registerMcpServerEndpoint("testMcpName", "1.1.1.1", 8848, "1.0.0");
     }
-
+    
     @Test
     void registerMcpServerEndpointWithInvalidParameters() {
         assertThrows(NacosApiException.class, () -> nacosAiService.registerMcpServerEndpoint("", null, -1, "1.0.0"));
@@ -157,14 +157,14 @@ class NacosAiServiceTest {
         assertThrows(NacosApiException.class,
                 () -> nacosAiService.registerMcpServerEndpoint("testMcpName", "1.1.1.1", -1, "1.0.0"));
     }
-
+    
     @Test
     void deregisterMcpServerEndpoint() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
         nacosAiService.deregisterMcpServerEndpoint("testMcpName", "1.1.1.1", 8848);
         verify(grpcClient).deregisterMcpServerEndpoint("testMcpName", "1.1.1.1", 8848);
     }
-
+    
     @Test
     void deregisterMcpServerEndpointWithInvalidParameters() {
         assertThrows(NacosApiException.class, () -> nacosAiService.deregisterMcpServerEndpoint("", null, -1));
@@ -173,7 +173,7 @@ class NacosAiServiceTest {
         assertThrows(NacosApiException.class,
                 () -> nacosAiService.deregisterMcpServerEndpoint("testMcpName", "1.1.1.1", -1));
     }
-
+    
     @Test
     void subscribeMcpServer() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -185,13 +185,13 @@ class NacosAiServiceTest {
         verify(aiChangeNotifier).registerListener(eq("testMcpName"), isNull(), any(McpServerListenerInvoker.class));
         verify(listener).onEvent(any(NacosMcpServerEvent.class));
     }
-
+    
     @Test
     void subscribeMcpServerWithInvalidParameters() {
         assertThrows(NacosApiException.class, () -> nacosAiService.subscribeMcpServer("", null));
         assertThrows(NacosApiException.class, () -> nacosAiService.subscribeMcpServer("testMcpName", null));
     }
-
+    
     @Test
     void unsubscribeMcpServer() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -200,7 +200,7 @@ class NacosAiServiceTest {
         verify(aiChangeNotifier).deregisterListener(eq("testMcpName"), isNull(), any(McpServerListenerInvoker.class));
         verify(grpcClient).unsubscribeMcpServer("testMcpName", null);
     }
-
+    
     @Test
     void unsubscribeMcpServerWithOtherListener() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -210,7 +210,7 @@ class NacosAiServiceTest {
         verify(aiChangeNotifier).deregisterListener(eq("testMcpName"), isNull(), any(McpServerListenerInvoker.class));
         verify(grpcClient, never()).unsubscribeMcpServer("testMcpName", null);
     }
-
+    
     @Test
     void unsubscribeMcpServerWithNullListener() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -218,12 +218,12 @@ class NacosAiServiceTest {
         verify(aiChangeNotifier, never()).deregisterListener(eq("testMcpName"), isNull(), any(McpServerListenerInvoker.class));
         verify(grpcClient, never()).unsubscribeMcpServer("testMcpName", null);
     }
-
+    
     @Test
     void unsubscribeMcpServerWithInvalidParameters() {
         assertThrows(NacosApiException.class, () -> nacosAiService.unsubscribeMcpServer("", null));
     }
-
+    
     @Test
     void registerAgentEndpointWithCollection() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -231,29 +231,29 @@ class NacosAiServiceTest {
         nacosAiService.registerAgentEndpoint("testAgent", endpoints);
         verify(grpcClient).registerAgentEndpoints("testAgent", endpoints);
     }
-
+    
     @Test
     void registerAgentEndpointWithCollectionInvalidAgentName() {
         Collection<AgentEndpoint> endpoints = createTestEndpoints();
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("", endpoints));
     }
-
+    
     @Test
     void registerAgentEndpointWithCollectionNullEndpoints() {
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", (Collection<AgentEndpoint>) null));
     }
-
+    
     @Test
     void registerAgentEndpointWithCollectionEmptyEndpoints() {
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", new ArrayList<>()));
     }
-
+    
     @Test
     void registerAgentEndpointWithCollectionNullEndpointInList() {
         Collection<AgentEndpoint> endpoints = Arrays.asList(new AgentEndpoint(), null);
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", endpoints));
     }
-
+    
     @Test
     void registerAgentEndpointWithCollectionEndpointWithoutVersion() {
         AgentEndpoint endpoint = new AgentEndpoint();
@@ -263,23 +263,23 @@ class NacosAiServiceTest {
         Collection<AgentEndpoint> endpoints = Arrays.asList(endpoint);
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", endpoints));
     }
-
+    
     @Test
     void registerAgentEndpointWithCollectionDifferentVersions() {
         AgentEndpoint endpoint1 = new AgentEndpoint();
         endpoint1.setAddress("1.1.1.1");
         endpoint1.setPort(8080);
         endpoint1.setVersion("1.0.0");
-
+        
         AgentEndpoint endpoint2 = new AgentEndpoint();
         endpoint2.setAddress("2.2.2.2");
         endpoint2.setPort(9090);
         endpoint2.setVersion("2.0.0");
-
+        
         Collection<AgentEndpoint> endpoints = Arrays.asList(endpoint1, endpoint2);
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", endpoints));
     }
-
+    
     private void injectMocks() throws NoSuchFieldException, IllegalAccessException {
         Field field = NacosAiService.class.getDeclaredField("grpcClient");
         field.setAccessible(true);
@@ -310,18 +310,18 @@ class NacosAiServiceTest {
         } catch (NacosException ignored) {
         }
     }
-
+    
     private Collection<AgentEndpoint> createTestEndpoints() {
         AgentEndpoint endpoint1 = new AgentEndpoint();
         endpoint1.setAddress("1.1.1.1");
         endpoint1.setPort(8080);
         endpoint1.setVersion("1.0.0");
-
+        
         AgentEndpoint endpoint2 = new AgentEndpoint();
         endpoint2.setAddress("2.2.2.2");
         endpoint2.setPort(9090);
         endpoint2.setVersion("1.0.0");
-
+        
         return Arrays.asList(endpoint1, endpoint2);
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/ai/NacosAiServiceTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/NacosAiServiceTest.java
@@ -59,35 +59,35 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NacosAiServiceTest {
-    
+
     @Mock
     private AiGrpcClient grpcClient;
-    
+
     @Mock
     private NacosMcpServerCacheHolder mcpServerCacheHolder;
-    
+
     @Mock
     private NacosAgentCardCacheHolder agentCardCacheHolder;
-    
+
     @Mock
     private AiChangeNotifier aiChangeNotifier;
-    
+
     NacosAiService nacosAiService;
-    
+
     @BeforeEach
     void setUp() throws NacosException {
         Properties properties = new Properties();
         properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1");
         nacosAiService = new NacosAiService(properties);
     }
-    
+
     @AfterEach
     void tearDown() throws NacosException {
         if (null != nacosAiService) {
             nacosAiService.shutdown();
         }
     }
-    
+
     @Test
     void testConstructorWithNamespace() throws NoSuchFieldException, IllegalAccessException, NacosException {
         Field field = NacosAiService.class.getDeclaredField("namespaceId");
@@ -106,19 +106,19 @@ class NacosAiServiceTest {
             }
         }
     }
-    
+
     @Test
     void getMcpServer() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
         when(grpcClient.queryMcpServer("testMcpName", "1.0.0")).thenReturn(new McpServerDetailInfo());
         assertNotNull(nacosAiService.getMcpServer("testMcpName", "1.0.0"));
     }
-    
+
     @Test
     void getMcpServerWithInvalidMcpName() throws NoSuchFieldException, IllegalAccessException, NacosException {
         assertThrows(NacosApiException.class, () -> nacosAiService.getMcpServer("", "1.0.0"));
     }
-    
+
     @Test
     void releaseMcpServer() throws NacosException, NoSuchFieldException, IllegalAccessException {
         injectMocks();
@@ -130,7 +130,7 @@ class NacosAiServiceTest {
         when(grpcClient.releaseMcpServer(serverSpecification, null, null, null)).thenReturn(id);
         assertEquals(id, nacosAiService.releaseMcpServer(serverSpecification, null));
     }
-    
+
     @Test
     void releaseMcpServerWithInvalidParameters() throws NacosException {
         assertThrows(NacosApiException.class, () -> nacosAiService.releaseMcpServer(null, null));
@@ -141,14 +141,14 @@ class NacosAiServiceTest {
         serverSpecification.setVersionDetail(new ServerVersionDetail());
         assertThrows(NacosApiException.class, () -> nacosAiService.releaseMcpServer(serverSpecification, null));
     }
-    
+
     @Test
     void registerMcpServerEndpoint() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
         nacosAiService.registerMcpServerEndpoint("testMcpName", "1.1.1.1", 8848, "1.0.0");
         verify(grpcClient).registerMcpServerEndpoint("testMcpName", "1.1.1.1", 8848, "1.0.0");
     }
-    
+
     @Test
     void registerMcpServerEndpointWithInvalidParameters() {
         assertThrows(NacosApiException.class, () -> nacosAiService.registerMcpServerEndpoint("", null, -1, "1.0.0"));
@@ -157,14 +157,14 @@ class NacosAiServiceTest {
         assertThrows(NacosApiException.class,
                 () -> nacosAiService.registerMcpServerEndpoint("testMcpName", "1.1.1.1", -1, "1.0.0"));
     }
-    
+
     @Test
     void deregisterMcpServerEndpoint() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
         nacosAiService.deregisterMcpServerEndpoint("testMcpName", "1.1.1.1", 8848);
         verify(grpcClient).deregisterMcpServerEndpoint("testMcpName", "1.1.1.1", 8848);
     }
-    
+
     @Test
     void deregisterMcpServerEndpointWithInvalidParameters() {
         assertThrows(NacosApiException.class, () -> nacosAiService.deregisterMcpServerEndpoint("", null, -1));
@@ -173,7 +173,7 @@ class NacosAiServiceTest {
         assertThrows(NacosApiException.class,
                 () -> nacosAiService.deregisterMcpServerEndpoint("testMcpName", "1.1.1.1", -1));
     }
-    
+
     @Test
     void subscribeMcpServer() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -185,13 +185,13 @@ class NacosAiServiceTest {
         verify(aiChangeNotifier).registerListener(eq("testMcpName"), isNull(), any(McpServerListenerInvoker.class));
         verify(listener).onEvent(any(NacosMcpServerEvent.class));
     }
-    
+
     @Test
     void subscribeMcpServerWithInvalidParameters() {
         assertThrows(NacosApiException.class, () -> nacosAiService.subscribeMcpServer("", null));
         assertThrows(NacosApiException.class, () -> nacosAiService.subscribeMcpServer("testMcpName", null));
     }
-    
+
     @Test
     void unsubscribeMcpServer() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -200,7 +200,7 @@ class NacosAiServiceTest {
         verify(aiChangeNotifier).deregisterListener(eq("testMcpName"), isNull(), any(McpServerListenerInvoker.class));
         verify(grpcClient).unsubscribeMcpServer("testMcpName", null);
     }
-    
+
     @Test
     void unsubscribeMcpServerWithOtherListener() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -210,7 +210,7 @@ class NacosAiServiceTest {
         verify(aiChangeNotifier).deregisterListener(eq("testMcpName"), isNull(), any(McpServerListenerInvoker.class));
         verify(grpcClient, never()).unsubscribeMcpServer("testMcpName", null);
     }
-    
+
     @Test
     void unsubscribeMcpServerWithNullListener() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -218,12 +218,12 @@ class NacosAiServiceTest {
         verify(aiChangeNotifier, never()).deregisterListener(eq("testMcpName"), isNull(), any(McpServerListenerInvoker.class));
         verify(grpcClient, never()).unsubscribeMcpServer("testMcpName", null);
     }
-    
+
     @Test
     void unsubscribeMcpServerWithInvalidParameters() {
         assertThrows(NacosApiException.class, () -> nacosAiService.unsubscribeMcpServer("", null));
     }
-    
+
     @Test
     void registerAgentEndpointWithCollection() throws NoSuchFieldException, IllegalAccessException, NacosException {
         injectMocks();
@@ -231,29 +231,29 @@ class NacosAiServiceTest {
         nacosAiService.registerAgentEndpoint("testAgent", endpoints);
         verify(grpcClient).registerAgentEndpoints("testAgent", endpoints);
     }
-    
+
     @Test
     void registerAgentEndpointWithCollectionInvalidAgentName() {
         Collection<AgentEndpoint> endpoints = createTestEndpoints();
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("", endpoints));
     }
-    
+
     @Test
     void registerAgentEndpointWithCollectionNullEndpoints() {
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", (Collection<AgentEndpoint>) null));
     }
-    
+
     @Test
     void registerAgentEndpointWithCollectionEmptyEndpoints() {
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", new ArrayList<>()));
     }
-    
+
     @Test
     void registerAgentEndpointWithCollectionNullEndpointInList() {
         Collection<AgentEndpoint> endpoints = Arrays.asList(new AgentEndpoint(), null);
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", endpoints));
     }
-    
+
     @Test
     void registerAgentEndpointWithCollectionEndpointWithoutVersion() {
         AgentEndpoint endpoint = new AgentEndpoint();
@@ -263,23 +263,23 @@ class NacosAiServiceTest {
         Collection<AgentEndpoint> endpoints = Arrays.asList(endpoint);
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", endpoints));
     }
-    
+
     @Test
     void registerAgentEndpointWithCollectionDifferentVersions() {
         AgentEndpoint endpoint1 = new AgentEndpoint();
         endpoint1.setAddress("1.1.1.1");
         endpoint1.setPort(8080);
         endpoint1.setVersion("1.0.0");
-        
+
         AgentEndpoint endpoint2 = new AgentEndpoint();
         endpoint2.setAddress("2.2.2.2");
         endpoint2.setPort(9090);
         endpoint2.setVersion("2.0.0");
-        
+
         Collection<AgentEndpoint> endpoints = Arrays.asList(endpoint1, endpoint2);
         assertThrows(NacosApiException.class, () -> nacosAiService.registerAgentEndpoint("testAgent", endpoints));
     }
-    
+
     private void injectMocks() throws NoSuchFieldException, IllegalAccessException {
         Field field = NacosAiService.class.getDeclaredField("grpcClient");
         field.setAccessible(true);
@@ -310,18 +310,18 @@ class NacosAiServiceTest {
         } catch (NacosException ignored) {
         }
     }
-    
+
     private Collection<AgentEndpoint> createTestEndpoints() {
         AgentEndpoint endpoint1 = new AgentEndpoint();
         endpoint1.setAddress("1.1.1.1");
         endpoint1.setPort(8080);
         endpoint1.setVersion("1.0.0");
-        
+
         AgentEndpoint endpoint2 = new AgentEndpoint();
         endpoint2.setAddress("2.2.2.2");
         endpoint2.setPort(9090);
         endpoint2.setVersion("1.0.0");
-        
+
         return Arrays.asList(endpoint1, endpoint2);
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/ai/NacosAiServiceTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/NacosAiServiceTest.java
@@ -127,7 +127,7 @@ class NacosAiServiceTest {
         serverSpecification.setVersionDetail(new ServerVersionDetail());
         serverSpecification.getVersionDetail().setVersion("1.0.0");
         String id = UUID.randomUUID().toString();
-        when(grpcClient.releaseMcpServer(serverSpecification, null, null)).thenReturn(id);
+        when(grpcClient.releaseMcpServer(serverSpecification, null, null, null)).thenReturn(id);
         assertEquals(id, nacosAiService.releaseMcpServer(serverSpecification, null));
     }
     


### PR DESCRIPTION
## What is the purpose of the change

当前 MCP Server 的注册/导入流程只覆盖了服务本身和工具能力，`resourceSpecification` 在服务端没有真正打通，导致资源规范会被忽略，detail 查询拿不到资源信息，`RESOURCE` 能力也无法自动推导。

这个 PR 补齐了 MCP Resource Registry 链路，让 MCP Server 在发布、导入、查询、更新、删除时都能正确处理资源规范。

## Brief changelog

- 为 `releaseMcpServer` 增加资源规范参数透传
- 更新 `AiService` 接口，支持资源规范
- 增加 MCP 资源相关常量和 dataId 模板
- 在 `McpAdminController` 中集成资源规范解析逻辑
- 扩展 `McpDetailForm` 和 `McpServerDetailInfo`，支持返回资源规范
- 在 `McpRequestUtil` 中实现资源规范解析
- 更新 `McpServerImportService`，支持导入资源规范
- 扩展 `McpServerOperationService`，支持资源规范的创建、更新、删除级联处理
- 增加单元测试覆盖资源规范相关场景

## Verifying this change

已通过本地接口复现和定向测试验证：

- 变更前：`resourceSpecification` 会被忽略，detail 中没有 `resourceSpec`，`capabilities` 中没有 `RESOURCE`
- 变更后：`resourceSpecification` 可被存储，detail 中可返回 `resourceSpec`，`capabilities` 中可自动包含 `RESOURCE`
