### PR TITLE
[AI] Support force-publish agentspecs for admin user

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
@@ -225,6 +225,21 @@ public class AgentSpecAdminController {
     }
     
     /**
+     * Force-publish an agentspec version, bypassing pipeline validation. Accepts draft (pipeline-rejected) and
+     * reviewing (pipeline in-progress) versions. Only admin users can call this endpoint.
+     */
+    @PostMapping("/force-publish")
+    @Secured(resource = Constants.AgentSpecs.ADMIN_PATH
+            + "/force-publish", action = ActionTypes.WRITE, signType = SignType.CONSOLE, apiType = ApiType.ADMIN_API)
+    public Result<String> forcePublish(AgentSpecPublishForm form) throws NacosException {
+        form.validate();
+        boolean updateLatest = form.getUpdateLatestLabel() == null || form.getUpdateLatestLabel();
+        agentSpecOperationService.forcePublish(form.getNamespaceId(), form.getAgentSpecName(), form.getVersion(),
+                updateLatest);
+        return Result.success("ok");
+    }
+    
+    /**
      * Update runtime route labels without changing version status.
      */
     @PutMapping("/labels")

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationService.java
@@ -215,6 +215,19 @@ public interface AgentSpecOperationService {
     void publish(String namespaceId, String name, String version, boolean updateLatestLabel) throws NacosException;
     
     /**
+     * Force-publish an agentspec version, bypassing pipeline validation.
+     * Accepts draft (pipeline-rejected) and reviewing (pipeline in-progress) versions.
+     * Should only be invoked by admin users.
+     *
+     * @param namespaceId       namespace ID
+     * @param name              agentspec name
+     * @param version           version to force-publish
+     * @param updateLatestLabel whether to update the "latest" label
+     */
+    void forcePublish(String namespaceId, String name, String version, boolean updateLatestLabel)
+            throws NacosException;
+    
+    /**
      * Update labels mapping (label -> version) without changing any version status.
      *
      * @param namespaceId namespace ID

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -871,6 +871,47 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     }
     
     @Override
+    public void forcePublish(String namespaceId, String name, String version, boolean updateLatestLabel)
+            throws NacosException {
+        AiResource meta = requireMeta(namespaceId, name);
+        VisibilityHelper.checkWritableResource(meta);
+        AgentSpecVersionInfo info = requireVersionInfo(meta);
+        
+        AiResourceVersion v = aiResourceVersionPersistService.find(namespaceId, name, RESOURCE_TYPE_AGENTSPEC,
+                version);
+        if (v == null) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                    "AgentSpec version not found: " + name + "@" + version);
+        }
+        if (VERSION_STATUS_ONLINE.equalsIgnoreCase(v.getStatus())) {
+            throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                    "Version is already online, force-publish is not needed: " + version);
+        }
+        
+        LOGGER.warn("[FORCE-PUBLISH] Bypassing pipeline validation for agentspec {}@{} by user {}", name, version,
+                VisibilityHelper.resolveCurrentIdentity());
+        
+        aiResourceVersionPersistService.updateStatus(namespaceId, name, RESOURCE_TYPE_AGENTSPEC, version,
+                VERSION_STATUS_ONLINE);
+        
+        if (StringUtils.equals(info.getEditingVersion(), version)) {
+            info.setEditingVersion(null);
+        }
+        if (StringUtils.equals(info.getReviewingVersion(), version)) {
+            info.setReviewingVersion(null);
+        }
+        Integer cnt = info.getOnlineCnt();
+        info.setOnlineCnt(cnt == null ? 1 : (cnt + 1));
+        if (info.getLabels() == null) {
+            info.setLabels(new HashMap<>(4));
+        }
+        if (updateLatestLabel) {
+            info.getLabels().put(LABEL_LATEST, version);
+        }
+        updateMetaVersionInfoCas(namespaceId, meta, info);
+    }
+    
+    @Override
     public void updateLabels(String namespaceId, String name, Map<String, String> labels) throws NacosException {
         AiResource meta = requireMeta(namespaceId, name);
         VisibilityHelper.checkWritableResource(meta);

--- a/console-ui-next/src/api/agentspec.ts
+++ b/console-ui-next/src/api/agentspec.ts
@@ -87,6 +87,15 @@ export const agentSpecApi = {
   }): ApiResult<string> =>
     client.post(`${BASE}/publish`, data) as ApiResult<string>,
 
+  /** 强制发布（跳过 pipeline 校验，仅限管理员） */
+  forcePublish: (data: {
+    namespaceId?: string;
+    agentSpecName: string;
+    version: string;
+    updateLatestLabel?: boolean;
+  }): ApiResult<string> =>
+    client.post(`${BASE}/force-publish`, data) as ApiResult<string>,
+
   /** 更新标签 */
   updateLabels: (data: {
     namespaceId?: string;

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAgentSpecController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAgentSpecController.java
@@ -44,6 +44,8 @@ import com.alibaba.nacos.core.model.form.PageForm;
 import com.alibaba.nacos.core.paramcheck.ExtractorManager;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.constant.SignType;
+
+import static com.alibaba.nacos.plugin.auth.constant.Constants.Resource.CONSOLE_RESOURCE_NAME_PREFIX;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -223,6 +225,20 @@ public class ConsoleAgentSpecController {
     public Result<String> publish(AgentSpecPublishForm form) throws NacosException {
         form.validate();
         agentSpecProxy.publish(form);
+        return Result.success("ok");
+    }
+    
+    /**
+     * Force-publish an agentspec version, bypassing pipeline validation. Accepts draft (pipeline-rejected) and
+     * reviewing (pipeline in-progress) versions. Restricted to admin users only (apiType = ADMIN_API enforces global
+     * admin check).
+     */
+    @PostMapping("/force-publish")
+    @Secured(resource = CONSOLE_RESOURCE_NAME_PREFIX
+            + "agentspecs", action = ActionTypes.WRITE, signType = SignType.CONSOLE, apiType = ApiType.CONSOLE_API)
+    public Result<String> forcePublish(AgentSpecPublishForm form) throws NacosException {
+        form.validate();
+        agentSpecProxy.forcePublish(form);
         return Result.success("ok");
     }
     

--- a/console/src/main/java/com/alibaba/nacos/console/handler/ai/AgentSpecHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/ai/AgentSpecHandler.java
@@ -143,6 +143,14 @@ public interface AgentSpecHandler {
     void publish(AgentSpecPublishForm form) throws NacosException;
 
     /**
+     * Force-publish a version, bypassing pipeline validation.
+     *
+     * @param form publish form
+     * @throws NacosException if operation failed
+     */
+    void forcePublish(AgentSpecPublishForm form) throws NacosException;
+
+    /**
      * Update runtime route labels without changing version status.
      *
      * @param form labels update form

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/AgentSpecInnerHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/AgentSpecInnerHandler.java
@@ -122,6 +122,13 @@ public class AgentSpecInnerHandler implements AgentSpecHandler {
     }
 
     @Override
+    public void forcePublish(AgentSpecPublishForm form) throws NacosException {
+        boolean updateLatest = form.getUpdateLatestLabel() == null || form.getUpdateLatestLabel();
+        agentSpecOperationService.forcePublish(form.getNamespaceId(), form.getAgentSpecName(), form.getVersion(),
+                updateLatest);
+    }
+
+    @Override
     public void updateLabels(AgentSpecLabelsUpdateForm form) throws NacosException {
         Map<String, String> labels = JacksonUtils.toObj(form.getLabels(), Map.class);
         agentSpecOperationService.updateLabels(form.getNamespaceId(), form.getAgentSpecName(), labels);

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/AgentSpecNoopHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/AgentSpecNoopHandler.java
@@ -114,6 +114,12 @@ public class AgentSpecNoopHandler implements AgentSpecHandler {
     }
 
     @Override
+    public void forcePublish(AgentSpecPublishForm form) throws NacosException {
+        throw new NacosApiException(NacosException.SERVER_NOT_IMPLEMENTED, ErrorCode.API_FUNCTION_DISABLED,
+                AGENTSPEC_NOT_ENABLED_MESSAGE);
+    }
+
+    @Override
     public void updateLabels(AgentSpecLabelsUpdateForm form) throws NacosException {
         throw new NacosApiException(NacosException.SERVER_NOT_IMPLEMENTED, ErrorCode.API_FUNCTION_DISABLED,
                 AGENTSPEC_NOT_ENABLED_MESSAGE);

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/AgentSpecRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/AgentSpecRemoteHandler.java
@@ -137,6 +137,12 @@ public class AgentSpecRemoteHandler implements AgentSpecHandler {
     }
 
     @Override
+    public void forcePublish(AgentSpecPublishForm form) throws NacosException {
+        clientHolder.getAiMaintainerService().agentSpec().forcePublish(form.getNamespaceId(),
+            form.getAgentSpecName(), form.getVersion(), form.getUpdateLatestLabel());
+    }
+
+    @Override
     public void updateLabels(AgentSpecLabelsUpdateForm form) throws NacosException {
         clientHolder.getAiMaintainerService().agentSpec().updateLabels(form.getNamespaceId(),
             form.getAgentSpecName(), form.getLabels());

--- a/console/src/main/java/com/alibaba/nacos/console/proxy/ai/AgentSpecProxy.java
+++ b/console/src/main/java/com/alibaba/nacos/console/proxy/ai/AgentSpecProxy.java
@@ -95,6 +95,10 @@ public class AgentSpecProxy {
         agentSpecHandler.publish(form);
     }
     
+    public void forcePublish(AgentSpecPublishForm form) throws NacosException {
+        agentSpecHandler.forcePublish(form);
+    }
+    
     public void updateLabels(AgentSpecLabelsUpdateForm form) throws NacosException {
         agentSpecHandler.updateLabels(form);
     }

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerService.java
@@ -239,6 +239,19 @@ public interface AgentSpecMaintainerService {
             throws NacosException;
     
     /**
+     * Force-publish an agentspec version, bypassing pipeline validation.
+     *
+     * @param namespaceId       namespace ID
+     * @param agentSpecName     agentspec name
+     * @param version           version
+     * @param updateLatestLabel update latest label, default true if null
+     * @return true if force-publish success
+     * @throws NacosException if fail to force-publish
+     */
+    boolean forcePublish(String namespaceId, String agentSpecName, String version, Boolean updateLatestLabel)
+            throws NacosException;
+    
+    /**
      * Update runtime labels mapping JSON.
      *
      * @param namespaceId    namespace ID

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerServiceImpl.java
@@ -250,6 +250,25 @@ public class AgentSpecMaintainerServiceImpl extends AbstractAiDelegateMaintainer
     }
     
     @Override
+    public boolean forcePublish(String namespaceId, String agentSpecName, String version, Boolean updateLatestLabel)
+            throws NacosException {
+        namespaceId = resolveNamespace(namespaceId);
+        Map<String, String> params = new HashMap<>(8);
+        params.put("namespaceId", namespaceId);
+        params.put("agentSpecName", agentSpecName);
+        params.put("version", version);
+        if (null != updateLatestLabel) {
+            params.put("updateLatestLabel", String.valueOf(updateLatestLabel));
+        }
+        HttpRequest httpRequest = buildHttpRequestBuilder(buildRequestResource(namespaceId, agentSpecName)).setHttpMethod(HttpMethod.POST)
+                .setPath(Constants.AdminApiPath.AI_AGENTSPEC_ADMIN_PATH + "/force-publish").setParamValue(params).build();
+        HttpRestResult<String> restResult = executeSyncHttpRequest(httpRequest);
+        Result<String> result = JacksonUtils.toObj(restResult.getData(), new TypeReference<Result<String>>() {
+        });
+        return ErrorCode.SUCCESS.getCode().equals(result.getCode());
+    }
+    
+    @Override
     public boolean updateLabels(String namespaceId, String agentSpecName, String labels) throws NacosException {
         namespaceId = resolveNamespace(namespaceId);
         Map<String, String> params = new HashMap<>(8);


### PR DESCRIPTION
## What is the purpose of the change

`SkillMaintainerService` already supports `forcePublish` (added in #14794), which allows admin users to bypass pipeline validation and directly publish a skill version. However, `AgentSpecMaintainerService` lacks the corresponding `forcePublish` method. This PR aligns AgentSpec with Skill by implementing the full `forcePublish` flow across all layers.

**forcePublish vs publish:**
- `publish`: requires version status to be `REVIEWING` or `ONLINE`, and pipeline must be approved.
- `forcePublish`: accepts `draft` / `reviewing` versions, bypasses pipeline validation entirely, only rejects already `ONLINE` versions.

## Brief changelog

- **Core Service Layer**: Added `forcePublish` to `AgentSpecOperationService` interface and implementation. The logic mirrors `SkillOperationServiceImpl.forcePublish` — validates version exists, rejects already-online versions, logs `[FORCE-PUBLISH]` warning, sets version status to ONLINE, clears editing/reviewing pointers, increments onlineCnt, and updates the latest label.
- **Admin Controller**: Added `POST /v3/admin/ai/agentspecs/force-publish` endpoint in `AgentSpecAdminController` with `signType=CONSOLE, apiType=ADMIN_API` security annotation (same pattern as Skill).
- **Maintainer Client SDK**: Added `forcePublish` to `AgentSpecMaintainerService` interface and HTTP implementation (`AgentSpecMaintainerServiceImpl`), calling the admin endpoint via POST.
- **Console Module**: Added `forcePublish` across `AgentSpecHandler` (interface), `AgentSpecInnerHandler`, `AgentSpecRemoteHandler`, `AgentSpecNoopHandler`, `AgentSpecProxy`, and `ConsoleAgentSpecController` (`POST /v3/console/ai/agentspecs/force-publish` with `signType=CONSOLE, apiType=CONSOLE_API`).
- **Frontend**: Added `forcePublish` API call in `console-ui-next/src/api/agentspec.ts`.

**Files changed (12 files, +157 lines):**

| Layer | File |
|-------|------|
| Core Service | `ai/.../AgentSpecOperationService.java` |
| Core Service | `ai/.../AgentSpecOperationServiceImpl.java` |
| Admin Controller | `ai/.../AgentSpecAdminController.java` |
| SDK Interface | `maintainer-client/.../AgentSpecMaintainerService.java` |
| SDK Impl | `maintainer-client/.../AgentSpecMaintainerServiceImpl.java` |
| Handler Interface | `console/.../AgentSpecHandler.java` |
| Inner Handler | `console/.../AgentSpecInnerHandler.java` |
| Remote Handler | `console/.../AgentSpecRemoteHandler.java` |
| Noop Handler | `console/.../AgentSpecNoopHandler.java` |
| Proxy | `console/.../AgentSpecProxy.java` |
| Console Controller | `console/.../ConsoleAgentSpecController.java` |
| Frontend API | `console-ui-next/src/api/agentspec.ts` |

## Verifying this change

- [x] Maven compilation passes (`mvn compile` on ai, maintainer-client, console modules).
- [x] Local standalone startup verified — both Admin API (`/v3/admin/ai/agentspecs/force-publish`) and Console API (`/v3/console/ai/agentspecs/force-publish`) endpoints are correctly registered and routed to business logic, producing identical behavior to the Skill `force-publish` endpoints.
- [x] Global `forcePublish` search confirms all layers are implemented with no gaps.

---

* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Format the pull request title like `[AI] Support force-publish agentspecs for admin user`.