### PR TITLE
[Bug] Fix TOCTOU race condition in removeSubscriberIndexes causing data loss

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManager.java
@@ -158,13 +158,9 @@ public class ClientServiceIndexesManager extends SmartSubscriber {
     }
     
     private void removeSubscriberIndexes(Service service, String clientId) {
-        Set<String> clientIds = subscriberIndexes.get(service);
-        if (clientIds == null) {
-            return;
-        }
-        clientIds.remove(clientId);
-        if (clientIds.isEmpty()) {
-            subscriberIndexes.remove(service);
-        }
+        subscriberIndexes.computeIfPresent(service, (s, clientIds) -> {
+            clientIds.remove(clientId);
+            return clientIds.isEmpty() ? null : clientIds;
+        });
     }
 }


### PR DESCRIPTION
## Issue Description
In `ClientServiceIndexesManager.removeSubscriberIndexes`, removing a subscriber uses a non-atomic check-then-act pattern:
1. `clientIds.remove(clientId)`
2. `if (clientIds.isEmpty()) { subscriberIndexes.remove(service); }`

If a concurrent thread adds a new subscriber (via `addSubscriberIndexes`) between step 1 and step 2, the newly added subscriber will be completely lost because the service entry is removed from `subscriberIndexes` in step 2. This causes Nacos to lose track of the new subscriber, and it will never receive service change notifications.

## Proposed Changes
Used `ConcurrentMap.computeIfPresent` to ensure the `isEmpty` check and the subsequent map removal are performed atomically. This is the exact same safe pattern already correctly utilized in `removePublisherIndexes` in the same file.

## General Checklist
- [x] Logic change explained clearly
- [x] No changes to public API surface
- [x] No additional dependencies introduced