### PR TITLE
fix(datasource): add missing ? placeholder for group_id LIKE in BaseConfigInfoMapper

### DIFF
--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-base/src/main/java/com/alibaba/nacos/plugin/datasource/impl/base/BaseConfigInfoMapper.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-base/src/main/java/com/alibaba/nacos/plugin/datasource/impl/base/BaseConfigInfoMapper.java
@@ -185,7 +185,7 @@ public abstract class BaseConfigInfoMapper extends AbstractMapper implements Con
             paramList.add(dataId);
         }
         if (!StringUtils.isBlank(group)) {
-            where += " AND group_id LIKE ";
+            where += " AND group_id LIKE ? ";
             paramList.add(group);
         }
         if (!StringUtils.isBlank(content)) {

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/ConfigInfoMapperByPostgresqlTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/ConfigInfoMapperByPostgresqlTest.java
@@ -106,6 +106,14 @@ class ConfigInfoMapperByPostgresqlTest {
         assertArrayEquals(new Object[] {tenantId, dataId, groupId, appName}, mapperResult.getParamList().toArray());
     }
     
+    @Test
+    void testFindConfigInfoBaseLikeFetchRows() {
+        MapperResult mapperResult = configInfoMapperByPostgresql.findConfigInfoBaseLikeFetchRows(context);
+        assertEquals("SELECT id,data_id,group_id,tenant_id,content FROM config_info WHERE "
+                + " 1=1 AND tenant_id=''  AND data_id LIKE ?  AND group_id LIKE ?   "
+                + "OFFSET " + startRow + " LIMIT " + pageSize, mapperResult.getSql());
+        assertArrayEquals(new Object[] {dataId, groupId}, mapperResult.getParamList().toArray());
+    }
     
     @Test
     void testGetTableName() {


### PR DESCRIPTION
## What is the purpose of the change

`BaseConfigInfoMapper.findConfigInfoBaseLikeFetchRows` builds a `LIKE` filter for `group_id` but appends `" AND group_id LIKE "` with no `?` placeholder, while still adding the `group` value to the parameter list. The resulting SQL is malformed and the parameter count no longer matches the placeholder count.

The `findConfigInfoBaseLikeFetchRows` method is overridden by the MySQL, Derby and Oracle mappers (all of which include the placeholder), so PostgreSQL — which inherits the base implementation as-is — is the only built-in database affected when the `group` filter is non-blank.

## Brief changelog

- `BaseConfigInfoMapper.findConfigInfoBaseLikeFetchRows`: add the missing `?` placeholder so the SQL has the same shape as the `data_id LIKE` and `content LIKE` branches in the same method (and the equivalent count-rows method on the interface).
- `ConfigInfoMapperByPostgresqlTest`: add `testFindConfigInfoBaseLikeFetchRowsWithGroupKeepsPlaceholderAndParamsAligned` covering the previously-uncovered `findConfigInfoBaseLikeFetchRows` path with a non-blank `group_id`. Asserts the full expected SQL and the exact parameter list, so any future regression of either side will be caught.

## Verifying this change

- Reverting the one-line fix in `BaseConfigInfoMapper` causes the new test to fail with a SQL string mismatch (the `group_id LIKE` clause has no `?` and the `paramList` still contains the group value), which confirms the test exercises the bug path.
- After the fix, `mvn -pl plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql -am test` and `mvn -B apache-rat:check checkstyle:check spotbugs:check -DskipTests` both pass on the affected modules.
- All existing MySQL / Derby / Oracle / PostgreSQL mapper tests continue to pass — the change only adds a placeholder on a code path no other built-in database hits.