### PR TITLE
fix(ai): sync SKILL.md front-matter version with metadata version on upload

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -1116,9 +1116,11 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         Executor executor = ExecutorUtils.getSkillStorageIoExecutor();
         List<CompletableFuture<Void>> tasks = new ArrayList<>();
 
-        // 1) Store SKILL.md as raw markdown content
+        // 1) Store SKILL.md with version synced to the storage version
         String mdPath = SKILL_MD_RESOURCE_NAME;
-        byte[] mdBytes = (skill.getSkillMd() == null ? "" : skill.getSkillMd()).getBytes(StandardCharsets.UTF_8);
+        String skillMdContent = SkillZipParser.syncVersionInSkillMd(
+                skill.getSkillMd() == null ? "" : skill.getSkillMd(), version);
+        byte[] mdBytes = skillMdContent.getBytes(StandardCharsets.UTF_8);
         StorageKey mdKey = NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId, skillName, version,
                 mdPath);
         files.add(mdPath);

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
@@ -103,6 +103,12 @@ public class SkillZipParser {
     private static final Pattern YAML_FRONT_MATTER = Pattern.compile(
             "^---\\s*\\n(.*?)\\n---\\s*\\n(.*)$", Pattern.DOTALL);
 
+    private static final Pattern TOP_LEVEL_VERSION_PATTERN = Pattern.compile(
+            "(?m)^(version\\s*:\\s*)(.+)$");
+
+    private static final Pattern NESTED_VERSION_PATTERN = Pattern.compile(
+            "(?m)^(\\s+version\\s*:\\s*)(.+)$");
+
     /**
      * Parse YAML front matter map from full SKILL.md content.
      *
@@ -119,6 +125,45 @@ public class SkillZipParser {
         }
         String yamlContent = matcher.group(1);
         return parseYamlFrontMatter(yamlContent);
+    }
+
+    /**
+     * Sync the version field in SKILL.md YAML front matter to match the target version.
+     * Handles both top-level {@code version:} and nested {@code metadata:\n  version:} formats.
+     * If no version field exists in the front matter, a top-level one is added.
+     *
+     * @param skillMd full SKILL.md content
+     * @param targetVersion the version string to set
+     * @return updated SKILL.md content with the version field matching targetVersion
+     */
+    public static String syncVersionInSkillMd(String skillMd, String targetVersion) {
+        if (StringUtils.isBlank(skillMd) || StringUtils.isBlank(targetVersion)) {
+            return skillMd;
+        }
+        Matcher fmMatcher = YAML_FRONT_MATTER.matcher(skillMd);
+        if (!fmMatcher.matches()) {
+            return skillMd;
+        }
+        String yamlContent = fmMatcher.group(1);
+        String bodyContent = fmMatcher.group(2);
+
+        String updatedYaml = replaceVersionInYaml(yamlContent, targetVersion);
+        if (updatedYaml.equals(yamlContent)) {
+            return skillMd;
+        }
+        return "---\n" + updatedYaml + "\n---\n" + bodyContent;
+    }
+
+    private static String replaceVersionInYaml(String yamlContent, String newVersion) {
+        Matcher m = TOP_LEVEL_VERSION_PATTERN.matcher(yamlContent);
+        if (m.find()) {
+            return m.replaceFirst(Matcher.quoteReplacement(m.group(1) + newVersion));
+        }
+        m = NESTED_VERSION_PATTERN.matcher(yamlContent);
+        if (m.find()) {
+            return m.replaceFirst(Matcher.quoteReplacement(m.group(1) + newVersion));
+        }
+        return yamlContent + "\nversion: " + newVersion;
     }
 
     /**

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
+import com.alibaba.nacos.ai.utils.SkillZipParser;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillBasicInfo;
 import com.alibaba.nacos.api.ai.model.skills.SkillMeta;
@@ -59,6 +60,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +76,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
+import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -427,6 +430,39 @@ class SkillOperationServiceImplTest {
         assertEquals("test-skill", result);
         verify(aiResourceVersionPersistService).insert(argThat(inserted -> inserted != null
                 && "3.0.8".equals(inserted.getVersion())));
+    }
+
+    @Test
+    void testUploadSkillFromZipSyncsVersionInStoredSkillMd() throws NacosException, IOException {
+        String namespaceId = "test-namespace";
+        byte[] zipBytes = createZipBytes("3.0.6");
+        AiResource meta = new AiResource();
+        meta.setNamespaceId(namespaceId);
+        meta.setName("test-skill");
+        meta.setType("skill");
+        meta.setStatus("enable");
+        meta.setMetaVersion(2L);
+        meta.setVersionInfo("{\"labels\":{},\"onlineCnt\":1}");
+        Page<com.alibaba.nacos.ai.model.AiResourceVersion> versions = new Page<>();
+        com.alibaba.nacos.ai.model.AiResourceVersion v1 = new com.alibaba.nacos.ai.model.AiResourceVersion();
+        v1.setVersion("3.0.6");
+        versions.setPageItems(List.of(v1));
+        when(aiResourcePersistService.find(eq(namespaceId), eq("test-skill"), anyString())).thenReturn(meta);
+        when(aiResourceVersionPersistService.list(eq(namespaceId), eq("test-skill"), anyString(), isNull(), anyInt(), anyInt()))
+                .thenReturn(versions);
+        when(aiResourcePersistService.updateMetaCas(eq(namespaceId), eq("test-skill"), anyString(), eq(2L), any()))
+                .thenReturn(true);
+
+        skillOperationService.uploadSkillFromZip(namespaceId, zipBytes, false);
+
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(storage, times(1)).save(keyCaptor.capture(), dataCaptor.capture());
+
+        String storedMd = new String(dataCaptor.getValue(), StandardCharsets.UTF_8);
+        Map<String, String> yaml = SkillZipParser.parseYamlFrontMatterFromMarkdown(storedMd);
+        assertEquals("3.0.7", yaml.get("version"),
+                "Stored SKILL.md version should match the bumped metadata version");
     }
 
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserTest.java
@@ -33,6 +33,7 @@ import java.util.zip.ZipOutputStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -569,5 +570,62 @@ class SkillZipParserTest {
             zos.closeEntry();
         }
         return baos.toByteArray();
+    }
+
+    // ========== syncVersionInSkillMd tests ==========
+
+    @Test
+    void testSyncVersionReplacesTopLevelVersion() {
+        String skillMd = "---\nname: my-skill\nversion: 1.0.0\ndescription: desc\n---\n\nBody content";
+        String result = SkillZipParser.syncVersionInSkillMd(skillMd, "2.0.0");
+        Map<String, String> yaml = SkillZipParser.parseYamlFrontMatterFromMarkdown(result);
+        assertEquals("2.0.0", yaml.get("version"));
+        assertTrue(result.contains("Body content"));
+    }
+
+    @Test
+    void testSyncVersionReplacesNestedMetadataVersion() {
+        String skillMd = "---\nname: my-skill\ndescription: desc\nmetadata:\n  version: 1.0.0\n  author: test\n---\n\nBody";
+        String result = SkillZipParser.syncVersionInSkillMd(skillMd, "1.0.1");
+        Map<String, String> yaml = SkillZipParser.parseYamlFrontMatterFromMarkdown(result);
+        assertEquals("1.0.1", yaml.get("metadata.version"));
+        assertTrue(result.contains("Body"));
+    }
+
+    @Test
+    void testSyncVersionAddsVersionWhenMissing() {
+        String skillMd = "---\nname: my-skill\ndescription: desc\n---\n\nBody";
+        String result = SkillZipParser.syncVersionInSkillMd(skillMd, "0.0.1");
+        Map<String, String> yaml = SkillZipParser.parseYamlFrontMatterFromMarkdown(result);
+        assertEquals("0.0.1", yaml.get("version"));
+        assertTrue(result.contains("Body"));
+    }
+
+    @Test
+    void testSyncVersionNoOpWhenAlreadyMatches() {
+        String skillMd = "---\nname: my-skill\nversion: 1.0.0\ndescription: desc\n---\n\nBody";
+        String result = SkillZipParser.syncVersionInSkillMd(skillMd, "1.0.0");
+        assertEquals(skillMd, result);
+    }
+
+    @Test
+    void testSyncVersionReplacesQuotedVersion() {
+        String skillMd = "---\nname: my-skill\nversion: \"1.0.0\"\ndescription: desc\n---\n\nBody";
+        String result = SkillZipParser.syncVersionInSkillMd(skillMd, "1.0.1");
+        Map<String, String> yaml = SkillZipParser.parseYamlFrontMatterFromMarkdown(result);
+        assertEquals("1.0.1", yaml.get("version"));
+    }
+
+    @Test
+    void testSyncVersionReturnsOriginalWhenNoFrontMatter() {
+        String skillMd = "No front matter here";
+        String result = SkillZipParser.syncVersionInSkillMd(skillMd, "1.0.0");
+        assertEquals(skillMd, result);
+    }
+
+    @Test
+    void testSyncVersionReturnsOriginalForBlankInput() {
+        assertNull(SkillZipParser.syncVersionInSkillMd(null, "1.0.0"));
+        assertEquals("", SkillZipParser.syncVersionInSkillMd("", "1.0.0"));
     }
 }


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.
## What is the purpose of the change
When the server bumps a skill version during upload (e.g. collision resolution from `3.0.6` to `3.0.7`), the stored SKILL.md content still contained the original version from the YAML front-matter, causing the SKILL.md `version` field to diverge from the actual metadata version. This fix ensures the two always stay in sync.
## Brief changelog
- Add `SkillZipParser.syncVersionInSkillMd()` utility that rewrites the version field in SKILL.md YAML front-matter to match a given target version. Supports top-level `version:`, nested `metadata: version:`, and auto-appends when no version field exists.
- Call `syncVersionInSkillMd()` in `SkillOperationServiceImpl.writeSkillToStorage()` before persisting, so all write paths (upload, overwrite, bootstrap) produce a SKILL.md whose version matches the resolved storage version.
- Add 7 unit tests in `SkillZipParserTest` covering top-level replace, nested replace, missing-field append, no-op when matched, quoted value, no front-matter, and blank input.
- Add 1 integration-level test in `SkillOperationServiceImplTest` verifying that a version-bumped upload stores a SKILL.md with the correct synced version.
## Verifying this change
- `mvn test -pl ai -Dtest="SkillZipParserTest"` — all 7 new `syncVersion*` tests pass.
- `mvn test -pl ai -Dtest="SkillOperationServiceImplTest#testUploadSkillFromZipSyncsVersionInStoredSkillMd"` — verifies stored SKILL.md contains bumped version after collision resolution.
- `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` — basic checks pass (with `docs/skill-admin-error-codes.md` excluded from RAT or pre-existing).
Follow this checklist to help us incorporate your contribution quickly and easily:
* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.