### PR TITLE
fix(auth): fix race conditions in CachedJwtTokenManager

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/token/impl/CachedJwtTokenManager.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/token/impl/CachedJwtTokenManager.java
@@ -82,11 +82,10 @@ public class CachedJwtTokenManager implements TokenManager {
      * @throws AccessException access exception
      */
     public String createToken(String username) throws AccessException {
-        if (userMap.containsKey(username)) {
-            String token = userMap.get(username).getToken();
-            long expiredTime = userMap.get(username).getExpiredTimeMills();
-            if (!needRefresh(expiredTime)) {
-                return token;
+        TokenEntity cached = userMap.get(username);
+        if (cached != null) {
+            if (!needRefresh(cached.getExpiredTimeMills())) {
+                return cached.getToken();
             }
         }
         String token = jwtTokenManager.createToken(username);
@@ -107,10 +106,11 @@ public class CachedJwtTokenManager implements TokenManager {
      * @throws AccessException access exception
      */
     public Authentication getAuthentication(String token) throws AccessException {
-        if (!tokenMap.containsKey(token)) {
-            return jwtTokenManager.getAuthentication(token);
+        TokenEntity cached = tokenMap.get(token);
+        if (cached != null) {
+            return cached.getAuthentication();
         }
-        return tokenMap.get(token).getAuthentication();
+        return jwtTokenManager.getAuthentication(token);
     }
     
     /**
@@ -120,47 +120,50 @@ public class CachedJwtTokenManager implements TokenManager {
      * @throws AccessException access exception
      */
     public void validateToken(String token) throws AccessException {
-        if (!tokenMap.containsKey(token)) {
-            // jwtTokenManager.validateToken(token) will throw runtime exception if token invalid
-            jwtTokenManager.validateToken(token);
-            // if token valid
-            Authentication authentication = jwtTokenManager.getAuthentication(token);
-            String username = authentication.getName();
-            if (username == null || username.isEmpty()) {
-                return;
-            }
-            long expiredTime = TimeUnit.SECONDS.toMillis(jwtTokenManager.getExpiredTimeInSeconds(token));
-            if (expiredTime <= System.currentTimeMillis()) {
-                return;
-            }
-            NacosUser user = jwtTokenManager.parseToken(token);
-            tokenMap.putIfAbsent(token, new TokenEntity(token, username, expiredTime, authentication, user));
+        if (tokenMap.get(token) != null) {
+            return;
         }
+        // jwtTokenManager.validateToken(token) will throw runtime exception if token invalid
+        jwtTokenManager.validateToken(token);
+        // if token valid
+        Authentication authentication = jwtTokenManager.getAuthentication(token);
+        String username = authentication.getName();
+        if (username == null || username.isEmpty()) {
+            return;
+        }
+        long expiredTime = TimeUnit.SECONDS.toMillis(jwtTokenManager.getExpiredTimeInSeconds(token));
+        if (expiredTime <= System.currentTimeMillis()) {
+            return;
+        }
+        NacosUser user = jwtTokenManager.parseToken(token);
+        tokenMap.putIfAbsent(token, new TokenEntity(token, username, expiredTime, authentication, user));
     }
     
     @Override
     public NacosUser parseToken(String token) throws AccessException {
-        if (!tokenMap.containsKey(token)) {
-            Authentication authentication = jwtTokenManager.getAuthentication(token);
-            String username = authentication.getName();
-            if (username == null || username.isEmpty()) {
-                throw new AccessException("invalid token, username is empty");
-            }
-            long expiredTime = TimeUnit.SECONDS.toMillis(jwtTokenManager.getExpiredTimeInSeconds(token));
-            if (expiredTime <= System.currentTimeMillis()) {
-                throw new AccessException("expired token");
-            }
-            NacosUser user = jwtTokenManager.parseToken(token);
-            tokenMap.putIfAbsent(token, new TokenEntity(token, username, expiredTime, authentication, user));
-            return user;
+        TokenEntity cached = tokenMap.get(token);
+        if (cached != null) {
+            return cached.getNacosUser();
         }
-        return tokenMap.get(token).getNacosUser();
+        Authentication authentication = jwtTokenManager.getAuthentication(token);
+        String username = authentication.getName();
+        if (username == null || username.isEmpty()) {
+            throw new AccessException("invalid token, username is empty");
+        }
+        long expiredTime = TimeUnit.SECONDS.toMillis(jwtTokenManager.getExpiredTimeInSeconds(token));
+        if (expiredTime <= System.currentTimeMillis()) {
+            throw new AccessException("expired token");
+        }
+        NacosUser user = jwtTokenManager.parseToken(token);
+        tokenMap.putIfAbsent(token, new TokenEntity(token, username, expiredTime, authentication, user));
+        return user;
     }
     
     public long getTokenTtlInSeconds(String token) throws AccessException {
-        if (tokenMap.containsKey(token)) {
+        TokenEntity cached = tokenMap.get(token);
+        if (cached != null) {
             return TimeUnit.MILLISECONDS.toSeconds(
-                    tokenMap.get(token).getExpiredTimeMills() - System.currentTimeMillis());
+                    cached.getExpiredTimeMills() - System.currentTimeMillis());
         }
         return jwtTokenManager.getTokenTtlInSeconds(token);
     }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/token/impl/CachedJwtTokenManagerTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/token/impl/CachedJwtTokenManagerTest.java
@@ -29,7 +29,6 @@ import org.springframework.security.core.Authentication;
 
 import java.lang.reflect.Field;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -144,6 +143,23 @@ class CachedJwtTokenManagerTest {
         cachedJwtTokenManager.createToken("nacos");
         long ttl = cachedJwtTokenManager.getTokenTtlInSeconds("token");
         assertTrue(ttl > 0);
+    }
+
+    @Test
+    void testValidateTokenSkipsWhenCached() throws Exception {
+        cachedJwtTokenManager.createToken("nacos");
+        assertDoesNotThrow(() -> cachedJwtTokenManager.validateToken("token"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testValidateTokenSafeWhenCacheEvictedConcurrently() throws Exception {
+        cachedJwtTokenManager.createToken("nacos");
+        Field tokenMapField = CachedJwtTokenManager.class.getDeclaredField("tokenMap");
+        tokenMapField.setAccessible(true);
+        Map<String, ?> tokenMap = (Map<String, ?>) tokenMapField.get(cachedJwtTokenManager);
+        tokenMap.clear();
+        assertDoesNotThrow(() -> cachedJwtTokenManager.validateToken("token"));
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/token/impl/CachedJwtTokenManagerTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/token/impl/CachedJwtTokenManagerTest.java
@@ -27,6 +27,11 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.security.core.Authentication;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -100,5 +105,89 @@ class CachedJwtTokenManagerTest {
     void testGetTokenValidityInSeconds() {
         assertTrue(cachedJwtTokenManager.getTokenValidityInSeconds() > 0);
     }
-    
+
+    @Test
+    void testCreateTokenReturnsCachedWhenNotExpired() throws Exception {
+        cachedJwtTokenManager.createToken("nacos");
+        when(jwtTokenManager.getTokenValidityInSeconds()).thenReturn(10000L);
+        String secondToken = cachedJwtTokenManager.createToken("nacos");
+        assertEquals("token", secondToken);
+    }
+
+    @Test
+    void testGetAuthenticationFallsBackWhenNotCached() throws AccessException {
+        Authentication result = cachedJwtTokenManager.getAuthentication("uncached-token");
+        assertNotNull(result);
+    }
+
+    @Test
+    void testGetAuthenticationReturnsCachedEntry() throws Exception {
+        cachedJwtTokenManager.createToken("nacos");
+        Authentication result = cachedJwtTokenManager.getAuthentication("token");
+        assertNotNull(result);
+    }
+
+    @Test
+    void testParseTokenFallsBackWhenNotCached() throws AccessException {
+        NacosUser result = cachedJwtTokenManager.parseToken("uncached-token");
+        assertNotNull(result);
+    }
+
+    @Test
+    void testGetTokenTtlFallsBackWhenNotCached() throws AccessException {
+        long ttl = cachedJwtTokenManager.getTokenTtlInSeconds("uncached-token");
+        assertTrue(ttl > 0);
+    }
+
+    @Test
+    void testGetTokenTtlReturnsCachedValue() throws Exception {
+        cachedJwtTokenManager.createToken("nacos");
+        long ttl = cachedJwtTokenManager.getTokenTtlInSeconds("token");
+        assertTrue(ttl > 0);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testCreateTokenSafeWhenCacheEvictedConcurrently() throws Exception {
+        cachedJwtTokenManager.createToken("nacos");
+        Field userMapField = CachedJwtTokenManager.class.getDeclaredField("userMap");
+        userMapField.setAccessible(true);
+        Map<String, ?> userMap = (Map<String, ?>) userMapField.get(cachedJwtTokenManager);
+        userMap.clear();
+        assertDoesNotThrow(() -> cachedJwtTokenManager.createToken("nacos"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testGetAuthenticationSafeWhenCacheEvictedConcurrently() throws Exception {
+        cachedJwtTokenManager.createToken("nacos");
+        Field tokenMapField = CachedJwtTokenManager.class.getDeclaredField("tokenMap");
+        tokenMapField.setAccessible(true);
+        Map<String, ?> tokenMap = (Map<String, ?>) tokenMapField.get(cachedJwtTokenManager);
+        tokenMap.clear();
+        assertDoesNotThrow(() -> cachedJwtTokenManager.getAuthentication("token"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testParseTokenSafeWhenCacheEvictedConcurrently() throws Exception {
+        cachedJwtTokenManager.createToken("nacos");
+        Field tokenMapField = CachedJwtTokenManager.class.getDeclaredField("tokenMap");
+        tokenMapField.setAccessible(true);
+        Map<String, ?> tokenMap = (Map<String, ?>) tokenMapField.get(cachedJwtTokenManager);
+        tokenMap.clear();
+        assertDoesNotThrow(() -> cachedJwtTokenManager.parseToken("token"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testGetTokenTtlSafeWhenCacheEvictedConcurrently() throws Exception {
+        cachedJwtTokenManager.createToken("nacos");
+        Field tokenMapField = CachedJwtTokenManager.class.getDeclaredField("tokenMap");
+        tokenMapField.setAccessible(true);
+        Map<String, ?> tokenMap = (Map<String, ?>) tokenMapField.get(cachedJwtTokenManager);
+        tokenMap.clear();
+        assertDoesNotThrow(() -> cachedJwtTokenManager.getTokenTtlInSeconds("token"));
+    }
+
 }


### PR DESCRIPTION
## Problem

`CachedJwtTokenManager` uses non-atomic `containsKey()` followed by `get()` on ConcurrentHashMap in multiple methods. When the scheduled cleanup task (`cleanExpiredToken`) evicts an entry between the `containsKey` check and the subsequent `get` call, `get()` returns null, causing a NullPointerException.

## Root Cause

ConcurrentHashMap guarantees atomicity of individual operations but not of compound check-then-act sequences. The pattern `if (map.containsKey(k)) { map.get(k).doSomething(); }` is unsafe because another thread can remove the key between the two calls.

## Fix

- Replace all `containsKey` + `get` patterns with a single `get` call followed by a null check
- Refactor `validateToken()` and `parseToken()` from nested-if to early-return style for the same fix
- 5 methods fixed: `createToken`, `getAuthentication`, `validateToken`, `parseToken`, `getTokenTtlInSeconds`

## Tests Added

| Change Point | Test |
|-------------|------|
| `createToken()` — single `get` on `userMap` | `testCreateTokenReturnsCachedWhenNotExpired()` — verifies cached token is returned |
| `createToken()` — safe when cache evicted | `testCreateTokenSafeWhenCacheEvictedConcurrently()` — clears userMap between calls, no NPE |
| `getAuthentication()` — single `get` on `tokenMap` | `testGetAuthenticationReturnsCachedEntry()`, `testGetAuthenticationFallsBackWhenNotCached()` |
| `getAuthentication()` — safe when cache evicted | `testGetAuthenticationSafeWhenCacheEvictedConcurrently()` — clears tokenMap, no NPE |
| `parseToken()` — single `get` on `tokenMap` | `testParseTokenFallsBackWhenNotCached()` — verifies fallback to jwtTokenManager |
| `parseToken()` — safe when cache evicted | `testParseTokenSafeWhenCacheEvictedConcurrently()` — clears tokenMap, no NPE |
| `getTokenTtlInSeconds()` — single `get` on `tokenMap` | `testGetTokenTtlReturnsCachedValue()`, `testGetTokenTtlFallsBackWhenNotCached()` |
| `getTokenTtlInSeconds()` — safe when cache evicted | `testGetTokenTtlSafeWhenCacheEvictedConcurrently()` — clears tokenMap, no NPE |

## Impact

- Prevents potential NullPointerException under concurrent access when the scheduled cleanup evicts tokens
- No behavioral change — all methods return the same results, just accessed atomically
- No changes to token lifecycle or expiration logic