### PR TITLE
feat(ai): add persistence trace for ai_resource_version write operations

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourceVersionPersistServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourceVersionPersistServiceImpl.java
@@ -69,31 +69,40 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
 
     @Override
     public long insert(AiResourceVersion version) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = mapper.insert(Arrays.asList("type", "author", "name", "c_desc", "status", "version", "namespace_id",
-                "storage", "publish_pipeline_info", "gmt_create@NOW()", "gmt_modified@NOW()"));
-
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-        jt.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
-            ps.setString(1, version.getType());
-            ps.setString(2, version.getAuthor());
-            ps.setString(3, version.getName());
-            ps.setString(4, version.getDesc());
-            ps.setString(5, version.getStatus());
-            ps.setString(6, version.getVersion());
-            ps.setString(7, normalizeNamespaceId(version.getNamespaceId()));
-            ps.setString(8, version.getStorage());
-            ps.setString(9, version.getPublishPipelineInfo());
-            return ps;
-        }, keyHolder);
-
-        Number key = keyHolder.getKey();
-        if (key == null) {
-            throw new IllegalStateException("insert ai_resource_version failed, no generated key");
+        String sqlOperation = "INSERT";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = mapper.insert(Arrays.asList("type", "author", "name", "c_desc", "status", "version", "namespace_id",
+                    "storage", "publish_pipeline_info", "gmt_create@NOW()", "gmt_modified@NOW()"));
+            
+            KeyHolder keyHolder = new GeneratedKeyHolder();
+            jt.update(connection -> {
+                PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
+                ps.setString(1, version.getType());
+                ps.setString(2, version.getAuthor());
+                ps.setString(3, version.getName());
+                ps.setString(4, version.getDesc());
+                ps.setString(5, version.getStatus());
+                ps.setString(6, version.getVersion());
+                ps.setString(7, normalizeNamespaceId(version.getNamespaceId()));
+                ps.setString(8, version.getStorage());
+                ps.setString(9, version.getPublishPipelineInfo());
+                return ps;
+            }, keyHolder);
+            
+            Number key = keyHolder.getKey();
+            if (key == null) {
+                throw new IllegalStateException("insert ai_resource_version failed, no generated key");
+            }
+            AiResourceVersionTraceHelper.traceSuccess(version.getType(), version.getName(), version.getVersion(),
+                    sqlOperation, 1);
+            return key.longValue();
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(version.getType(), version.getName(), version.getVersion(),
+                    sqlOperation, e.getMessage());
+            throw e;
         }
-        return key.longValue();
     }
 
     @Override
@@ -138,73 +147,137 @@ public class AiResourceVersionPersistServiceImpl implements AiResourceVersionPer
 
     @Override
     public int delete(String namespaceId, String name, String type, String version) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = mapper.delete(Arrays.asList("namespace_id", "name", "type", "version"));
-        return jt.update(sql, normalizeNamespaceId(namespaceId), name, type, version);
+        String sqlOperation = "DELETE_BY_PK";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = mapper.delete(Arrays.asList("namespace_id", "name", "type", "version"));
+            int affected = jt.update(sql, normalizeNamespaceId(namespaceId), name, type, version);
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, affected);
+            return affected;
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation, e.getMessage());
+            throw e;
+        }
     }
 
     @Override
     public int deleteByName(String namespaceId, String name) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = mapper.delete(Arrays.asList("namespace_id", "name"));
-        return jt.update(sql, normalizeNamespaceId(namespaceId), name);
+        String sqlOperation = "DELETE_BY_NAME";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = mapper.delete(Arrays.asList("namespace_id", "name"));
+            int affected = jt.update(sql, normalizeNamespaceId(namespaceId), name);
+            AiResourceVersionTraceHelper.traceSuccess(null, name, null, sqlOperation, affected);
+            return affected;
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(null, name, null, sqlOperation, e.getMessage());
+            throw e;
+        }
     }
 
     @Override
     public int deleteByNameAndType(String namespaceId, String name, String type) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = mapper.delete(Arrays.asList("namespace_id", "name", "type"));
-        return jt.update(sql, normalizeNamespaceId(namespaceId), name, type);
+        String sqlOperation = "DELETE_BY_NAME_TYPE";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = mapper.delete(Arrays.asList("namespace_id", "name", "type"));
+            int affected = jt.update(sql, normalizeNamespaceId(namespaceId), name, type);
+            AiResourceVersionTraceHelper.traceSuccess(type, name, null, sqlOperation, affected);
+            return affected;
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, null, sqlOperation, e.getMessage());
+            throw e;
+        }
     }
 
     @Override
     public int updateStatus(String namespaceId, String name, String type, String version, String status) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = "UPDATE ai_resource_version SET status=?, gmt_modified=" + mapper.getFunction("NOW()")
