### PR TITLE
[Fix #14807] Clean legacy nacos-ai-prompt mirror on prompt deletion

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
@@ -582,9 +582,22 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             }
         }
         
+        // Delete legacy latest mirror in nacos-ai-prompt group
+        deleteLegacyLatestMirror(namespaceId, promptKey);
+        
         // Delete DB rows
         aiResourceVersionPersistService.deleteByNameAndType(namespaceId, promptKey, RESOURCE_TYPE_PROMPT);
         aiResourcePersistService.delete(namespaceId, promptKey, RESOURCE_TYPE_PROMPT);
+    }
+    
+    private void deleteLegacyLatestMirror(String namespaceId, String promptKey) {
+        try {
+            final String latestDataId = PromptVersionUtils.buildDataId(promptKey);
+            configOperationService.deleteConfig(latestDataId, Constants.Prompt.PROMPT_GROUP, namespaceId, null, null,
+                    "nacos", null);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to delete legacy latest mirror for prompt: {}", promptKey, e);
+        }
     }
     
     @Override

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
@@ -551,6 +551,41 @@ class PromptOperationServiceImplTest {
         verify(aiResourcePersistService).delete(NS, PROMPT_KEY, PROMPT_TYPE);
     }
     
+    @Test
+    void testDeletePromptShouldCleanLegacyLatestMirror() throws NacosException {
+        AiResource meta = createMeta(PROMPT_KEY, 1L, "{\"labels\":{\"latest\":\"0.0.1\"}}");
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE)).thenReturn(meta);
+        
+        Page<AiResourceVersion> vPage = new Page<>();
+        vPage.setPageItems(Collections.singletonList(createVersionRow("0.0.1", "online")));
+        when(aiResourceVersionPersistService.listAll(eq(NS), eq(PROMPT_KEY), eq(1), eq(200))).thenReturn(vPage);
+        
+        service.deletePrompt(NS, PROMPT_KEY);
+        
+        // Should delete legacy mirror: dataId=test-prompt.json, group=nacos-ai-prompt
+        verify(configOperationService).deleteConfig(eq(PROMPT_KEY + ".json"), eq("nacos-ai-prompt"), eq(NS),
+                any(), any(), eq("nacos"), any());
+    }
+    
+    @Test
+    void testDeletePromptShouldNotFailWhenLegacyMirrorDeleteThrows() throws NacosException {
+        AiResource meta = createMeta(PROMPT_KEY, 1L, "{\"labels\":{}}");
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE)).thenReturn(meta);
+        
+        Page<AiResourceVersion> emptyPage = new Page<>();
+        emptyPage.setPageItems(new ArrayList<>());
+        when(aiResourceVersionPersistService.listAll(eq(NS), eq(PROMPT_KEY), eq(1), eq(200))).thenReturn(emptyPage);
+        
+        when(configOperationService.deleteConfig(anyString(), anyString(), anyString(), any(), any(), anyString(),
+                any())).thenThrow(new RuntimeException("simulated failure"));
+        
+        // Should NOT throw despite legacy mirror delete failure
+        service.deletePrompt(NS, PROMPT_KEY);
+        
+        verify(aiResourceVersionPersistService).deleteByNameAndType(NS, PROMPT_KEY, PROMPT_TYPE);
+        verify(aiResourcePersistService).delete(NS, PROMPT_KEY, PROMPT_TYPE);
+    }
+    
     // ========== getPromptDetail / getPromptVersionDetail ==========
     
     @Test


### PR DESCRIPTION
Related #14807

## What is the purpose of the change

When a prompt is deleted through the new lifecycle governance API, the legacy latest mirror config (`{promptKey}.json` in `nacos-ai-prompt` group) is not cleaned up. This leaves orphan configs in the legacy storage location.

## Brief changelog

- Add `deleteLegacyLatestMirror` to the `deletePrompt` flow in `PromptOperationServiceImpl`
- Delete `{promptKey}.json` from `nacos-ai-prompt` group when a prompt is removed
- Failure to delete the legacy mirror is caught and logged as a warning, does not block the main deletion

## Verifying this change

This change includes unit tests:
- `testDeletePromptShouldCleanLegacyLatestMirror` — verifies `configOperationService.deleteConfig` is called with the correct dataId/group
- `testDeletePromptShouldNotFailWhenLegacyMirrorDeleteThrows` — verifies deletion completes even when legacy mirror cleanup throws an exception

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

