### PR TITLE
[ISSUE #14992] Fix v3 client instance distro routing

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/web/DistroIpPortTagGenerator.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/web/DistroIpPortTagGenerator.java
@@ -23,6 +23,11 @@ import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.core.utils.ReuseHttpServletRequest;
 import com.alibaba.nacos.naming.healthcheck.RsInfo;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Distro IP and port tag generator.
  *
@@ -40,9 +45,18 @@ public class DistroIpPortTagGenerator implements DistroTagGenerator {
     public String getResponsibleTag(ReuseHttpServletRequest request) {
         String ip = request.getParameter(PARAMETER_IP);
         String port = request.getParameter(PARAMETER_PORT);
+        Map<String, String> bodyParameters = null;
+        if (StringUtils.isBlank(ip) || StringUtils.isBlank(port)) {
+            bodyParameters = parseBodyParameters(request);
+            ip = StringUtils.isBlank(ip) ? bodyParameters.get(PARAMETER_IP) : ip;
+            port = StringUtils.isBlank(port) ? bodyParameters.get(PARAMETER_PORT) : port;
+        }
         if (StringUtils.isBlank(ip)) {
             // some old version clients using beat parameter
             String beatStr = request.getParameter(PARAMETER_BEAT);
+            if (StringUtils.isBlank(beatStr) && null != bodyParameters) {
+                beatStr = bodyParameters.get(PARAMETER_BEAT);
+            }
             if (StringUtils.isNotBlank(beatStr)) {
                 try {
                     RsInfo rsInfo = JacksonUtils.toObj(beatStr, RsInfo.class);
@@ -57,5 +71,30 @@ public class DistroIpPortTagGenerator implements DistroTagGenerator {
         }
         port = StringUtils.isBlank(port) ? "0" : port.trim();
         return ip + InternetAddressUtil.IP_PORT_SPLITER + port;
+    }
+    
+    private Map<String, String> parseBodyParameters(ReuseHttpServletRequest request) {
+        Map<String, String> result = new HashMap<>(4);
+        try {
+            Object body = request.getBody();
+            if (!(body instanceof String)) {
+                return result;
+            }
+            String bodyString = (String) body;
+            if (StringUtils.isBlank(bodyString)) {
+                return result;
+            }
+            for (String each : bodyString.split("&")) {
+                int index = each.indexOf('=');
+                if (index <= 0) {
+                    continue;
+                }
+                String key = URLDecoder.decode(each.substring(0, index), StandardCharsets.UTF_8);
+                String value = URLDecoder.decode(each.substring(index + 1), StandardCharsets.UTF_8);
+                result.put(key, value);
+            }
+        } catch (Exception ignored) {
+        }
+        return result;
     }
 }

--- a/naming/src/main/java/com/alibaba/nacos/naming/web/NamingConfig.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/web/NamingConfig.java
@@ -37,6 +37,8 @@ public class NamingConfig {
     
     private static final String URL_PATTERNS_V2 = "/v2/ns/*";
     
+    private static final String URL_PATTERNS_V3_CLIENT = "/v3/client/ns/*";
+    
     private static final String DISTRO_FILTER = "distroFilter";
     
     private static final String SERVICE_NAME_FILTER = "serviceNameFilter";
@@ -60,7 +62,7 @@ public class NamingConfig {
     public FilterRegistrationBean<DistroFilter> distroFilterRegistration() {
         FilterRegistrationBean<DistroFilter> registration = new FilterRegistrationBean<>();
         registration.setFilter(distroFilter());
-        registration.addUrlPatterns(URL_PATTERNS);
+        registration.addUrlPatterns(URL_PATTERNS, URL_PATTERNS_V3_CLIENT);
         registration.setName(DISTRO_FILTER);
         registration.setOrder(7);
         return registration;

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/DistroIpPortTagGeneratorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/DistroIpPortTagGeneratorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.web;
+
+import com.alibaba.nacos.common.http.param.MediaType;
+import com.alibaba.nacos.core.utils.ReuseHttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DistroIpPortTagGeneratorTest {
+
+    private final DistroIpPortTagGenerator generator = new DistroIpPortTagGenerator();
+
+    @Test
+    void testGetResponsibleTagFromRequestParameters() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nacos/v3/client/ns/instance");
+        request.addParameter("ip", "1.1.1.1");
+        request.addParameter("port", "8848");
+
+        assertEquals("1.1.1.1:8848", generator.getResponsibleTag(new ReuseHttpServletRequest(request)));
+    }
+
+    @Test
+    void testGetResponsibleTagFromFormBody() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/nacos/v3/client/ns/instance");
+        request.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        request.setContent("serviceName=test&ip=1.1.1.1&port=8848".getBytes(StandardCharsets.UTF_8));
+
+        assertEquals("1.1.1.1:8848", generator.getResponsibleTag(new ReuseHttpServletRequest(request)));
+    }
+
+    @Test
+    void testGetResponsibleTagFromBeatInFormBody() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/nacos/v1/ns/instance/beat");
+        request.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        request.setContent("beat=%7B%22ip%22%3A%221.1.1.1%22%2C%22port%22%3A8848%7D".getBytes(StandardCharsets.UTF_8));
+
+        assertEquals("1.1.1.1:8848", generator.getResponsibleTag(new ReuseHttpServletRequest(request)));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/NamingConfigTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/NamingConfigTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.web;
+
+import com.alibaba.nacos.core.code.ControllerMethodsCache;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class NamingConfigTest {
+
+    @Test
+    void testDistroFilterContainsV3NamingPaths() {
+        NamingConfig config = new NamingConfig(mock(ControllerMethodsCache.class));
+        FilterRegistrationBean<DistroFilter> registration = config.distroFilterRegistration();
+
+        assertTrue(registration.getUrlPatterns().contains("/v1/ns/*"));
+        assertTrue(registration.getUrlPatterns().contains("/v3/client/ns/*"));
+    }
+}


### PR DESCRIPTION
Fixes #14992.

## What is the purpose of the change

Fix v3 client naming instance register, heartbeat and deregister in cluster mode. Requests to `/v3/client/ns/instance` now participate in Distro routing like the legacy `/v1/ns/instance/beat` flow, so instance changes land on the responsible node and can be synchronized to the cluster.

## Brief changelog

- Register `DistroFilter` for `/v3/client/ns/*`.
- Let `DistroIpPortTagGenerator` read `ip`, `port`, and legacy `beat` from form body when servlet parameters are unavailable.
- Build `RsInfo` for v3 heartbeat so missing ephemeral instances can be auto-registered by `InstanceOperator#handleBeat`.
- Default v3 client API register/deregister instances to ephemeral unless `ephemeral=false` is explicitly provided.
- Add unit tests for v3 distro filter registration, body tag parsing, heartbeat payload, and ephemeral defaults.

## Verifying this change

- [x] `mvn -pl naming -am -Dtest=InstanceOpenApiControllerTest,InstanceOperatorClientImplTest,DistroIpPortTagGeneratorTest,NamingConfigTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `mvn -pl naming -am -DskipTests package apache-rat:check checkstyle:check spotbugs:check`
- [x] `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check -DskipTests`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction.
* [x] Run basic compile, RAT, Checkstyle and SpotBugs checks.
* [ ] Full install and integration-test suites were not run locally.