-                + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, status, normalizeNamespaceId(namespaceId), name, type, version);
+        String sqlOperation = "UPDATE_STATUS";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = "UPDATE ai_resource_version SET status=?, gmt_modified=" + mapper.getFunction("NOW()")
+                    + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
+            int affected = jt.update(sql, status, normalizeNamespaceId(namespaceId), name, type, version);
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, affected);
+            return affected;
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation, e.getMessage());
+            throw e;
+        }
     }
 
     @Override
     public int updateStorage(String namespaceId, String name, String type, String version, String storage) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = "UPDATE ai_resource_version SET storage=?, gmt_modified=" + mapper.getFunction("NOW()")
-                + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, storage, normalizeNamespaceId(namespaceId), name, type, version);
+        String sqlOperation = "UPDATE_STORAGE";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = "UPDATE ai_resource_version SET storage=?, gmt_modified=" + mapper.getFunction("NOW()")
+                    + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
+            int affected = jt.update(sql, storage, normalizeNamespaceId(namespaceId), name, type, version);
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, affected);
+            return affected;
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation, e.getMessage());
+            throw e;
+        }
     }
 
     @Override
     public int updateStorageAndDesc(String namespaceId, String name, String type, String version, String storage,
             String desc) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = "UPDATE ai_resource_version SET storage=?, c_desc=?, gmt_modified=" + mapper.getFunction("NOW()")
-                + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, storage, desc, normalizeNamespaceId(namespaceId), name, type, version);
+        String sqlOperation = "UPDATE_STORAGE_DESC";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = "UPDATE ai_resource_version SET storage=?, c_desc=?, gmt_modified=" + mapper.getFunction("NOW()")
+                    + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
+            int affected = jt.update(sql, storage, desc, normalizeNamespaceId(namespaceId), name, type, version);
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, affected);
+            return affected;
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation, e.getMessage());
+            throw e;
+        }
     }
 
     @Override
     public int updatePublishPipelineInfo(String namespaceId, String name, String type, String version,
             String publishPipelineInfo) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = "UPDATE ai_resource_version SET publish_pipeline_info=?, gmt_modified=" + mapper.getFunction("NOW()")
-                + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, publishPipelineInfo, normalizeNamespaceId(namespaceId), name, type, version);
+        String sqlOperation = "UPDATE_PUBLISH_PIPELINE_INFO";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = "UPDATE ai_resource_version SET publish_pipeline_info=?, gmt_modified="
+                    + mapper.getFunction("NOW()") + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
+            int affected = jt.update(sql, publishPipelineInfo, normalizeNamespaceId(namespaceId), name, type, version);
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, affected);
+            return affected;
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation, e.getMessage());
+            throw e;
+        }
     }
 
     @Override
     public int incrementDownloadCount(String namespaceId, String name, String type, String version, long increment) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = "UPDATE ai_resource_version SET download_count = download_count + ?, gmt_modified="
-                + mapper.getFunction("NOW()") + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
-        return jt.update(sql, increment, normalizeNamespaceId(namespaceId), name, type, version);
+        String sqlOperation = "UPDATE_DOWNLOAD_COUNT";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = "UPDATE ai_resource_version SET download_count = download_count + ?, gmt_modified="
+                    + mapper.getFunction("NOW()") + " WHERE namespace_id=? AND name=? AND type=? AND version=?";
+            int affected = jt.update(sql, increment, normalizeNamespaceId(namespaceId), name, type, version);
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, affected);
+            return affected;
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation, e.getMessage());
+            throw e;
+        }
     }
     
     private String normalizeNamespaceId(String namespaceId) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourceVersionTraceHelper.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourceVersionTraceHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.repository;
