### PR TITLE
fix(auth): make AuthConfigs plugin map volatile and read once

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/AuthConfigs.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/AuthConfigs.java
@@ -89,7 +89,7 @@ public class AuthConfigs extends Subscriber<ServerConfigChangeEvent> {
     
     private boolean hasGlobalAdminRole;
     
-    private Map<String, Properties> authPluginProperties = new HashMap<>();
+    private volatile Map<String, Properties> authPluginProperties = new HashMap<>();
     
     public AuthConfigs() {
         NotifyCenter.registerSubscriber(this);
@@ -196,11 +196,12 @@ public class AuthConfigs extends Subscriber<ServerConfigChangeEvent> {
     }
     
     public Properties getAuthPluginProperties(String authType) {
-        if (!authPluginProperties.containsKey(authType)) {
+        Properties properties = authPluginProperties.get(authType);
+        if (properties == null) {
             LOGGER.warn("Can't find properties for type {}, will use empty properties", authType);
             return new Properties();
         }
-        return authPluginProperties.get(authType);
+        return properties;
     }
     
     @JustForTest

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/configuration/AuthConfigsTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/configuration/AuthConfigsTest.java
@@ -22,6 +22,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AuthConfigsTest {
@@ -58,5 +63,64 @@ class AuthConfigsTest {
         assertEquals(TEST_CACHING_ENABLED, authConfigs.isCachingEnabled());
         assertEquals(TEST_SERVER_IDENTITY_KEY, authConfigs.getServerIdentityKey());
         assertEquals(TEST_SERVER_IDENTITY_VALUE, authConfigs.getServerIdentityValue());
+    }
+
+    @Test
+    void testGetAuthPluginPropertiesNeverReturnsNullDuringConcurrentRefresh() throws InterruptedException {
+        // Reproduces the check-then-act race: previously `getAuthPluginProperties` read
+        // the field twice (`containsKey` then `get`), so if a refresh swapped in a map
+        // missing the key in between, `get` returned null and the method propagated null
+        // to callers instead of falling back to the empty-properties branch.
+        int readerThreads = 8;
+        int durationMillis = 300;
+        String pluginType = "raceProbePlugin";
+        String pluginEnabledKey = "nacos.core.auth.plugin." + pluginType + ".enabled";
+        MockEnvironment withKey = new MockEnvironment();
+        withKey.setProperty(pluginEnabledKey, "true");
+        MockEnvironment withoutKey = new MockEnvironment();
+        withoutKey.setProperty("nacos.core.auth.plugin.otherPlugin.enabled", "true");
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread[] readers = new Thread[readerThreads];
+        for (int i = 0; i < readerThreads; i++) {
+            readers[i] = new Thread(() -> {
+                try {
+                    start.await();
+                    long deadline = System.currentTimeMillis() + durationMillis;
+                    while (System.currentTimeMillis() < deadline) {
+                        Properties properties = authConfigs.getAuthPluginProperties(pluginType);
+                        if (properties == null) {
+                            throw new AssertionError("getAuthPluginProperties returned null mid-refresh");
+                        }
+                    }
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            }, "auth-configs-reader-" + i);
+            readers[i].start();
+        }
+        Thread refresher = new Thread(() -> {
+            try {
+                start.await();
+                long deadline = System.currentTimeMillis() + durationMillis;
+                int counter = 0;
+                while (System.currentTimeMillis() < deadline) {
+                    EnvUtil.setEnvironment((counter++ % 2 == 0) ? withKey : withoutKey);
+                    authConfigs.onEvent(ServerConfigChangeEvent.newEvent());
+                }
+            } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+            }
+        }, "auth-configs-refresher");
+        refresher.start();
+        start.countDown();
+        refresher.join(TimeUnit.SECONDS.toMillis(5));
+        for (Thread reader : readers) {
+            reader.join(TimeUnit.SECONDS.toMillis(5));
+        }
+        Throwable observed = failure.get();
+        if (observed != null) {
+            throw new AssertionError(observed);
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`AuthConfigs.authPluginProperties` (`plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/AuthConfigs.java`) is reassigned by `refreshPluginProperties` whenever a `ServerConfigChangeEvent` fires on `onEvent`, while request-handling threads call `getAuthPluginProperties` concurrently. Two issues exist on the read path:

1. The field has no `volatile` modifier, so a reassignment performed on the event thread is not guaranteed to be visible to other threads (and the new map's writes inside `refreshPluginProperties` only happen-before publication if the field is `volatile`).
2. `getAuthPluginProperties` reads the field twice — once via `containsKey`, then via `get`. If a refresh swaps in a map missing the requested key between the two reads, `get` returns `null` and the method propagates `null` to callers instead of falling back to the empty-`Properties` branch as intended.

This is the same race that was fixed for `ConfigChangeConfigs` in #14988 and is being addressed for `NacosServerAuthConfig` in a separate PR (the two configs live in different modules and are functionally independent — splitting per the one-issue-per-PR convention).

## Brief changelog

- `AuthConfigs.authPluginProperties`: declared `volatile` so refresh-thread reassignments and the contents of the new map are guaranteed-visible to readers.
- `AuthConfigs.getAuthPluginProperties`: reads the field once, null-checks the lookup, and falls back to a fresh empty `Properties` whenever the key is absent — eliminating the check-then-act window.
- `AuthConfigsTest`: adds `testGetAuthPluginPropertiesNeverReturnsNullDuringConcurrentRefresh`, which spins up 8 reader threads against a refresher thread that alternates two environments (one with the probe key, one without) and asserts no reader ever observes a `null` result.

## Verifying this change

- Reverting the source change (single-`get` + null check restored to the original `containsKey` + `get` pattern) makes the new test fail with `getAuthPluginProperties returned null mid-refresh` (verified locally).
- After the fix, `mvn -pl plugin-default-impl/nacos-default-auth-plugin -am test -Dtest=AuthConfigsTest` and `mvn -pl plugin-default-impl/nacos-default-auth-plugin -am apache-rat:check checkstyle:check spotbugs:check -DskipTests` both pass.
- Existing `testUpgradeFromEvent` continues to pass — the change preserves the documented contract that `getAuthPluginProperties` returns a non-null `Properties` (empty when the type is unknown).