### PR TITLE
Fix #14951: hasMember() false positives due to StringUtils.contains() fuzzy match

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
@@ -294,9 +294,10 @@ public class ServerMemberManager implements NacosMemberManager {
             return true;
         }
         
-        // If only IP information is passed in, a fuzzy match is required
+        // If only IP information is passed in, extract IP from key for exact match
         for (Map.Entry<String, Member> entry : serverList.entrySet()) {
-            if (StringUtils.contains(entry.getKey(), address)) {
+            String keyIp = entry.getKey().split(":")[0];
+            if (keyIp.equals(address)) {
                 result = true;
                 break;
             }


### PR DESCRIPTION
## Fix GitHub Issue #14951

### Problem
The `hasMember()` method in `ServerMemberManager.java` used `StringUtils.contains()` for fuzzy IP matching, causing false positives. For example:
- `hasMember("8.8")` would incorrectly return `true` when `"10.8.8.1:8848"` exists in the server list

### Solution
Replace the fuzzy `StringUtils.contains(entry.getKey(), address)` check with an exact IP extraction and match:

```java
String keyIp = entry.getKey().split(":")[0];
if (keyIp.equals(address)) {
    result = true;
    break;
}
```

This extracts the IP portion from the address key (before the colon) and compares it exactly against the provided address, ensuring only exact IP matches are found.


### Files Changed
- `core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java`

### Issue Reference
Fixes #14951