### PR TITLE
[Feature #14807] Extend prompt API models with lifecycle governance fields

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -805,6 +805,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         if (StringUtils.equals(info.getReviewingVersion(), version)) {
             info.setReviewingVersion(null);
         }
+        // Always increment here because directPublishWithoutPipeline is only called for non-online versions
         Integer cnt = info.getOnlineCnt();
         info.setOnlineCnt(cnt == null ? 1 : (cnt + 1));
         if (info.getLabels() == null) {
@@ -850,17 +851,20 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         }
         
         // 1) version status -> online (idempotent)
-        if (!VERSION_STATUS_ONLINE.equalsIgnoreCase(v.getStatus())) {
+        boolean alreadyOnline = VERSION_STATUS_ONLINE.equalsIgnoreCase(v.getStatus());
+        if (!alreadyOnline) {
             aiResourceVersionPersistService.updateStatus(namespaceId, name, RESOURCE_TYPE_AGENTSPEC, version,
                     VERSION_STATUS_ONLINE);
         }
         
-        // 2) meta: clear working pointers, onlineCnt++, update latest label if required
+        // 2) meta: clear working pointers, onlineCnt++ (only when not already online), update latest label if required
         if (StringUtils.equals(info.getReviewingVersion(), version)) {
             info.setReviewingVersion(null);
         }
-        Integer cnt = info.getOnlineCnt();
-        info.setOnlineCnt(cnt == null ? 1 : (cnt + 1));
+        if (!alreadyOnline) {
+            Integer cnt = info.getOnlineCnt();
+            info.setOnlineCnt(cnt == null ? 1 : (cnt + 1));
+        }
         if (info.getLabels() == null) {
             info.setLabels(new HashMap<>(4));
         }
@@ -965,6 +969,13 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
                     "AgentSpec version not found: " + name + "@" + version);
         }
         String targetStatus = online ? VERSION_STATUS_ONLINE : VERSION_STATUS_OFFLINE;
+        String currentStatus = v.getStatus();
+        
+        // Skip if already in target status
+        if (targetStatus.equalsIgnoreCase(currentStatus)) {
+            return;
+        }
+        
         aiResourceVersionPersistService.updateStatus(namespaceId, name, RESOURCE_TYPE_AGENTSPEC, version,
                 targetStatus);
         Integer cnt = info.getOnlineCnt() == null ? 0 : info.getOnlineCnt();

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -908,16 +908,19 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         }
 
         // 1) version status -> online (idempotent)
-        if (!VERSION_STATUS_ONLINE.equalsIgnoreCase(v.getStatus())) {
+        boolean alreadyOnline = VERSION_STATUS_ONLINE.equalsIgnoreCase(v.getStatus());
+        if (!alreadyOnline) {
             aiResourceVersionPersistService.updateStatus(namespaceId, name, RESOURCE_TYPE_SKILL, version, VERSION_STATUS_ONLINE);
         }
 
-        // 2) meta: clear working pointers, onlineCnt++, update latest label if required
+        // 2) meta: clear working pointers, onlineCnt++ (only when not already online), update latest label if required
         if (StringUtils.equals(info.getReviewingVersion(), version)) {
             info.setReviewingVersion(null);
         }
-        Integer cnt = info.getOnlineCnt();
-        info.setOnlineCnt(cnt == null ? 1 : (cnt + 1));
+        if (!alreadyOnline) {
+            Integer cnt = info.getOnlineCnt();
+            info.setOnlineCnt(cnt == null ? 1 : (cnt + 1));
+        }
         if (info.getLabels() == null) {
             info.setLabels(new HashMap<>(4));
         }
@@ -1049,6 +1052,13 @@ public class SkillOperationServiceImpl implements SkillOperationService {
                     "Skill version not found: " + name + "@" + version);
         }
         String targetStatus = online ? VERSION_STATUS_ONLINE : VERSION_STATUS_OFFLINE;
+        String currentStatus = v.getStatus();
+        
+        // Skip if already in target status
+        if (targetStatus.equalsIgnoreCase(currentStatus)) {
+            return;
+        }
+        
         aiResourceVersionPersistService.updateStatus(namespaceId, name, RESOURCE_TYPE_SKILL, version, targetStatus);
         // onlineCnt is best-effort, list/search uses it as hint
         Integer cnt = info.getOnlineCnt() == null ? 0 : info.getOnlineCnt();

