### PR TITLE
Fix missing logs for trace subscriber callback exceptions

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/trace/NacosCombinedTraceSubscriber.java
+++ b/core/src/main/java/com/alibaba/nacos/core/trace/NacosCombinedTraceSubscriber.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.notify.listener.SmartSubscriber;
 import com.alibaba.nacos.common.trace.event.TraceEvent;
 import com.alibaba.nacos.common.trace.publisher.TraceEventPublisherFactory;
+import com.alibaba.nacos.core.utils.Loggers;
 import com.alibaba.nacos.plugin.trace.NacosTracePluginManager;
 import com.alibaba.nacos.plugin.trace.spi.NacosTraceSubscriber;
 
@@ -87,7 +88,9 @@ public class NacosCombinedTraceSubscriber extends SmartSubscriber {
     private void onEvent0(NacosTraceSubscriber subscriber, TraceEvent event) {
         try {
             subscriber.onEvent(event);
-        } catch (Exception ignored) {
+        } catch (Exception ex) {
+            Loggers.CORE.warn("Trace subscriber callback failed, subscriberName={}, subscriberClass={}, eventType={}",
+                    subscriber.getName(), subscriber.getClass().getName(), event.getClass().getName(), ex);
         }
     }
     


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

This change fixes a troubleshooting gap in trace plugin callback handling.
When a trace subscriber throws an exception, the exception was previously swallowed silently, which made plugin failures hard to diagnose in production.
This PR keeps the original fault-isolation behavior (no exception propagation to business flow) while improving observability by logging callback failures.

## Brief changelog

Add warning log when trace subscriber callback throws an exception.
Include subscriber name, subscriber class, and event type in the log message.
Keep existing behavior unchanged: callback exceptions are still caught and not propagated.

## Verifying this change

Confirmed the changed class has no IDE compile errors.


Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

