### PR TITLE
[ISSUE #14833] Add AI resource trace logging and fix prompt bizTags handling in both UIs

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/PromptAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/PromptAdminController.java
@@ -60,7 +60,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -283,23 +282,6 @@ public class PromptAdminController {
         });
     }
     
-    private List<String> parseBizTags(String bizTags) {
-        if (bizTags == null) {
-            return null;
-        }
-        if (bizTags.trim().isEmpty()) {
-            return new ArrayList<>(0);
-        }
-        String[] split = bizTags.split(",");
-        List<String> result = new ArrayList<>(split.length);
-        for (String each : split) {
-            if (each != null && !each.trim().isEmpty()) {
-                result.add(each.trim());
-            }
-        }
-        return result;
-    }
-    
     // ========== Legacy compatibility endpoints (deprecated) ==========
     
     /**
@@ -314,7 +296,7 @@ public class PromptAdminController {
         form.validate();
         boolean success = promptOperationService.publishPromptVersion(form.getNamespaceId(), form.getPromptKey(),
                 form.getVersion(), form.getTemplate(), form.getCommitMsg(), form.getDescription(),
-                parseBizTags(form.getBizTags()), parseVariables(form.getVariables()));
+                form.getBizTags(), parseVariables(form.getVariables()));
         return Result.success(success);
     }
     
@@ -389,7 +371,7 @@ public class PromptAdminController {
             throws NacosException {
         form.validate();
         boolean success = promptOperationService.updatePromptMetadata(form.getNamespaceId(), form.getPromptKey(),
-                form.getDescription(), parseBizTags(form.getBizTags()));
+                form.getDescription(), form.getBizTags());
         return Result.success(success);
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.index.McpServerIndex;
 import com.alibaba.nacos.ai.model.mcp.McpServerIndexData;
 import com.alibaba.nacos.ai.model.mcp.McpServerStorageInfo;
+import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.ai.utils.McpConfigUtils;
 import com.alibaba.nacos.ai.utils.McpRequestUtil;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
@@ -384,6 +385,9 @@ public class McpServerOperationService {
         
         // Delete the relevant cache after a successful database operation
         invalidateCacheAfterDbOperation(namespaceId, serverSpecification.getName(), id);
+        AiResourceTraceService.logSuccess("mcp", serverSpecification.getName(),
+                versionDetail.getVersion(), AiResourceTraceService.OP_CREATE_DRAFT,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
         
         return id;
     }
@@ -489,6 +493,9 @@ public class McpServerOperationService {
         // Delete the relevant cache after a successful database operation
         invalidateCacheAfterDbUpdateOperation(namespaceId, mcpServerVersionInfo.getName(),
                 serverSpecification.getName(), mcpServerId);
+        AiResourceTraceService.logSuccess("mcp", serverSpecification.getName(),
+                updateVersion, isPublish ? AiResourceTraceService.OP_PUBLISH : AiResourceTraceService.OP_UPDATE_DRAFT,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**
@@ -523,6 +530,10 @@ public class McpServerOperationService {
         
         // Delete the relevant cache after a successful database operation
         invalidateCacheAfterDbOperation(namespaceId, mcpName, mcpServerId);
+        AiResourceTraceService.logSuccess("mcp", mcpName, version,
+                StringUtils.isNotEmpty(version) ? AiResourceTraceService.OP_DELETE_VERSION
+                        : AiResourceTraceService.OP_DELETE_RESOURCE,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     private void injectToolAndEndpoint(String namespaceId, String mcpServerId, McpServerStorageInfo serverSpecification,

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/VisibilityHelper.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/VisibilityHelper.java
@@ -78,6 +78,20 @@ public class VisibilityHelper {
     }
     
     /**
+     * Resolve the client IP from request context.
+     *
+     * @return client IP address, empty string when absent
+     */
+    public static String resolveClientIp() {
+        try {
+            String sourceIp = RequestContextHolder.getContext().getBasicContext().getAddressContext().getSourceIp();
+            return sourceIp == null ? "" : sourceIp;
+        } catch (Exception e) {
+            return "";
+        }
+    }
+    
+    /**
      * Filter candidate resources by read permission for current user.
      *
      * @param candidates candidate resources

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationService.java
@@ -18,7 +18,9 @@ package com.alibaba.nacos.ai.service.a2a;
 
 import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.service.SyncEffectService;
+import com.alibaba.nacos.ai.service.VisibilityHelper;
 import com.alibaba.nacos.ai.service.a2a.identity.AgentIdCodecHolder;
+import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.ai.utils.AgentCardUtil;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.a2a.AgentCard;
@@ -111,6 +113,9 @@ public class A2aServerOperationService {
             configOperationService.publishConfig(configFormVersion, agentCardConfigRequest, null);
             
             syncEffectService.toSync(configFormVersion, startOperationTime);
+            AiResourceTraceService.logSuccess("a2a", agentCard.getName(), agentCard.getVersion(),
+                    AiResourceTraceService.OP_CREATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+                    VisibilityHelper.resolveClientIp());
         } catch (ConfigAlreadyExistsException e) {
             throw new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
                     String.format("AgentCard name %s already exist", agentCard.getName()));
@@ -177,6 +182,10 @@ public class A2aServerOperationService {
             
             configOperationService.deleteConfig(encodedName, AGENT_GROUP, namespaceId, null, null, "nacos", null);
         }
+        AiResourceTraceService.logSuccess("a2a", agentName, version,
+                StringUtils.isNotEmpty(version) ? AiResourceTraceService.OP_DELETE_VERSION
+                        : AiResourceTraceService.OP_DELETE_RESOURCE,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**
@@ -236,6 +245,9 @@ public class A2aServerOperationService {
         configOperationService.publishConfig(versionConfigForm, versionConfigRequestInfo, null);
         
         syncEffectService.toSync(versionConfigForm, startOperationTime);
+        AiResourceTraceService.logSuccess("a2a", agentCard.getName(), agentCard.getVersion(),
+                setAsLatest ? AiResourceTraceService.OP_PUBLISH : AiResourceTraceService.OP_UPDATE_DRAFT,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
 import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
+import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.ai.utils.AgentSpecSeedArchiveReader;
 import com.alibaba.nacos.ai.utils.AgentSpecZipParser;
@@ -377,6 +378,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             // Brand-new agentspec: create v1 draft
             String version = "v1";
             createDraftWithAgentSpec(namespaceId, agentSpec, version, null, true);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, version, AiResourceTraceService.OP_UPLOAD,
+                    VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
             return name;
         }
         
@@ -389,6 +392,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         String newVersion = nextVersion(namespaceId, name);
         createDraftWithAgentSpec(namespaceId, agentSpec, newVersion, meta, false);
         resourceManager.syncImportedMeta(namespaceId, meta, agentSpec.getDescription(), agentSpec.getBizTags());
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, newVersion, AiResourceTraceService.OP_UPLOAD,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
         return name;
     }
     
@@ -626,6 +631,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             emptyAgentSpec.setName(name);
             emptyAgentSpec.setNamespaceId(namespaceId);
             createDraftWithAgentSpec(namespaceId, emptyAgentSpec, "v1", null, true);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, "v1", AiResourceTraceService.OP_CREATE_DRAFT,
+                    VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
             return "v1";
         }
 
@@ -642,6 +649,9 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             emptyAgentSpec.setName(name);
             emptyAgentSpec.setNamespaceId(namespaceId);
             createDraftWithAgentSpec(namespaceId, emptyAgentSpec, newVersion, meta, false);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, newVersion,
+                    AiResourceTraceService.OP_CREATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+                    VisibilityHelper.resolveClientIp());
             return newVersion;
         }
 
@@ -658,6 +668,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         // Step 3: Update meta's editingVersion pointer
         info.setEditingVersion(newVersion);
         resourceManager.updateVersionInfoCas(namespaceId, meta, info);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, newVersion, AiResourceTraceService.OP_CREATE_DRAFT,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
         return newVersion;
     }
     
@@ -676,6 +688,9 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         // Auto-create brand-new draft when meta does not exist (unlike Skill, AgentSpec's updateDraft supports auto-creation)
         if (meta == null) {
             createDraftWithAgentSpec(namespaceId, draftAgentSpec, "v1", null, true);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, "v1",
+                    AiResourceTraceService.OP_CREATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+                    VisibilityHelper.resolveClientIp());
             return;
         }
         // Confirm write permission and an editing draft exists
@@ -694,6 +709,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         aiResourceVersionPersistService.updateStorageAndDesc(namespaceId, name, RESOURCE_TYPE_AGENTSPEC, editing,
             buildStorageJson(namespaceId, name, editing), draftAgentSpec.getDescription());
         resourceManager.bumpMetaDescription(namespaceId, meta, draftAgentSpec.getDescription());
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, editing, AiResourceTraceService.OP_UPDATE_DRAFT,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**
@@ -719,6 +736,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         // Step 2: Clear meta's editingVersion pointer
         info.setEditingVersion(null);
         resourceManager.updateVersionInfoCas(namespaceId, meta, info);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, editing, AiResourceTraceService.OP_DELETE_DRAFT,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**
@@ -811,6 +830,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         AiResource meta = resourceManager.requireMeta(namespaceId, name, RESOURCE_TYPE_AGENTSPEC);
         VisibilityHelper.checkWritableResource(meta);
         resourceManager.updateBizTagsCas(namespaceId, meta, bizTags);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, null, AiResourceTraceService.OP_UPDATE_BIZ_TAGS,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationService.java
@@ -254,7 +254,7 @@ public interface PromptOperationService {
      */
     @Deprecated
     boolean publishPromptVersion(String namespaceId, String promptKey, String version, String template,
-            String commitMsg, String description, List<String> bizTags, List<PromptVariable> variables)
+            String commitMsg, String description, String bizTags, List<PromptVariable> variables)
             throws NacosException;
     
     /**
@@ -296,6 +296,6 @@ public interface PromptOperationService {
      * @deprecated Use {@link #updateDescription} and {@link #updateBizTags} instead.
      */
     @Deprecated
