### PR TITLE
fix(auth): read cached map once in remote auth services to avoid TOCTOU

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceRemoteImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceRemoteImpl.java
@@ -91,8 +91,9 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService imple
     
     @Override
     public List<PermissionInfo> getPermissions(String role) {
-        if (getCachedPermissionInfoMap().containsKey(role)) {
-            return getCachedPermissionInfoMap().get(role);
+        List<PermissionInfo> cached = getCachedPermissionInfoMap().get(role);
+        if (cached != null) {
+            return cached;
         }
         reload();
         return getCachedPermissionInfoMap().get(role);
@@ -114,8 +115,9 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService imple
     
     @Override
     public List<RoleInfo> getRoles(String username) {
-        if (getCachedRoleInfoMap().containsKey(username)) {
-            return getCachedRoleInfoMap().get(username);
+        List<RoleInfo> cached = getCachedRoleInfoMap().get(username);
+        if (cached != null) {
+            return cached;
         }
         reload();
         return getCachedRoleInfoMap().get(username);

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/users/NacosUserServiceRemoteImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/users/NacosUserServiceRemoteImpl.java
@@ -98,8 +98,9 @@ public class NacosUserServiceRemoteImpl extends AbstractCachedUserService implem
     
     @Override
     public User getUser(String username) {
-        if (getCachedUserMap().containsKey(username)) {
-            return getCachedUserMap().get(username);
+        User cached = getCachedUserMap().get(username);
+        if (cached != null) {
+            return cached;
         }
         reload();
         return getCachedUserMap().get(username);

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceRemoteImplTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceRemoteImplTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.roles;
+
+import com.alibaba.nacos.plugin.auth.impl.configuration.AuthConfigs;
+import com.alibaba.nacos.plugin.auth.impl.persistence.PermissionInfo;
+import com.alibaba.nacos.plugin.auth.impl.persistence.RoleInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for cache-access semantics on {@link NacosRoleServiceRemoteImpl#getPermissions(String)}
+ * and {@link NacosRoleServiceRemoteImpl#getRoles(String)}.
+ */
+@ExtendWith(MockitoExtension.class)
+class NacosRoleServiceRemoteImplTest {
+
+    @Mock
+    private AuthConfigs authConfigs;
+
+    @Test
+    void testGetPermissionsReadsCachedMapOnceOnHit() throws Exception {
+        // Reproduces the same TOCTOU pattern as getUser/getRoles: previously
+        // containsKey + get were issued through two separate getCached* calls,
+        // which let the scheduled reload swap the map reference between them and
+        // produce inconsistent observations. After the fix the map is read once.
+        NacosRoleServiceRemoteImpl service = new NacosRoleServiceRemoteImpl(authConfigs);
+        PermissionInfo permissionInfo = new PermissionInfo();
+        permissionInfo.setRole("admin");
+        permissionInfo.setResource("ns:*:*");
+        permissionInfo.setAction("rw");
+        List<PermissionInfo> permissions = Collections.singletonList(permissionInfo);
+        CountingMap<String, List<PermissionInfo>> cache = new CountingMap<>();
+        cache.put("admin", permissions);
+        injectField("permissionInfoMap", service, cache);
+
+        List<PermissionInfo> result = service.getPermissions("admin");
+
+        assertSame(permissions, result, "cache hit must return the cached permission list");
+        assertEquals(1, cache.getCount.get(), "cache hit must read the map exactly once");
+        assertEquals(0, cache.containsKeyCount.get(), "fix must not consult containsKey separately");
+    }
+
+    @Test
+    void testGetRolesReadsCachedMapOnceOnHit() throws Exception {
+        NacosRoleServiceRemoteImpl service = new NacosRoleServiceRemoteImpl(authConfigs);
+        RoleInfo roleInfo = new RoleInfo();
+        roleInfo.setRole("admin");
+        roleInfo.setUsername("alice");
+        List<RoleInfo> roles = Collections.singletonList(roleInfo);
+        CountingMap<String, List<RoleInfo>> cache = new CountingMap<>();
+        cache.put("alice", roles);
+        injectField("roleInfoMap", service, cache);
+
+        List<RoleInfo> result = service.getRoles("alice");
+
+        assertSame(roles, result, "cache hit must return the cached role list");
+        assertEquals(1, cache.getCount.get(), "cache hit must read the map exactly once");
+        assertEquals(0, cache.containsKeyCount.get(), "fix must not consult containsKey separately");
+    }
+
+    private static void injectField(String fieldName, NacosRoleServiceRemoteImpl service, Map<String, ?> map)
+            throws Exception {
+        Field field = AbstractCachedRoleService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(service, map);
+    }
+
+    private static final class CountingMap<K, V> extends ConcurrentHashMap<K, V> {
+
+        private static final long serialVersionUID = 1L;
+
+        final AtomicInteger getCount = new AtomicInteger();
+
+        final AtomicInteger containsKeyCount = new AtomicInteger();
+
+        @Override
+        public V get(Object key) {
+            getCount.incrementAndGet();
+            return super.get(key);
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            containsKeyCount.incrementAndGet();
+            return super.containsKey(key);
+        }
+    }
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/users/NacosUserServiceRemoteImplTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/users/NacosUserServiceRemoteImplTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.impl.users;
+
+import com.alibaba.nacos.plugin.auth.impl.configuration.AuthConfigs;
+import com.alibaba.nacos.plugin.auth.impl.persistence.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link NacosUserServiceRemoteImpl#getUser(String)} cache-access semantics.
+ */
+@ExtendWith(MockitoExtension.class)
+class NacosUserServiceRemoteImplTest {
+
+    @Mock
+    private AuthConfigs authConfigs;
+
+    @Test
+    void testGetUserReadsCachedMapOnceOnHit() throws Exception {
+        // Reproduces the TOCTOU pattern where getUser previously called containsKey
+        // and then get on getCachedUserMap() — two separate field reads. Between the
+        // two, the scheduled reload could swap the map reference, so containsKey
+        // could observe true while get on the new snapshot returned null. The fix
+        // reads the map once and inspects the value, guaranteeing a consistent view.
+        NacosUserServiceRemoteImpl service = new NacosUserServiceRemoteImpl(authConfigs);
+        User alice = new User();
+        alice.setUsername("alice");
+        alice.setPassword("pwd");
+        CountingMap<String, User> cache = new CountingMap<>();
+        cache.put("alice", alice);
+        injectCachedUserMap(service, cache);
+
+        User result = service.getUser("alice");
+
+        assertSame(alice, result, "cache hit must return the cached user");
+        assertEquals(1, cache.getCount.get(), "cache hit must read the map exactly once");
+        assertEquals(0, cache.containsKeyCount.get(), "fix must not consult containsKey separately");
+    }
+
+    private static void injectCachedUserMap(NacosUserServiceRemoteImpl service, java.util.Map<String, User> map)
+            throws Exception {
+        Field field = AbstractCachedUserService.class.getDeclaredField("userMap");
+        field.setAccessible(true);
+        field.set(service, map);
+    }
+
+    private static final class CountingMap<K, V> extends ConcurrentHashMap<K, V> {
+
+        private static final long serialVersionUID = 1L;
+
+        final AtomicInteger getCount = new AtomicInteger();
+
+        final AtomicInteger containsKeyCount = new AtomicInteger();
+
+        @Override
+        public V get(Object key) {
+            getCount.incrementAndGet();
+            return super.get(key);
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            containsKeyCount.incrementAndGet();
+            return super.containsKey(key);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Three look-up methods in the remote auth services consult the cached map twice in a row through two separate `getCached*()` accessor calls:

- `NacosUserServiceRemoteImpl.getUser(String)`
- `NacosRoleServiceRemoteImpl.getPermissions(String)`
- `NacosRoleServiceRemoteImpl.getRoles(String)`

Each one followed the same shape:

```java
if (getCachedUserMap().containsKey(username)) {
    return getCachedUserMap().get(username);
}
reload();
return getCachedUserMap().get(username);
```

The two cache accessors back onto fields published by `@Scheduled reload()` in `AbstractCachedUserService` / `AbstractCachedRoleService`, which rebuild a fresh `ConcurrentHashMap` and reassign the field every 15 s. The scheduled swap can interleave between the `containsKey` call and the matching `get` call, so the second accessor returns a value from a different snapshot than the one we just verified.

## Root Cause

A classic check-then-act / TOCTOU race: the predicate (`containsKey`) and the action (`get`) execute against two independent reads of a reload-replaceable field.

Failure mode in production:

1. Reader: `containsKey("alice")` → snapshot A says yes.
2. Scheduler: reload swaps in snapshot B (alice no longer present, e.g. just deleted).
3. Reader: `get("alice")` → returns `null`.
4. Caller now observes a `null` user/role/permission list immediately after the cache reported the key as present, leading either to NPEs in downstream code paths or to spurious "not found" results on resources that very much do exist.

The race is independent of, and not closed by, declaring the underlying field `volatile` — that only fixes visibility of each individual read, not atomicity across two reads.

## Fix

Read the map once into a local, then inspect the value with a null check before deciding whether to reload. `ConcurrentHashMap` forbids `null` values, so `containsKey == true` and `get != null` are equivalent — behaviour is preserved exactly. The reload-then-retry fallback at the end of each method is untouched.

```java
User cached = getCachedUserMap().get(username);
if (cached != null) {
    return cached;
}
reload();
return getCachedUserMap().get(username);
```

Three call sites, two files. No API or wire-format change.

## Tests Added

New per-site tests using a `CountingMap` extension of `ConcurrentHashMap` that increments separate counters in its overridden `get` and `containsKey` methods. After the fix each test observes exactly one `get` call and zero `containsKey` calls on a cache hit; before the fix the tests fail with `expected: <1> but was: <2>` because `ConcurrentHashMap.containsKey` is internally implemented as `get(key) != null` and the explicit `get` adds a second invocation.

| Change point | Test |
|--------------|------|
| `NacosUserServiceRemoteImpl.getUser` reads cached map once on hit | `NacosUserServiceRemoteImplTest#testGetUserReadsCachedMapOnceOnHit` |
| `NacosRoleServiceRemoteImpl.getPermissions(String)` reads cached map once on hit | `NacosRoleServiceRemoteImplTest#testGetPermissionsReadsCachedMapOnceOnHit` |
| `NacosRoleServiceRemoteImpl.getRoles(String)` reads cached map once on hit | `NacosRoleServiceRemoteImplTest#testGetRolesReadsCachedMapOnceOnHit` |

Verified by reverting the production change and re-running: all three new tests fail with the original code (`expected: <1> but was: <2>`) and pass once the fix is reapplied. `mvn -pl plugin-default-impl/nacos-default-auth-plugin test` reports 162 tests passing; checkstyle is clean.

## Impact

- Scope: 9 added / 6 removed lines across two production files plus two dedicated test classes.
- Affects: any deployment using the remote variants of the auth plugin (`NacosUserServiceRemoteImpl`, `NacosRoleServiceRemoteImpl`), and by extension `AbstractCheckedRoleService.hasPermission` / `hasGlobalAdminRole(...)` which call these methods on every authorization decision.
- Does not change the cache reload schedule, the reload trigger on miss, the result returned to callers in any consistent state, or the equivalent direct-DB implementations (which only access the cache once and are not affected).
- Independent of and complementary to PR #14996 (volatile publication of `userMap`): this PR closes the cross-read atomicity hole, that PR closes the per-read visibility hole. Reverting either fix leaves the other one's behaviour intact.