+
+import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.sys.env.EnvUtil;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Helper for ai_resource_version persistence trace logging.
+ */
+final class AiResourceVersionTraceHelper {
+    
+    static final String TRACE_PERSIST_SUCCESS_ENABLED_KEY = "nacos.ai.resource.trace.persist.success.enabled";
+    
+    private AiResourceVersionTraceHelper() {
+    }
+    
+    static boolean isPersistSuccessTraceEnabled() {
+        return EnvUtil.getProperty(TRACE_PERSIST_SUCCESS_ENABLED_KEY, Boolean.class, false);
+    }
+    
+    static void traceSuccess(String resourceType, String resourceName, String version, String sqlOperation, int rowsAffected) {
+        if (!isPersistSuccessTraceEnabled()) {
+            return;
+        }
+        AiResourceTraceService.logSuccess(resourceType, resourceName, version, AiResourceTraceService.OP_VERSION_ROW_PERSIST,
+                "-", "-", buildExt(sqlOperation, rowsAffected, null));
+    }
+    
+    static void traceFailure(String resourceType, String resourceName, String version, String sqlOperation, String errorMsg) {
+        AiResourceTraceService.logFailure(resourceType, resourceName, version, AiResourceTraceService.OP_VERSION_ROW_PERSIST,
+                "-", "-", buildExt(sqlOperation, null, errorMsg));
+    }
+    
+    static String buildExt(String sqlOperation, Integer rowsAffected, String errorMsg) {
+        Map<String, Object> ext = new LinkedHashMap<>(4);
+        ext.put("sqlOperation", StringUtils.defaultIfBlank(sqlOperation, "-"));
+        if (rowsAffected != null) {
+            ext.put("rowsAffected", rowsAffected);
+        }
+        if (StringUtils.isNotBlank(errorMsg)) {
+            ext.put("error", errorMsg);
+        }
+        return JacksonUtils.toJson(ext);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/EmbeddedAiResourceVersionPersistServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/EmbeddedAiResourceVersionPersistServiceImpl.java
@@ -66,27 +66,36 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
 
     @Override
     public long insert(AiResourceVersion version) {
-        AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
-                TableConstant.AI_RESOURCE_VERSION);
-        String sql = mapper.insert(Arrays.asList("type", "author", "name", "c_desc", "status", "version", "namespace_id",
-                "storage", "publish_pipeline_info", "gmt_create@NOW()", "gmt_modified@NOW()"));
-
-        Object[] args = new Object[] {version.getType(), version.getAuthor(), version.getName(), version.getDesc(),
-                version.getStatus(), version.getVersion(), normalizeNamespaceId(version.getNamespaceId()),
-                version.getStorage(), version.getPublishPipelineInfo()};
-
-        EmbeddedStorageContextHolder.addSqlContext(sql, args);
-        Boolean success = databaseOperate.blockUpdate();
-        if (success == null || !success) {
-            throw new IllegalStateException("insert ai_resource_version failed");
+        String sqlOperation = "INSERT";
+        try {
+            AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+                    TableConstant.AI_RESOURCE_VERSION);
+            String sql = mapper.insert(Arrays.asList("type", "author", "name", "c_desc", "status", "version", "namespace_id",
+                    "storage", "publish_pipeline_info", "gmt_create@NOW()", "gmt_modified@NOW()"));
+            
+            Object[] args = new Object[] {version.getType(), version.getAuthor(), version.getName(), version.getDesc(),
+                    version.getStatus(), version.getVersion(), normalizeNamespaceId(version.getNamespaceId()),
+                    version.getStorage(), version.getPublishPipelineInfo()};
+            
+            EmbeddedStorageContextHolder.addSqlContext(sql, args);
+            Boolean success = databaseOperate.blockUpdate();
+            if (success == null || !success) {
+                throw new IllegalStateException("insert ai_resource_version failed");
+            }
+            
+            AiResourceVersion inserted = find(version.getNamespaceId(), version.getName(), version.getType(),
+                    version.getVersion());
+            if (inserted == null || inserted.getId() == null) {
+                throw new IllegalStateException("insert ai_resource_version failed, cannot query inserted row");
+            }
+            AiResourceVersionTraceHelper.traceSuccess(version.getType(), version.getName(), version.getVersion(),
+                    sqlOperation, 1);
+            return inserted.getId();
+        } catch (RuntimeException e) {
+            AiResourceVersionTraceHelper.traceFailure(version.getType(), version.getName(), version.getVersion(),
+                    sqlOperation, e.getMessage());
+            throw e;
         }
-
-        AiResourceVersion inserted = find(version.getNamespaceId(), version.getName(), version.getType(),
-                version.getVersion());
-        if (inserted == null || inserted.getId() == null) {
-            throw new IllegalStateException("insert ai_resource_version failed, cannot query inserted row");
-        }
-        return inserted.getId();
     }
 
     @Override
@@ -126,8 +135,10 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
 
     @Override
     public int delete(String namespaceId, String name, String type, String version) {
+        String sqlOperation = "DELETE_BY_PK";
         AiResourceVersion existed = find(namespaceId, name, type, version);
         if (existed == null) {
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 0);
             return 0;
         }
 
@@ -138,22 +149,34 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
         EmbeddedStorageContextHolder.addSqlContext(sql,
                 new Object[] {normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
-        return (success != null && success) ? 1 : 0;
+        if (success == null || !success) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation, "delete blockUpdate failed");
+            return 0;
+        }
+        AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 1);
+        return 1;
     }
 
     @Override
     public int deleteByName(String namespaceId, String name) {
+        String sqlOperation = "DELETE_BY_NAME";
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = mapper.delete(Arrays.asList("namespace_id", "name"));
 
         EmbeddedStorageContextHolder.addSqlContext(sql, new Object[] {normalizeNamespaceId(namespaceId), name});
         Boolean success = databaseOperate.blockUpdate();
-        return (success != null && success) ? 1 : 0;
+        if (success == null || !success) {
+            AiResourceVersionTraceHelper.traceFailure(null, name, null, sqlOperation, "delete by name blockUpdate failed");
+            return 0;
+        }
+        AiResourceVersionTraceHelper.traceSuccess(null, name, null, sqlOperation, 1);
+        return 1;
     }
 
     @Override
     public int deleteByNameAndType(String namespaceId, String name, String type) {
+        String sqlOperation = "DELETE_BY_NAME_TYPE";
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
                 TableConstant.AI_RESOURCE_VERSION);
         String sql = mapper.delete(Arrays.asList("namespace_id", "name", "type"));
