### PR TITLE
[ISSUE #14981] fix(config): keep publishConfig idempotent when concurrent inserts race

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -222,7 +222,14 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
             ConfigInfoStateWrapper configInfoState = findConfigInfoState(configInfo.getDataId(), configInfo.getGroup(),
                     configInfo.getTenant());
             if (configInfoState == null) {
-                return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                try {
+                    return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                } catch (DataIntegrityViolationException raceWithConcurrentInsert) {
+                    // Another thread inserted the same dataId/group/tenant in the gap between the
+                    // findConfigInfoState above and our insert. Treat this as the update path and
+                    // keep publishConfig idempotent instead of surfacing a 500 to the caller.
+                    return updateConfigInfo(configInfo, srcIp, srcUser, configAdvanceInfo);
+                }
             } else {
                 return updateConfigInfo(configInfo, srcIp, srcUser, configAdvanceInfo);
             }
@@ -241,7 +248,14 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
             ConfigInfoStateWrapper configInfoState = findConfigInfoState(configInfo.getDataId(), configInfo.getGroup(),
                     configInfo.getTenant());
             if (configInfoState == null) {
-                return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                try {
+                    return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                } catch (DataIntegrityViolationException raceWithConcurrentInsert) {
+                    // Lost the insert race against another thread. Switch to the CAS update path so
+                    // the caller gets the same result it would have gotten if the row had already
+                    // been visible at the findConfigInfoState check.
+                    return updateConfigInfoCas(configInfo, srcIp, srcUser, configAdvanceInfo);
+                }
             } else {
                 return updateConfigInfoCas(configInfo, srcIp, srcUser, configAdvanceInfo);
             }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
@@ -280,7 +281,112 @@ class ExternalConfigInfoPersistServiceImplTest {
         } catch (Exception e) {
             assertEquals("mock fail", e.getMessage());
         }
-        
+
+    }
+
+    @Test
+    void testInsertOrUpdateRecoversFromConcurrentInsertRace() {
+        // Reproduces the race in #14981: two threads call publishConfig for the same
+        // dataId/group/tenant; both see findConfigInfoState() == null and both attempt INSERT.
+        // The losing thread used to surface a 500 (DataIntegrityViolationException). After the
+        // fix, it should recover by switching to the UPDATE path so publishConfig stays idempotent.
+        String dataId = "dataId";
+        String group = "group";
+        String tenant = "tenant";
+        String content = "content-race";
+        ConfigInfo configInfo = new ConfigInfo(dataId, group, tenant, null, content);
+        configInfo.setEncryptedDataKey("key-race");
+
+        // findConfigInfoState returns null on the first probe (no row visible yet to this thread).
+        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant}),
+                eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
+
+        // The INSERT loses the race against another concurrent insert: PostgreSQL/MySQL surface
+        // a unique constraint violation, which Spring wraps as DataIntegrityViolationException.
+        long insertConfigInfoId = 12345678765L;
+        GeneratedKeyHolder generatedKeyHolder = TestCaseUtils.createGeneratedKeyHolder(insertConfigInfoId);
+        externalStorageUtilsMockedStatic.when(ExternalStorageUtils::createKeyHolder).thenReturn(generatedKeyHolder);
+        Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class), any(KeyHolder.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate key value violates unique constraint"));
+
+        // After the recovery falls through to updateConfigInfo, the row inserted by the winning
+        // thread is now visible. Mock the ConfigAllInfo lookup that updateConfigInfo performs.
+        ConfigAllInfo configAllInfoFromOtherThread = new ConfigAllInfo();
+        configAllInfoFromOtherThread.setDataId(dataId);
+        configAllInfoFromOtherThread.setGroup(group);
+        configAllInfoFromOtherThread.setTenant(tenant);
+        configAllInfoFromOtherThread.setAppName("winner-app");
+        configAllInfoFromOtherThread.setMd5("winner-md5");
+        configAllInfoFromOtherThread.setId(insertConfigInfoId);
+        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant}),
+                eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(configAllInfoFromOtherThread);
+
+        // The UPDATE is allowed to succeed (returns affected rows).
+        Mockito.when(jdbcTemplate.update(anyString(), any(Object[].class))).thenReturn(1);
+        Mockito.when(jdbcTemplate.update(anyString(), any(Object.class), any(Object.class), any(Object.class),
+                any(Object.class), any(Object.class), any(Object.class), any(Object.class), any(Object.class),
+                any(Object.class), any(Object.class), any(Object.class), any(Object.class), any(Object.class),
+                any(Object.class))).thenReturn(1);
+
+        Map<String, Object> configAdvanceInfo = new HashMap<>();
+        configAdvanceInfo.put("config_tags", "tag1");
+
+        // The race must be absorbed by the persistence layer: no exception escapes to the caller.
+        ConfigOperateResult result =
+                externalConfigInfoPersistService.insertOrUpdate("srcIp", "srcUser", configInfo, configAdvanceInfo);
+        assertTrue(result != null);
+
+        // Verify both that the insert was attempted AND that the update was performed against the
+        // row the winner had committed.
+        Mockito.verify(jdbcTemplate, times(1))
+                .update(any(PreparedStatementCreator.class), any(KeyHolder.class));
+        Mockito.verify(historyConfigInfoPersistService, times(1))
+                .insertConfigHistoryAtomic(eq(configAllInfoFromOtherThread.getId()), any(ConfigInfo.class), eq("srcIp"),
+                        eq("srcUser"), any(Timestamp.class), eq("U"), eq("formal"), eq(null), any());
+    }
+
+    @Test
+    void testInsertOrUpdateCasRecoversFromConcurrentInsertRace() {
+        // Same race as above, but on the CAS publish path. The recovery must hand off to
+        // updateConfigInfoCas so a stale CAS md5 surfaces as a "Cas publish fail" / success=false
+        // result instead of a 500.
+        String dataId = "dataId";
+        String group = "group";
+        String tenant = "tenant";
+        String content = "content-cas-race";
+        String casMd5 = "cas-md5";
+        ConfigInfo configInfo = new ConfigInfo(dataId, group, tenant, null, content);
+        configInfo.setMd5(casMd5);
+        configInfo.setEncryptedDataKey("key-cas-race");
+
+        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant}),
+                eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
+
+        long insertConfigInfoId = 99999999999L;
+        GeneratedKeyHolder generatedKeyHolder = TestCaseUtils.createGeneratedKeyHolder(insertConfigInfoId);
+        externalStorageUtilsMockedStatic.when(ExternalStorageUtils::createKeyHolder).thenReturn(generatedKeyHolder);
+        Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class), any(KeyHolder.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate key value violates unique constraint"));
+
+        // After recovery, the CAS UPDATE finds the row written by the other thread but its md5
+        // differs from our casMd5, so it returns 0 affected rows (CAS check fails). That maps to
+        // ConfigOperateResult(success=false), which the caller turns into a controlled error
+        // ("Cas publish fail, server md5 may have changed.") rather than a 500.
+        Mockito.when(jdbcTemplate.update(anyString(), any(Object.class), any(Object.class), any(Object.class),
+                any(Object.class), any(Object.class), any(Object.class), any(Object.class), any(Object.class),
+                any(Object.class), any(Object.class), any(Object.class), any(Object.class), any(Object.class),
+                any(Object.class), any(Object.class))).thenReturn(0);
+
+        Map<String, Object> configAdvanceInfo = new HashMap<>();
+
+        ConfigOperateResult result =
+                externalConfigInfoPersistService.insertOrUpdateCas("srcIp", "srcUser", configInfo, configAdvanceInfo);
+        assertFalse(result.isSuccess(),
+                "race-recovered CAS publish should report success=false when the existing row's md5 no longer matches");
+
+        // Insert was attempted exactly once and was the trigger for falling through to CAS update.
+        Mockito.verify(jdbcTemplate, times(1))
+                .update(any(PreparedStatementCreator.class), any(KeyHolder.class));
     }
     
     @Test


