### PR TITLE
feat(ai): Support multi-namespace prompt migration and legacy data cleanup

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/config/LegacyPromptData.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/LegacyPromptData.java
@@ -29,6 +29,8 @@ import java.util.Map;
  */
 public class LegacyPromptData {
     
+    private String namespaceId;
+    
     private String promptKey;
     
     private String description;
@@ -40,6 +42,14 @@ public class LegacyPromptData {
     private String latestVersion;
     
     private List<String> versions;
+    
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+    
+    public void setNamespaceId(String namespaceId) {
+        this.namespaceId = namespaceId;
+    }
     
     public String getPromptKey() {
         return promptKey;

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/NacosPromptLegacyDataReader.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/NacosPromptLegacyDataReader.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.utils.PromptDataIdUtils;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
 import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.response.Namespace;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.model.ConfigAllInfo;
@@ -27,7 +28,9 @@ import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
 import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
+import com.alibaba.nacos.core.service.NamespaceOperationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -55,16 +58,22 @@ public class NacosPromptLegacyDataReader implements PromptLegacyDataReader {
     
     private static final String PROMPT_GROUP = Constants.Prompt.PROMPT_GROUP;
     
-    private static final String DEFAULT_NAMESPACE = com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
-    
     private final ConfigInfoPersistService configInfoPersistService;
     
     private final ConfigQueryChainService configQueryChainService;
     
+    private final ConfigOperationService configOperationService;
+    
+    private final NamespaceOperationService namespaceOperationService;
+    
     public NacosPromptLegacyDataReader(ConfigInfoPersistService configInfoPersistService,
-            ConfigQueryChainService configQueryChainService) {
+            ConfigQueryChainService configQueryChainService,
+            ConfigOperationService configOperationService,
+            NamespaceOperationService namespaceOperationService) {
         this.configInfoPersistService = configInfoPersistService;
         this.configQueryChainService = configQueryChainService;
+        this.configOperationService = configOperationService;
+        this.namespaceOperationService = namespaceOperationService;
     }
     
     @Override
@@ -74,22 +83,25 @@ public class NacosPromptLegacyDataReader implements PromptLegacyDataReader {
     
     @Override
     public List<LegacyPromptData> scanLegacyPrompts() {
-        List<String> promptKeys = scanPromptKeys();
+        List<String> namespaceIds = getAllNamespaceIds();
         List<LegacyPromptData> result = new ArrayList<>();
-        for (String promptKey : promptKeys) {
-            LegacyPromptData data = buildLegacyPromptData(promptKey);
-            if (data != null) {
-                result.add(data);
+        for (String namespaceId : namespaceIds) {
+            List<String> promptKeys = scanPromptKeys(namespaceId);
+            for (String promptKey : promptKeys) {
+                LegacyPromptData data = buildLegacyPromptData(namespaceId, promptKey);
+                if (data != null) {
+                    result.add(data);
+                }
             }
         }
         return result;
     }
     
     @Override
-    public PromptVersionInfo readVersionContent(String promptKey, String version) {
+    public PromptVersionInfo readVersionContent(String namespaceId, String promptKey, String version) {
         String versionDataId = PromptDataIdUtils.buildVersionDataId(promptKey, version);
         ConfigAllInfo configAllInfo = configInfoPersistService.findConfigAllInfo(versionDataId, PROMPT_GROUP,
-                DEFAULT_NAMESPACE);
+                namespaceId);
         if (configAllInfo == null || StringUtils.isBlank(configAllInfo.getContent())) {
             return null;
         }
@@ -113,12 +125,26 @@ public class NacosPromptLegacyDataReader implements PromptLegacyDataReader {
         return info;
     }
     
-    private List<String> scanPromptKeys() {
+    private List<String> getAllNamespaceIds() {
+        List<String> ids = new ArrayList<>();
+        try {
+            List<Namespace> namespaces = namespaceOperationService.getNamespaceList();
+            for (Namespace ns : namespaces) {
+                ids.add(ns.getNamespace());
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to list namespaces, fallback to default only: {}", e.getMessage());
+            ids.add(com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID);
+        }
+        return ids;
+    }
+    
+    private List<String> scanPromptKeys(String namespaceId) {
         List<String> promptKeys = new ArrayList<>();
         int pageNo = 1;
         while (true) {
             Page<ConfigInfo> page = configInfoPersistService.findConfigInfo4Page(pageNo, SCAN_PAGE_SIZE, null,
-                    PROMPT_GROUP, DEFAULT_NAMESPACE, null);
+                    PROMPT_GROUP, namespaceId, null);
             if (page == null || page.getPageItems() == null || page.getPageItems().isEmpty()) {
                 break;
             }
@@ -138,18 +164,19 @@ public class NacosPromptLegacyDataReader implements PromptLegacyDataReader {
         return promptKeys;
     }
     
-    private LegacyPromptData buildLegacyPromptData(String promptKey) {
-        LegacyDescriptor descriptor = readConfigJson(
+    private LegacyPromptData buildLegacyPromptData(String namespaceId, String promptKey) {
+        LegacyDescriptor descriptor = readConfigJson(namespaceId,
                 PromptDataIdUtils.buildDescriptorDataId(promptKey), LegacyDescriptor.class);
-        LegacyLabelVersionMapping mapping = readConfigJson(
+        LegacyLabelVersionMapping mapping = readConfigJson(namespaceId,
                 PromptDataIdUtils.buildLabelVersionMappingDataId(promptKey), LegacyLabelVersionMapping.class);
         
         if (mapping == null || mapping.versions == null || mapping.versions.isEmpty()) {
-            LOGGER.warn("Prompt '{}' has no versions in mapping, skip", promptKey);
+            LOGGER.warn("Prompt '{}' in namespace '{}' has no versions in mapping, skip", promptKey, namespaceId);
             return null;
         }
         
         LegacyPromptData data = new LegacyPromptData();
+        data.setNamespaceId(namespaceId);
         data.setPromptKey(promptKey);
         data.setDescription(descriptor != null ? descriptor.description : null);
         data.setBizTags(descriptor != null ? descriptor.bizTags : null);
@@ -159,8 +186,8 @@ public class NacosPromptLegacyDataReader implements PromptLegacyDataReader {
         return data;
     }
     
-    private <T> T readConfigJson(String dataId, Class<T> clazz) {
-        String content = readConfigContent(dataId);
+    private <T> T readConfigJson(String namespaceId, String dataId, Class<T> clazz) {
+        String content = readConfigContent(namespaceId, dataId);
         if (StringUtils.isBlank(content)) {
             return null;
         }
@@ -172,10 +199,10 @@ public class NacosPromptLegacyDataReader implements PromptLegacyDataReader {
         }
     }
     
-    private String readConfigContent(String dataId) {
+    private String readConfigContent(String namespaceId, String dataId) {
         try {
             ConfigQueryChainRequest request = ConfigQueryChainRequest.buildConfigQueryChainRequest(dataId,
-                    PROMPT_GROUP, DEFAULT_NAMESPACE);
+                    PROMPT_GROUP, namespaceId);
             ConfigQueryChainResponse response = configQueryChainService.handle(request);
             if (response.getStatus() == ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND) {
                 return null;
@@ -184,6 +211,26 @@ public class NacosPromptLegacyDataReader implements PromptLegacyDataReader {
         } catch (Exception e) {
             LOGGER.warn("Failed to read config '{}': {}", dataId, e.getMessage());
             return null;
+        }
+    }
+    
+    @Override
+    public void cleanupLegacyData(String namespaceId, String promptKey, List<String> versions) {
+        deleteConfigSilently(namespaceId, PromptDataIdUtils.buildDescriptorDataId(promptKey));
+        deleteConfigSilently(namespaceId, PromptDataIdUtils.buildLabelVersionMappingDataId(promptKey));
+        if (versions != null) {
+            for (String version : versions) {
+                deleteConfigSilently(namespaceId, PromptDataIdUtils.buildVersionDataId(promptKey, version));
+            }
+        }
+        LOGGER.info("Cleaned up legacy config for prompt '{}' in namespace '{}'", promptKey, namespaceId);
+    }
+    
+    private void deleteConfigSilently(String namespaceId, String dataId) {
+        try {
+            configOperationService.deleteConfig(dataId, PROMPT_GROUP, namespaceId, null, null, "nacos", null);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to cleanup legacy config '{}': {}", dataId, e.getMessage());
         }
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
@@ -49,8 +49,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -189,7 +191,8 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
                     migrated++;
                 } catch (Exception e) {
                     failed++;
-                    LOGGER.error("Failed to migrate prompt '{}': {}", prompt.getPromptKey(), e.getMessage(), e);
+                    LOGGER.error("Failed to migrate prompt '{}' in namespace '{}': {}", prompt.getPromptKey(),
+                            prompt.getNamespaceId(), e.getMessage(), e);
                 }
             }
             
@@ -205,39 +208,58 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
     }
     
     private List<LegacyPromptData> filterNeedsMigration(List<LegacyPromptData> allPrompts) {
-        String namespace = com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
         List<LegacyPromptData> result = new ArrayList<>();
         for (LegacyPromptData prompt : allPrompts) {
+            String namespace = prompt.getNamespaceId();
             AiResource existing = aiResourcePersistService.find(namespace, prompt.getPromptKey(), RESOURCE_TYPE_PROMPT);
             if (existing == null) {
                 result.add(prompt);
                 continue;
             }
-            if (prompt.getVersions() != null) {
-                for (String version : prompt.getVersions()) {
-                    AiResourceVersion versionRow = aiResourceVersionPersistService.find(namespace,
-                            prompt.getPromptKey(), RESOURCE_TYPE_PROMPT, version);
-                    if (versionRow == null) {
-                        result.add(prompt);
-                        break;
-                    }
+            if (prompt.getVersions() != null && !prompt.getVersions().isEmpty()) {
+                if (hasUnmigratedVersions(namespace, prompt.getPromptKey(), prompt.getVersions())) {
+                    result.add(prompt);
                 }
             }
         }
         return result;
     }
     
+    private boolean hasUnmigratedVersions(String namespace, String promptKey, List<String> legacyVersions) {
+        Set<String> migratedVersions = new HashSet<>();
+        int pageNo = 1;
+        int pageSize = legacyVersions.size() + 10;
+        com.alibaba.nacos.api.model.Page<AiResourceVersion> page = aiResourceVersionPersistService.list(
+                namespace, promptKey, RESOURCE_TYPE_PROMPT, null, pageNo, pageSize);
+        if (page != null && page.getPageItems() != null) {
+            for (AiResourceVersion v : page.getPageItems()) {
+                migratedVersions.add(v.getVersion());
+            }
+        }
+        for (String version : legacyVersions) {
+            if (!migratedVersions.contains(version)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
     private void migrateOnePrompt(LegacyPromptData prompt, PromptLegacyDataReader reader) throws Exception {
-        String namespace = com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
+        String namespace = prompt.getNamespaceId();
         String promptKey = prompt.getPromptKey();
         
         if (prompt.getVersions() == null || prompt.getVersions().isEmpty()) {
-            LOGGER.warn("Prompt '{}' has no versions, skip migration", promptKey);
+            LOGGER.warn("Prompt '{}' in namespace '{}' has no versions, skip migration", promptKey, namespace);
             return;
         }
         
+        Map<String, String> labels = prompt.getLabels() != null ? new HashMap<>(prompt.getLabels()) : new HashMap<>();
+        if (StringUtils.isNotBlank(prompt.getLatestVersion()) && !labels.containsKey("latest")) {
+            labels.put("latest", prompt.getLatestVersion());
+        }
+        
         Map<String, Object> versionInfoMap = new HashMap<>(8);
-        versionInfoMap.put("labels", prompt.getLabels() != null ? prompt.getLabels() : new HashMap<>());
+        versionInfoMap.put("labels", labels);
         versionInfoMap.put("editingVersion", null);
         versionInfoMap.put("reviewingVersion", null);
         versionInfoMap.put("onlineCnt", prompt.getVersions().size());
@@ -254,11 +276,12 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
         
         try {
             aiResourcePersistService.insert(resource);
-            LOGGER.info("Migrated prompt '{}' resource record to DB", promptKey);
+            LOGGER.info("Migrated prompt '{}' in namespace '{}' resource record to DB", promptKey, namespace);
         } catch (Exception e) {
             AiResource existing = aiResourcePersistService.find(namespace, promptKey, RESOURCE_TYPE_PROMPT);
             if (existing != null) {
-                LOGGER.info("Prompt '{}' resource record already exists, continue with version migration", promptKey);
+                LOGGER.info("Prompt '{}' in namespace '{}' resource record already exists, continue with version migration",
+                        promptKey, namespace);
             } else {
                 throw e;
             }
@@ -281,13 +304,32 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
             LOGGER.warn("Failed to refresh legacy mirror for prompt '{}': {}", promptKey, e.getMessage());
         }
         
-        LOGGER.info("Migrated prompt '{}': {}/{} versions", promptKey, versionsMigrated,
-                prompt.getVersions().size());
+        LOGGER.info("Migrated prompt '{}' in namespace '{}': {}/{} versions", promptKey, namespace,
+                versionsMigrated, prompt.getVersions().size());
+    }
+    
+    /**
+     * Clean up legacy storage entries for a prompt. Should be called when a prompt is deleted
+     * in the new system to prevent the migration task from re-importing it on next restart.
+     *
+     * <p>Delegates to the active {@link PromptLegacyDataReader} implementation, which knows
+     * the specific legacy storage format and location.</p>
+     *
+     * @param namespaceId namespace ID
+     * @param promptKey   prompt key
+     * @param versions    version strings to clean up
+     */
+    public void cleanupLegacyConfig(String namespaceId, String promptKey, List<String> versions) {
+        PromptLegacyDataReader reader = resolveLegacyDataReader();
+        if (reader == null) {
+            return;
+        }
+        reader.cleanupLegacyData(namespaceId, promptKey, versions);
     }
     
     private void migrateOneVersion(String namespace, String promptKey, String version,
             PromptLegacyDataReader reader) throws Exception {
-        PromptVersionInfo versionInfo = reader.readVersionContent(promptKey, version);
+        PromptVersionInfo versionInfo = reader.readVersionContent(namespace, promptKey, version);
         if (versionInfo == null) {
             LOGGER.warn("No content found for prompt '{}' version '{}', skip", promptKey, version);
             return;

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
@@ -109,7 +110,7 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
     
     public PromptDataMigrationTask(AiResourcePersistService aiResourcePersistService,
             AiResourceVersionPersistService aiResourceVersionPersistService,
-            PromptOperationService promptOperationService,
+            @Lazy PromptOperationService promptOperationService,
             ConfigQueryChainService configQueryChainService, ConfigOperationService configOperationService,
             List<PromptLegacyDataReader> legacyDataReaders) {
         this.aiResourcePersistService = aiResourcePersistService;

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/PromptLegacyDataReader.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/PromptLegacyDataReader.java
@@ -55,9 +55,23 @@ public interface PromptLegacyDataReader {
     /**
      * Read the content of a specific prompt version from legacy storage.
      *
-     * @param promptKey prompt key
-     * @param version   version string
+     * @param namespaceId namespace ID
+     * @param promptKey   prompt key
+     * @param version     version string
      * @return version info with template/variables/srcUser/commitMsg, or null if not found
      */
-    PromptVersionInfo readVersionContent(String promptKey, String version);
+    PromptVersionInfo readVersionContent(String namespaceId, String promptKey, String version);
+    
+    /**
+     * Clean up legacy storage entries for a prompt after it has been deleted in the new system.
+     * This prevents the migration task from re-importing deleted prompts on next restart.
+     *
+     * <p>Default implementation is no-op for backward compatibility with existing implementations.</p>
+     *
+     * @param namespaceId namespace ID
+     * @param promptKey   prompt key
+     * @param versions    version strings to clean up
+     */
+    default void cleanupLegacyData(String namespaceId, String promptKey, List<String> versions) {
+    }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.ai.service.prompt;
 
+import com.alibaba.nacos.ai.config.PromptDataMigrationTask;
 import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.model.AiResourceVersion;
@@ -110,15 +111,19 @@ public class PromptOperationServiceImpl implements PromptOperationService {
     
     private final AiResourceManager resourceManager;
     
+    private final PromptDataMigrationTask promptDataMigrationTask;
+    
     public PromptOperationServiceImpl(PublishPipelineExecutor publishPipelineExecutor,
             PipelineExecutionRepository pipelineExecutionRepository,
             ConfigOperationService configOperationService,
-            AiResourceManager resourceManager) {
+            AiResourceManager resourceManager,
+            PromptDataMigrationTask promptDataMigrationTask) {
         this.storageRouter = AiResourceStorageRouter.getInstance();
         this.publishPipelineExecutor = publishPipelineExecutor;
         this.pipelineExecutionRepository = pipelineExecutionRepository;
         this.configOperationService = configOperationService;
         this.resourceManager = resourceManager;
+        this.promptDataMigrationTask = promptDataMigrationTask;
     }
     
     // ========== Admin APIs ==========
@@ -583,6 +588,15 @@ public class PromptOperationServiceImpl implements PromptOperationService {
         
         // Delete legacy latest mirror in nacos-ai-prompt group
         deleteLegacyLatestMirror(namespaceId, promptKey);
+        
+        // Clean up legacy Config entries (descriptor, mapping, version configs) to prevent re-migration
+        List<String> versionStrings = new ArrayList<>();
+        for (AiResourceVersion v : allVersions) {
+            if (v != null) {
+                versionStrings.add(v.getVersion());
+            }
+        }
+        promptDataMigrationTask.cleanupLegacyConfig(namespaceId, promptKey, versionStrings);
         
         // Delete DB rows
         resourceManager.deleteVersionsByNameAndType(namespaceId, promptKey, RESOURCE_TYPE_PROMPT);

--- a/ai/src/test/java/com/alibaba/nacos/ai/config/PromptDataMigrationTaskTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/config/PromptDataMigrationTaskTest.java
@@ -26,6 +26,7 @@ import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
 import com.alibaba.nacos.ai.utils.PromptDataIdUtils;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
 import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.response.Namespace;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
 import com.alibaba.nacos.config.server.model.ConfigAllInfo;
@@ -34,6 +35,7 @@ import com.alibaba.nacos.config.server.service.ConfigOperationService;
 import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
 import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
+import com.alibaba.nacos.core.service.NamespaceOperationService;
 import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
 import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
@@ -55,13 +57,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -104,6 +113,9 @@ class PromptDataMigrationTaskTest {
     @Mock
     private AiResourceStorage storage;
     
+    @Mock
+    private NamespaceOperationService namespaceOperationService;
+    
     private PromptDataMigrationTask task;
     
     private NacosPromptLegacyDataReader nacosReader;
@@ -117,7 +129,11 @@ class PromptDataMigrationTaskTest {
         AiResourceStorageRouter.reset();
         lenient().when(storage.type()).thenReturn("nacos_config");
         AiResourceStorageRouter.join(storage);
-        nacosReader = new NacosPromptLegacyDataReader(configInfoPersistService, configQueryChainService);
+        Namespace defaultNs = new Namespace(NS, "public");
+        lenient().when(namespaceOperationService.getNamespaceList())
+                .thenReturn(Collections.singletonList(defaultNs));
+        nacosReader = new NacosPromptLegacyDataReader(configInfoPersistService, configQueryChainService,
+                configOperationService, namespaceOperationService);
         List<PromptLegacyDataReader> readers = Collections.singletonList(nacosReader);
         task = new PromptDataMigrationTask(aiResourcePersistService, aiResourceVersionPersistService,
                 promptOperationService, configQueryChainService, configOperationService, readers);
@@ -127,6 +143,7 @@ class PromptDataMigrationTaskTest {
     void tearDown() {
         EnvUtil.setEnvironment(CACHED_ENVIRONMENT);
         System.clearProperty("nacos.ai.prompt.migration.enabled");
+        System.clearProperty("nacos.ai.prompt.migration.provider");
     }
     
     // ========== onApplicationEvent guard conditions ==========
@@ -148,6 +165,8 @@ class PromptDataMigrationTaskTest {
     void testShouldSkipWhenDisabled() {
         System.setProperty("nacos.ai.prompt.migration.enabled", "false");
         EnvUtil.setEnvironment(new StandardEnvironment());
+        nacosReader = new NacosPromptLegacyDataReader(configInfoPersistService, configQueryChainService,
+                configOperationService, namespaceOperationService);
         List<PromptLegacyDataReader> readers = Collections.singletonList(nacosReader);
         task = new PromptDataMigrationTask(aiResourcePersistService, aiResourceVersionPersistService,
                 promptOperationService, configQueryChainService, configOperationService, readers);
@@ -178,7 +197,7 @@ class PromptDataMigrationTaskTest {
         // ai_resource record exists
         when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT))
                 .thenReturn(new AiResource());
-        // All versions also exist in DB
+        // All versions also exist in DB — mock list() which is used by hasUnmigratedVersions
         LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
         mapping.promptKey = PROMPT_KEY;
         mapping.versions = Collections.singletonList("0.0.1");
@@ -186,10 +205,12 @@ class PromptDataMigrationTaskTest {
         mappingResp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
         mappingResp.setContent(JacksonUtils.toJson(mapping));
         when(configQueryChainService.handle(any())).thenReturn(mappingResp);
+        Page<AiResourceVersion> versionPage = new Page<>();
         AiResourceVersion existingVersion = new AiResourceVersion();
         existingVersion.setVersion("0.0.1");
-        when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT, "0.0.1"))
-                .thenReturn(existingVersion);
+        versionPage.setPageItems(Collections.singletonList(existingVersion));
+        when(aiResourceVersionPersistService.list(eq(NS), eq(PROMPT_KEY), eq(RESOURCE_TYPE_PROMPT),
+                any(), anyInt(), anyInt())).thenReturn(versionPage);
         
         task.onApplicationEvent(createRootContextEvent());
         
@@ -438,6 +459,522 @@ class PromptDataMigrationTaskTest {
         
         // Should not insert anything when mapping has no versions
         verify(aiResourcePersistService, after(ASYNC_TIMEOUT).never()).insert(any(AiResource.class));
+    }
+    
+    // ========== Multi-namespace tests ==========
+    
+    @Test
+    void testShouldMigratePromptsFromMultipleNamespaces() throws Exception {
+        String ns2 = "dev-namespace";
+        
+        // Two namespaces
+        Namespace defaultNs = new Namespace(NS, "public");
+        Namespace devNs = new Namespace(ns2, "dev");
+        when(namespaceOperationService.getNamespaceList()).thenReturn(Arrays.asList(defaultNs, devNs));
+        nacosReader = new NacosPromptLegacyDataReader(configInfoPersistService, configQueryChainService,
+                configOperationService, namespaceOperationService);
+        task = new PromptDataMigrationTask(aiResourcePersistService, aiResourceVersionPersistService,
+                promptOperationService, configQueryChainService, configOperationService,
+                Collections.singletonList(nacosReader));
+        
+        // Scan: one prompt in each namespace
+        String prompt2 = "dev-prompt";
+        Page<ConfigInfo> scanPageNs1 = buildScanPage(PROMPT_KEY);
+        Page<ConfigInfo> scanPageNs2 = buildScanPage(prompt2);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPageNs1);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(ns2), any()))
+                .thenReturn(scanPageNs2);
+        
+        // Neither migrated yet
+        when(aiResourcePersistService.find(eq(NS), eq(PROMPT_KEY), eq(RESOURCE_TYPE_PROMPT))).thenReturn(null);
+        when(aiResourcePersistService.find(eq(ns2), eq(prompt2), eq(RESOURCE_TYPE_PROMPT))).thenReturn(null);
+        
+        // Version not in DB
+        when(aiResourceVersionPersistService.find(eq(NS), eq(PROMPT_KEY), eq(RESOURCE_TYPE_PROMPT), eq("0.0.1")))
+                .thenReturn(null);
+        when(aiResourceVersionPersistService.find(eq(ns2), eq(prompt2), eq(RESOURCE_TYPE_PROMPT), eq("0.0.1")))
+                .thenReturn(null);
+        
+        // Config reads
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req = invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                LegacyDescriptor desc = new LegacyDescriptor();
+                desc.description = "desc";
+                resp.setContent(JacksonUtils.toJson(desc));
+            } else if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+                mapping.versions = Collections.singletonList("0.0.1");
+                mapping.latestVersion = "0.0.1";
+                resp.setContent(JacksonUtils.toJson(mapping));
+            } else {
+                resp.setContent("{}");
+            }
+            return resp;
+        });
+        
+        // readVersionContent
+        PromptVersionInfo versionContent = new PromptVersionInfo();
+        versionContent.setTemplate("Hello");
+        ConfigAllInfo versionConfigAllInfo = new ConfigAllInfo();
+        versionConfigAllInfo.setContent(JacksonUtils.toJson(versionContent));
+        when(configInfoPersistService.findConfigAllInfo(any(), eq(PROMPT_GROUP), any()))
+                .thenReturn(versionConfigAllInfo);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // Both prompts should be migrated: 2 meta inserts
+        verify(aiResourcePersistService, timeout(ASYNC_TIMEOUT).times(2)).insert(any(AiResource.class));
+        // 2 version inserts
+        verify(aiResourceVersionPersistService, timeout(ASYNC_TIMEOUT).times(2)).insert(any(AiResourceVersion.class));
+    }
+    
+    @Test
+    void testShouldFallbackToDefaultNamespaceWhenNamespaceListFails() throws Exception {
+        // Namespace service throws exception
+        when(namespaceOperationService.getNamespaceList()).thenThrow(new RuntimeException("connection refused"));
+        nacosReader = new NacosPromptLegacyDataReader(configInfoPersistService, configQueryChainService,
+                configOperationService, namespaceOperationService);
+        task = new PromptDataMigrationTask(aiResourcePersistService, aiResourceVersionPersistService,
+                promptOperationService, configQueryChainService, configOperationService,
+                Collections.singletonList(nacosReader));
+        
+        // Default namespace has a prompt
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP),
+                eq(com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID), any())).thenReturn(scanPage);
+        
+        // Not yet migrated
+        when(aiResourcePersistService.find(eq(com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID),
+                eq(PROMPT_KEY), eq(RESOURCE_TYPE_PROMPT))).thenReturn(null);
+        when(aiResourceVersionPersistService.find(
+                eq(com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID),
+                eq(PROMPT_KEY), eq(RESOURCE_TYPE_PROMPT), eq("0.0.1"))).thenReturn(null);
+        
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req = invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                LegacyDescriptor desc = new LegacyDescriptor();
+                desc.promptKey = PROMPT_KEY;
+                resp.setContent(JacksonUtils.toJson(desc));
+            } else if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+                mapping.versions = Collections.singletonList("0.0.1");
+                mapping.latestVersion = "0.0.1";
+                resp.setContent(JacksonUtils.toJson(mapping));
+            } else {
+                resp.setContent("{}");
+            }
+            return resp;
+        });
+        
+        PromptVersionInfo versionContent = new PromptVersionInfo();
+        versionContent.setTemplate("Hello");
+        ConfigAllInfo versionConfigAllInfo = new ConfigAllInfo();
+        versionConfigAllInfo.setContent(JacksonUtils.toJson(versionContent));
+        when(configInfoPersistService.findConfigAllInfo(any(), eq(PROMPT_GROUP),
+                eq(com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID))).thenReturn(versionConfigAllInfo);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // Should still migrate the default namespace prompt
+        verify(aiResourcePersistService, timeout(ASYNC_TIMEOUT)).insert(any(AiResource.class));
+    }
+    
+    // ========== cleanupLegacyConfig tests ==========
+    
+    @Test
+    void testCleanupLegacyConfigShouldDeleteDescriptorMappingAndVersionConfigs() throws Exception {
+        List<String> versions = Arrays.asList("0.0.1", "0.0.2");
+        
+        nacosReader.cleanupLegacyData(NS, PROMPT_KEY, versions);
+        
+        // descriptor
+        verify(configOperationService).deleteConfig(
+                eq(PromptDataIdUtils.buildDescriptorDataId(PROMPT_KEY)),
+                eq(PROMPT_GROUP), eq(NS), any(), any(), eq("nacos"), any());
+        // label-version-mapping
+        verify(configOperationService).deleteConfig(
+                eq(PromptDataIdUtils.buildLabelVersionMappingDataId(PROMPT_KEY)),
+                eq(PROMPT_GROUP), eq(NS), any(), any(), eq("nacos"), any());
+        // version configs
+        verify(configOperationService).deleteConfig(
+                eq(PromptDataIdUtils.buildVersionDataId(PROMPT_KEY, "0.0.1")),
+                eq(PROMPT_GROUP), eq(NS), any(), any(), eq("nacos"), any());
+        verify(configOperationService).deleteConfig(
+                eq(PromptDataIdUtils.buildVersionDataId(PROMPT_KEY, "0.0.2")),
+                eq(PROMPT_GROUP), eq(NS), any(), any(), eq("nacos"), any());
+        // Total: 2 (descriptor + mapping) + 2 (versions) = 4
+        verify(configOperationService, times(4)).deleteConfig(any(), any(), any(), any(), any(), any(), any());
+    }
+    
+    @Test
+    void testCleanupLegacyConfigShouldHandleNullVersions() throws Exception {
+        nacosReader.cleanupLegacyData(NS, PROMPT_KEY, null);
+        
+        // Only descriptor + mapping deleted, no version deletes
+        verify(configOperationService, times(2)).deleteConfig(any(), any(), any(), any(), any(), any(), any());
+    }
+    
+    @Test
+    void testCleanupLegacyConfigShouldSuppressDeleteExceptions() throws Exception {
+        // First delete throws, second should still proceed
+        when(configOperationService.deleteConfig(
+                eq(PromptDataIdUtils.buildDescriptorDataId(PROMPT_KEY)),
+                eq(PROMPT_GROUP), eq(NS), any(), any(), eq("nacos"), any()))
+                .thenThrow(new RuntimeException("delete failed"));
+        
+        nacosReader.cleanupLegacyData(NS, PROMPT_KEY, Collections.singletonList("0.0.1"));
+        
+        // mapping delete should still be called despite descriptor delete failure
+        verify(configOperationService).deleteConfig(
+                eq(PromptDataIdUtils.buildLabelVersionMappingDataId(PROMPT_KEY)),
+                eq(PROMPT_GROUP), eq(NS), any(), any(), eq("nacos"), any());
+        // version delete should still be called
+        verify(configOperationService).deleteConfig(
+                eq(PromptDataIdUtils.buildVersionDataId(PROMPT_KEY, "0.0.1")),
+                eq(PROMPT_GROUP), eq(NS), any(), any(), eq("nacos"), any());
+    }
+    
+    @Test
+    void testCleanupLegacyConfigViaTaskShouldDelegateToReader() {
+        task.cleanupLegacyConfig(NS, PROMPT_KEY, Arrays.asList("0.0.1"));
+        
+        // Should delegate to nacosReader which calls deleteConfig
+        verify(configOperationService, atLeastOnce()).deleteConfig(any(), any(), any(), any(), any(), any(), any());
+    }
+    
+    @Test
+    void testCleanupLegacyConfigViaTaskShouldNoopWhenNoReaderFound() {
+        // Use a provider type that doesn't match any reader
+        System.setProperty("nacos.ai.prompt.migration.provider", "nonexistent");
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        task = new PromptDataMigrationTask(aiResourcePersistService, aiResourceVersionPersistService,
+                promptOperationService, configQueryChainService, configOperationService,
+                Collections.singletonList(nacosReader));
+        
+        task.cleanupLegacyConfig(NS, PROMPT_KEY, Arrays.asList("0.0.1"));
+        
+        // No deleteConfig calls since reader not found
+        verify(configOperationService, never()).deleteConfig(any(), any(), any(), any(), any(), any(), any());
+    }
+    
+    // ========== hasUnmigratedVersions / filterNeedsMigration edge cases ==========
+    
+    @Test
+    void testShouldDetectPartiallyMigratedPrompt() throws Exception {
+        // Prompt exists in DB but only 1 of 2 versions migrated
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT)).thenReturn(new AiResource());
+        
+        // Legacy has 2 versions
+        LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+        mapping.promptKey = PROMPT_KEY;
+        mapping.versions = Arrays.asList("0.0.1", "0.0.2");
+        mapping.latestVersion = "0.0.2";
+        
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req = invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                LegacyDescriptor desc = new LegacyDescriptor();
+                desc.promptKey = PROMPT_KEY;
+                resp.setContent(JacksonUtils.toJson(desc));
+            } else if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                resp.setContent(JacksonUtils.toJson(mapping));
+            } else {
+                resp.setContent("{}");
+            }
+            return resp;
+        });
+        
+        // Only version 0.0.1 is in DB; 0.0.2 is not
+        Page<AiResourceVersion> versionPage = new Page<>();
+        AiResourceVersion v1 = new AiResourceVersion();
+        v1.setVersion("0.0.1");
+        versionPage.setPageItems(Collections.singletonList(v1));
+        when(aiResourceVersionPersistService.list(eq(NS), eq(PROMPT_KEY), eq(RESOURCE_TYPE_PROMPT),
+                any(), anyInt(), anyInt())).thenReturn(versionPage);
+        
+        // Version 0.0.1 already exists, 0.0.2 does not
+        when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT, "0.0.1"))
+                .thenReturn(v1);
+        when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT, "0.0.2"))
+                .thenReturn(null);
+        
+        // readVersionContent
+        PromptVersionInfo versionContent = new PromptVersionInfo();
+        versionContent.setTemplate("Hello");
+        ConfigAllInfo versionConfigAllInfo = new ConfigAllInfo();
+        versionConfigAllInfo.setContent(JacksonUtils.toJson(versionContent));
+        when(configInfoPersistService.findConfigAllInfo(any(), eq(PROMPT_GROUP), eq(NS)))
+                .thenReturn(versionConfigAllInfo);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // Meta insert will be attempted (may throw duplicate, that's fine — existing check handles it)
+        // At least one version insert should happen (for 0.0.2)
+        verify(aiResourceVersionPersistService, timeout(ASYNC_TIMEOUT).atLeastOnce())
+                .insert(any(AiResourceVersion.class));
+    }
+    
+    @Test
+    void testShouldSkipWhenAllVersionsAlreadyMigratedViaListCheck() throws Exception {
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT)).thenReturn(new AiResource());
+        
+        LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+        mapping.promptKey = PROMPT_KEY;
+        mapping.versions = Arrays.asList("0.0.1", "0.0.2");
+        
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req = invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                LegacyDescriptor desc = new LegacyDescriptor();
+                resp.setContent(JacksonUtils.toJson(desc));
+            } else if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                resp.setContent(JacksonUtils.toJson(mapping));
+            }
+            return resp;
+        });
+        
+        // Both versions already in DB
+        Page<AiResourceVersion> versionPage = new Page<>();
+        AiResourceVersion v1 = new AiResourceVersion();
+        v1.setVersion("0.0.1");
+        AiResourceVersion v2 = new AiResourceVersion();
+        v2.setVersion("0.0.2");
+        versionPage.setPageItems(Arrays.asList(v1, v2));
+        when(aiResourceVersionPersistService.list(eq(NS), eq(PROMPT_KEY), eq(RESOURCE_TYPE_PROMPT),
+                any(), anyInt(), anyInt())).thenReturn(versionPage);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // All migrated — no inserts
+        verify(aiResourcePersistService, after(ASYNC_TIMEOUT).never()).insert(any(AiResource.class));
+    }
+    
+    // ========== latestVersion label auto-fill test ==========
+    
+    @Test
+    void testShouldAutoFillLatestLabelWhenMissing() throws Exception {
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT)).thenReturn(null);
+        
+        // Mapping has latestVersion but labels does NOT contain "latest" key
+        LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+        mapping.promptKey = PROMPT_KEY;
+        mapping.versions = Collections.singletonList("0.0.1");
+        mapping.latestVersion = "0.0.1";
+        mapping.labels = new HashMap<>(); // no "latest" key
+        
+        LegacyDescriptor descriptor = new LegacyDescriptor();
+        descriptor.promptKey = PROMPT_KEY;
+        descriptor.description = "test";
+        
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req = invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                resp.setContent(JacksonUtils.toJson(descriptor));
+            } else if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                resp.setContent(JacksonUtils.toJson(mapping));
+            } else {
+                resp.setContent("{}");
+            }
+            return resp;
+        });
+        
+        when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT, "0.0.1")).thenReturn(null);
+        
+        PromptVersionInfo versionContent = new PromptVersionInfo();
+        versionContent.setTemplate("Hello");
+        ConfigAllInfo versionConfigAllInfo = new ConfigAllInfo();
+        versionConfigAllInfo.setContent(JacksonUtils.toJson(versionContent));
+        when(configInfoPersistService.findConfigAllInfo(any(), eq(PROMPT_GROUP), eq(NS)))
+                .thenReturn(versionConfigAllInfo);
+        
+        // Capture the inserted AiResource to verify versionInfo contains "latest" label
+        org.mockito.ArgumentCaptor<AiResource> resourceCaptor = org.mockito.ArgumentCaptor.forClass(AiResource.class);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        verify(aiResourcePersistService, timeout(ASYNC_TIMEOUT)).insert(resourceCaptor.capture());
+        AiResource inserted = resourceCaptor.getValue();
+        assertNotNull(inserted.getVersionInfo());
+        assertTrue(inserted.getVersionInfo().contains("\"latest\""));
+        assertTrue(inserted.getVersionInfo().contains("0.0.1"));
+    }
+    
+    // ========== NacosPromptLegacyDataReader scan edge cases ==========
+    
+    @Test
+    void testScanShouldPaginateCorrectly() {
+        // First page: full (100 items), second page: partial (1 item), third page: null
+        List<ConfigInfo> page1Items = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            ConfigInfo info = new ConfigInfo();
+            // Only some are descriptor dataIds
+            if (i < 3) {
+                info.setDataId(PromptDataIdUtils.buildDescriptorDataId("prompt-" + i));
+            } else {
+                info.setDataId("some-other-config-" + i);
+            }
+            info.setGroup(PROMPT_GROUP);
+            page1Items.add(info);
+        }
+        Page<ConfigInfo> page1 = new Page<>();
+        page1.setPageItems(page1Items);
+        
+        List<ConfigInfo> page2Items = new ArrayList<>();
+        ConfigInfo lastItem = new ConfigInfo();
+        lastItem.setDataId(PromptDataIdUtils.buildDescriptorDataId("prompt-last"));
+        lastItem.setGroup(PROMPT_GROUP);
+        page2Items.add(lastItem);
+        Page<ConfigInfo> page2 = new Page<>();
+        page2.setPageItems(page2Items);
+        
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(page1);
+        when(configInfoPersistService.findConfigInfo4Page(eq(2), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(page2);
+        
+        // Mapping returns empty versions so buildLegacyPromptData returns null — that's fine,
+        // we just want to verify pagination works
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+            mapping.versions = new ArrayList<>();
+            resp.setContent(JacksonUtils.toJson(mapping));
+            return resp;
+        });
+        
+        List<LegacyPromptData> result = nacosReader.scanLegacyPrompts();
+        
+        // All 4 descriptor dataIds found, but all skipped because no versions
+        assertTrue(result.isEmpty());
+        // Verify both pages were queried
+        verify(configInfoPersistService).findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any());
+        verify(configInfoPersistService).findConfigInfo4Page(eq(2), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any());
+    }
+    
+    @Test
+    void testReadVersionContentShouldFallbackToRawTemplateOnParseFailure() {
+        String versionDataId = PromptDataIdUtils.buildVersionDataId(PROMPT_KEY, "0.0.1");
+        ConfigAllInfo configAllInfo = new ConfigAllInfo();
+        configAllInfo.setContent("This is plain text, not JSON");
+        configAllInfo.setMd5("abc123");
+        configAllInfo.setCreateUser("testUser");
+        when(configInfoPersistService.findConfigAllInfo(eq(versionDataId), eq(PROMPT_GROUP), eq(NS)))
+                .thenReturn(configAllInfo);
+        
+        PromptVersionInfo result = nacosReader.readVersionContent(NS, PROMPT_KEY, "0.0.1");
+        
+        assertNotNull(result);
+        assertEquals("This is plain text, not JSON", result.getTemplate());
+        assertEquals(PROMPT_KEY, result.getPromptKey());
+        assertEquals("0.0.1", result.getVersion());
+        assertEquals("abc123", result.getMd5());
+        assertEquals("testUser", result.getSrcUser());
+    }
+    
+    @Test
+    void testReadVersionContentShouldReturnNullWhenConfigNotFound() {
+        String versionDataId = PromptDataIdUtils.buildVersionDataId(PROMPT_KEY, "0.0.1");
+        when(configInfoPersistService.findConfigAllInfo(eq(versionDataId), eq(PROMPT_GROUP), eq(NS)))
+                .thenReturn(null);
+        
+        PromptVersionInfo result = nacosReader.readVersionContent(NS, PROMPT_KEY, "0.0.1");
+        
+        assertNull(result);
+    }
+    
+    @Test
+    void testReadVersionContentShouldReturnNullWhenContentIsBlank() {
+        String versionDataId = PromptDataIdUtils.buildVersionDataId(PROMPT_KEY, "0.0.1");
+        ConfigAllInfo configAllInfo = new ConfigAllInfo();
+        configAllInfo.setContent("   ");
+        when(configInfoPersistService.findConfigAllInfo(eq(versionDataId), eq(PROMPT_GROUP), eq(NS)))
+                .thenReturn(configAllInfo);
+        
+        PromptVersionInfo result = nacosReader.readVersionContent(NS, PROMPT_KEY, "0.0.1");
+        
+        assertNull(result);
+    }
+    
+    // ========== Stale marker recovery test ==========
+    
+    @Test
+    void testShouldRecoverFromStaleMarkerAndMigrate() throws Exception {
+        Page<ConfigInfo> scanPage = buildScanPage(PROMPT_KEY);
+        when(configInfoPersistService.findConfigInfo4Page(eq(1), eq(100), any(), eq(PROMPT_GROUP), eq(NS), any()))
+                .thenReturn(scanPage);
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT)).thenReturn(null);
+        when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT, "0.0.1")).thenReturn(null);
+        
+        // First publishConfig: marker already exists (stale); after delete+retry: succeeds
+        when(configOperationService.publishConfig(any(), any(), any()))
+                .thenThrow(new ConfigAlreadyExistsException("marker exists"))
+                .thenReturn(true);
+        
+        // configQueryChainService: return stale timestamp for marker check, proper data for scan
+        when(configQueryChainService.handle(any())).thenAnswer(invocation -> {
+            com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest req = invocation.getArgument(0);
+            String dataId = req.getDataId();
+            ConfigQueryChainResponse resp = new ConfigQueryChainResponse();
+            resp.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+            if ("nacos.ai.prompt.migration".equals(dataId)) {
+                // Return a timestamp from 15 minutes ago (stale)
+                resp.setContent(String.valueOf(System.currentTimeMillis() - 15 * 60 * 1000L));
+            } else if (dataId != null && dataId.endsWith(".descriptor.json")) {
+                LegacyDescriptor desc = new LegacyDescriptor();
+                desc.promptKey = PROMPT_KEY;
+                resp.setContent(JacksonUtils.toJson(desc));
+            } else if (dataId != null && dataId.endsWith(".label-version-mapping.json")) {
+                LegacyLabelVersionMapping mapping = new LegacyLabelVersionMapping();
+                mapping.versions = Collections.singletonList("0.0.1");
+                mapping.latestVersion = "0.0.1";
+                resp.setContent(JacksonUtils.toJson(mapping));
+            } else {
+                resp.setContent("{}");
+            }
+            return resp;
+        });
+        
+        PromptVersionInfo versionContent = new PromptVersionInfo();
+        versionContent.setTemplate("Hello");
+        ConfigAllInfo versionConfigAllInfo = new ConfigAllInfo();
+        versionConfigAllInfo.setContent(JacksonUtils.toJson(versionContent));
+        when(configInfoPersistService.findConfigAllInfo(any(), eq(PROMPT_GROUP), eq(NS)))
+                .thenReturn(versionConfigAllInfo);
+        
+        task.onApplicationEvent(createRootContextEvent());
+        
+        // Should recover from stale marker and proceed with migration
+        verify(aiResourcePersistService, timeout(ASYNC_TIMEOUT)).insert(any(AiResource.class));
     }
     
     // ========== Helper methods ==========

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.ai.service.prompt;
 
