### PR TITLE
[ISSUE#14952] fix(console-ui-next): fix incorrect protocol value when restToMcp switch is off

### DIFF
--- a/console-ui-next/src/pages/newMcpServer/index.tsx
+++ b/console-ui-next/src/pages/newMcpServer/index.tsx
@@ -364,7 +364,7 @@ export default function NewMcpServerPage() {
     const serverSpec: Record<string, unknown> = {
       name: serverName.trim(),
       frontProtocol,
-      protocol: isStdio ? 'stdio' : transportProtocol,
+      protocol: isStdio ? 'stdio' : restToMcpSwitch ? transportProtocol : frontProtocol,
       description: description.trim() || undefined,
       enabled,
       versionDetail: { version: version.trim() },


### PR DESCRIPTION
## What is the purpose of the change

Fix the bug where creating an MCP Server with `mcp-streamable` protocol in the new console UI incorrectly sets the `protocol` field to `http` (the default value of `transportProtocol`), causing the server to be displayed as "HTTP to MCP" mode unexpectedly.

Closes #14952

## Brief changelog

- In `buildSubmitData()`, when `restToMcpSwitch` is off, use `frontProtocol` instead of `transportProtocol` as the `protocol` value.

## Root Cause

In `console-ui-next/src/pages/newMcpServer/index.tsx`, the `protocol` field was always set to `transportProtocol` for non-stdio protocols:

```typescript
// Before (bug)
protocol: isStdio ? 'stdio' : transportProtocol,
```

When user selects `mcp-streamable` and does NOT enable the "REST to MCP" switch:
- `transportProtocol` defaults to `'http'`
- So `protocol` is set to `'http'`
- The UI then interprets `protocol === 'http'` as "HTTP to MCP" mode

The old console correctly handles this by checking `restToMcpSwitch` before deciding the protocol value.

## Fix

```typescript
// After (fix)
protocol: isStdio ? 'stdio' : restToMcpSwitch ? transportProtocol : frontProtocol,
```

Now when `restToMcpSwitch` is off, `protocol` correctly uses `frontProtocol` (e.g., `'mcp-streamable'`).

## Verify this change

1. Open the new console UI
2. Create a new MCP Server with `mcp-streamable` protocol
3. Do NOT enable the "REST to MCP" switch
4. Publish the server
5. Verify the server card does NOT show the "HTTP转换" badge