### PR TITLE
[ISSUE#11122] fix(naming): accept healthCheckEnabled as switch entry alias

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchEntry.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchEntry.java
@@ -51,6 +51,8 @@ public class SwitchEntry {
     
     public static final String CHECK = "check";
     
+    public static final String HEALTH_CHECK_ENABLED = "healthCheckEnabled";
+    
     public static final String PUSH_ENABLED = "pushEnabled";
     
     public static final String SERVICE_STATUS_SYNC_PERIOD = "serviceStatusSynchronizationPeriodMillis";

--- a/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/misc/SwitchManager.java
@@ -186,7 +186,7 @@ public class SwitchManager extends RequestProcessor4CP {
                 tempSwitchDomain.setDistroEnabled(enabled);
             }
             
-            if (entry.equals(SwitchEntry.CHECK)) {
+            if (entry.equals(SwitchEntry.CHECK) || entry.equals(SwitchEntry.HEALTH_CHECK_ENABLED)) {
                 boolean enabled = Boolean.parseBoolean(value);
                 tempSwitchDomain.setHealthCheckEnabled(enabled);
             }

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
@@ -124,4 +124,27 @@ class SwitchManagerTest {
         switchManager.update(SwitchEntry.ENABLE_STANDALONE, "", true);
         assertTrue(switchDomain.isEnableStandalone());
     }
+
+    @Test
+    void testUpdateHealthCheckEnabledWithLegacyCheckEntry() throws Exception {
+        assertTrue(switchDomain.isHealthCheckEnabled());
+        switchManager.update(SwitchEntry.CHECK, "false", true);
+        assertFalse(switchDomain.isHealthCheckEnabled());
+        switchManager.update(SwitchEntry.CHECK, "true", true);
+        assertTrue(switchDomain.isHealthCheckEnabled());
+    }
+
+    @Test
+    void testUpdateHealthCheckEnabledWithExposedFieldName() throws Exception {
+        assertTrue(switchDomain.isHealthCheckEnabled());
+        switchManager.update(SwitchEntry.HEALTH_CHECK_ENABLED, "false", true);
+        assertFalse(switchDomain.isHealthCheckEnabled());
+        switchManager.update(SwitchEntry.HEALTH_CHECK_ENABLED, "true", true);
+        assertTrue(switchDomain.isHealthCheckEnabled());
+    }
+
+    @Test
+    void testHealthCheckEnabledEntryConstantValue() {
+        assertEquals("healthCheckEnabled", SwitchEntry.HEALTH_CHECK_ENABLED);
+    }
 }


### PR DESCRIPTION
## Problem

Fixes #11122.

`GET /v3/admin/ns/operator/switches` exposes the health-check toggle under the
JSON field name `healthCheckEnabled`. However, `PUT /v3/admin/ns/operator/switches`
silently no-ops when callers send `entry=healthCheckEnabled`; the only entry name
that actually toggles `SwitchDomain.healthCheckEnabled` is the legacy short name
`check`. Users who copy the field name straight from the GET response see the
request return success while the value remains unchanged.

## Root Cause

`SwitchManager.update(entry, value, debug)` only matches `SwitchEntry.CHECK`
(value `"check"`) for this toggle. There is no fall-through for the field name
`healthCheckEnabled`, so requests using the exposed field name fall past every
branch and the update is a no-op (the cloned `tempSwitchDomain` is then written
back unchanged).

The maintainer's suggested direction in the issue thread was to accept either
the legacy key or the new key.

## Fix

- Add `SwitchEntry.HEALTH_CHECK_ENABLED = "healthCheckEnabled"` so the constant
  matches the JSON field name returned by the GET endpoint.
- In `SwitchManager.update`, match either `SwitchEntry.CHECK` or
  `SwitchEntry.HEALTH_CHECK_ENABLED` for the `setHealthCheckEnabled` branch.
  The legacy `check` alias is preserved for backwards compatibility.

No behavioral change for existing clients that use `check`. The fix is scoped
strictly to the inconsistency reported in #11122; other legacy short-name
entries (`distro`, `batch`) are intentionally left untouched.

## Tests Added

| Change point | Test |
|--------------|------|
| `SwitchEntry.HEALTH_CHECK_ENABLED` constant value matches the JSON field name | `testHealthCheckEnabledEntryConstantValue()` asserts the constant equals `"healthCheckEnabled"` |
| New entry alias toggles `healthCheckEnabled` true→false→true | `testUpdateHealthCheckEnabledWithExposedFieldName()` |
| Legacy `check` alias still toggles `healthCheckEnabled` (regression) | `testUpdateHealthCheckEnabledWithLegacyCheckEntry()` |

All 14 tests in `SwitchManagerTest` pass locally.

## Impact

- Public REST API: `PUT /v3/admin/ns/operator/switches` now also accepts
  `entry=healthCheckEnabled`. The legacy `entry=check` form continues to work.
- No change to `SwitchDomain` serialized form, the CP write path, or any other
  switch entry.
- Out of scope: the secondary symptom in the issue where `debug=false` requires
  an established CP cluster to apply the change. That is a separate concern
  about the consistency-protocol path, not the entry-name asymmetry.