### PR TITLE
fix(common): compare VersionUtils version parts numerically

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/VersionUtils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/VersionUtils.java
@@ -17,9 +17,7 @@
 package com.alibaba.nacos.common.utils;
 
 import java.io.InputStream;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -59,8 +57,6 @@ public class VersionUtils {
         }
     }
     
-    private static final Comparator<String> STRING_COMPARATOR = String::compareTo;
-    
     /**
      * compare two version who is latest.
      *
@@ -75,15 +71,25 @@ public class VersionUtils {
         if (sA.length != expectSize || sB.length != expectSize) {
             throw new IllegalArgumentException("version must be like x.y.z(-beta)");
         }
-        int first = Objects.compare(sA[0], sB[0], STRING_COMPARATOR);
-        if (first != 0) {
-            return first;
+        int major = Integer.compare(parseVersionPart(sA[0], versionA), parseVersionPart(sB[0], versionB));
+        if (major != 0) {
+            return major;
         }
-        int second = Objects.compare(sA[1], sB[1], STRING_COMPARATOR);
-        if (second != 0) {
-            return second;
+        int minor = Integer.compare(parseVersionPart(sA[1], versionA), parseVersionPart(sB[1], versionB));
+        if (minor != 0) {
+            return minor;
         }
-        return Objects.compare(sA[2].split("-")[0], sB[2].split("-")[0], STRING_COMPARATOR);
+        int patchA = parseVersionPart(sA[2].split("-")[0], versionA);
+        int patchB = parseVersionPart(sB[2].split("-")[0], versionB);
+        return Integer.compare(patchA, patchB);
+    }
+
+    private static int parseVersionPart(String part, String originalVersion) {
+        try {
+            return Integer.parseInt(part);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("version must be like x.y.z(-beta), got: " + originalVersion, e);
+        }
     }
     
     public static String getFullClientVersion() {

--- a/common/src/test/java/com/alibaba/nacos/common/utils/VersionUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/VersionUtilsTest.java
@@ -69,6 +69,32 @@ class VersionUtilsTest {
     void testVersionCompareEtWithChar() {
         assertEquals(0, VersionUtils.compareVersion("1.2.1", "1.2.1-beta"));
     }
+
+    @Test
+    void testVersionCompareTwoDigitMinorIsGreaterThanSingleDigit() {
+        assertTrue(VersionUtils.compareVersion("1.10.0", "1.9.0") > 0);
+        assertTrue(VersionUtils.compareVersion("1.9.0", "1.10.0") < 0);
+    }
+
+    @Test
+    void testVersionCompareTwoDigitMajorIsGreaterThanSingleDigit() {
+        assertTrue(VersionUtils.compareVersion("10.0.0", "9.0.0") > 0);
+        assertTrue(VersionUtils.compareVersion("9.0.0", "10.0.0") < 0);
+    }
+
+    @Test
+    void testVersionCompareTwoDigitPatchIsGreaterThanSingleDigit() {
+        assertTrue(VersionUtils.compareVersion("1.0.10", "1.0.9") > 0);
+        assertTrue(VersionUtils.compareVersion("1.0.9-beta", "1.0.10-beta") < 0);
+    }
+
+    @Test
+    void testVersionCompareNonNumericPartIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> VersionUtils.compareVersion("1.x.0", "1.0.0"));
+        assertThrows(IllegalArgumentException.class,
+                () -> VersionUtils.compareVersion("1.0.0", "a.b.c"));
+    }
     
     @Test
     void testVersionCompareResourceNotExist() {


### PR DESCRIPTION
## Problem

`VersionUtils.compareVersion(String, String)` is documented to compare versions "like x.y.z(-beta)", but it calls `String::compareTo` on each dot-separated segment, which is lexicographical. As soon as any major / minor / patch segment crosses 10, the sign of the result flips:

| Input | Returned | Expected |
|---|---|---|
| `compareVersion("1.10.0", "1.9.0")` | negative (`"10" < "9"` lexicographically) | positive |
| `compareVersion("10.0.0", "9.0.0")` | negative | positive |
| `compareVersion("1.0.10", "1.0.9")`  | negative | positive |

The existing tests all use single-digit segments (`"1.2.x"`, `"1.3.x"`, …), so the regression is not caught today.

This method is used at runtime by `ConfigChangeClusterSyncRequestHandler.checkCompatity`:

```java
if (VersionUtils.compareVersion(version, ignoreCheckVersion) >= 0) {
    return false;
}
```

Once Nacos server releases cross any two-digit segment (minor or patch — a plausible horizon given the current `3.x` track), this branch flips from "new enough, skip tenant check" to the opposite, silently changing cluster-sync behaviour.

## Root Cause

`common/src/main/java/com/alibaba/nacos/common/utils/VersionUtils.java:78-86` used:

```java
int first  = Objects.compare(sA[0], sB[0], STRING_COMPARATOR);
int second = Objects.compare(sA[1], sB[1], STRING_COMPARATOR);
return Objects.compare(sA[2].split("-")[0], sB[2].split("-")[0], STRING_COMPARATOR);
```

`STRING_COMPARATOR` is just `String::compareTo`, so all three segments were ordered by char-by-char Unicode comparison rather than by numeric value.

## Fix

Parse each `major`, `minor`, and `patch` segment as an `int` and compare with `Integer.compare`. The pre-release suffix on `patch` (`"1.0.0-beta"`) is still stripped before numeric parse, matching the documented `x.y.z(-beta)` format. If any segment is non-numeric (for example `"1.x.0"`), the parser now throws `IllegalArgumentException` with the offending version string — consistent with the existing "version must be like x.y.z(-beta)" error.

As a by-product, the private `STRING_COMPARATOR` constant and its `Comparator` / `Objects` imports became unused. They are removed in the same change because leaving them violates the project's "no unused imports" rule and keeping them would only hide dead code.

## Tests Added

| Change point | Test |
|---|---|
| Numeric comparison on minor > 9 | `testVersionCompareTwoDigitMinorIsGreaterThanSingleDigit` (`"1.10.0"` vs `"1.9.0"`, both directions) |
| Numeric comparison on major > 9 | `testVersionCompareTwoDigitMajorIsGreaterThanSingleDigit` (`"10.0.0"` vs `"9.0.0"`, both directions) |
| Numeric comparison on patch > 9 including `-beta` suffix handling | `testVersionCompareTwoDigitPatchIsGreaterThanSingleDigit` (`"1.0.10"` vs `"1.0.9"`, plus `"1.0.9-beta"` vs `"1.0.10-beta"`) |
| Non-numeric segment now rejected with `IllegalArgumentException` | `testVersionCompareNonNumericPartIsRejected` (`"1.x.0"` and `"a.b.c"`) |

All previous tests in `VersionUtilsTest` (single-digit comparisons, `-beta` handling, 4-part version rejection, resource-missing path, semver / vN suites) continue to pass unchanged.

Run:

```
mvn -pl common test -Dtest=VersionUtilsTest
```

Result locally: 37 tests, 0 failures.

## Impact

- Behaviour of `compareVersion` is corrected for any version that contains a segment ≥ 10. Comparisons among pre-existing single-digit versions (`"1.2.0"` vs `"1.3.0"` etc.) are unchanged.
- Callers affected in this repo: `ConfigChangeClusterSyncRequestHandler.checkCompatity`. That code already handled exceptions via a surrounding `try / catch (Exception e)` block, so the stricter non-numeric rejection cannot propagate out of that compatibility check.
- No API surface change; only the internal comparison strategy and the removal of an unused private constant.