### PR TITLE
[ISSUE #15033] fix(deps): drop Micrometer 1.12.8 override so Prometheus actuator endpoint is exposed

### DIFF
--- a/core/src/test/java/com/alibaba/nacos/core/monitor/MetricsMonitorTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/monitor/MetricsMonitorTest.java
@@ -19,7 +19,7 @@ package com.alibaba.nacos.core.monitor;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/core/src/test/java/com/alibaba/nacos/core/monitor/NacosMeterRegistryCenterTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/monitor/NacosMeterRegistryCenterTest.java
@@ -21,7 +21,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/MetricsMonitorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/MetricsMonitorTest.java
@@ -21,7 +21,7 @@ import com.alibaba.nacos.naming.core.v2.pojo.BatchInstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/pom.xml
+++ b/pom.xml
@@ -160,9 +160,6 @@
         <!-- Maven Central Portal -->
         <central.publishing.maven.version>0.7.0</central.publishing.maven.version>
 
-        <!-- override dependency version -->
-        <micrometer.version>1.12.8</micrometer.version>
-        
         <!-- native -->
         <native-maven-plugin.version>0.10.2</native-maven-plugin.version>
     </properties>
@@ -1137,29 +1134,6 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${protobuf-java.version}</version>
-            </dependency>
-            
-            <!-- Micrometer -->
-            
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-core</artifactId>
-                <version>${micrometer.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-registry-prometheus</artifactId>
-                <version>${micrometer.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-registry-influx</artifactId>
-                <version>${micrometer.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-registry-elastic</artifactId>
-                <version>${micrometer.version}</version>
             </dependency>
             
             <dependency>


### PR DESCRIPTION
## Problem

`/nacos/actuator/prometheus` is silently missing on Nacos `3.2.x` even when `management.endpoints.web.exposure.include=*` is set, as reported in #15033. As a result Prometheus cannot scrape Nacos metrics from the actuator endpoint.

## Root Cause

The top-level `pom.xml` kept an explicit `micrometer.version` override that pre-dates the Spring Boot upgrade:

```xml
<!-- override dependency version -->
<micrometer.version>1.12.8</micrometer.version>
```

In commit `e7c2b7bc5` Nacos moved from Spring Boot 3.4.10 to 3.5.13, but this property was not updated. Spring Boot 3.5's `PrometheusMetricsExportAutoConfiguration` is wired against the new `prometheus-metrics-core` based registry shipped with Micrometer 1.13+, and matches against `io.prometheus:prometheus-metrics-exposition-formats` on the classpath. Micrometer 1.12 still ships the legacy `simpleclient`-based registry and does not pull in the new `prometheus-metrics-*` artifacts. With the version pinned at 1.12, the autoconfig conditions never match, the Prometheus registry bean is never created, and the actuator endpoint is silently dropped from the discovery payload.

This matches the maintainer triage on the issue: "spring boot 3.5 之后依赖的 prometheus registry 版本变了，导致 spring boot autoconfiguration 条件未满足。修复方式，升级 prometheus registry 到对应版本即可."

## Fix

Drop the override and the four redundant `<dependencyManagement>` entries that referenced `${micrometer.version}` so the `spring-boot-dependencies` BOM (already imported) supplies matching micrometer + prometheus-metrics versions for the active Spring Boot release.

`pom.xml`:

- Remove the `<micrometer.version>1.12.8</micrometer.version>` property and its leading "override dependency version" comment.
- Remove the `<dependency>` blocks for `io.micrometer:micrometer-core`, `…-registry-prometheus`, `…-registry-influx`, `…-registry-elastic` from `<dependencyManagement>` (all four were only there to apply the override version).

After the change, `mvn dependency:list` resolves the expected combination on the current Spring Boot 3.5.13 BOM:

```
io.micrometer:micrometer-core:jar:1.15.10:compile
io.micrometer:micrometer-registry-prometheus:jar:1.15.10:compile
io.prometheus:prometheus-metrics-exposition-formats:jar:1.3.10:runtime
```

`prometheus-metrics-exposition-formats` is the artifact whose presence Spring Boot 3.5 keys the `/actuator/prometheus` autoconfig on. With Micrometer 1.15.10 + that artifact on the classpath, the autoconfig condition is satisfied and the endpoint is registered.

The legacy `io.micrometer.prometheus.PrometheusMeterRegistry` class no longer exists in 1.15 (it moved with the registry rewrite). Three test files referenced it, in each case only as a type token for a `context.getBean(...)` mock — no instances are ever constructed. Migrate the imports to the current package, which is the documented replacement:

| File | Change |
|------|--------|
| `core/src/test/java/com/alibaba/nacos/core/monitor/MetricsMonitorTest.java` | `io.micrometer.prometheus.PrometheusMeterRegistry` → `io.micrometer.prometheusmetrics.PrometheusMeterRegistry` |
| `core/src/test/java/com/alibaba/nacos/core/monitor/NacosMeterRegistryCenterTest.java` | same |
| `naming/src/test/java/com/alibaba/nacos/naming/monitor/MetricsMonitorTest.java` | same |

No `main/` code references `PrometheusMeterRegistry` directly.

## Tests Added

No new tests are added — the existing `MetricsMonitorTest` and `NacosMeterRegistryCenterTest` suites cover the same `context.getBean(PrometheusMeterRegistry.class)` paths against the migrated import. They become a regression check that the type token still resolves under the BOM-managed Micrometer.

| Change Point | Test |
|--------------|------|
| Type token migration in core tests | Existing `MetricsMonitorTest` (9 tests) and `NacosMeterRegistryCenterTest` (9 tests) — both compile and pass against `io.micrometer.prometheusmetrics.PrometheusMeterRegistry`. |
| Type token migration in naming test | Existing `MetricsMonitorTest` in naming (4 tests) — compiles and passes. |
| Removal of dependencyManagement override | Reactor compile + test-compile for `core` and `naming` modules succeed (would fail with `package io.micrometer.prometheus does not exist` if any caller still depended on the legacy package). |

The end-to-end "endpoint is exposed under `*` exposure" assertion is genuinely an integration test and requires a running server; that scenario is the one called out in #15033 and is exactly what the fix re-enables. The maintainer's diagnosis ("升级 prometheus registry 到对应版本即可") is the same recipe applied here.

Verification:

```
mvn -pl core,naming -am -B compile apache-rat:check checkstyle:check spotbugs:check -DskipTests
# 0 violations / 0 findings
mvn -pl core -am test -Dtest=MetricsMonitorTest,NacosMeterRegistryCenterTest -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
mvn -pl naming -am test -Dtest=MetricsMonitorTest -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

## Impact

- Behavior: `/nacos/actuator/prometheus` re-appears in the actuator discovery payload and serves the Prometheus exposition format whenever the actuator endpoint is exposed (`management.endpoints.web.exposure.include` includes `prometheus` or `*`).
- API: no public-API changes. The package rename of `PrometheusMeterRegistry` is internal — Nacos has no `main/` code that imports it.
- Other registries: `micrometer-registry-influx` and `micrometer-registry-elastic` similarly fall back to the BOM-managed version (also part of the same Micrometer release line), so behavior for those backends is unchanged or aligned with Spring Boot 3.5's expectations.
- Risk: limited to whatever differences exist between Micrometer 1.12.8 and the 1.15.x BOM-managed line; that gap is exactly the gap Spring Boot 3.5 was upgraded against, so this PR realigns Nacos with its own framework choice.
