### PR TITLE
fix(config): add null check for optional ids parameter in exportConfigV2

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
@@ -307,7 +307,9 @@ public class ConsoleConfigController {
     public ResponseEntity<byte[]> exportConfigV2(ConfigFormV3 configForm,
             @RequestParam(value = "ids", required = false) List<Long> ids) throws Exception {
         configForm.blurSearchValidate();
-        ids.removeAll(Collections.singleton(null));
+        if (ids != null) {
+            ids.removeAll(Collections.singleton(null));
+        }
         String namespaceId = NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId());
         String dataId = configForm.getDataId();
         String groupName = configForm.getGroupName();

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigControllerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigControllerTest.java
@@ -73,6 +73,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -331,9 +332,29 @@ public class ConsoleConfigControllerTest {
         int actualStatus = response.getStatus();
         
         assertEquals(200, actualStatus);
-        
+
     }
-    
+
+    @Test
+    void testExportConfigV2WithoutIds() throws Exception {
+        String dataId = "dataId2.json";
+        String group = "group2";
+        String tenant = "tenant234";
+        String appname = "appname2";
+
+        byte[] serializedData = new byte[]{1, 2, 3};
+        ResponseEntity<byte[]> responseEntity = new ResponseEntity<>(serializedData, HttpStatus.OK);
+
+        Mockito.when(configProxy.exportConfigV2(eq(dataId), eq(group), eq(tenant), eq(appname), isNull()))
+                .thenReturn(responseEntity);
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get("/v3/console/cs/config/export2")
+                .param("dataId", dataId).param("groupName", group).param("tenant", tenant)
+                .param("appName", appname);
+
+        MockHttpServletResponse response = mockmvc.perform(builder).andReturn().getResponse();
+        assertEquals(200, response.getStatus());
+    }
+
     @Test
     void testImportAndPublishConfig() throws Exception {
         String srcUser = "testUser";


### PR DESCRIPTION
## Problem

The `exportConfigV2` endpoint in `ConsoleConfigController` crashes with a NullPointerException when the `ids` request parameter is omitted. The parameter is declared with `required = false`, but the code calls `ids.removeAll(Collections.singleton(null))` without a null check.

## Root Cause

The `@RequestParam(value = "ids", required = false) List<Long> ids` parameter can be null when not provided in the request, but line 310 directly calls a method on it without null safety.

## Fix

- Add a null check before calling `ids.removeAll()` to guard against NPE when the parameter is omitted

## Tests Added

| Change Point | Test |
|-------------|------|
| Null check for `ids` parameter | `testExportConfigV2WithoutIds()` — calls the export endpoint without the `ids` parameter, verifies 200 response instead of NPE |

## Impact

- Prevents server crash when calling the V2 config export API without specifying config IDs
- No behavioral change when IDs are provided