### PR TITLE
fix(plugin/control): allocate CharsetDecoder per call in DiskUtils.readFile

### DIFF
--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/utils/DiskUtils.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/utils/DiskUtils.java
@@ -51,8 +51,6 @@ public final class DiskUtils {
     
     private static final Charset CHARSET = StandardCharsets.UTF_8;
     
-    private static final CharsetDecoder DECODER = CHARSET.newDecoder();
-    
     /**
      * read this file content.
      *
@@ -60,13 +58,16 @@ public final class DiskUtils {
      * @return content
      */
     public static String readFile(File file) {
+        // CharsetDecoder is documented as not safe for concurrent use, so allocate one per call
+        // instead of sharing a static instance across threads.
+        CharsetDecoder decoder = CHARSET.newDecoder();
         try (FileChannel fileChannel = new FileInputStream(file).getChannel()) {
             StringBuilder text = new StringBuilder();
             ByteBuffer buffer = ByteBuffer.allocate(4096);
             CharBuffer charBuffer = CharBuffer.allocate(4096);
             while (fileChannel.read(buffer) != -1) {
                 buffer.flip();
-                DECODER.decode(buffer, charBuffer, false);
+                decoder.decode(buffer, charBuffer, false);
                 charBuffer.flip();
                 while (charBuffer.hasRemaining()) {
                     text.append(charBuffer.get());

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/utils/DiskUtilsTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/utils/DiskUtilsTest.java
@@ -24,7 +24,14 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -65,5 +72,80 @@ class DiskUtilsTest {
         File tmpFile = Files.createTempFile(UUID.randomUUID().toString(), ".ut").toFile();
         DiskUtils.deleteQuietly(tmpFile);
         assertFalse(tmpFile.exists());
+    }
+
+    @Test
+    void testReadFileConcurrentlyReturnsCorrectContent() throws Exception {
+        // Two distinct payloads, each large enough that decoding is non-trivial. If readFile shares a
+        // CharsetDecoder instance across threads, concurrent decodes will corrupt each other and the
+        // returned string will not equal the file's actual content.
+        File fileA = Files.createTempFile("nacos-disk-utils-concurrent-a", ".txt").toFile();
+        File fileB = Files.createTempFile("nacos-disk-utils-concurrent-b", ".txt").toFile();
+        fileA.deleteOnExit();
+        fileB.deleteOnExit();
+        String contentA = repeat("alpha-rule-", 1024);
+        String contentB = repeat("beta-rule-", 1024);
+        Files.write(fileA.toPath(), contentA.getBytes(StandardCharsets.UTF_8));
+        Files.write(fileB.toPath(), contentB.getBytes(StandardCharsets.UTF_8));
+
+        int threads = 16;
+        int iterationsPerThread = 50;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<Void>> futures = new ArrayList<>(threads);
+            for (int i = 0; i < threads; i++) {
+                final boolean readA = i % 2 == 0;
+                final File target = readA ? fileA : fileB;
+                final String expected = readA ? contentA : contentB;
+                futures.add(pool.submit(() -> {
+                    start.await();
+                    for (int j = 0; j < iterationsPerThread; j++) {
+                        String actual = DiskUtils.readFile(target);
+                        assertEquals(expected, actual,
+                                "concurrent readFile returned corrupted content for " + target.getName());
+                    }
+                    return null;
+                }));
+            }
+            start.countDown();
+            for (Future<Void> f : futures) {
+                f.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void testReadFileWithMultiByteUtf8Content() throws IOException {
+        // Regression: readFile must round-trip non-ASCII UTF-8 content.
+        File f = Files.createTempFile("nacos-disk-utils-utf8", ".txt").toFile();
+        f.deleteOnExit();
+        String content = "限流规则-中文内容-αβγ-🚀";
+        Files.write(f.toPath(), content.getBytes(StandardCharsets.UTF_8));
+        assertEquals(content, DiskUtils.readFile(f));
+    }
+
+    @Test
+    void testReadFileSequentialCallsAreIndependent() throws IOException {
+        // Regression: a previously shared static CharsetDecoder kept state across calls. Each call must
+        // observe a clean decoder regardless of what the previous call read.
+        File f = Files.createTempFile("nacos-disk-utils-sequential", ".txt").toFile();
+        f.deleteOnExit();
+        String first = "first-payload-数据A";
+        String second = "second-payload-数据B";
+        Files.write(f.toPath(), first.getBytes(StandardCharsets.UTF_8));
+        assertEquals(first, DiskUtils.readFile(f));
+        Files.write(f.toPath(), second.getBytes(StandardCharsets.UTF_8));
+        assertEquals(second, DiskUtils.readFile(f));
+    }
+
+    private static String repeat(String token, int times) {
+        StringBuilder sb = new StringBuilder(token.length() * times);
+        for (int i = 0; i < times; i++) {
+            sb.append(token).append(i);
+        }
+        return sb.toString();
     }
 }


### PR DESCRIPTION
## Problem

`DiskUtils.readFile` in the `plugin/control` module is invoked from `LocalDiskRuleStorage` whenever the server loads a connection-rule file or a TPS rule file from disk. When two threads call `readFile` concurrently — for example while loading multiple TPS rules — they share a single decoder instance and can return mojibake or truncated content. Even sequential calls can observe leftover decoder state from the previous invocation.

## Root Cause

`DiskUtils` declares the decoder as a static field:

```java
private static final CharsetDecoder DECODER = CHARSET.newDecoder();
```

`java.nio.charset.CharsetDecoder` is documented as not safe for concurrent use, and a decoder retains internal state between `decode(...)` calls. Sharing one static instance across every caller violates both invariants: concurrent decodes interleave each other's state, and a decoder that finished a previous call mid-character carries that residue into the next call.

## Fix

Move the decoder allocation into `readFile` so each invocation gets its own instance. The static field is removed.

- `plugin/control/src/main/java/com/alibaba/nacos/plugin/control/utils/DiskUtils.java`
  - Remove `private static final CharsetDecoder DECODER`.
  - Allocate `CharsetDecoder decoder = CHARSET.newDecoder();` at the top of `readFile`, with a comment explaining the thread-safety reason.
  - Use the local `decoder` in the existing decode loop.

The fix is intentionally minimal: no other lines of `readFile` are changed, and behavior for any single-threaded caller is unchanged.

## Tests Added

`plugin/control/src/test/java/com/alibaba/nacos/plugin/control/utils/DiskUtilsTest.java` gains three tests covering each change point:

| Change Point | Test |
|--------------|------|
| Per-call decoder under concurrency | `testReadFileConcurrentlyReturnsCorrectContent` — 16 threads × 50 iterations alternating between two files with distinct payloads; asserts each read returns the exact file content. Fails on the prior shared-decoder code with corrupted strings. |
| Per-call decoder eliminates cross-call state | `testReadFileSequentialCallsAreIndependent` — writes payload A, reads, overwrites with payload B, reads again; both reads must return their exact content. |
| Decode loop still handles non-ASCII | `testReadFileWithMultiByteUtf8Content` — round-trips a string containing CJK, Greek, and an emoji to guard against any regression in the decode loop after the refactor. |

Existing tests (`testReadFile`, `testWriteFile`, `testDeleteQuietly`) continue to pass.

Verification:

```
mvn -pl plugin/control -am test -Dtest=DiskUtilsTest -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
mvn -pl plugin/control -am -B compile apache-rat:check checkstyle:check spotbugs:check -DskipTests
# 0 Checkstyle violations, 0 SpotBugs findings
```

## Impact

- Callers: `LocalDiskRuleStorage.getConnectionRule()` and `LocalDiskRuleStorage.getTpsRule(...)` are the production call sites; both benefit from the fix without any change to their own code.
- Behavior: identical for any single-threaded read of valid UTF-8 content. The change closes a concurrency hole and removes leaked decoder state across calls.
- Performance: one additional `CharsetDecoder` allocation per `readFile` call. These calls happen on rule load, not on the request hot path, so the cost is negligible.
- Scope: limited to `plugin/control`. The same anti-pattern exists in `sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java` and will be addressed in a separate PR per the one-fix-per-PR policy.
