### PR TITLE
fix(sys): make DiskUtils.readFile correct for multi-byte UTF-8

### DIFF
--- a/sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java
+++ b/sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java
@@ -74,8 +74,6 @@ public final class DiskUtils {
     
     private static final Charset CHARSET = StandardCharsets.UTF_8;
     
-    private static final CharsetDecoder DECODER = CHARSET.newDecoder();
-    
     /**
      * Touch file.
      *
@@ -194,6 +192,9 @@ public final class DiskUtils {
      * @return content
      */
     public static String readFile(File file) {
+        // CharsetDecoder is documented as not safe for concurrent use, so allocate one per call
+        // instead of sharing a static instance across threads.
+        CharsetDecoder decoder = CHARSET.newDecoder();
         try (FileInputStream fis = new FileInputStream(file);
                 FileChannel fileChannel = fis.getChannel()) {
             StringBuilder text = new StringBuilder();
@@ -201,13 +202,25 @@ public final class DiskUtils {
             CharBuffer charBuffer = CharBuffer.allocate(4096);
             while (fileChannel.read(buffer) != -1) {
                 buffer.flip();
-                DECODER.decode(buffer, charBuffer, false);
+                decoder.decode(buffer, charBuffer, false);
                 charBuffer.flip();
                 while (charBuffer.hasRemaining()) {
                     text.append(charBuffer.get());
                 }
-                buffer.clear();
+                // compact() preserves any bytes the decoder did not consume - typically the leading
+                // bytes of a multi-byte UTF-8 character that straddles the 4096-byte chunk boundary.
+                // The previous clear() silently discarded those bytes, corrupting any non-ASCII
+                // content longer than one chunk.
+                buffer.compact();
                 charBuffer.clear();
+            }
+            // Flush the trailing partial input and any decoder state once the stream is exhausted.
+            buffer.flip();
+            decoder.decode(buffer, charBuffer, true);
+            decoder.flush(charBuffer);
+            charBuffer.flip();
+            while (charBuffer.hasRemaining()) {
+                text.append(charBuffer.get());
             }
             return text.toString();
         } catch (IOException e) {

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/DiskUtilsTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/DiskUtilsTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
@@ -451,5 +452,65 @@ class DiskUtilsTest {
             result.deleteOnExit();
             nonWritableDir.deleteOnExit();
         }
+    }
+
+    @Test
+    void testReadFileWithMultiByteUtf8AcrossChunkBoundary() throws IOException {
+        // Reproduces the corruption that happens when a multi-byte UTF-8 character straddles the
+        // 4096-byte read-buffer boundary. The decode loop reads the first chunk, the decoder
+        // reports UNDERFLOW because the trailing bytes are an incomplete UTF-8 sequence, and the
+        // unconsumed bytes are dropped if the buffer is cleared instead of compacted.
+        //
+        // Layout (UTF-8): 4094 ASCII bytes + 3-byte CJK ('中', E4 B8 AD) + 200 ASCII bytes.
+        // The CJK character occupies bytes 4094..4096, so its trailing byte falls in the second
+        // chunk. With buffer.clear() the leading two bytes are discarded and the second chunk
+        // starts at the orphaned continuation byte AD, producing a malformed sequence and
+        // truncating the rest of the file. With buffer.compact() the leading bytes are preserved
+        // and the character round-trips cleanly.
+        File f = Files.createTempFile("nacos-sys-disk-utils-chunk-boundary", ".txt").toFile();
+        f.deleteOnExit();
+        StringBuilder content = new StringBuilder(4094 + 1 + 200);
+        for (int i = 0; i < 4094; i++) {
+            content.append('a');
+        }
+        content.append('中'); // '中', encodes to E4 B8 AD in UTF-8
+        for (int i = 0; i < 200; i++) {
+            content.append('b');
+        }
+        String expected = content.toString();
+        byte[] encoded = expected.getBytes(StandardCharsets.UTF_8);
+        // Sanity-check the layout so future edits to the test cannot accidentally make it pass.
+        assertEquals(4094 + 3 + 200, encoded.length);
+        assertEquals((byte) 0xe4, encoded[4094]);
+        assertEquals((byte) 0xb8, encoded[4095]);
+        assertEquals((byte) 0xad, encoded[4096]);
+        Files.write(f.toPath(), encoded);
+
+        assertEquals(expected, DiskUtils.readFile(f));
+    }
+
+    @Test
+    void testReadFileWithSmallMultiByteUtf8Content() throws IOException {
+        // Regression: small non-ASCII content that fits in a single 4096-byte chunk must continue
+        // to round-trip correctly.
+        File f = Files.createTempFile("nacos-sys-disk-utils-utf8", ".txt").toFile();
+        f.deleteOnExit();
+        String content = "限流规则-中文内容-αβγ-🚀";
+        Files.write(f.toPath(), content.getBytes(StandardCharsets.UTF_8));
+        assertEquals(content, DiskUtils.readFile(f));
+    }
+
+    @Test
+    void testReadFileSequentialCallsAreIndependent() throws IOException {
+        // Each readFile call must observe a clean decoder regardless of what the previous call
+        // read; the previous code shared one static CharsetDecoder across all callers.
+        File f = Files.createTempFile("nacos-sys-disk-utils-sequential", ".txt").toFile();
+        f.deleteOnExit();
+        String first = "first-payload-数据A";
+        String second = "second-payload-数据B";
+        Files.write(f.toPath(), first.getBytes(StandardCharsets.UTF_8));
+        assertEquals(first, DiskUtils.readFile(f));
+        Files.write(f.toPath(), second.getBytes(StandardCharsets.UTF_8));
+        assertEquals(second, DiskUtils.readFile(f));
     }
 }


### PR DESCRIPTION
## Problem

`com.alibaba.nacos.sys.utils.DiskUtils.readFile(File)` is invoked from many modules — `core/listener/startup/NacosCoreStartUp`, `core/persistence/DerbySnapshotOperation`, `core/persistence/DistributedDatabaseOperateImpl`, `core/plugin/PluginStateSnapshotOperation`, `console/handler/impl/AbstractServerStateHandler` (announcement / guide files), `naming/misc/SwitchManager` (via `readFileBytes`), and others. As written it has two correctness bugs that surface the moment a file contains non-ASCII content (Chinese / Japanese / emoji / accented characters):

1. **Decoder is process-wide static.** The decoder is held as `private static final CharsetDecoder DECODER`. `java.nio.charset.CharsetDecoder` is documented as not safe for concurrent use, and a decoder retains internal state between `decode(...)` calls. One instance shared by every `readFile` caller violates both invariants.
2. **`buffer.clear()` discards unconsumed bytes.** When a multi-byte UTF-8 character straddles the 4096-byte chunk boundary the decoder reports `UNDERFLOW` and leaves the leading bytes of the character in the `ByteBuffer`. The current loop then calls `buffer.clear()`, which throws those leading bytes away. The next `read()` starts on an orphaned UTF-8 continuation byte, the decoder reports malformed input, and the rest of the file is silently truncated. A standalone reproducer with `4094 'a' + '中' + 200 'b'` returns just `4094 'a'` on the current code.

Both bugs are inside the same loop and are two halves of "stream UTF-8 correctly".

## Fix

`sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java`:

- Drop `private static final CharsetDecoder DECODER` and allocate a fresh `CharsetDecoder` at the top of `readFile`. Per-call allocation costs one short-lived object — these calls happen on startup / state-restore paths, not on the request hot path — and gives every caller an isolated, freshly-reset decoder.
- Replace `buffer.clear()` with `buffer.compact()` inside the read loop so any bytes the decoder did not consume survive into the next `fileChannel.read(...)`.
- After the loop terminates on EOF, flush the trailing partial input and any state the decoder is still holding:

  ```java
  buffer.flip();
  decoder.decode(buffer, charBuffer, true);
  decoder.flush(charBuffer);
  ```

  Without this, the very last multi-byte character of a file whose tail spans the final chunk would still be dropped.

## Tests Added

`sys/src/test/java/com/alibaba/nacos/sys/utils/DiskUtilsTest.java`:

| Change Point | Test |
|--------------|------|
| `buffer.compact()` over chunk boundary + EOF flush | `testReadFileWithMultiByteUtf8AcrossChunkBoundary` — builds `4094 'a' + '中' + 200 'b'` so the 3 UTF-8 bytes of `'中'` land at byte indices 4094..4096 (asserted explicitly so future edits cannot accidentally make the test pass). The test reads the file back and asserts the exact round-trip. **Fails deterministically against `upstream/develop` HEAD (the trailing 200 chars vanish) and passes only after the fix.** |
| Per-call decoder, no leftover state across invocations | `testReadFileSequentialCallsAreIndependent` — writes payload A, reads, overwrites with payload B, reads again. Both reads must return their exact content. |
| Single-chunk non-ASCII still round-trips | `testReadFileWithSmallMultiByteUtf8Content` — guards small non-ASCII content as a regression. |

Existing `testRead*` / `testWrite*` / `testTouch*` / `testDelete*` / `testLineIterator*` tests in `DiskUtilsTest` (44 of them) continue to pass.

Verification:

```
mvn -pl sys -am test -Dtest=DiskUtilsTest -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 47, Failures: 0, Errors: 0, Skipped: 0
mvn -pl sys -am -B compile apache-rat:check checkstyle:check spotbugs:check -DskipTests
# 0 Checkstyle violations, 0 SpotBugs findings
```

Reverting just the `DiskUtils.java` change locally (with the new test in place) reproduces the failure deterministically:
`testReadFileWithMultiByteUtf8AcrossChunkBoundary <<< FAILURE`.

## Impact

- Production callers: many — `NacosCoreStartUp`, `DerbySnapshotOperation`, `DistributedDatabaseOperateImpl`, `PluginStateSnapshotOperation`, `AbstractServerStateHandler` (announcement / guide loaders), `SwitchManager` (via `readFileBytes`), among others. After the fix they round-trip file content with multi-byte UTF-8 cleanly regardless of how the bytes line up with the 4096-byte read boundary.
- Behavior on ASCII-only content: unchanged.
- Behavior on small (≤ one chunk) non-ASCII content: unchanged.
- Performance: one extra short-lived `CharsetDecoder` allocation per `readFile` call. Negligible against the I/O.
- Risk: bounded — the new finalize block runs once per call and only against bytes the decoder did not already consume. ASCII content has none, so the cost is just a `flip` + an empty `decode` + an empty `flush`.
- Scope: limited to `sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java`. The same fix for `plugin/control/.../DiskUtils.java` was split across #15065 (per-call decoder, merged) and #15073 (chunk-boundary follow-up, in review).
