### PR TITLE
fix: mark cluster metrics response as failed when member is unreachable (#14806)

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3.java
@@ -166,6 +166,7 @@ public class MetricsControllerV3 {
             Loggers.CORE.error(
                     "Get config metrics error from member address={}, ip={},dataId={},group={},namespaceId={},error={}",
                     member.getAddress(), ip, dataId, group, namespaceId, throwable);
+            responseMap.put("__error__", "failed");
             latch.countDown();
         }
         


### PR DESCRIPTION
## Bug Description

Issue: #14806

When calling `/v3/admin/cs/metrics/cluster` in a multi-node Nacos cluster, if one member node is unreachable, the API still returns HTTP 200 with business `code=0` (success), even though the result is incomplete/partial.

**Root Cause:** In `ClusterMetricsCallBack.onError()`, only the error is logged but `responseMap` is never updated to signal the failure. After `latch.await()` completes (3 seconds timeout), the endpoint returns `Result.success(responseMap)` with whatever was collected — which may be empty if all nodes failed.

## Fix

Add `responseMap.put("__error__", "failed")` in `onError()` so clients can distinguish between:
- Full success: has data, no `__error__` key
- Partial/total failure: `__error__=failed` present in response

```java
// Before:
public void onError(Throwable throwable) {
    Loggers.CORE.error("Get config metrics error from member...", throwable);
    latch.countDown();
}

// After:
public void onError(Throwable throwable) {
    Loggers.CORE.error("Get config metrics error from member...", throwable);
    responseMap.put("__error__", "failed");
    latch.countDown();
}
```

## Impact

Clients can now reliably detect when cluster metrics aggregation partially or completely failed due to member node issues.