### PR TITLE
[ISSUE #14806] Fix partial failure visibility in v3 cluster metrics aggregation

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
@@ -55,9 +55,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -101,8 +104,10 @@ public class MetricsControllerV3 {
         
         Loggers.CORE.info("Get cluster config metrics received, ip={},dataId={},groupName={},namespaceId={}", ip,
                 dataId, groupName, namespaceId);
-        Map<String, Object> responseMap = new HashMap<>(3);
+        Map<String, Object> responseMap = new ConcurrentHashMap<>(3);
         Collection<Member> members = serverMemberManager.allMembers();
+        Set<String> respondedMembers = ConcurrentHashMap.newKeySet();
+        Set<String> failedMembers = ConcurrentHashMap.newKeySet();
         final NacosAsyncRestTemplate nacosAsyncRestTemplate = HttpClientBeanHolder.getNacosAsyncRestTemplate(
                 Loggers.CLUSTER);
         CountDownLatch latch = new CountDownLatch(members.size());
@@ -115,15 +120,43 @@ public class MetricsControllerV3 {
             AuthHeaderUtil.addIdentityToHeader(header, NacosAuthConfigHolder.getInstance()
                     .getNacosAuthConfigByScope(NacosServerAuthConfig.NACOS_SERVER_AUTH_SCOPE));
             nacosAsyncRestTemplate.get(url, header, query, new GenericType<Map>() {
-            }.getType(), new ClusterMetricsCallBack(responseMap, latch, dataId, groupName, namespaceId, ip, member));
+            }.getType(),
+                    new ClusterMetricsCallBack(responseMap, latch, respondedMembers, failedMembers, dataId, groupName,
+                            namespaceId, ip, member));
         }
