### PR TITLE
[Feature #14807] Add prompt data migration framework with SPI extensibility

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/config/LegacyPromptData.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/LegacyPromptData.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.config;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unified legacy prompt data for migration. Holds prompt metadata and version list
+ * (without version content, which is loaded on demand via
+ * {@link PromptLegacyDataReader#readVersionContent}).
+ *
+ * @author nacos
+ * @since 3.2.0
+ */
+public class LegacyPromptData {
+    
+    private String promptKey;
+    
+    private String description;
+    
+    private List<String> bizTags;
+    
+    private Map<String, String> labels;
+    
+    private String latestVersion;
+    
+    private List<String> versions;
+    
+    public String getPromptKey() {
+        return promptKey;
+    }
+    
+    public void setPromptKey(String promptKey) {
+        this.promptKey = promptKey;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public List<String> getBizTags() {
+        return bizTags;
+    }
+    
+    public void setBizTags(List<String> bizTags) {
+        this.bizTags = bizTags;
+    }
+    
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+    
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
+    }
+    
+    public String getLatestVersion() {
+        return latestVersion;
+    }
+    
+    public void setLatestVersion(String latestVersion) {
+        this.latestVersion = latestVersion;
+    }
+    
+    public List<String> getVersions() {
+        return versions;
+    }
+    
+    public void setVersions(List<String> versions) {
+        this.versions = versions;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/NacosPromptLegacyDataReader.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/NacosPromptLegacyDataReader.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.config;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.utils.PromptDataIdUtils;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.config.server.model.ConfigAllInfo;
+import com.alibaba.nacos.config.server.model.ConfigInfo;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Default {@link PromptLegacyDataReader} for open-source Nacos.
+ * Reads legacy prompt data from Nacos Config ({@code nacos-ai-prompt} group).
+ *
+ * @author nacos
+ * @since 3.2.0
+ */
+@Component
+public class NacosPromptLegacyDataReader implements PromptLegacyDataReader {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(NacosPromptLegacyDataReader.class);
+    
+    public static final String TYPE = "nacos";
+    
+    private static final int SCAN_PAGE_SIZE = 100;
+    
+    private static final String PROMPT_GROUP = Constants.Prompt.PROMPT_GROUP;
+    
+    private static final String DEFAULT_NAMESPACE = com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
+    
+    private final ConfigInfoPersistService configInfoPersistService;
+    
+    private final ConfigQueryChainService configQueryChainService;
+    
+    public NacosPromptLegacyDataReader(ConfigInfoPersistService configInfoPersistService,
+            ConfigQueryChainService configQueryChainService) {
+        this.configInfoPersistService = configInfoPersistService;
+        this.configQueryChainService = configQueryChainService;
+    }
+    
+    @Override
+    public String type() {
+        return TYPE;
+    }
+    
+    @Override
+    public List<LegacyPromptData> scanLegacyPrompts() {
+        List<String> promptKeys = scanPromptKeys();
+        List<LegacyPromptData> result = new ArrayList<>();
+        for (String promptKey : promptKeys) {
+            LegacyPromptData data = buildLegacyPromptData(promptKey);
+            if (data != null) {
+                result.add(data);
+            }
+        }
+        return result;
+    }
+    
+    @Override
+    public PromptVersionInfo readVersionContent(String promptKey, String version) {
+        String versionDataId = PromptDataIdUtils.buildVersionDataId(promptKey, version);
+        ConfigAllInfo configAllInfo = configInfoPersistService.findConfigAllInfo(versionDataId, PROMPT_GROUP,
+                DEFAULT_NAMESPACE);
+        if (configAllInfo == null || StringUtils.isBlank(configAllInfo.getContent())) {
+            return null;
+        }
+        PromptVersionInfo info;
+        try {
+            info = JacksonUtils.toObj(configAllInfo.getContent(), PromptVersionInfo.class);
+        } catch (Exception e) {
+            info = new PromptVersionInfo();
+            info.setTemplate(configAllInfo.getContent());
+        }
+        info.setPromptKey(promptKey);
+        info.setVersion(version);
+        // Use Config table md5 if not already in content JSON
+        if (info.getMd5() == null && configAllInfo.getMd5() != null) {
+            info.setMd5(configAllInfo.getMd5());
+        }
+        // srcUser from createUser (Config advance info)
+        if (info.getSrcUser() == null && configAllInfo.getCreateUser() != null) {
+            info.setSrcUser(configAllInfo.getCreateUser());
+        }
+        return info;
+    }
+    
+    private List<String> scanPromptKeys() {
+        List<String> promptKeys = new ArrayList<>();
+        int pageNo = 1;
+        while (true) {
+            Page<ConfigInfo> page = configInfoPersistService.findConfigInfo4Page(pageNo, SCAN_PAGE_SIZE, null,
+                    PROMPT_GROUP, DEFAULT_NAMESPACE, null);
+            if (page == null || page.getPageItems() == null || page.getPageItems().isEmpty()) {
+                break;
+            }
+            for (ConfigInfo info : page.getPageItems()) {
+                if (PromptDataIdUtils.isDescriptorDataId(info.getDataId())) {
+                    String key = PromptDataIdUtils.extractPromptKeyFromDescriptorDataId(info.getDataId());
+                    if (StringUtils.isNotBlank(key)) {
+                        promptKeys.add(key);
+                    }
+                }
+            }
+            if (page.getPageItems().size() < SCAN_PAGE_SIZE) {
+                break;
+            }
+            pageNo++;
+        }
+        return promptKeys;
+    }
+    
+    private LegacyPromptData buildLegacyPromptData(String promptKey) {
+        LegacyDescriptor descriptor = readConfigJson(
+                PromptDataIdUtils.buildDescriptorDataId(promptKey), LegacyDescriptor.class);
+        LegacyLabelVersionMapping mapping = readConfigJson(
+                PromptDataIdUtils.buildLabelVersionMappingDataId(promptKey), LegacyLabelVersionMapping.class);
+        
+        if (mapping == null || mapping.versions == null || mapping.versions.isEmpty()) {
+            LOGGER.warn("Prompt '{}' has no versions in mapping, skip", promptKey);
+            return null;
+        }
+        
+        LegacyPromptData data = new LegacyPromptData();
+        data.setPromptKey(promptKey);
+        data.setDescription(descriptor != null ? descriptor.description : null);
+        data.setBizTags(descriptor != null ? descriptor.bizTags : null);
+        data.setLabels(mapping.labels != null ? mapping.labels : new HashMap<>());
+        data.setLatestVersion(mapping.latestVersion);
+        data.setVersions(mapping.versions);
+        return data;
+    }
+    
+    private <T> T readConfigJson(String dataId, Class<T> clazz) {
+        String content = readConfigContent(dataId);
+        if (StringUtils.isBlank(content)) {
+            return null;
+        }
+        try {
+            return JacksonUtils.toObj(content, clazz);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse config '{}' as {}: {}", dataId, clazz.getSimpleName(), e.getMessage());
+            return null;
+        }
+    }
+    
+    private String readConfigContent(String dataId) {
+        try {
+            ConfigQueryChainRequest request = ConfigQueryChainRequest.buildConfigQueryChainRequest(dataId,
+                    PROMPT_GROUP, DEFAULT_NAMESPACE);
+            ConfigQueryChainResponse response = configQueryChainService.handle(request);
+            if (response.getStatus() == ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND) {
+                return null;
+            }
+            return response.getContent();
+        } catch (Exception e) {
+            LOGGER.warn("Failed to read config '{}': {}", dataId, e.getMessage());
+            return null;
+        }
+    }
+    
+    // ========== Legacy Config JSON structures (for deserialization only) ==========
+    
+    /**
+     * Legacy prompt descriptor stored in Config as {promptKey}.descriptor.json.
+     */
+    static class LegacyDescriptor {
+        
+        public int schemaVersion = 1;
+        
+        public String promptKey;
+        
+        public String description;
+        
+        public List<String> bizTags = new ArrayList<>();
+        
+        public Long gmtModified;
+    }
+    
+    /**
+     * Legacy prompt label/version mapping stored in Config as {promptKey}.label-version-mapping.json.
+     */
+    static class LegacyLabelVersionMapping {
+        
+        public int schemaVersion = 1;
+        
+        public String promptKey;
+        
+        public List<String> versions = new ArrayList<>();
+        
+        public Map<String, String> labels = new HashMap<>();
+        
+        public String latestVersion;
+        
+        public Long gmtModified;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.config;
+
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.ai.service.prompt.PromptOperationService;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
+import com.alibaba.nacos.api.ai.model.prompt.PromptUtils;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.executor.ExecutorFactory;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.common.utils.ThreadFactoryBuilder;
+import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
+import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
+import com.alibaba.nacos.config.server.model.form.ConfigForm;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
+import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Migrates prompt data from legacy storage to the new DB + SPI typed storage architecture.
+ *
+ * <p>Uses {@link PromptLegacyDataReader} to read legacy data. The active reader is selected
+ * by {@code nacos.ai.prompt.migration.provider} (default: {@code nacos}).</p>
+ *
+ * @author nacos
+ */
+@Component
+public class PromptDataMigrationTask implements ApplicationListener<ApplicationReadyEvent> {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(PromptDataMigrationTask.class);
+    
+    private static final String MIGRATION_MARKER_DATA_ID = "nacos.ai.prompt.migration";
+    
+    private static final String MIGRATION_MARKER_GROUP = "nacos_internal";
+    
+    private static final long MIGRATION_MARKER_STALE_MILLIS = 10 * 60 * 1000L;
+    
+    private static final String RESOURCE_TYPE_PROMPT = "prompt";
+    
+    private static final String VERSION_STATUS_ONLINE = "online";
+    
+    private static final String META_STATUS_ENABLE = "enable";
+    
+    private static final String STORAGE_PROVIDER_NACOS_CONFIG = "nacos_config";
+    
+    private static final String PROMPT_STORAGE_PROVIDER_CONFIG_KEY = "nacos.ai.prompt.storage.provider";
+    
+    private static final String MIGRATION_ENABLED_KEY = "nacos.ai.prompt.migration.enabled";
+    
+    private static final String MIGRATION_PROVIDER_KEY = "nacos.ai.prompt.migration.provider";
+    
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+    
+    private final ExecutorService migrationExecutor = ExecutorFactory.Managed.newSingleExecutorService(
+            PromptDataMigrationTask.class.getCanonicalName(),
+            new ThreadFactoryBuilder().daemon(true).nameFormat("nacos-ai-prompt-migration-%d").build());
+    
+    private final AiResourcePersistService aiResourcePersistService;
+    
+    private final AiResourceVersionPersistService aiResourceVersionPersistService;
+    
+    private final PromptOperationService promptOperationService;
+    
+    private final ConfigQueryChainService configQueryChainService;
+    
+    private final ConfigOperationService configOperationService;
+    
+    private final List<PromptLegacyDataReader> legacyDataReaders;
+    
+    public PromptDataMigrationTask(AiResourcePersistService aiResourcePersistService,
+            AiResourceVersionPersistService aiResourceVersionPersistService,
+            PromptOperationService promptOperationService,
+            ConfigQueryChainService configQueryChainService, ConfigOperationService configOperationService,
+            List<PromptLegacyDataReader> legacyDataReaders) {
+        this.aiResourcePersistService = aiResourcePersistService;
+        this.aiResourceVersionPersistService = aiResourceVersionPersistService;
+        this.promptOperationService = promptOperationService;
+        this.configQueryChainService = configQueryChainService;
+        this.configOperationService = configOperationService;
+        this.legacyDataReaders = legacyDataReaders != null ? legacyDataReaders : new ArrayList<>();
+    }
+    
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if (event.getApplicationContext().getParent() != null) {
+            return;
+        }
+        if (!initialized.compareAndSet(false, true)) {
+            return;
+        }
+        boolean enabled = Boolean.parseBoolean(EnvUtil.getProperty(MIGRATION_ENABLED_KEY, "true"));
+        if (!enabled) {
+            LOGGER.info("Prompt data migration is disabled via {}", MIGRATION_ENABLED_KEY);
+            return;
+        }
+        migrationExecutor.execute(this::executeMigration);
+    }
+    
+    private PromptLegacyDataReader resolveLegacyDataReader() {
+        String providerType = EnvUtil.getProperty(MIGRATION_PROVIDER_KEY, NacosPromptLegacyDataReader.TYPE);
+        for (PromptLegacyDataReader reader : legacyDataReaders) {
+            if (providerType.equals(reader.type())) {
+                LOGGER.info("Using PromptLegacyDataReader: {}", reader.type());
+                return reader;
+            }
+        }
+        LOGGER.warn("No PromptLegacyDataReader found for type '{}', skip migration", providerType);
+        return null;
+    }
+    
+    private void executeMigration() {
+        boolean markerCreated = false;
+        try {
+            PromptLegacyDataReader reader = resolveLegacyDataReader();
+            if (reader == null) {
+                return;
+            }
+            
+            List<LegacyPromptData> allPrompts = reader.scanLegacyPrompts();
+            if (allPrompts.isEmpty()) {
+                LOGGER.info("No legacy prompt data found by reader '{}', skip migration", reader.type());
+                return;
+            }
+            
+            List<LegacyPromptData> needsMigration = filterNeedsMigration(allPrompts);
+            if (needsMigration.isEmpty()) {
+                LOGGER.info("All {} legacy prompts already migrated, skip", allPrompts.size());
+                return;
+            }
+            
+            markerCreated = tryAcquireMigrationMarker();
+            if (!markerCreated) {
+                LOGGER.info("Skip prompt migration because another node is migrating");
+                return;
+            }
+            
+            needsMigration = filterNeedsMigration(allPrompts);
+            if (needsMigration.isEmpty()) {
+                LOGGER.info("All legacy prompts already migrated after acquiring marker");
+                return;
+            }
+            
+            LOGGER.info("Start prompt data migration: {} prompts to migrate out of {} total",
+                    needsMigration.size(), allPrompts.size());
+            
+            int migrated = 0;
+            int failed = 0;
+            for (LegacyPromptData prompt : needsMigration) {
+                try {
+                    migrateOnePrompt(prompt, reader);
+                    migrated++;
+                } catch (Exception e) {
+                    failed++;
+                    LOGGER.error("Failed to migrate prompt '{}': {}", prompt.getPromptKey(), e.getMessage(), e);
+                }
+            }
+            
+            LOGGER.info("Prompt data migration completed: migrated={}, failed={}, skipped={}",
+                    migrated, failed, allPrompts.size() - needsMigration.size());
+        } catch (Exception e) {
+            LOGGER.error("Prompt data migration failed unexpectedly", e);
+        } finally {
+            if (markerCreated) {
+                releaseMigrationMarker();
+            }
+        }
+    }
+    
+    private List<LegacyPromptData> filterNeedsMigration(List<LegacyPromptData> allPrompts) {
+        String namespace = com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
+        List<LegacyPromptData> result = new ArrayList<>();
+        for (LegacyPromptData prompt : allPrompts) {
+            AiResource existing = aiResourcePersistService.find(namespace, prompt.getPromptKey(), RESOURCE_TYPE_PROMPT);
+            if (existing == null) {
+                result.add(prompt);
+                continue;
+            }
+            if (prompt.getVersions() != null) {
+                for (String version : prompt.getVersions()) {
+                    AiResourceVersion versionRow = aiResourceVersionPersistService.find(namespace,
+                            prompt.getPromptKey(), RESOURCE_TYPE_PROMPT, version);
+                    if (versionRow == null) {
+                        result.add(prompt);
+                        break;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+    
+    private void migrateOnePrompt(LegacyPromptData prompt, PromptLegacyDataReader reader) throws Exception {
+        String namespace = com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
+        String promptKey = prompt.getPromptKey();
+        
+        if (prompt.getVersions() == null || prompt.getVersions().isEmpty()) {
+            LOGGER.warn("Prompt '{}' has no versions, skip migration", promptKey);
+            return;
+        }
+        
+        Map<String, Object> versionInfoMap = new HashMap<>(8);
+        versionInfoMap.put("labels", prompt.getLabels() != null ? prompt.getLabels() : new HashMap<>());
+        versionInfoMap.put("editingVersion", null);
+        versionInfoMap.put("reviewingVersion", null);
+        versionInfoMap.put("onlineCnt", prompt.getVersions().size());
+        
+        AiResource resource = new AiResource();
+        resource.setNamespaceId(namespace);
+        resource.setName(promptKey);
+        resource.setType(RESOURCE_TYPE_PROMPT);
+        resource.setDesc(prompt.getDescription());
+        resource.setStatus(META_STATUS_ENABLE);
+        resource.setMetaVersion(1L);
+        resource.setVersionInfo(JacksonUtils.toJson(versionInfoMap));
+        resource.setBizTags(prompt.getBizTags() != null ? JacksonUtils.toJson(prompt.getBizTags()) : "[]");
+        
+        try {
+            aiResourcePersistService.insert(resource);
+            LOGGER.info("Migrated prompt '{}' resource record to DB", promptKey);
+        } catch (Exception e) {
+            AiResource existing = aiResourcePersistService.find(namespace, promptKey, RESOURCE_TYPE_PROMPT);
+            if (existing != null) {
+                LOGGER.info("Prompt '{}' resource record already exists, continue with version migration", promptKey);
+            } else {
+                throw e;
+            }
+        }
+        
+        int versionsMigrated = 0;
+        for (String version : prompt.getVersions()) {
+            try {
+                migrateOneVersion(namespace, promptKey, version, reader);
+                versionsMigrated++;
+            } catch (Exception e) {
+                LOGGER.error("Failed to migrate prompt '{}' version '{}': {}", promptKey, version,
+                        e.getMessage(), e);
+            }
+        }
+        
+        try {
+            promptOperationService.refreshLatestMirror(namespace, promptKey);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to refresh legacy mirror for prompt '{}': {}", promptKey, e.getMessage());
+        }
+        
+        LOGGER.info("Migrated prompt '{}': {}/{} versions", promptKey, versionsMigrated,
+                prompt.getVersions().size());
+    }
+    
+    private void migrateOneVersion(String namespace, String promptKey, String version,
+            PromptLegacyDataReader reader) throws Exception {
+        PromptVersionInfo versionInfo = reader.readVersionContent(promptKey, version);
+        if (versionInfo == null) {
+            LOGGER.warn("No content found for prompt '{}' version '{}', skip", promptKey, version);
+            return;
+        }
+        
+        versionInfo.setPromptKey(promptKey);
+        versionInfo.setVersion(version);
+        
+        // Pre-compute md5 from content without md5 field
+        versionInfo.setMd5(null);
+        String contentJson = JacksonUtils.toJson(versionInfo);
+        String md5 = com.alibaba.nacos.common.utils.MD5Utils.md5Hex(contentJson,
+                java.nio.charset.StandardCharsets.UTF_8.name());
+        versionInfo.setMd5(md5);
+        
+        // Write to typed storage FIRST (idempotent overwrite)
+        writeToTypedStorage(namespace, promptKey, version, versionInfo);
+        
+        // Then create DB record (idempotent: skip if exists)
+        AiResourceVersion existing = aiResourceVersionPersistService.find(namespace, promptKey,
+                RESOURCE_TYPE_PROMPT, version);
+        if (existing != null) {
+            LOGGER.debug("Prompt '{}' version '{}' already in DB, skip insert", promptKey, version);
+            return;
+        }
+        
+        AiResourceVersion versionRecord = new AiResourceVersion();
+        versionRecord.setNamespaceId(namespace);
+        versionRecord.setName(promptKey);
+        versionRecord.setType(RESOURCE_TYPE_PROMPT);
+        versionRecord.setVersion(version);
+        versionRecord.setStatus(VERSION_STATUS_ONLINE);
+        versionRecord.setAuthor(versionInfo.getSrcUser() != null ? versionInfo.getSrcUser() : "-");
+        versionRecord.setDesc(versionInfo.getCommitMsg() != null ? versionInfo.getCommitMsg() : "migrated from legacy config");
+        versionRecord.setStorage(buildStorageJson(namespace, promptKey, version));
+        
+        try {
+            aiResourceVersionPersistService.insert(versionRecord);
+        } catch (Exception e) {
+            AiResourceVersion check = aiResourceVersionPersistService.find(namespace, promptKey,
+                    RESOURCE_TYPE_PROMPT, version);
+            if (check != null) {
+                LOGGER.debug("Prompt '{}' version '{}' inserted by another node, skip", promptKey, version);
+            } else {
+                throw e;
+            }
+        }
+        LOGGER.debug("Migrated prompt '{}' version '{}'", promptKey, version);
+    }
+    
+    private boolean tryAcquireMigrationMarker() {
+        for (int i = 0; i < 2; i++) {
+            try {
+                ConfigForm form = new ConfigForm();
+                form.setNamespaceId(com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID);
+                form.setGroup(MIGRATION_MARKER_GROUP);
+                form.setDataId(MIGRATION_MARKER_DATA_ID);
+                form.setContent(String.valueOf(System.currentTimeMillis()));
+                form.setSrcUser("nacos");
+                ConfigRequestInfo requestInfo = new ConfigRequestInfo();
+                requestInfo.setUpdateForExist(false);
+                configOperationService.publishConfig(form, requestInfo, null);
+                return true;
+            } catch (ConfigAlreadyExistsException e) {
+                if (isMigrationMarkerStale()) {
+                    LOGGER.warn("Found stale prompt migration marker, removing and retrying");
+                    releaseMigrationMarker();
+                    continue;
+                }
+                return false;
+            } catch (Exception e) {
+                LOGGER.error("Failed to create prompt migration marker", e);
+                return false;
+            }
+        }
+        return false;
+    }
+    
+    private boolean isMigrationMarkerStale() {
+        try {
+            ConfigQueryChainRequest request = ConfigQueryChainRequest.buildConfigQueryChainRequest(
+                    MIGRATION_MARKER_DATA_ID, MIGRATION_MARKER_GROUP,
+                    com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID);
+            ConfigQueryChainResponse response = configQueryChainService.handle(request);
+            if (response.getStatus() == ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND
+                    || StringUtils.isBlank(response.getContent())) {
+                return false;
+            }
+            long markerTime = Long.parseLong(response.getContent().trim());
+            return System.currentTimeMillis() - markerTime > MIGRATION_MARKER_STALE_MILLIS;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to inspect prompt migration marker", e);
+            return false;
+        }
+    }
+    
+    private void releaseMigrationMarker() {
+        try {
+            configOperationService.deleteConfig(MIGRATION_MARKER_DATA_ID, MIGRATION_MARKER_GROUP,
+                    com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID, null, null, "nacos", null);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to delete prompt migration marker", e);
+        }
+    }
+    
+    private void writeToTypedStorage(String namespace, String promptKey, String version,
+            PromptVersionInfo versionInfo) throws NacosException {
+        String provider = resolveStorageProvider();
+        byte[] contentBytes = JacksonUtils.toJson(versionInfo).getBytes(StandardCharsets.UTF_8);
+        StorageKey storageKey = NacosConfigAiResourceStorage.buildStorageKey(provider, namespace,
+                NacosConfigAiResourceStorage.RESOURCE_TYPE_PROMPT, promptKey, version,
+                PromptUtils.PROMPT_MAIN_DATA_ID);
+        AiResourceStorageRouter.getInstance().route(storageKey).save(storageKey, contentBytes);
+    }
+    
+    private static String buildStorageJson(String namespace, String promptKey, String version) {
+        Map<String, Object> json = new HashMap<>(4);
+        json.put("provider", resolveStorageProvider());
+        json.put("scope", namespace + ":" + promptKey + ":" + version);
+        json.put("files", Collections.singletonList(PromptUtils.PROMPT_MAIN_DATA_ID));
+        return JacksonUtils.toJson(json);
+    }
+    
+    private static String resolveStorageProvider() {
+        String provider = EnvUtil.getProperty(PROMPT_STORAGE_PROVIDER_CONFIG_KEY, STORAGE_PROVIDER_NACOS_CONFIG);
+        return StringUtils.isBlank(provider) ? STORAGE_PROVIDER_NACOS_CONFIG : provider.trim();
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/PromptLegacyDataReader.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/PromptLegacyDataReader.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.config;
+
+import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
+
+import java.util.List;
+
+/**
+ * SPI interface for reading legacy prompt data during migration.
+ *
+ * <p>Different environments (open-source Nacos vs commercial) may store prompt data
+ * in different legacy formats. Implementations provide the ability to scan and read
+ * legacy prompt data for migration to the new DB + typed storage architecture.</p>
+ *
+ * <p>The default implementation ({@code nacos}) reads from Nacos Config
+ * ({@code nacos-ai-prompt} group). Commercial implementations can provide their own
+ * {@code @Component} bean to override.</p>
+ *
+ * @author nacos
+ * @since 3.2.0
+ */
+public interface PromptLegacyDataReader {
+    
+    /**
+     * Provider type identifier. Used to select the active reader via configuration
+     * property {@code nacos.ai.prompt.migration.provider}.
+     *
+     * @return type string, e.g. "nacos"
+     */
+    String type();
+    
+    /**
+     * Scan legacy storage and return all prompts with their metadata and version lists.
+     * Version content is NOT included; use {@link #readVersionContent} to load on demand.
+     *
+     * @return list of legacy prompt data
+     */
+    List<LegacyPromptData> scanLegacyPrompts();
+    
+    /**
+     * Read the content of a specific prompt version from legacy storage.
+     *
+     * @param promptKey prompt key
+     * @param version   version string
+     * @return version info with template/variables/srcUser/commitMsg, or null if not found
+     */
+    PromptVersionInfo readVersionContent(String promptKey, String version);
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/config/PromptDataMigrationTaskTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/config/PromptDataMigrationTaskTest.java
@@ -1,0 +1,465 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.config;
+
+import com.alibaba.nacos.ai.config.NacosPromptLegacyDataReader.LegacyDescriptor;
+import com.alibaba.nacos.ai.config.NacosPromptLegacyDataReader.LegacyLabelVersionMapping;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.ai.service.prompt.PromptOperationService;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.utils.PromptDataIdUtils;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
+import com.alibaba.nacos.config.server.model.ConfigAllInfo;
+import com.alibaba.nacos.config.server.model.ConfigInfo;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
+import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
+import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for PromptDataMigrationTask.
+ *
+ * @author nacos
+ */
+@ExtendWith(MockitoExtension.class)
+class PromptDataMigrationTaskTest {
+    
+    private static final String NS = "public";
+    
+    private static final String PROMPT_KEY = "test-prompt";
+    
+    private static final String PROMPT_GROUP = "nacos-ai-prompt";
+    
+    private static final String RESOURCE_TYPE_PROMPT = "prompt";
+    
+    private static final long ASYNC_TIMEOUT = 2000L;
+    
+    @Mock
+    private AiResourcePersistService aiResourcePersistService;
+    
+    @Mock
+    private AiResourceVersionPersistService aiResourceVersionPersistService;
+    
+    @Mock
+    private PromptOperationService promptOperationService;
+    
+    @Mock
+    private ConfigInfoPersistService configInfoPersistService;
+    
+    @Mock
+    private ConfigQueryChainService configQueryChainService;
+    
+    @Mock
+    private ConfigOperationService configOperationService;
+    
+    @Mock
+    private AiResourceStorage storage;
+    
+    private PromptDataMigrationTask task;
+    
+    private NacosPromptLegacyDataReader nacosReader;
+    
+    private static final org.springframework.core.env.ConfigurableEnvironment CACHED_ENVIRONMENT =
+            EnvUtil.getEnvironment();
+    
+    @BeforeEach
+    void setUp() {
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        AiResourceStorageRouter.reset();
+        lenient().when(storage.type()).thenReturn("nacos_config");
+        AiResourceStorageRouter.join(storage);
+        nacosReader = new NacosPromptLegacyDataReader(configInfoPersistService, configQueryChainService);
+        List<PromptLegacyDataReader> readers = Collections.singletonList(nacosReader);
+        task = new PromptDataMigrationTask(aiResourcePersistService, aiResourceVersionPersistService,
+                promptOperationService, configQueryChainService, configOperationService, readers);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(CACHED_ENVIRONMENT);
+        System.clearProperty("nacos.ai.prompt.migration.enabled");
+    }
+    
+    // ========== onApplicationEvent guard conditions ==========
+    
+    @Test
+    void testShouldSkipWhenNotRootContext() {
+        ApplicationReadyEvent event = mock(ApplicationReadyEvent.class);
+        ConfigurableApplicationContext ctx = mock(ConfigurableApplicationContext.class);
+        when(event.getApplicationContext()).thenReturn(ctx);
+        when(ctx.getParent()).thenReturn(mock(ConfigurableApplicationContext.class));
+        
+        task.onApplicationEvent(event);
+        
+        verify(configInfoPersistService, after(500).never())
+                .findConfigInfo4Page(anyInt(), anyInt(), any(), any(), any(), any());
+    }
+    
+    @Test
+    void testShouldSkipWhenDisabled() {
+        System.setProperty("nacos.ai.prompt.migration.enabled", "false");
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        List<PromptLegacyDataReader> readers = Collections.singletonList(nacosReader);
+        task = new PromptDataMigrationTask(aiResourcePersistService, aiResourceVersionPersistService,
+                promptOperationService, configQueryChainService, configOperationService, readers);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        verify(configInfoPersistService, after(500).never())
+                .findConfigInfo4Page(anyInt(), anyInt(), any(), any(), any(), any());
+    }
+    
+    // ========== scan / filter / migration flow ==========
+    
+    @Test
+    void testShouldSkipWhenNoLegacyData() {
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(null);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        verify(aiResourcePersistService, after(ASYNC_TIMEOUT).never()).insert(any(AiResource.class));
+    }
+    
+    @Test
+    void testShouldSkipWhenAllAlreadyMigrated() throws Exception {
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        // ai_resource record exists
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT))
+                .thenReturn(new AiResource());
+        // All versions also exist in DB
+        LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+        mapping.promptKey = PROMPT_KEY;
+        mapping.versions = Collections.singletonList("0.0.1");
+        ConfigQueryChainResponse mappingResp = new ConfigQueryChainResponse();
+        mappingResp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        mappingResp.setContent(JacksonUtils.toJson(mapping));
+        when(configQueryChainService.handle(any())).thenReturn(mappingResp);
+        AiResourceVersion existingVersion = new AiResourceVersion();
+        existingVersion.setVersion("0.0.1");
+        when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT, "0.0.1"))
+                .thenReturn(existingVersion);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        verify(aiResourcePersistService, after(ASYNC_TIMEOUT).never()).insert(any(AiResource.class));
+    }
+    
+    @Test
+    void testShouldAcquireMarkerAndMigratePromptSuccessfully() throws Exception {
+        // 1. Scan returns one descriptor dataId
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        
+        // 2. Not yet migrated
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT)).thenReturn(null);
+        
+        // 3. Marker creation succeeds (no exception from publishConfig)
+        
+        // 4. Config reads: descriptor + mapping + version content
+        LegacyDescriptor descriptor = new LegacyDescriptor();
+        descriptor.promptKey = PROMPT_KEY;
+        descriptor.description = "test desc";
+        descriptor.bizTags = Arrays.asList("tag1");
+        
+        LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+        mapping.promptKey = PROMPT_KEY;
+        mapping.versions = Collections.singletonList("0.0.1");
+        mapping.latestVersion = "0.0.1";
+        Map<String, String> labels = new HashMap<>();
+        labels.put("latest", "0.0.1");
+        mapping.labels = labels;
+        
+        PromptVersionInfo versionContent = new PromptVersionInfo();
+        versionContent.setPromptKey(PROMPT_KEY);
+        versionContent.setVersion("0.0.1");
+        versionContent.setTemplate("Hello {{name}}");
+        
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            Object arg = invocation.getArgument(0);
+            if (arg instanceof com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest) {
+                com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req =
+                        (com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest) arg;
+                String dataId = req.getDataId();
+                ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+                resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+                if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                    resp.setContent(JacksonUtils.toJson(descriptor));
+                } else if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                    resp.setContent(JacksonUtils.toJson(mapping));
+                } else {
+                    resp.setContent(JacksonUtils.toJson(versionContent));
+                }
+                return resp;
+            }
+            return new ConfigQueryChainResponse();
+        });
+        
+        // 5. Version not yet in DB
+        when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT, "0.0.1")).thenReturn(null);
+        
+        // 6. readVersionContent uses configInfoPersistService.findConfigAllInfo, not configQueryChainService
+        ConfigAllInfo versionConfigAllInfo = new ConfigAllInfo();
+        versionConfigAllInfo.setContent(JacksonUtils.toJson(versionContent));
+        when(configInfoPersistService.findConfigAllInfo(any(), eq(PROMPT_GROUP), eq(NS)))
+                .thenReturn(versionConfigAllInfo);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // Verify: meta record inserted
+        verify(aiResourcePersistService, timeout(ASYNC_TIMEOUT)).insert(any(AiResource.class));
+        // Verify: version record inserted
+        verify(aiResourceVersionPersistService, timeout(ASYNC_TIMEOUT)).insert(any(AiResourceVersion.class));
+        // Verify: content written to typed storage
+        verify(storage, timeout(ASYNC_TIMEOUT)).save(any(StorageKey.class), any(byte[].class));
+        // Verify: legacy mirror refreshed
+        verify(promptOperationService, timeout(ASYNC_TIMEOUT)).refreshLatestMirror(NS, PROMPT_KEY);
+        // Verify: marker released
+        verify(configOperationService, timeout(ASYNC_TIMEOUT))
+                .deleteConfig(eq("nacos.ai.prompt.migration"), eq("nacos_internal"), eq(NS), any(), any(),
+                        eq("nacos"), any());
+    }
+    
+    @Test
+    void testShouldSkipWhenMarkerAcquireFails() throws Exception {
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT)).thenReturn(null);
+        
+        // Marker creation fails: another node holds it
+        when(configOperationService.publishConfig(any(), any(), any()))
+                .thenThrow(new ConfigAlreadyExistsException("marker exists"));
+        
+        // Answer-based mock: return proper data for scan reads, timestamp for marker staleness check
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req =
+                    invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                LegacyDescriptor desc = new LegacyDescriptor();
+                desc.promptKey = PROMPT_KEY;
+                resp.setContent(JacksonUtils.toJson(desc));
+            } else if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+                mapping.promptKey = PROMPT_KEY;
+                mapping.versions = Collections.singletonList("0.0.1");
+                resp.setContent(JacksonUtils.toJson(mapping));
+            } else {
+                // Marker staleness check: return current timestamp (not stale)
+                resp.setContent(String.valueOf(System.currentTimeMillis()));
+            }
+            return resp;
+        });
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // Should NOT proceed with migration
+        verify(aiResourcePersistService, after(ASYNC_TIMEOUT).never()).insert(any(AiResource.class));
+    }
+    
+    @Test
+    void testMigrateOneVersionShouldSkipDbInsertWhenAlreadyExists() throws Exception {
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        // First call: ai_resource not found (needs migration); after insert: found
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT))
+                .thenReturn(null);
+        
+        LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+        mapping.promptKey = PROMPT_KEY;
+        mapping.versions = Collections.singletonList("0.0.1");
+        mapping.latestVersion = "0.0.1";
+        
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req = invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                resp.setContent(JacksonUtils.toJson(mapping));
+            } else if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                LegacyDescriptor desc = new LegacyDescriptor();
+                desc.promptKey = PROMPT_KEY;
+                resp.setContent(JacksonUtils.toJson(desc));
+            } else {
+                resp.setContent("{}");
+            }
+            return resp;
+        });
+        
+        // Version already exists in DB — DB insert should be skipped, but storage write still happens
+        AiResourceVersion existingVersion = new AiResourceVersion();
+        existingVersion.setVersion("0.0.1");
+        when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT, "0.0.1"))
+                .thenReturn(existingVersion);
+        
+        // readVersionContent uses configInfoPersistService.findConfigAllInfo
+        PromptVersionInfo versionContent = new PromptVersionInfo();
+        versionContent.setPromptKey(PROMPT_KEY);
+        versionContent.setVersion("0.0.1");
+        versionContent.setTemplate("Hello");
+        ConfigAllInfo versionConfigAllInfo = new ConfigAllInfo();
+        versionConfigAllInfo.setContent(JacksonUtils.toJson(versionContent));
+        when(configInfoPersistService.findConfigAllInfo(any(), eq(PROMPT_GROUP), eq(NS)))
+                .thenReturn(versionConfigAllInfo);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // Meta should still be inserted
+        verify(aiResourcePersistService, timeout(ASYNC_TIMEOUT)).insert(any(AiResource.class));
+        // Storage write still happens (idempotent overwrite)
+        verify(storage, timeout(ASYNC_TIMEOUT)).save(any(StorageKey.class), any(byte[].class));
+        // But version DB insert should be skipped
+        verify(aiResourceVersionPersistService, after(ASYNC_TIMEOUT).never()).insert(any(AiResourceVersion.class));
+    }
+    
+    @Test
+    void testShouldReleaseMigrationMarkerEvenOnFailure() throws Exception {
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT)).thenReturn(null);
+        
+        // Proper scan mock for descriptor + mapping reads
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req =
+                    invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                LegacyDescriptor desc = new LegacyDescriptor();
+                desc.promptKey = PROMPT_KEY;
+                resp.setContent(JacksonUtils.toJson(desc));
+            } else if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+                mapping.promptKey = PROMPT_KEY;
+                mapping.versions = Collections.singletonList("0.0.1");
+                resp.setContent(JacksonUtils.toJson(mapping));
+            }
+            return resp;
+        });
+        
+        // Migration fails during ai_resource insert
+        when(aiResourcePersistService.insert(any(AiResource.class)))
+                .thenThrow(new RuntimeException("DB failure"));
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // Marker should still be released in finally block
+        verify(configOperationService, timeout(ASYNC_TIMEOUT))
+                .deleteConfig(eq("nacos.ai.prompt.migration"), eq("nacos_internal"), eq(NS), any(), any(),
+                        eq("nacos"), any());
+    }
+    
+    @Test
+    void testShouldSkipPromptWhenMappingHasNoVersions() throws Exception {
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        
+        // Mapping with no versions — buildLegacyPromptData returns null, so scan yields empty list
+        LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+        mapping.promptKey = PROMPT_KEY;
+        mapping.versions = new ArrayList<>();
+        
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req = invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                resp.setContent(JacksonUtils.toJson(mapping));
+            } else if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                resp.setContent("{}");
+            } else {
+                resp.setContent("{}");
+            }
+            return resp;
+        });
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // Should not insert anything when mapping has no versions
+        verify(aiResourcePersistService, after(ASYNC_TIMEOUT).never()).insert(any(AiResource.class));
+    }
+    
+    // ========== Helper methods ==========
+    
+    private ApplicationReadyEvent createRootContextEvent() {
+        ApplicationReadyEvent event = mock(ApplicationReadyEvent.class);
+        ConfigurableApplicationContext ctx = mock(ConfigurableApplicationContext.class);
+        when(event.getApplicationContext()).thenReturn(ctx);
+        when(ctx.getParent()).thenReturn(null);
+        return event;
+    }
+    
+    private Page<ConfigInfo> buildScanPage(String... promptKeys) {
+        Page<ConfigInfo> page = new Page<>();
+        List<ConfigInfo> items = new ArrayList<>();
+        for (String key : promptKeys) {
+            ConfigInfo info = new ConfigInfo();
+            info.setDataId(PromptDataIdUtils.buildDescriptorDataId(key));
+            info.setGroup(PROMPT_GROUP);
+            items.add(info);
+        }
+        page.setPageItems(items);
+        return page;
+    }
+}


### PR DESCRIPTION

Related #14807

## What is the purpose of the change

Add a data migration framework for prompts, migrating legacy config-based prompts to the new DB + Config dual-storage architecture introduced in previous PRs. The migration is designed to be safe in multi-node deployments and extensible via SPI.

## Brief changelog

- Add `PromptDataMigrationTask` for migrating legacy config-based prompts to DB + Config dual storage
- Add `PromptLegacyDataReader` SPI interface for reading legacy prompt data, allowing custom migration sources
- Add `NacosPromptLegacyDataReader` as default SPI implementation that reads from Nacos config storage
- Add `LegacyPromptData` model for legacy prompt data representation
- Implement multi-node safe migration with distributed locking and idempotency checks
- Add comprehensive unit tests for `PromptDataMigrationTask` (465 lines)

## Verifying this change

This change includes unit tests:
- `PromptDataMigrationTaskTest` covering migration lifecycle, idempotency, distributed lock contention, error handling, and SPI loading

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

