### PR TITLE
[ISSUE #14815] build(style): apply Spotless formatting to k8s-sync and istio modules

### DIFF
--- a/istio/src/main/java/com/alibaba/nacos/istio/IstioApp.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/IstioApp.java
@@ -29,7 +29,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @SpringBootApplication
 public class IstioApp {
-
+    
     public static void main(String[] args) {
         SpringApplication.run(IstioApp.class, args);
     }

--- a/istio/src/main/java/com/alibaba/nacos/istio/api/ApiConstants.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/api/ApiConstants.java
@@ -20,40 +20,46 @@ package com.alibaba.nacos.istio.api;
  * @author special.fy
  */
 public class ApiConstants {
-
+    
     /**
      * Default api prefix of any type of google protocol buffer.
      */
     public static final String API_TYPE_PREFIX = "type.googleapis.com/";
-
+    
     /**
      * Istio crd type url for mcp over xds
      * TODO Support other Istio crd, such as gateway, vs, dr and so on.
      */
-    public static final String SERVICE_ENTRY_PROTO_PACKAGE = "networking.istio.io/v1alpha3/ServiceEntry";
+    public static final String SERVICE_ENTRY_PROTO_PACKAGE =
+            "networking.istio.io/v1alpha3/ServiceEntry";
     public static final String MESH_CONFIG_PROTO_PACKAGE = "core/v1alpha1/MeshConfig";
-
+    
     /**
      * Istio crd type url for mcp
      */
     public static final String MCP_PREFIX = "istio/";
-    public static final String SERVICE_ENTRY_COLLECTION = MCP_PREFIX + "networking/v1alpha3/serviceentries";
-
+    public static final String SERVICE_ENTRY_COLLECTION =
+            MCP_PREFIX + "networking/v1alpha3/serviceentries";
+    
     /**
      * Istio crd type url of api.
      */
     public static final String MCP_RESOURCE_PROTO = API_TYPE_PREFIX + "istio.mcp.v1alpha1.Resource";
-    public static final String SERVICE_ENTRY_PROTO = API_TYPE_PREFIX + "istio.networking.v1alpha3.ServiceEntry";
-
+    public static final String SERVICE_ENTRY_PROTO =
+            API_TYPE_PREFIX + "istio.networking.v1alpha3.ServiceEntry";
+    
     /**
      * Standard xds type url
      * TODO Support lds, rds and sds
      */
     public static final String CLUSTER_TYPE = API_TYPE_PREFIX + "envoy.config.cluster.v3.Cluster";
-    public static final String ENDPOINT_TYPE = API_TYPE_PREFIX + "envoy.config.endpoint.v3.ClusterLoadAssignment";
+    public static final String ENDPOINT_TYPE =
+            API_TYPE_PREFIX + "envoy.config.endpoint.v3.ClusterLoadAssignment";
     
-    public static final String LISTENER_TYPE = API_TYPE_PREFIX + "envoy.config.listener.v3.Listener";
+    public static final String LISTENER_TYPE =
+            API_TYPE_PREFIX + "envoy.config.listener.v3.Listener";
     
-    public static final String ROUTE_TYPE = API_TYPE_PREFIX + "envoy.config.route.v3.RouteConfiguration";
+    public static final String ROUTE_TYPE =
+            API_TYPE_PREFIX + "envoy.config.route.v3.RouteConfiguration";
     
 }

--- a/istio/src/main/java/com/alibaba/nacos/istio/api/ApiGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/api/ApiGenerator.java
@@ -27,7 +27,7 @@ import java.util.List;
  * @author special.fy
  */
 public interface ApiGenerator<T> {
-
+    
     /**
      * Generate data based on resource snapshot.
      *

--- a/istio/src/main/java/com/alibaba/nacos/istio/api/ApiGeneratorFactory.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/api/ApiGeneratorFactory.java
@@ -36,15 +36,15 @@ import static com.alibaba.nacos.istio.api.ApiConstants.*;
  */
 @Component
 public class ApiGeneratorFactory {
-
+    
     private final Map<String, ApiGenerator<?>> apiGeneratorMap;
-
+    
     public ApiGeneratorFactory() {
         apiGeneratorMap = new HashMap<>(2);
         // mcp over xds
         apiGeneratorMap.put(SERVICE_ENTRY_PROTO_PACKAGE, ServiceEntryXdsGenerator.getInstance());
         // TODO Support other api generator
-
+        
         //xds
         apiGeneratorMap.put(CLUSTER_TYPE, CdsGenerator.getInstance());
         apiGeneratorMap.put(ENDPOINT_TYPE, EdsGenerator.getInstance());
@@ -54,10 +54,10 @@ public class ApiGeneratorFactory {
         // mcp
         apiGeneratorMap.put(SERVICE_ENTRY_COLLECTION, ServiceEntryMcpGenerator.getInstance());
     }
-
+    
     public ApiGenerator<?> getApiGenerator(String typeUrl) {
         ApiGenerator<?> apiGenerator = apiGeneratorMap.get(typeUrl);
-        return apiGenerator != null ? apiGenerator :
-                (typeUrl.startsWith(MCP_PREFIX) ? EmptyMcpGenerator.getInstance() : EmptyXdsGenerator.getInstance());
+        return apiGenerator != null ? apiGenerator : (typeUrl.startsWith(MCP_PREFIX)
+                ? EmptyMcpGenerator.getInstance() : EmptyXdsGenerator.getInstance());
     }
 }

--- a/istio/src/main/java/com/alibaba/nacos/istio/common/AbstractConnection.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/common/AbstractConnection.java
@@ -28,37 +28,37 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author special.fy
  */
 public abstract class AbstractConnection<MessageT> {
-
+    
     private static AtomicLong connectIdGenerator = new AtomicLong(0);
-
+    
     private String connectionId;
-
+    
     protected StreamObserver<MessageT> streamObserver;
-
+    
     private final Map<String, WatchedStatus> watchedResources;
-
+    
     public AbstractConnection(StreamObserver<MessageT> streamObserver) {
         this.streamObserver = streamObserver;
         this.watchedResources = new HashMap<>(1 << 4);
     }
-
+    
     public void setConnectionId(String clientId) {
         long id = connectIdGenerator.getAndIncrement();
         this.connectionId = clientId + "-" + id;
     }
-
+    
     public String getConnectionId() {
         return connectionId;
     }
-
+    
     public void addWatchedResource(String resourceType, WatchedStatus watchedStatus) {
         watchedResources.put(resourceType, watchedStatus);
     }
-
+    
     public WatchedStatus getWatchedStatusByType(String resourceType) {
         return watchedResources.get(resourceType);
     }
-
+    
     /**
      * Push data to grpc connection.
      *

--- a/istio/src/main/java/com/alibaba/nacos/istio/common/Debounce.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/common/Debounce.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Callable;
  * @date 2022/8/20 9:05
  */
 public class Debounce implements Callable<PushRequest> {
+    
     private Date startDebounce;
     
     private Date lastConfigUpdateTime;
@@ -67,6 +68,7 @@ public class Debounce implements Callable<PushRequest> {
                     startDebounce = lastConfigUpdateTime;
                     pushRequest = otherRequest;
                     new Timer().schedule(new TimerTask() {
+                        
                         @Override
                         public void run() {
                             if (free) {
@@ -90,7 +92,8 @@ public class Debounce implements Callable<PushRequest> {
         long eventDelay = System.currentTimeMillis() - startDebounce.getTime();
         long quietTime = System.currentTimeMillis() - lastConfigUpdateTime.getTime();
         
-        if (eventDelay > istioConfig.getDebounceMax() || quietTime > istioConfig.getDebounceAfter()) {
+        if (eventDelay > istioConfig.getDebounceMax()
+                || quietTime > istioConfig.getDebounceAfter()) {
             if (pushRequest != null) {
                 free = false;
                 flag = true;
@@ -98,6 +101,7 @@ public class Debounce implements Callable<PushRequest> {
             }
         } else {
             new Timer().schedule(new TimerTask() {
+                
                 @Override
                 public void run() {
                     if (free) {

--- a/istio/src/main/java/com/alibaba/nacos/istio/common/EventProcessor.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/common/EventProcessor.java
@@ -64,7 +64,8 @@ public class EventProcessor implements ApplicationListener<ContextRefreshedEvent
         try {
             requests.put(pushRequest);
         } catch (InterruptedException e) {
-            Loggers.MAIN.warn("There are too many events, this event {} will be ignored.", pushRequest.getReason());
+            Loggers.MAIN.warn("There are too many events, this event {} will be ignored.",
+                    pushRequest.getReason());
             // set the interrupted flag
             Thread.currentThread().interrupt();
         }
@@ -100,7 +101,8 @@ public class EventProcessor implements ApplicationListener<ContextRefreshedEvent
                 try {
                     // Today we only care about service event,
                     // so we simply ignore event until the last task has been completed.
-                    PushRequest pushRequest = requests.poll(MAX_WAIT_EVENT_TIME, TimeUnit.MILLISECONDS);
+                    PushRequest pushRequest =
+                            requests.poll(MAX_WAIT_EVENT_TIME, TimeUnit.MILLISECONDS);
                     if (pushRequest != null) {
                         hasNewEvent = true;
                         lastEvent = pushRequest;
@@ -156,6 +158,7 @@ public class EventProcessor implements ApplicationListener<ContextRefreshedEvent
         if (null == nacosMcpService) {
             nacosMcpService = ApplicationUtils.getBean(NacosMcpService.class);
         }
-        return Objects.nonNull(resourceManager) && Objects.nonNull(nacosMcpService) && Objects.nonNull(nacosXdsService);
+        return Objects.nonNull(resourceManager) && Objects.nonNull(nacosMcpService)
+                && Objects.nonNull(nacosXdsService);
     }
 }

--- a/istio/src/main/java/com/alibaba/nacos/istio/common/IstioConfigProcessor.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/common/IstioConfigProcessor.java
@@ -57,6 +57,7 @@ public class IstioConfigProcessor {
     
     public IstioConfigProcessor() {
         NotifyCenter.registerSubscriber(new Subscriber() {
+            
             @Override
             public void onEvent(Event event) {
                 if (event instanceof IstioConfigChangeEvent) {
@@ -78,7 +79,7 @@ public class IstioConfigProcessor {
                 }
                 
             }
-
+            
             @Override
             public Class<? extends Event> subscribeType() {
                 return IstioConfigChangeEvent.class;
@@ -91,7 +92,7 @@ public class IstioConfigProcessor {
             Loggers.MAIN.warn("Configuration content is null or empty.");
             return false;
         }
-    
+        
         Map<String, Object> obj;
         try {
             obj = yaml.load(content);
@@ -102,27 +103,30 @@ public class IstioConfigProcessor {
         
         String apiVersion = obj.containsKey("apiVersion") ? (String) obj.get("apiVersion") : "";
         String kind = obj.containsKey("kind") ? (String) obj.get("kind") : "";
-    
+        
         return API_VERSION.equals(apiVersion) && (VIRTUAL_SERVICE.equals(kind)
-                || DESTINATION_RULE.equals(kind)) && obj.containsKey("metadata") && obj.containsKey("spec");
+                || DESTINATION_RULE.equals(kind)) && obj.containsKey("metadata")
+                && obj.containsKey("spec");
     }
     
     public boolean tryParseContent(String content) {
-    
+        
         if (content == null || content.trim().isEmpty()) {
             Loggers.MAIN.warn("Configuration content is null or empty.");
             return false;
         }
-    
+        
         try {
             Map<String, Object> obj = yaml.load(content);
             String kind = (String) obj.get("kind");
             if (VIRTUAL_SERVICE.equals(kind)) {
                 VirtualService virtualService = yaml.loadAs(content, VirtualService.class);
-                Loggers.MAIN.info("Configuration Content was successfully parsed as VirtualService.");
+                Loggers.MAIN
+                        .info("Configuration Content was successfully parsed as VirtualService.");
             } else if (DESTINATION_RULE.equals(kind)) {
                 DestinationRule destinationRule = yaml.loadAs(content, DestinationRule.class);
-                Loggers.MAIN.info("Configuration Content was successfully parsed as DestinationRule.");
+                Loggers.MAIN
+                        .info("Configuration Content was successfully parsed as DestinationRule.");
             } else {
                 Loggers.MAIN.warn("Unknown Config : Unknown 'kind' field in content: {}", kind);
                 return false;

--- a/istio/src/main/java/com/alibaba/nacos/istio/common/NacosResourceManager.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/common/NacosResourceManager.java
@@ -28,35 +28,35 @@ import java.util.Map;
  */
 @Component
 public class NacosResourceManager {
-
+    
     private ResourceSnapshot resourceSnapshot;
-
+    
     @Autowired
     NacosServiceInfoResourceWatcher serviceInfoResourceWatcher;
-
+    
     @Autowired
     private IstioConfig istioConfig;
-
+    
     public NacosResourceManager() {
         resourceSnapshot = new ResourceSnapshot(istioConfig);
     }
-
+    
     public Map<String, IstioService> services() {
         return serviceInfoResourceWatcher.snapshot();
     }
-
+    
     public IstioConfig getIstioConfig() {
         return istioConfig;
     }
-
+    
     public synchronized ResourceSnapshot getResourceSnapshot() {
         return resourceSnapshot;
     }
-
+    
     public synchronized void setResourceSnapshot(ResourceSnapshot resourceSnapshot) {
         this.resourceSnapshot = resourceSnapshot;
     }
-
+    
     public void initResourceSnapshot() {
         ResourceSnapshot resourceSnapshot = getResourceSnapshot();
         resourceSnapshot.initResourceSnapshot(this);

--- a/istio/src/main/java/com/alibaba/nacos/istio/common/NacosServiceInfoResourceWatcher.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/common/NacosServiceInfoResourceWatcher.java
@@ -50,7 +50,7 @@ import static com.alibaba.nacos.istio.util.IstioExecutor.debouncePushChange;
  */
 @org.springframework.stereotype.Service
 public class NacosServiceInfoResourceWatcher extends SmartSubscriber {
-
+    
     private final Map<String, IstioService> serviceInfoMap = new ConcurrentHashMap<>(16);
     
     private final Queue<PushRequest> pushRequestQueue = new ConcurrentLinkedQueue<>();
@@ -62,7 +62,7 @@ public class NacosServiceInfoResourceWatcher extends SmartSubscriber {
     
     @Autowired
     private ServiceStorage serviceStorage;
-
+    
     @Autowired
     private EventProcessor eventProcessor;
     
@@ -93,7 +93,8 @@ public class NacosServiceInfoResourceWatcher extends SmartSubscriber {
         
         if (event instanceof ClientOperationEvent.ClientRegisterServiceEvent) {
             // If service changed, push to all subscribers.
-            ClientOperationEvent.ClientRegisterServiceEvent clientRegisterServiceEvent = (ClientOperationEvent.ClientRegisterServiceEvent) event;
+            ClientOperationEvent.ClientRegisterServiceEvent clientRegisterServiceEvent =
+                    (ClientOperationEvent.ClientRegisterServiceEvent) event;
             Service service = clientRegisterServiceEvent.getService();
             String serviceName = IstioCrdUtil.buildServiceName(service);
             
@@ -108,12 +109,12 @@ public class NacosServiceInfoResourceWatcher extends SmartSubscriber {
             }
             pushRequestQueue.add(pushRequest);
         } else if (event instanceof ClientOperationEvent.ClientDeregisterServiceEvent) {
-            ClientOperationEvent.ClientDeregisterServiceEvent clientDeregisterServiceEvent = (ClientOperationEvent
-                    .ClientDeregisterServiceEvent) event;
+            ClientOperationEvent.ClientDeregisterServiceEvent clientDeregisterServiceEvent =
+                    (ClientOperationEvent.ClientDeregisterServiceEvent) event;
             Service service = clientDeregisterServiceEvent.getService();
             String serviceName = IstioCrdUtil.buildServiceName(service);
             PushRequest pushRequest;
-    
+            
             boolean full = update(serviceName, service);
             if (serviceStorage.getPushData(service).ipCount() <= 0) {
                 pushRequest = new PushRequest(serviceName, true);
@@ -123,7 +124,8 @@ public class NacosServiceInfoResourceWatcher extends SmartSubscriber {
             }
             pushRequestQueue.add(pushRequest);
         } else if (event instanceof InfoChangeEvent.ServiceInfoChangeEvent) {
-            InfoChangeEvent.ServiceInfoChangeEvent serviceInfoChangeEvent = (InfoChangeEvent.ServiceInfoChangeEvent) event;
+            InfoChangeEvent.ServiceInfoChangeEvent serviceInfoChangeEvent =
+                    (InfoChangeEvent.ServiceInfoChangeEvent) event;
             Service service = serviceInfoChangeEvent.getService();
             String serviceName = IstioCrdUtil.buildServiceName(service);
             PushRequest pushRequest = new PushRequest(serviceName, true);
@@ -132,10 +134,11 @@ public class NacosServiceInfoResourceWatcher extends SmartSubscriber {
             pushRequestQueue.add(pushRequest);
             
         } else if (event instanceof InfoChangeEvent.InstanceInfoChangeEvent) {
-            InfoChangeEvent.InstanceInfoChangeEvent instanceInfoChangeEvent = (InfoChangeEvent.InstanceInfoChangeEvent) event;
+            InfoChangeEvent.InstanceInfoChangeEvent instanceInfoChangeEvent =
+                    (InfoChangeEvent.InstanceInfoChangeEvent) event;
             Service service = instanceInfoChangeEvent.getService();
             String serviceName = IstioCrdUtil.buildServiceName(service);
-    
+            
             boolean full = update(serviceName, service);
             PushRequest pushRequest = new PushRequest(serviceName, full);
             pushRequestQueue.add(pushRequest);
@@ -143,13 +146,13 @@ public class NacosServiceInfoResourceWatcher extends SmartSubscriber {
     }
     
     private void init() {
-        Set<String> namespaces =  ServiceManager.getInstance().getAllNamespaces();
+        Set<String> namespaces = ServiceManager.getInstance().getAllNamespaces();
         for (String namespace : namespaces) {
             Set<Service> services = ServiceManager.getInstance().getSingletons(namespace);
             if (services.isEmpty()) {
                 continue;
             }
-        
+            
             for (Service service : services) {
                 String serviceName = IstioCrdUtil.buildServiceName(service);
                 ServiceInfo serviceInfo = serviceStorage.getPushData(service);
@@ -179,13 +182,15 @@ public class NacosServiceInfoResourceWatcher extends SmartSubscriber {
     }
     
     private class ToNotify implements Runnable {
+        
         @Override
         public void run() {
             while (true) {
                 if (pushRequestQueue.size() > 0) {
                     PushRequest updatePush;
-                    Future<PushRequest> futureUpdate = debouncePushChange(new Debounce(pushRequestQueue, istioConfig));
-    
+                    Future<PushRequest> futureUpdate =
+                            debouncePushChange(new Debounce(pushRequestQueue, istioConfig));
+                    
                     try {
                         updatePush = futureUpdate.get();
                         if (updatePush != null) {

--- a/istio/src/main/java/com/alibaba/nacos/istio/common/ResourceSnapshot.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/common/ResourceSnapshot.java
@@ -29,14 +29,15 @@ import java.util.concurrent.atomic.AtomicLong;
  * @author special.fy
  */
 public class ResourceSnapshot {
+    
     private static AtomicLong versionSuffix = new AtomicLong(0);
     
     private final IstioResources istioResources;
     
     private IstioConfig istioConfig;
-
+    
     private boolean isCompleted;
-
+    
     private String version;
     
     public ResourceSnapshot(IstioConfig istioConfig) {
@@ -44,19 +45,19 @@ public class ResourceSnapshot {
         istioResources = new IstioResources(new ConcurrentHashMap<String, IstioService>(16));
         this.istioConfig = istioConfig;
     }
-
+    
     public synchronized void initResourceSnapshot(NacosResourceManager manager) {
         if (isCompleted) {
             return;
         }
-
+        
         initIstioResources(manager);
-
+        
         generateVersion();
-
+        
         isCompleted = true;
     }
-
+    
     private void generateVersion() {
         String time = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(new Date());
         version = time + "/" + versionSuffix.getAndIncrement();
@@ -77,7 +78,7 @@ public class ResourceSnapshot {
     public boolean isCompleted() {
         return isCompleted;
     }
-
+    
     public String getVersion() {
         return version;
     }

--- a/istio/src/main/java/com/alibaba/nacos/istio/common/WatchedStatus.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/common/WatchedStatus.java
@@ -23,57 +23,57 @@ import java.util.Set;
  * @author special.fy
  */
 public class WatchedStatus {
-
+    
     private String type;
     
     private boolean lastAckOrNack;
     
     private Set<String> lastSubscribe;
-
+    
     private String latestVersion;
-
+    
     private String latestNonce;
-
+    
     private String ackedVersion;
-
+    
     private String ackedNonce;
-
+    
     public String getType() {
         return type;
     }
-
+    
     public void setType(String type) {
         this.type = type;
     }
-
+    
     public String getLatestVersion() {
         return latestVersion;
     }
-
+    
     public void setLatestVersion(String latestVersion) {
         this.latestVersion = latestVersion;
     }
-
+    
     public String getLatestNonce() {
         return latestNonce;
     }
-
+    
     public void setLatestNonce(String latestNonce) {
         this.latestNonce = latestNonce;
     }
-
+    
     public String getAckedVersion() {
         return ackedVersion;
     }
-
+    
     public void setAckedVersion(String ackedVersion) {
         this.ackedVersion = ackedVersion;
     }
-
+    
     public String getAckedNonce() {
         return ackedNonce;
     }
-
+    
     public void setAckedNonce(String ackedNonce) {
         this.ackedNonce = ackedNonce;
     }

--- a/istio/src/main/java/com/alibaba/nacos/istio/config/IstioEnabledFilter.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/config/IstioEnabledFilter.java
@@ -48,7 +48,8 @@ public class IstioEnabledFilter implements NacosPackageExcludeFilter {
         String functionMode = EnvUtil.getFunctionMode();
         // When not specified naming mode or specified all mode, the naming module not start and load.
         if (isNamingDisabled(functionMode)) {
-            LOGGER.warn("Istio module disabled because function mode is {}, and Istio depend naming module",
+            LOGGER.warn(
+                    "Istio module disabled because function mode is {}, and Istio depend naming module",
                     functionMode);
             return true;
         }

--- a/istio/src/main/java/com/alibaba/nacos/istio/mcp/EmptyMcpGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/mcp/EmptyMcpGenerator.java
@@ -27,9 +27,9 @@ import java.util.List;
  * @author special.fy
  */
 public class EmptyMcpGenerator implements ApiGenerator<Resource> {
-
+    
     private volatile static EmptyMcpGenerator singleton = null;
-
+    
     public static EmptyMcpGenerator getInstance() {
         if (singleton == null) {
             synchronized (EmptyMcpGenerator.class) {
@@ -40,14 +40,15 @@ public class EmptyMcpGenerator implements ApiGenerator<Resource> {
         }
         return singleton;
     }
-
+    
     @Override
     public List<Resource> generate(PushRequest pushRequest) {
         return new ArrayList<>();
     }
     
     @Override
-    public List<io.envoyproxy.envoy.service.discovery.v3.Resource> deltaGenerate(PushRequest pushRequest) {
+    public List<io.envoyproxy.envoy.service.discovery.v3.Resource> deltaGenerate(
+            PushRequest pushRequest) {
         return new ArrayList<>();
     }
 }

--- a/istio/src/main/java/com/alibaba/nacos/istio/mcp/McpConnection.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/mcp/McpConnection.java
@@ -26,24 +26,25 @@ import istio.mcp.v1alpha1.Mcp;
  * @author special.fy
  */
 public class McpConnection extends AbstractConnection<Mcp.Resources> {
-
+    
     public McpConnection(StreamObserver<Mcp.Resources> streamObserver) {
         super(streamObserver);
     }
-
+    
     @Override
     public synchronized void push(Mcp.Resources response, WatchedStatus watchedStatus) {
         if (Loggers.MAIN.isDebugEnabled()) {
             Loggers.MAIN.debug("Mcp.Resources: {}", response.toString());
         }
-
+        
         this.streamObserver.onNext(response);
-
+        
         // Update watched status
         watchedStatus.setLatestVersion(response.getSystemVersionInfo());
         watchedStatus.setLatestNonce(response.getNonce());
-
-        Loggers.MAIN.info("mcp: push, type: {}, connection-id {}, version {}, nonce {}, resource size {}.",
+        
+        Loggers.MAIN.info(
+                "mcp: push, type: {}, connection-id {}, version {}, nonce {}, resource size {}.",
                 watchedStatus.getType(),
                 getConnectionId(),
                 response.getSystemVersionInfo(),

--- a/istio/src/main/java/com/alibaba/nacos/istio/mcp/NacosMcpService.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/mcp/NacosMcpService.java
@@ -46,30 +46,33 @@ import static com.alibaba.nacos.istio.api.ApiConstants.SERVICE_ENTRY_COLLECTION;
 @Service
 public class NacosMcpService extends ResourceSourceGrpc.ResourceSourceImplBase {
     
-    private final Map<String, AbstractConnection<Mcp.Resources>> connections = new ConcurrentHashMap<>(16);
-
+    private final Map<String, AbstractConnection<Mcp.Resources>> connections =
+            new ConcurrentHashMap<>(16);
+    
     @Autowired
     ApiGeneratorFactory apiGeneratorFactory;
-
+    
     @Autowired
     NacosResourceManager resourceManager;
-
+    
     public boolean hasClientConnection() {
         return connections.size() != 0;
     }
-
+    
     @Override
-    public StreamObserver<Mcp.RequestResources> establishResourceStream(StreamObserver<Mcp.Resources> responseObserver) {
-
+    public StreamObserver<Mcp.RequestResources> establishResourceStream(
+            StreamObserver<Mcp.Resources> responseObserver) {
+        
         // TODO add authN
-
+        
         // Init snapshot of nacos service info.
         resourceManager.initResourceSnapshot();
         AbstractConnection<Mcp.Resources> newConnection = new McpConnection(responseObserver);
-
+        
         return new StreamObserver<Mcp.RequestResources>() {
+            
             private boolean initRequest = true;
-
+            
             @Override
             public void onNext(Mcp.RequestResources requestResources) {
                 // init connection
@@ -78,13 +81,14 @@ public class NacosMcpService extends ResourceSourceGrpc.ResourceSourceImplBase {
                     connections.put(newConnection.getConnectionId(), newConnection);
                     initRequest = false;
                 }
-
+                
                 process(requestResources, newConnection);
             }
             
             @Override
             public void onError(Throwable throwable) {
-                Loggers.MAIN.error("mcp: {} stream error.", newConnection.getConnectionId(), throwable);
+                Loggers.MAIN.error("mcp: {} stream error.", newConnection.getConnectionId(),
+                        throwable);
                 clear();
             }
             
@@ -93,28 +97,32 @@ public class NacosMcpService extends ResourceSourceGrpc.ResourceSourceImplBase {
                 responseObserver.onCompleted();
                 clear();
             }
-
+            
             private void clear() {
                 connections.remove(newConnection.getConnectionId());
             }
         };
     }
-
-    private void process(Mcp.RequestResources requestResources, AbstractConnection<Mcp.Resources> connection) {
+    
+    private void process(Mcp.RequestResources requestResources,
+            AbstractConnection<Mcp.Resources> connection) {
         if (!shouldPush(requestResources, connection)) {
             return;
         }
-    
+        
         PushRequest pushRequest = new PushRequest(resourceManager.getResourceSnapshot(), true);
         
-        Mcp.Resources response = buildMcpResourcesResponse(requestResources.getCollection(), pushRequest);
-        connection.push(response, connection.getWatchedStatusByType(requestResources.getCollection()));
+        Mcp.Resources response =
+                buildMcpResourcesResponse(requestResources.getCollection(), pushRequest);
+        connection.push(response,
+                connection.getWatchedStatusByType(requestResources.getCollection()));
     }
-
-    private boolean shouldPush(Mcp.RequestResources requestResources, AbstractConnection<Mcp.Resources> connection) {
+    
+    private boolean shouldPush(Mcp.RequestResources requestResources,
+            AbstractConnection<Mcp.Resources> connection) {
         String type = requestResources.getCollection();
         String connectionId = connection.getConnectionId();
-
+        
         if (requestResources.getErrorDetail().getCode() != 0) {
             Loggers.MAIN.error("mcp: ACK error, connection-id: {}, code: {}, message: {}",
                     connectionId,
@@ -122,19 +130,19 @@ public class NacosMcpService extends ResourceSourceGrpc.ResourceSourceImplBase {
                     requestResources.getErrorDetail().getMessage());
             return false;
         }
-
+        
         WatchedStatus watchedStatus;
         if (requestResources.getResponseNonce().isEmpty()) {
             Loggers.MAIN.info("mcp: init request, type {}, connection-id {}, is incremental {}",
                     type, connectionId, requestResources.getIncremental());
-
+            
             watchedStatus = new WatchedStatus();
             watchedStatus.setType(type);
             connection.addWatchedResource(type, watchedStatus);
-
+            
             return true;
         }
-
+        
         watchedStatus = connection.getWatchedStatusByType(type);
         if (watchedStatus == null) {
             Loggers.MAIN.info("mcp: reconnect, type {}, connection-id {}, is incremental {}",
@@ -144,41 +152,45 @@ public class NacosMcpService extends ResourceSourceGrpc.ResourceSourceImplBase {
             connection.addWatchedResource(type, watchedStatus);
             return true;
         }
-
+        
         if (!watchedStatus.getLatestNonce().equals(requestResources.getResponseNonce())) {
-            Loggers.MAIN.warn("mcp: request dis match, type {}, connection-id {}", type, connectionId);
+            Loggers.MAIN.warn("mcp: request dis match, type {}, connection-id {}", type,
+                    connectionId);
             return false;
         }
-
+        
         // This request is ack, we should record nonce.
         watchedStatus.setAckedNonce(requestResources.getResponseNonce());
         Loggers.MAIN.info("mcp: ack, type {}, connection-id {}, nonce {}", type, connectionId,
                 requestResources.getResponseNonce());
         return false;
     }
-
+    
     public void handleEvent(PushRequest pushRequest) {
         if (connections.size() == 0) {
             return;
         }
-    
+        
         Loggers.MAIN.info("mcp: event {} trigger push.", pushRequest.getReason());
         
-        Mcp.Resources serviceEntryMcpResponse = buildMcpResourcesResponse(SERVICE_ENTRY_COLLECTION, pushRequest);
-    
+        Mcp.Resources serviceEntryMcpResponse =
+                buildMcpResourcesResponse(SERVICE_ENTRY_COLLECTION, pushRequest);
+        
         for (AbstractConnection<Mcp.Resources> connection : connections.values()) {
-            WatchedStatus watchedStatus = connection.getWatchedStatusByType(SERVICE_ENTRY_COLLECTION);
+            WatchedStatus watchedStatus =
+                    connection.getWatchedStatusByType(SERVICE_ENTRY_COLLECTION);
             if (watchedStatus != null) {
                 connection.push(serviceEntryMcpResponse, watchedStatus);
             }
         }
     }
-
+    
     private Mcp.Resources buildMcpResourcesResponse(String type, PushRequest pushRequest) {
         @SuppressWarnings("unchecked")
-        ApiGenerator<Resource> serviceEntryGenerator = (ApiGenerator<Resource>) apiGeneratorFactory.getApiGenerator(type);
+        ApiGenerator<Resource> serviceEntryGenerator =
+                (ApiGenerator<Resource>) apiGeneratorFactory.getApiGenerator(type);
         List<Resource> rawResources = serviceEntryGenerator.generate(pushRequest);
-
+        
         String nonce = NonceGenerator.generateNonce();
         return Mcp.Resources.newBuilder()
                 .setCollection(type)

--- a/istio/src/main/java/com/alibaba/nacos/istio/mcp/ServiceEntryMcpGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/mcp/ServiceEntryMcpGenerator.java
@@ -42,7 +42,7 @@ public class ServiceEntryMcpGenerator implements ApiGenerator<Resource> {
     private List<ServiceEntryWrapper> serviceEntries;
     
     private static volatile ServiceEntryMcpGenerator singleton = null;
-
+    
     public static ServiceEntryMcpGenerator getInstance() {
         if (singleton == null) {
             synchronized (ServiceEntryMcpGenerator.class) {
@@ -53,20 +53,22 @@ public class ServiceEntryMcpGenerator implements ApiGenerator<Resource> {
         }
         return singleton;
     }
-
+    
     @Override
     public List<Resource> generate(PushRequest pushRequest) {
         List<Resource> result = new ArrayList<>();
         serviceEntries = new ArrayList<>(16);
         ResourceSnapshot resourceSnapshot = pushRequest.getResourceSnapshot();
-    
+        
         IstioConfig istioConfig = resourceSnapshot.getIstioConfig();
-        Map<String, IstioService> serviceInfoMap = resourceSnapshot.getIstioResources().getIstioServiceMap();
-    
+        Map<String, IstioService> serviceInfoMap =
+                resourceSnapshot.getIstioResources().getIstioServiceMap();
+        
         for (Map.Entry<String, IstioService> entry : serviceInfoMap.entrySet()) {
             String serviceName = entry.getKey();
             
-            ServiceEntryWrapper serviceEntryWrapper = buildServiceEntry(serviceName, serviceName + istioConfig.getDomainSuffix(), serviceInfoMap.get(serviceName));
+            ServiceEntryWrapper serviceEntryWrapper = buildServiceEntry(serviceName,
+                    serviceName + istioConfig.getDomainSuffix(), serviceInfoMap.get(serviceName));
             if (serviceEntryWrapper != null) {
                 serviceEntries.add(serviceEntryWrapper);
             }
@@ -74,18 +76,21 @@ public class ServiceEntryMcpGenerator implements ApiGenerator<Resource> {
         
         for (ServiceEntryWrapper serviceEntryWrapper : serviceEntries) {
             MetadataOuterClass.Metadata metadata = serviceEntryWrapper.getMetadata();
-            ServiceEntryOuterClass.ServiceEntry serviceEntry = serviceEntryWrapper.getServiceEntry();
-
-            Any any = Any.newBuilder().setValue(serviceEntry.toByteString()).setTypeUrl(SERVICE_ENTRY_PROTO).build();
-
+            ServiceEntryOuterClass.ServiceEntry serviceEntry =
+                    serviceEntryWrapper.getServiceEntry();
+            
+            Any any = Any.newBuilder().setValue(serviceEntry.toByteString())
+                    .setTypeUrl(SERVICE_ENTRY_PROTO).build();
+            
             result.add(Resource.newBuilder().setBody(any).setMetadata(metadata).build());
         }
-
+        
         return result;
     }
     
     @Override
-    public List<io.envoyproxy.envoy.service.discovery.v3.Resource> deltaGenerate(PushRequest pushRequest) {
+    public List<io.envoyproxy.envoy.service.discovery.v3.Resource> deltaGenerate(
+            PushRequest pushRequest) {
         return new ArrayList<>();
     }
 }

--- a/istio/src/main/java/com/alibaba/nacos/istio/misc/IstioConfig.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/misc/IstioConfig.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class IstioConfig {
-
+    
     @Value("${nacos.istio.mcp.server.enabled:false}")
     private boolean serverEnabled = false;
     @Value("${nacos.istio.mcp.server.port:18848}")
@@ -44,15 +44,15 @@ public class IstioConfig {
     
     @Value("${nacos.istio.domain.suffix:nacos}")
     private String domainSuffix;
-
+    
     public boolean isServerEnabled() {
         return serverEnabled;
     }
-
+    
     public int getServerPort() {
         return serverPort;
     }
-
+    
     public String getDomainSuffix() {
         return domainSuffix;
     }

--- a/istio/src/main/java/com/alibaba/nacos/istio/server/IstioServer.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/server/IstioServer.java
@@ -34,18 +34,18 @@ import java.io.IOException;
  */
 @Service
 public class IstioServer {
-
+    
     private Server server;
-
+    
     @Autowired
     private IstioConfig istioConfig;
-
+    
     @Autowired
     private ServerInterceptor serverInterceptor;
-
+    
     @Autowired
     private NacosMcpService nacosMcpService;
-
+    
     @Autowired
     private NacosXdsService nacosXdsService;
     
@@ -56,7 +56,7 @@ public class IstioServer {
      */
     @PostConstruct
     public void start() throws IOException {
-
+        
         if (!istioConfig.isServerEnabled()) {
             Loggers.MAIN.info("The Nacos Istio server is disabled.");
             return;
@@ -64,19 +64,22 @@ public class IstioServer {
         
         Loggers.MAIN.info("Nacos Istio server, starting Nacos Istio server...");
         
-        server = ServerBuilder.forPort(istioConfig.getServerPort()).addService(ServerInterceptors.intercept(nacosMcpService, serverInterceptor))
-                .addService(ServerInterceptors.intercept(nacosXdsService, serverInterceptor)).build();
+        server = ServerBuilder.forPort(istioConfig.getServerPort())
+                .addService(ServerInterceptors.intercept(nacosMcpService, serverInterceptor))
+                .addService(ServerInterceptors.intercept(nacosXdsService, serverInterceptor))
+                .build();
         server.start();
-
+        
         Runtime.getRuntime().addShutdownHook(new Thread() {
+            
             @Override
             public void run() {
-
+                
                 IstioServer.this.stop();
             }
         });
     }
-
+    
     /**
      * Stop.
      */

--- a/istio/src/main/java/com/alibaba/nacos/istio/server/ServerInterceptor.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/server/ServerInterceptor.java
@@ -30,15 +30,15 @@ import java.net.SocketAddress;
  */
 @Component
 public class ServerInterceptor implements io.grpc.ServerInterceptor {
-
+    
     @Override
     public <R, T> ServerCall.Listener<R> interceptCall(ServerCall<R, T> call, Metadata headers,
-                                                       ServerCallHandler<R, T> next) {
+            ServerCallHandler<R, T> next) {
         SocketAddress address = call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
         String methodName = call.getMethodDescriptor().getFullMethodName();
-
+        
         Loggers.MAIN.info("remote address: {}, method: {}", address, methodName);
-
+        
         return next.startCall(call, headers);
     }
 }

--- a/istio/src/main/java/com/alibaba/nacos/istio/util/IstioCrdUtil.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/util/IstioCrdUtil.java
@@ -41,27 +41,32 @@ import java.util.regex.Pattern;
  * @author special.fy
  */
 public class IstioCrdUtil {
-
+    
     public static final String VALID_DEFAULT_GROUP_NAME = "DEFAULT-GROUP";
-
+    
     public static final String ISTIO_HOSTNAME = "istio.hostname";
-
-    public static final String VALID_LABEL_KEY_FORMAT = "^([a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?)*/)?((?:[A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$";
     
-    public static final String VALID_LABEL_VALUE_FORMAT = "^((?:[A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$";
+    public static final String VALID_LABEL_KEY_FORMAT =
+            "^([a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?)*/)?((?:[A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$";
     
-    public static String buildClusterName(TrafficDirection direction, String subset, String hostName, int port) {
+    public static final String VALID_LABEL_VALUE_FORMAT =
+            "^((?:[A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$";
+    
+    public static String buildClusterName(TrafficDirection direction, String subset,
+            String hostName, int port) {
         return direction.toString().toLowerCase() + "|" + port + "|" + subset + "|" + hostName;
     }
     
     public static String buildServiceName(Service service) {
-        String group = !Constants.DEFAULT_GROUP.equals(service.getGroup()) ? service.getGroup() : VALID_DEFAULT_GROUP_NAME;
-
+        String group = !Constants.DEFAULT_GROUP.equals(service.getGroup()) ? service.getGroup()
+                : VALID_DEFAULT_GROUP_NAME;
+        
         // DEFAULT_GROUP is invalid for istio,because the istio host only supports: [0-9],[A-Z],[a-z],-,*
         return service.getName() + "." + group + "." + service.getNamespace();
     }
     
-    public static String parseServiceEntryNameToServiceName(String serviceEntryName, String domain) {
+    public static String parseServiceEntryNameToServiceName(String serviceEntryName,
+            String domain) {
         return serviceEntryName.substring(0, serviceEntryName.length() - domain.length() - 1);
     }
     
@@ -70,21 +75,26 @@ public class IstioCrdUtil {
         return str.substring(0, str.length() - domain.length() - 1);
     }
     
-    public static ServiceEntryWrapper buildServiceEntry(String serviceName, String hostName, IstioService istioService) {
+    public static ServiceEntryWrapper buildServiceEntry(String serviceName, String hostName,
+            IstioService istioService) {
         if (istioService.getHosts().isEmpty()) {
             return null;
         }
-
-        ServiceEntryOuterClass.ServiceEntry.Builder serviceEntryBuilder = ServiceEntryOuterClass.ServiceEntry
-                .newBuilder().setResolution(ServiceEntryOuterClass.ServiceEntry.Resolution.STATIC)
-                .setLocation(ServiceEntryOuterClass.ServiceEntry.Location.MESH_INTERNAL);
-
+        
+        ServiceEntryOuterClass.ServiceEntry.Builder serviceEntryBuilder =
+                ServiceEntryOuterClass.ServiceEntry
+                        .newBuilder()
+                        .setResolution(ServiceEntryOuterClass.ServiceEntry.Resolution.STATIC)
+                        .setLocation(ServiceEntryOuterClass.ServiceEntry.Location.MESH_INTERNAL);
+        
         int port = 0;
         String protocol = "http";
         List<WorkloadEntry> endpoints = buildWorkloadEntry(istioService.getHosts());
         
-        serviceEntryBuilder.addHosts(hostName).addPorts(GatewayOuterClass.Port.newBuilder().setNumber(port)
-                .setName(protocol).setProtocol(protocol.toUpperCase()).build()).addAllEndpoints(endpoints);
+        serviceEntryBuilder.addHosts(hostName)
+                .addPorts(GatewayOuterClass.Port.newBuilder().setNumber(port)
+                        .setName(protocol).setProtocol(protocol.toUpperCase()).build())
+                .addAllEndpoints(endpoints);
         ServiceEntryOuterClass.ServiceEntry serviceEntry = serviceEntryBuilder.build();
         
         Date createTimestamp = istioService.getCreateTimeStamp();
@@ -92,25 +102,27 @@ public class IstioCrdUtil {
                 .setName(istioService.getNamespace() + "/" + serviceName)
                 .putAnnotations("virtual", "1")
                 .putLabels("registryType", "nacos")
-                .setCreateTime(Timestamp.newBuilder().setSeconds(createTimestamp.getTime() / 1000).build())
+                .setCreateTime(
+                        Timestamp.newBuilder().setSeconds(createTimestamp.getTime() / 1000).build())
                 .setVersion(String.valueOf(istioService.getRevision())).build();
         
         return new ServiceEntryWrapper(metadata, serviceEntry);
     }
     
-    public static List<WorkloadEntryOuterClass.WorkloadEntry> buildWorkloadEntry(List<IstioEndpoint> istioEndpointList) {
+    public static List<WorkloadEntryOuterClass.WorkloadEntry> buildWorkloadEntry(
+            List<IstioEndpoint> istioEndpointList) {
         List<WorkloadEntryOuterClass.WorkloadEntry> result = new ArrayList<>();
         
         for (IstioEndpoint istioEndpoint : istioEndpointList) {
             if (!istioEndpoint.isHealthy() || !istioEndpoint.isEnabled()) {
                 continue;
             }
-
+            
             Map<String, String> metadata = new HashMap<>(1 << 3);
             if (StringUtils.isNotEmpty(istioEndpoint.getClusterName())) {
                 metadata.put("cluster", istioEndpoint.getClusterName());
             }
-
+            
             for (Map.Entry<String, String> entry : istioEndpoint.getLabels().entrySet()) {
                 if (!Pattern.matches(VALID_LABEL_KEY_FORMAT, entry.getKey())) {
                     continue;
@@ -121,9 +133,12 @@ public class IstioCrdUtil {
                 metadata.put(entry.getKey().toLowerCase(), entry.getValue());
             }
             
-            WorkloadEntryOuterClass.WorkloadEntry workloadEntry = WorkloadEntryOuterClass.WorkloadEntry.newBuilder()
-                    .setAddress(istioEndpoint.getAdder()).setWeight(istioEndpoint.getWeight())
-                    .putAllLabels(metadata).putPorts(istioEndpoint.getProtocol(), istioEndpoint.getPort()).build();
+            WorkloadEntryOuterClass.WorkloadEntry workloadEntry =
+                    WorkloadEntryOuterClass.WorkloadEntry.newBuilder()
+                            .setAddress(istioEndpoint.getAdder())
+                            .setWeight(istioEndpoint.getWeight())
+                            .putAllLabels(metadata)
+                            .putPorts(istioEndpoint.getProtocol(), istioEndpoint.getPort()).build();
             
             result.add(workloadEntry);
         }

--- a/istio/src/main/java/com/alibaba/nacos/istio/util/IstioExecutor.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/util/IstioExecutor.java
@@ -29,9 +29,10 @@ import java.util.concurrent.Future;
  * @author special.fy
  */
 public class IstioExecutor {
+    
     private static final ExecutorService EVENT_HANDLE_EXECUTOR = ExecutorFactory.Managed
             .newSingleExecutorService(ClassUtils.getCanonicalName(IstioApp.class),
-                new NameThreadFactory("com.alibaba.nacos.istio.event.handle"));
+                    new NameThreadFactory("com.alibaba.nacos.istio.event.handle"));
     
     private static final ExecutorService PUSH_CHANGE_EXECUTOR = ExecutorFactory.Managed
             .newSingleExecutorService(ClassUtils.getCanonicalName(IstioApp.class),
@@ -40,7 +41,7 @@ public class IstioExecutor {
     private static final ExecutorService CYCLE_DEBOUNCE_EXECUTOR = ExecutorFactory.Managed
             .newSingleExecutorService(ClassUtils.getCanonicalName(IstioApp.class),
                     new NameThreadFactory("com.alibaba.nacos.istio.cycle.debounce"));
-
+    
     public static <V> Future<V> asyncHandleEvent(Callable<V> task) {
         return EVENT_HANDLE_EXECUTOR.submit(task);
     }

--- a/istio/src/main/java/com/alibaba/nacos/istio/util/NonceGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/util/NonceGenerator.java
@@ -22,7 +22,7 @@ import com.alibaba.nacos.common.utils.UuidUtils;
  * @author special.fy
  */
 public class NonceGenerator {
-
+    
     public static String generateNonce() {
         return UuidUtils.generateUuid().replace("-", "");
     }

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/CdsGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/CdsGenerator.java
@@ -65,22 +65,29 @@ public final class CdsGenerator implements ApiGenerator<Any> {
         }
         List<Any> result = new ArrayList<>();
         IstioConfig istioConfig = pushRequest.getResourceSnapshot().getIstioConfig();
-        Map<String, IstioService> istioServiceMap = pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
+        Map<String, IstioService> istioServiceMap =
+                pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
         for (Map.Entry<String, IstioService> entry : istioServiceMap.entrySet()) {
             String name = buildClusterName(TrafficDirection.OUTBOUND, "",
-                    entry.getKey() + '.' +  istioConfig.getDomainSuffix(), entry.getValue().getPort());
+                    entry.getKey() + '.' + istioConfig.getDomainSuffix(),
+                    entry.getValue().getPort());
             
-            Cluster.Builder cluster = Cluster.newBuilder().setName(name).setType(Cluster.DiscoveryType.EDS)
-                    .setEdsClusterConfig(Cluster.EdsClusterConfig.newBuilder().setServiceName(name).setEdsConfig(
-                            ConfigSource.newBuilder().setAds(AggregatedConfigSource.newBuilder())
-                                    .setResourceApiVersionValue(V2_VALUE).build()).build());
+            Cluster.Builder cluster =
+                    Cluster.newBuilder().setName(name).setType(Cluster.DiscoveryType.EDS)
+                            .setEdsClusterConfig(Cluster.EdsClusterConfig
+                                    .newBuilder().setServiceName(name).setEdsConfig(
+                                            ConfigSource.newBuilder()
+                                                    .setAds(AggregatedConfigSource.newBuilder())
+                                                    .setResourceApiVersionValue(V2_VALUE).build())
+                                    .build());
             if ("grpc".equals(entry.getValue().getProtocol())) {
                 cluster.setHttp2ProtocolOptions(Http2ProtocolOptions.newBuilder().build());
             } else {
                 cluster.setHttpProtocolOptions(Http1ProtocolOptions.newBuilder().build());
             }
-    
-            result.add(Any.newBuilder().setValue(cluster.build().toByteString()).setTypeUrl(CLUSTER_TYPE).build());
+            
+            result.add(Any.newBuilder().setValue(cluster.build().toByteString())
+                    .setTypeUrl(CLUSTER_TYPE).build());
         }
         
         return result;

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/DeltaConnection.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/DeltaConnection.java
@@ -47,7 +47,8 @@ public class DeltaConnection extends AbstractConnection<DeltaDiscoveryResponse> 
         watchedStatus.setLatestVersion(response.getSystemVersionInfo());
         watchedStatus.setLatestNonce(response.getNonce());
         
-        Loggers.MAIN.info("delta: push, type: {}, connection-id {}, version {}, nonce {}, resource size {}.",
+        Loggers.MAIN.info(
+                "delta: push, type: {}, connection-id {}, version {}, nonce {}, resource size {}.",
                 watchedStatus.getType(),
                 getConnectionId(),
                 response.getSystemVersionInfo(),
@@ -55,4 +56,3 @@ public class DeltaConnection extends AbstractConnection<DeltaDiscoveryResponse> 
                 response.getResourcesCount());
     }
 }
-

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/EdsGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/EdsGenerator.java
@@ -63,7 +63,8 @@ public final class EdsGenerator implements ApiGenerator<Any> {
     public List<Any> generate(PushRequest pushRequest) {
         List<Any> result = new ArrayList<>();
         IstioConfig istioConfig = pushRequest.getResourceSnapshot().getIstioConfig();
-        Map<String, IstioService> istioServiceMap = pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
+        Map<String, IstioService> istioServiceMap =
+                pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
         if (pushRequest.getReason().size() != 0) {
             for (String reason : pushRequest.getReason()) {
                 IstioService istioService = istioServiceMap.get(reason);
@@ -77,7 +78,8 @@ public final class EdsGenerator implements ApiGenerator<Any> {
         } else {
             for (Map.Entry<String, IstioService> entry : istioServiceMap.entrySet()) {
                 String name = buildClusterName(TrafficDirection.OUTBOUND, "",
-                        entry.getKey() + '.' + istioConfig.getDomainSuffix(), entry.getValue().getPort());
+                        entry.getKey() + '.' + istioConfig.getDomainSuffix(),
+                        entry.getValue().getPort());
                 Any any = buildEndpoint(name, entry.getValue());
                 if (any != null) {
                     result.add(any);
@@ -96,16 +98,20 @@ public final class EdsGenerator implements ApiGenerator<Any> {
         List<Resource> result = new ArrayList<>();
         Set<String> reason = pushRequest.getReason();
         IstioConfig istioConfig = pushRequest.getResourceSnapshot().getIstioConfig();
-        Map<String, IstioService> istioServiceMap = pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
+        Map<String, IstioService> istioServiceMap =
+                pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
         
         if (pushRequest.getSubscribe().size() != 0) {
             for (String subscribe : pushRequest.getSubscribe()) {
-                String serviceName = parseClusterNameToServiceName(subscribe, istioConfig.getDomainSuffix());
+                String serviceName =
+                        parseClusterNameToServiceName(subscribe, istioConfig.getDomainSuffix());
                 if (reason.contains(serviceName)) {
                     if (istioServiceMap.containsKey(serviceName)) {
                         Any any = buildEndpoint(subscribe, istioServiceMap.get(serviceName));
                         if (any != null) {
-                            result.add(Resource.newBuilder().setResource(any).setVersion(pushRequest.getResourceSnapshot().getVersion()).build());
+                            result.add(Resource.newBuilder().setResource(any)
+                                    .setVersion(pushRequest.getResourceSnapshot().getVersion())
+                                    .build());
                         } else {
                             pushRequest.addRemoved(subscribe);
                         }
@@ -117,10 +123,12 @@ public final class EdsGenerator implements ApiGenerator<Any> {
         } else {
             for (Map.Entry<String, IstioService> entry : istioServiceMap.entrySet()) {
                 String name = buildClusterName(TrafficDirection.OUTBOUND, "",
-                        entry.getKey() + '.' + istioConfig.getDomainSuffix(), entry.getValue().getPort());
+                        entry.getKey() + '.' + istioConfig.getDomainSuffix(),
+                        entry.getValue().getPort());
                 Any any = buildEndpoint(name, entry.getValue());
                 if (any != null) {
-                    result.add(Resource.newBuilder().setResource(any).setVersion(pushRequest.getResourceSnapshot().getVersion()).build());
+                    result.add(Resource.newBuilder().setResource(any)
+                            .setVersion(pushRequest.getResourceSnapshot().getVersion()).build());
                 } else {
                     pushRequest.addRemoved(name);
                 }
@@ -136,12 +144,13 @@ public final class EdsGenerator implements ApiGenerator<Any> {
         }
         
         List<IstioEndpoint> istioEndpoints = istioService.getHosts();
-        Map<String, LocalityLbEndpoints.Builder> llbEndpointsBuilder = new HashMap<>(istioEndpoints.size());
-    
+        Map<String, LocalityLbEndpoints.Builder> llbEndpointsBuilder =
+                new HashMap<>(istioEndpoints.size());
+        
         for (IstioEndpoint istioEndpoint : istioEndpoints) {
             String label = istioEndpoint.getStringLocality();
             LbEndpoint lbEndpoint = istioEndpoint.getLbEndpoint();
-        
+            
             if (!llbEndpointsBuilder.containsKey(label)) {
                 LocalityLbEndpoints.Builder llbEndpointBuilder = LocalityLbEndpoints.newBuilder()
                         .setLocality(istioEndpoint.getLocality()).addLbEndpoints(lbEndpoint);
@@ -150,14 +159,15 @@ public final class EdsGenerator implements ApiGenerator<Any> {
                 llbEndpointsBuilder.get(label).addLbEndpoints(lbEndpoint);
             }
         }
-    
+        
         List<LocalityLbEndpoints> listlle = new ArrayList<>();
         for (LocalityLbEndpoints.Builder builder : llbEndpointsBuilder.values()) {
             int weight = 0;
             for (LbEndpoint lbEndpoint : builder.getLbEndpointsList()) {
                 weight += lbEndpoint.getLoadBalancingWeight().getValue();
             }
-            LocalityLbEndpoints lle = builder.setLoadBalancingWeight(UInt32Value.newBuilder().setValue(weight)).build();
+            LocalityLbEndpoints lle = builder
+                    .setLoadBalancingWeight(UInt32Value.newBuilder().setValue(weight)).build();
             listlle.add(lle);
         }
         
@@ -165,7 +175,8 @@ public final class EdsGenerator implements ApiGenerator<Any> {
             return null;
         }
         
-        ClusterLoadAssignment cla = ClusterLoadAssignment.newBuilder().setClusterName(name).addAllEndpoints(listlle).build();
+        ClusterLoadAssignment cla = ClusterLoadAssignment.newBuilder().setClusterName(name)
+                .addAllEndpoints(listlle).build();
         return Any.newBuilder().setValue(cla.toByteString()).setTypeUrl(ENDPOINT_TYPE).build();
     }
 }

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/EmptyXdsGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/EmptyXdsGenerator.java
@@ -28,9 +28,9 @@ import java.util.List;
  * @author special.fy
  */
 public class EmptyXdsGenerator implements ApiGenerator<Any> {
-
+    
     private static volatile EmptyXdsGenerator singleton = null;
-
+    
     public static EmptyXdsGenerator getInstance() {
         if (singleton == null) {
             synchronized (EmptyXdsGenerator.class) {

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/LdsGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/LdsGenerator.java
@@ -65,7 +65,8 @@ public class LdsGenerator implements ApiGenerator<Any> {
     
     private static final String ACCESS_LOGGER_NAME = "envoy.access_loggers.stdout";
     
-    private static final String TYPE_URL_ACCESS_LOG = "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog";
+    private static final String TYPE_URL_ACCESS_LOG =
+            "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog";
     
     private static final int DEFAULT_PORT_INCREMENT = 1;
     
@@ -75,7 +76,8 @@ public class LdsGenerator implements ApiGenerator<Any> {
     
     public static final String DEFAULT_FILTER_CHAIN_NAME = "filter_chain_0";
     
-    public static final String DEFAULT_FILTER_TYPE = "envoy.filters.network.http_connection_manager";
+    public static final String DEFAULT_FILTER_TYPE =
+            "envoy.filters.network.http_connection_manager";
     
     public static final String DEFAULT_HTTPMANAGER_PREFIX = "ingress_http";
     
@@ -99,8 +101,9 @@ public class LdsGenerator implements ApiGenerator<Any> {
         if (!pushRequest.isFull()) {
             return null;
         }
-        Map<String, IstioService> istioServiceMap = pushRequest.getResourceSnapshot().getIstioResources()
-                .getIstioServiceMap();
+        Map<String, IstioService> istioServiceMap =
+                pushRequest.getResourceSnapshot().getIstioResources()
+                        .getIstioServiceMap();
         List<Any> result = new ArrayList<>();
         result.add(buildBootstrapListener());
         
@@ -109,7 +112,8 @@ public class LdsGenerator implements ApiGenerator<Any> {
                 IstioService istioService = entry.getValue();
                 if (istioService != null) {
                     String rdsName = entry.getKey() + ROUTE_CONFIGURATION_SUFFIX;
-                    result.add(buildDynamicListener(entry.getKey(), INIT_LISTENER_ADDRESS, istioService.getPort(),
+                    result.add(buildDynamicListener(entry.getKey(), INIT_LISTENER_ADDRESS,
+                            istioService.getPort(),
                             rdsName));
                 } else {
                     Loggers.MAIN.error("Attempt to create listener for non-existent service");
@@ -128,7 +132,8 @@ public class LdsGenerator implements ApiGenerator<Any> {
      * Constructs a default Envoy listener configuration with specified parameters.
      * This method prepares the necessary configurations for both bootstrap and non-bootstrap scenarios.
      */
-    private static Any buildDefaultListener(String listenerName, String listenerAddress, int listenerPort,
+    private static Any buildDefaultListener(String listenerName, String listenerAddress,
+            int listenerPort,
             String rdsName, boolean isBootstrap) {
         if (isValid(listenerName, listenerPort, rdsName, isBootstrap)) {
             Loggers.MAIN.error("Listener name, Listener port and RDS name cannot be null.");
@@ -140,21 +145,30 @@ public class LdsGenerator implements ApiGenerator<Any> {
         listenerAddress = (listenerAddress == null) ? INIT_LISTENER_ADDRESS : listenerAddress;
         int portValue = isBootstrap ? INIT_LISTENER_PORT : listenerPort + DEFAULT_PORT_INCREMENT;
         listenerBuilder.setAddress(Address.newBuilder()
-                .setSocketAddress(SocketAddress.newBuilder().setAddress(listenerAddress).setPortValue(portValue)));
+                .setSocketAddress(SocketAddress.newBuilder().setAddress(listenerAddress)
+                        .setPortValue(portValue)));
         
         String routeConfigName =
-                isBootstrap ? INIT_LISTENER + ROUTE_CONFIGURATION_SUFFIX : listenerName + ROUTE_CONFIGURATION_SUFFIX;
+                isBootstrap ? INIT_LISTENER + ROUTE_CONFIGURATION_SUFFIX
+                        : listenerName + ROUTE_CONFIGURATION_SUFFIX;
         String virtualHostName = isBootstrap ? INIT_LISTENER : listenerName;
         
-        RouteConfiguration routeConfiguration = RouteConfiguration.newBuilder().setName(routeConfigName)
-                .addVirtualHosts(VirtualHost.newBuilder().setName(virtualHostName).addDomains("*").addRoutes(
-                        Route.newBuilder().setMatch(RouteMatch.newBuilder().setPrefix("/").build())
-                                .setRoute(RouteAction.newBuilder().setCluster(BOOTSTRAP_UPSTREAM_CLUSTER).build())
-                                .build()).build()).build();
+        RouteConfiguration routeConfiguration = RouteConfiguration.newBuilder()
+                .setName(routeConfigName)
+                .addVirtualHosts(VirtualHost.newBuilder().setName(virtualHostName).addDomains("*")
+                        .addRoutes(
+                                Route.newBuilder()
+                                        .setMatch(RouteMatch.newBuilder().setPrefix("/").build())
+                                        .setRoute(RouteAction.newBuilder()
+                                                .setCluster(BOOTSTRAP_UPSTREAM_CLUSTER).build())
+                                        .build())
+                        .build())
+                .build();
         
         HttpConnectionManager httpConnectionManager = HttpConnectionManager.newBuilder()
                 .setStatPrefix(DEFAULT_HTTPMANAGER_PREFIX).addAccessLog(buildAccessLog())
-                .setCodecType(HttpConnectionManager.CodecType.AUTO).setRouteConfig(routeConfiguration)
+                .setCodecType(HttpConnectionManager.CodecType.AUTO)
+                .setRouteConfig(routeConfiguration)
                 .addHttpFilters(createHttpFilter()).build();
         
         listenerBuilder.addFilterChains(createFilterChain(httpConnectionManager));
@@ -169,14 +183,16 @@ public class LdsGenerator implements ApiGenerator<Any> {
      * This is used during the startup phase of the Envoy server to construct the base configuration.
      */
     private static Any buildBootstrapListener() {
-        return buildDefaultListener(INIT_LISTENER_NAME, INIT_LISTENER_ADDRESS, INIT_LISTENER_PORT, null, true);
+        return buildDefaultListener(INIT_LISTENER_NAME, INIT_LISTENER_ADDRESS, INIT_LISTENER_PORT,
+                null, true);
     }
     
     /**
      * Constructs a default listener configuration for static environments.
      * This method is designed to provide configurations for scenarios where dynamic discovery services might not be used.
      */
-    private static Any buildDefaultStaticListener(String listenerName, String listenerAddress, int listenerPort,
+    private static Any buildDefaultStaticListener(String listenerName, String listenerAddress,
+            int listenerPort,
             String rdsName) {
         if (INIT_LISTENER.equals(listenerName)) {
             return buildBootstrapListener();
@@ -188,7 +204,8 @@ public class LdsGenerator implements ApiGenerator<Any> {
      * Constructs a listener configuration for environments using dynamic service discovery.
      * This method prepares the listener to utilize dynamic routing and service discovery services with rds.
      */
-    private static Any buildDynamicListener(String listenerName, String listenerAddress, int listenerPort,
+    private static Any buildDynamicListener(String listenerName, String listenerAddress,
+            int listenerPort,
             String rdsName) {
         if (INIT_LISTENER.equals(listenerName)) {
             return buildBootstrapListener();
@@ -207,11 +224,13 @@ public class LdsGenerator implements ApiGenerator<Any> {
                         .setPortValue(listenerPort + DEFAULT_PORT_INCREMENT)));
         ConfigSource configSource = createConfigSource();
         
-        Rds rds = Rds.newBuilder().setConfigSource(configSource).setRouteConfigName(rdsName).build();
+        Rds rds =
+                Rds.newBuilder().setConfigSource(configSource).setRouteConfigName(rdsName).build();
         
         HttpConnectionManager httpConnectionManager = HttpConnectionManager.newBuilder()
                 .setStatPrefix(DEFAULT_HTTPMANAGER_PREFIX).addAccessLog(buildAccessLog())
-                .setCodecType(HttpConnectionManager.CodecType.AUTO).setRds(rds).addHttpFilters(createHttpFilter())
+                .setCodecType(HttpConnectionManager.CodecType.AUTO).setRds(rds)
+                .addHttpFilters(createHttpFilter())
                 .build();
         
         listenerBuilder.addFilterChains(createFilterChain(httpConnectionManager));
@@ -224,7 +243,8 @@ public class LdsGenerator implements ApiGenerator<Any> {
     
     private static AccessLog buildAccessLog() {
         return AccessLog.newBuilder().setName(ACCESS_LOGGER_NAME)
-                .setTypedConfig(Any.newBuilder().setTypeUrl(TYPE_URL_ACCESS_LOG).setValue(ByteString.EMPTY).build())
+                .setTypedConfig(Any.newBuilder().setTypeUrl(TYPE_URL_ACCESS_LOG)
+                        .setValue(ByteString.EMPTY).build())
                 .build();
     }
     
@@ -240,11 +260,13 @@ public class LdsGenerator implements ApiGenerator<Any> {
     
     private static FilterChain createFilterChain(HttpConnectionManager httpConnectionManager) {
         return FilterChain.newBuilder().setName(DEFAULT_FILTER_CHAIN_NAME).addFilters(
-                        Filter.newBuilder().setName(DEFAULT_FILTER_TYPE).setTypedConfig(Any.pack(httpConnectionManager)))
+                Filter.newBuilder().setName(DEFAULT_FILTER_TYPE)
+                        .setTypedConfig(Any.pack(httpConnectionManager)))
                 .build();
     }
     
-    private static boolean isValid(String listenerName, int listenerPort, String rdsName, boolean isBootstrap) {
+    private static boolean isValid(String listenerName, int listenerPort, String rdsName,
+            boolean isBootstrap) {
         return !isBootstrap && ((listenerName == null) || (listenerPort == 0) || (rdsName == null));
     }
 }

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/NacosXdsService.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/NacosXdsService.java
@@ -54,33 +54,38 @@ import static com.alibaba.nacos.istio.xds.RdsGenerator.DEFAULT_ROUTE_CONFIGURATI
  * @author special.fy
  */
 @Service
-public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase {
-
-    private final Map<String, AbstractConnection<DiscoveryResponse>> connections = new ConcurrentHashMap<>(16);
+public class NacosXdsService
+        extends AggregatedDiscoveryServiceGrpc.AggregatedDiscoveryServiceImplBase {
     
-    private final Map<String, AbstractConnection<DeltaDiscoveryResponse>> deltaConnections = new ConcurrentHashMap<>(16);
-
+    private final Map<String, AbstractConnection<DiscoveryResponse>> connections =
+            new ConcurrentHashMap<>(16);
+    
+    private final Map<String, AbstractConnection<DeltaDiscoveryResponse>> deltaConnections =
+            new ConcurrentHashMap<>(16);
+    
     public boolean hasClientConnection() {
         return connections.size() != 0 || deltaConnections.size() != 0;
     }
     
     @Autowired
     ApiGeneratorFactory apiGeneratorFactory;
-
+    
     @Autowired
     NacosResourceManager resourceManager;
-
+    
     @Override
-    public StreamObserver<DiscoveryRequest> streamAggregatedResources(StreamObserver<DiscoveryResponse> responseObserver) {
+    public StreamObserver<DiscoveryRequest> streamAggregatedResources(
+            StreamObserver<DiscoveryResponse> responseObserver) {
         // TODO add authN
-
+        
         // Init snapshot of nacos service info.
         resourceManager.initResourceSnapshot();
         AbstractConnection<DiscoveryResponse> newConnection = new XdsConnection(responseObserver);
-
+        
         return new StreamObserver<DiscoveryRequest>() {
+            
             private boolean initRequest = true;
-
+            
             @Override
             public void onNext(DiscoveryRequest discoveryRequest) {
                 // init connection
@@ -89,51 +94,56 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
                     connections.put(newConnection.getConnectionId(), newConnection);
                     initRequest = false;
                 }
-
+                
                 process(discoveryRequest, newConnection);
             }
-
+            
             @Override
             public void onError(Throwable throwable) {
-                Loggers.MAIN.error("xds: {} stream error.", newConnection.getConnectionId(), throwable);
+                Loggers.MAIN.error("xds: {} stream error.", newConnection.getConnectionId(),
+                        throwable);
                 clear();
             }
-
+            
             @Override
             public void onCompleted() {
                 Loggers.MAIN.info("xds: {} stream close.", newConnection.getConnectionId());
                 responseObserver.onCompleted();
                 clear();
             }
-
+            
             private void clear() {
                 connections.remove(newConnection.getConnectionId());
             }
         };
     }
-
-    public void process(DiscoveryRequest discoveryRequest, AbstractConnection<DiscoveryResponse> connection) {
+    
+    public void process(DiscoveryRequest discoveryRequest,
+            AbstractConnection<DiscoveryResponse> connection) {
         if (!shouldPush(discoveryRequest, connection)) {
             return;
         }
-    
+        
         Set<String> resourceNames = new HashSet<>(discoveryRequest.getResourceNamesList());
         PushRequest pushRequest = new PushRequest(resourceManager.getResourceSnapshot(), true);
         IstioConfig istioConfig = pushRequest.getResourceSnapshot().getIstioConfig();
-    
+        
         if (discoveryRequest.getTypeUrl().equals(CLUSTER_TYPE)) {
             for (String resourceName : resourceNames) {
-                String reason = parseClusterNameToServiceName(resourceName, istioConfig.getDomainSuffix());
+                String reason =
+                        parseClusterNameToServiceName(resourceName, istioConfig.getDomainSuffix());
                 pushRequest.addReason(reason);
             }
         }
-    
-        if (discoveryRequest.getTypeUrl().equals(LISTENER_TYPE) && discoveryRequest.getResponseNonce().isEmpty()) {
+        
+        if (discoveryRequest.getTypeUrl().equals(LISTENER_TYPE)
+                && discoveryRequest.getResponseNonce().isEmpty()) {
             String reason = INIT_LISTENER;
             pushRequest.addReason(reason);
         }
-    
-        if (discoveryRequest.getTypeUrl().equals(ROUTE_TYPE) && discoveryRequest.getResponseNonce().isEmpty()) {
+        
+        if (discoveryRequest.getTypeUrl().equals(ROUTE_TYPE)
+                && discoveryRequest.getResponseNonce().isEmpty()) {
             String reason = DEFAULT_ROUTE_CONFIGURATION;
             pushRequest.addReason(reason);
             for (String resourceName : resourceNames) {
@@ -141,21 +151,23 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
             }
         }
         
-        DiscoveryResponse response = buildDiscoveryResponse(discoveryRequest.getTypeUrl(), pushRequest);
+        DiscoveryResponse response =
+                buildDiscoveryResponse(discoveryRequest.getTypeUrl(), pushRequest);
         connection.push(response, connection.getWatchedStatusByType(discoveryRequest.getTypeUrl()));
     }
-
-    private boolean shouldPush(DiscoveryRequest discoveryRequest, AbstractConnection<DiscoveryResponse> connection) {
+    
+    private boolean shouldPush(DiscoveryRequest discoveryRequest,
+            AbstractConnection<DiscoveryResponse> connection) {
         String type = discoveryRequest.getTypeUrl();
         String connectionId = connection.getConnectionId();
-
+        
         // Suitable for bug of istio
         // See https://github.com/istio/istio/pull/34633
         if (type.equals(MESH_CONFIG_PROTO_PACKAGE)) {
             Loggers.MAIN.info("xds: type {} should be ignored.", type);
             return false;
         }
-
+        
         if (discoveryRequest.getErrorDetail().getCode() != 0) {
             Loggers.MAIN.error("xds: ACK error, connection-id: {}, code: {}, message: {}",
                     connectionId,
@@ -163,7 +175,7 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
                     discoveryRequest.getErrorDetail().getMessage());
             return false;
         }
-
+        
         WatchedStatus watchedStatus;
         if (discoveryRequest.getResponseNonce().isEmpty()) {
             Loggers.MAIN.info("xds: init request, type {}, connection-id {}, version {}",
@@ -176,41 +188,43 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
             Loggers.MAIN.info("watchedStatus: {}",
                     watchedStatus);
             connection.addWatchedResource(discoveryRequest.getTypeUrl(), watchedStatus);
-
+            
             return true;
         }
-
+        
         watchedStatus = connection.getWatchedStatusByType(discoveryRequest.getTypeUrl());
         if (watchedStatus == null) {
             Loggers.MAIN.info("xds: reconnect, type {}, connection-id {}, version {}, nonce {}.",
-                    type, connectionId, discoveryRequest.getVersionInfo(), discoveryRequest.getResponseNonce());
+                    type, connectionId, discoveryRequest.getVersionInfo(),
+                    discoveryRequest.getResponseNonce());
             Loggers.MAIN.info("xds: content {},{}",
-                            discoveryRequest.getTypeUrl(), discoveryRequest.getResourceNamesList());
-           
+                    discoveryRequest.getTypeUrl(), discoveryRequest.getResourceNamesList());
+            
             watchedStatus = new WatchedStatus();
             watchedStatus.setType(discoveryRequest.getTypeUrl());
             Loggers.MAIN.info("watchedStatus: {}",
                     watchedStatus);
             connection.addWatchedResource(discoveryRequest.getTypeUrl(), watchedStatus);
-
+            
             return true;
         }
-
+        
         if (!watchedStatus.getLatestNonce().equals(discoveryRequest.getResponseNonce())) {
             Loggers.MAIN.warn("xds: request dis match, type {}, connection-id {}",
                     discoveryRequest.getTypeUrl(),
                     connection.getConnectionId());
             return false;
         }
-
+        
         // This request is ack, we should record version and nonce.
         watchedStatus.setAckedVersion(discoveryRequest.getVersionInfo());
         watchedStatus.setAckedNonce(discoveryRequest.getResponseNonce());
-        Loggers.MAIN.info("xds: ack, type {}, connection-id {}, version {}, nonce {}", type, connectionId,
+        Loggers.MAIN.info("xds: ack, type {}, connection-id {}, version {}, nonce {}", type,
+                connectionId,
                 discoveryRequest.getVersionInfo(), discoveryRequest.getResponseNonce());
         return false;
     }
-
+    
     public void handleEvent(PushRequest pushRequest) {
         if (connections.size() == 0) {
             return;
@@ -218,9 +232,11 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
         
         for (AbstractConnection<DiscoveryResponse> connection : connections.values()) {
             //mcp
-            WatchedStatus watchedStatus = connection.getWatchedStatusByType(SERVICE_ENTRY_PROTO_PACKAGE);
+            WatchedStatus watchedStatus =
+                    connection.getWatchedStatusByType(SERVICE_ENTRY_PROTO_PACKAGE);
             if (watchedStatus != null) {
-                DiscoveryResponse serviceEntryResponse = buildDiscoveryResponse(SERVICE_ENTRY_PROTO_PACKAGE, pushRequest);
+                DiscoveryResponse serviceEntryResponse =
+                        buildDiscoveryResponse(SERVICE_ENTRY_PROTO_PACKAGE, pushRequest);
                 connection.push(serviceEntryResponse, watchedStatus);
             }
             //CDS
@@ -255,7 +271,7 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
         if (connections.size() == 0) {
             return;
         }
-
+        
         for (AbstractConnection<DiscoveryResponse> connection : connections.values()) {
             //RDS
             WatchedStatus watchedStatus;
@@ -272,7 +288,7 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
             }
         }
     }
-
+    
     private DiscoveryResponse buildDiscoveryResponse(String type, PushRequest pushRequest) {
         @SuppressWarnings("unchecked")
         ApiGenerator<Any> generator = (ApiGenerator<Any>) apiGeneratorFactory.getApiGenerator(type);
@@ -290,12 +306,15 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
     }
     
     @Override
-    public StreamObserver<DeltaDiscoveryRequest> deltaAggregatedResources(StreamObserver<DeltaDiscoveryResponse> responseObserver) {
+    public StreamObserver<DeltaDiscoveryRequest> deltaAggregatedResources(
+            StreamObserver<DeltaDiscoveryResponse> responseObserver) {
         // Init snapshot of nacos service info.
         resourceManager.initResourceSnapshot();
-        AbstractConnection<DeltaDiscoveryResponse> newConnection = new DeltaConnection(responseObserver);
+        AbstractConnection<DeltaDiscoveryResponse> newConnection =
+                new DeltaConnection(responseObserver);
         
         return new StreamObserver<DeltaDiscoveryRequest>() {
+            
             private boolean initRequest = true;
             
             @Override
@@ -312,7 +331,8 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
             
             @Override
             public void onError(Throwable throwable) {
-                Loggers.MAIN.error("delta xds: {} stream error.", newConnection.getConnectionId(), throwable);
+                Loggers.MAIN.error("delta xds: {} stream error.", newConnection.getConnectionId(),
+                        throwable);
                 clear();
             }
             
@@ -329,22 +349,28 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
         };
     }
     
-    public void deltaProcess(DeltaDiscoveryRequest deltaDiscoveryRequest, AbstractConnection<DeltaDiscoveryResponse> connection) {
+    public void deltaProcess(DeltaDiscoveryRequest deltaDiscoveryRequest,
+            AbstractConnection<DeltaDiscoveryResponse> connection) {
         if (!deltaShouldPush(deltaDiscoveryRequest, connection)) {
             return;
         }
         ResourceSnapshot resourceSnapshot = resourceManager.getResourceSnapshot();
         PushRequest pushRequest = new PushRequest(resourceSnapshot, true);
         
-        Set<String> subscribe = new HashSet<>(deltaDiscoveryRequest.getResourceNamesSubscribeList());
+        Set<String> subscribe =
+                new HashSet<>(deltaDiscoveryRequest.getResourceNamesSubscribeList());
         pushRequest.setSubscribe(subscribe);
-        connection.getWatchedStatusByType(deltaDiscoveryRequest.getTypeUrl()).setLastSubscribe(subscribe);
+        connection.getWatchedStatusByType(deltaDiscoveryRequest.getTypeUrl())
+                .setLastSubscribe(subscribe);
         
-        DeltaDiscoveryResponse response = buildDeltaDiscoveryResponse(deltaDiscoveryRequest.getTypeUrl(), pushRequest);
-        connection.push(response, connection.getWatchedStatusByType(deltaDiscoveryRequest.getTypeUrl()));
+        DeltaDiscoveryResponse response =
+                buildDeltaDiscoveryResponse(deltaDiscoveryRequest.getTypeUrl(), pushRequest);
+        connection.push(response,
+                connection.getWatchedStatusByType(deltaDiscoveryRequest.getTypeUrl()));
     }
     
-    private boolean deltaShouldPush(DeltaDiscoveryRequest deltaDiscoveryRequest, AbstractConnection<DeltaDiscoveryResponse> connection) {
+    private boolean deltaShouldPush(DeltaDiscoveryRequest deltaDiscoveryRequest,
+            AbstractConnection<DeltaDiscoveryResponse> connection) {
         String type = deltaDiscoveryRequest.getTypeUrl();
         String connectionId = connection.getConnectionId();
         
@@ -396,8 +422,10 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
         // This request is ack, we should record version and nonce.
         //TODO: setAckedVersion
         watchedStatus.setAckedNonce(deltaDiscoveryRequest.getResponseNonce());
-        watchedStatus.setLastSubscribe(new HashSet<>(deltaDiscoveryRequest.getResourceNamesSubscribeList()));
-        Loggers.MAIN.info("delta xds: ack, type {}, connection-id {}, nonce {}", type, connectionId, deltaDiscoveryRequest.getResponseNonce());
+        watchedStatus.setLastSubscribe(
+                new HashSet<>(deltaDiscoveryRequest.getResourceNamesSubscribeList()));
+        Loggers.MAIN.info("delta xds: ack, type {}, connection-id {}, nonce {}", type, connectionId,
+                deltaDiscoveryRequest.getResponseNonce());
         return false;
     }
     
@@ -407,10 +435,12 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
         }
         pushRequest.setFull(pushRequest.getResourceSnapshot().getIstioConfig().isFullEnabled());
         for (AbstractConnection<DeltaDiscoveryResponse> connection : deltaConnections.values()) {
-            WatchedStatus watchedStatus = connection.getWatchedStatusByType(SERVICE_ENTRY_PROTO_PACKAGE);
+            WatchedStatus watchedStatus =
+                    connection.getWatchedStatusByType(SERVICE_ENTRY_PROTO_PACKAGE);
             if (watchedStatus != null && watchedStatus.isLastAckOrNack()) {
                 pushRequest.setSubscribe(watchedStatus.getLastSubscribe());
-                DeltaDiscoveryResponse serviceEntryResponse = buildDeltaDiscoveryResponse(SERVICE_ENTRY_PROTO_PACKAGE, pushRequest);
+                DeltaDiscoveryResponse serviceEntryResponse =
+                        buildDeltaDiscoveryResponse(SERVICE_ENTRY_PROTO_PACKAGE, pushRequest);
                 if (serviceEntryResponse != null) {
                     connection.push(serviceEntryResponse, watchedStatus);
                 }
@@ -419,7 +449,8 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
             WatchedStatus edsWatchedStatus = connection.getWatchedStatusByType(ENDPOINT_TYPE);
             if (edsWatchedStatus != null && edsWatchedStatus.isLastAckOrNack()) {
                 pushRequest.setSubscribe(edsWatchedStatus.getLastSubscribe());
-                DeltaDiscoveryResponse edsResponse = buildDeltaDiscoveryResponse(ENDPOINT_TYPE, pushRequest);
+                DeltaDiscoveryResponse edsResponse =
+                        buildDeltaDiscoveryResponse(ENDPOINT_TYPE, pushRequest);
                 if (edsResponse != null) {
                     connection.push(edsResponse, edsWatchedStatus);
                 }
@@ -427,9 +458,11 @@ public class NacosXdsService extends AggregatedDiscoveryServiceGrpc.AggregatedDi
         }
     }
     
-    private DeltaDiscoveryResponse buildDeltaDiscoveryResponse(String type, PushRequest pushRequest) {
+    private DeltaDiscoveryResponse buildDeltaDiscoveryResponse(String type,
+            PushRequest pushRequest) {
         @SuppressWarnings("unchecked")
-        ApiGenerator<Resource> generator = (ApiGenerator<Resource>) apiGeneratorFactory.getApiGenerator(type);
+        ApiGenerator<Resource> generator =
+                (ApiGenerator<Resource>) apiGeneratorFactory.getApiGenerator(type);
         List<Resource> rawResources = generator.deltaGenerate(pushRequest);
         if (rawResources == null) {
             return null;

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/RdsGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/RdsGenerator.java
@@ -79,9 +79,10 @@ public class RdsGenerator implements ApiGenerator<Any> {
         List<Any> result = new ArrayList<>();
         Set<String> reasons = pushRequest.getReason();
         if (reasons.contains(DEFAULT_ROUTE_CONFIGURATION)) {
-            reasons.stream().filter(reason -> !DEFAULT_ROUTE_CONFIGURATION.equals(reason)).forEach(reason -> {
-                result.add(buildDefaultRouteConfiguration(reason));
-            });
+            reasons.stream().filter(reason -> !DEFAULT_ROUTE_CONFIGURATION.equals(reason))
+                    .forEach(reason -> {
+                        result.add(buildDefaultRouteConfiguration(reason));
+                    });
         } else if (reasons.contains(CONFIG_REASON)) {
             reasons.stream().filter(reason -> !CONFIG_REASON.equals(reason)).forEach(reason -> {
                 VirtualService vs = parseContent(reason, VirtualService.class);
@@ -110,13 +111,20 @@ public class RdsGenerator implements ApiGenerator<Any> {
             virtualHostName = routeConfigurationName.substring(0,
                     routeConfigurationName.length() - ROUTE_CONFIGURATION_SUFFIX.length());
         }
-        RouteConfiguration routeConfiguration = RouteConfiguration.newBuilder().setName(routeConfigurationName)
-                .addVirtualHosts(VirtualHost.newBuilder().setName(virtualHostName).addDomains("*").addRoutes(
-                        Route.newBuilder().setMatch(RouteMatch.newBuilder().setPrefix("/").build())
-                                .setRoute(RouteAction.newBuilder().setCluster(BOOTSTRAP_UPSTREAM_CLUSTER).build())
-                                .build()).build()).build();
+        RouteConfiguration routeConfiguration = RouteConfiguration.newBuilder()
+                .setName(routeConfigurationName)
+                .addVirtualHosts(VirtualHost.newBuilder().setName(virtualHostName).addDomains("*")
+                        .addRoutes(
+                                Route.newBuilder()
+                                        .setMatch(RouteMatch.newBuilder().setPrefix("/").build())
+                                        .setRoute(RouteAction.newBuilder()
+                                                .setCluster(BOOTSTRAP_UPSTREAM_CLUSTER).build())
+                                        .build())
+                        .build())
+                .build();
         
-        return Any.newBuilder().setValue(routeConfiguration.toByteString()).setTypeUrl(ROUTE_TYPE).build();
+        return Any.newBuilder().setValue(routeConfiguration.toByteString()).setTypeUrl(ROUTE_TYPE)
+                .build();
     }
     
     /***
@@ -125,16 +133,19 @@ public class RdsGenerator implements ApiGenerator<Any> {
      * @param pushRequest PushRequest
      * @return
      */
-    public static Any generateRdsFromVirtualService(VirtualService virtualService, PushRequest pushRequest) {
+    public static Any generateRdsFromVirtualService(VirtualService virtualService,
+            PushRequest pushRequest) {
         List<VirtualService.Spec.Http> httpRoutes = virtualService.getSpec().getHttp();
         List<String> hosts = virtualService.getSpec().getHosts();
-        Map<String, IstioService> istioServiceMap = pushRequest.getResourceSnapshot().getIstioResources()
-                .getIstioServiceMap();
+        Map<String, IstioService> istioServiceMap =
+                pushRequest.getResourceSnapshot().getIstioResources()
+                        .getIstioServiceMap();
         List<String> hostnames = getMatchingHostnames(hosts, pushRequest);
         String virtualHostName = virtualService.getMetadata().getName();
         for (Map.Entry<String, IstioService> entry : istioServiceMap.entrySet()) {
             if (entry.getKey().contains(virtualHostName)) {
-                virtualHostName = buildClusterName(TrafficDirection.OUTBOUND, "", entry.getKey() + DOMAIN_SUFFIX,
+                virtualHostName = buildClusterName(TrafficDirection.OUTBOUND, "",
+                        entry.getKey() + DOMAIN_SUFFIX,
                         entry.getValue().getPort());
                 Loggers.MAIN.info("Setting virtualHostName: {}", virtualHostName);
             }
@@ -149,7 +160,8 @@ public class RdsGenerator implements ApiGenerator<Any> {
         RouteConfiguration routeConfiguration = RouteConfiguration.newBuilder()
                 .setName(virtualService.getMetadata().getName() + ROUTE_CONFIGURATION_SUFFIX)
                 .addVirtualHosts(virtualHostBuilder).build();
-        return Any.newBuilder().setValue(routeConfiguration.toByteString()).setTypeUrl(ROUTE_TYPE).build();
+        return Any.newBuilder().setValue(routeConfiguration.toByteString()).setTypeUrl(ROUTE_TYPE)
+                .build();
         
     }
     
@@ -159,8 +171,9 @@ public class RdsGenerator implements ApiGenerator<Any> {
     
     private static List<String> getMatchingHostnames(List<String> hosts, PushRequest pushRequest) {
         List<String> hostnames = new ArrayList<>();
-        Map<String, IstioService> istioServiceMap = pushRequest.getResourceSnapshot().getIstioResources()
-                .getIstioServiceMap();
+        Map<String, IstioService> istioServiceMap =
+                pushRequest.getResourceSnapshot().getIstioResources()
+                        .getIstioServiceMap();
         for (String host : hosts) {
             if ("*".equals(host)) {
                 hostnames.add("*");
@@ -168,8 +181,9 @@ public class RdsGenerator implements ApiGenerator<Any> {
             }
             for (Map.Entry<String, IstioService> entry : istioServiceMap.entrySet()) {
                 if (entry.getKey().contains(host)) {
-                    String hostname = buildClusterName(TrafficDirection.OUTBOUND, "", host + DOMAIN_SUFFIX,
-                            entry.getValue().getPort());
+                    String hostname =
+                            buildClusterName(TrafficDirection.OUTBOUND, "", host + DOMAIN_SUFFIX,
+                                    entry.getValue().getPort());
                     Loggers.MAIN.info("Matching hostname: {}", hostname);
                     hostnames.add(hostname);
                 }
@@ -178,7 +192,8 @@ public class RdsGenerator implements ApiGenerator<Any> {
         return hostnames;
     }
     
-    private static void processHttpRoute(VirtualService.Spec.Http httpRoute, VirtualHost.Builder virtualHostBuilder,
+    private static void processHttpRoute(VirtualService.Spec.Http httpRoute,
+            VirtualHost.Builder virtualHostBuilder,
             PushRequest pushRequest) {
         Route.Builder routeBuilder = Route.newBuilder();
         
@@ -194,7 +209,8 @@ public class RdsGenerator implements ApiGenerator<Any> {
                 routeMatchBuilder.setPath(match.getUri().getExact());
             } else if (match.getUri().getRegex() != null) {
                 // 检查是否定义了正则表达式
-                RegexMatcher regexMatcher = RegexMatcher.newBuilder().setRegex(match.getUri().getRegex()).build();
+                RegexMatcher regexMatcher =
+                        RegexMatcher.newBuilder().setRegex(match.getUri().getRegex()).build();
                 routeMatchBuilder.setSafeRegex(regexMatcher);
             }
             routeBuilder.setMatch(routeMatchBuilder);
@@ -208,10 +224,12 @@ public class RdsGenerator implements ApiGenerator<Any> {
         virtualHostBuilder.addRoutes(routeBuilder);
     }
     
-    private static void setRouteAction(VirtualService.Spec.Http httpRoute, Route.Builder routeBuilder,
+    private static void setRouteAction(VirtualService.Spec.Http httpRoute,
+            Route.Builder routeBuilder,
             PushRequest pushRequest) {
-        Map<String, IstioService> istioServiceMap = pushRequest.getResourceSnapshot().getIstioResources()
-                .getIstioServiceMap();
+        Map<String, IstioService> istioServiceMap =
+                pushRequest.getResourceSnapshot().getIstioResources()
+                        .getIstioServiceMap();
         RouteAction.Builder routeActionBuilder = RouteAction.newBuilder();
         String hostName = httpRoute.getRoute().get(0).getDestination().getHost();
         if (httpRoute.getRewrite() != null) {
@@ -220,7 +238,8 @@ public class RdsGenerator implements ApiGenerator<Any> {
         String destName = hostName;
         for (Map.Entry<String, IstioService> entry : istioServiceMap.entrySet()) {
             if (entry.getKey().contains(hostName)) {
-                destName = buildClusterName(TrafficDirection.OUTBOUND, "", entry.getKey() + DOMAIN_SUFFIX,
+                destName = buildClusterName(TrafficDirection.OUTBOUND, "",
+                        entry.getKey() + DOMAIN_SUFFIX,
                         entry.getValue().getPort());
                 Loggers.MAIN.info("Setting route action to destination: {}", destName);
             }
@@ -228,7 +247,8 @@ public class RdsGenerator implements ApiGenerator<Any> {
         routeBuilder.setRoute(routeActionBuilder.setCluster(destName));
     }
     
-    private static void setRedirectAction(VirtualService.Spec.Http.Redirect redirect, Route.Builder routeBuilder) {
+    private static void setRedirectAction(VirtualService.Spec.Http.Redirect redirect,
+            Route.Builder routeBuilder) {
         RedirectAction.Builder redirectBuilder = RedirectAction.newBuilder();
         if (redirect.getUri() != null) {
             redirectBuilder.setPathRedirect(redirect.getUri());

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/ServiceEntryXdsGenerator.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/ServiceEntryXdsGenerator.java
@@ -40,11 +40,11 @@ import static com.alibaba.nacos.istio.util.IstioCrdUtil.parseServiceEntryNameToS
  * @author special.fy
  */
 public final class ServiceEntryXdsGenerator implements ApiGenerator<Any> {
-
+    
     private static volatile ServiceEntryXdsGenerator singleton = null;
     
     private List<ServiceEntryWrapper> serviceEntries;
-
+    
     public static ServiceEntryXdsGenerator getInstance() {
         if (singleton == null) {
             synchronized (ServiceEntryXdsGenerator.class) {
@@ -55,18 +55,20 @@ public final class ServiceEntryXdsGenerator implements ApiGenerator<Any> {
         }
         return singleton;
     }
-
+    
     @Override
     public List<Any> generate(PushRequest pushRequest) {
         List<Resource> resources = new ArrayList<>();
         serviceEntries = new ArrayList<>(16);
         IstioConfig istioConfig = pushRequest.getResourceSnapshot().getIstioConfig();
-        Map<String, IstioService> serviceInfoMap = pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
-    
+        Map<String, IstioService> serviceInfoMap =
+                pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
+        
         for (Map.Entry<String, IstioService> entry : serviceInfoMap.entrySet()) {
             String serviceName = entry.getKey();
             
-            ServiceEntryWrapper serviceEntryWrapper = buildServiceEntry(serviceName, serviceName + istioConfig.getDomainSuffix(), serviceInfoMap.get(serviceName));
+            ServiceEntryWrapper serviceEntryWrapper = buildServiceEntry(serviceName,
+                    serviceName + istioConfig.getDomainSuffix(), serviceInfoMap.get(serviceName));
             if (serviceEntryWrapper != null) {
                 serviceEntries.add(serviceEntryWrapper);
             }
@@ -74,22 +76,25 @@ public final class ServiceEntryXdsGenerator implements ApiGenerator<Any> {
         for (ServiceEntryWrapper serviceEntryWrapper : serviceEntries) {
             Metadata metadata = serviceEntryWrapper.getMetadata();
             ServiceEntry serviceEntry = serviceEntryWrapper.getServiceEntry();
-
-            Any any = Any.newBuilder().setValue(serviceEntry.toByteString()).setTypeUrl(SERVICE_ENTRY_PROTO).build();
-
+            
+            Any any = Any.newBuilder().setValue(serviceEntry.toByteString())
+                    .setTypeUrl(SERVICE_ENTRY_PROTO).build();
+            
             resources.add(Resource.newBuilder().setBody(any).setMetadata(metadata).build());
         }
-
+        
         List<Any> result = new ArrayList<>();
         for (Resource resource : resources) {
-            result.add(Any.newBuilder().setValue(resource.toByteString()).setTypeUrl(MCP_RESOURCE_PROTO).build());
+            result.add(Any.newBuilder().setValue(resource.toByteString())
+                    .setTypeUrl(MCP_RESOURCE_PROTO).build());
         }
-    
+        
         return result;
     }
     
     @Override
-    public List<io.envoyproxy.envoy.service.discovery.v3.Resource> deltaGenerate(PushRequest pushRequest) {
+    public List<io.envoyproxy.envoy.service.discovery.v3.Resource> deltaGenerate(
+            PushRequest pushRequest) {
         if (pushRequest.isFull()) {
             return null;
         }
@@ -98,14 +103,17 @@ public final class ServiceEntryXdsGenerator implements ApiGenerator<Any> {
         serviceEntries = new ArrayList<>();
         Set<String> reason = pushRequest.getReason();
         IstioConfig istioConfig = pushRequest.getResourceSnapshot().getIstioConfig();
-        Map<String, IstioService> istioServiceMap = pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
+        Map<String, IstioService> istioServiceMap =
+                pushRequest.getResourceSnapshot().getIstioResources().getIstioServiceMap();
         
         if (pushRequest.getSubscribe().size() != 0) {
             for (String subscribe : pushRequest.getSubscribe()) {
-                String serviceName = parseServiceEntryNameToServiceName(subscribe, istioConfig.getDomainSuffix());
+                String serviceName = parseServiceEntryNameToServiceName(subscribe,
+                        istioConfig.getDomainSuffix());
                 if (reason.contains(serviceName)) {
                     if (istioServiceMap.containsKey(serviceName)) {
-                        ServiceEntryWrapper serviceEntryWrapper = buildServiceEntry(serviceName, subscribe, istioServiceMap.get(serviceName));
+                        ServiceEntryWrapper serviceEntryWrapper = buildServiceEntry(serviceName,
+                                subscribe, istioServiceMap.get(serviceName));
                         if (serviceEntryWrapper != null) {
                             serviceEntries.add(serviceEntryWrapper);
                         } else {
@@ -119,7 +127,8 @@ public final class ServiceEntryXdsGenerator implements ApiGenerator<Any> {
         } else {
             for (Map.Entry<String, IstioService> entry : istioServiceMap.entrySet()) {
                 String hostName = entry.getKey() + "." + istioConfig.getDomainSuffix();
-                ServiceEntryWrapper serviceEntryWrapper = buildServiceEntry(entry.getKey(), hostName, entry.getValue());
+                ServiceEntryWrapper serviceEntryWrapper =
+                        buildServiceEntry(entry.getKey(), hostName, entry.getValue());
                 if (serviceEntryWrapper != null) {
                     serviceEntries.add(serviceEntryWrapper);
                 } else {
@@ -128,14 +137,17 @@ public final class ServiceEntryXdsGenerator implements ApiGenerator<Any> {
             }
         }
         
-        
         for (ServiceEntryWrapper serviceEntryWrapper : serviceEntries) {
-            ServiceEntryOuterClass.ServiceEntry serviceEntry = serviceEntryWrapper.getServiceEntry();
-
-            Any any = Any.newBuilder().setValue(serviceEntry.toByteString()).setTypeUrl(SERVICE_ENTRY_PROTO).build();
-
-            result.add(io.envoyproxy.envoy.service.discovery.v3.Resource.newBuilder().setResource(any).setVersion(
-                    pushRequest.getResourceSnapshot().getVersion()).build());
+            ServiceEntryOuterClass.ServiceEntry serviceEntry =
+                    serviceEntryWrapper.getServiceEntry();
+            
+            Any any = Any.newBuilder().setValue(serviceEntry.toByteString())
+                    .setTypeUrl(SERVICE_ENTRY_PROTO).build();
+            
+            result.add(io.envoyproxy.envoy.service.discovery.v3.Resource.newBuilder()
+                    .setResource(any).setVersion(
+                            pushRequest.getResourceSnapshot().getVersion())
+                    .build());
         }
         
         return result;

--- a/istio/src/main/java/com/alibaba/nacos/istio/xds/XdsConnection.java
+++ b/istio/src/main/java/com/alibaba/nacos/istio/xds/XdsConnection.java
@@ -26,24 +26,25 @@ import io.grpc.stub.StreamObserver;
  * @author special.fy
  */
 public class XdsConnection extends AbstractConnection<DiscoveryResponse> {
-
+    
     public XdsConnection(StreamObserver<DiscoveryResponse> streamObserver) {
         super(streamObserver);
     }
-
+    
     @Override
     public synchronized void push(DiscoveryResponse response, WatchedStatus watchedStatus) {
         if (Loggers.MAIN.isDebugEnabled()) {
             Loggers.MAIN.debug("discoveryResponse: {}", response.toString());
         }
-
+        
         this.streamObserver.onNext(response);
-
+        
         // Update watched status
         watchedStatus.setLatestVersion(response.getVersionInfo());
         watchedStatus.setLatestNonce(response.getNonce());
-
-        Loggers.MAIN.info("xds: push, type: {}, connection-id {}, version {}, nonce {}, resource size {}.",
+        
+        Loggers.MAIN.info(
+                "xds: push, type: {}, connection-id {}, version {}, nonce {}, resource size {}.",
                 watchedStatus.getType(),
                 getConnectionId(),
                 response.getVersionInfo(),

--- a/istio/src/test/java/com/alibaba/nacos/istio/config/IstioEnabledFilterTest.java
+++ b/istio/src/test/java/com/alibaba/nacos/istio/config/IstioEnabledFilterTest.java
@@ -54,24 +54,28 @@ class IstioEnabledFilterTest {
     @Test
     void isExcludedOnlyNamingFunction() {
         ReflectionTestUtils.setField(EnvUtil.class, "functionModeType", "naming");
-        assertTrue(istioEnabledFilter.isExcluded("com.alibaba.nacos.istio.server.IstioServer", null));
+        assertTrue(
+                istioEnabledFilter.isExcluded("com.alibaba.nacos.istio.server.IstioServer", null));
     }
     
     @Test
     void isExcludedOnlyConfigFunction() {
         ReflectionTestUtils.setField(EnvUtil.class, "functionModeType", "config");
-        assertTrue(istioEnabledFilter.isExcluded("com.alibaba.nacos.istio.server.IstioServer", null));
+        assertTrue(
+                istioEnabledFilter.isExcluded("com.alibaba.nacos.istio.server.IstioServer", null));
     }
     
     @Test
     void isExcludedDisabled() {
         environment.setProperty("nacos.extension.naming.istio.enabled", "false");
-        assertTrue(istioEnabledFilter.isExcluded("com.alibaba.nacos.istio.server.IstioServer", null));
+        assertTrue(
+                istioEnabledFilter.isExcluded("com.alibaba.nacos.istio.server.IstioServer", null));
     }
     
     @Test
     void isExcludedEnabled() {
         environment.setProperty("nacos.extension.naming.istio.enabled", "true");
-        assertFalse(istioEnabledFilter.isExcluded("com.alibaba.nacos.istio.server.IstioServer", null));
+        assertFalse(
+                istioEnabledFilter.isExcluded("com.alibaba.nacos.istio.server.IstioServer", null));
     }
 }

--- a/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncConfig.java
+++ b/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncConfig.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class K8sSyncConfig {
+    
     @Value("${nacos.k8s.sync.enabled:false}")
     private boolean enabled = false;
     

--- a/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncEnabledFilter.java
+++ b/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncEnabledFilter.java
@@ -47,7 +47,8 @@ public class K8sSyncEnabledFilter implements NacosPackageExcludeFilter {
         String functionMode = EnvUtil.getFunctionMode();
         // When not specified naming mode or specified all mode, the naming module not start and load.
         if (isNamingDisabled(functionMode)) {
-            LOGGER.warn("K8s Sync module disabled because function mode is {}, and K8s Sync depend naming module",
+            LOGGER.warn(
+                    "K8s Sync module disabled because function mode is {}, and K8s Sync depend naming module",
                     functionMode);
             return true;
         }

--- a/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
+++ b/k8s-sync/src/main/java/com/alibaba/nacos/k8s/sync/K8sSyncServer.java
@@ -88,6 +88,7 @@ public class K8sSyncServer {
         Loggers.MAIN.info("Starting Nacos k8s-sync ...");
         startInformer();
         Runtime.getRuntime().addShutdownHook(new Thread() {
+            
             @Override
             public void run() {
                 Loggers.MAIN.info("Stopping Nacos k8s-sync ...");
@@ -114,15 +115,16 @@ public class K8sSyncServer {
         // set the global default api-client
         Configuration.setDefaultApiClient(apiClient);
         coreV1Api = new CoreV1Api();
-
+        
         OkHttpClient httpClient = apiClient.getHttpClient().newBuilder().build();
         apiClient.setHttpClient(httpClient);
-    
+        
         factory = new SharedInformerFactory(apiClient);
         SharedIndexInformer<V1Service> serviceInformer =
                 factory.sharedIndexInformerFor(
                         (CallGeneratorParams params) -> {
-                            CoreV1Api.APIlistServiceForAllNamespacesRequest request = coreV1Api.listServiceForAllNamespaces();
+                            CoreV1Api.APIlistServiceForAllNamespacesRequest request =
+                                    coreV1Api.listServiceForAllNamespaces();
                             request.resourceVersion(params.resourceVersion);
                             request.timeoutSeconds(params.timeoutSeconds);
                             request.watch(params.watch);
@@ -134,7 +136,8 @@ public class K8sSyncServer {
         SharedIndexInformer<V1Endpoints> endpointInformer =
                 factory.sharedIndexInformerFor(
                         (CallGeneratorParams params) -> {
-                            CoreV1Api.APIlistEndpointsForAllNamespacesRequest request = coreV1Api.listEndpointsForAllNamespaces();
+                            CoreV1Api.APIlistEndpointsForAllNamespacesRequest request =
+                                    coreV1Api.listEndpointsForAllNamespaces();
                             request.resourceVersion(params.resourceVersion);
                             request.timeoutSeconds(params.timeoutSeconds);
                             request.watch(params.watch);
@@ -145,6 +148,7 @@ public class K8sSyncServer {
         
         serviceInformer.addEventHandler(
                 new ResourceEventHandler<V1Service>() {
+                    
                     @Override
                     public void onAdd(V1Service service) {
                         if (service.getMetadata() == null || service.getSpec() == null) {
@@ -154,18 +158,22 @@ public class K8sSyncServer {
                         String namespace = service.getMetadata().getNamespace();
                         List<V1ServicePort> servicePorts = service.getSpec().getPorts();
                         try {
-                            registerService(namespace, serviceName, servicePorts, false, endpointInformer);
-                            Loggers.MAIN.info("add service, namespace:" + namespace + " serviceName: " + serviceName);
+                            registerService(namespace, serviceName, servicePorts, false,
+                                    endpointInformer);
+                            Loggers.MAIN.info("add service, namespace:" + namespace
+                                    + " serviceName: " + serviceName);
                         } catch (Exception e) {
-                            Loggers.MAIN.warn("add service fail, message:" + e.getMessage() + " namespace:"
-                                    + namespace + " serviceName: " + serviceName);
+                            Loggers.MAIN.warn(
+                                    "add service fail, message:" + e.getMessage() + " namespace:"
+                                            + namespace + " serviceName: " + serviceName);
                         }
                     }
-                
+                    
                     @Override
                     public void onUpdate(V1Service oldService, V1Service newService) {
                         if (oldService.getMetadata() == null || oldService.getSpec() == null
-                                || newService.getMetadata() == null || newService.getSpec() == null) {
+                                || newService.getMetadata() == null
+                                || newService.getSpec() == null) {
                             return;
                         }
                         List<V1ServicePort> oldServicePorts = oldService.getSpec().getPorts();
@@ -174,14 +182,17 @@ public class K8sSyncServer {
                         List<V1ServicePort> newServicePorts = newService.getSpec().getPorts();
                         boolean portChanged = compareServicePorts(oldServicePorts, newServicePorts);
                         try {
-                            registerService(namespace, serviceName, newServicePorts, portChanged, endpointInformer);
-                            Loggers.MAIN.info("update service, namespace: " + namespace + " serviceName: " + serviceName);
+                            registerService(namespace, serviceName, newServicePorts, portChanged,
+                                    endpointInformer);
+                            Loggers.MAIN.info("update service, namespace: " + namespace
+                                    + " serviceName: " + serviceName);
                         } catch (Exception e) {
-                            Loggers.MAIN.warn("update service fail, message: " + e.getMessage() + " namespace: "
+                            Loggers.MAIN.warn("update service fail, message: " + e.getMessage()
+                                    + " namespace: "
                                     + namespace + " serviceName: " + serviceName);
                         }
                     }
-                
+                    
                     @Override
                     public void onDelete(V1Service service, boolean deletedFinalStateUnknown) {
                         if (service.getMetadata() == null) {
@@ -191,15 +202,17 @@ public class K8sSyncServer {
                         String namespace = service.getMetadata().getNamespace();
                         try {
                             unregisterService(namespace, serviceName);
-                            Loggers.MAIN.info("delete service, namespace:" + namespace + " serviceName:" + serviceName);
+                            Loggers.MAIN.info("delete service, namespace:" + namespace
+                                    + " serviceName:" + serviceName);
                         } catch (Exception e) {
                             Loggers.MAIN.warn("delete service fail, message: " + e.getMessage()
                                     + " namespace:" + namespace + " serviceName:" + serviceName);
                         }
                     }
                 });
-    
+        
         endpointInformer.addEventHandler(new ResourceEventHandler<V1Endpoints>() {
+            
             @Override
             public void onAdd(V1Endpoints obj) {
                 if (obj.getMetadata() == null) {
@@ -208,19 +221,22 @@ public class K8sSyncServer {
                 String serviceName = obj.getMetadata().getName();
                 String namespace = obj.getMetadata().getNamespace();
                 Set<String> addIpSet = getIpFromEndpoints(obj);
-
+                
                 //TODO 因为需要指定namespace，这里servicelister需要重新new，是否可以优化,比如说作为单例的放到map中
-                Lister<V1Service> serviceLister = new Lister<>(serviceInformer.getIndexer(), namespace);
+                Lister<V1Service> serviceLister =
+                        new Lister<>(serviceInformer.getIndexer(), namespace);
                 V1Service service = serviceLister.get(serviceName);
                 List<V1ServicePort> servicePorts = service.getSpec().getPorts();
                 try {
                     registerInstances(addIpSet, namespace, serviceName, servicePorts);
-                    Loggers.MAIN.info("add instances, namespace:" + namespace + " serviceName: " + serviceName);
+                    Loggers.MAIN.info("add instances, namespace:" + namespace + " serviceName: "
+                            + serviceName);
                 } catch (NacosException e) {
-                    Loggers.MAIN.warn("add instances fail, message:" + e.getMessage() + " namespace:" + namespace + ", serviceName: " + serviceName);
+                    Loggers.MAIN.warn("add instances fail, message:" + e.getMessage()
+                            + " namespace:" + namespace + ", serviceName: " + serviceName);
                 }
             }
-
+            
             @Override
             public void onUpdate(V1Endpoints oldObj, V1Endpoints newObj) {
                 if (newObj.getMetadata() == null) {
@@ -228,18 +244,21 @@ public class K8sSyncServer {
                 }
                 String serviceName = newObj.getMetadata().getName();
                 String namespace = newObj.getMetadata().getNamespace();
-                Lister<V1Service> serviceLister = new Lister<>(serviceInformer.getIndexer(), namespace);
+                Lister<V1Service> serviceLister =
+                        new Lister<>(serviceInformer.getIndexer(), namespace);
                 V1Service service = serviceLister.get(serviceName);
                 List<V1ServicePort> servicePorts = service.getSpec().getPorts();
                 try {
                     registerService(namespace, serviceName, servicePorts, false, endpointInformer);
-                    Loggers.MAIN.info("update instances, namespace:" + namespace + " serviceName: " + serviceName);
+                    Loggers.MAIN.info("update instances, namespace:" + namespace + " serviceName: "
+                            + serviceName);
                 } catch (NacosException e) {
-                    Loggers.MAIN.warn("update instances fail, message:" + e.getMessage() + " namespace:"
-                            + namespace + ", serviceName: " + serviceName);
+                    Loggers.MAIN
+                            .warn("update instances fail, message:" + e.getMessage() + " namespace:"
+                                    + namespace + ", serviceName: " + serviceName);
                 }
             }
-
+            
             @Override
             public void onDelete(V1Endpoints obj, boolean deletedFinalStateUnknown) {
                 if (obj.getMetadata() == null) {
@@ -249,15 +268,18 @@ public class K8sSyncServer {
                 String namespace = obj.getMetadata().getNamespace();
                 Set<String> deleteIpSet = getIpFromEndpoints(obj);
                 try {
-                    List<? extends Instance> oldInstanceList = instanceOperatorClient.listAllInstances(namespace, serviceName);
+                    List<? extends Instance> oldInstanceList =
+                            instanceOperatorClient.listAllInstances(namespace, serviceName);
                     unregisterInstances(deleteIpSet, namespace, serviceName, oldInstanceList);
-                    Loggers.MAIN.info("delete instances, namespace:" + namespace + ", serviceName: " + serviceName);
+                    Loggers.MAIN.info("delete instances, namespace:" + namespace + ", serviceName: "
+                            + serviceName);
                 } catch (NacosException e) {
-                    Loggers.MAIN.info("delete instances fail, namespace:" + namespace + ", serviceName: " + serviceName);
+                    Loggers.MAIN.info("delete instances fail, namespace:" + namespace
+                            + ", serviceName: " + serviceName);
                 }
             }
         });
-
+        
         // Wait until the cache of each informer has been fully synced before proceeding.
         // This ensures that the local cache contains the latest and complete resource data.
         long timeout = 30000L;
@@ -308,19 +330,22 @@ public class K8sSyncServer {
      * @param portChanged port is changed or not
      * @throws NacosException nacos exception during registering
      */
-    public void registerService(String namespace, String serviceName, List<V1ServicePort> servicePorts, boolean portChanged,
+    public void registerService(String namespace, String serviceName,
+            List<V1ServicePort> servicePorts, boolean portChanged,
             SharedIndexInformer<V1Endpoints> endpointInformer) throws NacosException {
         //TODO defaultnamespace 常量
         
-        Service service = Service.newService(namespace, Constants.DEFAULT_GROUP, serviceName, false);
+        Service service =
+                Service.newService(namespace, Constants.DEFAULT_GROUP, serviceName, false);
         ServiceManager.getInstance().getSingleton(service);
         
         //NotifyCenter.publishEvent(new NamingTraceEvent.RegisterServiceTraceEvent(System.currentTimeMillis(),
         //        namespace, Constants.DEFAULT_GROUP, serviceName));
         
         Set<String> oldIpSet = new HashSet<>();
-        List<? extends Instance> oldInstanceList = instanceOperatorClient.listAllInstances(namespace, serviceName);
-        for (Instance instance:oldInstanceList) {
+        List<? extends Instance> oldInstanceList =
+                instanceOperatorClient.listAllInstances(namespace, serviceName);
+        for (Instance instance : oldInstanceList) {
             oldIpSet.add(instance.getIp());
         }
         Lister<V1Endpoints> endpointLister = new Lister<>(endpointInformer.getIndexer(), namespace);
@@ -349,8 +374,9 @@ public class K8sSyncServer {
      * @throws NacosException nacos exception during unregistering
      */
     public void unregisterService(String namespace, String serviceName) throws NacosException {
-        List<? extends Instance> instancelist = instanceOperatorClient.listAllInstances(namespace, serviceName);
-        for (Instance instance:instancelist) {
+        List<? extends Instance> instancelist =
+                instanceOperatorClient.listAllInstances(namespace, serviceName);
+        for (Instance instance : instancelist) {
             instanceOperatorClient.removeInstance(namespace, serviceName, instance);
         }
         serviceOperatorV2.delete(namespace, serviceName);
@@ -367,13 +393,13 @@ public class K8sSyncServer {
      */
     public void registerInstances(Set<String> addIpSet, String namespace, String serviceName,
             List<V1ServicePort> servicePorts) throws NacosException {
-        for (V1ServicePort servicePort:servicePorts) {
+        for (V1ServicePort servicePort : servicePorts) {
             int port = servicePort.getPort();
             if (!servicePort.getTargetPort().isInteger()) {
                 continue;
             }
             int targetPort = servicePort.getTargetPort().getIntValue();
-            for (String ip:addIpSet) {
+            for (String ip : addIpSet) {
                 Instance instance = createInstance(ip, targetPort, serviceName, port);
                 instanceOperatorClient.registerInstance(namespace, serviceName, instance);
             }
@@ -391,7 +417,7 @@ public class K8sSyncServer {
      */
     public void unregisterInstances(Set<String> deleteIpSet, String namespace, String serviceName,
             List<? extends Instance> oldInstanceList) throws NacosException {
-        for (Instance instance:oldInstanceList) {
+        for (Instance instance : oldInstanceList) {
             if (deleteIpSet.contains(instance.getIp())) {
                 instanceOperatorClient.removeInstance(namespace, serviceName, instance);
             }
@@ -401,8 +427,8 @@ public class K8sSyncServer {
     public Set<String> getIpFromEndpoints(V1Endpoints endpoints) {
         Set<String> ipSet = new HashSet<>();
         List<V1EndpointSubset> endpointSubsetList = endpoints.getSubsets();
-        for (V1EndpointSubset endpointSubset:endpointSubsetList) {
-            for (V1EndpointAddress endpointAddress:endpointSubset.getAddresses()) {
+        for (V1EndpointSubset endpointSubset : endpointSubsetList) {
+            for (V1EndpointAddress endpointAddress : endpointSubset.getAddresses()) {
                 ipSet.add(endpointAddress.getIp());
             }
         }
@@ -415,11 +441,13 @@ public class K8sSyncServer {
      * @param oldServicePorts old service ports list
      * @param newServicePorts new service ports list
      */
-    public boolean compareServicePorts(List<V1ServicePort> oldServicePorts, List<V1ServicePort> newServicePorts) {
+    public boolean compareServicePorts(List<V1ServicePort> oldServicePorts,
+            List<V1ServicePort> newServicePorts) {
         if (oldServicePorts.size() != newServicePorts.size()) {
             return false;
         }
-        return oldServicePorts.containsAll(newServicePorts) && newServicePorts.containsAll(oldServicePorts);
+        return oldServicePorts.containsAll(newServicePorts)
+                && newServicePorts.containsAll(oldServicePorts);
     }
     
     /**
@@ -428,13 +456,13 @@ public class K8sSyncServer {
      */
     public ApiClient getOutsideApiClient() throws IOException {
         String kubeConfigPath = k8sSyncConfig.getKubeConfig();
-
+        
         // loading the out-of-cluster config, a kubeconfig from file-system
         ApiClient apiClient = ClientBuilder
                 .kubeconfig(KubeConfig.loadKubeConfig(
                         Files.newBufferedReader(Paths.get(kubeConfigPath), StandardCharsets.UTF_8)))
                 .build();
-
+        
         // set the global default api-client to the in-cluster one from above
         Configuration.setDefaultApiClient(apiClient);
         return apiClient;

--- a/k8s-sync/src/test/java/com/alibaba/nacos/k8s/sync/K8sSyncEnabledFilterTest.java
+++ b/k8s-sync/src/test/java/com/alibaba/nacos/k8s/sync/K8sSyncEnabledFilterTest.java
@@ -48,30 +48,35 @@ class K8sSyncEnabledFilterTest {
     
     @Test
     void getResponsiblePackagePrefix() {
-        assertEquals("com.alibaba.nacos.k8s.sync", k8sSyncEnabledFilter.getResponsiblePackagePrefix());
+        assertEquals("com.alibaba.nacos.k8s.sync",
+                k8sSyncEnabledFilter.getResponsiblePackagePrefix());
     }
     
     @Test
     void isExcludedOnlyNamingFunction() {
         ReflectionTestUtils.setField(EnvUtil.class, "functionModeType", "naming");
-        assertTrue(k8sSyncEnabledFilter.isExcluded("com.alibaba.nacos.k8s.sync.K8sSyncEnabledFilter", null));
+        assertTrue(k8sSyncEnabledFilter
+                .isExcluded("com.alibaba.nacos.k8s.sync.K8sSyncEnabledFilter", null));
     }
     
     @Test
     void isExcludedOnlyConfigFunction() {
         ReflectionTestUtils.setField(EnvUtil.class, "functionModeType", "config");
-        assertTrue(k8sSyncEnabledFilter.isExcluded("com.alibaba.nacos.k8s.sync.K8sSyncEnabledFilter", null));
+        assertTrue(k8sSyncEnabledFilter
+                .isExcluded("com.alibaba.nacos.k8s.sync.K8sSyncEnabledFilter", null));
     }
     
     @Test
     void isExcludedDisabled() {
         environment.setProperty("nacos.k8s.sync.enabled", "false");
-        assertTrue(k8sSyncEnabledFilter.isExcluded("com.alibaba.nacos.k8s.sync.K8sSyncEnabledFilter", null));
+        assertTrue(k8sSyncEnabledFilter
+                .isExcluded("com.alibaba.nacos.k8s.sync.K8sSyncEnabledFilter", null));
     }
     
     @Test
     void isExcludedEnabled() {
         environment.setProperty("nacos.k8s.sync.enabled", "true");
-        assertFalse(k8sSyncEnabledFilter.isExcluded("com.alibaba.nacos.k8s.sync.K8sSyncEnabledFilter", null));
+        assertFalse(k8sSyncEnabledFilter
+                .isExcluded("com.alibaba.nacos.k8s.sync.K8sSyncEnabledFilter", null));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Apply Spotless Eclipse JDT Formatter to `k8s-sync` and `istio` modules as part of the codebase-wide formatting effort. Split from #15072 by module as requested.

## Brief changelog

- Format 37 Java files in `k8s-sync/` and `istio/` with Eclipse JDT Formatter (line width 100)
- Pure whitespace/formatting changes, no logic changes

## Verifying this change

This change only modifies code formatting. No functional logic is altered.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.