### PR TITLE
[BUG] Fix equals and hashCode contract violation in ManagerListenerWrap

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
@@ -640,7 +640,7 @@ public class CacheData {
         
         @Override
         public int hashCode() {
-            return super.hashCode();
+            return listener.hashCode();
         }
         
     }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a violation of the `equals()` and `hashCode()` contract in the `ManagerListenerWrap` class inside `CacheData.java`.

Currently, `ManagerListenerWrap` overrides `equals()` to compare the internal `listener` field:
```java
@Override
public boolean equals(Object obj) {
    if (null == obj || obj.getClass() != getClass()) { return false; }
    if (obj == this) { return true; }
    ManagerListenerWrap other = (ManagerListenerWrap) obj;
    return listener.equals(other.listener);
}
```
## Brief changelog
* Overridden `hashCode()` in `ManagerListenerWrap` to return `listener.hashCode()`, ensuring consistency with the `equals()` implementation."