### PR TITLE
Fix: mark failed cluster metrics members in responseMap (fix #14806)

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
@@ -101,8 +101,7 @@ public class MetricsControllerV3 {
         
         Loggers.CORE.info("Get cluster config metrics received, ip={},dataId={},groupName={},namespaceId={}", ip,
                 dataId, groupName, namespaceId);
-        Map<String, Object> responseMap = new HashMap<>();
-        Map<String, Object> failedMembers = new HashMap<>();
+        Map<String, Object> responseMap = new HashMap<>(3);
         Collection<Member> members = serverMemberManager.allMembers();
         final NacosAsyncRestTemplate nacosAsyncRestTemplate = HttpClientBeanHolder.getNacosAsyncRestTemplate(
                 Loggers.CLUSTER);
@@ -116,7 +115,7 @@ public class MetricsControllerV3 {
             AuthHeaderUtil.addIdentityToHeader(header, NacosAuthConfigHolder.getInstance()
                     .getNacosAuthConfigByScope(NacosServerAuthConfig.NACOS_SERVER_AUTH_SCOPE));
             nacosAsyncRestTemplate.get(url, header, query, new GenericType<Map>() {
-            }.getType(), new ClusterMetricsCallBack(responseMap, failedMembers, latch, dataId, groupName, namespaceId, ip, member));
+            }.getType(), new ClusterMetricsCallBack(responseMap, latch, dataId, groupName, namespaceId, ip, member));
         }
         try {
             latch.await(3L, TimeUnit.SECONDS);
@@ -124,22 +123,12 @@ public class MetricsControllerV3 {
             e.printStackTrace();
         }
         
-        if (responseMap.isEmpty()) {
-            responseMap.put("code", 1);
-            responseMap.put("message", "partial failure: no metrics returned from any member");
-        }
-        if (!failedMembers.isEmpty()) {
-            responseMap.put("failedMembers", failedMembers);
-            responseMap.put("code", 1);
-            responseMap.put("message", "partial failure: some members failed");
-        }
         return Result.success(responseMap);
     }
     
     static class ClusterMetricsCallBack implements Callback<Map> {
         
         Map<String, Object> responseMap;
-        Map<String, Object> failedMembers;
         
         CountDownLatch latch;
         
@@ -153,11 +142,9 @@ public class MetricsControllerV3 {
         
         Member member;
         
-        public ClusterMetricsCallBack(Map<String, Object> responseMap, Map<String, Object> failedMembers,
-                CountDownLatch latch, String dataId,
+        public ClusterMetricsCallBack(Map<String, Object> responseMap, CountDownLatch latch, String dataId,
                 String group, String namespaceId, String ip, Member member) {
             this.responseMap = responseMap;
-            this.failedMembers = failedMembers;
             this.latch = latch;
             this.dataId = dataId;
             this.group = group;
@@ -179,7 +166,7 @@ public class MetricsControllerV3 {
             Loggers.CORE.error(
                     "Get config metrics error from member address={}, ip={},dataId={},group={},namespaceId={},error={}",
                     member.getAddress(), ip, dataId, group, namespaceId, throwable);
-            failedMembers.put(member.getAddress(), throwable.getMessage());
+            responseMap.put("error", "Failed to get metrics from member: " + member.getAddress());
             latch.countDown();
         }
         

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
@@ -101,7 +101,8 @@ public class MetricsControllerV3 {
         
         Loggers.CORE.info("Get cluster config metrics received, ip={},dataId={},groupName={},namespaceId={}", ip,
                 dataId, groupName, namespaceId);
-        Map<String, Object> responseMap = new HashMap<>(3);
+        Map<String, Object> responseMap = new HashMap<>();
+        Map<String, Object> failedMembers = new HashMap<>();
         Collection<Member> members = serverMemberManager.allMembers();
         final NacosAsyncRestTemplate nacosAsyncRestTemplate = HttpClientBeanHolder.getNacosAsyncRestTemplate(
                 Loggers.CLUSTER);
@@ -115,7 +116,7 @@ public class MetricsControllerV3 {
             AuthHeaderUtil.addIdentityToHeader(header, NacosAuthConfigHolder.getInstance()
                     .getNacosAuthConfigByScope(NacosServerAuthConfig.NACOS_SERVER_AUTH_SCOPE));
             nacosAsyncRestTemplate.get(url, header, query, new GenericType<Map>() {
-            }.getType(), new ClusterMetricsCallBack(responseMap, latch, dataId, groupName, namespaceId, ip, member));
+            }.getType(), new ClusterMetricsCallBack(responseMap, failedMembers, latch, dataId, groupName, namespaceId, ip, member));
         }
         try {
             latch.await(3L, TimeUnit.SECONDS);
@@ -123,12 +124,22 @@ public class MetricsControllerV3 {
             e.printStackTrace();
         }
         
+        if (responseMap.isEmpty()) {
+            responseMap.put("code", 1);
+            responseMap.put("message", "partial failure: no metrics returned from any member");
+        }
+        if (!failedMembers.isEmpty()) {
+            responseMap.put("failedMembers", failedMembers);
+            responseMap.put("code", 1);
+            responseMap.put("message", "partial failure: some members failed");
+        }
         return Result.success(responseMap);
     }
     
     static class ClusterMetricsCallBack implements Callback<Map> {
         
         Map<String, Object> responseMap;
+        Map<String, Object> failedMembers;
         
         CountDownLatch latch;
         
@@ -142,9 +153,11 @@ public class MetricsControllerV3 {
         
         Member member;
         
-        public ClusterMetricsCallBack(Map<String, Object> responseMap, CountDownLatch latch, String dataId,
+        public ClusterMetricsCallBack(Map<String, Object> responseMap, Map<String, Object> failedMembers,
+                CountDownLatch latch, String dataId,
                 String group, String namespaceId, String ip, Member member) {
             this.responseMap = responseMap;
+            this.failedMembers = failedMembers;
             this.latch = latch;
             this.dataId = dataId;
             this.group = group;
@@ -166,6 +179,7 @@ public class MetricsControllerV3 {
             Loggers.CORE.error(
                     "Get config metrics error from member address={}, ip={},dataId={},group={},namespaceId={},error={}",
                     member.getAddress(), ip, dataId, group, namespaceId, throwable);
+            failedMembers.put(member.getAddress(), throwable.getMessage());
             latch.countDown();
         }
         


### PR DESCRIPTION
## Bug Description

Issue: #14806

When requesting \ in a multi-node Nacos cluster and one member is unreachable, the API still returns HTTP 200 with business \ (success) and empty data.

Server logs show member fetch failure (\), but the response gives clients no indication that aggregation was partial.

## Root Cause

In \, the \ handler only logs the error but does **not** update the shared \. When all members either succeed or error without updating the map, the final response contains no error indication.

## Fix

In \, add the failed member address and error message to \ with key \:

\\n
This allows clients to detect partial failures by checking for \ keys in the response.

## Alternative Considered

Another approach would be to return a non-zero \ when any member fails, but that would break the existing success/single-member semantics. The \ key approach is backward-compatible while providing the needed failure visibility.