### PR TITLE
[BUG] Fix cross-thread visibility and race conditions for ManagerListenerWrap inNotifying

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
@@ -419,7 +419,7 @@ public class CacheData {
     private void safeNotifyListener(final String dataId, final String group, final String content, final String type,
             final String md5, final String encryptedDataKey, final ManagerListenerWrap listenerWrap) {
         final Listener listener = listenerWrap.listener;
-        if (listenerWrap.inNotifying) {
+        if (!listenerWrap.inNotifying.compareAndSet(false, true)) {
             LOGGER.warn(
                     "[{}] [notify-currentSkip] dataId={}, group={},tenant={}, md5={}, listener={}, listener is not finish yet,will try next time.",
                     envName, dataId, group, tenant, md5, listener);
@@ -457,7 +457,6 @@ public class CacheData {
                             new LongNotifyHandler(listener.getClass().getSimpleName(), dataId, group, tenant, md5,
                                     notifyWarnTimeout, Thread.currentThread()), notifyWarnTimeout,
                             TimeUnit.MILLISECONDS);
-                    listenerWrap.inNotifying = true;
                     listener.receiveConfigInfo(contentTmp);
                     // compare lastContent and content
                     if (listener instanceof AbstractConfigChangeListener) {
@@ -481,7 +480,7 @@ public class CacheData {
                     LOGGER.error("[{}] [notify-error] dataId={}, group={},tenant={}, md5={}, listener={} tx={}",
                             envName, dataId, group, tenant, md5, listener, getTrace(t.getStackTrace(), 3));
                 } finally {
-                    listenerWrap.inNotifying = false;
+                    listenerWrap.inNotifying.set(false);
                     Thread.currentThread().setContextClassLoader(myClassLoader);
                     if (timeSchedule != null) {
                         timeSchedule.cancel(true);
@@ -504,6 +503,7 @@ public class CacheData {
                 job.run();
             }
         } catch (Throwable t) {
+            listenerWrap.inNotifying.set(false);
             LOGGER.error("[{}] [notify-listener-error] dataId={}, group={},tenant={}, md5={}, listener={} throwable={}",
                     envName, dataId, group, tenant, md5, listener, t.getCause());
         }
@@ -601,7 +601,7 @@ public class CacheData {
     
     private static class ManagerListenerWrap {
         
-        boolean inNotifying = false;
+        final AtomicBoolean inNotifying = new AtomicBoolean(false);
         
         final Listener listener;
         

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/CacheDataTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/CacheDataTest.java
@@ -263,5 +263,37 @@ class CacheDataTest {
         assertEquals(PropertyChangeType.MODIFIED, changeItemReceived.get().getChangeItem("c").getType());
         assertEquals(PropertyChangeType.ADDED, changeItemReceived.get().getChangeItem("d").getType());
     }
-    
+
+    @Test
+    void testNotifyTaskExecutorExceptionResetsInNotifying() throws NacosException {
+        ConfigFilterChainManager filter = new ConfigFilterChainManager(new Properties());
+        final CacheData data = new CacheData(filter, "name1", "key_executor_fail", "group", "tenant");
+        
+        Listener listener = new Listener() {
+            @Override
+            public Executor getExecutor() {
+                return command -> {
+                    throw new java.util.concurrent.RejectedExecutionException("Mock ThreadPool Full");
+                };
+            }
+            
+            @Override
+            public void receiveConfigInfo(String configInfo) {
+            }
+        };
+        data.addListener(listener);
+        data.setContent("new_content_trigger");
+        
+        // When checking listener MD5, the RejectedExecutionException will be thrown.
+        // It shouldn't block the caller, and the inNotifying flag must be correctly reset.
+        data.checkListenerMd5();
+        
+        // Assert that the flag inNotifying is false (which allows further checkListenerMd5 invocations).
+        // Since we cannot directly access the private inNotifying field of ManagerListenerWrap,
+        // we can trigger another content change and see if the exception is thrown again.
+        data.setContent("another_content_trigger");
+        // If it was deadlocked (inNotifying=true), the checkListenerMd5() would just warn and return.
+        // If the reset works, it will try to submit again and throw the exception again.
+        data.checkListenerMd5();
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
This PR fixes a critical cross-thread visibility and race condition bug in the `ManagerListenerWrap` inner class within `CacheData.java`.
Currently, the `inNotifying` field is a plain `boolean`. It is read by the Nacos Client polling thread (`checkListenerMd5`) and written asynchronously by user-provided custom `Executor` threads inside the `NotifyTask`.
This causes two severe concurrency issues:
1. **Visibility Issue:** Because `inNotifying` is not `volatile`, JIT compiler optimizations may cache the value. As a result, the Nacos polling thread might never see the `inNotifying = false` update from the user's thread, causing the listener to be permanently skipped for future configuration change events.
2. **Atomicity Issue (Race Condition):** The `if (listenerWrap.inNotifying)` check and the subsequent setting to `true` have no synchronization. Multiple checking threads can enter simultaneously, leading to the same listener being invoked concurrently multiple times.
## Brief changelog
* Refactored the `inNotifying` field from a plain `boolean` to `final AtomicBoolean inNotifying`.
* Used `inNotifying.compareAndSet(false, true)` to atomically perform the status check and the lock acquisition at the entry of `safeNotifyListener`, preventing concurrent duplicate notifications.
* Removed the delayed `inNotifying = true` assignment inside `NotifyTask.run()` as it is now securely acquired upfront.
* Replaced `inNotifying = false` with `inNotifying.set(false)` in the `finally` block to correctly and visibly release the lock."