@@ -161,12 +184,20 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
         EmbeddedStorageContextHolder.addSqlContext(sql,
                 new Object[] {normalizeNamespaceId(namespaceId), name, type});
         Boolean success = databaseOperate.blockUpdate();
-        return (success != null && success) ? 1 : 0;
+        if (success == null || !success) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, null, sqlOperation,
+                    "delete by name and type blockUpdate failed");
+            return 0;
+        }
+        AiResourceVersionTraceHelper.traceSuccess(type, name, null, sqlOperation, 1);
+        return 1;
     }
 
     @Override
     public int updateStatus(String namespaceId, String name, String type, String version, String status) {
+        String sqlOperation = "UPDATE_STATUS";
         if (find(namespaceId, name, type, version) == null) {
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 0);
             return 0;
         }
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
@@ -177,12 +208,19 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
         EmbeddedStorageContextHolder.addSqlContext(sql,
                 new Object[] {status, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
-        return (success != null && success) ? 1 : 0;
+        if (success == null || !success) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation, "update status blockUpdate failed");
+            return 0;
+        }
+        AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 1);
+        return 1;
     }
 
     @Override
     public int updateStorage(String namespaceId, String name, String type, String version, String storage) {
+        String sqlOperation = "UPDATE_STORAGE";
         if (find(namespaceId, name, type, version) == null) {
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 0);
             return 0;
         }
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
@@ -193,13 +231,20 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
         EmbeddedStorageContextHolder.addSqlContext(sql,
                 new Object[] {storage, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
-        return (success != null && success) ? 1 : 0;
+        if (success == null || !success) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation, "update storage blockUpdate failed");
+            return 0;
+        }
+        AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 1);
+        return 1;
     }
 
     @Override
     public int updateStorageAndDesc(String namespaceId, String name, String type, String version, String storage,
             String desc) {
+        String sqlOperation = "UPDATE_STORAGE_DESC";
         if (find(namespaceId, name, type, version) == null) {
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 0);
             return 0;
         }
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
@@ -210,13 +255,21 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
         EmbeddedStorageContextHolder.addSqlContext(sql,
                 new Object[] {storage, desc, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
-        return (success != null && success) ? 1 : 0;
+        if (success == null || !success) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation,
+                    "update storage and desc blockUpdate failed");
+            return 0;
+        }
+        AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 1);
+        return 1;
     }
 
     @Override
     public int updatePublishPipelineInfo(String namespaceId, String name, String type, String version,
             String publishPipelineInfo) {
+        String sqlOperation = "UPDATE_PUBLISH_PIPELINE_INFO";
         if (find(namespaceId, name, type, version) == null) {
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 0);
             return 0;
         }
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
@@ -227,12 +280,20 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
         EmbeddedStorageContextHolder.addSqlContext(sql,
                 new Object[] {publishPipelineInfo, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
-        return (success != null && success) ? 1 : 0;
+        if (success == null || !success) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation,
+                    "update publish pipeline info blockUpdate failed");
+            return 0;
+        }
+        AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 1);
+        return 1;
     }
 
     @Override
     public int incrementDownloadCount(String namespaceId, String name, String type, String version, long increment) {
+        String sqlOperation = "UPDATE_DOWNLOAD_COUNT";
         if (find(namespaceId, name, type, version) == null) {
+            AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 0);
             return 0;
         }
         AiResourceVersionMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
