### PR TITLE
fix(auth): make NacosServerAuthConfig plugin map volatile and read once

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/auth/NacosServerAuthConfig.java
+++ b/core/src/main/java/com/alibaba/nacos/core/auth/NacosServerAuthConfig.java
@@ -59,7 +59,7 @@ public class NacosServerAuthConfig extends AbstractDynamicConfig implements Naco
     
     private String serverIdentityValue;
     
-    private Map<String, Properties> authPluginProperties = new HashMap<>();
+    private volatile Map<String, Properties> authPluginProperties = new HashMap<>();
     
     public NacosServerAuthConfig() {
         super("NacosServerAuth");
@@ -138,11 +138,12 @@ public class NacosServerAuthConfig extends AbstractDynamicConfig implements Naco
     }
     
     public Properties getAuthPluginProperties(String authType) {
-        if (!authPluginProperties.containsKey(authType)) {
+        Properties properties = authPluginProperties.get(authType);
+        if (properties == null) {
             LOGGER.warn("Can't find properties for type {}, will use empty properties", authType);
             return new Properties();
         }
-        return authPluginProperties.get(authType);
+        return properties;
     }
     
     @Override

--- a/core/src/test/java/com/alibaba/nacos/core/auth/NacosServerAuthConfigTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/auth/NacosServerAuthConfigTest.java
@@ -20,6 +20,7 @@ package com.alibaba.nacos.core.auth;
 import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.auth.config.AuthErrorCode;
+import com.alibaba.nacos.common.event.ServerConfigChangeEvent;
 import com.alibaba.nacos.plugin.auth.constant.Constants;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -30,6 +31,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -146,5 +150,67 @@ class NacosServerAuthConfigTest {
         assertNotNull(str);
         assertTrue(str.contains("NacosServerAuthConfig"));
         assertTrue(str.contains("authEnabled"));
+    }
+
+    @Test
+    void testGetAuthPluginPropertiesNeverReturnsNullDuringConcurrentRefresh() throws InterruptedException {
+        // Reproduces the check-then-act race: previously `getAuthPluginProperties` read
+        // the field twice (`containsKey` then `get`), so if a refresh swapped in a map
+        // missing the key in between, `get` returned null and the method propagated null
+        // to callers instead of falling back to the empty-properties branch.
+        NacosServerAuthConfig config = new NacosServerAuthConfig();
+        int readerThreads = 8;
+        int durationMillis = 300;
+        String pluginType = "raceProbePlugin";
+        String pluginEnabledKey = "nacos.core.auth.plugin." + pluginType + ".enabled";
+        MockEnvironment withKey = new MockEnvironment();
+        withKey.setProperty(Constants.Auth.NACOS_CORE_AUTH_ENABLED, "false");
+        withKey.setProperty(pluginEnabledKey, "true");
+        MockEnvironment withoutKey = new MockEnvironment();
+        withoutKey.setProperty(Constants.Auth.NACOS_CORE_AUTH_ENABLED, "false");
+        withoutKey.setProperty("nacos.core.auth.plugin.otherPlugin.enabled", "true");
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread[] readers = new Thread[readerThreads];
+        for (int i = 0; i < readerThreads; i++) {
+            readers[i] = new Thread(() -> {
+                try {
+                    start.await();
+                    long deadline = System.currentTimeMillis() + durationMillis;
+                    while (System.currentTimeMillis() < deadline) {
+                        Properties properties = config.getAuthPluginProperties(pluginType);
+                        if (properties == null) {
+                            throw new AssertionError("getAuthPluginProperties returned null mid-refresh");
+                        }
+                    }
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            }, "auth-config-reader-" + i);
+            readers[i].start();
+        }
+        Thread refresher = new Thread(() -> {
+            try {
+                start.await();
+                long deadline = System.currentTimeMillis() + durationMillis;
+                int counter = 0;
+                while (System.currentTimeMillis() < deadline) {
+                    EnvUtil.setEnvironment((counter++ % 2 == 0) ? withKey : withoutKey);
+                    config.onEvent(ServerConfigChangeEvent.newEvent());
+                }
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        }, "auth-config-refresher");
+        refresher.start();
+        start.countDown();
+        refresher.join(TimeUnit.SECONDS.toMillis(5));
+        for (Thread reader : readers) {
+            reader.join(TimeUnit.SECONDS.toMillis(5));
+        }
+        Throwable observed = failure.get();
+        if (observed != null) {
+            throw new AssertionError(observed);
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`NacosServerAuthConfig.authPluginProperties` (`core/src/main/java/com/alibaba/nacos/core/auth/NacosServerAuthConfig.java`) is reassigned by `refreshPluginProperties` whenever the dynamic-config refresh path runs (triggered via `AbstractDynamicConfig.onEvent` on `ServerConfigChangeEvent`), while request-handling threads call `getAuthPluginProperties` concurrently. Two issues exist on the read path:

1. The field has no `volatile` modifier, so a reassignment performed on the refresh thread is not guaranteed to be visible to other threads (and the new map's writes inside `refreshPluginProperties` only happen-before publication if the field is `volatile`).
2. `getAuthPluginProperties` reads the field twice — once via `containsKey`, then via `get`. If a refresh swaps in a map missing the requested key between the two reads, `get` returns `null` and the method propagates `null` to callers instead of falling back to the empty-`Properties` branch as intended.

This mirrors the same race that was fixed in `ConfigChangeConfigs` in #14988; `AuthConfigs` in the auth plugin module has the same pattern and is being addressed in a separate PR.

## Brief changelog

- `NacosServerAuthConfig.authPluginProperties`: declared `volatile` so refresh-thread reassignments and the contents of the new map are guaranteed-visible to readers.
- `NacosServerAuthConfig.getAuthPluginProperties`: reads the field once, null-checks the lookup, and falls back to a fresh empty `Properties` whenever the key is absent — eliminating the check-then-act window.
- `NacosServerAuthConfigTest`: adds `testGetAuthPluginPropertiesNeverReturnsNullDuringConcurrentRefresh`, which spins up 8 reader threads against a refresher thread that alternates two environments (one with the probe key, one without) and asserts no reader ever observes a `null` result.

## Verifying this change

- Reverting the source change (single-`get` + null check restored to the original `containsKey` + `get` pattern) makes the new test fail with `getAuthPluginProperties returned null mid-refresh` (verified locally).
- After the fix, `mvn -pl core -am test -Dtest=NacosServerAuthConfigTest` and `mvn -pl core -am apache-rat:check checkstyle:check spotbugs:check -DskipTests` both pass.
- All existing tests in `NacosServerAuthConfigTest` continue to pass — the change preserves the documented contract that `getAuthPluginProperties` returns a non-null `Properties` (empty when the type is unknown).