--- a/ai/src/main/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorage.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorage.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.ai.storage;
 
 import com.alibaba.nacos.api.ai.model.NacosAiConfigKeyCodec;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecUtils;
+import com.alibaba.nacos.api.ai.model.prompt.PromptUtils;
 import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
 import com.alibaba.nacos.api.config.ConfigType;
 import com.alibaba.nacos.api.exception.NacosException;
@@ -39,11 +40,11 @@ import java.nio.charset.StandardCharsets;
 /**
  * Nacos Config based {@link AiResourceStorage} implementation.
  *
- * <p>Supports both Skill and AgentSpec resource types via parameterized group prefixes.
+ * <p>Supports Skill, AgentSpec and Prompt resource types via parameterized group prefixes.
  * StorageKey.key format:
  * <ul>
  *   <li>Legacy (Skill): {@code namespaceId:name:version:filePath} (4-part, defaults to skill__ prefix)</li>
- *   <li>Typed: {@code namespaceId:resourceType:name:version:filePath} (5-part, resourceType = "skill" or "agentspec")</li>
+ *   <li>Typed: {@code namespaceId:resourceType:name:version:filePath} (5-part, resourceType = "skill", "agentspec" or "prompt")</li>
  * </ul>
  * File path convention: main = {@link #getMainFilePath()} / {@link #getMainFilePath(String)},
  * resources = {@link #getResourceFilePath(String, String)} / {@link #getAgentSpecResourceFilePath(String, String)},
@@ -58,6 +59,9 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
 
     /** Resource type identifier for AgentSpec storage keys. */
     public static final String RESOURCE_TYPE_AGENTSPEC = "agentspec";
