### PR TITLE
hide AI resource configs from config management list

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3.java
@@ -37,6 +37,7 @@ import com.alibaba.nacos.common.utils.Pair;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.constant.ParametersField;
+import com.alibaba.nacos.plugin.datasource.constants.AiResourceGroupType;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.config.server.model.ConfigAllInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
@@ -174,6 +175,10 @@ public class ConfigControllerV3 {
         // check params
         String dataId = configForm.getDataId();
         String groupName = configForm.getGroupName();
+        if (AiResourceGroupType.matches(groupName, dataId)) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                    "Config not exist, please publish Config first.");
+        }
         ConfigAllInfo configAllInfo = configInfoPersistService.findConfigAllInfo(dataId, groupName, namespaceId);
         if (Objects.isNull(configAllInfo)) {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3.java
@@ -37,6 +37,7 @@ import com.alibaba.nacos.common.utils.Pair;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.constant.ParametersField;
+import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.config.server.model.ConfigAllInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfoGrayWrapper;
@@ -349,6 +350,7 @@ public class ConfigControllerV3 {
         if (StringUtils.isNotBlank(configDetail)) {
             configAdvanceInfo.put("content", configDetail);
         }
+        configAdvanceInfo.put(FieldConstant.EXCLUDE_INTERNAL_GROUPS, Boolean.TRUE);
         int pageNo = pageForm.getPageNo();
         int pageSize = pageForm.getPageSize();
         String namespaceId = NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId());

--- a/config/src/main/java/com/alibaba/nacos/config/server/remote/ConfigQueryRequestHandler.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/remote/ConfigQueryRequestHandler.java
@@ -41,6 +41,7 @@ import com.alibaba.nacos.core.paramcheck.impl.ConfigRequestParamExtractor;
 import com.alibaba.nacos.core.remote.RequestHandler;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.constant.SignType;
+import com.alibaba.nacos.plugin.datasource.constants.AiResourceGroupType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -84,6 +85,10 @@ public class ConfigQueryRequestHandler extends RequestHandler<ConfigQueryRequest
             
             String requestIpApp = meta.getLabels().get(CLIENT_APPNAME_HEADER);
             String clientIp = meta.getClientIp();
+            
+            if (AiResourceGroupType.matches(group, dataId)) {
+                return handlerConfigNotFound(dataId, group, tenant, requestIpApp, clientIp, notify);
+            }
             
             ConfigQueryChainRequest chainRequest = ConfigChainRequestExtractorService.getExtractor()
                     .extract(request, meta);

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImpl.java
@@ -780,6 +780,9 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         if (!StringUtils.isBlank(content)) {
             context.putWhereParameter(FieldConstant.CONTENT, content);
         }
+        if (configAdvanceInfo != null && Boolean.TRUE.equals(configAdvanceInfo.get(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            context.putWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS, Boolean.TRUE);
+        }
         context.setStartRow((pageNo - 1) * pageSize);
         context.setPageSize(pageSize);
         
@@ -918,6 +921,9 @@ public class EmbeddedConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         if (StringUtils.isNotBlank(types)) {
             String[] typesArr = types.split(Symbols.COMMA);
             context.putWhereParameter(FieldConstant.TYPE, typesArr);
+        }
+        if (configAdvanceInfo != null && Boolean.TRUE.equals(configAdvanceInfo.get(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            context.putWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS, Boolean.TRUE);
         }
         
         if (StringUtils.isNotBlank(configTags)) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -807,6 +807,9 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         if (!StringUtils.isBlank(content)) {
             context.putWhereParameter(FieldConstant.CONTENT, content);
         }
+        if (configAdvanceInfo != null && Boolean.TRUE.equals(configAdvanceInfo.get(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            context.putWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS, Boolean.TRUE);
+        }
         context.setStartRow((pageNo - 1) * pageSize);
         context.setPageSize(pageSize);
         
@@ -932,6 +935,9 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
         if (StringUtils.isNotBlank(types)) {
             String[] typesArr = types.split(Symbols.COMMA);
             context.putWhereParameter(FieldConstant.TYPE, typesArr);
+        }
+        if (configAdvanceInfo != null && Boolean.TRUE.equals(configAdvanceInfo.get(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            context.putWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS, Boolean.TRUE);
         }
         
         if (StringUtils.isNotBlank(configTags)) {

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3Test.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.common.http.param.MediaType;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
+import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.config.server.model.ConfigAllInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfoGrayWrapper;
@@ -226,6 +227,7 @@ class ConfigControllerV3Test {
         page.setPagesAvailable(2);
         page.setPageItems(configInfoList);
         Map<String, Object> configAdvanceInfo = new HashMap<>(8);
+        configAdvanceInfo.put(FieldConstant.EXCLUDE_INTERNAL_GROUPS, Boolean.TRUE);
         
         when(configDetailService.findConfigInfoPage("accurate", 1, 10, "test", "test", "public",
                 configAdvanceInfo)).thenReturn(page);
@@ -258,6 +260,7 @@ class ConfigControllerV3Test {
         page.setPagesAvailable(2);
         page.setPageItems(configInfoList);
         Map<String, Object> configAdvanceInfo = new HashMap<>(8);
+        configAdvanceInfo.put(FieldConstant.EXCLUDE_INTERNAL_GROUPS, Boolean.TRUE);
         
         when(configDetailService.findConfigInfoPage("blur", 1, 10, "test", "test", "public",
                 configAdvanceInfo)).thenReturn(page);

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3Test.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.config.server.controller.v3;
 
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.config.model.ConfigBasicInfo;
 import com.alibaba.nacos.api.config.model.ConfigCloneInfo;
 import com.alibaba.nacos.api.config.model.ConfigGrayInfo;
@@ -70,6 +71,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -148,6 +150,22 @@ class ConfigControllerV3Test {
                 .param("dataId", "test").param("groupName", "test").param("namespaceId", "").param("tag", "");
         int actualValue = mockmvc.perform(builder).andReturn().getResponse().getStatus();
         assertEquals(200, actualValue);
+    }
+    
+    @Test
+    void testGetConfigBlockedForAiResource() throws Exception {
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get(Constants.CONFIG_ADMIN_V3_PATH)
+                .param("dataId", "SKILL.md").param("groupName", "skill_enc.abc__enc.def")
+                .param("namespaceId", "").param("tag", "");
+        try {
+            mockmvc.perform(builder);
+        } catch (Exception e) {
+            Throwable cause = e.getCause();
+            assertTrue(cause instanceof NacosException);
+            assertEquals(NacosException.NOT_FOUND, ((NacosException) cause).getErrCode());
+            return;
+        }
+        throw new AssertionError("Expected NacosApiException to be thrown");
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigQueryRequestHandlerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigQueryRequestHandlerTest.java
@@ -365,4 +365,17 @@ class ConfigQueryRequestHandlerTest {
         
     }
     
+    @Test
+    void testHandleBlockedForAiResource() throws Exception {
+        ConfigQueryRequest configQueryRequest = new ConfigQueryRequest();
+        configQueryRequest.setDataId("SKILL.md");
+        configQueryRequest.setGroup("skill_enc.abc__enc.def");
+        RequestMeta requestMeta = new RequestMeta();
+        requestMeta.setClientIp("127.0.0.1");
+        
+        ConfigQueryResponse response = configQueryRequestHandler.handle(configQueryRequest, requestMeta);
+        assertEquals(CONFIG_NOT_FOUND, response.getErrorCode());
+        assertNull(response.getContent());
+    }
+    
 }

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
@@ -33,6 +33,7 @@ import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.constant.ParametersField;
+import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.config.server.controller.parameters.SameNamespaceCloneConfigBean;
 import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
 import com.alibaba.nacos.config.server.model.form.ConfigFormV3;
@@ -208,6 +209,7 @@ public class ConsoleConfigController {
         if (StringUtils.isNotBlank(configForm.getType())) {
             configAdvanceInfo.put(ParametersField.TYPES, configForm.getType());
         }
+        configAdvanceInfo.put(FieldConstant.EXCLUDE_INTERNAL_GROUPS, Boolean.TRUE);
         int pageNo = pageForm.getPageNo();
         int pageSize = pageForm.getPageSize();
         String namespaceId = NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId());
@@ -248,6 +250,7 @@ public class ConsoleConfigController {
         if (StringUtils.isNotBlank(configDetail)) {
             configAdvanceInfo.put("content", configDetail);
         }
+        configAdvanceInfo.put(FieldConstant.EXCLUDE_INTERNAL_GROUPS, Boolean.TRUE);
         int pageNo = pageForm.getPageNo();
         int pageSize = pageForm.getPageSize();
         String namespaceId = NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId());

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
@@ -26,13 +26,16 @@ import com.alibaba.nacos.api.config.model.ConfigGrayInfo;
 import com.alibaba.nacos.api.config.model.ConfigListenerInfo;
 import com.alibaba.nacos.api.config.model.SameConfigPolicy;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.constant.ParametersField;
+import com.alibaba.nacos.plugin.datasource.constants.AiResourceGroupType;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.config.server.controller.parameters.SameNamespaceCloneConfigBean;
 import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
@@ -99,6 +102,10 @@ public class ConsoleConfigController {
         String namespaceId = NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId());
         String dataId = configForm.getDataId();
         String groupName = configForm.getGroupName();
+        if (AiResourceGroupType.matches(groupName, dataId)) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                    "Config not exist, please publish Config first.");
+        }
         return Result.success(configProxy.getConfigDetail(dataId, groupName, namespaceId));
     }
     

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigControllerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigControllerTest.java
@@ -17,6 +17,7 @@
 
 package com.alibaba.nacos.console.controller.v3.config;
 
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.config.model.ConfigBasicInfo;
 import com.alibaba.nacos.api.config.model.ConfigDetailInfo;
@@ -128,6 +129,22 @@ public class ConsoleConfigControllerTest {
         assertEquals("testDataId", resultConfigAllInfo.getDataId());
         assertEquals("testGroup", resultConfigAllInfo.getGroupName());
         assertEquals("testContent", resultConfigAllInfo.getContent());
+    }
+    
+    @Test
+    void testGetConfigDetailBlockedForAiResource() throws Exception {
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get("/v3/console/cs/config")
+                .param("dataId", "content.json").param("groupName", "prompt__myPrompt")
+                .param("namespaceId", "testNamespace");
+        try {
+            mockmvc.perform(builder);
+        } catch (Exception e) {
+            Throwable cause = e.getCause();
+            assertTrue(cause instanceof NacosException);
+            assertEquals(NacosException.NOT_FOUND, ((NacosException) cause).getErrCode());
+            return;
+        }
+        throw new AssertionError("Expected NacosApiException to be thrown");
     }
     
     @Test

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-base/src/main/java/com/alibaba/nacos/plugin/datasource/impl/base/BaseConfigInfoMapper.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-base/src/main/java/com/alibaba/nacos/plugin/datasource/impl/base/BaseConfigInfoMapper.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.plugin.datasource.dialect.DatabaseDialect;
 import com.alibaba.nacos.plugin.datasource.manager.DatabaseDialectManager;
 import com.alibaba.nacos.plugin.datasource.mapper.AbstractMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.mapper.ext.InternalGroupExclusionHelper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 
@@ -226,6 +227,9 @@ public abstract class BaseConfigInfoMapper extends AbstractMapper implements Con
             where.append(" AND content LIKE ? ");
             paramList.add(content);
         }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusion(where, paramList);
+        }
         int startRow = context.getStartRow();
         int pageSize = context.getPageSize();
         String resultSql = getLimitPageSqlWithOffset(sql + where, startRow, pageSize);
@@ -269,6 +273,9 @@ public abstract class BaseConfigInfoMapper extends AbstractMapper implements Con
         if (!StringUtils.isBlank(content)) {
             where.append(" AND content LIKE ? ");
             paramList.add(content);
+        }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusion(where, paramList);
         }
         int startRow = context.getStartRow();
         int pageSize = context.getPageSize();

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/ConfigInfoMapperByDerby.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ext.WhereBuilder;
+import com.alibaba.nacos.plugin.datasource.mapper.ext.InternalGroupExclusionHelper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 
@@ -218,6 +219,9 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
             where.append(SQL_DERBY_ESCAPE_BACK_SLASH_FOR_LIKE);
             paramList.add(content);
         }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusion(where, paramList);
+        }
         
         // Derby 分页语法
         return new MapperResult(
@@ -261,6 +265,9 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
         if (!ArrayUtils.isEmpty(types)) {
             where.and().in("type", types);
         }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusionWithEscape(where);
+        }
         return where.build();
     }
     
