### PR TITLE
fix(naming): apply enableStandalone switch only when value is non-empty

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
@@ -265,7 +265,7 @@ public class SwitchManager extends RequestProcessor4CP {
             
             if (entry.equals(SwitchEntry.ENABLE_STANDALONE)) {
                 
-                if (!StringUtils.isNotEmpty(value)) {
+                if (StringUtils.isNotEmpty(value)) {
                     tempSwitchDomain.setEnableStandalone(Boolean.parseBoolean(value));
                 }
             }

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
@@ -25,7 +25,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -100,5 +102,26 @@ class SwitchManagerTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> switchManager.update(SwitchEntry.PUSH_VERSION, "ruby:1.0.0", true));
         assertEquals("unsupported client type: ruby", exception.getMessage());
+    }
+
+    @Test
+    void testUpdateEnableStandaloneToFalseAppliesValue() throws Exception {
+        assertTrue(switchDomain.isEnableStandalone());
+        switchManager.update(SwitchEntry.ENABLE_STANDALONE, "false", true);
+        assertFalse(switchDomain.isEnableStandalone());
+    }
+
+    @Test
+    void testUpdateEnableStandaloneToTrueAppliesValue() throws Exception {
+        switchDomain.setEnableStandalone(false);
+        switchManager.update(SwitchEntry.ENABLE_STANDALONE, "true", true);
+        assertTrue(switchDomain.isEnableStandalone());
+    }
+
+    @Test
+    void testUpdateEnableStandaloneWithEmptyValueIsNoOp() throws Exception {
+        assertTrue(switchDomain.isEnableStandalone());
+        switchManager.update(SwitchEntry.ENABLE_STANDALONE, "", true);
+        assertTrue(switchDomain.isEnableStandalone());
     }
 }


### PR DESCRIPTION
## Problem

The `SwitchManager.update()` handler for `SwitchEntry.ENABLE_STANDALONE` is gated by `!StringUtils.isNotEmpty(value)`, which inverts the intent of the check. As a result, the `enableStandalone` switch cannot be toggled at runtime through the switch API:

- When the caller sends `value="true"` or `value="false"` (the normal case), the condition is `false` and the setter is skipped entirely, so the change is silently dropped.
- When the caller sends an empty string, the condition is `true` and the setter runs with `Boolean.parseBoolean("")`, which is always `false`. Since `enableStandalone` defaults to `true`, this is both meaningless and the opposite of the default.

In effect the switch has been stuck on its default value ever since the code was introduced.

## Root Cause

`naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java:268` uses the negated helper:

```java
if (!StringUtils.isNotEmpty(value)) {
    tempSwitchDomain.setEnableStandalone(Boolean.parseBoolean(value));
}
```

The surrounding branches in the same method (`LIMITED_URL_MAP`, etc.) all follow the pattern "apply the value when it is non-empty", so the `!` is a copy-paste style inversion and not intentional.

## Fix

Remove the negation so the setter runs when `value` is non-empty, and an empty value becomes a no-op (matching the rest of the method):

```java
if (StringUtils.isNotEmpty(value)) {
    tempSwitchDomain.setEnableStandalone(Boolean.parseBoolean(value));
}
```

## Tests Added

| Change point | Test |
|--------------|------|
| Non-empty `"false"` now toggles the flag off | `testUpdateEnableStandaloneToFalseAppliesValue` |
| Non-empty `"true"` now toggles the flag on | `testUpdateEnableStandaloneToTrueAppliesValue` |
| Empty value is a no-op (preserves prior state) | `testUpdateEnableStandaloneWithEmptyValueIsNoOp` |

Run:

```
mvn -pl naming test -Dtest=SwitchManagerTest
```

All 11 tests pass locally.

## Impact

- Only affects the `ENABLE_STANDALONE` branch of `SwitchManager.update()`.
- Restores the documented behavior of the `enableStandalone` switch entry without touching any other switch entry, API surface, or persistence path.
- No change to the debug / non-debug code path: the update still flows through either `update(tempSwitchDomain)` or `updateWithConsistency(tempSwitchDomain)` depending on the `debug` flag.