+import com.alibaba.nacos.ai.config.PromptDataMigrationTask;
 import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.model.AiResourceVersion;
 import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
@@ -104,6 +105,9 @@ class PromptOperationServiceImplTest {
     @Mock
     private ConfigOperationService configOperationService;
     
+    @Mock
+    private PromptDataMigrationTask promptDataMigrationTask;
+    
     private PromptOperationServiceImpl service;
     
     private static final org.springframework.core.env.ConfigurableEnvironment CACHED_ENVIRONMENT =
@@ -127,7 +131,7 @@ class PromptOperationServiceImplTest {
         AiResourceManager resourceManager = new AiResourceManager(aiResourcePersistService, aiResourceVersionPersistService,
                 pipelineExecutionRepository);
         service = new PromptOperationServiceImpl(publishPipelineExecutor, pipelineExecutionRepository,
-                configOperationService, resourceManager);
+                configOperationService, resourceManager, promptDataMigrationTask);
         mockVisibilityManager = mock(VisibilityPluginManager.class);
         lenient().when(mockVisibilityManager.findVisibilityService(anyString())).thenReturn(Optional.empty());
         visibilityManagerStatic = mockStatic(VisibilityPluginManager.class);


### PR DESCRIPTION
## What is the purpose of the change

The prompt data migration task previously only scanned the default namespace (`public`) for legacy Config-based prompt data. Users who created prompts in custom namespaces would have their data silently skipped during migration to the new DB + typed storage architecture.

Additionally, when a prompt was deleted in the new system, the legacy Config entries (descriptor, label-version-mapping, version configs) were left behind. On the next server restart, the migration task would re-import the deleted prompt — effectively "resurrecting" it.

This PR fixes both issues.

## Brief changelog

- `LegacyPromptData`: Add `namespaceId` field so each scanned prompt carries its namespace context.
- `PromptLegacyDataReader` (interface): Add `namespaceId` parameter to `readVersionContent`; add `cleanupLegacyData` default method for post-deletion cleanup.
- `NacosPromptLegacyDataReader`: 
  - Inject `NamespaceOperationService` to dynamically list all namespaces instead of hardcoding default.
  - Propagate `namespaceId` through all internal scan/read methods.
  - Implement `cleanupLegacyData` to delete descriptor, mapping, and version Config entries via `ConfigOperationService`.
  - Fallback to default namespace if `getNamespaceList()` fails.
- `PromptDataMigrationTask`:
  - Read namespace from `LegacyPromptData` instead of hardcoding.
  - Optimize `filterNeedsMigration` to use batch `list()` + `HashSet` comparison instead of per-version `find()`.
  - Auto-fill `latest` label from `latestVersion` when labels map is missing it.
  - Expose `cleanupLegacyConfig` public method for use during prompt deletion.
- `PromptOperationServiceImpl`: Call `cleanupLegacyConfig` during `deletePrompt` to prevent re-migration on next restart.
- `PromptDataMigrationTaskTest`: Expand from 7 to 24 test cases covering multi-namespace migration, namespace fallback, legacy cleanup (normal/null-versions/exception-suppression/delegation/no-reader), partial version migration, batch version check, latest-label auto-fill, scan pagination, readVersionContent edge cases (parse failure/not found/blank content), and stale marker recovery.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

