### PR TITLE
fix(plugin/control): preserve multi-byte UTF-8 chars across DiskUtils chunk boundaries

### DIFF
--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/utils/DiskUtils.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/utils/DiskUtils.java
@@ -72,8 +72,20 @@ public final class DiskUtils {
                 while (charBuffer.hasRemaining()) {
                     text.append(charBuffer.get());
                 }
-                buffer.clear();
+                // compact() preserves any bytes the decoder did not consume - typically the leading
+                // bytes of a multi-byte UTF-8 character that straddles the 4096-byte chunk boundary.
+                // The previous clear() silently discarded those bytes, corrupting any non-ASCII
+                // content longer than one chunk.
+                buffer.compact();
                 charBuffer.clear();
+            }
+            // Flush the trailing partial input and any decoder state once the stream is exhausted.
+            buffer.flip();
+            decoder.decode(buffer, charBuffer, true);
+            decoder.flush(charBuffer);
+            charBuffer.flip();
+            while (charBuffer.hasRemaining()) {
+                text.append(charBuffer.get());
             }
             return text.toString();
         } catch (IOException e) {

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/utils/DiskUtilsTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/utils/DiskUtilsTest.java
@@ -141,6 +141,41 @@ class DiskUtilsTest {
         assertEquals(second, DiskUtils.readFile(f));
     }
 
+    @Test
+    void testReadFileWithMultiByteUtf8AcrossChunkBoundary() throws IOException {
+        // Reproduces the corruption that happens when a multi-byte UTF-8 character straddles the
+        // 4096-byte read-buffer boundary. The decode loop reads the first chunk, the decoder
+        // reports UNDERFLOW because the trailing bytes are an incomplete UTF-8 sequence, and the
+        // unconsumed bytes are dropped if the buffer is cleared instead of compacted.
+        //
+        // Layout (UTF-8): 4094 ASCII bytes + 3-byte CJK ('中', E4 B8 AD) + 200 ASCII bytes.
+        // The CJK character occupies bytes 4094..4096, so its trailing byte falls in the second
+        // chunk. With buffer.clear() the leading two bytes are discarded and the second chunk
+        // starts at the orphaned continuation byte AD, producing a malformed sequence and
+        // truncating the rest of the file. With buffer.compact() the leading bytes are preserved
+        // and the character round-trips cleanly.
+        File f = Files.createTempFile("nacos-disk-utils-chunk-boundary", ".txt").toFile();
+        f.deleteOnExit();
+        StringBuilder content = new StringBuilder(4094 + 1 + 200);
+        for (int i = 0; i < 4094; i++) {
+            content.append('a');
+        }
+        content.append('中'); // '中', encodes to E4 B8 AD in UTF-8
+        for (int i = 0; i < 200; i++) {
+            content.append('b');
+        }
+        String expected = content.toString();
+        byte[] encoded = expected.getBytes(StandardCharsets.UTF_8);
+        // Sanity-check the layout so future edits to the test cannot accidentally make it pass.
+        assertEquals(4094 + 3 + 200, encoded.length);
+        assertEquals((byte) 0xe4, encoded[4094]);
+        assertEquals((byte) 0xb8, encoded[4095]);
+        assertEquals((byte) 0xad, encoded[4096]);
+        Files.write(f.toPath(), encoded);
+
+        assertEquals(expected, DiskUtils.readFile(f));
+    }
+
     private static String repeat(String token, int times) {
         StringBuilder sb = new StringBuilder(token.length() * times);
         for (int i = 0; i < times; i++) {


### PR DESCRIPTION
## Problem

Even after #15065, `DiskUtils.readFile` in `plugin/control` still corrupts non-ASCII content whenever a UTF-8 byte sequence straddles the 4096-byte read-buffer boundary. A standalone reproducer with the file layout

```
4094 'a' (ASCII) + '中' (UTF-8 E4 B8 AD) + 200 'b' (ASCII)   # 4297 bytes
```

reads back as just `4094 'a'` — the trailing `'中'` and the 200 ASCII bytes that follow it are silently dropped on every call. Any rule file with non-ASCII content longer than 4 KB is affected.

## Root Cause

The decode loop in `readFile` is:

```java
while (fileChannel.read(buffer) != -1) {
    buffer.flip();
    decoder.decode(buffer, charBuffer, false);
    charBuffer.flip();
    while (charBuffer.hasRemaining()) { text.append(charBuffer.get()); }
    buffer.clear();         // ← drops any bytes the decoder did not consume
    charBuffer.clear();
}
```

When a multi-byte UTF-8 character straddles the 4096-byte boundary the decoder consumes the complete characters and reports `UNDERFLOW`, leaving the leading bytes of the partial character in the `ByteBuffer`. `buffer.clear()` then discards those leading bytes. The next `fileChannel.read(...)` starts at file-position 4096, so the orphaned UTF-8 continuation byte (`AD` in the example above) is the first byte the decoder sees on the next chunk. The decoder reports malformed input and the rest of the file is silently lost.

A second, related bug: there is no finalize step after the read loop. Even with `compact()`, a trailing partial sequence at the very end of the file would still be held by either the buffer or the decoder. Calling `decoder.decode(buffer, charBuffer, true)` + `decoder.flush(charBuffer)` once the stream is exhausted is the canonical way to drain both.

## Fix

`plugin/control/src/main/java/com/alibaba/nacos/plugin/control/utils/DiskUtils.java`:

- Replace `buffer.clear()` with `buffer.compact()` inside the read loop so any unconsumed bytes survive into the next `fileChannel.read(...)`.
- After the loop, finalize the stream:

  ```java
  buffer.flip();
  decoder.decode(buffer, charBuffer, true);
  decoder.flush(charBuffer);
  ```

  and drain `charBuffer` once more.

The change is purely additive on top of the per-call `CharsetDecoder` allocation that #15065 introduced.

## Tests Added

`plugin/control/src/test/java/com/alibaba/nacos/plugin/control/utils/DiskUtilsTest.java`:

| Change Point | Test |
|--------------|------|
| `compact()` over chunk boundary + EOF flush | `testReadFileWithMultiByteUtf8AcrossChunkBoundary` — builds `4094 'a' + '中' + 200 'b'` so the 3 UTF-8 bytes of `'中'` land at byte indices 4094..4096 (asserted explicitly so future edits cannot accidentally make it pass). The test reads the file back and asserts the exact round-trip. **Fails deterministically against `upstream/develop` HEAD (the trailing 200 chars vanish) and passes only after the fix.** |

Existing 6 tests in `DiskUtilsTest` continue to pass.

Verification:

```
mvn -pl plugin/control -am test -Dtest=DiskUtilsTest -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
mvn -pl plugin/control -am -B compile apache-rat:check checkstyle:check spotbugs:check -DskipTests
# 0 Checkstyle violations, 0 SpotBugs findings
```

Reverting just the `DiskUtils.java` change locally (with the new test in place) reproduces the failure deterministically:
`testReadFileWithMultiByteUtf8AcrossChunkBoundary <<< FAILURE`.

## Impact

- Production callers: `LocalDiskRuleStorage.getConnectionRule()` and `LocalDiskRuleStorage.getTpsRule(...)`. After this fix they round-trip rule content with non-ASCII characters cleanly regardless of how the bytes line up with the 4096-byte read boundary.
- Behavior on ASCII-only content: unchanged.
- Behavior on small (≤ one chunk) non-ASCII content: unchanged.
- Risk: limited to the body of `readFile`. The new finalize block runs once per call and only against bytes the decoder did not already consume, so it has no observable cost on ASCII content.
- Scope: the same bug also exists in `sys/src/main/java/com/alibaba/nacos/sys/utils/DiskUtils.java` and is being fixed in #15068 (will be updated to include the same `compact()` + finalize change).

This is a follow-up to #15065, which addressed only the per-call decoder concern and left the chunk-boundary corruption in place.
