### PR TITLE
[AI] Harden AgentSpecZipParser against Zip Slip / Zip Bomb / entry-count DoS

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecZipParser.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecResource;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecUtils;
 import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
@@ -168,6 +169,11 @@ public class AgentSpecZipParser {
      *   <li>Enforces maximum number of entries ({@link #MAX_ZIP_ENTRIES})
      *       to prevent entry-count flooding attacks</li>
      * </ul>
+     *
+     * <p>Security-limit violations are reported as {@link NacosRuntimeException} (not {@link IOException})
+     * because they represent invalid user input rather than an underlying I/O failure. The caller
+     * {@link #parseAgentSpecFromZip(byte[], String)} translates them into a {@link NacosApiException}
+     * for the HTTP layer.
      */
     private static List<ZipEntryData> unzipToEntries(byte[] zipBytes) throws IOException {
         List<ZipEntryData> result = new ArrayList<>();
@@ -187,7 +193,7 @@ public class AgentSpecZipParser {
                     continue;
                 }
                 if (result.size() >= MAX_ZIP_ENTRIES) {
-                    throw new IOException(
+                    throw new NacosRuntimeException(ErrorCode.PARAMETER_VALIDATE_ERROR.getCode(),
                             "ZIP file contains too many entries (max " + MAX_ZIP_ENTRIES + ")");
                 }
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -195,7 +201,7 @@ public class AgentSpecZipParser {
                 while ((n = zis.read(buffer)) != -1) {
                     totalSize += n;
                     if (totalSize > MAX_TOTAL_UNCOMPRESSED_BYTES) {
-                        throw new IOException(
+                        throw new NacosRuntimeException(ErrorCode.PARAMETER_VALIDATE_ERROR.getCode(),
                                 "ZIP decompressed size exceeds limit ("
                                         + (MAX_TOTAL_UNCOMPRESSED_BYTES / 1024 / 1024) + "MB)");
                     }

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecZipParser.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecResource;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecUtils;
+import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.JacksonUtils;
@@ -67,6 +68,16 @@ public class AgentSpecZipParser {
     private static final String METADATA_ENCODING = "encoding";
     
     private static final String METADATA_ENCODING_BASE64 = "base64";
+    
+    /**
+     * Maximum total decompressed size allowed (50MB). Prevents Zip Bomb attacks.
+     */
+    private static final long MAX_TOTAL_UNCOMPRESSED_BYTES = 50L * 1024 * 1024;
+    
+    /**
+     * Maximum number of entries allowed in a ZIP file. Prevents entry-count flooding attacks.
+     */
+    private static final int MAX_ZIP_ENTRIES = 500;
     
     /** File extensions treated as binary; content will be stored as Base64. */
     private static final Set<String> BINARY_EXTENSIONS = new HashSet<>();
@@ -147,9 +158,20 @@ public class AgentSpecZipParser {
     /**
      * Unzip to list of (name, raw bytes). Does not decode as text so binary files are preserved.
      * Uses Apache Commons Compress to support zip files with STORED entries that have data descriptor.
+     *
+     * <p>Security hardening (mirrors {@link SkillZipParser#unzipToEntries(byte[])}):
+     * <ul>
+     *   <li>Rejects entries with path traversal sequences (..) or absolute paths via
+     *       {@link SkillUtils#validatePathSafety(String)}</li>
+     *   <li>Enforces maximum total decompressed size ({@link #MAX_TOTAL_UNCOMPRESSED_BYTES})
+     *       to prevent Zip Bomb attacks</li>
+     *   <li>Enforces maximum number of entries ({@link #MAX_ZIP_ENTRIES})
+     *       to prevent entry-count flooding attacks</li>
+     * </ul>
      */
     private static List<ZipEntryData> unzipToEntries(byte[] zipBytes) throws IOException {
         List<ZipEntryData> result = new ArrayList<>();
+        long totalSize = 0;
         try (ZipArchiveInputStream zis = new ZipArchiveInputStream(new ByteArrayInputStream(zipBytes),
                 StandardCharsets.UTF_8.name(), true, true)) {
             ZipArchiveEntry entry;
@@ -159,12 +181,24 @@ public class AgentSpecZipParser {
                     continue;
                 }
                 String name = entry.getName();
+                // Security: reject path traversal (..) and absolute paths.
+                SkillUtils.validatePathSafety(name);
                 if (name != null && (name.startsWith("__MACOSX/") || name.contains("/__MACOSX/"))) {
                     continue;
+                }
+                if (result.size() >= MAX_ZIP_ENTRIES) {
+                    throw new IOException(
+                            "ZIP file contains too many entries (max " + MAX_ZIP_ENTRIES + ")");
                 }
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 int n;
                 while ((n = zis.read(buffer)) != -1) {
+                    totalSize += n;
+                    if (totalSize > MAX_TOTAL_UNCOMPRESSED_BYTES) {
+                        throw new IOException(
+                                "ZIP decompressed size exceeds limit ("
+                                        + (MAX_TOTAL_UNCOMPRESSED_BYTES / 1024 / 1024) + "MB)");
+                    }
                     out.write(buffer, 0, n);
                 }
                 result.add(new ZipEntryData(name, out.toByteArray()));

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentSpecZipParserSecurityTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentSpecZipParserSecurityTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.utils;
+
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Security tests: verify that {@link AgentSpecZipParser} is hardened against malicious Zip uploads.
+ *
+ * <p>Covers three attack vectors:
+ * <ul>
+ *   <li>Zip Slip (path-traversal attack): entry name contains "../" sequences</li>
+ *   <li>Zip bomb (decompressed-size attack): decompressed total exceeds the configured limit</li>
+ *   <li>Entry-count attack: too many entries inside a single zip</li>
+ * </ul>
+ *
+ * @author nacos
+ */
+class AgentSpecZipParserSecurityTest {
+
+    private static final String NAMESPACE_ID = "test-ns";
+
+    private static final String VALID_MANIFEST = "{\"version\":\"1.0\",\"description\":\"test\","
+            + "\"worker\":{\"suggested_name\":\"test-worker\"}}";
+
+    // ---- Test 1: path-traversal attack (Zip Slip) ----
+
+    @Test
+    void testPathTraversalAttackShouldBeRejected() throws IOException {
+        // Build a malicious zip containing a path-traversal entry.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            // Legitimate manifest.json.
+            addZipEntry(zos, "manifest.json", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+            // Malicious entry: path traversal.
+            addZipEntry(zos, "../../etc/passwd", "root:x:0:0".getBytes(StandardCharsets.UTF_8));
+        }
+        byte[] zipBytes = baos.toByteArray();
+
+        // Expectation: parsing should fail and reject the traversal entry.
+        try {
+            AgentSpecZipParser.parseAgentSpecFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the path-traversal zip to be rejected, but parsing succeeded (security hole!)");
+        } catch (SecurityException | NacosApiException e) {
+            // Expected: traversal rejected.
+            System.out.println("[PASS] Path-traversal attack correctly rejected: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testAbsolutePathEntryShouldBeRejected() throws IOException {
+        // Build a malicious zip containing an absolute-path entry.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            addZipEntry(zos, "manifest.json", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+            // Malicious entry: absolute path.
+            addZipEntry(zos, "/etc/shadow", "malicious".getBytes(StandardCharsets.UTF_8));
+        }
+        byte[] zipBytes = baos.toByteArray();
+
+        try {
+            AgentSpecZipParser.parseAgentSpecFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the absolute-path zip to be rejected, but parsing succeeded (security hole!)");
+        } catch (SecurityException | NacosApiException e) {
+            System.out.println("[PASS] Absolute-path attack correctly rejected: " + e.getMessage());
+        }
+    }
+
+    // ---- Test 2: zip bomb (decompressed-size attack) ----
+
+    @Test
+    void testZipBombShouldBeRejected() throws IOException {
+        // Build a zip whose decompressed size is huge: 110 entries x 1 MB = 110 MB,
+        // which exceeds the 50 MB MAX_TOTAL_UNCOMPRESSED_BYTES limit inside the parser.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            addZipEntry(zos, "manifest.json", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+            // Create many large entries.
+            byte[] largeContent = new byte[1024 * 1024]; // 1 MB of zeros (compresses extremely well).
+            for (int i = 0; i < 110; i++) {
+                addZipEntry(zos, "config/large_file_" + i + ".txt", largeContent);
+            }
+        }
+        byte[] zipBytes = baos.toByteArray();
+
+        try {
+            AgentSpecZipParser.parseAgentSpecFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the zip bomb to be rejected, but parsing succeeded (security hole!)");
+        } catch (NacosApiException e) {
+            // Verify the rejection reason is the decompressed-size limit.
+            boolean isDecompressSizeError = e.getMessage().contains("decompressed size")
+                    || e.getMessage().contains("exceeds limit");
+            boolean isZipSizeError = e.getMessage().contains("must not exceed");
+            assertTrue(isDecompressSizeError || isZipSizeError,
+                    "Expected rejection due to the decompressed-size limit, actual error: " + e.getMessage());
+            System.out.println("[PASS] Zip-bomb attack correctly rejected: " + e.getMessage());
+        } catch (Exception e) {
+            // OutOfMemoryError or any other exception means the guard is missing.
+            fail("Zip bomb was not properly guarded, unexpected exception: "
+                    + e.getClass().getName() + ": " + e.getMessage());
+        }
+    }
+
+    // ---- Test 3: entry-count attack ----
+
+    @Test
+    void testTooManyEntriesShouldBeRejected() throws IOException {
+        // Build a zip with more than 500 entries (the MAX_ZIP_ENTRIES cap).
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            addZipEntry(zos, "manifest.json", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+            byte[] smallContent = "x".getBytes(StandardCharsets.UTF_8);
+            for (int i = 0; i < 600; i++) {
+                addZipEntry(zos, "config/entry_" + i + ".txt", smallContent);
+            }
+        }
+        byte[] zipBytes = baos.toByteArray();
+
+        try {
+            AgentSpecZipParser.parseAgentSpecFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the too-many-entries zip to be rejected, but parsing succeeded (security hole!)");
+        } catch (NacosApiException e) {
+            boolean isEntryCountError = e.getMessage().contains("too many entries")
+                    || e.getMessage().contains("max");
+            assertTrue(isEntryCountError,
+                    "Expected rejection due to the entry-count limit, actual error: " + e.getMessage());
+            System.out.println("[PASS] Entry-count attack correctly rejected: " + e.getMessage());
+        }
+    }
+
+    // ---- Helpers ----
+
+    private static void addZipEntry(ZipOutputStream zos, String name, byte[] data) throws IOException {
+        ZipEntry entry = new ZipEntry(name);
+        zos.putNextEntry(entry);
+        zos.write(data);
+        zos.closeEntry();
+    }
+}


### PR DESCRIPTION
## Bug / Feature Description

`AgentSpecZipParser#unzipToEntries` is missing the three security checks that `SkillZipParser` already enforces for the Skill upload path. The Zip is parsed entirely in-memory, but without these checks a crafted upload can:

1. **Zip Slip / absolute path** — entries named `../../etc/passwd` or `/etc/shadow` are accepted and flow into downstream processing (no `SkillUtils.validatePathSafety(name)` call).
2. **Zip Bomb (memory DoS)** — a small zip (~KB) can expand to GBs because there is no running cap on total decompressed bytes. JVM can OOM and take down the Nacos process.
3. **Entry-count flooding** — a zip with millions of tiny entries exhausts heap/CPU because there is no cap on the number of entries.

For comparison, `SkillZipParser` already does all three checks (`ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java:243~278`).

## Fix

Mirror the `SkillZipParser` hardening in `AgentSpecZipParser` — minimal diff,no behavioural change for legitimate uploads:

- Add `SkillUtils.validatePathSafety(name)` on every entry (rejects `..` and absolute paths, throws `SecurityException`).
- New constant `MAX_TOTAL_UNCOMPRESSED_BYTES = 50 MB`; running `totalSize`  accumulator throws `IOException` as soon as the cap is crossed.
- New constant `MAX_ZIP_ENTRIES = 500`; running count throws `IOException` when exceeded. Limits chosen to match `SkillZipParser` exactly.

## Tests

- All 12 existing tests in `AgentSpecZipParserTest` / `AgentSpecZipParserPathsTest`  still pass — no functional regression for legitimate AgentSpec packages.
- New `AgentSpecZipParserSecurityTest` adds 4 cases that precisely reproduce  the three attack classes:
    - `testPathTraversalAttackShouldBeRejected`  (`../../etc/passwd`)
    - `testAbsolutePathEntryShouldBeRejected`    (`/etc/shadow`)
    - `testZipBombShouldBeRejected`              (110 × 1 MB zero-fill entries)
    - `testTooManyEntriesShouldBeRejected`       (600 entries)