@@ -243,7 +304,13 @@ public class EmbeddedAiResourceVersionPersistServiceImpl implements AiResourceVe
         EmbeddedStorageContextHolder.addSqlContext(sql,
                 new Object[] {increment, normalizeNamespaceId(namespaceId), name, type, version});
         Boolean success = databaseOperate.blockUpdate();
-        return (success != null && success) ? 1 : 0;
+        if (success == null || !success) {
+            AiResourceVersionTraceHelper.traceFailure(type, name, version, sqlOperation,
+                    "increment download count blockUpdate failed");
+            return 0;
+        }
+        AiResourceVersionTraceHelper.traceSuccess(type, name, version, sqlOperation, 1);
+        return 1;
     }
     
     private String normalizeNamespaceId(String namespaceId) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/trace/AiResourceTraceService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/trace/AiResourceTraceService.java
@@ -153,6 +153,11 @@ public class AiResourceTraceService {
      */
     public static final String OP_DISABLE = "DISABLE";
     
+    /**
+     * Persist layer row-level operation on ai_resource_version.
+     */
+    public static final String OP_VERSION_ROW_PERSIST = "VERSION_ROW_PERSIST";
+    
     // ==================== Status Constants ====================
     
     /**

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/repository/AiResourceVersionTraceHelperTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/repository/AiResourceVersionTraceHelperTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.repository;
+
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiResourceVersionTraceHelperTest {
+    
+    @AfterEach
+    void cleanUp() {
+        EnvUtil.setEnvironment(new StandardEnvironment());
+    }
+    
+    @Test
+    void buildExtShouldContainSqlOperationRowsAndError() {
+        String ext = AiResourceVersionTraceHelper.buildExt("UPDATE_STATUS", 3, "timeout");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> extMap = JacksonUtils.toObj(ext, Map.class);
+        
+        assertEquals("UPDATE_STATUS", extMap.get("sqlOperation"));
+        assertEquals(3, ((Number) extMap.get("rowsAffected")).intValue());
+        assertEquals("timeout", extMap.get("error"));
+    }
+    
+    @Test
+    void buildExtShouldUseDefaultSqlOperation() {
+        String ext = AiResourceVersionTraceHelper.buildExt("", null, null);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> extMap = JacksonUtils.toObj(ext, Map.class);
+        
+        assertEquals("-", extMap.get("sqlOperation"));
+    }
+    
+    @Test
+    void shouldReturnFalseByDefaultForSuccessTraceSwitch() {
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        assertFalse(AiResourceVersionTraceHelper.isPersistSuccessTraceEnabled());
+    }
+    
+    @Test
+    void shouldReadSuccessTraceSwitchFromEnvironment() {
+        StandardEnvironment env = new StandardEnvironment();
+        MutablePropertySources propertySources = env.getPropertySources();
+        propertySources.addFirst(new MapPropertySource("test-ai-trace", Map.of(
+                AiResourceVersionTraceHelper.TRACE_PERSIST_SUCCESS_ENABLED_KEY, "true"
+        )));
+        EnvUtil.setEnvironment(env);
+        
+        assertTrue(AiResourceVersionTraceHelper.isPersistSuccessTraceEnabled());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds persistence-layer trace coverage for `ai_resource_version` write operations.
It reuses the existing AI trace pipeline (`AiResourceTraceService` + `ai-resource-trace.log`) and avoids introducing a new logging format.

## Brief changelog

- Add `OP_VERSION_ROW_PERSIST` operation constant in `AiResourceTraceService`
- Add `AiResourceVersionTraceHelper` to standardize ext payload (`sqlOperation`, `rowsAffected`, `error`)
- Integrate trace into write paths of:
  - `AiResourceVersionPersistServiceImpl`
  - `EmbeddedAiResourceVersionPersistServiceImpl`
- Add a success-log switch:
  - `nacos.ai.resource.trace.persist.success.enabled` (default `false`)
- Add unit test: `AiResourceVersionTraceHelperTest`

## Verifying this change

```bash
./mvnw -pl ai -am -Dtest=AiResourceVersionTraceHelperTest "-Dsurefire.failIfNoSpecifiedTests=false" test
```

##Result:

Tests run: 4
Failures: 0
Errors: 0
BUILD SUCCESS


##Related to #14833