+
+    /** Resource type identifier for Prompt storage keys. */
+    public static final String RESOURCE_TYPE_PROMPT = "prompt";
 
     /**
      * Build storage key for Skill resources (legacy 4-part format).
@@ -84,7 +88,7 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
      *
      * @param provider     storage provider (e.g. {@link #TYPE})
      * @param namespaceId  namespace
-     * @param resourceType resource type ({@link #RESOURCE_TYPE_SKILL} or {@link #RESOURCE_TYPE_AGENTSPEC})
+     * @param resourceType resource type ({@link #RESOURCE_TYPE_SKILL}, {@link #RESOURCE_TYPE_AGENTSPEC} or {@link #RESOURCE_TYPE_PROMPT})
      * @param name         resource name (skill name or agentspec name)
      * @param version      version
      * @param filePath     file path (use {@link #getMainFilePath(String)} or resource file path helpers)
@@ -267,6 +271,8 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
                 group = AgentSpecUtils.buildAgentSpecVersionGroup(name, version);
             } else if (RESOURCE_TYPE_SKILL.equals(resourceType)) {
                 group = SkillUtils.buildSkillVersionGroup(name, version);
+            } else if (RESOURCE_TYPE_PROMPT.equals(resourceType)) {
+                group = PromptUtils.buildPromptVersionGroup(name, version);
             } else {
                 throw new IllegalArgumentException("Unknown resource type: " + resourceType);
             }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
@@ -64,6 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -549,6 +550,99 @@ class AgentSpecOperationServiceImplTest {
         NacosApiException ex = assertThrows(NacosApiException.class,
                 () -> service.forcePublish(namespaceId, agentSpecName, version, true));
         assertEquals(NacosException.INVALID_PARAM, ex.getErrCode());
+    }
+
+    @Test
+    void testPublishShouldBeIdempotentWhenVersionAlreadyOnline() throws NacosException {
+        String namespaceId = "test-ns";
+        String agentSpecName = "my-agentspec";
+        String version = "v1";
+
+        AiResource meta = new AiResource();
+        meta.setName(agentSpecName);
+        meta.setType("agentspec");
+        meta.setNamespaceId(namespaceId);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"reviewingVersion\":\"v1\",\"labels\":{},\"onlineCnt\":2}");
+        when(aiResourcePersistService.find(eq(namespaceId), eq(agentSpecName), anyString())).thenReturn(meta);
+        when(aiResourcePersistService.updateMetaCas(eq(namespaceId), eq(agentSpecName), eq("agentspec"), eq(1L), any()))
+                .thenReturn(true);
+
+        AiResourceVersion v = new AiResourceVersion();
+        v.setVersion(version);
+        v.setStatus("online");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(agentSpecName), anyString(), eq(version)))
+                .thenReturn(v);
+
+        service.publish(namespaceId, agentSpecName, version, true);
+
+        // Should NOT call updateStatus since already online
+        verify(aiResourceVersionPersistService, never()).updateStatus(anyString(), anyString(), anyString(),
+                anyString(), anyString());
+        // onlineCnt should remain 2 (not incremented)
+        verify(aiResourcePersistService).updateMetaCas(eq(namespaceId), eq(agentSpecName), eq("agentspec"), eq(1L),
+                argThat(resource -> {
+                    Map<?, ?> info = JacksonUtils.toObj(resource.getVersionInfo(), Map.class);
+                    return ((Number) info.get("onlineCnt")).intValue() == 2;
+                }));
+    }
+
+    @Test
+    void testChangeOnlineStatusShouldSkipWhenAlreadyOnline() throws NacosException {
+        String namespaceId = "test-ns";
+        String agentSpecName = "my-agentspec";
+        String version = "v1";
+
+        AiResource meta = new AiResource();
+        meta.setName(agentSpecName);
+        meta.setType("agentspec");
+        meta.setNamespaceId(namespaceId);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"labels\":{},\"onlineCnt\":1}");
+        when(aiResourcePersistService.find(eq(namespaceId), eq(agentSpecName), anyString())).thenReturn(meta);
+
+        AiResourceVersion v = new AiResourceVersion();
+        v.setVersion(version);
+        v.setStatus("online");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(agentSpecName), anyString(), eq(version)))
+                .thenReturn(v);
+
+        service.changeOnlineStatus(namespaceId, agentSpecName, "version", version, true);
+
+        // Should NOT call updateStatus or updateMetaCas
+        verify(aiResourceVersionPersistService, never()).updateStatus(anyString(), anyString(), anyString(),
+                anyString(), anyString());
+        verify(aiResourcePersistService, never()).updateMetaCas(anyString(), anyString(), anyString(), anyLong(), any());
+    }
+
+    @Test
+    void testChangeOnlineStatusShouldSkipWhenAlreadyOffline() throws NacosException {
+        String namespaceId = "test-ns";
+        String agentSpecName = "my-agentspec";
+        String version = "v1";
+
+        AiResource meta = new AiResource();
+        meta.setName(agentSpecName);
+        meta.setType("agentspec");
+        meta.setNamespaceId(namespaceId);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"labels\":{},\"onlineCnt\":0}");
+        when(aiResourcePersistService.find(eq(namespaceId), eq(agentSpecName), anyString())).thenReturn(meta);
+
+        AiResourceVersion v = new AiResourceVersion();
+        v.setVersion(version);
+        v.setStatus("offline");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(agentSpecName), anyString(), eq(version)))
+                .thenReturn(v);
+
+        service.changeOnlineStatus(namespaceId, agentSpecName, "version", version, false);
+
+        verify(aiResourceVersionPersistService, never()).updateStatus(anyString(), anyString(), anyString(),
+                anyString(), anyString());
+        verify(aiResourcePersistService, never()).updateMetaCas(anyString(), anyString(), anyString(), anyLong(), any());
     }
 
     private byte[] createValidZipBytes() throws IOException {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
@@ -74,6 +74,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -1140,5 +1141,105 @@ class SkillOperationServiceImplTest {
         NacosApiException ex = assertThrows(NacosApiException.class,
                 () -> skillOperationService.forcePublish(namespaceId, skillName, version, true));
         assertEquals(NacosException.INVALID_PARAM, ex.getErrCode());
+    }
+
+    @Test
+    void testPublishShouldBeIdempotentWhenVersionAlreadyOnline() throws NacosException {
+        String namespaceId = "test-ns";
+        String skillName = "my-skill";
+        String version = "v1";
+
+        AiResource meta = new AiResource();
+        meta.setName(skillName);
+        meta.setType("skill");
+        meta.setNamespaceId(namespaceId);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"reviewingVersion\":\"v1\",\"labels\":{},\"onlineCnt\":2}");
+        when(aiResourcePersistService.find(eq(namespaceId), eq(skillName), anyString())).thenReturn(meta);
+        when(aiResourcePersistService.updateMetaCas(eq(namespaceId), eq(skillName), eq("skill"), eq(1L), any()))
+                .thenReturn(true);
+
+        com.alibaba.nacos.ai.model.AiResourceVersion v = new com.alibaba.nacos.ai.model.AiResourceVersion();
+        v.setVersion(version);
+        v.setStatus("online");
+        v.setStorage("{\"provider\":\"nacos_config\",\"scope\":\"test-ns:my-skill:v1\",\"files\":[\"SKILL.md\"]}");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(), eq(version)))
+                .thenReturn(v);
+
+        com.alibaba.nacos.ai.model.skills.SkillIndexManifest manifest =
+                new com.alibaba.nacos.ai.model.skills.SkillIndexManifest();
+        manifest.setVersions(new HashMap<>());
+        manifest.setLabels(new HashMap<>());
+        when(manifestService.loadForUpdate(eq(namespaceId), eq(skillName))).thenReturn(manifest);
+
+        skillOperationService.publish(namespaceId, skillName, version, true);
+
+        // Should NOT call updateStatus since already online
+        verify(aiResourceVersionPersistService, never()).updateStatus(anyString(), anyString(), anyString(),
+                anyString(), anyString());
+        // onlineCnt should remain 2 (not incremented)
+        verify(aiResourcePersistService).updateMetaCas(eq(namespaceId), eq(skillName), eq("skill"), eq(1L),
+                argThat(resource -> {
+                    Map<?, ?> info = JacksonUtils.toObj(resource.getVersionInfo(), Map.class);
+                    return ((Number) info.get("onlineCnt")).intValue() == 2;
+                }));
+    }
+
+    @Test
+    void testChangeOnlineStatusShouldSkipWhenVersionAlreadyOnline() throws NacosException {
+        String namespaceId = "test-ns";
+        String skillName = "my-skill";
+        String version = "v1";
+
+        AiResource meta = new AiResource();
+        meta.setName(skillName);
+        meta.setType("skill");
+        meta.setNamespaceId(namespaceId);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"labels\":{},\"onlineCnt\":1}");
+        when(aiResourcePersistService.find(eq(namespaceId), eq(skillName), anyString())).thenReturn(meta);
+
+        com.alibaba.nacos.ai.model.AiResourceVersion v = new com.alibaba.nacos.ai.model.AiResourceVersion();
+        v.setVersion(version);
+        v.setStatus("online");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(), eq(version)))
+                .thenReturn(v);
+
+        skillOperationService.changeOnlineStatus(namespaceId, skillName, "version", version, true);
+
+        // Should NOT call updateStatus or updateMetaCas since already in target status
+        verify(aiResourceVersionPersistService, never()).updateStatus(anyString(), anyString(), anyString(),
+                anyString(), anyString());
+        verify(aiResourcePersistService, never()).updateMetaCas(anyString(), anyString(), anyString(), anyLong(), any());
+    }
+
+    @Test
+    void testChangeOnlineStatusShouldSkipWhenVersionAlreadyOffline() throws NacosException {
+        String namespaceId = "test-ns";
+        String skillName = "my-skill";
+        String version = "v1";
+
+        AiResource meta = new AiResource();
+        meta.setName(skillName);
+        meta.setType("skill");
+        meta.setNamespaceId(namespaceId);
+        meta.setStatus("enable");
+        meta.setMetaVersion(1L);
+        meta.setVersionInfo("{\"labels\":{},\"onlineCnt\":0}");
+        when(aiResourcePersistService.find(eq(namespaceId), eq(skillName), anyString())).thenReturn(meta);
+
+        com.alibaba.nacos.ai.model.AiResourceVersion v = new com.alibaba.nacos.ai.model.AiResourceVersion();
+        v.setVersion(version);
+        v.setStatus("offline");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(), eq(version)))
+                .thenReturn(v);
+
+        skillOperationService.changeOnlineStatus(namespaceId, skillName, "version", version, false);
+
+        verify(aiResourceVersionPersistService, never()).updateStatus(anyString(), anyString(), anyString(),
+                anyString(), anyString());
+        verify(aiResourcePersistService, never()).updateMetaCas(anyString(), anyString(), anyString(), anyLong(), any());
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorageTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorageTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.ai.storage;
 
 import com.alibaba.nacos.api.ai.model.NacosAiConfigKeyCodec;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecUtils;
+import com.alibaba.nacos.api.ai.model.prompt.PromptUtils;
 import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
 import org.junit.jupiter.api.Test;
@@ -266,6 +267,47 @@ class NacosConfigAiResourceStorageTest {
                 assertEquals(expectedPath, parts.dataId());
                 assertTrue(parts.dataId().startsWith(AgentSpecUtils.RESOURCE_DATA_ID_PREFIX));
                 assertTrue(parts.dataId().endsWith(AgentSpecUtils.RESOURCE_DATA_ID_SUFFIX));
+            }
+        }
+    }
+
+    // ---- 5-part typed key format: Prompt ----
+
+    @Test
+    void testBuildStorageKeyTypedPromptFormat() {
+        StorageKey key = NacosConfigAiResourceStorage.buildStorageKey(
+                NacosConfigAiResourceStorage.TYPE, "ns1",
+                NacosConfigAiResourceStorage.RESOURCE_TYPE_PROMPT, "myPrompt", "1.0.0", "content.json");
+        assertNotNull(key);
+        assertEquals("ns1:prompt:myPrompt:1.0.0:content.json", key.getKey());
+    }
+
+    @Test
+    void testParseTypedPromptKeyProducesPromptGroupPrefix() {
+        StorageKey key = new StorageKey(NacosConfigAiResourceStorage.TYPE,
+                "ns1:prompt:myPrompt:1.0.0:content.json");
+        NacosConfigAiResourceStorage.KeyParts parts = NacosConfigAiResourceStorage.parse(key);
+        assertEquals("ns1", parts.namespaceId());
+        assertEquals(PromptUtils.buildPromptVersionGroup("myPrompt", "1.0.0"), parts.group());
+        assertEquals("content.json", parts.dataId());
+    }
+
+    @Test
+    void testPromptGroupNamingConventionWithDeterministicInputs() {
+        List<String> namespaceIds = Arrays.asList("public", "test-ns", "ns-1");
+        List<String> names = Arrays.asList("greeting", "code-review", "translate_en");
+        List<String> versions = Arrays.asList("1.0.0", "2.3.4", "10.20.30");
+        for (String namespaceId : namespaceIds) {
+            for (String name : names) {
+                for (String version : versions) {
+                    StorageKey key = NacosConfigAiResourceStorage.buildStorageKey(
+                            NacosConfigAiResourceStorage.TYPE, namespaceId,
+                            NacosConfigAiResourceStorage.RESOURCE_TYPE_PROMPT,
+                            name, version, PromptUtils.PROMPT_MAIN_DATA_ID);
+                    NacosConfigAiResourceStorage.KeyParts parts = NacosConfigAiResourceStorage.parse(key);
+                    assertEquals(PromptUtils.buildPromptVersionGroup(name, version), parts.group());
+                    assertTrue(parts.group().startsWith(PromptUtils.PROMPT_GROUP_PREFIX));
+                }
             }
         }
     }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptMetaInfo.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptMetaInfo.java
@@ -17,9 +17,7 @@
 package com.alibaba.nacos.api.ai.model.prompt;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Prompt meta information.
@@ -30,9 +28,15 @@ public class PromptMetaInfo extends PromptMetaSummary {
     
     private static final long serialVersionUID = 1L;
     
+    /**
+     * Version string list for backward compatibility with legacy clients.
+     */
     private List<String> versions = new ArrayList<>();
     
