### PR TITLE
[ISSUE #15038] docs(auth): clarify SDK and admin auth scopes

### DIFF
--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -259,9 +259,10 @@ nacos.security.ignore.urls=/,/error,/**/*.css,/**/*.js,/**/*.html,/**/*.map,/**/
 nacos.core.auth.system.type=nacos
 
 ### If turn on auth system:
-# Whether open nacos server API auth system
+# Whether open nacos server API auth system. It controls SDK and gRPC request authentication.
+# Enable this together with nacos.core.auth.admin.enabled when client-side SDK/gRPC requests also need RBAC checks.
 nacos.core.auth.enabled=true
-# Whether open nacos admin API auth system
+# Whether open nacos admin API auth system. It controls /v3/admin/* HTTP request authentication only.
 nacos.core.auth.admin.enabled=true
 # Whether open nacos console API auth system
 nacos.core.auth.console.enabled=true

--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -264,7 +264,7 @@ nacos.core.auth.system.type=nacos
 nacos.core.auth.enabled=true
 # Whether open nacos admin API auth system. It controls /v3/admin/* HTTP request authentication only.
 nacos.core.auth.admin.enabled=true
-# Whether open nacos console API auth system
+# Whether open nacos console API auth system. It controls /v3/console/* HTTP request authentication only.
 nacos.core.auth.console.enabled=true
 
 ### Turn on/off caching of auth information. By turning on this switch, the update of auth information would have a 15 seconds delay.

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -275,7 +275,7 @@ nacos.core.auth.system.type=nacos
 nacos.core.auth.enabled=false
 # Whether open nacos admin API auth system. It controls /v3/admin/* HTTP request authentication only.
 nacos.core.auth.admin.enabled=true
-# Whether open nacos console API auth system
+# Whether open nacos console API auth system. It controls /v3/console/* HTTP request authentication only.
 nacos.core.auth.console.enabled=true
 
 ### Turn on/off caching of auth information. By turning on this switch, the update of auth information would have a 15 seconds delay.

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -270,9 +270,10 @@ nacos.security.ignore.urls=/,/error,/**/*.css,/**/*.js,/**/*.html,/**/*.map,/**/
 nacos.core.auth.system.type=nacos
 
 ### If turn on auth system:
-# Whether open nacos server API auth system
+# Whether open nacos server API auth system. It controls SDK and gRPC request authentication.
+# Enable this together with nacos.core.auth.admin.enabled when client-side SDK/gRPC requests also need RBAC checks.
 nacos.core.auth.enabled=false
-# Whether open nacos admin API auth system
+# Whether open nacos admin API auth system. It controls /v3/admin/* HTTP request authentication only.
 nacos.core.auth.admin.enabled=true
 # Whether open nacos console API auth system
 nacos.core.auth.console.enabled=true


### PR DESCRIPTION
## Problem

Issue #15038 shows that users can confuse the two auth scopes because `nacos.core.auth.admin.enabled` protects `/v3/admin/*` HTTP APIs, while SDK and gRPC requests are controlled by `nacos.core.auth.enabled`.

## Root Cause

The shipped configuration templates describe both switches as generic auth switches, but do not say which request paths each one covers. This makes it easy to enable admin API auth and assume SDK/gRPC requests are covered too.

## Fix

- Clarify that `nacos.core.auth.enabled` controls SDK and gRPC request authentication.
- Clarify that `nacos.core.auth.admin.enabled` controls only `/v3/admin/*` HTTP request authentication.
- Add the same wording to both runtime configuration templates.

## Tests Added

Not applicable. This PR only updates comments in `application.properties` templates and does not change runtime code.

## Impact

No behavior or default value changes. The update only helps operators choose the correct auth switch when they need RBAC checks for SDK/gRPC traffic.

Fixes #15038