### PR TITLE
fix: signal partial failure in /v3/admin/cs/metrics/cluster API

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
@@ -123,6 +123,13 @@ public class MetricsControllerV3 {
             e.printStackTrace();
         }
         
+        // Check if any member failed during aggregation
+        boolean hasPartialFailure = responseMap.keySet().stream()
+                .anyMatch(k -> k.startsWith("_nacos_metrics_member_error_"));
+        if (hasPartialFailure) {
+            responseMap.put("_nacos_metrics_partial_failure", true);
+            return Result.success(responseMap);
+        }
         return Result.success(responseMap);
     }
     
@@ -166,6 +173,7 @@ public class MetricsControllerV3 {
             Loggers.CORE.error(
                     "Get config metrics error from member address={}, ip={},dataId={},group={},namespaceId={},error={}",
                     member.getAddress(), ip, dataId, group, namespaceId, throwable);
+            responseMap.put("_nacos_metrics_member_error_" + member.getAddress(), true);
             latch.countDown();
         }
         


### PR DESCRIPTION
## Bug Description

Issue: #14806

When requesting `/v3/admin/cs/metrics/cluster` in a multi-node Nacos cluster, if one member node fails (connection refused, timeout, etc.), the API still returns HTTP 200 with `code=0` and empty data. Server logs show the error but clients cannot detect the failure.

## Root Cause

In `MetricsControllerV3.ClusterMetricsCallBack.onError()`, errors are only logged but the `responseMap` is not updated. When `latch.await()` completes, the method returns `Result.success(responseMap)` with an empty map, indistinguishable from full success.

## Fix

1. **onError()**: Mark the failed member address in `responseMap` with key `_nacos_metrics_member_error_<address>` = `true`
2. **metric()**: Before returning, check if any `_nacos_metrics_member_error_*` keys exist; if so, set `_nacos_metrics_partial_failure` = `true` in the response

Clients can now detect partial failures by checking:
- `_nacos_metrics_partial_failure` = `true`, or
- Any key matching `_nacos_metrics_member_error_<address>` = `true`

## Testing

1. Start 2-node Nacos cluster
2. Call `/v3/admin/cs/metrics/cluster` on node 1
3. Stop node 2
4. Call API again - now returns `_nacos_metrics_partial_failure=true`