-    boolean updatePromptMetadata(String namespaceId, String promptKey, String description, List<String> bizTags)
+    boolean updatePromptMetadata(String namespaceId, String promptKey, String description, String bizTags)
             throws NacosException;
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
@@ -634,14 +634,7 @@ public class PromptOperationServiceImpl implements PromptOperationService {
         detail.setOnlineCnt(versionInfo.getOnlineCnt());
         detail.setLabels(versionInfo.getLabels());
         detail.setGmtModified(meta.getGmtModified() == null ? null : meta.getGmtModified().getTime());
-        
-        if (meta.getBizTags() != null) {
-            try {
-                detail.setBizTags(JacksonUtils.toObj(meta.getBizTags(), List.class));
-            } catch (Exception e) {
-                detail.setBizTags(new ArrayList<>());
-            }
-        }
+        detail.setBizTags(meta.getBizTags());
         
         // Load version list
         List<AiResourceVersion> allVersions = loadAllVersionRows(namespaceId, promptKey);
@@ -724,13 +717,7 @@ public class PromptOperationServiceImpl implements PromptOperationService {
                 summary.setLabels(vInfo != null ? vInfo.getLabels() : null);
                 summary.setGmtModified(
                         resource.getGmtModified() == null ? null : resource.getGmtModified().getTime());
-                if (resource.getBizTags() != null) {
-                    try {
-                        summary.setBizTags(JacksonUtils.toObj(resource.getBizTags(), List.class));
-                    } catch (Exception e) {
-                        summary.setBizTags(new ArrayList<>());
-                    }
-                }
+                summary.setBizTags(resource.getBizTags());
                 items.add(summary);
             }
         }
@@ -1272,10 +1259,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
     @Deprecated
     @Override
     public boolean publishPromptVersion(String namespaceId, String promptKey, String version, String template,
-            String commitMsg, String description, List<String> bizTags, List<PromptVariable> variables)
+            String commitMsg, String description, String bizTags, List<PromptVariable> variables)
             throws NacosException {
-        String bizTagsJson = (bizTags != null) ? JacksonUtils.toJson(bizTags) : null;
-        createDraft(namespaceId, promptKey, null, version, template, variables, commitMsg, description, bizTagsJson);
+        createDraft(namespaceId, promptKey, null, version, template, variables, commitMsg, description, bizTags);
         submit(namespaceId, promptKey, version);
         return true;
     }
