### PR TITLE
[coverage] Add unit tests for maintainer-client AI module interface default methods.

### DIFF
--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/A2aMaintainerServiceDefaultMethodsTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/A2aMaintainerServiceDefaultMethodsTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.maintainer.client.ai;
+
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCard;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardVersionInfo;
+import com.alibaba.nacos.api.ai.model.a2a.AgentVersionDetail;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.maintainer.client.model.HttpRequest;
+import com.alibaba.nacos.maintainer.client.remote.ClientHttpProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for A2aMaintainerService interface default methods.
+ * Tests the convenience methods that provide simplified parameter signatures.
+ *
+ * @author nacos
+ */
+@ExtendWith(MockitoExtension.class)
+class A2aMaintainerServiceDefaultMethodsTest {
+
+    @Mock
+    private ClientHttpProxy clientHttpProxy;
+
+    private A2aMaintainerService a2aService;
+
+    @BeforeEach
+    void setUp() throws NacosException, NoSuchFieldException, IllegalAccessException {
+        Properties properties = new Properties();
+        properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1:8848");
+        AiMaintainerService aiMaintainerService = AiMaintainerFactory.createAiMaintainerService(properties);
+
+        Field a2aServiceField = NacosAiMaintainerServiceImpl.class.getDeclaredField("a2aMaintainerService");
+        a2aServiceField.setAccessible(true);
+        a2aService = (A2aMaintainerService) a2aServiceField.get(aiMaintainerService);
+
+        injectMockClientHttpProxy(a2aService);
+    }
+
+    private void injectMockClientHttpProxy(Object service) throws NoSuchFieldException, IllegalAccessException {
+        Field contextField = AbstractAiDelegateMaintainerService.class.getDeclaredField("context");
+        contextField.setAccessible(true);
+        Object context = contextField.get(service);
+        Field clientHttpProxyField = AiMaintainerHttpContext.class.getDeclaredField("clientHttpProxy");
+        clientHttpProxyField.setAccessible(true);
+        clientHttpProxyField.set(context, clientHttpProxy);
+    }
+
+    // ========== registerAgent default method tests ==========
+
+    @Test
+    @DisplayName("registerAgent(agentCard) should use default namespace")
+    void testRegisterAgentWithDefaultNamespace() throws NacosException {
+        AgentCard card = new AgentCard();
+        card.setName("testAgent");
+        card.setVersion("1.0");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(a2aService.registerAgent(card));
+    }
+
+    @Test
+    @DisplayName("registerAgent(agentCard, namespaceId) should use default registration type")
+    void testRegisterAgentWithNamespace() throws NacosException {
+        AgentCard card = new AgentCard();
+        card.setName("testAgent");
+        card.setVersion("1.0");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(a2aService.registerAgent(card, "public"));
+    }
+
+    // ========== getAgentCard default method tests ==========
+
+    @Test
+    @DisplayName("getAgentCard(agentName) should use default namespace")
+    void testGetAgentCardWithDefaultNamespace() throws NacosException {
+        AgentCardDetailInfo detail = new AgentCardDetailInfo();
+        detail.setName("testAgent");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(detail)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        AgentCardDetailInfo result = a2aService.getAgentCard("testAgent");
+        assertNotNull(result);
+        assertEquals("testAgent", result.getName());
+    }
+
+    @Test
+    @DisplayName("getAgentCard(agentName, namespaceId) should use empty registration type")
+    void testGetAgentCardWithNamespace() throws NacosException {
+        AgentCardDetailInfo detail = new AgentCardDetailInfo();
+        detail.setName("testAgent");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(detail)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        AgentCardDetailInfo result = a2aService.getAgentCard("testAgent", "public");
+        assertNotNull(result);
+        assertEquals("testAgent", result.getName());
+    }
+
+    @Test
+    @DisplayName("getAgentCard(agentName, namespaceId, type) should use empty version")
+    void testGetAgentCardWithNamespaceAndType() throws NacosException {
+        AgentCardDetailInfo detail = new AgentCardDetailInfo();
+        detail.setName("testAgent");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(detail)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        AgentCardDetailInfo result = a2aService.getAgentCard("testAgent", "public", "url");
+        assertNotNull(result);
+        assertEquals("testAgent", result.getName());
+    }
+
+    // ========== updateAgentCard default method tests ==========
+
+    @Test
+    @DisplayName("updateAgentCard(agentCard) should use default namespace")
+    void testUpdateAgentCardWithDefaultNamespace() throws NacosException {
+        AgentCard card = new AgentCard();
+        card.setName("testAgent");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(a2aService.updateAgentCard(card));
+    }
+
+    @Test
+    @DisplayName("updateAgentCard(agentCard, namespaceId) should set as latest")
+    void testUpdateAgentCardWithNamespace() throws NacosException {
+        AgentCard card = new AgentCard();
+        card.setName("testAgent");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(a2aService.updateAgentCard(card, "public"));
+    }
+
+    @Test
+    @DisplayName("updateAgentCard(agentCard, namespaceId, setAsLatest) should use empty registration type")
+    void testUpdateAgentCardWithNamespaceAndLatestFlag() throws NacosException {
+        AgentCard card = new AgentCard();
+        card.setName("testAgent");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(a2aService.updateAgentCard(card, "public", false));
+    }
+
+    // ========== deleteAgent default method tests ==========
+
+    @Test
+    @DisplayName("deleteAgent(agentName) should use default namespace")
+    void testDeleteAgentWithDefaultNamespace() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(a2aService.deleteAgent("testAgent"));
+    }
+
+    @Test
+    @DisplayName("deleteAgent(agentName, namespaceId) should use empty version")
+    void testDeleteAgentWithNamespace() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(a2aService.deleteAgent("testAgent", "public"));
+    }
+
+    // ========== listAllVersionOfAgent default method tests ==========
+
+    @Test
+    @DisplayName("listAllVersionOfAgent(agentName) should use default namespace")
+    void testListAllVersionOfAgentWithDefaultNamespace() throws NacosException {
+        AgentVersionDetail version = new AgentVersionDetail();
+        version.setVersion("1.0");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(Collections.singletonList(version))));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        List<AgentVersionDetail> result = a2aService.listAllVersionOfAgent("testAgent");
+        assertNotNull(result);
+        assertEquals(1, result.size());
+    }
+
+    // ========== searchAgentCardsByName default method tests ==========
+
+    @Test
+    @DisplayName("searchAgentCardsByName(pattern) should use default namespace and top 100")
+    void testSearchAgentCardsByNameWithPatternOnly() throws NacosException {
+        Page<AgentCardVersionInfo> page = new Page<>();
+        page.setTotalCount(0);
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<AgentCardVersionInfo> result = a2aService.searchAgentCardsByName("test");
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("searchAgentCardsByName(pattern, pageNo, pageSize) should use default namespace")
+    void testSearchAgentCardsByNameWithPagination() throws NacosException {
+        Page<AgentCardVersionInfo> page = new Page<>();
+        page.setTotalCount(0);
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<AgentCardVersionInfo> result = a2aService.searchAgentCardsByName("test", 1, 10);
+        assertNotNull(result);
+    }
+
+    // ========== listAgentCards default method tests ==========
+
+    @Test
+    @DisplayName("listAgentCards() should use default namespace and top 100")
+    void testListAgentCardsWithNoArgs() throws NacosException {
+        Page<AgentCardVersionInfo> page = new Page<>();
+        page.setTotalCount(0);
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<AgentCardVersionInfo> result = a2aService.listAgentCards();
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("listAgentCards(pageNo, pageSize) should use default namespace")
+    void testListAgentCardsWithPagination() throws NacosException {
+        Page<AgentCardVersionInfo> page = new Page<>();
+        page.setTotalCount(0);
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<AgentCardVersionInfo> result = a2aService.listAgentCards(1, 10);
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("listAgentCards(namespaceId, pageNo, pageSize) should use empty agent name")
+    void testListAgentCardsWithNamespace() throws NacosException {
+        Page<AgentCardVersionInfo> page = new Page<>();
+        page.setTotalCount(0);
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<AgentCardVersionInfo> result = a2aService.listAgentCards("public", 1, 10);
+        assertNotNull(result);
+    }
+}

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerServiceDefaultMethodsTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/AgentSpecMaintainerServiceDefaultMethodsTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.maintainer.client.ai;
+
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecBasicInfo;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecMeta;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecSummary;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.maintainer.client.model.HttpRequest;
+import com.alibaba.nacos.maintainer.client.remote.ClientHttpProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for AgentSpecMaintainerService interface default methods.
+ * Tests the convenience methods that provide simplified parameter signatures.
+ *
+ * @author nacos
+ */
+@ExtendWith(MockitoExtension.class)
+class AgentSpecMaintainerServiceDefaultMethodsTest {
+
+    @Mock
+    private ClientHttpProxy clientHttpProxy;
+
+    private AgentSpecMaintainerService agentSpecService;
+
+    @BeforeEach
+    void setUp() throws NacosException, NoSuchFieldException, IllegalAccessException {
+        Properties properties = new Properties();
+        properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1:8848");
+        AiMaintainerService aiMaintainerService = AiMaintainerFactory.createAiMaintainerService(properties);
+
+        Field agentSpecServiceField = NacosAiMaintainerServiceImpl.class.getDeclaredField("agentSpecMaintainerService");
+        agentSpecServiceField.setAccessible(true);
+        agentSpecService = (AgentSpecMaintainerService) agentSpecServiceField.get(aiMaintainerService);
+
+        injectMockClientHttpProxy(agentSpecService);
+    }
+
+    private void injectMockClientHttpProxy(Object service) throws NoSuchFieldException, IllegalAccessException {
+        Field contextField = AbstractAiDelegateMaintainerService.class.getDeclaredField("context");
+        contextField.setAccessible(true);
+        Object context = contextField.get(service);
+        Field clientHttpProxyField = AiMaintainerHttpContext.class.getDeclaredField("clientHttpProxy");
+        clientHttpProxyField.setAccessible(true);
+        clientHttpProxyField.set(context, clientHttpProxy);
+    }
+
+    // ========== getAgentSpecDetail default method tests ==========
+
+    @Test
+    @DisplayName("getAgentSpecDetail(agentSpecName) should use default namespace")
+    void testGetAgentSpecDetailWithDefaultNamespace() throws NacosException {
+        AgentSpec agentSpec = new AgentSpec();
+        agentSpec.setName("testAgentSpec");
+        AgentSpecMeta meta = new AgentSpecMeta();
+        meta.setEditingVersion("v1");
+
+        HttpRestResult<String> metaResult = new HttpRestResult<>();
+        metaResult.setData(JacksonUtils.toJson(Result.success(meta)));
+        HttpRestResult<String> specResult = new HttpRestResult<>();
+        specResult.setData(JacksonUtils.toJson(Result.success(agentSpec)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(metaResult, specResult);
+
+        AgentSpec result = agentSpecService.getAgentSpecDetail("testAgentSpec");
+        assertNotNull(result);
+        assertEquals("testAgentSpec", result.getName());
+    }
+
+    // ========== getAgentSpecVersionDetail default method tests ==========
+
+    @Test
+    @DisplayName("getAgentSpecVersionDetail(agentSpecName, version) should use default namespace")
+    void testGetAgentSpecVersionDetailWithDefaultNamespace() throws NacosException {
+        AgentSpec agentSpec = new AgentSpec();
+        agentSpec.setName("testAgentSpec");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(agentSpec)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        AgentSpec result = agentSpecService.getAgentSpecVersionDetail("testAgentSpec", "v1");
+        assertNotNull(result);
+        assertEquals("testAgentSpec", result.getName());
+    }
+
+    // ========== deleteAgentSpec default method tests ==========
+
+    @Test
+    @DisplayName("deleteAgentSpec(agentSpecName) should use default namespace")
+    void testDeleteAgentSpecWithDefaultNamespace() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        boolean result = agentSpecService.deleteAgentSpec("testAgentSpec");
+        assertTrue(result);
+    }
+
+    // ========== listAgentSpecs default method tests ==========
+
+    @Test
+    @DisplayName("listAgentSpecs(agentSpecName, pageNo, pageSize) should use default namespace and blur search")
+    void testListAgentSpecsWithDefaults() throws NacosException {
+        Page<AgentSpecBasicInfo> page = new Page<>();
+        page.setTotalCount(1);
+        page.setPageItems(Collections.singletonList(new AgentSpecBasicInfo()));
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<AgentSpecBasicInfo> result = agentSpecService.listAgentSpecs("testAgentSpec", 1, 10);
+        assertNotNull(result);
+        assertEquals(1, result.getTotalCount());
+    }
+
+    // ========== listAgentSpecAdminItems default method tests ==========
+
+    @Test
+    @DisplayName("listAgentSpecAdminItems with orderBy/owner/scope should delegate to simpler version")
+    void testListAgentSpecAdminItemsWithFilters() throws NacosException {
+        Page<AgentSpecSummary> page = new Page<>();
+        page.setTotalCount(0);
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<AgentSpecSummary> result = agentSpecService.listAgentSpecAdminItems("public", "test", "blur", null, null, null, 1, 10);
+        assertNotNull(result);
+    }
+
+    // ========== uploadAgentSpecFromZip default method tests ==========
+
+    @Test
+    @DisplayName("uploadAgentSpecFromZip(namespaceId, zipBytes) should not overwrite")
+    void testUploadAgentSpecFromZipWithNamespace() throws NacosException {
+        byte[] zipBytes = "test zip content".getBytes();
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("uploadedAgentSpec")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        String result = agentSpecService.uploadAgentSpecFromZip("public", zipBytes);
+        assertEquals("uploadedAgentSpec", result);
+    }
+
+    @Test
+    @DisplayName("uploadAgentSpecFromZip(zipBytes) should use default namespace and not overwrite")
+    void testUploadAgentSpecFromZipWithDefaults() throws NacosException {
+        byte[] zipBytes = "test zip content".getBytes();
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("uploadedAgentSpec")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        String result = agentSpecService.uploadAgentSpecFromZip(zipBytes);
+        assertEquals("uploadedAgentSpec", result);
+    }
+
+    private static void assertTrue(boolean result) {
+        org.junit.jupiter.api.Assertions.assertTrue(result);
+    }
+}

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/AiMaintainerServiceDefaultMethodsTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/AiMaintainerServiceDefaultMethodsTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.maintainer.client.ai;
+
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCard;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardVersionInfo;
+import com.alibaba.nacos.api.ai.model.a2a.AgentVersionDetail;
+
+import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.maintainer.client.model.HttpRequest;
+import com.alibaba.nacos.maintainer.client.remote.ClientHttpProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for AiMaintainerService interface default methods.
+ * Tests the delegation methods that forward calls to mcp() and a2a() sub-services.
+ *
+ * @author nacos
+ */
+@ExtendWith(MockitoExtension.class)
+class AiMaintainerServiceDefaultMethodsTest {
+
+    @Mock
+    private ClientHttpProxy clientHttpProxy;
+
+    private AiMaintainerService aiMaintainerService;
+
+    @BeforeEach
+    void setUp() throws NacosException, NoSuchFieldException, IllegalAccessException {
+        Properties properties = new Properties();
+        properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1:8848");
+        aiMaintainerService = AiMaintainerFactory.createAiMaintainerService(properties);
+        
+        // Inject mock into mcp service
+        Field mcpServiceField = NacosAiMaintainerServiceImpl.class.getDeclaredField("mcpMaintainerService");
+        mcpServiceField.setAccessible(true);
+        Object mcpService = mcpServiceField.get(aiMaintainerService);
+        injectMockClientHttpProxy(mcpService);
+        
+        // Inject mock into a2a service
+        Field a2aServiceField = NacosAiMaintainerServiceImpl.class.getDeclaredField("a2aMaintainerService");
+        a2aServiceField.setAccessible(true);
+        Object a2aService = a2aServiceField.get(aiMaintainerService);
+        injectMockClientHttpProxy(a2aService);
+    }
+
+    private void injectMockClientHttpProxy(Object service) throws NoSuchFieldException, IllegalAccessException {
+        Field contextField = AbstractAiDelegateMaintainerService.class.getDeclaredField("context");
+        contextField.setAccessible(true);
+        Object context = contextField.get(service);
+        Field clientHttpProxyField = AiMaintainerHttpContext.class.getDeclaredField("clientHttpProxy");
+        clientHttpProxyField.setAccessible(true);
+        clientHttpProxyField.set(context, clientHttpProxy);
+    }
+
+    // ========== AiMaintainerService -> mcp() delegation tests ==========
+
+    @Test
+    @DisplayName("AiMaintainerService.listMcpServer should delegate to mcp()")
+    void testListMcpServerDelegation() throws NacosException {
+        Page<McpServerBasicInfo> page = new Page<>();
+        page.setTotalCount(1);
+        page.setPageItems(Collections.singletonList(new McpServerBasicInfo()));
+        
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<McpServerBasicInfo> result = aiMaintainerService.listMcpServer("public", "test", 1, 10);
+        assertNotNull(result);
+        assertEquals(1, result.getTotalCount());
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.searchMcpServer should delegate to mcp()")
+    void testSearchMcpServerDelegation() throws NacosException {
+        Page<McpServerBasicInfo> page = new Page<>();
+        page.setTotalCount(1);
+        page.setPageItems(Collections.singletonList(new McpServerBasicInfo()));
+        
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<McpServerBasicInfo> result = aiMaintainerService.searchMcpServer("public", "test", 1, 10);
+        assertNotNull(result);
+        assertEquals(1, result.getTotalCount());
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.getMcpServerDetail should delegate to mcp()")
+    void testGetMcpServerDetailDelegation() throws NacosException {
+        McpServerDetailInfo detail = new McpServerDetailInfo();
+        detail.setName("testMcp");
+        
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(detail)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        McpServerDetailInfo result = aiMaintainerService.getMcpServerDetail("public", "testMcp", "id", "1.0");
+        assertNotNull(result);
+        assertEquals("testMcp", result.getName());
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.createMcpServer should delegate to mcp()")
+    void testCreateMcpServerDelegation() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("mcp-id-123")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        String result = aiMaintainerService.createMcpServer("public", "testMcp", new McpServerBasicInfo(), null, null);
+        assertEquals("mcp-id-123", result);
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.updateMcpServer should delegate to mcp()")
+    void testUpdateMcpServerDelegation() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        boolean result = aiMaintainerService.updateMcpServer("public", "testMcp", true, new McpServerBasicInfo(), null, null, false);
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.deleteMcpServer should delegate to mcp()")
+    void testDeleteMcpServerDelegation() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        boolean result = aiMaintainerService.deleteMcpServer("public", "testMcp", "id", "1.0");
+        assertTrue(result);
+    }
+
+    // ========== AiMaintainerService -> a2a() delegation tests ==========
+
+    @Test
+    @DisplayName("AiMaintainerService.registerAgent should delegate to a2a()")
+    void testRegisterAgentDelegation() throws NacosException {
+        AgentCard card = new AgentCard();
+        card.setName("testAgent");
+        
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        boolean result = aiMaintainerService.registerAgent(card, "public", "url");
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.getAgentCard should delegate to a2a()")
+    void testGetAgentCardDelegation() throws NacosException {
+        AgentCardDetailInfo detail = new AgentCardDetailInfo();
+        detail.setName("testAgent");
+        
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(detail)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        AgentCardDetailInfo result = aiMaintainerService.getAgentCard("testAgent", "public", "url", "1.0");
+        assertNotNull(result);
+        assertEquals("testAgent", result.getName());
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.updateAgentCard should delegate to a2a()")
+    void testUpdateAgentCardDelegation() throws NacosException {
+        AgentCard card = new AgentCard();
+        card.setName("testAgent");
+        
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        boolean result = aiMaintainerService.updateAgentCard(card, "public", true, "url");
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.deleteAgent should delegate to a2a()")
+    void testDeleteAgentDelegation() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        boolean result = aiMaintainerService.deleteAgent("testAgent", "public", "1.0");
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.listAllVersionOfAgent should delegate to a2a()")
+    void testListAllVersionOfAgentDelegation() throws NacosException {
+        AgentVersionDetail version = new AgentVersionDetail();
+        version.setVersion("1.0");
+        
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(Collections.singletonList(version))));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        List<AgentVersionDetail> result = aiMaintainerService.listAllVersionOfAgent("testAgent", "public");
+        assertNotNull(result);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.searchAgentCardsByName should delegate to a2a()")
+    void testSearchAgentCardsByNameDelegation() throws NacosException {
+        Page<AgentCardVersionInfo> page = new Page<>();
+        page.setTotalCount(1);
+        
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<AgentCardVersionInfo> result = aiMaintainerService.searchAgentCardsByName("public", "test", 1, 10);
+        assertNotNull(result);
+        assertEquals(1, result.getTotalCount());
+    }
+
+    @Test
+    @DisplayName("AiMaintainerService.listAgentCards should delegate to a2a()")
+    void testListAgentCardsDelegation() throws NacosException {
+        Page<AgentCardVersionInfo> page = new Page<>();
+        page.setTotalCount(1);
+        
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<AgentCardVersionInfo> result = aiMaintainerService.listAgentCards("public", "testAgent", 1, 10);
+        assertNotNull(result);
+        assertEquals(1, result.getTotalCount());
+    }
+}

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/PromptMaintainerServiceDefaultMethodsTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/PromptMaintainerServiceDefaultMethodsTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.maintainer.client.ai;
+
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.model.prompt.PromptMetaInfo;
+import com.alibaba.nacos.api.ai.model.prompt.PromptMetaSummary;
+
+import com.alibaba.nacos.api.ai.model.prompt.PromptVersionSummary;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.maintainer.client.model.HttpRequest;
+import com.alibaba.nacos.maintainer.client.remote.ClientHttpProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for PromptMaintainerService interface default methods.
+ * Tests the convenience methods that provide simplified parameter signatures.
+ *
+ * @author nacos
+ */
+@ExtendWith(MockitoExtension.class)
+class PromptMaintainerServiceDefaultMethodsTest {
+
+    @Mock
+    private ClientHttpProxy clientHttpProxy;
+
+    private PromptMaintainerService promptService;
+
+    @BeforeEach
+    void setUp() throws NacosException, NoSuchFieldException, IllegalAccessException {
+        Properties properties = new Properties();
+        properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1:8848");
+        AiMaintainerService aiMaintainerService = AiMaintainerFactory.createAiMaintainerService(properties);
+
+        Field promptServiceField = NacosAiMaintainerServiceImpl.class.getDeclaredField("promptMaintainerService");
+        promptServiceField.setAccessible(true);
+        promptService = (PromptMaintainerService) promptServiceField.get(aiMaintainerService);
+
+        injectMockClientHttpProxy(promptService);
+    }
+
+    private void injectMockClientHttpProxy(Object service) throws NoSuchFieldException, IllegalAccessException {
+        Field contextField = AbstractAiDelegateMaintainerService.class.getDeclaredField("context");
+        contextField.setAccessible(true);
+        Object context = contextField.get(service);
+        Field clientHttpProxyField = AiMaintainerHttpContext.class.getDeclaredField("clientHttpProxy");
+        clientHttpProxyField.setAccessible(true);
+        clientHttpProxyField.set(context, clientHttpProxy);
+    }
+
+    // ========== listPrompts default method tests ==========
+
+    @Test
+    @DisplayName("listPrompts(promptKey, pageNo, pageSize) should use default namespace and blur search")
+    void testListPromptsWithDefaults() throws NacosException {
+        Page<PromptMetaSummary> page = new Page<>();
+        page.setTotalCount(1);
+        page.setPageItems(Collections.singletonList(new PromptMetaSummary()));
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<PromptMetaSummary> result = promptService.listPrompts("testPrompt", 1, 10);
+        assertNotNull(result);
+        assertEquals(1, result.getTotalCount());
+    }
+
+    // ========== deletePrompt default method tests ==========
+
+    @Test
+    @DisplayName("deletePrompt(promptKey) should use default namespace")
+    void testDeletePromptWithDefaultNamespace() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(true)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(promptService.deletePrompt("testPrompt"));
+    }
+
+    // ========== listPromptVersions default method tests ==========
+
+    @Test
+    @DisplayName("listPromptVersions(promptKey, pageNo, pageSize) should use default namespace")
+    void testListPromptVersionsWithDefaultNamespace() throws NacosException {
+        Page<PromptVersionSummary> page = new Page<>();
+        page.setTotalCount(1);
+        page.setPageItems(Collections.singletonList(new PromptVersionSummary()));
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<PromptVersionSummary> result = promptService.listPromptVersions("testPrompt", 1, 10);
+        assertNotNull(result);
+        assertEquals(1, result.getTotalCount());
+    }
+
+    // ========== getPromptMeta default method tests (deprecated) ==========
+
+    @Test
+    @DisplayName("getPromptMeta(promptKey) should use default namespace")
+    void testGetPromptMetaWithDefaultNamespace() throws NacosException {
+        PromptMetaInfo meta = new PromptMetaInfo();
+        meta.setPromptKey("testPrompt");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(meta)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        PromptMetaInfo result = promptService.getPromptMeta("testPrompt");
+        assertNotNull(result);
+        assertEquals("testPrompt", result.getPromptKey());
+    }
+
+    // ========== publishPrompt default method tests (deprecated) ==========
+
+    @Test
+    @DisplayName("publishPrompt(promptKey, version, template, commitMsg) should use default namespace")
+    void testPublishPromptWithDefaults() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(true)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(promptService.publishPrompt("testPrompt", "v1", "template content", "commit message"));
+    }
+
+    @Test
+    @DisplayName("publishPrompt(namespaceId, promptKey, version, template, commitMsg, description) should work")
+    void testPublishPromptWithoutBizTags() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(true)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(promptService.publishPrompt("public", "testPrompt", "v1", "template", "commit", "description"));
+    }
+
+    @Test
+    @DisplayName("publishPrompt with variables should delegate to non-variables version")
+    void testPublishPromptWithVariables() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(true)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(promptService.publishPrompt("public", "testPrompt", "v1", "template", "commit", "desc", null, "{}"));
+    }
+
+    // ========== updatePromptMetadata default method tests (deprecated) ==========
+
+    @Test
+    @DisplayName("updatePromptMetadata(namespaceId, promptKey, description) should work")
+    void testUpdatePromptMetadataWithoutBizTags() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(true)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        assertTrue(promptService.updatePromptMetadata("public", "testPrompt", "new description"));
+    }
+}

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerServiceDefaultMethodsTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerServiceDefaultMethodsTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.maintainer.client.ai;
+
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.model.skills.Skill;
+import com.alibaba.nacos.api.ai.model.skills.SkillMeta;
+import com.alibaba.nacos.api.ai.model.skills.SkillSummary;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.maintainer.client.model.HttpRequest;
+import com.alibaba.nacos.maintainer.client.remote.ClientHttpProxy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for SkillMaintainerService interface default methods.
+ * Tests the convenience methods that provide simplified parameter signatures.
+ *
+ * @author nacos
+ */
+@ExtendWith(MockitoExtension.class)
+class SkillMaintainerServiceDefaultMethodsTest {
+
+    @Mock
+    private ClientHttpProxy clientHttpProxy;
+
+    private SkillMaintainerService skillService;
+
+    @BeforeEach
+    void setUp() throws NacosException, NoSuchFieldException, IllegalAccessException {
+        Properties properties = new Properties();
+        properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1:8848");
+        AiMaintainerService aiMaintainerService = AiMaintainerFactory.createAiMaintainerService(properties);
+
+        Field skillServiceField = NacosAiMaintainerServiceImpl.class.getDeclaredField("skillMaintainerService");
+        skillServiceField.setAccessible(true);
+        skillService = (SkillMaintainerService) skillServiceField.get(aiMaintainerService);
+
+        injectMockClientHttpProxy(skillService);
+    }
+
+    private void injectMockClientHttpProxy(Object service) throws NoSuchFieldException, IllegalAccessException {
+        Field contextField = AbstractAiDelegateMaintainerService.class.getDeclaredField("context");
+        contextField.setAccessible(true);
+        Object context = contextField.get(service);
+        Field clientHttpProxyField = AiMaintainerHttpContext.class.getDeclaredField("clientHttpProxy");
+        clientHttpProxyField.setAccessible(true);
+        clientHttpProxyField.set(context, clientHttpProxy);
+    }
+
+    // ========== getSkillMeta default method tests ==========
+
+    @Test
+    @DisplayName("getSkillMeta(skillName) should use default namespace")
+    void testGetSkillMetaWithDefaultNamespace() throws NacosException {
+        SkillMeta meta = new SkillMeta();
+        meta.setEditingVersion("v1");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(meta)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        SkillMeta result = skillService.getSkillMeta("testSkill");
+        assertNotNull(result);
+        assertEquals("v1", result.getEditingVersion());
+    }
+
+    // ========== getSkillVersionDetail default method tests ==========
+
+    @Test
+    @DisplayName("getSkillVersionDetail(skillName, version) should use default namespace")
+    void testGetSkillVersionDetailWithDefaultNamespace() throws NacosException {
+        Skill skill = new Skill();
+        skill.setName("testSkill");
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(skill)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Skill result = skillService.getSkillVersionDetail("testSkill", "v1");
+        assertNotNull(result);
+        assertEquals("testSkill", result.getName());
+    }
+
+    // ========== deleteSkill default method tests ==========
+
+    @Test
+    @DisplayName("deleteSkill(skillName) should use default namespace")
+    void testDeleteSkillWithDefaultNamespace() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("ok")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        boolean result = skillService.deleteSkill("testSkill");
+        assertTrue(result);
+    }
+
+    // ========== listSkills default method tests ==========
+
+    @Test
+    @DisplayName("listSkills(skillName, pageNo, pageSize) should use default namespace and blur search")
+    void testListSkillsWithDefaults() throws NacosException {
+        Page<SkillSummary> page = new Page<>();
+        page.setTotalCount(1);
+        page.setPageItems(Collections.singletonList(new SkillSummary()));
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<SkillSummary> result = skillService.listSkills("testSkill", 1, 10);
+        assertNotNull(result);
+        assertEquals(1, result.getTotalCount());
+    }
+
+    @Test
+    @DisplayName("listSkills with orderBy/owner/scope should delegate to base version")
+    void testListSkillsWithFilters() throws NacosException {
+        Page<SkillSummary> page = new Page<>();
+        page.setTotalCount(0);
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<SkillSummary> result = skillService.listSkills("public", "test", "blur", "download_count", "alice", "PUBLIC", 1, 10);
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("listSkills with bizTag should delegate to base version")
+    void testListSkillsWithBizTag() throws NacosException {
+        Page<SkillSummary> page = new Page<>();
+        page.setTotalCount(0);
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success(page)));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        Page<SkillSummary> result = skillService.listSkills("public", "test", "blur", null, null, null, "retail", 1, 10);
+        assertNotNull(result);
+    }
+
+    // ========== uploadSkillFromZip default method tests ==========
+
+    @Test
+    @DisplayName("uploadSkillFromZip(zipBytes) should use default namespace and not overwrite")
+    void testUploadSkillFromZipWithDefaults() throws NacosException {
+        byte[] zipBytes = "test zip content".getBytes();
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("uploadedSkill")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        String result = skillService.uploadSkillFromZip(zipBytes);
+        assertEquals("uploadedSkill", result);
+    }
+
+    @Test
+    @DisplayName("uploadSkillFromZip(namespaceId, zipBytes) should not overwrite")
+    void testUploadSkillFromZipWithNamespace() throws NacosException {
+        byte[] zipBytes = "test zip content".getBytes();
+
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("uploadedSkill")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        String result = skillService.uploadSkillFromZip("public", zipBytes);
+        assertEquals("uploadedSkill", result);
+    }
+
+    // ========== createDraft default method tests ==========
+
+    @Test
+    @DisplayName("createDraft(namespaceId, skillCard) should create new skill")
+    void testCreateDraftWithSkillCard() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("v1")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        String result = skillService.createDraft("public", "{}");
+        assertEquals("v1", result);
+    }
+
+    @Test
+    @DisplayName("createDraft(namespaceId, skillName, basedOnVersion) should fork")
+    void testCreateDraftFork() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("v2")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        String result = skillService.createDraft("public", "testSkill", "v1");
+        assertEquals("v2", result);
+    }
+
+    @Test
+    @DisplayName("createDraft(namespaceId, skillName, basedOnVersion, targetVersion) should fork with target")
+    void testCreateDraftForkWithTarget() throws NacosException {
+        HttpRestResult<String> mockResult = new HttpRestResult<>();
+        mockResult.setData(JacksonUtils.toJson(Result.success("v2")));
+        when(clientHttpProxy.executeSyncHttpRequest(any(HttpRequest.class))).thenReturn(mockResult);
+
+        String result = skillService.createDraft("public", "testSkill", "v1", "v2");
+        assertEquals("v2", result);
+    }
+}


### PR DESCRIPTION
- Add AiMaintainerServiceDefaultMethodsTest (13 tests)
- Add A2aMaintainerServiceDefaultMethodsTest (16 tests)
- Add AgentSpecMaintainerServiceDefaultMethodsTest (7 tests)
- Add SkillMaintainerServiceDefaultMethodsTest (11 tests)
- Add PromptMaintainerServiceDefaultMethodsTest (8 tests)

Coverage improved from 91.58% to 98% for maintainer-client AI package. All 291 tests pass.

Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

XXXXX

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

