### PR TITLE
fix(config): make ConfigChangeConfigs plugin map volatile and read once

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigs.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigs.java
@@ -43,7 +43,7 @@ public class ConfigChangeConfigs extends Subscriber<ServerConfigChangeEvent> {
     
     private static final String PREFIX = ConfigChangeConstants.NACOS_CORE_CONFIG_PLUGIN_PREFIX;
     
-    private Map<String, Properties> configPluginProperties = new HashMap<>();
+    private volatile Map<String, Properties> configPluginProperties = new HashMap<>();
     
     public ConfigChangeConfigs() {
         NotifyCenter.registerSubscriber(this);
@@ -70,13 +70,14 @@ public class ConfigChangeConfigs extends Subscriber<ServerConfigChangeEvent> {
     }
     
     public Properties getPluginProperties(String configPluginType) {
-        if (!configPluginProperties.containsKey(configPluginType)) {
+        Properties properties = configPluginProperties.get(configPluginType);
+        if (properties == null) {
             LOGGER.warn(
                     "[ConfigChangeConfigs]Can't find config plugin properties for type {}, will use empty properties",
                     configPluginType);
             return new Properties();
         }
-        return configPluginProperties.get(configPluginType);
+        return properties;
     }
     
     @Override

--- a/config/src/test/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigsTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigsTest.java
@@ -18,11 +18,19 @@ package com.alibaba.nacos.config.server.configuration;
 
 import com.alibaba.nacos.common.event.ServerConfigChangeEvent;
 import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -44,6 +52,11 @@ class ConfigChangeConfigsTest {
         configChangeConfigs = new ConfigChangeConfigs();
     }
     
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(environment);
+    }
+    
     @Test
     void testEnable() {
         assertTrue(Boolean.parseBoolean(configChangeConfigs.getPluginProperties("mockPlugin").getProperty("enabled")));
@@ -54,6 +67,75 @@ class ConfigChangeConfigsTest {
         environment.setProperty("nacos.core.config.plugin.mockPlugin.enabled", "false");
         configChangeConfigs.onEvent(ServerConfigChangeEvent.newEvent());
         assertFalse(Boolean.parseBoolean(configChangeConfigs.getPluginProperties("mockPlugin").getProperty("enabled")));
+    }
+    
+    @Test
+    void testGetPluginPropertiesReturnsEmptyForUnknownType() {
+        Properties properties = configChangeConfigs.getPluginProperties("notRegistered");
+        assertNotNull(properties);
+        assertTrue(properties.isEmpty());
+        assertNull(properties.getProperty("enabled"));
+    }
+    
+    @Test
+    void testGetPluginPropertiesNeverReturnsNullDuringConcurrentRefresh() throws InterruptedException {
+        // Reproduces the check-then-act race: previously `getPluginProperties` reloaded
+        // the field between `containsKey` and `get`, so if a refresh swapped in a map
+        // missing the key in between, `get` returned null and the method propagated null.
+        // The fix reads the field once and treats a null lookup as the empty-properties
+        // branch. Two environments are alternated: one with the probe key, one without.
+        int readerThreads = 8;
+        int durationMillis = 300;
+        String pluginType = "raceProbePlugin";
+        String pluginEnabledKey = "nacos.core.config.plugin." + pluginType + ".enabled";
+        MockEnvironment withKey = new MockEnvironment();
+        withKey.setProperty(pluginEnabledKey, "true");
+        MockEnvironment withoutKey = new MockEnvironment();
+        withoutKey.setProperty("nacos.core.config.plugin.otherPlugin.enabled", "true");
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread[] readers = new Thread[readerThreads];
+        for (int i = 0; i < readerThreads; i++) {
+            readers[i] = new Thread(() -> {
+                try {
+                    start.await();
+                    long deadline = System.currentTimeMillis() + durationMillis;
+                    while (System.currentTimeMillis() < deadline) {
+                        Properties properties = configChangeConfigs.getPluginProperties(pluginType);
+                        if (properties == null) {
+                            throw new AssertionError("getPluginProperties returned null mid-refresh");
+                        }
+                    }
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            }, "config-change-reader-" + i);
+            readers[i].start();
+        }
+        Thread refresher = new Thread(() -> {
+            try {
+                start.await();
+                long deadline = System.currentTimeMillis() + durationMillis;
+                int counter = 0;
+                while (System.currentTimeMillis() < deadline) {
+                    EnvUtil.setEnvironment((counter++ % 2 == 0) ? withKey : withoutKey);
+                    configChangeConfigs.onEvent(ServerConfigChangeEvent.newEvent());
+                }
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        }, "config-change-refresher");
+        refresher.start();
+
+        start.countDown();
+        refresher.join(TimeUnit.SECONDS.toMillis(5));
+        for (Thread reader : readers) {
+            reader.join(TimeUnit.SECONDS.toMillis(5));
+        }
+
+        if (failure.get() != null) {
+            throw new AssertionError("Concurrent reader observed failure", failure.get());
+        }
     }
     
 }


### PR DESCRIPTION
## Problem

`ConfigChangeConfigs` (`config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigs.java`) holds plugin properties in a `Map<String, Properties>` field that is rebuilt and reassigned every time a `ServerConfigChangeEvent` arrives. Request-handling threads read the same field via `getPluginProperties(String)` (called from `ConfigChangeAspect`), and the read path has two concurrency issues:

1. `configPluginProperties` is not `volatile`, so a reassignment performed on the event thread is not guaranteed to be visible to other threads.
2. `getPluginProperties` reads the field twice — first for `containsKey`, then for `get`. If a refresh swaps in a new map between the two reads and the new map no longer contains the requested key, `get` returns `null` and the method returns `null` instead of the documented empty-properties fallback. Callers like `ConfigChangeAspect.getProperties` then NPE.

## Root Cause

`getPluginProperties` re-reads the mutable field between the existence check and the value lookup. The new added concurrent test reproduces this by alternating two `Environment` instances on a refresher thread while readers hammer `getPluginProperties`; without the fix, the readers observe `null` returns within a few hundred milliseconds.

## Fix

- Mark `configPluginProperties` as `volatile` so a refresh is visible to readers without a happens-before edge from another lock.
- Read the field exactly once in `getPluginProperties`, then null-check the result. The empty-properties fallback is taken whenever the key is absent regardless of refresh interleaving.

## Tests Added

`config/src/test/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigsTest.java`:

| Change Point | Test |
|--------------|------|
| Single-read + null-check returns empty `Properties` for unknown plugin types | `testGetPluginPropertiesReturnsEmptyForUnknownType` — calls `getPluginProperties(\"notRegistered\")` and asserts the result is non-null and empty |
| Concurrent refresh no longer races with `getPluginProperties` to return `null` | `testGetPluginPropertiesNeverReturnsNullDuringConcurrentRefresh` — 8 reader threads loop on `getPluginProperties(\"raceProbePlugin\")` while a refresher thread alternates `EnvUtil.setEnvironment` between an environment that contains the key and one that does not, and fires `ServerConfigChangeEvent` repeatedly. Fails reliably on the unfixed code (`getPluginProperties returned null mid-refresh`); passes after the fix |

Existing `testEnable` / `testUpgradeEnable` continue to pass, so reload semantics are preserved.

Verified locally:
- `mvn -pl config -Dtest=ConfigChangeConfigsTest test` — 4/4 green after fix; the new concurrent test fails on a clean `upstream/develop` checkout without the fix.
- `mvn -pl config -DskipTests checkstyle:check apache-rat:check com.github.spotbugs:spotbugs-maven-plugin:check` — clean.

## Impact

Confined to `ConfigChangeConfigs`. The map is still rebuilt in full on each refresh and swapped atomically; readers either see the previous map or the new map, never `null`. The empty-properties fallback (already documented behavior) is now taken whenever a key is absent, eliminating the latent NPE on the `ConfigChangeAspect` path during config reloads.