### PR TITLE
fix: return failure status when cluster metrics member request fails (fix #14806)

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
@@ -166,6 +166,8 @@ public class MetricsControllerV3 {
             Loggers.CORE.error(
                     "Get config metrics error from member address={}, ip={},dataId={},group={},namespaceId={},error={}",
                     member.getAddress(), ip, dataId, group, namespaceId, throwable);
+            responseMap.put("error", "failed");
+            responseMap.put("errorMember", member.getAddress());
             latch.countDown();
         }
         


### PR DESCRIPTION
## Bug Description

Issue: #14806

When calling `/v3/admin/cs/metrics/cluster` in a cluster where one member is unreachable, the API returns HTTP 200 with `code=0` and empty data, even though the server logs show member fetch failure (`Connection refused`).

This is because `ClusterMetricsCallBack.onError()` only logs the error but does not update the `responseMap` to indicate failure. After `latch.await(3L, TimeUnit.SECONDS)`, the empty `responseMap` is returned as success.

## Fix

In `ClusterMetricsCallBack.onError()`, add failure markers to `responseMap`:
- `responseMap.put("error", "failed")`
- `responseMap.put("errorMember", member.getAddress())`

This allows clients to distinguish partial failure from full success.

## Before
```java
public void onError(Throwable throwable) {
    Loggers.CORE.error("Get config metrics error from member...", throwable);
    latch.countDown();  // responseMap unchanged - empty map returned as success
}
```

## After
```java
public void onError(Throwable throwable) {
    Loggers.CORE.error("Get config metrics error from member...", throwable);
    responseMap.put("error", "failed");
    responseMap.put("errorMember", member.getAddress());
    latch.countDown();
}
```

## Testing

1. Start 2-node Nacos cluster (ports 8848, 8850)
2. Call `GET /nacos/v3/admin/cs/metrics/cluster?ip=127.0.0.1&dataId=test&groupName=DEFAULT_GROUP&namespaceId=public`
3. Stop node 8850
4. Call same endpoint on node 8848
5. **Before fix**: Returns `{"code":0,"message":"success","data":{}}` (misleading)
6. **After fix**: Returns `{"code":0,"message":"success","data":{"error":"failed","errorMember":"127.0.0.1:8850"}}`