### PR DESCRIPTION
## Problem

In a Nacos cluster with an external RDBMS, two concurrent `publishConfig` calls for the same `dataId`/`group`/`tenant` can lose a small fraction of requests with HTTP 500 and a unique-constraint violation in the server log. On PostgreSQL the symptom is "duplicate key value violates unique constraint `uk_configinfo_datagrouptenant`" (#14981); MySQL and Derby surface analogous integrity violations under the same window. The user expects `publishConfig` to remain idempotent.

## Root Cause

`ExternalConfigInfoPersistServiceImpl#insertOrUpdate` and `#insertOrUpdateCas` first probe `findConfigInfoState` and then either `addConfigInfo` (INSERT path) or `updateConfigInfo` / `updateConfigInfoCas` (UPDATE path). Two concurrent threads can both observe "no row" from the probe and both run the INSERT; one wins and commits, the other loses with `DataIntegrityViolationException`. The existing surrounding `catch (Exception)` re-throws after logging, so the loser's request returns 500.

```java
ConfigInfoStateWrapper configInfoState = findConfigInfoState(dataId, group, tenant);
if (configInfoState == null) {
    return addConfigInfo(...);   // ← race loser hits unique-constraint violation here
} else {
    return updateConfigInfo(...);
}
```

## Fix

Wrap the INSERT in a localized `try/catch` for `DataIntegrityViolationException` and fall through to the UPDATE path when it fires. The recovery delivers the same outcome the caller would have gotten if the winner's row had been visible at the probe.

`config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java`:

- `insertOrUpdate`: on `DataIntegrityViolationException` from `addConfigInfo`, call `updateConfigInfo`.
- `insertOrUpdateCas`: on `DataIntegrityViolationException` from `addConfigInfo`, call `updateConfigInfoCas`. A stale `casMd5` still surfaces correctly — `updateConfigInfoCas` returns `ConfigOperateResult(success=false)`, and the controller layer turns that into the existing "Cas publish fail, server md5 may have changed" error rather than 500.

The fix is intentionally localized to the persistence layer's check-then-act window. No SQL or schema changes; no controller / service-layer changes.

## Tests Added

`config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java`:

| Change Point | Test |
|--------------|------|
| `insertOrUpdate` recovers via `updateConfigInfo` after losing the insert race | `testInsertOrUpdateRecoversFromConcurrentInsertRace` — mocks `findConfigInfoState` to return null, then makes the row INSERT throw `DataIntegrityViolationException`. Asserts no exception escapes, the INSERT was attempted exactly once, and the history record was written via the UPDATE path (`"U"` op type). |
| `insertOrUpdateCas` recovers via `updateConfigInfoCas` after losing the insert race | `testInsertOrUpdateCasRecoversFromConcurrentInsertRace` — same race shape on the CAS path, with the recovery UPDATE returning 0 affected rows (CAS check fails because the winner's md5 differs from `casMd5`). Asserts the result reports `success=false` instead of throwing. |

The full `ExternalConfigInfoPersistServiceImplTest` suite (40 tests including the two new ones) passes; the existing `testInsertOrUpdateOfException` still asserts that non-integrity errors (e.g. `CannotGetJdbcConnectionException`) still propagate, so the new catch is properly scoped to integrity violations only.

Verification:

```
mvn -pl config -am test -Dtest=ExternalConfigInfoPersistServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 40, Failures: 0, Errors: 0, Skipped: 0
mvn -pl config -am -B compile apache-rat:check checkstyle:check spotbugs:check -DskipTests
# 0 Checkstyle violations, 0 SpotBugs findings
```

## Impact

- Behavior: concurrent `publishConfig` calls for the same key on PostgreSQL / MySQL / Derby no longer leak a 500 to the client when they lose the insert race; the loser silently recovers via UPDATE, preserving the documented idempotency of the publish API.
- Scope: limited to the External (cluster + external RDBMS) impl. The Embedded impl serializes writes through the Raft leader, so the same window does not occur there in practice and is left unchanged per the one-fix-per-PR policy.
- API: no public-API changes. The new `catch` is internal to the persistence service.
- Performance: no change in the success path. Only the rare race-loser case incurs the cost of a second statement (the UPDATE) instead of the previous behavior of throwing.
- Risk: bounded — `DataIntegrityViolationException` is Spring's narrow wrapper for unique-constraint violations from JDBC drivers; non-integrity failures (connection drops, etc.) still propagate as before.