@@ -1316,13 +1302,13 @@ public class PromptOperationServiceImpl implements PromptOperationService {
     
     @Deprecated
     @Override
-    public boolean updatePromptMetadata(String namespaceId, String promptKey, String description, List<String> bizTags)
+    public boolean updatePromptMetadata(String namespaceId, String promptKey, String description, String bizTags)
             throws NacosException {
         if (description != null) {
             updateDescription(namespaceId, promptKey, description);
         }
         if (bizTags != null) {
-            updateBizTags(namespaceId, promptKey, JacksonUtils.toJson(bizTags));
+            updateBizTags(namespaceId, promptKey, bizTags);
         }
         return true;
     }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
@@ -532,6 +532,10 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             info.setOnlineCnt(Math.max(0, cnt - 1));
         }
         updateMetaVersionInfoCas(namespaceId, meta, info);
+        String traceOp = online ? AiResourceTraceService.OP_ONLINE_VERSION
+                : AiResourceTraceService.OP_OFFLINE_VERSION;
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_PROMPT, promptKey, version, traceOp,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     @Override
@@ -549,6 +553,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
         
         info.setLabels(newLabels);
         updateMetaVersionInfoCas(namespaceId, meta, info);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_PROMPT, promptKey, null,
+                AiResourceTraceService.OP_UPDATE_LABELS, VisibilityHelper.resolveCurrentIdentity(),
+                VisibilityHelper.resolveClientIp());
         
         // Refresh latest mirror if latest label changed
         if (labels != null && labels.containsKey(LABEL_LATEST)) {
@@ -575,6 +582,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
         AiResource meta = requireMeta(namespaceId, promptKey);
         VisibilityHelper.checkWritableResource(meta);
         updateMetaDescriptionCas(namespaceId, meta, description);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_PROMPT, promptKey, null,
+                AiResourceTraceService.OP_UPDATE_DESCRIPTION, VisibilityHelper.resolveCurrentIdentity(),
+                VisibilityHelper.resolveClientIp());
     }
     
     @Override

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
 import com.alibaba.nacos.ai.service.VisibilityHelper;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionResult;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
@@ -174,6 +175,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             newMeta.setVersionInfo(JacksonUtils.toJson(info));
             newMeta.setMetaVersion(1L);
             aiResourcePersistService.insert(newMeta);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE_PROMPT, promptKey, version,
+                    AiResourceTraceService.OP_CREATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+                    VisibilityHelper.resolveClientIp());
             
             return version;
         }
@@ -211,6 +215,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             
             info.setEditingVersion(newVersion);
             updateMetaVersionInfoCas(namespaceId, meta, info);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE_PROMPT, promptKey, newVersion,
+                    AiResourceTraceService.OP_CREATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+                    VisibilityHelper.resolveClientIp(), "basedOn=" + basedOnVersion);
             return newVersion;
         }
         
@@ -234,6 +241,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
         
         info.setEditingVersion(newVersion);
         updateMetaVersionInfoCas(namespaceId, meta, info);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_PROMPT, promptKey, newVersion,
+                AiResourceTraceService.OP_CREATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+                VisibilityHelper.resolveClientIp());
         return newVersion;
     }
     
@@ -271,6 +281,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             aiResourceVersionPersistService.updateStorageAndDesc(namespaceId, promptKey, RESOURCE_TYPE_PROMPT,
                     editing, storageJson, commitMsg);
         }
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_PROMPT, promptKey, editing,
+                AiResourceTraceService.OP_UPDATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+                VisibilityHelper.resolveClientIp());
     }
     
     @Override
@@ -295,6 +308,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             aiResourceVersionPersistService.delete(namespaceId, promptKey, RESOURCE_TYPE_PROMPT, editing);
             deletePromptStorageForVersion(namespaceId, promptKey, editing);
         }
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_PROMPT, promptKey, editing,
+                AiResourceTraceService.OP_DELETE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+                VisibilityHelper.resolveClientIp());
     }
     
     @Override
@@ -549,6 +565,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
         AiResource meta = requireMeta(namespaceId, promptKey);
         VisibilityHelper.checkWritableResource(meta);
         updateMetaBizTagsCas(namespaceId, meta, bizTags);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_PROMPT, promptKey, null,
+                AiResourceTraceService.OP_UPDATE_BIZ_TAGS, VisibilityHelper.resolveCurrentIdentity(),
+                VisibilityHelper.resolveClientIp());
     }
     
     @Override

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/resource/AiResourceManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/resource/AiResourceManager.java
@@ -28,6 +28,7 @@ import com.alibaba.nacos.ai.service.VisibilityHelper;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
 import com.alibaba.nacos.ai.service.repository.QueryCondition;
+import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.ai.service.visibility.DefaultVisibilityAdvisorConverter;
 import com.alibaba.nacos.ai.service.visibility.VisibilityAdvisorConverter;
 import com.alibaba.nacos.api.exception.NacosException;
@@ -209,6 +210,9 @@ public class AiResourceManager {
                     nv.setExt(latest.getExt());
                 });
         handleStrictCasResult(result);
