### PR TITLE
[ISSUE #14908] fix(ai): SkillRemoteHandler#createDraft passes skillCard as targetVersion and loses targetVersion

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillRemoteHandler.java
@@ -120,7 +120,7 @@ public class SkillRemoteHandler implements SkillHandler {
     @Override
     public String createDraft(SkillDraftCreateForm form) throws NacosException {
         return clientHolder.getAiMaintainerService().skill().createDraft(form.getNamespaceId(), form.getSkillName(),
-                form.getBasedOnVersion(), form.getSkillCard());
+                form.getBasedOnVersion(), form.getTargetVersion(), form.getSkillCard());
     }
 
     @Override

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillRemoteHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/ai/SkillRemoteHandlerTest.java
@@ -205,7 +205,7 @@ class SkillRemoteHandlerTest {
         form.setSkillName(SKILL_NAME);
         form.setBasedOnVersion("v1");
         form.prepareCreateDraftRequest();
-        when(skillMaintainerService.createDraft(eq(NAMESPACE_ID), eq(SKILL_NAME), eq("v1"), isNull())).thenReturn("v2");
+        when(skillMaintainerService.createDraft(eq(NAMESPACE_ID), eq(SKILL_NAME), eq("v1"), isNull(), isNull())).thenReturn("v2");
         
         String result = skillRemoteHandler.createDraft(form);
         


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## What this PR does / why we need it

`SkillRemoteHandler#createDraft` was calling the 4-parameter overload of `SkillMaintainerService#createDraft`, passing `form.getSkillCard()` into the `targetVersion` argument slot. The 4-parameter overload then delegates to the 5-parameter version with `skillCard = null`, causing:

1. `targetVersion` to receive the skill card JSON string (wrong value).
2. `skillCard` to be silently set to `null`, losing the actual skill content.

## Which issue(s) this PR fixes

Fixes #14908

## How Has This Been Tested?

- Updated `SkillRemoteHandlerTest#testCreateDraft` to mock the correct 5-parameter signature.

## Special notes for your reviewer

The fix is a one-line change — adding the missing `targetVersion` argument and keeping `skillCard` in its correct position:

```java
// Before (buggy)
createDraft(namespaceId, skillName, basedOnVersion, form.getSkillCard())

// After (fixed)
createDraft(namespaceId, skillName, basedOnVersion, form.getTargetVersion(), form.getSkillCard())
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)