@@ -292,6 +299,9 @@ public class ConfigInfoMapperByDerby extends AbstractMapperByDerby implements Co
         }
         if (!ArrayUtils.isEmpty(types)) {
             where.and().in("type", types);
+        }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusionWithEscape(where);
         }
         
         where.orderBy("id").offset(context.getStartRow(), context.getPageSize());

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/mysql/ConfigInfoMapperByMySql.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.mapper.ext.InternalGroupExclusionHelper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 
@@ -212,6 +213,9 @@ public class ConfigInfoMapperByMySql extends AbstractMapperByMysql implements Co
             innerSql.append(" AND content LIKE ?");
             paramList.add(content);
         }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusion(innerSql, paramList);
+        }
         
         // 先分页，减少后续 JOIN 的数据量
         innerSql.append(" ORDER BY id LIMIT ").append(context.getStartRow()).append(",").append(context.getPageSize());
@@ -275,6 +279,9 @@ public class ConfigInfoMapperByMySql extends AbstractMapperByMysql implements Co
                 paramList.add(types[i]);
             }
             innerSql.append(")");
+        }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusion(innerSql, paramList);
         }
         
         // 先分页，减少后续 JOIN 的数据量

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoMapperByOracle.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/ConfigInfoMapperByOracle.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
+import com.alibaba.nacos.plugin.datasource.mapper.ext.InternalGroupExclusionHelper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 
@@ -215,6 +216,9 @@ public class ConfigInfoMapperByOracle  extends AbstractMapperByOracle implements
             idSql.append(" AND content LIKE ?");
             paramList.add(content);
         }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusion(idSql, paramList);
