### PR TITLE
fix(config): replace deprecated AccessControlException with SecurityException

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/filter/CircuitFilter.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/filter/CircuitFilter.java
@@ -41,7 +41,6 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.security.AccessControlException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -94,7 +93,7 @@ public class CircuitFilter implements Filter {
             }
             
             chain.doFilter(req, response);
-        } catch (AccessControlException e) {
+        } catch (SecurityException e) {
             resp.sendError(HttpServletResponse.SC_FORBIDDEN, "access denied: " + ExceptionUtil.getAllExceptionMsg(e));
         } catch (Throwable e) {
             DEFAULT_LOG.warn("[CURCUIT-FILTER] Server failed: ", e);

--- a/config/src/test/java/com/alibaba/nacos/config/server/filter/CircuitFilterTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/filter/CircuitFilterTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.filter;
+
+import com.alibaba.nacos.consistency.cp.CPProtocol;
+import com.alibaba.nacos.core.cluster.ServerMemberManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Field;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CircuitFilterTest {
+
+    private CircuitFilter filter;
+
+    @Mock
+    private ServerMemberManager memberManager;
+
+    @Mock
+    private CPProtocol protocol;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        filter = new CircuitFilter();
+        injectField(filter, "memberManager", memberManager);
+        injectField(filter, "protocol", protocol);
+        injectField(filter, "isOpenService", true);
+        injectField(filter, "isDowngrading", false);
+    }
+
+    @Test
+    void testSecurityExceptionReturns403() throws Exception {
+        doThrow(new SecurityException("access denied")).when(chain).doFilter(request, response);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendError(eq(HttpServletResponse.SC_FORBIDDEN), contains("access denied"));
+    }
+
+    @Test
+    void testSecurityExceptionFromDownstreamAuthFilterReturns403() throws Exception {
+        doThrow(new SecurityException("Authority validation failed")).when(chain).doFilter(request, response);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendError(eq(HttpServletResponse.SC_FORBIDDEN), contains("Authority validation failed"));
+    }
+
+    @Test
+    void testServiceNotOpenReturns503() throws Exception {
+        injectField(filter, "isOpenService", false);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+                "In the node initialization, unable to process any requests at this time");
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void testDowngradingReturns503() throws Exception {
+        injectField(filter, "isDowngrading", true);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+                "Unable to process the request at this time: System triggered degradation");
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void testGenericExceptionReturns500() throws Exception {
+        doThrow(new RuntimeException("internal error")).when(chain).doFilter(request, response);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).sendError(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR), contains("internal error"));
+    }
+
+    @Test
+    void testNormalRequestPassesThrough() throws Exception {
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).sendError(eq(HttpServletResponse.SC_FORBIDDEN), contains("access denied"));
+    }
+
+    private static void injectField(Object target, String fieldName, Object value) throws Exception {
+        Field field = CircuitFilter.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
https://github.com/alibaba/nacos/issues/15004

Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

-  In the `CircuitFilter.doFilter()` method, replace the deprecated `AccessControlException` with `SecurityException`. The `AccessControlException` class has been marked for removal, so it will cause compilation failures in the future. Since `AccessControlException` extends `SecurityException`, catching `SecurityException` preserves the same "access denied → 403" behavior.
- 在 `CircuitFilter.doFilter()` 方法中，将已弃用的 `AccessControlException` 替换为 `SecurityException`。`AccessControlException` 类已被标记移除，因此在未来该类将导致编译失败。由于 `AccessControlException` 继承自 `SecurityException`，捕获 `SecurityException` 可以保持相同的“拒绝访问 → 403”行为。

## Brief changelog

- In `config/src/main/java/com/alibaba/nacos/config/server/filter/CircuitFilter.java`: catch `SecurityException` instead of the deprecated `AccessControlException` (which has been marked for removal), and return 403 for all security-related exceptions thrown by the downstream filter chain.
- 在 `config/src/main/java/com/alibaba/nacos/config/server/filter/CircuitFilter.java` 中：捕获 `SecurityException` 而非已标记移除的 `AccessControlException`，对下游过滤器链抛出的所有与安全相关的异常均返回 403。

## Verifying this change

- Added `CircuitFilterTest` with 6 test cases covering:
  - `SecurityException` → 403 (SC_FORBIDDEN) response
  - Auth-related `SecurityException` → 403 response
  - Service not open → 503 response
  - Degradation → 503 response
  - Generic exception → 500 response
  - Normal request passes through
- Verified with `mvn test -pl config -Dtest=CircuitFilterTest` (6/6 passed)

- 新增了 `CircuitFilterTest` 测试类，包含 6 个测试用例：
  - `SecurityException` → 403（SC_FORBIDDEN）响应
  - 与认证相关的 `SecurityException` → 403 响应
  - 服务未开放 → 503 响应
  - 服务降级 → 503 响应
  - 通用异常 → 500 响应
  - 正常请求正常放行
- 通过 `mvn test -pl config -Dtest=CircuitFilterTest` 验证通过（6/6 通过）

## Test cases covering the review feedback

| Test | Description |
|------|-------------|
| `testSecurityExceptionReturns403` | `SecurityException` thrown by downstream filter → 403 response |
| `testSecurityExceptionFromDownstreamAuthFilterReturns403` | `SecurityException` with auth message → 403 response |
| `testServiceNotOpenReturns503` | Service not open → 503, chain not invoked |
| `testDowngradingReturns503` | Downgrading state → 503, chain not invoked |
| `testGenericExceptionReturns500` | Generic exception → 500 |
| `testNormalRequestPassesThrough` | Normal flow → chain invoked, no error sent |

The first two tests directly address the reviewer's question about whether `CircuitFilter` should treat all `SecurityException` from downstream as access-denied (403). They verify that any `SecurityException` thrown in the filter chain is mapped to `SC_FORBIDDEN` with an "access denied" message.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

