### PR TITLE
fix(core): use ConcurrentHashMap for ExtractorManager caches

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/paramcheck/ExtractorManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/paramcheck/ExtractorManager.java
@@ -27,8 +27,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * param checker to manager Extractor.
@@ -81,9 +82,9 @@ public class ExtractorManager {
         }
     }
     
-    private static HashMap<Class<? extends AbstractRpcParamExtractor>, AbstractRpcParamExtractor> rpcManager = new HashMap<>();
+    private static Map<Class<? extends AbstractRpcParamExtractor>, AbstractRpcParamExtractor> rpcManager = new ConcurrentHashMap<>();
     
-    private static HashMap<Class<? extends AbstractHttpParamExtractor>, AbstractHttpParamExtractor> httpManager = new HashMap<>();
+    private static Map<Class<? extends AbstractHttpParamExtractor>, AbstractHttpParamExtractor> httpManager = new ConcurrentHashMap<>();
     
     static {
         NacosServiceLoader.load(AbstractHttpParamExtractor.class).forEach(checker -> {

--- a/core/src/test/java/com/alibaba/nacos/core/paramcheck/ExtractorManagerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/paramcheck/ExtractorManagerTest.java
@@ -23,9 +23,18 @@ import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -80,5 +89,65 @@ class ExtractorManagerTest {
         AbstractRpcParamExtractor rpc = ExtractorManager.getRpcExtractor(extractor);
         assertNotNull(rpc);
         assertEquals(ConfigRequestParamExtractor.class.getSimpleName(), rpc.getClass().getSimpleName());
+    }
+
+    @Test
+    void getRpcExtractorCachesDefaultInstanceAcrossCalls() {
+        ExtractorManager.Extractor extractor = DefaultExtractorController.class.getAnnotation(ExtractorManager.Extractor.class);
+        assertNotNull(extractor);
+        AbstractRpcParamExtractor first = ExtractorManager.getRpcExtractor(extractor);
+        AbstractRpcParamExtractor second = ExtractorManager.getRpcExtractor(extractor);
+        assertSame(first, second);
+    }
+
+    @Test
+    void getHttpExtractorCachesDefaultInstanceAcrossCalls() {
+        ExtractorManager.Extractor extractor = DefaultExtractorController.class.getAnnotation(ExtractorManager.Extractor.class);
+        assertNotNull(extractor);
+        AbstractHttpParamExtractor first = ExtractorManager.getHttpExtractor(extractor);
+        AbstractHttpParamExtractor second = ExtractorManager.getHttpExtractor(extractor);
+        assertSame(first, second);
+    }
+
+    @Test
+    void concurrentGetRpcExtractorReturnsSameInstanceAndDoesNotCorrupt() throws Exception {
+        ExtractorManager.Extractor extractor = DefaultExtractorController.class.getAnnotation(ExtractorManager.Extractor.class);
+        assertNotNull(extractor);
+
+        int threadCount = 32;
+        int iterationsPerThread = 200;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch doneGate = new CountDownLatch(threadCount);
+        Set<AbstractRpcParamExtractor> observed = ConcurrentHashMap.newKeySet();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                pool.submit(() -> {
+                    try {
+                        startGate.await();
+                        for (int j = 0; j < iterationsPerThread; j++) {
+                            AbstractRpcParamExtractor rpc = ExtractorManager.getRpcExtractor(extractor);
+                            assertNotNull(rpc);
+                            observed.add(rpc);
+                            AbstractHttpParamExtractor http = ExtractorManager.getHttpExtractor(extractor);
+                            assertNotNull(http);
+                        }
+                    } catch (Throwable t) {
+                        failure.compareAndSet(null, t);
+                    } finally {
+                        doneGate.countDown();
+                    }
+                });
+            }
+            startGate.countDown();
+            assertTrue(doneGate.await(30, TimeUnit.SECONDS), "concurrent workers did not finish in time");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(failure.get(), "concurrent access should not throw");
+        assertEquals(1, observed.size(), "all callers must observe the same cached extractor instance");
     }
 }


### PR DESCRIPTION
## Problem

`ExtractorManager` holds two static caches — `rpcManager` and `httpManager` — that are plain `HashMap` instances populated once in a static initializer and then mutated at runtime via `Map.computeIfAbsent` inside `getRpcExtractor()` and `getHttpExtractor()`.

Those getters are invoked from request-path filters:

- `core/src/main/java/com/alibaba/nacos/core/paramcheck/ParamCheckerFilter.java:82`
- `core/src/main/java/com/alibaba/nacos/core/namespace/filter/NamespaceValidationRequestFilter.java:110`
- `core/src/main/java/com/alibaba/nacos/core/remote/grpc/RemoteParamCheckFilter.java:58`

All three run on every inbound HTTP or gRPC request, so under any real load several threads can be calling `computeIfAbsent` on the same map at the same time. `java.util.HashMap` is not safe for concurrent structural modification; in practice this can:

- corrupt internal buckets and lose entries,
- return `null` where a value should exist,
- leave the map in a state where subsequent reads throw,
- under contention with rehashing, spin in a tight loop on older JDKs.

Because the annotation-to-extractor mapping is resolved per request, a single corrupted cache entry can send wrong extractors to every handler that targets the affected class.

## Root Cause

`core/src/main/java/com/alibaba/nacos/core/paramcheck/ExtractorManager.java:84-86` declared the caches as `HashMap`:

```java
private static HashMap<Class<? extends AbstractRpcParamExtractor>, AbstractRpcParamExtractor> rpcManager = new HashMap<>();

private static HashMap<Class<? extends AbstractHttpParamExtractor>, AbstractHttpParamExtractor> httpManager = new HashMap<>();
```

The static initializer populates them once, but the getters that follow call `computeIfAbsent` on every request:

```java
public static AbstractRpcParamExtractor getRpcExtractor(Extractor extractor) {
    return rpcManager.computeIfAbsent(extractor.rpcExtractor(), (key) -> new DefaultGrpcExtractor());
}
```

That is a concurrent structural modification on a non-thread-safe map.

## Fix

Switch both fields to `ConcurrentHashMap`, exposed via the `Map` interface:

```java
private static Map<Class<? extends AbstractRpcParamExtractor>, AbstractRpcParamExtractor> rpcManager = new ConcurrentHashMap<>();

private static Map<Class<? extends AbstractHttpParamExtractor>, AbstractHttpParamExtractor> httpManager = new ConcurrentHashMap<>();
```

`ConcurrentHashMap.computeIfAbsent` is atomic per key, so two threads resolving the same extractor class will always receive the same cached instance and the map itself remains consistent. No behaviour, visibility, or existing static-init population change.

The diff contains no unrelated style changes: existing indentation and blank-line formatting are preserved.

## Tests Added

| Change point | Test |
|--------------|------|
| Default extractor is cached and the same instance is returned on repeated calls | `getRpcExtractorCachesDefaultInstanceAcrossCalls`, `getHttpExtractorCachesDefaultInstanceAcrossCalls` |
| Concurrent callers see a single cached instance and no access throws | `concurrentGetRpcExtractorReturnsSameInstanceAndDoesNotCorrupt` (32 threads × 200 iterations, collects observed extractor identities into a `ConcurrentHashMap.newKeySet()` and asserts size == 1) |

Run:

```
mvn -pl core test -Dtest=ExtractorManagerTest
mvn -pl core test -Dtest="ParamCheckerFilterTest,NamespaceValidationRequestFilterTest,ParamExtractorTest,ExtractorManagerTest"
```

Both pass locally (8 and 27 tests respectively).

## Impact

- Only `ExtractorManager`'s two static caches change type.
- No API contract change: both fields keep the same access modifiers, the same declared `Map` behaviour, and the same keys/values.
- All existing callers (`ParamCheckerFilter`, `NamespaceValidationRequestFilter`, `RemoteParamCheckFilter`) continue to work unchanged — they only rely on `computeIfAbsent`, which behaves identically on `ConcurrentHashMap`.