-    private Map<String, String> labels = new HashMap<>();
+    /**
+     * Detailed version summaries including status, author, etc.
+     */
+    private List<PromptVersionSummary> versionDetails = new ArrayList<>();
     
     public List<String> getVersions() {
         return versions;
@@ -42,11 +46,11 @@ public class PromptMetaInfo extends PromptMetaSummary {
         this.versions = versions;
     }
     
-    public Map<String, String> getLabels() {
-        return labels;
+    public List<PromptVersionSummary> getVersionDetails() {
+        return versionDetails;
     }
     
-    public void setLabels(Map<String, String> labels) {
-        this.labels = labels;
+    public void setVersionDetails(List<PromptVersionSummary> versionDetails) {
+        this.versionDetails = versionDetails;
     }
 }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptMetaSummary.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptMetaSummary.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.api.ai.model.prompt;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Prompt meta summary for prompt list response.
@@ -40,6 +41,26 @@ public class PromptMetaSummary implements Serializable {
     private String latestVersion;
     
     private Long gmtModified;
+    
+    /**
+     * The version currently being edited (draft).
+     */
+    private String editingVersion;
+    
+    /**
+     * The version currently under pipeline review.
+     */
+    private String reviewingVersion;
+    
+    /**
+     * Number of online versions.
+     */
+    private Integer onlineCnt;
+    
+    /**
+     * Label to version mapping, e.g. {"latest":"1.0.0","stable":"0.9.0"}.
+     */
+    private Map<String, String> labels;
     
     public int getSchemaVersion() {
         return schemaVersion;
@@ -87,5 +108,37 @@ public class PromptMetaSummary implements Serializable {
     
     public void setGmtModified(Long gmtModified) {
         this.gmtModified = gmtModified;
+    }
+    
+    public String getEditingVersion() {
+        return editingVersion;
+    }
+    
+    public void setEditingVersion(String editingVersion) {
+        this.editingVersion = editingVersion;
+    }
+    
+    public String getReviewingVersion() {
+        return reviewingVersion;
+    }
+    
+    public void setReviewingVersion(String reviewingVersion) {
+        this.reviewingVersion = reviewingVersion;
+    }
+    
+    public Integer getOnlineCnt() {
+        return onlineCnt;
+    }
+    
+    public void setOnlineCnt(Integer onlineCnt) {
+        this.onlineCnt = onlineCnt;
+    }
+    
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+    
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
     }
 }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptUtils.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.ai.model.prompt;
+
+import com.alibaba.nacos.api.ai.model.NacosAiConfigKeyCodec;
+import com.alibaba.nacos.api.utils.StringUtils;
+
+/**
+ * Utility class for Prompt storage operations.
+ * Mirrors {@link com.alibaba.nacos.api.ai.model.skills.SkillUtils} and
+ * {@link com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecUtils} patterns with Prompt-specific constants.
+ *
+ * @author nacos
+ */
+public class PromptUtils {
+    
+    /**
+     * Prompt versioned group prefix. Each prompt version is stored in a group named
+     * {@code prompt__{enc_promptKey}__{enc_version}}.
+     */
+    public static final String PROMPT_GROUP_PREFIX = "prompt__";
+    
+    /**
+     * Main content dataId for prompt version storage.
+     */
+    public static final String PROMPT_MAIN_DATA_ID = "content.json";
+    
+    private static final String DOUBLE_UNDERSCORE = "__";
+    
+    private PromptUtils() {
+    }
+    
+    /**
+     * Build the Nacos Config group for a specific prompt version.
+     *
+     * @param promptKey prompt key (name)
+     * @param version   version string, e.g. "1.0.0"
+     * @return config group string, e.g. "prompt__{enc_promptKey}__{enc_version}"
+     * @throws IllegalArgumentException if promptKey or version is blank
+     */
+    public static String buildPromptVersionGroup(String promptKey, String version) {
+        if (StringUtils.isBlank(promptKey)) {
+            throw new IllegalArgumentException("Prompt key cannot be blank");
+        }
+        if (StringUtils.isBlank(version)) {
+            throw new IllegalArgumentException("Version cannot be blank");
+        }
+        return PROMPT_GROUP_PREFIX + NacosAiConfigKeyCodec.encodeVersionedGroupSegment(promptKey)
+                + DOUBLE_UNDERSCORE + NacosAiConfigKeyCodec.encodeVersionedGroupSegment(version);
+    }
+}

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptVersionSummary.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptVersionSummary.java
@@ -31,6 +31,8 @@ public class PromptVersionSummary implements Serializable {
     
     private String version;
     
+    private String status;
+    
     private String commitMsg;
     
     private String srcUser;
@@ -51,6 +53,14 @@ public class PromptVersionSummary implements Serializable {
     
     public void setVersion(String version) {
         this.version = version;
+    }
+    
+    public String getStatus() {
+        return status;
+    }
+    
+    public void setStatus(String status) {
+        this.status = status;
     }
     
     public String getCommitMsg() {

--- a/api/src/test/java/com/alibaba/nacos/api/ai/model/prompt/PromptUtilsTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/model/prompt/PromptUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.ai.model.prompt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link PromptUtils}.
+ *
+ * @author nacos
+ */
+class PromptUtilsTest {
+
+    @Test
+    void testBuildPromptVersionGroupBasic() {
+        String group = PromptUtils.buildPromptVersionGroup("greeting", "1.0.0");
+        assertTrue(group.startsWith(PromptUtils.PROMPT_GROUP_PREFIX));
+        // Should contain encoded promptKey and version separated by double underscore
+        assertTrue(group.contains("__"));
+    }
+
+    @Test
+    void testBuildPromptVersionGroupDeterministicOutput() {
+        String group1 = PromptUtils.buildPromptVersionGroup("greeting", "1.0.0");
+        String group2 = PromptUtils.buildPromptVersionGroup("greeting", "1.0.0");
+        assertEquals(group1, group2);
+    }
+
+    @Test
+    void testBuildPromptVersionGroupDifferentVersionsProduceDifferentGroups() {
+        String group1 = PromptUtils.buildPromptVersionGroup("greeting", "1.0.0");
+        String group2 = PromptUtils.buildPromptVersionGroup("greeting", "2.0.0");
+        assertTrue(!group1.equals(group2));
+    }
+
+    @Test
+    void testBuildPromptVersionGroupDifferentKeysProduceDifferentGroups() {
+        String group1 = PromptUtils.buildPromptVersionGroup("greeting", "1.0.0");
+        String group2 = PromptUtils.buildPromptVersionGroup("farewell", "1.0.0");
+        assertTrue(!group1.equals(group2));
+    }
+
+    @Test
+    void testBuildPromptVersionGroupShouldThrowOnBlankKey() {
+        assertThrows(IllegalArgumentException.class,
+                () -> PromptUtils.buildPromptVersionGroup("", "1.0.0"));
+        assertThrows(IllegalArgumentException.class,
+                () -> PromptUtils.buildPromptVersionGroup(null, "1.0.0"));
+        assertThrows(IllegalArgumentException.class,
+                () -> PromptUtils.buildPromptVersionGroup("  ", "1.0.0"));
+    }
+
+    @Test
+    void testBuildPromptVersionGroupShouldThrowOnBlankVersion() {
+        assertThrows(IllegalArgumentException.class,
+                () -> PromptUtils.buildPromptVersionGroup("greeting", ""));
+        assertThrows(IllegalArgumentException.class,
+                () -> PromptUtils.buildPromptVersionGroup("greeting", null));
+        assertThrows(IllegalArgumentException.class,
+                () -> PromptUtils.buildPromptVersionGroup("greeting", "  "));
+    }
+
+    @Test
+    void testPromptMainDataIdConstant() {
+        assertEquals("content.json", PromptUtils.PROMPT_MAIN_DATA_ID);
+    }
+
+    @Test
+    void testPromptGroupPrefixConstant() {
+        assertEquals("prompt__", PromptUtils.PROMPT_GROUP_PREFIX);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Related #14807 

Prompt management currently uses a flat config-only storage model (descriptor + label-version-mapping + version configs), which is different from Skill and AgentSpec's DB + typed-storage dual-storage model with full lifecycle governance. This PR is the first step to align Prompt with the same architecture.

## Brief changelog

- Add lifecycle governance fields (`editingVersion`, `reviewingVersion`, `onlineCnt`, `labels`, `status`) to prompt API model classes, consistent with Skill and AgentSpec.
- Add `PromptUtils` for storage key construction.
- Fix publish/online/offline idempotency (same fix applied to Skill and AgentSpec).

## Verifying this change

- `mvn compile -pl api,ai,console,maintainer-client -am` passes.
- `mvn test -pl ai` — 839 tests, 0 failures.
- Existing Skill and AgentSpec behavior is not affected.
Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

