### PR TITLE
fix: mark cluster metrics partial failure in responseMap (fix #14806)

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
@@ -166,6 +166,7 @@ public class MetricsControllerV3 {
             Loggers.CORE.error(
                     "Get config metrics error from member address={}, ip={},dataId={},group={},namespaceId={},error={}",
                     member.getAddress(), ip, dataId, group, namespaceId, throwable);
+            responseMap.put("error", "Failed to get metrics from member: " + member.getAddress());
             latch.countDown();
         }
         


### PR DESCRIPTION
## Bug Description

Issue: #14806

When requesting `/v3/admin/cs/metrics/cluster` in a cluster where one member is unreachable, the API still returns HTTP 200 with business `code=0` and empty data, even though server logs clearly show `Connection refused` errors.

The `ClusterMetricsCallBack.onError()` method only logs the error but does not update the `responseMap` to indicate failure. This causes clients to believe aggregation succeeded completely when the result is actually partial/incomplete.

## Fix

In `ClusterMetricsCallBack.onError()`, add an entry to `responseMap` with key `"error"` and a descriptive message:

```java
responseMap.put("error", "Failed to get metrics from member: " + member.getAddress());
```

This allows clients to detect partial failures:
- If the response contains an `error` field, at least one member failed
- The `error` value names the failing member

## Testing

- [x] Existing unit tests pass
- [x] Manual verification: stop one cluster member, request metrics, observe `error` field in response

## Expected Behavior After Fix

```json
{
  "code": 0,
  "message": "success",
  "data": {
    "cacheMetrics": [],
    "error": "Failed to get metrics from member: 127.0.0.1:8850"
  }
}
```