### PR TITLE
fix(auth): reject login with LDAP-prefixed usernames to prevent auth bypass

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/authenticate/LdapAuthenticationManager.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/authenticate/LdapAuthenticationManager.java
@@ -64,6 +64,10 @@ public class LdapAuthenticationManager extends AbstractAuthenticationManager {
             username = username.toLowerCase();
         }
         
+        if (username.toUpperCase().startsWith(AuthConstants.LDAP_PREFIX)) {
+            throw new AccessException("user not found!");
+        }
+        
         try {
             return super.authenticate(username, rawPassword);
         } catch (AccessException | UsernameNotFoundException ignored) {

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/authenticate/LdapAuthenticationManagerTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/authenticate/LdapAuthenticationManagerTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ldap.core.LdapTemplate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -69,5 +70,27 @@ public class LdapAuthenticationManagerTest {
         when(userDetailsService.loadUserByUsername(anyString())).thenReturn(nacosUserDetails);
         NacosUser authenticate = ldapAuthenticationManager.authenticate("nacos", "test");
         assertEquals(user.getUsername(), authenticate.getUserName());
+    }
+
+    @Test
+    void testAuthenticateWithLdapPrefixRejected() {
+        assertThrows(AccessException.class, () -> ldapAuthenticationManager.authenticate("LDAP_admin", "nacos"));
+    }
+
+    @Test
+    void testAuthenticateWithLdapPrefixLowercaseRejected() {
+        assertThrows(AccessException.class, () -> ldapAuthenticationManager.authenticate("ldap_admin", "nacos"));
+    }
+
+    @Test
+    void testAuthenticateWithLdapPrefixMixedCaseRejected() {
+        assertThrows(AccessException.class, () -> ldapAuthenticationManager.authenticate("Ldap_admin", "nacos"));
+    }
+
+    @Test
+    void testAuthenticateWithLdapPrefixCaseInsensitiveRejected() {
+        LdapAuthenticationManager caseInsensitiveManager = new LdapAuthenticationManager(ldapTemplate,
+                userDetailsService, jwtTokenManager, roleService, "", false);
+        assertThrows(AccessException.class, () -> caseInsensitiveManager.authenticate("LDAP_admin", "nacos"));
     }
 }


### PR DESCRIPTION
## Problem

When LDAP authentication is enabled, proxy users are created in the local database with a well-known default password. An attacker can bypass LDAP authentication entirely by logging in with the internal `LDAP_` prefix username and the default password, gaining full access without contacting the LDAP server.

## Root Cause

`LdapAuthenticationManager.authenticate()` calls `super.authenticate()` first, which checks the local database. Since LDAP proxy users are stored as `LDAP_<username>` with a hardcoded encoded password, an attacker who sends `LDAP_admin` as the username with the default password will pass local DB authentication before LDAP is ever contacted.

## Fix

- Add a check in `LdapAuthenticationManager.authenticate()` that rejects any login attempt where the username starts with the `LDAP_` prefix (case-insensitive)
- This ensures the internal LDAP prefix cannot be used as a direct login username, forcing LDAP users to always authenticate through the LDAP server
- Normal (non-LDAP) local users and legitimate LDAP login flow (which uses unprefixed usernames) are not affected

## Tests Added

| Change Point | Test |
|-------------|------|
| Reject username with `LDAP_` prefix (uppercase) | `testAuthenticateWithLdapPrefixRejected()` — verifies `AccessException` is thrown |
| Reject username with `ldap_` prefix (lowercase) | `testAuthenticateWithLdapPrefixLowercaseRejected()` — verifies case-insensitive check |
| Reject username with `Ldap_` prefix (mixed case) | `testAuthenticateWithLdapPrefixMixedCaseRejected()` — verifies mixed case is caught |
| Reject in case-insensitive mode | `testAuthenticateWithLdapPrefixCaseInsensitiveRejected()` — verifies rejection when `caseSensitive=false` |

## Impact

- Closes the authentication bypass vulnerability for LDAP-enabled Nacos deployments
- No impact on non-LDAP authentication or normal LDAP login flow (users login with their original username, not the prefixed version)
- No behavioral change for existing legitimate users

Fixes #14862