### PR TITLE
test(api): complete valid clusterName TODO in NamingUtilsTest（#14865）

### DIFF
--- a/api/src/test/java/com/alibaba/nacos/api/naming/utils/NamingUtilsTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/naming/utils/NamingUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -245,11 +246,10 @@ class NamingUtilsTest {
         }
         instanceList.remove(instance);
         
-        // TODO valid clusterName
+        // valid clusterName
         instance.setClusterName("cluster1");
         instanceList.add(instance);
-        NamingUtils.batchCheckInstanceIsLegal(instanceList);
-        assertTrue(true);
+        assertDoesNotThrow(() -> NamingUtils.batchCheckInstanceIsLegal(instanceList));
         
         instanceList.remove(instance);
         


### PR DESCRIPTION
## Summary

This PR completes and refines the TODO section for the valid clusterName path in `NamingUtilsTest#testBatchCheckInstanceIsLegal`.

- Updated test assertion style for clarity
- No production code changes
- Behavior remains unchanged

## Related Issue

Closes #<issue-id>

## Test Plan

- [x] Run `mvn -pl api -Dtest=NamingUtilsTest test`
- [x] Ensure all updated assertions pass