+        }
 
         // 先分页，减少后续 JOIN 的数据量
         idSql.append(" ORDER BY id OFFSET ")
@@ -290,6 +294,9 @@ public class ConfigInfoMapperByOracle  extends AbstractMapperByOracle implements
                 paramList.add(types[i]);
             }
             idSql.append(")");
+        }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusion(idSql, paramList);
         }
 
         // 先分页，减少后续 JOIN 的数据量

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/AiResourceGroupType.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/AiResourceGroupType.java
@@ -103,6 +103,44 @@ public enum AiResourceGroupType {
     }
     
     /**
+     * Check if a given group and dataId match any AI resource pattern.
+     *
+     * @param group  the group_id value
+     * @param dataId the data_id value
+     * @return true if the pair matches an internal AI resource config
+     */
+    public static boolean matches(String group, String dataId) {
+        if (group == null) {
+            return false;
+        }
+        for (AiResourceGroupType type : values()) {
+            if (!group.startsWith(type.groupPrefix)) {
+                continue;
+            }
+            DataIdMatcher[] matchers = type.dataIdMatchers;
+            if (matchers == null) {
+                return true;
+            }
+            if (dataId == null) {
+                continue;
+            }
+            for (DataIdMatcher m : matchers) {
+                if (m.like) {
+                    String prefix = m.pattern.endsWith("%") ? m.pattern.substring(0, m.pattern.length() - 1) : m.pattern;
+                    if (dataId.startsWith(prefix)) {
+                        return true;
+                    }
+                } else {
+                    if (dataId.equals(m.pattern)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+    
+    /**
      * Describes a dataId matching rule — either a LIKE pattern or an exact value.
      */
     public static class DataIdMatcher {

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/AiResourceGroupType.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/AiResourceGroupType.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.constants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AI Resource types stored via AiResourceStorage, whose configs should be hidden from the config list.
+ *
+ * <p>Each enum value declares its group prefix used in config_info.group_id. SQL filtering dynamically iterates all
+ * enum values, so no SQL change is needed when adding a new AI Resource type.
+ *
+ * <p>To add a new AI Resource type:
+ * <ol>
+ *   <li>Add an enum value with its group prefix</li>
+ *   <li>Done. SQL filtering will automatically pick it up.</li>
+ * </ol>
+ *
+ * @author sai
+ */
+public enum AiResourceGroupType {
+    
+    SKILL("skill_"),
+    
+    AGENTSPEC("agentspec__"),
+    
+    PROMPT("prompt__");
+    
+    private final String groupPrefix;
+    
+    AiResourceGroupType(String groupPrefix) {
+        this.groupPrefix = groupPrefix;
+    }
+    
+    public String getGroupPrefix() {
+        return groupPrefix;
+    }
+    
+    /**
+     * Get LIKE pattern for SQL: prefix + '%'.
+     *
+     * @return the LIKE pattern string
+     */
+    public String getLikePattern() {
+        return groupPrefix + "%";
+    }
+    
+    /**
+     * Collect all LIKE patterns from all enum values.
+     *
+     * @return list of LIKE patterns
+     */
+    public static List<String> allLikePatterns() {
+        List<String> result = new ArrayList<>();
+        for (AiResourceGroupType type : values()) {
+            result.add(type.getLikePattern());
+        }
+        return result;
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/AiResourceGroupType.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/AiResourceGroupType.java
@@ -16,18 +16,20 @@
 
 package com.alibaba.nacos.plugin.datasource.constants;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * AI Resource types stored via AiResourceStorage, whose configs should be hidden from the config list.
  *
- * <p>Each enum value declares its group prefix used in config_info.group_id. SQL filtering dynamically iterates all
- * enum values, so no SQL change is needed when adding a new AI Resource type.
+ * <p>Each enum value declares its group prefix and optionally known dataId patterns. Two filtering modes:
+ * <ul>
+ *   <li><b>Group-only</b> ({@code dataIdMatchers == null}): excludes ALL configs matching the group prefix.
+ *       Use when dataId formats are too diverse to enumerate.</li>
+ *   <li><b>Compound</b> ({@code dataIdMatchers} populated): excludes only configs matching BOTH group prefix
+ *       AND one of the dataId patterns. Reduces false positives for user configs sharing group prefixes.</li>
+ * </ul>
  *
  * <p>To add a new AI Resource type:
  * <ol>
- *   <li>Add an enum value with its group prefix</li>
+ *   <li>Add an enum value with its group prefix and dataId matchers (or null for group-only)</li>
  *   <li>Done. SQL filtering will automatically pick it up.</li>
  * </ol>
  *
@@ -35,16 +37,47 @@ import java.util.List;
  */
 public enum AiResourceGroupType {
     
-    SKILL("skill_"),
+    /**
+     * Skill manifest (index) config.
+     *
+     * <p>Group format: {@code skill_{name}} (no version suffix), e.g. {@code skill_mySkill}.
+     * Built by {@code SkillUtils.buildSkillGroup()}, which uses {@code encodeManifestGroupNameSegment}
+     * (conditionally encodes to {@code enc.{hex}} only when the name contains invalid characters or {@code __}).
+     * DataId is always the fixed value {@code skill_index.json}.</p>
+     */
+    SKILL_MANIFEST("skill_", new DataIdMatcher[]{
+            DataIdMatcher.exact("skill_index.json"),
+            DataIdMatcher.exact("skill.json")
+    }),
     
-    AGENTSPEC("agentspec__"),
+    /**
+     * Skill version file configs (SKILL.md, resource files, etc.).
+     *
+     * <p>Group format: {@code skill_enc.{hex}__enc.{hex}}, e.g. {@code skill_enc.6d79...__enc.312e...}.
+     * Built by {@code SkillUtils.buildSkillVersionGroup()}, which uses {@code encodeVersionedGroupSegment}
+     * (unconditionally encodes both name and version segments), so the group always starts with {@code skill_enc.}.
+     * DataIds can be arbitrary file paths ({@code SKILL.md}, {@code README.md}, {@code enc.{hex}}), so group-only
+     * filtering is used.</p>
+     */
+    SKILL_VERSION("skill_enc.", null),
     
-    PROMPT("prompt__");
+    AGENTSPEC("agentspec__", new DataIdMatcher[]{
+            DataIdMatcher.like("resource_%"),
+            DataIdMatcher.exact("manifest.json"),
+            DataIdMatcher.exact("agentspec_index.json")
+    }),
+    
+    PROMPT("prompt__", new DataIdMatcher[]{
+            DataIdMatcher.exact("content.json")
+    });
     
     private final String groupPrefix;
     
-    AiResourceGroupType(String groupPrefix) {
+    private final DataIdMatcher[] dataIdMatchers;
+    
+    AiResourceGroupType(String groupPrefix, DataIdMatcher[] dataIdMatchers) {
         this.groupPrefix = groupPrefix;
+        this.dataIdMatchers = dataIdMatchers;
     }
     
     public String getGroupPrefix() {
@@ -52,7 +85,7 @@ public enum AiResourceGroupType {
     }
     
     /**
-     * Get LIKE pattern for SQL: prefix + '%'.
+     * Get LIKE pattern for group_id SQL: prefix + '%'.
      *
      * @return the LIKE pattern string
      */
@@ -61,15 +94,48 @@ public enum AiResourceGroupType {
     }
     
     /**
-     * Collect all LIKE patterns from all enum values.
+     * Get the dataId matchers for this AI resource type.
      *
-     * @return list of LIKE patterns
+     * @return array of DataIdMatcher
      */
-    public static List<String> allLikePatterns() {
-        List<String> result = new ArrayList<>();
-        for (AiResourceGroupType type : values()) {
-            result.add(type.getLikePattern());
+    public DataIdMatcher[] getDataIdMatchers() {
+        return dataIdMatchers;
+    }
+    
+    /**
+     * Describes a dataId matching rule — either a LIKE pattern or an exact value.
+     */
+    public static class DataIdMatcher {
+        
+        private final String pattern;
+        
+        private final boolean like;
+        
+        private DataIdMatcher(String pattern, boolean like) {
+            this.pattern = pattern;
+            this.like = like;
         }
-        return result;
+        
+        /**
+         * Create a LIKE matcher (e.g. 'resource_%').
+         */
+        public static DataIdMatcher like(String pattern) {
+            return new DataIdMatcher(pattern, true);
+        }
+        
+        /**
+         * Create an exact-match matcher (e.g. 'skill_index.json').
+         */
+        public static DataIdMatcher exact(String value) {
+            return new DataIdMatcher(value, false);
+        }
+        
+        public String getPattern() {
+            return pattern;
+        }
+        
+        public boolean isLike() {
+            return like;
+        }
     }
 }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/FieldConstant.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/constants/FieldConstant.java
@@ -127,4 +127,6 @@ public class FieldConstant {
     public static final String SCOPE = "scope";
     
     public static final String OWNER = "owner";
+    
+    public static final String EXCLUDE_INTERNAL_GROUPS = "excludeInternalGroups";
 }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ConfigInfoMapper.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.ext.WhereBuilder;
+import com.alibaba.nacos.plugin.datasource.mapper.ext.InternalGroupExclusionHelper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 
@@ -353,6 +354,9 @@ public interface ConfigInfoMapper extends Mapper {
             where.append(" AND content LIKE ? ");
             paramList.add(content);
         }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusion(where, paramList);
+        }
         return new MapperResult(sqlCount + where, paramList);
     }
     
@@ -405,6 +409,9 @@ public interface ConfigInfoMapper extends Mapper {
         }
         if (!ArrayUtils.isEmpty(types)) {
             where.and().in("type", types);
+        }
+        if (Boolean.TRUE.equals(context.getWhereParameter(FieldConstant.EXCLUDE_INTERNAL_GROUPS))) {
+            InternalGroupExclusionHelper.appendExclusion(where);
         }
         return where.build();
     }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/InternalGroupExclusionHelper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/InternalGroupExclusionHelper.java
@@ -17,11 +17,19 @@
 package com.alibaba.nacos.plugin.datasource.mapper.ext;
 
 import com.alibaba.nacos.plugin.datasource.constants.AiResourceGroupType;
+import com.alibaba.nacos.plugin.datasource.constants.AiResourceGroupType.DataIdMatcher;
 
 import java.util.List;
 
 /**
  * Utility to build SQL exclusion conditions for internal AI resource configs.
+ *
+ * <p>Supports two filtering modes per {@link AiResourceGroupType}:
+ * <ul>
+ *   <li><b>Group-only</b> (dataIdMatchers is null): {@code AND group_id NOT LIKE ?}</li>
+ *   <li><b>Compound</b> (dataIdMatchers populated):
+ *       {@code AND NOT (group_id LIKE ? AND (data_id LIKE ? OR data_id = ? OR ...))}</li>
+ * </ul>
  *
  * <p>Reads patterns from {@link AiResourceGroupType} enum dynamically. When a new AI Resource type is added to the
  * enum, the exclusion SQL will automatically include it without any code change here.
@@ -34,39 +42,90 @@ public final class InternalGroupExclusionHelper {
     }
     
     /**
-     * Append NOT LIKE conditions to a WhereBuilder. Used by interface default methods (standard SQL without ESCAPE).
+     * Append exclusion conditions to a WhereBuilder. Used by interface default methods (standard SQL without ESCAPE).
      *
      * @param where the WhereBuilder to append conditions to
      */
     public static void appendExclusion(WhereBuilder where) {
         for (AiResourceGroupType type : AiResourceGroupType.values()) {
-            where.and().notLike("group_id", type.getLikePattern());
+            DataIdMatcher[] matchers = type.getDataIdMatchers();
+            if (matchers == null) {
+                where.and().notLike("group_id", type.getLikePattern());
+            } else {
+                where.and().not().startParentheses().like("group_id", type.getLikePattern())
+                        .and().startParentheses();
+                appendDataIdMatchers(where, matchers, false);
+                where.endParentheses().endParentheses();
+            }
         }
     }
     
     /**
-     * Append NOT LIKE conditions to a raw StringBuilder with parameter list. Used by MySQL/Oracle/Base which use manual
-     * StringBuilder SQL building.
+     * Append exclusion conditions to a raw StringBuilder with parameter list. Used by MySQL/Oracle/Base which use
+     * manual StringBuilder SQL building.
      *
      * @param sql       the StringBuilder to append SQL conditions to
-     * @param paramList the parameter list to add LIKE pattern values to
+     * @param paramList the parameter list to add values to
      */
     public static void appendExclusion(StringBuilder sql, List<Object> paramList) {
         for (AiResourceGroupType type : AiResourceGroupType.values()) {
-            sql.append(" AND group_id NOT LIKE ?");
-            paramList.add(type.getLikePattern());
+            DataIdMatcher[] matchers = type.getDataIdMatchers();
+            if (matchers == null) {
+                sql.append(" AND group_id NOT LIKE ?");
+                paramList.add(type.getLikePattern());
+            } else {
+                sql.append(" AND NOT (group_id LIKE ? AND (");
+                paramList.add(type.getLikePattern());
+                for (int i = 0; i < matchers.length; i++) {
+                    if (i > 0) {
+                        sql.append(" OR ");
+                    }
+                    if (matchers[i].isLike()) {
+                        sql.append("data_id LIKE ?");
+                    } else {
+                        sql.append("data_id = ?");
+                    }
+                    paramList.add(matchers[i].getPattern());
+                }
+                sql.append("))");
+            }
         }
     }
     
     /**
-     * Append NOT LIKE conditions with explicit ESCAPE to a WhereBuilder. Used by Derby which requires explicit ESCAPE
-     * clause.
+     * Append exclusion conditions with explicit ESCAPE to a WhereBuilder. Used by Derby which requires explicit ESCAPE
+     * clause for LIKE patterns.
      *
      * @param where the WhereBuilder to append conditions to
      */
     public static void appendExclusionWithEscape(WhereBuilder where) {
         for (AiResourceGroupType type : AiResourceGroupType.values()) {
-            where.and().notLikeWithEscape("group_id", type.getLikePattern());
+            DataIdMatcher[] matchers = type.getDataIdMatchers();
+            if (matchers == null) {
+                where.and().notLikeWithEscape("group_id", type.getLikePattern());
+            } else {
+                where.and().not().startParentheses().likeWithEscape("group_id", type.getLikePattern())
+                        .and().startParentheses();
+                appendDataIdMatchers(where, matchers, true);
+                where.endParentheses().endParentheses();
+            }
+        }
+    }
+    
+    private static void appendDataIdMatchers(WhereBuilder where, DataIdMatcher[] matchers, boolean withEscape) {
+        for (int i = 0; i < matchers.length; i++) {
+            if (i > 0) {
+                where.or();
+            }
+            if (matchers[i].isLike()) {
+                if (withEscape) {
+                    where.likeWithEscape("data_id", matchers[i].getPattern());
+                } else {
+                    where.like("data_id", matchers[i].getPattern());
+                }
+            } else {
+                where.eq("data_id", matchers[i].getPattern());
+            }
         }
     }
 }

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/InternalGroupExclusionHelper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/InternalGroupExclusionHelper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.mapper.ext;
+
+import com.alibaba.nacos.plugin.datasource.constants.AiResourceGroupType;
+
+import java.util.List;
+
+/**
+ * Utility to build SQL exclusion conditions for internal AI resource configs.
+ *
+ * <p>Reads patterns from {@link AiResourceGroupType} enum dynamically. When a new AI Resource type is added to the
+ * enum, the exclusion SQL will automatically include it without any code change here.
+ *
+ * @author sai
+ */
+public final class InternalGroupExclusionHelper {
+    
+    private InternalGroupExclusionHelper() {
+    }
+    
+    /**
+     * Append NOT LIKE conditions to a WhereBuilder. Used by interface default methods (standard SQL without ESCAPE).
+     *
+     * @param where the WhereBuilder to append conditions to
+     */
+    public static void appendExclusion(WhereBuilder where) {
+        for (AiResourceGroupType type : AiResourceGroupType.values()) {
+            where.and().notLike("group_id", type.getLikePattern());
+        }
+    }
+    
+    /**
+     * Append NOT LIKE conditions to a raw StringBuilder with parameter list. Used by MySQL/Oracle/Base which use manual
+     * StringBuilder SQL building.
+     *
+     * @param sql       the StringBuilder to append SQL conditions to
+     * @param paramList the parameter list to add LIKE pattern values to
+     */
+    public static void appendExclusion(StringBuilder sql, List<Object> paramList) {
+        for (AiResourceGroupType type : AiResourceGroupType.values()) {
+            sql.append(" AND group_id NOT LIKE ?");
+            paramList.add(type.getLikePattern());
+        }
+    }
+    
+    /**
+     * Append NOT LIKE conditions with explicit ESCAPE to a WhereBuilder. Used by Derby which requires explicit ESCAPE
+     * clause.
+     *
+     * @param where the WhereBuilder to append conditions to
+     */
+    public static void appendExclusionWithEscape(WhereBuilder where) {
+        for (AiResourceGroupType type : AiResourceGroupType.values()) {
+            where.and().notLikeWithEscape("group_id", type.getLikePattern());
+        }
+    }
+}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
@@ -76,6 +76,16 @@ public final class WhereBuilder {
     }
     
     /**
+     * Build NOT.
+     *
+     * @return Return {@link WhereBuilder}
+     */
+    public WhereBuilder not() {
+        where.append(" NOT");
+        return this;
+    }
+    
+    /**
      * Build OR.
      *
      * @return Return {@link WhereBuilder}

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/ext/WhereBuilder.java
@@ -123,6 +123,32 @@ public final class WhereBuilder {
         parameters.add(parameter);
         return this;
     }
+    
+    /**
+     * Build NOT LIKE.
+     *
+     * @param filed Filed name
+     * @param parameter Parameters
+     * @return Return {@link WhereBuilder}
+     */
+    public WhereBuilder notLike(String filed, Object parameter) {
+        where.append(filed).append(" NOT LIKE ? ");
+        parameters.add(parameter);
+        return this;
+    }
+    
+    /**
+     * Build NOT LIKE with escape.
+     *
+     * @param filed Filed name
+     * @param parameter Parameters
+     * @return Return {@link WhereBuilder}
+     */
+    public WhereBuilder notLikeWithEscape(String filed, Object parameter) {
+        where.append(filed).append(" NOT LIKE ? ESCAPE '\\' ");
+        parameters.add(parameter);
+        return this;
+    }
     /**
      * Build IN.
      *

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/constants/AiResourceGroupTypeTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/constants/AiResourceGroupTypeTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.constants;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiResourceGroupTypeTest {
+    
+    @Test
+    void testMatchesNullGroup() {
+        assertFalse(AiResourceGroupType.matches(null, "any"));
+    }
+    
+    @Test
+    void testMatchesNonAiGroup() {
+        assertFalse(AiResourceGroupType.matches("DEFAULT_GROUP", "some.json"));
+    }
+    
+    @Test
+    void testMatchesSkillManifestExact() {
+        assertTrue(AiResourceGroupType.matches("skill_mySkill", "skill_index.json"));
+        assertTrue(AiResourceGroupType.matches("skill_mySkill", "skill.json"));
+    }
+    
+    @Test
+    void testMatchesSkillManifestNonMatchingDataId() {
+        assertFalse(AiResourceGroupType.matches("skill_mySkill", "other.json"));
+    }
+    
+    @Test
+    void testMatchesSkillVersionGroupOnly() {
+        // SKILL_VERSION uses group-only filtering (dataIdMatchers == null)
+        assertTrue(AiResourceGroupType.matches("skill_enc.6d79__enc.312e", "SKILL.md"));
+        assertTrue(AiResourceGroupType.matches("skill_enc.6d79__enc.312e", "README.md"));
+        assertTrue(AiResourceGroupType.matches("skill_enc.6d79__enc.312e", "enc.7265666572"));
+        assertTrue(AiResourceGroupType.matches("skill_enc.6d79__enc.312e", null));
+    }
+    
+    @Test
+    void testMatchesAgentspecCompound() {
+        assertTrue(AiResourceGroupType.matches("agentspec__myAgent", "resource_foo"));
+        assertTrue(AiResourceGroupType.matches("agentspec__myAgent", "manifest.json"));
+        assertTrue(AiResourceGroupType.matches("agentspec__myAgent", "agentspec_index.json"));
+    }
+    
+    @Test
+    void testMatchesAgentspecNonMatchingDataId() {
+        assertFalse(AiResourceGroupType.matches("agentspec__myAgent", "other.json"));
+    }
+    
+    @Test
+    void testMatchesPromptCompound() {
+        assertTrue(AiResourceGroupType.matches("prompt__myPrompt", "content.json"));
+    }
+    
+    @Test
+    void testMatchesPromptNonMatchingDataId() {
+        assertFalse(AiResourceGroupType.matches("prompt__myPrompt", "other.json"));
+    }
+    
+    @Test
+    void testMatchesCompoundWithNullDataId() {
+        // Compound types with null dataId should not match
+        assertFalse(AiResourceGroupType.matches("skill_mySkill", null));
+        assertFalse(AiResourceGroupType.matches("agentspec__myAgent", null));
+        assertFalse(AiResourceGroupType.matches("prompt__myPrompt", null));
+    }
+}


### PR DESCRIPTION
PR Body

   Please do not create a Pull Request without creating an issue first.

   What is the purpose of the change

   Internal AI resource configs (skill, agentspec, prompt) are stored in the same config_info table as user configs, but should not be visible to external callers through config management APIs. This PR hides them from all config list, search, and single-config get
   endpoints (HTTP Admin, HTTP Console, gRPC Client SDK) while preserving the AI module's ability to read and write them internally.

   Brief changelog

   - Add AiResourceGroupType enum with dual-mode filtering (group-only vs compound group+dataId) and DataIdMatcher inner class in plugin/datasource.
   - Add InternalGroupExclusionHelper utility and WhereBuilder.not() to generate SQL exclusion conditions from enum values.
   - Modify config list SQL mappers (MySQL, Derby, Oracle, Base, interface defaults) and persistence services to exclude AI resource configs via EXCLUDE_INTERNAL_GROUPS context flag.
   - Split SKILL type into SKILL_MANIFEST (compound) and SKILL_VERSION (group-only) to reduce false positives for user configs sharing skill_ group prefix.
   - Add AiResourceGroupType.matches(group, dataId) static method for runtime checking and intercept get requests at ConfigControllerV3, ConsoleConfigController, and ConfigQueryRequestHandler.
   - Add unit tests for AiResourceGroupType.matches() and AI resource interception in all three get paths.

   Verifying this change

   - mvn clean install -pl plugin/datasource,config,console -DskipTests — verify compilation
   - mvn test -pl plugin/datasource -Dtest=AiResourceGroupTypeTest — verify matches() logic
   - mvn test -pl config -Dtest=ConfigControllerV3Test — verify HTTP Admin get interception
   - mvn test -pl console -Dtest=ConsoleConfigControllerTest — verify HTTP Console get interception
   - mvn test -pl config -Dtest=ConfigQueryRequestHandlerTest — verify gRPC client get interception