+        String operation = enable ? AiResourceTraceService.OP_ENABLE : AiResourceTraceService.OP_DISABLE;
+        AiResourceTraceService.logSuccess(meta.getType(), meta.getName(), null, operation,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**
@@ -555,6 +559,8 @@ public class AiResourceManager {
         info.setEditingVersion(null);
         info.setReviewingVersion(version);
         updateVersionInfoCas(namespaceId, meta, info);
+        AiResourceTraceService.logSuccess(type, name, version, AiResourceTraceService.OP_SUBMIT_REVIEW,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**
@@ -633,6 +639,8 @@ public class AiResourceManager {
             info.getLabels().put(AiResourceConstants.LABEL_LATEST, version);
         }
         updateVersionInfoCas(namespaceId, meta, info);
+        AiResourceTraceService.logSuccess(type, name, version, AiResourceTraceService.OP_PUBLISH,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
         return v;
     }
     
@@ -677,6 +685,8 @@ public class AiResourceManager {
             info.getLabels().put(AiResourceConstants.LABEL_LATEST, version);
         }
         updateVersionInfoCas(namespaceId, meta, info);
+        AiResourceTraceService.logSuccess(type, name, version, AiResourceTraceService.OP_FORCE_PUBLISH,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
         return v;
     }
     
@@ -707,6 +717,8 @@ public class AiResourceManager {
         }
         info.setLabels(labels == null ? null : new LinkedHashMap<>(labels));
         updateVersionInfoCas(namespaceId, meta, info);
+        AiResourceTraceService.logSuccess(type, name, null, AiResourceTraceService.OP_UPDATE_LABELS,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**
@@ -721,6 +733,8 @@ public class AiResourceManager {
             throw new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.SERVER_ERROR,
                     "Failed to update scope for " + type + ": " + name);
         }
+        AiResourceTraceService.logSuccess(type, name, null, AiResourceTraceService.OP_UPDATE_SCOPE,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp(), "scope=" + scope);
     }
     
     /**
@@ -746,6 +760,9 @@ public class AiResourceManager {
         Integer cnt = info.getOnlineCnt() == null ? 0 : info.getOnlineCnt();
         info.setOnlineCnt(online ? cnt + 1 : Math.max(0, cnt - 1));
         updateVersionInfoCas(namespaceId, meta, info);
+        String operation = online ? AiResourceTraceService.OP_ONLINE_VERSION : AiResourceTraceService.OP_OFFLINE_VERSION;
+        AiResourceTraceService.logSuccess(type, name, version, operation,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
         return v;
     }
     
@@ -855,6 +872,8 @@ public class AiResourceManager {
                 storageDeleter.deleteStorage(v);
             }
         }
+        AiResourceTraceService.logSuccess(type, name, null, AiResourceTraceService.OP_DELETE_RESOURCE,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
     
     /**
@@ -905,6 +924,11 @@ public class AiResourceManager {
                         }
                     }
                 }
+                AiResourceTraceService.logSuccess(type, name, version, AiResourceTraceService.OP_REVIEW_REJECTED,
+                        "system", "", result == null ? null : result.getExecutionId());
+            } else {
+                AiResourceTraceService.logSuccess(type, name, version, AiResourceTraceService.OP_REVIEW_APPROVED,
+                        "system", "", result.getExecutionId());
             }
         } catch (Throwable ex) {
             LOGGER.error("Pipeline callback failed for {}@{}", name, version, ex);

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
 import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
+import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.ai.utils.ExecutorUtils;
 import com.alibaba.nacos.ai.utils.SkillZipParser;
@@ -175,6 +176,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         if (meta == null) {
             // Brand-new skill: create draft directly
             createDraftWithSkill(namespaceId, skill, uploadVersion, null, true);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE_SKILL, name, uploadVersion, AiResourceTraceService.OP_UPLOAD,
+                    VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
             return name;
         }
 
@@ -186,6 +189,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         // Step 4: Resolve version conflicts and create new draft
         String newVersion = resolveFinalUploadVersion(namespaceId, name, uploadVersion);
         createDraftWithSkill(namespaceId, skill, newVersion, meta, false);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_SKILL, name, newVersion, AiResourceTraceService.OP_UPLOAD,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
         return name;
     }
 
@@ -598,6 +603,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
                     ? resolveFinalUploadVersion(namespaceId, name, resolveUploadVersion(initialContent.getSkillMd(), null))
                     : resolveSpecifiedDraftVersion(namespaceId, name, targetVersion, null, null);
             createDraftWithSkill(namespaceId, initialContent, version, null, true);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE_SKILL, name, version, AiResourceTraceService.OP_CREATE_DRAFT,
+                    VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
             return version;
         }
 
@@ -642,6 +649,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
             info.setEditingVersion(newVersion);
             resourceManager.updateVersionInfoCas(namespaceId, meta, info);
         }
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_SKILL, name, newVersion, AiResourceTraceService.OP_CREATE_DRAFT,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
         return newVersion;
     }
 
@@ -680,6 +689,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         aiResourceVersionPersistService.updateStorage(namespaceId, name, RESOURCE_TYPE_SKILL, editing,
                 buildStorageJson(namespaceId, name, editing, files));
         resourceManager.bumpMetaDescription(namespaceId, meta, draftSkill.getDescription());
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_SKILL, name, editing, AiResourceTraceService.OP_UPDATE_DRAFT,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
 
     /**
@@ -708,6 +719,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
             aiResourceVersionPersistService.delete(namespaceId, name, RESOURCE_TYPE_SKILL, editing);
             deleteSkillStorageForVersion(namespaceId, name, editing, v.getStorage());
         }
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_SKILL, name, editing, AiResourceTraceService.OP_DELETE_DRAFT,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
 
     /**
@@ -818,6 +831,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         AiResource meta = resourceManager.requireMeta(namespaceId, name, RESOURCE_TYPE_SKILL);
         VisibilityHelper.checkWritableResource(meta);
         resourceManager.updateBizTagsCas(namespaceId, meta, bizTags);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE_SKILL, name, null, AiResourceTraceService.OP_UPDATE_BIZ_TAGS,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
 
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/trace/AiResourceTraceService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/trace/AiResourceTraceService.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.trace;
+
+import com.alibaba.nacos.ai.utils.AiLogUtil;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * AI resource trace service for auditing AI resource version operations.
+ *
+ * <p>Logs are output in JSON format with ISO 8601 timestamps, designed for ELK/Loki integration.</p>
+ *
+ * <p>Log format example:</p>
+ * <pre>
+ * {"timestamp":"2026-03-30T10:15:30Z","operator":"admin","resource_type":"skill",
+ *  "resource_id":"my-skill","version":"v1.0","operation":"PUBLISH","status":"SUCCESS","ip":"192.168.1.1"}
+ * </pre>
+ *
+ * @author nacos
+ * @since 3.2.1
+ */
+public class AiResourceTraceService {
+    
+    // ==================== Operation Constants ====================
+    
+    /**
+     * Create a new draft version.
+     */
+    public static final String OP_CREATE_DRAFT = "CREATE_DRAFT";
+    
+    /**
+     * Update an existing draft version.
+     */
+    public static final String OP_UPDATE_DRAFT = "UPDATE_DRAFT";
+    
+    /**
+     * Delete a draft version.
+     */
+    public static final String OP_DELETE_DRAFT = "DELETE_DRAFT";
+    
+    /**
+     * Upload a skill/resource.
+     */
+    public static final String OP_UPLOAD = "UPLOAD";
+    
+    /**
+     * Submit version for review.
+     */
+    public static final String OP_SUBMIT_REVIEW = "SUBMIT_REVIEW";
+    
+    /**
+     * Review approved.
+     */
+    public static final String OP_REVIEW_APPROVED = "REVIEW_APPROVED";
+    
+    /**
+     * Review rejected.
+     */
+    public static final String OP_REVIEW_REJECTED = "REVIEW_REJECTED";
+    
+    /**
+     * Force skip review (admin operation).
+     */
+    public static final String OP_REVIEW_FORCE_SKIP = "REVIEW_FORCE_SKIP";
+    
+    /**
+     * Publish a version to online.
+     */
+    public static final String OP_PUBLISH = "PUBLISH";
+    
+    /**
+     * Force publish (bypass review).
+     */
+    public static final String OP_FORCE_PUBLISH = "FORCE_PUBLISH";
+    
+    /**
+     * Take a version offline.
+     */
+    public static final String OP_OFFLINE_VERSION = "OFFLINE_VERSION";
+    
+    /**
+     * Bring a version back online.
+     */
+    public static final String OP_ONLINE_VERSION = "ONLINE_VERSION";
+    
+    /**
+     * Delete a version.
+     */
+    public static final String OP_DELETE_VERSION = "DELETE_VERSION";
+    
+    /**
+     * Delete the entire resource (including all versions).
+     */
+    public static final String OP_DELETE_RESOURCE = "DELETE_RESOURCE";
+    
+    /**
+     * Set/update label for a version.
+     */
+    public static final String OP_SET_LABEL = "SET_LABEL";
+    
+    /**
+     * Remove label from a version.
+     */
+    public static final String OP_REMOVE_LABEL = "REMOVE_LABEL";
+    
+    /**
+     * Update labels.
+     */
+    public static final String OP_UPDATE_LABELS = "UPDATE_LABELS";
+    
+    /**
+     * Update resource scope.
+     */
+    public static final String OP_UPDATE_SCOPE = "UPDATE_SCOPE";
+    
+    /**
+     * Update resource bizTags.
+     */
+    public static final String OP_UPDATE_BIZ_TAGS = "UPDATE_BIZ_TAGS";
+    
+    /**
+     * Enable resource.
+     */
+    public static final String OP_ENABLE = "ENABLE";
+    
+    /**
+     * Disable resource.
+     */
+    public static final String OP_DISABLE = "DISABLE";
+    
+    // ==================== Status Constants ====================
+    
+    /**
+     * Operation succeeded.
+     */
+    public static final String STATUS_SUCCESS = "SUCCESS";
+    
+    /**
+     * Operation failed.
+     */
+    public static final String STATUS_FAILURE = "FAILURE";
+    
+    // ==================== Logging Methods ====================
+    
+    /**
+     * Log a successful AI resource operation.
+     *
+     * @param resourceType the type of resource (e.g., "skill", "agentspec", "mcp", "prompt")
+     * @param resourceId   the resource identifier (name)
+     * @param version      the version being operated on (nullable)
+     * @param operation    the operation type (use OP_* constants)
+     * @param operator     the operator identity (user id or username)
+     * @param clientIp     the client IP address
+     */
+    public static void logSuccess(String resourceType, String resourceId, String version, String operation,
+            String operator, String clientIp) {
+        log(resourceType, resourceId, version, operation, STATUS_SUCCESS, operator, clientIp, null);
+    }
+    
+    /**
+     * Log a successful AI resource operation with extra info.
+     *
+     * @param resourceType the type of resource (e.g., "skill", "agentspec", "mcp", "prompt")
+     * @param resourceId   the resource identifier (name)
+     * @param version      the version being operated on (nullable)
+     * @param operation    the operation type (use OP_* constants)
+     * @param operator     the operator identity (user id or username)
+     * @param clientIp     the client IP address
+     * @param ext          extra information (nullable)
+     */
+    public static void logSuccess(String resourceType, String resourceId, String version, String operation,
+            String operator, String clientIp, String ext) {
+        log(resourceType, resourceId, version, operation, STATUS_SUCCESS, operator, clientIp, ext);
+    }
+    
+    /**
+     * Log a failed AI resource operation.
+     *
+     * @param resourceType the type of resource (e.g., "skill", "agentspec", "mcp", "prompt")
+     * @param resourceId   the resource identifier (name)
+     * @param version      the version being operated on (nullable)
+     * @param operation    the operation type (use OP_* constants)
+     * @param operator     the operator identity (user id or username)
+     * @param clientIp     the client IP address
+     * @param errorMsg     the error message
+     */
+    public static void logFailure(String resourceType, String resourceId, String version, String operation,
+            String operator, String clientIp, String errorMsg) {
+        log(resourceType, resourceId, version, operation, STATUS_FAILURE, operator, clientIp, errorMsg);
+    }
+    
+    /**
+     * Log an AI resource operation event.
+     *
+     * @param resourceType the type of resource (e.g., "skill", "agentspec", "mcp", "prompt")
+     * @param resourceId   the resource identifier (name)
+     * @param version      the version being operated on (nullable)
+     * @param operation    the operation type (use OP_* constants)
+     * @param status       the operation status (SUCCESS or FAILURE)
+     * @param operator     the operator identity (user id or username)
+     * @param clientIp     the client IP address
+     * @param ext          extra information or error message (nullable)
+     */
+    public static void log(String resourceType, String resourceId, String version, String operation, String status,
+            String operator, String clientIp, String ext) {
+        if (!AiLogUtil.TRACE_LOG.isInfoEnabled()) {
+            return;
+        }
+        
+        Map<String, Object> logEntry = new LinkedHashMap<>(10);
+        logEntry.put("timestamp", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+        logEntry.put("operator", StringUtils.defaultIfBlank(operator, "-"));
+        logEntry.put("resource_type", StringUtils.defaultIfBlank(resourceType, "-"));
+        logEntry.put("resource_id", StringUtils.defaultIfBlank(resourceId, "-"));
+        if (StringUtils.isNotBlank(version)) {
+            logEntry.put("version", version);
+        }
+        logEntry.put("operation", StringUtils.defaultIfBlank(operation, "-"));
+        logEntry.put("status", StringUtils.defaultIfBlank(status, "-"));
+        logEntry.put("ip", StringUtils.defaultIfBlank(clientIp, "-"));
+        if (StringUtils.isNotBlank(ext)) {
+            logEntry.put("ext", ext);
+        }
+        
+        AiLogUtil.TRACE_LOG.info(JacksonUtils.toJson(logEntry));
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/trace/AiResourceTraceService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/trace/AiResourceTraceService.java
@@ -134,6 +134,11 @@ public class AiResourceTraceService {
     public static final String OP_UPDATE_SCOPE = "UPDATE_SCOPE";
     
     /**
+     * Update resource description.
+     */
+    public static final String OP_UPDATE_DESCRIPTION = "UPDATE_DESCRIPTION";
+    
+    /**
      * Update resource bizTags.
      */
     public static final String OP_UPDATE_BIZ_TAGS = "UPDATE_BIZ_TAGS";

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AiLogUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AiLogUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AI module log util.
+ *
+ * @author nacos
+ */
+public class AiLogUtil {
+    
+    /**
+     * AI resource trace log for auditing AI resource version operations.
+     */
+    public static final Logger TRACE_LOG = LoggerFactory.getLogger("com.alibaba.nacos.ai.resource.trace");
+}

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptMetaSummary.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/prompt/PromptMetaSummary.java
@@ -17,8 +17,6 @@
 package com.alibaba.nacos.api.ai.model.prompt;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -36,7 +34,7 @@ public class PromptMetaSummary implements Serializable {
     
     private String description;
     
-    private List<String> bizTags = new ArrayList<>();
+    private String bizTags;
     
     private String latestVersion;
     
@@ -86,11 +84,11 @@ public class PromptMetaSummary implements Serializable {
         this.description = description;
     }
     
-    public List<String> getBizTags() {
+    public String getBizTags() {
         return bizTags;
     }
     
-    public void setBizTags(List<String> bizTags) {
+    public void setBizTags(String bizTags) {
         this.bizTags = bizTags;
     }
     

--- a/console-ui-next/src/components/ai/prompt/PromptCard.tsx
+++ b/console-ui-next/src/components/ai/prompt/PromptCard.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import dayjs from 'dayjs';
-import type { PromptMetaSummary } from '@/types/prompt';
+import { parseBizTags, type PromptMetaSummary } from '@/types/prompt';
 
 interface PromptCardProps {
   prompt: PromptMetaSummary;
@@ -25,7 +25,7 @@ export function PromptCard({
 }: PromptCardProps) {
   const { t } = useTranslation();
 
-  const bizTags = (prompt.bizTags || []).slice(0, 2);
+  const bizTags = parseBizTags(prompt.bizTags).slice(0, 2);
 
   return (
     <Card

--- a/console-ui-next/src/pages/promptDetail/index.tsx
+++ b/console-ui-next/src/pages/promptDetail/index.tsx
@@ -70,6 +70,7 @@ import { promptApi } from '@/api/prompt';
 import { cn } from '@/lib/utils';
 import dayjs from 'dayjs';
 import { parsePipelineInfo } from '@/types/skill';
+import { parseBizTags } from '@/types/prompt';
 import { PromptVersionTimeline } from '@/pages/promptManagement/components/PromptVersionTimeline';
 import { PipelineStatusDisplay } from '@/pages/skillManagement/components/PipelineStatusDisplay';
 import { LabelBindDialog } from '@/components/ai/LabelBindDialog';
@@ -525,7 +526,7 @@ export default function PromptDetailPage() {
   // --- Edit metadata ---
   const handleEdit = () => {
     setEditDescription(meta?.description || '');
-    setEditBizTags(meta?.bizTags || []);
+    setEditBizTags(parseBizTags(meta?.bizTags));
     setEditTagInput('');
     setEditDialogOpen(true);
   };
@@ -695,9 +696,9 @@ export default function PromptDetailPage() {
                     {dayjs(meta.gmtModified).format('YYYY-MM-DD HH:mm')}
                   </span>
                 )}
-                {meta.bizTags && meta.bizTags.length > 0 && (
+                {meta.bizTags && parseBizTags(meta.bizTags).length > 0 && (
                   <div className="flex items-center gap-1">
-                    {meta.bizTags.slice(0, 3).map((tag) => (
+                    {parseBizTags(meta.bizTags).slice(0, 3).map((tag) => (
                       <Badge key={tag} variant="outline" className="text-[10px] px-1.5 py-0">{tag}</Badge>
                     ))}
                   </div>
@@ -995,9 +996,9 @@ export default function PromptDetailPage() {
               </Button>
             </div>
             <CardContent className="p-3.5">
-              {meta.bizTags && meta.bizTags.length > 0 ? (
+              {meta.bizTags && parseBizTags(meta.bizTags).length > 0 ? (
                 <div className="flex flex-wrap gap-1.5">
-                  {meta.bizTags.map((tag) => (
+                  {parseBizTags(meta.bizTags).map((tag) => (
                     <DetailTagChip key={tag} label={tag} />
                   ))}
                 </div>
@@ -1303,7 +1304,7 @@ export default function PromptDetailPage() {
       <BizTagEditDialog
         open={bizTagDialogOpen}
         onOpenChange={setBizTagDialogOpen}
-        tags={meta?.bizTags || []}
+        tags={parseBizTags(meta?.bizTags)}
         placeholder={t('prompt.tagPlaceholder')}
         emptyText={t('prompt.noLabels')}
         onSave={handleSaveBizTags}

--- a/console-ui-next/src/stores/__tests__/prompt-store.test.ts
+++ b/console-ui-next/src/stores/__tests__/prompt-store.test.ts
@@ -8,7 +8,7 @@ const mockGovernanceData = {
   schemaVersion: 1,
   promptKey: 'test-prompt',
   description: 'test',
-  bizTags: [],
+  bizTags: '',
   latestVersion: '1.0.0',
   gmtModified: Date.now(),
   editingVersion: null,

--- a/console-ui-next/src/types/prompt.ts
+++ b/console-ui-next/src/types/prompt.ts
@@ -20,7 +20,7 @@ export interface PromptMetaSummary {
   schemaVersion: number;
   promptKey: string;
   description: string;
-  bizTags: string[];
+  bizTags: string; // raw string, use parseBizTags() to get string[]
   latestVersion: string;
   gmtModified: number;
   editingVersion: string | null;
@@ -141,4 +141,16 @@ export interface PromptBizTagsUpdateData {
   promptKey: string;
   bizTags: string;
   namespaceId?: string;
+}
+
+/** Safely parse bizTags string into an array (handles JSON array, comma-separated, or plain string) */
+export function parseBizTags(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    // fallback: treat as comma-separated
+    return raw.split(',').map((s) => s.trim()).filter(Boolean);
+  }
 }

--- a/console-ui/src/pages/AI/PromptDetail/PromptDetail.js
+++ b/console-ui/src/pages/AI/PromptDetail/PromptDetail.js
@@ -73,6 +73,10 @@ class PromptDetail extends React.Component {
       editingDescription: false,
       descriptionValue: '',
       savingDescription: false,
+      // BizTags editing
+      editingBizTags: false,
+      bizTagsValue: '',
+      savingBizTags: false,
       // Pipeline
       pipelineInfo: null,
       // Operation states
@@ -354,6 +358,67 @@ class PromptDetail extends React.Component {
       error: () => {
         this.setState({ savingDescription: false });
         Message.error(locale.updateDescFailed || 'Failed to update description');
+      },
+    });
+  };
+
+  // ===== BizTags Editor =====
+
+  handleEditBizTags = () => {
+    const bizTags = this.state.governanceData?.bizTags;
+    let parsed = [];
+    if (bizTags) {
+      try {
+        const arr = JSON.parse(bizTags);
+        parsed = Array.isArray(arr) ? arr : [];
+      } catch (e) {
+        parsed = bizTags
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean);
+      }
+    }
+    this.setState({
+      editingBizTags: true,
+      bizTagsValue: parsed.join(','),
+    });
+  };
+
+  handleCancelBizTags = () => {
+    this.setState({ editingBizTags: false });
+  };
+
+  handleSaveBizTags = () => {
+    const { locale = {} } = this.props;
+    const { bizTagsValue } = this.state;
+    const promptKey = getParams('promptKey') || '';
+    const namespaceId = getParams('namespace') || '';
+    const tags = bizTagsValue
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+    const bizTagsJson = JSON.stringify(tags);
+
+    this.setState({ savingBizTags: true });
+
+    request({
+      method: 'PUT',
+      url: 'v3/console/ai/prompt/biz-tags',
+      data: { promptKey, bizTags: bizTagsJson, namespaceId },
+      contentType: 'application/x-www-form-urlencoded',
+      success: data => {
+        this.setState({ savingBizTags: false });
+        if (data && data.code === 0) {
+          Message.success(locale.bizTagsUpdateSuccess || 'Biz tags updated');
+          this.setState({ editingBizTags: false });
+          this.loadGovernanceData();
+        } else {
+          Message.error(data?.message || locale.updateBizTagsFailed || 'Failed to update biz tags');
+        }
+      },
+      error: () => {
+        this.setState({ savingBizTags: false });
+        Message.error(locale.updateBizTagsFailed || 'Failed to update biz tags');
       },
     });
   };
@@ -1063,6 +1128,9 @@ class PromptDetail extends React.Component {
       editingDescription,
       descriptionValue,
       savingDescription,
+      editingBizTags,
+      bizTagsValue,
+      savingBizTags,
       optimizeDialogVisible,
       variableValues,
       userInput,
@@ -1095,7 +1163,19 @@ class PromptDetail extends React.Component {
     const editingVersionStr = governanceData?.editingVersion || null;
     const reviewingVersionStr = governanceData?.reviewingVersion || null;
     const description = governanceData?.description || '';
-    const bizTags = governanceData?.bizTags || [];
+    const bizTags = (() => {
+      const raw = governanceData?.bizTags;
+      if (!raw) return [];
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch (e) {
+        return raw
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean);
+      }
+    })();
     const isDraft = selectedVersionStatus === 'draft';
     const isReviewing = selectedVersionStatus === 'reviewing';
 
@@ -1276,16 +1356,41 @@ class PromptDetail extends React.Component {
               </span>
             )}
           </div>
-          {bizTags.length > 0 && (
-            <div className="tags-row">
-              <span className="meta-label">{locale.bizTags || 'Biz Tags'}:</span>
-              {bizTags.map(tag => (
-                <Tag key={tag} size="small" style={{ borderRadius: 4 }}>
-                  {tag}
-                </Tag>
-              ))}
-            </div>
-          )}
+          <div className="tags-row">
+            <span className="meta-label">{locale.bizTags || 'Biz Tags'}:</span>
+            {editingBizTags ? (
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flex: 1 }}>
+                <Input
+                  value={bizTagsValue}
+                  onChange={val => this.setState({ bizTagsValue: val })}
+                  style={{ flex: 1 }}
+                  placeholder={locale.bizTagsPlaceholder || 'Enter tags separated by commas'}
+                />
+                <Button
+                  size="small"
+                  type="primary"
+                  onClick={this.handleSaveBizTags}
+                  loading={savingBizTags}
+                >
+                  {locale.save || 'Save'}
+                </Button>
+                <Button size="small" onClick={this.handleCancelBizTags}>
+                  {locale.cancel || 'Cancel'}
+                </Button>
+              </div>
+            ) : (
+              <span className="description-text">
+                {bizTags.length > 0
+                  ? bizTags.map(tag => (
+                      <Tag key={tag} size="small" style={{ borderRadius: 4 }}>
+                        {tag}
+                      </Tag>
+                    ))
+                  : '--'}
+                <Icon type="edit" className="edit-icon" onClick={this.handleEditBizTags} />
+              </span>
+            )}
+          </div>
           {versionLabels.length > 0 && (
             <div className="tags-row">
               <span className="meta-label">{locale.versionLabels || 'Labels'}:</span>

--- a/console-ui/src/pages/AI/PromptManagement/PromptManagement.js
+++ b/console-ui/src/pages/AI/PromptManagement/PromptManagement.js
@@ -393,18 +393,20 @@ class PromptManagement extends React.Component {
               )}
             />
             <Table.Column
-              title={locale.bizTags || 'Biz Tags'}
-              dataIndex="bizTags"
+              title={locale.labels || 'Labels'}
+              dataIndex="labels"
               width={150}
               cell={value => {
-                if (!value || !Array.isArray(value) || value.length === 0) return '--';
-                const displayed = value.slice(0, 2);
-                const rest = value.slice(2);
+                if (!value || typeof value !== 'object') return '--';
+                const keys = Object.keys(value);
+                if (keys.length === 0) return '--';
+                const displayed = keys.slice(0, 2);
+                const rest = keys.slice(2);
                 return (
                   <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', alignItems: 'center' }}>
-                    {displayed.map(tag => (
-                      <Tag key={tag} size="small" style={{ borderRadius: 4 }}>
-                        {tag}
+                    {displayed.map(key => (
+                      <Tag key={key} size="small" style={{ borderRadius: 4 }}>
+                        {key}
                       </Tag>
                     ))}
                     {rest.length > 0 && (
@@ -417,9 +419,9 @@ class PromptManagement extends React.Component {
                         triggerType="hover"
                         closable={false}
                       >
-                        {rest.map(tag => (
-                          <Tag key={tag} size="small" style={{ margin: 2 }}>
-                            {tag}
+                        {rest.map(key => (
+                          <Tag key={key} size="small" style={{ margin: 2 }}>
+                            {key}
                           </Tag>
                         ))}
                       </Balloon>

--- a/distribution/conf/nacos-logback.xml
+++ b/distribution/conf/nacos-logback.xml
@@ -615,6 +615,24 @@
         </encoder>
     </appender>
     
+    <!--AI module logback config-->
+    <appender name="aiResourceTrace"
+        class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_HOME}/ai-resource-trace.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_HOME}/ai-resource-trace.log.%d{yyyy-MM-dd}.%i</fileNamePattern>
+            <maxFileSize>1GB</maxFileSize>
+            <maxHistory>15</maxHistory>
+            <totalSizeCap>7GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+        <encoder>
+            <Pattern>%msg%n</Pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+    
     <logger name="com.alibaba.nacos.address.main" additivity="false" level="INFO">
         <appender-ref ref="nacos-address"/>
     </logger>
@@ -711,6 +729,10 @@
     <logger name="com.alibaba.nacos.k8s.sync.main" additivity="false">
         <level value="DEBUG"/>
         <appender-ref ref="k8s-sync-main"/>
+    </logger>
+
+    <logger name="com.alibaba.nacos.ai.resource.trace" additivity="false" level="INFO">
+        <appender-ref ref="aiResourceTrace"/>
     </logger>
 
     <logger name="com.alibaba.nacos.core.protocol.raft" additivity="false" level="INFO">


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

  ## What is the purpose of the change

  Add a dedicated JSON-formatted audit trace log (`ai_resource_trace.log`) for all AI resource lifecycle operations (skill, agentspec, prompt, mcp, a2a), designed for ELK/Loki integration. Additionally, fix prompt `bizTags` handling throughout the stack — backend model
  type was mismatched with actual storage format, causing silent failures in both legacy and new console UIs.

  ## Brief changelog

  - Add `AiResourceTraceService` with operation constants and JSON log methods, `AiLogUtil` with dedicated logger, and `VisibilityHelper.resolveClientIp()` for IP extraction.
  - Integrate trace logs across all AI resource services: Skill, AgentSpec, Prompt, McpServer, A2aServer, and AiResourceManager (covering create, update, delete, publish, review, online/offline, labels, scope, enable/disable).
  - Configure `RollingFileAppender` in `nacos-logback.xml` (1GB maxFileSize, 15 days retention).
  - Fix `PromptMetaSummary.bizTags` from `List<String>` to `String` to match actual storage format, remove broken JSON deserialization in read/write paths.
  - Add `OP_UPDATE_DESCRIPTION` constant and trace logging for `changeOnlineStatus`, `updateLabels`, `updateDescription` operations that were previously missing.
  - Fix legacy UI: prompt list page now displays label keys instead of broken bizTags; add inline bizTags editing in prompt detail page.
  - Fix new UI: correct `bizTags` TypeScript type from `string[]` to `string`, add `parseBizTags()` utility, update `PromptCard`, `PromptDetailPage`, and related tests.

  ## Verifying this change

  - Backend static checks:
    ```bash
    mvn -B clean package apache-rat:check spotbugs:check -DskipTests

  - Unit tests:
  mvn clean install -DskipITs

  - Manual verification:
    - Perform prompt label update, online/offline toggle, description update — confirm JSON trace entries appear in ai_resource_trace.log.
    - Legacy UI: prompt list shows label keys correctly; prompt detail page supports inline bizTags editing.
    - New UI: prompt card and detail page display bizTags correctly after parseBizTags() fix.


  Follow this checklist to help us incorporate your contribution quickly and easily:

  [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
  [ ] Format the pull request title like [ISSUE #123] Fix UnknownException when host config not exist. Each commit in the pull request should have a meaningful subject line and body.
  [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
  [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in test module https://github.
  com/alibaba/nacos/tree/master/test.
  [ ] Run mvn -B clean package apache-rat:check spotbugs:check -DskipTests to make sure basic checks pass. Run mvn clean install -DskipITs to make sure unit-test pass. Run mvn clean test-compile failsafe:integration-test  to make sure integration-test pass.