+        boolean completed = false;
         try {
-            latch.await(3L, TimeUnit.SECONDS);
+            completed = latch.await(3L, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            Thread.currentThread().interrupt();
+            Loggers.CORE.warn("Interrupted while waiting cluster config metrics, ip={},dataId={},groupName={},namespaceId={}",
+                    ip, dataId, groupName, namespaceId, e);
+            failedMembers.addAll(getAllMemberAddresses(members));
+        }
+        if (!completed) {
+            for (Member member : members) {
+                String address = member.getAddress();
+                if (!respondedMembers.contains(address)) {
+                    failedMembers.add(address);
+                }
+            }
+        }
+        if (!failedMembers.isEmpty()) {
+            List<String> failedMemberList = new java.util.ArrayList<>(failedMembers);
+            Collections.sort(failedMemberList);
+            responseMap.put("_partial", Boolean.TRUE);
+            responseMap.put("_failedMembers", failedMemberList);
         }
         
         return Result.success(responseMap);
+    }
+
+    private Set<String> getAllMemberAddresses(Collection<Member> members) {
+        Set<String> addresses = ConcurrentHashMap.newKeySet();
+        for (Member member : members) {
+            addresses.add(member.getAddress());
+        }
+        return addresses;
     }
     
     static class ClusterMetricsCallBack implements Callback<Map> {
@@ -131,6 +164,10 @@ public class MetricsControllerV3 {
         Map<String, Object> responseMap;
         
         CountDownLatch latch;
+
+        Set<String> respondedMembers;
+
+        Set<String> failedMembers;
         
         String dataId;
         
@@ -142,10 +179,12 @@ public class MetricsControllerV3 {
         
         Member member;
         
-        public ClusterMetricsCallBack(Map<String, Object> responseMap, CountDownLatch latch, String dataId,
-                String group, String namespaceId, String ip, Member member) {
+        public ClusterMetricsCallBack(Map<String, Object> responseMap, CountDownLatch latch, Set<String> respondedMembers,
+                Set<String> failedMembers, String dataId, String group, String namespaceId, String ip, Member member) {
             this.responseMap = responseMap;
             this.latch = latch;
+            this.respondedMembers = respondedMembers;
+            this.failedMembers = failedMembers;
             this.dataId = dataId;
             this.group = group;
             this.namespaceId = namespaceId;
@@ -155,14 +194,22 @@ public class MetricsControllerV3 {
         
         @Override
         public void onReceive(RestResult<Map> result) {
-            if (result.ok()) {
-                responseMap.putAll(result.getData());
+            try {
+                respondedMembers.add(member.getAddress());
+                if (result != null && result.ok() && result.getData() != null) {
+                    responseMap.putAll(result.getData());
+                } else {
+                    failedMembers.add(member.getAddress());
+                }
+            } finally {
+                latch.countDown();
             }
-            latch.countDown();
         }
         
         @Override
         public void onError(Throwable throwable) {
+            respondedMembers.add(member.getAddress());
+            failedMembers.add(member.getAddress());
             Loggers.CORE.error(
                     "Get config metrics error from member address={}, ip={},dataId={},group={},namespaceId={},error={}",
                     member.getAddress(), ip, dataId, group, namespaceId, throwable);
@@ -171,6 +218,8 @@ public class MetricsControllerV3 {
         
         @Override
         public void onCancel() {
+            respondedMembers.add(member.getAddress());
+            failedMembers.add(member.getAddress());
             latch.countDown();
         }
     }

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/MetricControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/MetricControllerV3Test.java
@@ -48,6 +48,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -135,8 +137,10 @@ class MetricControllerV3Test {
         String tenant = "t1";
         String ip = "192.168.0.1";
         Map<String, Object> responseMap = new HashMap<>();
+        Set<String> respondedMembers = ConcurrentHashMap.newKeySet();
+        Set<String> failedMembers = ConcurrentHashMap.newKeySet();
         MetricsControllerV3.ClusterMetricsCallBack clusterMetricsCallBack = new MetricsControllerV3.ClusterMetricsCallBack(
-                responseMap, latch, dataId, group, tenant, ip, m1);
+            responseMap, latch, respondedMembers, failedMembers, dataId, group, tenant, ip, m1);
         clusterMetricsCallBack.onReceive(result1);
         //fail result
         RestResult<Map> result2 = new RestResult<>();
@@ -150,6 +154,8 @@ class MetricControllerV3Test {
         clusterMetricsCallBack.onCancel();
         clusterMetricsCallBack.onCancel();
         assertEquals(stringObjectHashMap, responseMap);
+        assertEquals(true, respondedMembers.contains("127.0.0.1:8848"));
+        assertEquals(true, failedMembers.contains("127.0.0.1:8848"));
         assertEquals(0, latch.getCount());
     }
     


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a visibility gap in v3 cluster config metrics aggregation.

Previously, when one or more cluster members failed (timeout/error/cancel), the endpoint still returned success without explicitly indicating that the cluster result was partial.

This change adds explicit partial-failure signals so callers can distinguish complete vs partial aggregation results.

## Brief changelog

- Use a thread-safe map for cluster aggregation response.
- Track per-member callback states (responded/failed).
- Improve timeout and interruption handling when waiting for member callbacks.
- Add partial-failure markers when any member fails:
  - _partial: true
  - _failedMembers: sorted list of failed member addresses
- Update unit tests to verify success/error/cancel callback paths and member-state tracking.

## Verifying this change

- Unit test:
  - MetricControllerV3Test
  - Result: Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
- Local manual reproduction (2-node no-auth cluster):
  - Stop one node and call cluster metrics endpoint
  - Response now includes partial-failure fields instead of silently looking complete

## Additional verification notes

I attempted to run the full project verification commands requested in the contribution checklist:

- mvn -B clean package apache-rat:check spotbugs:check -DskipTests
- mvn clean install -DskipITs
- mvn clean test-compile failsafe:integration-test

These commands are currently blocked by an unrelated pre-existing checkstyle issue in nacos-common:

- File: AbstractNacosRestTemplate.java
- Rule: CommentsIndentation

This issue is outside the scope of this PR and not introduced by the changes in this patch.

Fixes #14806

Checklist status you can use

- [x] Make sure there is a Github issue filed for the change.
- [x] Format the pull request title like [ISSUE #123] ...
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify logic correction.
- [ ] Run mvn -B clean package apache-rat:check spotbugs:check -DskipTests (blocked by unrelated nacos-common checkstyle issue)
- [ ] Run mvn clean install -DskipITs (blocked by unrelated nacos-common checkstyle issue)
- [ ] Run mvn clean test-compile failsafe:integration-test (blocked by unrelated nacos-common checkstyle issue)