### PR TITLE
fix(config): add null check for metaDataItem in config import

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/config/ConfigInnerHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/config/ConfigInnerHandler.java
@@ -334,8 +334,12 @@ public class ConfigInnerHandler implements ConfigHandler {
     private Result<Map<String, Object>> parseImportDataV2(String srcUser, ZipUtils.UnZipResult unziped,
             List<ConfigAllInfo> configInfoList, List<Map<String, String>> unrecognizedList, String namespace) {
         ZipUtils.ZipItem metaDataItem = unziped.getMetaDataItem();
-        String metaData = metaDataItem.getItemData();
         Map<String, Object> failedData = new HashMap<>(4);
+        if (metaDataItem == null) {
+            failedData.put("succCount", 0);
+            return Result.failure(ErrorCode.METADATA_ILLEGAL, failedData);
+        }
+        String metaData = metaDataItem.getItemData();
         
         ConfigMetadata configMetadata = YamlParserUtil.loadObject(metaData, ConfigMetadata.class);
         if (configMetadata == null || CollectionUtils.isEmpty(configMetadata.getMetadata())) {

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/config/ConfigInnerHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/config/ConfigInnerHandlerTest.java
@@ -337,6 +337,18 @@ class ConfigInnerHandlerTest {
             assertEquals(ErrorCode.METADATA_ILLEGAL.getCode(), actual.getCode());
         }
     }
+
+    @Test
+    void importAndPublishConfigWithNullMetadataItem() throws NacosException {
+        ZipUtils.UnZipResult unziped = new ZipUtils.UnZipResult(new ArrayList<>(), null);
+        MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", "test".getBytes());
+        try (MockedStatic<ZipUtils> zipUtilsMockedStatic = Mockito.mockStatic(ZipUtils.class)) {
+            zipUtilsMockedStatic.when(() -> ZipUtils.unzip(eq(file.getBytes()))).thenReturn(unziped);
+            Result<Map<String, Object>> actual = configInnerHandler.importAndPublishConfig("srcUser", "public",
+                    SameConfigPolicy.OVERWRITE, file, "srcIp", "requestIpApp");
+            assertEquals(ErrorCode.METADATA_ILLEGAL.getCode(), actual.getCode());
+        }
+    }
     
     @Test
     void importAndPublishConfigWithWrongMetadata() throws NacosException {


### PR DESCRIPTION
## Problem

When importing a configuration ZIP file via the V2 import API, the server crashes with a NullPointerException if the ZIP file does not contain the required metadata file (`.metadata.yml`). The error message `Cannot invoke "...ZipItem.getItemData()" because "metaDataItem" is null` provides no actionable guidance to the user.

## Root Cause

In `ConfigInnerHandler.parseImportDataV2()`, `unziped.getMetaDataItem()` returns null when the ZIP archive lacks a metadata file, but the code immediately calls `metaDataItem.getItemData()` without a null check.

## Fix

- Add a null check for `metaDataItem` before accessing its data
- When null, return a proper `METADATA_ILLEGAL` error response instead of crashing
- Move `failedData` map initialization before the null check so it can be used in the error response

## Tests Added

| Change Point | Test |
|-------------|------|
| Null check for `metaDataItem` | `importAndPublishConfigWithNullMetadataItem()` — creates an `UnZipResult` with null metadata, verifies `METADATA_ILLEGAL` error code is returned instead of NPE |

## Impact

- Prevents server crash when importing ZIP files without metadata
- Returns a clear error response (`METADATA_ILLEGAL`) that helps users understand the issue
- No change to behavior when metadata file is present

Fixes #14785