### PR TITLE
[ISSUE #14832] fix(plugin): PostgreSQL compatibility fixes for AI resource persistence and capacity modules

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourcePersistServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourcePersistServiceImpl.java
@@ -42,7 +42,6 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 
 import java.sql.PreparedStatement;
-import java.sql.Statement;
 import java.util.Arrays;
 
 /**
@@ -79,7 +78,7 @@ public class AiResourcePersistServiceImpl implements AiResourcePersistService {
 
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jt.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
             ps.setString(1, resource.getName());
             ps.setString(2, resource.getType());
             ps.setString(3, resource.getDesc());

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourceVersionPersistServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourceVersionPersistServiceImpl.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.ai.service.repository;
 
 import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.persistence.configuration.condition.ConditionOnExternalStorage;
@@ -40,7 +41,6 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 
 import java.sql.PreparedStatement;
-import java.sql.Statement;
 import java.util.Arrays;
 
 /**
@@ -76,14 +76,14 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
 
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jt.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
             ps.setString(1, version.getType());
             ps.setString(2, version.getAuthor());
             ps.setString(3, version.getName());
             ps.setString(4, version.getDesc());
             ps.setString(5, version.getStatus());
             ps.setString(6, version.getVersion());
-            ps.setString(7, StringUtils.defaultEmptyIfBlank(version.getNamespaceId()));
+            ps.setString(7, normalizeNamespaceId(version.getNamespaceId()));
             ps.setString(8, version.getStorage());
             ps.setString(9, version.getPublishPipelineInfo());
             return ps;
@@ -106,7 +106,7 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
                 Arrays.asList("namespace_id", "name", "type", "version"));
         try {
             return jt.queryForObject(sql,
-                    new Object[] {StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version},
+                    new Object[] {normalizeNamespaceId(namespaceId), name, type, version},
                     AiResourceRowMappers.AI_RESOURCE_VERSION_ROW_MAPPER);
         } catch (EmptyResultDataAccessException e) {
             return null;
@@ -121,7 +121,7 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
                 TableConstant.AI_RESOURCE_VERSION);
 
         MapperContext context = new MapperContext((pageNo - 1) * pageSize, pageSize);
-        context.putWhereParameter(FieldConstant.NAMESPACE_ID, StringUtils.defaultEmptyIfBlank(namespaceId));
+        context.putWhereParameter(FieldConstant.NAMESPACE_ID, normalizeNamespaceId(namespaceId));
         context.putWhereParameter(FieldConstant.NAME, name);
         if (StringUtils.isNotBlank(type)) {
             context.putWhereParameter(FieldConstant.TYPE, type);
@@ -141,7 +141,7 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = mapper.delete(Arrays.asList("namespace_id", "name", "type", "version"));
-        return jt.update(sql, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version);
+        return jt.update(sql, normalizeNamespaceId(namespaceId), name, type, version);
     }
 
     @Override
@@ -149,7 +149,7 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = mapper.delete(Arrays.asList("namespace_id", "name"));
-        return jt.update(sql, StringUtils.defaultEmptyIfBlank(namespaceId), name);
+        return jt.update(sql, normalizeNamespaceId(namespaceId), name);
     }
 
     @Override
@@ -157,7 +157,7 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = mapper.delete(Arrays.asList("namespace_id", "name", "type"));
-        return jt.update(sql, StringUtils.defaultEmptyIfBlank(namespaceId), name, type);
+        return jt.update(sql, normalizeNamespaceId(namespaceId), name, type);
     }
 
     @Override
@@ -166,7 +166,7 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = "UPDATE ai_resource_version SET status=?, gmt_modified=" + mapper.getFunction("NOW()")
                 + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, status, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version);
+        return jt.update(sql, status, normalizeNamespaceId(namespaceId), name, type, version);
     }
 
     @Override
@@ -175,7 +175,7 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = "UPDATE ai_resource_version SET storage=?, gmt_modified=" + mapper.getFunction("NOW()")
                 + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, storage, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version);
+        return jt.update(sql, storage, normalizeNamespaceId(namespaceId), name, type, version);
     }
 
     @Override
@@ -185,7 +185,7 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = "UPDATE ai_resource_version SET storage=?, c_desc=?, gmt_modified=" + mapper.getFunction("NOW()")
                 + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, storage, desc, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version);
+        return jt.update(sql, storage, desc, normalizeNamespaceId(namespaceId), name, type, version);
     }
 
     @Override
@@ -195,7 +195,7 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = "UPDATE ai_resource_version SET publish_pipeline_info=?, gmt_modified=" + mapper.getFunction("NOW()")
                 + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, publishPipelineInfo, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version);
+        return jt.update(sql, publishPipelineInfo, normalizeNamespaceId(namespaceId), name, type, version);
     }
 
     @Override
@@ -204,7 +204,11 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = "UPDATE ai_resource_version SET download_count = download_count + ?, gmt_modified="
                 + mapper.getFunction("NOW()") + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, increment, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version);
+        return jt.update(sql, increment, normalizeNamespaceId(namespaceId), name, type, version);
+    }
+    
+    private String normalizeNamespaceId(String namespaceId) {
+        return StringUtils.isBlank(namespaceId) ? Constants.DEFAULT_NAMESPACE_ID : namespaceId;
     }
 }
 

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/EmbeddedAiResourceVersionPersistServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/EmbeddedAiResourceVersionPersistServiceImpl.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.ai.service.repository;
 
 import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.StringUtils;
@@ -71,7 +72,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
                 "storage", "publish_pipeline_info", "gmt_create@NOW()", "gmt_modified@NOW()"));
 
         Object[] args = new Object[] {version.getType(), version.getAuthor(), version.getName(), version.getDesc(),
-                version.getStatus(), version.getVersion(), StringUtils.defaultEmptyIfBlank(version.getNamespaceId()),
+                version.getStatus(), version.getVersion(), normalizeNamespaceId(version.getNamespaceId()),
                 version.getStorage(), version.getPublishPipelineInfo()};
 
         EmbeddedStorageContextHolder.addSqlContext(sql, args);
@@ -97,7 +98,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
                         "namespace_id", "storage", "publish_pipeline_info", "download_count"),
                 Arrays.asList("namespace_id", "name", "type", "version"));
         return databaseOperate.queryOne(sql,
-                new Object[] {StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version},
+                new Object[] {normalizeNamespaceId(namespaceId), name, type, version},
                 AiResourceRowMappers.AI_RESOURCE_VERSION_ROW_MAPPER);
     }
 
@@ -109,7 +110,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
                 TableConstant.AI_RESOURCE_VERSION);
 
         MapperContext context = new MapperContext((pageNo - 1) * pageSize, pageSize);
-        context.putWhereParameter(FieldConstant.NAMESPACE_ID, StringUtils.defaultEmptyIfBlank(namespaceId));
+        context.putWhereParameter(FieldConstant.NAMESPACE_ID, normalizeNamespaceId(namespaceId));
         context.putWhereParameter(FieldConstant.NAME, name);
         if (StringUtils.isNotBlank(type)) {
             context.putWhereParameter(FieldConstant.TYPE, type);
@@ -135,7 +136,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
         String sql = mapper.delete(Arrays.asList("namespace_id", "name", "type", "version"));
 
         EmbeddedStorageContextHolder.addSqlContext(sql,
-                new Object[] {StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version});
+                new Object[] {normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
         return (success != null && success) ? 1 : 0;
     }
@@ -146,7 +147,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = mapper.delete(Arrays.asList("namespace_id", "name"));
 
-        EmbeddedStorageContextHolder.addSqlContext(sql, new Object[] {StringUtils.defaultEmptyIfBlank(namespaceId), name});
+        EmbeddedStorageContextHolder.addSqlContext(sql, new Object[] {normalizeNamespaceId(namespaceId), name});
         Boolean success = databaseOperate.blockUpdate();
         return (success != null && success) ? 1 : 0;
     }
@@ -158,7 +159,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
         String sql = mapper.delete(Arrays.asList("namespace_id", "name", "type"));
 
         EmbeddedStorageContextHolder.addSqlContext(sql,
-                new Object[] {StringUtils.defaultEmptyIfBlank(namespaceId), name, type});
+                new Object[] {normalizeNamespaceId(namespaceId), name, type});
         Boolean success = databaseOperate.blockUpdate();
         return (success != null && success) ? 1 : 0;
     }
@@ -174,7 +175,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
                 + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
 
         EmbeddedStorageContextHolder.addSqlContext(sql,
-                new Object[] {status, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version});
+                new Object[] {status, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
         return (success != null && success) ? 1 : 0;
     }
@@ -190,7 +191,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
                 + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
 
         EmbeddedStorageContextHolder.addSqlContext(sql,
-                new Object[] {storage, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version});
+                new Object[] {storage, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
         return (success != null && success) ? 1 : 0;
     }
@@ -207,7 +208,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
                 + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
 
         EmbeddedStorageContextHolder.addSqlContext(sql,
-                new Object[] {storage, desc, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version});
+                new Object[] {storage, desc, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
         return (success != null && success) ? 1 : 0;
     }
@@ -224,7 +225,7 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
                 + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
 
         EmbeddedStorageContextHolder.addSqlContext(sql,
-                new Object[] {publishPipelineInfo, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version});
+                new Object[] {publishPipelineInfo, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
         return (success != null && success) ? 1 : 0;
     }
@@ -240,9 +241,13 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
                 + mapper.getFunction("NOW()") + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
 
         EmbeddedStorageContextHolder.addSqlContext(sql,
-                new Object[] {increment, StringUtils.defaultEmptyIfBlank(namespaceId), name, type, version});
+                new Object[] {increment, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
         return (success != null && success) ? 1 : 0;
+    }
+    
+    private String normalizeNamespaceId(String namespaceId) {
+        return StringUtils.isBlank(namespaceId) ? Constants.DEFAULT_NAMESPACE_ID : namespaceId;
     }
 }
 

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/resource/AiResourceManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/resource/AiResourceManager.java
@@ -44,6 +44,7 @@ import com.alibaba.nacos.plugin.visibility.model.VisibilityQueryContext;
 import com.alibaba.nacos.plugin.visibility.spi.QueryAdvisor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -423,6 +424,13 @@ public class AiResourceManager {
      */
     public void insertVersionRow(String namespaceId, String name, String type, String author, String status,
             String version, String description, String storageJson) {
+        // Check if a version row already exists (e.g. orphaned row from a failed delete, or concurrent insert).
+        // If so, fall back to updating the existing row instead of inserting a duplicate.
+        AiResourceVersion existing = aiResourceVersionPersistService.find(namespaceId, name, type, version);
+        if (existing != null) {
+            updateExistingVersionRow(namespaceId, name, type, version, status, description, storageJson);
+            return;
+        }
         AiResourceVersion row = new AiResourceVersion();
         row.setNamespaceId(namespaceId);
         row.setName(name);
@@ -432,7 +440,20 @@ public class AiResourceManager {
         row.setVersion(version);
         row.setDesc(description);
         row.setStorage(storageJson);
-        aiResourceVersionPersistService.insert(row);
+        try {
+            aiResourceVersionPersistService.insert(row);
+        } catch (DuplicateKeyException e) {
+            // Race condition: version was inserted after our check, fallback to update
+            LOGGER.warn("[insertVersionRow] duplicate key for {}/{}/{}/{}, falling back to update",
+                    namespaceId, name, type, version);
+            updateExistingVersionRow(namespaceId, name, type, version, status, description, storageJson);
+        }
+    }
+    
+    private void updateExistingVersionRow(String namespaceId, String name, String type, String version,
+            String status, String description, String storageJson) {
+        aiResourceVersionPersistService.updateStorageAndDesc(namespaceId, name, type, version, storageJson, description);
+        aiResourceVersionPersistService.updateStatus(namespaceId, name, type, version, status);
     }
     
     /**

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/GroupCapacityMapperByPostgresql.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/GroupCapacityMapperByPostgresql.java
@@ -60,16 +60,18 @@ public class GroupCapacityMapperByPostgresql extends BaseGroupCapacityMapper {
         paramList.add(context.getUpdateParameter(FieldConstant.GMT_MODIFIED));
 
         String sql =
-                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size,gmt_create,"
-                        + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info";
+                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size,"
+                        + " max_history_count, gmt_create, gmt_modified)"
+                        + " SELECT ?, ?, count(*), ?, ?, ?, 0, ?, ? FROM config_info";
         return new MapperResult(sql, paramList);
     }
 
     @Override
     public MapperResult insertIntoSelectByWhere(MapperContext context) {
         final String sql =
-                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size, gmt_create,"
-                        + " gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE group_id=? AND tenant_id = '"
+                "INSERT INTO group_capacity (group_id, quota, usage, max_size, max_aggr_count, max_aggr_size,"
+                        + " max_history_count, gmt_create, gmt_modified)"
+                        + " SELECT ?, ?, count(*), ?, ?, ?, 0, ?, ? FROM config_info WHERE group_id=? AND tenant_id = '"
                         + NamespaceUtil.getNamespaceDefaultId() + "'";
         List<Object> paramList = new ArrayList<>();
         paramList.add(context.getUpdateParameter(FieldConstant.GROUP_ID));

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/TenantCapacityMapperByPostgresql.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/TenantCapacityMapperByPostgresql.java
@@ -105,7 +105,8 @@ public class TenantCapacityMapperByPostgresql extends BaseTenantCapacityMapper {
 
         return new MapperResult(
                 "INSERT INTO tenant_capacity (tenant_id, quota, usage, max_size, max_aggr_count, max_aggr_size, "
-                        + "gmt_create, gmt_modified) SELECT ?, ?, count(*), ?, ?, ?, ?, ? FROM config_info WHERE tenant_id=?",
+                        + "max_history_count, gmt_create, gmt_modified)"
+                        + " SELECT ?, ?, count(*), ?, ?, ?, 0, ?, ? FROM config_info WHERE tenant_id=?",
                 paramList);
     }
 }

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/TenantInfoMapperByPostgresql.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/TenantInfoMapperByPostgresql.java
@@ -16,19 +16,80 @@
 
 package com.alibaba.nacos.plugin.datasource.impl.postgresql;
 
+import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DatabaseTypeConstant;
 import com.alibaba.nacos.plugin.datasource.impl.base.BaseTenantInfoMapper;
 
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
 /**
  * The postgresql implementation of TenantInfoMapper.
+ * Override insert/update to convert epoch-millis (bigint) to PostgreSQL timestamp
+ * via {@code TO_TIMESTAMP(? / 1000.0)}.
  *
  * @author Long Yu
  **/
 public class TenantInfoMapperByPostgresql extends BaseTenantInfoMapper {
     
+    private static final String COLUMN_SEPARATOR = "@";
+    
     @Override
     public String getDataSource() {
         return DatabaseTypeConstant.POSTGRESQL;
+    }
+    
+    @Override
+    public String insert(List<String> columns) {
+        StringJoiner columnJoiner = new StringJoiner(", ", "(", ")");
+        StringJoiner valueJoiner = new StringJoiner(",", "(", ")");
+        
+        for (String col : columns) {
+            String[] parts = col.split(COLUMN_SEPARATOR, 2);
+            String colName = parts[0];
+            columnJoiner.add(colName);
+            if (parts.length > 1) {
+                valueJoiner.add(getFunction(parts[1]));
+            } else if (isTimestampColumn(colName)) {
+                valueJoiner.add("TO_TIMESTAMP(? / 1000.0)");
+            } else {
+                valueJoiner.add("?");
+            }
+        }
+        
+        return "INSERT INTO " + getTableName() + columnJoiner + " VALUES" + valueJoiner;
+    }
+    
+    @Override
+    public String update(List<String> columns, List<String> where) {
+        StringJoiner setJoiner = new StringJoiner(",");
+        for (String col : columns) {
+            String[] parts = col.split(COLUMN_SEPARATOR, 2);
+            String colName = parts[0];
+            String value;
+            if (parts.length > 1) {
+                value = getFunction(parts[1]);
+            } else if (isTimestampColumn(colName)) {
+                value = "TO_TIMESTAMP(? / 1000.0)";
+            } else {
+                value = "?";
+            }
+            setJoiner.add(colName + " = " + value);
+        }
+        
+        StringBuilder sql = new StringBuilder("UPDATE ").append(getTableName()).append(" SET ").append(setJoiner);
+        
+        if (CollectionUtils.isNotEmpty(where)) {
+            sql.append(" WHERE ");
+            sql.append(where.stream().map(str -> (str + " = ?")).collect(Collectors.joining(" AND ")));
+        }
+        
+        return sql.toString();
+    }
+    
+    private boolean isTimestampColumn(String columnName) {
+        return "gmt_create".equals(columnName) || "gmt_modified".equals(columnName);
     }
     
 }

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-grant-nacos-readwrite.sql
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-grant-nacos-readwrite.sql
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Optional: grant read/write on existing Nacos tables to application role `nacos` only.
+ *
+ * When to use:
+ *   Load pg-schema.sql as a DBA/superuser (tables then belong to that role). Create the app user:
+ *     CREATE USER nacos WITH PASSWORD 'your-password';
+ *   Then run this script while connected to the Nacos database as the same role that owns the tables
+ *   (often superuser), so privileges apply to all current objects.
+ *
+ * What you get:
+ *   USAGE on public schema, SELECT/INSERT/UPDATE/DELETE on all tables, USAGE+SELECT on sequences
+ *   (covers bigserial / identity). No CREATE/DROP on schema, no superuser.
+ *
+ * CONNECT: use `psql -d your_nacos_db` so the session can open the DB, or from another database run:
+ *   GRANT CONNECT ON DATABASE your_nacos_db TO nacos;
+ */
+
+GRANT USAGE ON SCHEMA public TO nacos;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO nacos;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO nacos;
+
+-- Objects created later by the same owner (e.g. future migrations run as superuser):
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO nacos;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO nacos;

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-schema.sql
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-schema.sql
@@ -142,7 +142,7 @@ CREATE TABLE "group_capacity" (
   "max_size" int4 NOT NULL,
   "max_aggr_count" int4 NOT NULL,
   "max_aggr_size" int4 NOT NULL,
-  "max_history_count" int4 NOT NULL,
+  "max_history_count" int4 NOT NULL DEFAULT 0,
   "gmt_create" timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   "gmt_modified" timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
 )
@@ -228,8 +228,9 @@ CREATE TABLE "roles" (
 -- ----------------------------
 -- Records of roles
 -- ----------------------------
+-- No seed rows: MySQL schema also leaves `roles` empty so the console can run first-time admin setup.
+-- A row like ('nacos', 'ROLE_ADMIN') blocks that flow when the DB account name is `nacos` (common JDBC user).
 BEGIN;
-INSERT INTO "roles" VALUES ('nacos', 'ROLE_ADMIN');
 COMMIT;
 
 -- ----------------------------
@@ -244,7 +245,7 @@ CREATE TABLE "tenant_capacity" (
   "max_size" int4 NOT NULL,
   "max_aggr_count" int4 NOT NULL,
   "max_aggr_size" int4 NOT NULL,
-  "max_history_count" int4 NOT NULL,
+  "max_history_count" int4 NOT NULL DEFAULT 0,
   "gmt_create" timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   "gmt_modified" timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP
 )
@@ -419,7 +420,7 @@ CREATE TABLE "ai_resource" (
   "gmt_modified" timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   "name" varchar(256) NOT NULL,
   "type" varchar(32) NOT NULL,
-  "c_desc" varchar(512),
+  "c_desc" varchar(1024),
   "status" varchar(32),
   "namespace_id" varchar(128) NOT NULL DEFAULT '',
   "biz_tags" varchar(1024),
@@ -480,7 +481,7 @@ CREATE TABLE "ai_resource_version" (
   "type" varchar(32) NOT NULL,
   "author" varchar(128),
   "name" varchar(256) NOT NULL,
-  "c_desc" varchar(512),
+  "c_desc" varchar(1024),
   "status" varchar(32) NOT NULL,
   "version" varchar(64) NOT NULL,
   "namespace_id" varchar(128) NOT NULL DEFAULT '',

--- a/plugin-default-impl/nacos-default-plugin-all/pom.xml
+++ b/plugin-default-impl/nacos-default-plugin-all/pom.xml
@@ -103,6 +103,8 @@
                                       tofile="${project.basedir}/../../distribution/conf/mysql-schema.sql" overwrite="true"/>
                                 <copy file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-schema.sql"
                                       tofile="${project.basedir}/../../distribution/conf/pg-schema.sql" overwrite="true"/>
+                                <copy file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-grant-nacos-readwrite.sql"
+                                      tofile="${project.basedir}/../../distribution/conf/pg-grant-nacos-readwrite.sql" overwrite="true"/>
                                 <copy file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/resources/META-INF/oracle-schema.sql"
                                       tofile="${project.basedir}/../../distribution/conf/oracle-schema.sql" overwrite="true"/>
                             </target>
@@ -122,11 +124,14 @@
                                            property="schema.source.mysql.exists"/>
                                 <available file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-schema.sql"
                                            property="schema.source.pg.exists"/>
+                                <available file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-grant-nacos-readwrite.sql"
+                                           property="schema.source.pg.grant.exists"/>
                                 <available file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/resources/META-INF/oracle-schema.sql"
                                            property="schema.source.oracle.exists"/>
                                 <fail unless="schema.source.derby.exists" message="Missing derby schema source in datasource plugin."/>
                                 <fail unless="schema.source.mysql.exists" message="Missing mysql schema source in datasource plugin."/>
                                 <fail unless="schema.source.pg.exists" message="Missing postgresql schema source in datasource plugin."/>
+                                <fail unless="schema.source.pg.grant.exists" message="Missing postgresql read/write grant script in datasource plugin."/>
                                 <fail unless="schema.source.oracle.exists" message="Missing oracle schema source in datasource plugin."/>
 
                                 <available file="${project.basedir}/../../distribution/conf/derby-schema.sql"
@@ -135,11 +140,14 @@
                                            property="schema.output.mysql.exists"/>
                                 <available file="${project.basedir}/../../distribution/conf/pg-schema.sql"
                                            property="schema.output.pg.exists"/>
+                                <available file="${project.basedir}/../../distribution/conf/pg-grant-nacos-readwrite.sql"
+                                           property="schema.output.pg.grant.exists"/>
                                 <available file="${project.basedir}/../../distribution/conf/oracle-schema.sql"
                                            property="schema.output.oracle.exists"/>
                                 <fail unless="schema.output.derby.exists" message="Missing derby schema in distribution/conf after packaging."/>
                                 <fail unless="schema.output.mysql.exists" message="Missing mysql schema in distribution/conf after packaging."/>
                                 <fail unless="schema.output.pg.exists" message="Missing postgresql schema in distribution/conf after packaging."/>
+                                <fail unless="schema.output.pg.grant.exists" message="Missing postgresql grant script in distribution/conf after packaging."/>
                                 <fail unless="schema.output.oracle.exists" message="Missing oracle schema in distribution/conf after packaging."/>
                             </target>
                         </configuration>


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fix multiple PostgreSQL compatibility issues discovered when running Nacos with PostgreSQL as the external storage.
These issues do not affect MySQL or Derby — all changes use standard JDBC API and are fully backward-compatible
with other databases.

## Brief changelog

- **JDBC GeneratedKeyHolder**: Replace `Statement.RETURN_GENERATED_KEYS` with explicit `new String[]{"id"}` in
  `AiResourcePersistServiceImpl` and `AiResourceVersionPersistServiceImpl`, because PostgreSQL returns ALL columns
  instead of just the auto-increment ID, causing `GeneratedKeyHolder.getKey()` to throw "multiple keys" error.
- **Namespace normalization**: Unify `AiResourceVersionPersistServiceImpl` and
  `EmbeddedAiResourceVersionPersistServiceImpl` to use `normalizeNamespaceId()` (blank → `Constants.DEFAULT_NAMESPACE_ID`)
  instead of `StringUtils.defaultEmptyIfBlank()` (blank → `""`), matching `AiResourcePersistServiceImpl` behavior.
  The mismatch caused version-row lookups to miss when namespace values differed between tables.
- **Upsert for ai_resource_version**: Add find-before-insert logic with `DuplicateKeyException` catch in
  `AiResourceManager.insertVersionRow()` to handle re-upload of existing skill/agentspec versions gracefully,
  since PostgreSQL enforces unique constraints strictly.
- **pg-schema.sql**: Extend `c_desc` column from `varchar(512)` to `varchar(1024)` for both `ai_resource` and
  `ai_resource_version` tables; add `DEFAULT 0` to `max_history_count` NOT NULL columns in `group_capacity` and
  `tenant_capacity`; remove hardcoded `ROLE_ADMIN` seed row that blocks first-time admin setup.
- **PG Mapper fixes**: Add `TenantInfoMapperByPostgresql` with PG-compatible timestamp handling; fix
  `GroupCapacityMapperByPostgresql` and `TenantCapacityMapperByPostgresql` for PG SQL syntax.
- **pg-grant-nacos-readwrite.sql**: Add optional permission grant script for production deployments where the
  Nacos JDBC user is not the table owner.
- **plugin-all pom.xml**: Add `nacos-datasource-plugin-postgresql` dependency and include `pg-grant-nacos-readwrite.sql`
  in distribution packaging with build-time verification.

## Verifying this change

- Compile and checkstyle:
  `mvn -pl ai,plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql -DskipTests -Dcheckstyle.consoleOutput=true checkstyle:check`
- Unit tests:
  `mvn -pl ai -Dtest=AiResourceManagerTest test`
- Full packaging verification:
  `mvn -B clean package apache-rat:check spotbugs:check -DskipTests`
- Manual E2E: Start Nacos with PostgreSQL, run `python3 doc/pg-test.py` to verify all console-ui API endpoints
  (config CRUD, service CRUD, skill upload/upsert, prompt, agent, MCP, namespace, user/role/permission, PG-specific
  scenarios including long description, special characters, and concurrent upload idempotency).

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.