### PR TITLE
fix(actuator): expose Prometheus endpoint in Spring Boot actuator

### DIFF
--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -49,7 +49,7 @@ nacos.server.main.port=8848
 
 #*************** Metrics Related Configurations ***************#
 ### Metrics for prometheus
-#management.endpoints.web.exposure.include=prometheus
+management.endpoints.web.exposure.include=prometheus,health,info,metrics
 
 ### Metrics for elastic search
 management.elastic.metrics.export.enabled=false

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -40,7 +40,7 @@ nacos.server.main.port=8848
 
 #*************** Metrics Related Configurations ***************#
 ### Metrics for prometheus
-#management.endpoints.web.exposure.include=prometheus
+management.endpoints.web.exposure.include=prometheus,health,info,metrics
 
 ### Metrics for elastic search
 management.metrics.export.elastic.enabled=false

--- a/server/src/main/java/com/alibaba/nacos/NacosServerBasicApplication.java
+++ b/server/src/main/java/com/alibaba/nacos/NacosServerBasicApplication.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos;
 import com.alibaba.nacos.server.NacosWebBeanTypeFilter;
 import com.alibaba.nacos.sys.filter.NacosTypeExcludeFilter;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -31,7 +32,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  *
  * @author xiweng.yy
  */
-@SpringBootApplication(exclude = {LdapAutoConfiguration.class})
+@SpringBootApplication(exclude = {LdapAutoConfiguration.class, PrometheusMetricsExportAutoConfiguration.class})
 @ComponentScan(excludeFilters = {
         @Filter(type = FilterType.CUSTOM, classes = {NacosTypeExcludeFilter.class, NacosWebBeanTypeFilter.class})})
 @EnableScheduling


### PR DESCRIPTION
## Issue

Fixes #15033

## Problem

In Nacos 3.2.1, the `/actuator/prometheus` endpoint is unavailable even when `management.endpoints.web.exposure.include=*` is configured. Other actuator endpoints (health, info, metrics, etc.) work correctly.

## Root Cause

Nacos 3.x uses a **parent-child Spring context** model:

- **Core context** (`NacosServerBasicApplication`): runs as `WebApplicationType.NONE` (no web server)
- **Web context** (`NacosServerWebApplication`): runs as a servlet web application with the core context as parent

`PrometheusMetricsExportAutoConfiguration` runs in the **core context** because:
1. `micrometer-registry-prometheus` is on the classpath (via `nacos-core`)
2. The auto-configuration is NOT conditional on web application type

This creates both `PrometheusMeterRegistry` and `PrometheusScrapeEndpoint` beans in the core context. Since the core context has no web server, the Prometheus endpoint cannot be exposed via HTTP.

When the web context starts, `@ConditionalOnMissingBean` detects the beans from the parent context and **skips** auto-configuration. As a result, `PrometheusScrapeEndpoint` is never registered in the web context where the actuator web server runs.

## Fix

1. **Exclude `PrometheusMetricsExportAutoConfiguration` from the core context** (`NacosServerBasicApplication`) so it auto-configures in the web context where the actuator web server is available.

2. **Update default `application.properties`** to expose the prometheus endpoint (previously commented out):
   ```properties
   management.endpoints.web.exposure.include=prometheus,health,info,metrics
   ```

## Impact

- `PrometheusMeterRegistry` will now be created in the web context instead of the core context
- Since `Metrics.globalRegistry` is a static `CompositeMeterRegistry`, adding `PrometheusMeterRegistry` later still captures all previously registered meters
- The `/actuator/prometheus` endpoint will be available for Prometheus scraping
- No impact on existing metrics collection

## Testing

Manually verify:
1. Start Nacos 3.2.1 in standalone mode
2. Configure `management.endpoints.web.exposure.include=prometheus` (or `*`)
3. Access `http://localhost:8848/nacos/actuator/prometheus`
4. Verify Prometheus-format metrics are returned