### PR TITLE
[ISSUE #14911] fix(plugin/auth): ship spring-ldap-core jar with default plugins

### DIFF
--- a/plugin-default-impl/nacos-default-plugin-all/pom.xml
+++ b/plugin-default-impl/nacos-default-plugin-all/pom.xml
@@ -166,7 +166,7 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.basedir}/../../distribution/plugins</outputDirectory>
-                            <includeArtifactIds>default-auth-plugin,nacos-oidc-auth-plugin,default-control-plugin,nacos-default-ai-pipeline-plugin,nacos-datasource-plugin-mysql,nacos-datasource-plugin-derby,nacos-datasource-plugin-postgresql,nacos-datasource-plugin-oracle,mysql-connector-j,derby,postgresql</includeArtifactIds>
+                            <includeArtifactIds>default-auth-plugin,nacos-oidc-auth-plugin,default-control-plugin,nacos-default-ai-pipeline-plugin,nacos-datasource-plugin-mysql,nacos-datasource-plugin-derby,nacos-datasource-plugin-postgresql,nacos-datasource-plugin-oracle,mysql-connector-j,derby,postgresql,spring-ldap-core</includeArtifactIds>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Problem

On startup Nacos 3.2.x aborts with:

```
Caused by: java.lang.IllegalStateException: Failed to introspect Class
  [com.alibaba.nacos.plugin.auth.impl.ldap.LdapAuthPluginConfig]
  from ClassLoader [org.springframework.boot.loader.launch.LaunchedClassLoader@...]
```

This happens even when the LDAP auth plugin is not enabled, because Spring 6 walks every `@Configuration` class on the classpath and resolves the parameter / return types of its `@Bean` methods before `@Conditional` checks are applied.

## Root Cause

`LdapAuthPluginConfig` declares `@Bean` methods whose signatures reference `LdapTemplate` and `LdapContextSource` from `spring-ldap-core`. Three things together hide that jar from the runtime classpath:

1. `default-auth-plugin` declares `spring-ldap-core` as a compile dependency but does not bundle it (no shade plugin).
2. No main classpath module (`auth`, `bootstrap`, `console`, `core`) declares `spring-ldap-core` either.
3. `nacos-default-plugin-all/pom.xml` runs `maven-dependency-plugin:copy-dependencies` with a whitelist (`includeArtifactIds`) that does not contain `spring-ldap-core`, so the jar is never copied into `distribution/plugins/`.

`distribution/bin/startup.sh` adds `${BASE_DIR}/plugins` to `loader.path`, so any jar that lands there is picked up by `LaunchedClassLoader`. Without `spring-ldap-core-*.jar` in `plugins/`, the `LdapTemplate` / `LdapContextSource` classes are unreachable and introspection fails.

## Fix

Add `spring-ldap-core` to the `copy-dependencies` whitelist in `nacos-default-plugin-all/pom.xml`. After `mvn package`, `distribution/plugins/spring-ldap-core-3.3.6.jar` ships alongside the plugin jars and the JDBC drivers, so `loader.path` picks it up at startup and Spring can resolve every `@Bean` signature in `LdapAuthPluginConfig`.

This mirrors the pattern already used for `mysql-connector-j`, `derby` and `postgresql`: a third-party jar that a plugin needs but that should not pollute the main classpath when the plugin is unused.

The transitive dependencies of `spring-ldap-core` (`spring-core/beans/context/tx`, `micrometer-core`) are already on the main classpath, so no additional artifacts need to be shipped.

## Tests Added

This is a build-config-only change; no Java logic is modified. Verification:

| Change Point | Verification |
|-------------|--------------|
| `spring-ldap-core` added to `includeArtifactIds` | Run `mvn -pl plugin-default-impl/nacos-default-plugin-all -am package` and confirm `distribution/plugins/spring-ldap-core-3.3.6.jar` is produced and contains `org/springframework/ldap/core/LdapTemplate.class` and `org/springframework/ldap/core/support/LdapContextSource.class`. |

Local verification:

```
$ ls distribution/plugins/spring-ldap-core-*.jar
distribution/plugins/spring-ldap-core-3.3.6.jar

$ unzip -l distribution/plugins/spring-ldap-core-3.3.6.jar | grep -E 'LdapTemplate\.class|LdapContextSource\.class'
69391  ...   org/springframework/ldap/core/LdapTemplate.class
  982  ...   org/springframework/ldap/core/support/LdapContextSource.class
```

## Impact

- `distribution/plugins/` gains one additional jar (`spring-ldap-core-3.3.6.jar`, ~400 KB).
- No code path is changed; LDAP behaviour is unaffected.
- Servers with the LDAP auth plugin disabled now start cleanly because Spring can fully introspect `LdapAuthPluginConfig`.
- Servers that enable LDAP behave exactly as before.

Fixes #14911