### PR TITLE
fix(ai): return variables field in prompt http client api

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/PromptClientController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/PromptClientController.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.form.prompt.PromptQueryForm;
 import com.alibaba.nacos.ai.param.PromptHttpParamExtractor;
 import com.alibaba.nacos.ai.service.prompt.PromptClientOperationService;
+import com.alibaba.nacos.ai.utils.PromptConvertUtils;
 import com.alibaba.nacos.api.ai.model.prompt.Prompt;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
 import com.alibaba.nacos.api.annotation.NacosApi;
@@ -62,7 +63,7 @@ public class PromptClientController {
         try {
             PromptVersionInfo result = promptOperationService.queryPrompt(form.getNamespaceId(), form.getPromptKey(),
                     form.getVersion(), form.getLabel(), form.getMd5());
-            return Result.success(convertToClientPrompt(result));
+            return Result.success(PromptConvertUtils.toClientPrompt(result));
         } catch (NacosException ex) {
             if (ex.getErrCode() == NacosException.NOT_MODIFIED) {
                 response.setStatus(NacosException.NOT_MODIFIED);
@@ -70,14 +71,5 @@ public class PromptClientController {
             }
             throw ex;
         }
-    }
-    
-    private Prompt convertToClientPrompt(PromptVersionInfo versionInfo) {
-        Prompt prompt = new Prompt();
-        prompt.setPromptKey(versionInfo.getPromptKey());
-        prompt.setVersion(versionInfo.getVersion());
-        prompt.setTemplate(versionInfo.getTemplate());
-        prompt.setMd5(versionInfo.getMd5());
-        return prompt;
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/QueryPromptRequestHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/QueryPromptRequestHandler.java
@@ -17,7 +17,7 @@
 package com.alibaba.nacos.ai.remote.handler;
 
 import com.alibaba.nacos.ai.service.prompt.PromptClientOperationService;
-import com.alibaba.nacos.api.ai.model.prompt.Prompt;
+import com.alibaba.nacos.ai.utils.PromptConvertUtils;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
 import com.alibaba.nacos.api.ai.remote.request.QueryPromptRequest;
 import com.alibaba.nacos.api.ai.remote.response.QueryPromptResponse;
@@ -67,7 +67,7 @@ public class QueryPromptRequestHandler extends RequestHandler<QueryPromptRequest
         try {
             PromptVersionInfo result = promptOperationService.queryPrompt(
                     request.getNamespaceId(), request.getPromptKey(), request.getVersion(), request.getLabel(), request.getMd5());
-            response.setPromptInfo(convertToClientPrompt(result));
+            response.setPromptInfo(PromptConvertUtils.toClientPrompt(result));
         } catch (NacosException e) {
             if (e.getErrCode() == NacosException.NOT_MODIFIED) {
                 response.setErrorInfo(NacosException.NOT_MODIFIED, "prompt data is up to date");
@@ -77,15 +77,5 @@ public class QueryPromptRequestHandler extends RequestHandler<QueryPromptRequest
             response.setErrorInfo(e.getErrCode(), e.getErrMsg());
         }
         return response;
-    }
-    
-    private Prompt convertToClientPrompt(PromptVersionInfo versionInfo) {
-        Prompt prompt = new Prompt();
-        prompt.setPromptKey(versionInfo.getPromptKey());
-        prompt.setVersion(versionInfo.getVersion());
-        prompt.setTemplate(versionInfo.getTemplate());
-        prompt.setMd5(versionInfo.getMd5());
-        prompt.setVariables(versionInfo.getVariables());
-        return prompt;
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/PromptConvertUtils.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/PromptConvertUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.utils;
+
+import com.alibaba.nacos.api.ai.model.prompt.Prompt;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
+
+/**
+ * Utility class for converting prompt related models.
+ *
+ * @author nacos
+ */
+public class PromptConvertUtils {
+    
+    private PromptConvertUtils() {
+    }
+    
+    /**
+     * Convert {@link PromptVersionInfo} to client-facing {@link Prompt}.
+     *
+     * @param versionInfo prompt version info from service layer, must not be {@code null}
+     * @return client-facing prompt
+     */
+    public static Prompt toClientPrompt(PromptVersionInfo versionInfo) {
+        Prompt prompt = new Prompt();
+        prompt.setPromptKey(versionInfo.getPromptKey());
+        prompt.setVersion(versionInfo.getVersion());
+        prompt.setTemplate(versionInfo.getTemplate());
+        prompt.setMd5(versionInfo.getMd5());
+        prompt.setVariables(versionInfo.getVariables());
+        return prompt;
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/PromptConvertUtilsTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/PromptConvertUtilsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.utils;
+
+import com.alibaba.nacos.api.ai.model.prompt.Prompt;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVariable;
+import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PromptConvertUtilsTest {
+    
+    @Test
+    void toClientPromptShouldCopyAllFields() {
+        PromptVersionInfo versionInfo = new PromptVersionInfo();
+        versionInfo.setPromptKey("demo");
+        versionInfo.setVersion("1.0.0");
+        versionInfo.setTemplate("Hello {{name}}");
+        versionInfo.setMd5("abc123");
+        List<PromptVariable> variables = Collections.singletonList(
+                new PromptVariable("name", "world", "user name"));
+        versionInfo.setVariables(variables);
+        
+        Prompt prompt = PromptConvertUtils.toClientPrompt(versionInfo);
+        
+        assertNotNull(prompt);
+        assertEquals("demo", prompt.getPromptKey());
+        assertEquals("1.0.0", prompt.getVersion());
+        assertEquals("Hello {{name}}", prompt.getTemplate());
+        assertEquals("abc123", prompt.getMd5());
+        assertSame(variables, prompt.getVariables());
+        assertEquals(1, prompt.getVariables().size());
+        assertEquals("name", prompt.getVariables().get(0).getName());
+    }
+    
+    @Test
+    void toClientPromptShouldKeepNullVariablesWhenAbsent() {
+        PromptVersionInfo versionInfo = new PromptVersionInfo();
+        versionInfo.setPromptKey("demo");
+        versionInfo.setVersion("1.0.0");
+        versionInfo.setTemplate("Hello");
+        versionInfo.setMd5("md5");
+        
+        Prompt prompt = PromptConvertUtils.toClientPrompt(versionInfo);
+        
+        assertNotNull(prompt);
+        assertNull(prompt.getVariables());
+    }
+    
+    @Test
+    void toClientPromptShouldPropagateNullFields() {
+        PromptVersionInfo versionInfo = new PromptVersionInfo();
+        
+        Prompt prompt = PromptConvertUtils.toClientPrompt(versionInfo);
+        
+        assertNotNull(prompt);
+        assertNull(prompt.getPromptKey());
+        assertNull(prompt.getVersion());
+        assertNull(prompt.getTemplate());
+        assertNull(prompt.getMd5());
+        assertNull(prompt.getVariables());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix the HTTP Open API for prompt runtime query returning `null` for the `variables` field. The gRPC channel works correctly, but `GET /v3/client/ai/prompt` always drops variables, so clients cannot obtain variable metadata.

## Brief changelog

- `PromptClientController`: the private `convertToClientPrompt` method missed `setVariables` when converting `PromptVersionInfo` to `Prompt`. This is now fixed.
- Extract the duplicated conversion logic from `PromptClientController` and `QueryPromptRequestHandler` into a dedicated utility class `PromptConvertUtils`, so the HTTP and gRPC paths cannot drift apart again.
- Replace both call sites with `PromptConvertUtils.toClientPrompt(...)` and clean up unused imports.
- Add `PromptConvertUtilsTest` covering: full field copy (including variables list reference equality), missing variables, and all-null propagation.

## Verifying this change

- New unit test `PromptConvertUtilsTest` covers the behavior of the extracted utility.
- Existing HTTP and gRPC tests still pass.
- Local smoke test: `GET /v3/client/ai/prompt` now returns the same `variables` payload as the gRPC response.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

