### PR TITLE
[ISSUE #14774] fix(plugin/oidc): shade Caffeine into plugin jar to avoid NoClassDefFoundError

### DIFF
--- a/plugin-default-impl/nacos-oidc-auth-plugin/pom.xml
+++ b/plugin-default-impl/nacos-oidc-auth-plugin/pom.xml
@@ -91,7 +91,7 @@
 
     <build>
         <plugins>
-            <!-- Create fat JAR with Nimbus dependencies included -->
+            <!-- Create fat JAR with runtime dependencies bundled and relocated -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -107,6 +107,7 @@
                                 <includes>
                                     <include>com.nimbusds:*</include>
                                     <include>net.minidev:*</include>
+                                    <include>com.github.ben-manes.caffeine:caffeine</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -117,6 +118,10 @@
                                 <relocation>
                                     <pattern>net.minidev</pattern>
                                     <shadedPattern>com.alibaba.nacos.shaded.minidev</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.github.benmanes.caffeine</pattern>
+                                    <shadedPattern>com.alibaba.nacos.shaded.caffeine</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>


### PR DESCRIPTION
## What is the purpose of the change

`nacos-oidc-auth-plugin` uses Caffeine for the JWKS cache (`JwksProvider#jwksCache`), but the `maven-shade-plugin` configuration only bundles `com.nimbusds:*` and `net.minidev:*`. The packaged plugin jar therefore does not contain any Caffeine classes and the bytecode still references the unshaded `com.github.benmanes.caffeine.cache.*`. When the plugin jar is loaded by a Nacos console process that does not provide Caffeine on its runtime classpath, the OIDC login handler fails with:

```
java.lang.NoClassDefFoundError: com/github/benmanes/caffeine/cache/Caffeine
```

This matches the failure reported in #14774.

## Brief changelog

- `plugin-default-impl/nacos-oidc-auth-plugin/pom.xml`:
  - add `com.github.ben-manes.caffeine:caffeine` to the shade `<includes>` so Caffeine classes are bundled into the plugin jar.
  - add a relocation for `com.github.benmanes.caffeine` → `com.alibaba.nacos.shaded.caffeine`, matching the existing convention used for `com.nimbusds` and `net.minidev`. This rewrites the bundled Caffeine classes and the bytecode references inside `JwksProvider` consistently, so they keep matching at runtime and avoid colliding with any Caffeine that a host process may already have on its classpath.

## Verifying this change

Before the fix:
- `mvn -pl plugin-default-impl/nacos-oidc-auth-plugin -am package -DskipTests` produces `nacos-oidc-auth-plugin-3.2.1.jar`.
- `jar tf … | grep caffeine` returns no entries — Caffeine is not bundled.
- `javap` on `JwksProvider.class` still references `com/github/benmanes/caffeine/cache/Cache`, which is not on the plugin classloader's runtime classpath, hence the `NoClassDefFoundError` reported in #14774.

After the fix:
- The same `mvn package` command now bundles Caffeine under `com/alibaba/nacos/shaded/caffeine/cache/...` (verified with `jar tf`).
- `javap` on `JwksProvider.class` inside the shaded jar references `com/alibaba/nacos/shaded/caffeine/cache/Cache`, which resolves to the bundled classes inside the same jar.
- `mvn -pl plugin-default-impl/nacos-oidc-auth-plugin -am test` and `mvn -pl … -am apache-rat:check checkstyle:check spotbugs:check -DskipTests` both pass — the change is limited to packaging configuration and does not touch any runtime code paths or test classpaths.

This change is a build-config-only fix (no Java source modified), so no new unit tests are added; the bug only manifests when the packaged plugin is loaded by a Nacos process whose classpath lacks Caffeine, which is not exercised by JUnit tests.