### PR TITLE
[Bug] Fix TOCTOU race condition and unsafe lazy init in CacheItem.initConfigGrayIfEmpty()

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/model/CacheItem.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/CacheItem.java
@@ -19,9 +19,9 @@ package com.alibaba.nacos.config.server.model;
 import com.alibaba.nacos.config.server.utils.SimpleReadWriteLock;
 import com.alibaba.nacos.core.utils.StringPool;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -80,7 +80,11 @@ public class CacheItem {
      */
     public void initConfigGrayIfEmpty() {
         if (this.configCacheGray == null) {
-            this.configCacheGray = new HashMap<>(4);
+            synchronized (this) {
+                if (this.configCacheGray == null) {
+                    this.configCacheGray = new ConcurrentHashMap<>(4);
+                }
+            }
         }
     }
 
@@ -91,9 +95,8 @@ public class CacheItem {
      */
     public void initConfigGrayIfEmpty(String grayName) {
         initConfigGrayIfEmpty();
-        if (!this.configCacheGray.containsKey(grayName)) {
-            this.configCacheGray.put(grayName, ConfigCacheFactoryDelegate.getInstance().createConfigCacheGray(grayName));
-        }
+        this.configCacheGray.computeIfAbsent(grayName,
+                k -> ConfigCacheFactoryDelegate.getInstance().createConfigCacheGray(k));
     }
 
     public List<ConfigCacheGray> getSortConfigGrays() {


### PR DESCRIPTION
## Issue Description
In `CacheItem.java`, `configCacheGray` was lazily initialized using a non-thread-safe `HashMap` and without synchronization (missing Double-Checked Locking). When multiple threads call `initConfigGrayIfEmpty(grayName)` concurrently, multiple `HashMap`s could be created, overwriting each other and causing memory leak and data loss.

Additionally, the method used a check-then-act pattern (`containsKey` + `put`) which is not atomic. In high-concurrency gray release configurations, this could lead to multiple `createConfigCacheGray()` executions for the same `grayName`, and throwing `ConcurrentModificationException` due to the non-thread-safe `HashMap` implementation.

## Proposed Changes
- Added Double-Checked Locking (DCL) around the lazy initialization of `configCacheGray` (which is already `volatile`).
- Changed `configCacheGray`'s underlying implementation from `HashMap` to `ConcurrentHashMap` to ensure thread safety during concurrent structural modifications.
- Replaced the `containsKey` + `put` pattern with `computeIfAbsent()` to guarantee that `ConfigCacheFactoryDelegate.createConfigCacheGray()` is executed exactly once per `grayName`, effectively eliminating the TOCTOU hazard and preventing corrupted pointers that could lead to NPE in the routing layer.

## General Checklist
- [x] Logic change explained clearly
- [x] No changes to public API surface
- [x] No additional dependencies introduced