### PR TITLE
test(sys): raise sys module line coverage to 99.59%

### DIFF
--- a/sys/src/test/java/com/alibaba/nacos/sys/env/EnvUtilTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/env/EnvUtilTest.java
@@ -432,19 +432,19 @@ class EnvUtilTest {
         environment.setProperty(Constants.AVAILABLE_PROCESSORS_BASIC, "4");
         assertEquals(2, EnvUtil.getAvailableProcessors(0.5d));
     }
-
+    
     @Test
     void testConstructor() {
         new EnvUtil();
     }
-
+    
     @Test
     void testResolveRequiredPlaceholdersSuccess() {
         environment.setProperty("nacos.custom.environment.enabled", "true");
         assertEquals("true",
             EnvUtil.resolveRequiredPlaceholders("${nacos.custom.environment.enabled}"));
     }
-
+    
     @Test
     void testSystemExit() {
         Runtime runtimeMock = mock(Runtime.class);

--- a/sys/src/test/java/com/alibaba/nacos/sys/env/EnvUtilTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/env/EnvUtilTest.java
@@ -432,4 +432,26 @@ class EnvUtilTest {
         environment.setProperty(Constants.AVAILABLE_PROCESSORS_BASIC, "4");
         assertEquals(2, EnvUtil.getAvailableProcessors(0.5d));
     }
+
+    @Test
+    void testConstructor() {
+        new EnvUtil();
+    }
+
+    @Test
+    void testResolveRequiredPlaceholdersSuccess() {
+        environment.setProperty("nacos.custom.environment.enabled", "true");
+        assertEquals("true",
+            EnvUtil.resolveRequiredPlaceholders("${nacos.custom.environment.enabled}"));
+    }
+
+    @Test
+    void testSystemExit() {
+        Runtime runtimeMock = mock(Runtime.class);
+        try (MockedStatic<Runtime> runtimeMocked = Mockito.mockStatic(Runtime.class)) {
+            runtimeMocked.when(Runtime::getRuntime).thenReturn(runtimeMock);
+            EnvUtil.systemExit();
+            verify(runtimeMock).exit(0);
+        }
+    }
 }

--- a/sys/src/test/java/com/alibaba/nacos/sys/file/WatchFileCenterTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/file/WatchFileCenterTest.java
@@ -273,7 +273,7 @@ class WatchFileCenterTest {
         final String path = file.getParentFile().getAbsolutePath();
         AtomicBoolean containAssert = new AtomicBoolean(false);
         WatchFileCenter.registerWatcher(path, new FileWatcher() {
-
+            
             @Override
             public void onChange(FileChangeEvent event) {
                 try {
@@ -284,7 +284,7 @@ class WatchFileCenterTest {
                     containAssert.set(true);
                 }
             }
-
+            
             @Override
             public boolean interest(String context) {
                 return true;
@@ -299,12 +299,12 @@ class WatchFileCenterTest {
         method.invoke(job);
         assertFalse(containAssert.get());
     }
-
+    
     @Test
     void testConstructor() {
         new WatchFileCenter();
     }
-
+    
     @Test
     void testShutdownIsIdempotent() {
         try {
@@ -315,7 +315,7 @@ class WatchFileCenterTest {
                 .set(false);
         }
     }
-
+    
     @Test
     void testRegisterReturnsFalseWhenAtMaxLimit() throws NacosException {
         Integer originalCnt =
@@ -330,7 +330,7 @@ class WatchFileCenterTest {
             ReflectionTestUtils.setField(WatchFileCenter.class, "NOW_WATCH_JOB_CNT", originalCnt);
         }
     }
-
+    
     @Test
     void testShutdownContinuesWhenJobShutdownThrows() throws Exception {
         Map<String, WatchFileCenter.WatchDirJob> manager =
@@ -349,7 +349,7 @@ class WatchFileCenterTest {
             ReflectionTestUtils.setField(WatchFileCenter.class, "NOW_WATCH_JOB_CNT", 0);
         }
     }
-
+    
     @Test
     void testRunCatchesUnexpectedThrowable() throws Exception {
         WatchFileCenter.WatchDirJob job = newDetachedJob();
@@ -366,7 +366,7 @@ class WatchFileCenterTest {
             shutdownDetachedJob(job);
         }
     }
-
+    
     @Test
     void testRunSkipsEmptyEvents() throws Exception {
         WatchFileCenter.WatchDirJob job = newDetachedJob();
@@ -386,7 +386,7 @@ class WatchFileCenterTest {
             shutdownDetachedJob(job);
         }
     }
-
+    
     @Test
     void testRunReturnsWhenExecutorAlreadyShutdown() throws Exception {
         WatchFileCenter.WatchDirJob job = newDetachedJob();
@@ -407,7 +407,7 @@ class WatchFileCenterTest {
             shutdownDetachedJob(job);
         }
     }
-
+    
     @Test
     void testRunDispatchesEventOverflowToExecutor() throws Exception {
         WatchFileCenter.WatchDirJob job = newDetachedJob();
@@ -444,7 +444,7 @@ class WatchFileCenterTest {
             shutdownDetachedJob(job);
         }
     }
-
+    
     @Test
     void testRunSwallowsClosedWatchServiceException() throws Exception {
         WatchFileCenter.WatchDirJob job = newDetachedJob();
@@ -460,7 +460,7 @@ class WatchFileCenterTest {
             shutdownDetachedJob(job);
         }
     }
-
+    
     @Test
     void testJobShutdownIgnoresIoExceptionOnWatchServiceClose() throws Exception {
         WatchFileCenter.WatchDirJob job = newDetachedJob();
@@ -473,7 +473,7 @@ class WatchFileCenterTest {
             shutdownDetachedJob(job);
         }
     }
-
+    
     @Test
     void testEventOverflowSkipsSubdirectory() throws Exception {
         String dirPath = Paths.get(System.getProperty("user.home"),
@@ -486,12 +486,12 @@ class WatchFileCenterTest {
         AtomicReference<String> seen = new AtomicReference<>(null);
         try {
             WatchFileCenter.registerWatcher(dirPath, new FileWatcher() {
-
+                
                 @Override
                 public void onChange(FileChangeEvent event) {
                     seen.set(String.valueOf(event.getContext()));
                 }
-
+                
                 @Override
                 public boolean interest(String context) {
                     return true;
@@ -519,7 +519,7 @@ class WatchFileCenterTest {
         ctor.setAccessible(true);
         return ctor.newInstance(dirPath);
     }
-
+    
     private static void shutdownDetachedJob(WatchFileCenter.WatchDirJob job) {
         try {
             ExecutorService exec = (ExecutorService) ReflectionTestUtils.getField(job,
@@ -539,14 +539,14 @@ class WatchFileCenterTest {
             }
         }
     }
-
+    
     private static String createEmptyTempDir(String prefix) throws Exception {
         String dirPath = Paths.get(System.getProperty("java.io.tmpdir"),
             prefix + System.nanoTime()).toString();
         DiskUtils.deleteDirThenMkdir(dirPath);
         return dirPath;
     }
-
+    
     private void func(final String fileName, final File file, final Consumer<String> consumer)
         throws Exception {
         CountDownLatch latch = new CountDownLatch(100);

--- a/sys/src/test/java/com/alibaba/nacos/sys/file/WatchFileCenterTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/file/WatchFileCenterTest.java
@@ -29,16 +29,25 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -54,9 +63,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -262,7 +273,7 @@ class WatchFileCenterTest {
         final String path = file.getParentFile().getAbsolutePath();
         AtomicBoolean containAssert = new AtomicBoolean(false);
         WatchFileCenter.registerWatcher(path, new FileWatcher() {
-            
+
             @Override
             public void onChange(FileChangeEvent event) {
                 try {
@@ -273,7 +284,7 @@ class WatchFileCenterTest {
                     containAssert.set(true);
                 }
             }
-            
+
             @Override
             public boolean interest(String context) {
                 return true;
@@ -288,7 +299,254 @@ class WatchFileCenterTest {
         method.invoke(job);
         assertFalse(containAssert.get());
     }
+
+    @Test
+    void testConstructor() {
+        new WatchFileCenter();
+    }
+
+    @Test
+    void testShutdownIsIdempotent() {
+        try {
+            assertDoesNotThrow(WatchFileCenter::shutdown);
+            assertDoesNotThrow(WatchFileCenter::shutdown);
+        } finally {
+            ((AtomicBoolean) ReflectionTestUtils.getField(WatchFileCenter.class, "CLOSED"))
+                .set(false);
+        }
+    }
+
+    @Test
+    void testRegisterReturnsFalseWhenAtMaxLimit() throws NacosException {
+        Integer originalCnt =
+            (Integer) ReflectionTestUtils.getField(WatchFileCenter.class, "NOW_WATCH_JOB_CNT");
+        Integer max = (Integer) ReflectionTestUtils.getField(WatchFileCenter.class,
+            "MAX_WATCH_FILE_JOB");
+        try {
+            ReflectionTestUtils.setField(WatchFileCenter.class, "NOW_WATCH_JOB_CNT", max);
+            FileWatcher watcher = mock(FileWatcher.class);
+            assertFalse(WatchFileCenter.registerWatcher(PATH, watcher));
+        } finally {
+            ReflectionTestUtils.setField(WatchFileCenter.class, "NOW_WATCH_JOB_CNT", originalCnt);
+        }
+    }
+
+    @Test
+    void testShutdownContinuesWhenJobShutdownThrows() throws Exception {
+        Map<String, WatchFileCenter.WatchDirJob> manager =
+            (Map<String, WatchFileCenter.WatchDirJob>) ReflectionTestUtils.getField(
+                WatchFileCenter.class, "MANAGER");
+        WatchFileCenter.WatchDirJob faulty = mock(WatchFileCenter.WatchDirJob.class);
+        doThrow(new RuntimeException("forced")).when(faulty).shutdown();
+        manager.put("__forced__", faulty);
+        try {
+            assertDoesNotThrow(WatchFileCenter::shutdown);
+            verify(faulty).shutdown();
+        } finally {
+            ((AtomicBoolean) ReflectionTestUtils.getField(WatchFileCenter.class, "CLOSED"))
+                .set(false);
+            manager.clear();
+            ReflectionTestUtils.setField(WatchFileCenter.class, "NOW_WATCH_JOB_CNT", 0);
+        }
+    }
+
+    @Test
+    void testRunCatchesUnexpectedThrowable() throws Exception {
+        WatchFileCenter.WatchDirJob job = newDetachedJob();
+        try {
+            WatchService mockWs = mock(WatchService.class);
+            when(mockWs.take()).thenAnswer(inv -> {
+                ReflectionTestUtils.setField(job, "watch", false);
+                throw new RuntimeException("forced");
+            });
+            ReflectionTestUtils.setField(job, "watchService", mockWs);
+            job.run();
+            verify(mockWs, atLeastOnce()).take();
+        } finally {
+            shutdownDetachedJob(job);
+        }
+    }
+
+    @Test
+    void testRunSkipsEmptyEvents() throws Exception {
+        WatchFileCenter.WatchDirJob job = newDetachedJob();
+        try {
+            WatchService mockWs = mock(WatchService.class);
+            WatchKey emptyKey = mock(WatchKey.class);
+            when(emptyKey.pollEvents()).thenReturn(Collections.emptyList());
+            when(mockWs.take()).thenAnswer(inv -> {
+                ReflectionTestUtils.setField(job, "watch", false);
+                return emptyKey;
+            });
+            ReflectionTestUtils.setField(job, "watchService", mockWs);
+            job.run();
+            verify(emptyKey).pollEvents();
+            verify(emptyKey).reset();
+        } finally {
+            shutdownDetachedJob(job);
+        }
+    }
+
+    @Test
+    void testRunReturnsWhenExecutorAlreadyShutdown() throws Exception {
+        WatchFileCenter.WatchDirJob job = newDetachedJob();
+        try {
+            WatchService mockWs = mock(WatchService.class);
+            ExecutorService mockExec = mock(ExecutorService.class);
+            when(mockExec.isShutdown()).thenReturn(true);
+            WatchKey withEvents = mock(WatchKey.class);
+            WatchEvent<?> event = mock(WatchEvent.class);
+            when(withEvents.pollEvents()).thenAnswer(inv -> Collections.singletonList(event));
+            when(mockWs.take()).thenReturn(withEvents);
+            ReflectionTestUtils.setField(job, "watchService", mockWs);
+            ReflectionTestUtils.setField(job, "callBackExecutor", mockExec);
+            job.run();
+            verify(mockExec).isShutdown();
+            verify(mockExec, never()).execute(any(Runnable.class));
+        } finally {
+            shutdownDetachedJob(job);
+        }
+    }
+
+    @Test
+    void testRunDispatchesEventOverflowToExecutor() throws Exception {
+        WatchFileCenter.WatchDirJob job = newDetachedJob();
+        try {
+            WatchService mockWs = mock(WatchService.class);
+            ExecutorService inlineExec = mock(ExecutorService.class);
+            when(inlineExec.isShutdown()).thenReturn(false);
+            doAnswer(inv -> {
+                ((Runnable) inv.getArgument(0)).run();
+                return null;
+            }).when(inlineExec).execute(any(Runnable.class));
+            WatchEvent<?> overflowEvent = mock(WatchEvent.class);
+            when(overflowEvent.kind()).thenAnswer(inv -> StandardWatchEventKinds.OVERFLOW);
+            WatchKey overflowKey = mock(WatchKey.class);
+            when(overflowKey.pollEvents())
+                .thenAnswer(inv -> Collections.singletonList(overflowEvent));
+            when(mockWs.take()).thenAnswer(inv -> {
+                ReflectionTestUtils.setField(job, "watch", false);
+                return overflowKey;
+            });
+            ReflectionTestUtils.setField(job, "watchService", mockWs);
+            ReflectionTestUtils.setField(job, "callBackExecutor", inlineExec);
+            // ensure listFiles() inside eventOverflow returns empty (no NPE) by pointing paths at
+            // an empty real dir
+            String overflowDir = createEmptyTempDir("watch_file_overflow_run_");
+            ReflectionTestUtils.setField(job, "paths", overflowDir);
+            try {
+                job.run();
+                verify(inlineExec).execute(any(Runnable.class));
+            } finally {
+                DiskUtils.deleteDirectory(overflowDir);
+            }
+        } finally {
+            shutdownDetachedJob(job);
+        }
+    }
+
+    @Test
+    void testRunSwallowsClosedWatchServiceException() throws Exception {
+        WatchFileCenter.WatchDirJob job = newDetachedJob();
+        try {
+            WatchService mockWs = mock(WatchService.class);
+            when(mockWs.take()).thenAnswer(inv -> {
+                ReflectionTestUtils.setField(job, "watch", false);
+                throw new ClosedWatchServiceException();
+            });
+            ReflectionTestUtils.setField(job, "watchService", mockWs);
+            assertDoesNotThrow(job::run);
+        } finally {
+            shutdownDetachedJob(job);
+        }
+    }
+
+    @Test
+    void testJobShutdownIgnoresIoExceptionOnWatchServiceClose() throws Exception {
+        WatchFileCenter.WatchDirJob job = newDetachedJob();
+        try {
+            WatchService mockWs = mock(WatchService.class);
+            doThrow(new IOException("forced")).when(mockWs).close();
+            ReflectionTestUtils.setField(job, "watchService", mockWs);
+            assertDoesNotThrow(job::shutdown);
+        } finally {
+            shutdownDetachedJob(job);
+        }
+    }
+
+    @Test
+    void testEventOverflowSkipsSubdirectory() throws Exception {
+        String dirPath = Paths.get(System.getProperty("user.home"),
+            "watch_file_overflow_subdir_" + System.nanoTime()).toString();
+        DiskUtils.deleteDirThenMkdir(dirPath);
+        File subDir = Paths.get(dirPath, "sub").toFile();
+        assertTrue(subDir.mkdir());
+        File regularFile = Paths.get(dirPath, "child.properties").toFile();
+        DiskUtils.touch(regularFile);
+        AtomicReference<String> seen = new AtomicReference<>(null);
+        try {
+            WatchFileCenter.registerWatcher(dirPath, new FileWatcher() {
+
+                @Override
+                public void onChange(FileChangeEvent event) {
+                    seen.set(String.valueOf(event.getContext()));
+                }
+
+                @Override
+                public boolean interest(String context) {
+                    return true;
+                }
+            });
+            Map<String, WatchFileCenter.WatchDirJob> map =
+                (Map<String, WatchFileCenter.WatchDirJob>) ReflectionTestUtils.getField(
+                    WatchFileCenter.class, "MANAGER");
+            WatchFileCenter.WatchDirJob job = map.get(dirPath);
+            Method method = WatchFileCenter.WatchDirJob.class.getDeclaredMethod("eventOverflow");
+            method.setAccessible(true);
+            method.invoke(job);
+            ThreadUtils.sleep(500L);
+            assertEquals("child.properties", seen.get());
+        } finally {
+            WatchFileCenter.deregisterAllWatcher(dirPath);
+            DiskUtils.deleteDirectory(dirPath);
+        }
+    }
     
+    private static WatchFileCenter.WatchDirJob newDetachedJob() throws Exception {
+        String dirPath = createEmptyTempDir("watch_file_detached_");
+        Constructor<WatchFileCenter.WatchDirJob> ctor =
+            WatchFileCenter.WatchDirJob.class.getDeclaredConstructor(String.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(dirPath);
+    }
+
+    private static void shutdownDetachedJob(WatchFileCenter.WatchDirJob job) {
+        try {
+            ExecutorService exec = (ExecutorService) ReflectionTestUtils.getField(job,
+                "callBackExecutor");
+            if (exec != null && !exec.isShutdown()) {
+                exec.shutdownNow();
+            }
+        } catch (Throwable ignore) {
+            // best-effort cleanup
+        }
+        Object pathField = ReflectionTestUtils.getField(job, "paths");
+        if (pathField instanceof String) {
+            try {
+                DiskUtils.deleteDirectory((String) pathField);
+            } catch (IOException ignore) {
+                // best-effort cleanup
+            }
+        }
+    }
+
+    private static String createEmptyTempDir(String prefix) throws Exception {
+        String dirPath = Paths.get(System.getProperty("java.io.tmpdir"),
+            prefix + System.nanoTime()).toString();
+        DiskUtils.deleteDirThenMkdir(dirPath);
+        return dirPath;
+    }
+
     private void func(final String fileName, final File file, final Consumer<String> consumer)
         throws Exception {
         CountDownLatch latch = new CountDownLatch(100);

--- a/sys/src/test/java/com/alibaba/nacos/sys/module/mock/IgnoreMockModuleStateBuilder.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/module/mock/IgnoreMockModuleStateBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.sys.module.mock;
+
+import com.alibaba.nacos.sys.module.ModuleState;
+import com.alibaba.nacos.sys.module.ModuleStateBuilder;
+
+public class IgnoreMockModuleStateBuilder implements ModuleStateBuilder {
+
+    @Override
+    public ModuleState build() {
+        return new ModuleState("ignored-mock");
+    }
+
+    @Override
+    public boolean isIgnore() {
+        return true;
+    }
+}

--- a/sys/src/test/java/com/alibaba/nacos/sys/module/mock/IgnoreMockModuleStateBuilder.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/module/mock/IgnoreMockModuleStateBuilder.java
@@ -20,12 +20,12 @@ import com.alibaba.nacos.sys.module.ModuleState;
 import com.alibaba.nacos.sys.module.ModuleStateBuilder;
 
 public class IgnoreMockModuleStateBuilder implements ModuleStateBuilder {
-
+    
     @Override
     public ModuleState build() {
         return new ModuleState("ignored-mock");
     }
-
+    
     @Override
     public boolean isIgnore() {
         return true;

--- a/sys/src/test/java/com/alibaba/nacos/sys/module/mock/NonMatchDeploymentMockModuleStateBuilder.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/module/mock/NonMatchDeploymentMockModuleStateBuilder.java
@@ -21,12 +21,12 @@ import com.alibaba.nacos.sys.module.ModuleState;
 import com.alibaba.nacos.sys.module.ModuleStateBuilder;
 
 public class NonMatchDeploymentMockModuleStateBuilder implements ModuleStateBuilder {
-
+    
     @Override
     public ModuleState build() {
         return new ModuleState("non-match-deployment-mock");
     }
-
+    
     @Override
     public boolean isMatchDeployment(DeploymentType type) {
         return false;

--- a/sys/src/test/java/com/alibaba/nacos/sys/module/mock/NonMatchDeploymentMockModuleStateBuilder.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/module/mock/NonMatchDeploymentMockModuleStateBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.sys.module.mock;
+
+import com.alibaba.nacos.sys.env.DeploymentType;
+import com.alibaba.nacos.sys.module.ModuleState;
+import com.alibaba.nacos.sys.module.ModuleStateBuilder;
+
+public class NonMatchDeploymentMockModuleStateBuilder implements ModuleStateBuilder {
+
+    @Override
+    public ModuleState build() {
+        return new ModuleState("non-match-deployment-mock");
+    }
+
+    @Override
+    public boolean isMatchDeployment(DeploymentType type) {
+        return false;
+    }
+}

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/DiskUtilsTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/DiskUtilsTest.java
@@ -537,32 +537,32 @@ class DiskUtilsTest {
         Files.write(f.toPath(), second.getBytes(StandardCharsets.UTF_8));
         assertEquals(second, DiskUtils.readFile(f));
     }
-
+    
     @Test
     void testConstructor() {
         new DiskUtils();
     }
-
+    
     @Test
     void testWriteFileWithNoSpaceCnTriggersExit() throws Exception {
         verifyDiskFullExit("设备上没有空间");
     }
-
+    
     @Test
     void testWriteFileWithNoSpaceEnTriggersExit() throws Exception {
         verifyDiskFullExit("No space left on device");
     }
-
+    
     @Test
     void testWriteFileWithDiskQuotaCnTriggersExit() throws Exception {
         verifyDiskFullExit("xx超出磁盘限额xx");
     }
-
+    
     @Test
     void testWriteFileWithDiskQuotaEnTriggersExit() throws Exception {
         verifyDiskFullExit("xx Disk quota exceeded xx");
     }
-
+    
     @Test
     void testWriteFileWithIoExceptionWithoutMessage() throws Exception {
         File targetFile = DiskUtils.createTmpFile(UUID.randomUUID().toString(), ".ut");
@@ -573,10 +573,10 @@ class DiskUtilsTest {
                 when(mock.getChannel()).thenReturn(channel);
                 when(channel.write(any(ByteBuffer.class))).thenThrow(new IOException());
             })) {
-            assertFalse(DiskUtils.writeFile(targetFile, new byte[]{1}, false));
+            assertFalse(DiskUtils.writeFile(targetFile, new byte[] {1}, false));
         }
     }
-
+    
     private void verifyDiskFullExit(String ioMessage) throws Exception {
         File targetFile = DiskUtils.createTmpFile(UUID.randomUUID().toString(), ".ut");
         targetFile.deleteOnExit();
@@ -590,11 +590,11 @@ class DiskUtilsTest {
             });
             MockedStatic<Runtime> runtimeMocked = Mockito.mockStatic(Runtime.class)) {
             runtimeMocked.when(Runtime::getRuntime).thenReturn(runtimeMock);
-            assertFalse(DiskUtils.writeFile(targetFile, new byte[]{1}, false));
+            assertFalse(DiskUtils.writeFile(targetFile, new byte[] {1}, false));
             verify(runtimeMock).exit(0);
         }
     }
-
+    
     @Test
     void testOpenFileRethrowsIoExceptionAsRuntimeException() {
         try (MockedConstruction<File> ignored =
@@ -607,7 +607,7 @@ class DiskUtilsTest {
                 () -> DiskUtils.openFile("nacos-tmp", "openFile-ioexception"));
         }
     }
-
+    
     @Test
     void testDecompressSkipsIllegalEntryName() throws IOException {
         File zipFile = Files.createTempFile("nacos-sys-illegal-zip", ".zip").toFile();
@@ -628,7 +628,7 @@ class DiskUtilsTest {
         assertFalse(new File(outDir.getParentFile(), "illegal.txt").exists());
         assertTrue(new File(outDir, "safe.txt").exists());
     }
-
+    
     @Test
     void testLineIteratorRemoveDelegatesToTarget() throws Exception {
         org.apache.commons.io.LineIterator targetMock =

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/DiskUtilsTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/DiskUtilsTest.java
@@ -20,19 +20,29 @@ import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Constructor;
 import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.Adler32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -40,7 +50,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class DiskUtilsTest {
     
@@ -522,5 +536,109 @@ class DiskUtilsTest {
         assertEquals(first, DiskUtils.readFile(f));
         Files.write(f.toPath(), second.getBytes(StandardCharsets.UTF_8));
         assertEquals(second, DiskUtils.readFile(f));
+    }
+
+    @Test
+    void testConstructor() {
+        new DiskUtils();
+    }
+
+    @Test
+    void testWriteFileWithNoSpaceCnTriggersExit() throws Exception {
+        verifyDiskFullExit("设备上没有空间");
+    }
+
+    @Test
+    void testWriteFileWithNoSpaceEnTriggersExit() throws Exception {
+        verifyDiskFullExit("No space left on device");
+    }
+
+    @Test
+    void testWriteFileWithDiskQuotaCnTriggersExit() throws Exception {
+        verifyDiskFullExit("xx超出磁盘限额xx");
+    }
+
+    @Test
+    void testWriteFileWithDiskQuotaEnTriggersExit() throws Exception {
+        verifyDiskFullExit("xx Disk quota exceeded xx");
+    }
+
+    @Test
+    void testWriteFileWithIoExceptionWithoutMessage() throws Exception {
+        File targetFile = DiskUtils.createTmpFile(UUID.randomUUID().toString(), ".ut");
+        targetFile.deleteOnExit();
+        try (MockedConstruction<FileOutputStream> ignored =
+            Mockito.mockConstruction(FileOutputStream.class, (mock, ctx) -> {
+                FileChannel channel = mock(FileChannel.class);
+                when(mock.getChannel()).thenReturn(channel);
+                when(channel.write(any(ByteBuffer.class))).thenThrow(new IOException());
+            })) {
+            assertFalse(DiskUtils.writeFile(targetFile, new byte[]{1}, false));
+        }
+    }
+
+    private void verifyDiskFullExit(String ioMessage) throws Exception {
+        File targetFile = DiskUtils.createTmpFile(UUID.randomUUID().toString(), ".ut");
+        targetFile.deleteOnExit();
+        Runtime runtimeMock = mock(Runtime.class);
+        try (MockedConstruction<FileOutputStream> ignored =
+            Mockito.mockConstruction(FileOutputStream.class, (mock, ctx) -> {
+                FileChannel channel = mock(FileChannel.class);
+                when(mock.getChannel()).thenReturn(channel);
+                when(channel.write(any(ByteBuffer.class)))
+                    .thenThrow(new IOException(ioMessage));
+            });
+            MockedStatic<Runtime> runtimeMocked = Mockito.mockStatic(Runtime.class)) {
+            runtimeMocked.when(Runtime::getRuntime).thenReturn(runtimeMock);
+            assertFalse(DiskUtils.writeFile(targetFile, new byte[]{1}, false));
+            verify(runtimeMock).exit(0);
+        }
+    }
+
+    @Test
+    void testOpenFileRethrowsIoExceptionAsRuntimeException() {
+        try (MockedConstruction<File> ignored =
+            Mockito.mockConstruction(File.class, (mock, ctx) -> {
+                when(mock.exists()).thenReturn(false);
+                when(mock.mkdirs()).thenReturn(true);
+                when(mock.createNewFile()).thenThrow(new IOException("forced"));
+            })) {
+            assertThrows(RuntimeException.class,
+                () -> DiskUtils.openFile("nacos-tmp", "openFile-ioexception"));
+        }
+    }
+
+    @Test
+    void testDecompressSkipsIllegalEntryName() throws IOException {
+        File zipFile = Files.createTempFile("nacos-sys-illegal-zip", ".zip").toFile();
+        zipFile.deleteOnExit();
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))) {
+            ZipEntry illegal = new ZipEntry("../illegal.txt");
+            zos.putNextEntry(illegal);
+            zos.write("evil".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+            ZipEntry safe = new ZipEntry("safe.txt");
+            zos.putNextEntry(safe);
+            zos.write("ok".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        File outDir = Files.createTempDirectory("nacos-sys-illegal-out").toFile();
+        outDir.deleteOnExit();
+        DiskUtils.decompress(zipFile.getAbsolutePath(), outDir.getAbsolutePath(), new Adler32());
+        assertFalse(new File(outDir.getParentFile(), "illegal.txt").exists());
+        assertTrue(new File(outDir, "safe.txt").exists());
+    }
+
+    @Test
+    void testLineIteratorRemoveDelegatesToTarget() throws Exception {
+        org.apache.commons.io.LineIterator targetMock =
+            mock(org.apache.commons.io.LineIterator.class);
+        doNothing().when(targetMock).remove();
+        Constructor<DiskUtils.LineIterator> ctor = DiskUtils.LineIterator.class
+            .getDeclaredConstructor(org.apache.commons.io.LineIterator.class);
+        ctor.setAccessible(true);
+        DiskUtils.LineIterator iterator = ctor.newInstance(targetMock);
+        iterator.remove();
+        verify(targetMock).remove();
     }
 }

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/InetUtilsTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/InetUtilsTest.java
@@ -16,22 +16,34 @@
 
 package com.alibaba.nacos.sys.utils;
 
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.sys.env.Constants;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.nacos.sys.env.Constants.NACOS_SERVER_IP;
+import static com.alibaba.nacos.sys.env.Constants.PREFER_HOSTNAME_OVER_IP;
+import static com.alibaba.nacos.sys.env.Constants.SYSTEM_PREFER_HOSTNAME_OVER_IP;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -40,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class InetUtilsTest {
@@ -206,14 +219,237 @@ class InetUtilsTest {
         InetUtils.IPChangeEvent event = new InetUtils.IPChangeEvent();
         event.setOldIP("192.168.1.1");
         event.setNewIP("192.168.1.2");
-        
+
         // 测试 getter 方法 (lines 292, 300)
         assertEquals("192.168.1.1", event.getOldIP());
         assertEquals("192.168.1.2", event.getNewIP());
-        
+
         // 测试 toString 方法 (line 309)
         String expected = "IPChangeEvent{oldIP='192.168.1.1', newIP='192.168.1.2'}";
         assertEquals(expected, event.toString());
     }
-    
+
+    @Test
+    void testConstructor() {
+        new InetUtils();
+    }
+
+    @Test
+    void testRefreshIpWithSystemPreferHostnameOverIp() throws Exception {
+        System.clearProperty(NACOS_SERVER_IP);
+        System.setProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP, "true");
+        try {
+            invokeRefreshIp();
+            assertNotNull(InetUtils.getSelfIP());
+        } finally {
+            System.clearProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP);
+            System.setProperty(NACOS_SERVER_IP, "1.1.1.1");
+            ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
+        }
+    }
+
+    @Test
+    void testRefreshIpWithEnvPreferHostnameOverIp() throws Exception {
+        System.clearProperty(NACOS_SERVER_IP);
+        MockEnvironment env = new MockEnvironment();
+        env.setProperty(PREFER_HOSTNAME_OVER_IP, "true");
+        EnvUtil.setEnvironment(env);
+        try {
+            invokeRefreshIp();
+            assertNotNull(InetUtils.getSelfIP());
+        } finally {
+            EnvUtil.setEnvironment(new MockEnvironment());
+            System.setProperty(NACOS_SERVER_IP, "1.1.1.1");
+            ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
+        }
+    }
+
+    @Test
+    void testGetPreferHostnameOverIpWhenHostnameDiffersFromCanonical() throws Exception {
+        System.setProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP, "true");
+        InetAddress address = mock(InetAddress.class);
+        when(address.getHostName()).thenReturn("short-name");
+        when(address.getCanonicalHostName()).thenReturn("short-name.example.com");
+        try (MockedStatic<InetAddress> mocked = Mockito.mockStatic(InetAddress.class)) {
+            mocked.when(InetAddress::getLocalHost).thenReturn(address);
+            String result = invokeGetPreferHostnameOverIp();
+            assertEquals("short-name.example.com", result);
+        } finally {
+            System.clearProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP);
+            ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
+        }
+    }
+
+    @Test
+    void testGetPreferHostnameOverIpWhenHostnameEqualsCanonical() throws Exception {
+        System.setProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP, "true");
+        InetAddress address = mock(InetAddress.class);
+        when(address.getHostName()).thenReturn("same-name");
+        when(address.getCanonicalHostName()).thenReturn("same-name");
+        try (MockedStatic<InetAddress> mocked = Mockito.mockStatic(InetAddress.class)) {
+            mocked.when(InetAddress::getLocalHost).thenReturn(address);
+            String result = invokeGetPreferHostnameOverIp();
+            assertEquals("same-name", result);
+        } finally {
+            System.clearProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP);
+            ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
+        }
+    }
+
+    @Test
+    void testGetPreferHostnameOverIpWhenLookupFails() throws Exception {
+        System.setProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP, "true");
+        try (MockedStatic<InetAddress> mocked = Mockito.mockStatic(InetAddress.class)) {
+            mocked.when(InetAddress::getLocalHost).thenThrow(new UnknownHostException("test"));
+            String result = invokeGetPreferHostnameOverIp();
+            assertNull(result);
+        } finally {
+            System.clearProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP);
+            ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
+        }
+    }
+
+    @Test
+    void testFindFirstNonLoopbackAddressFallbackToLocalHost() throws Exception {
+        InetAddress local = mock(InetAddress.class);
+        when(local.getHostAddress()).thenReturn("127.0.0.42");
+        try (MockedStatic<NetworkInterface> nicMocked = Mockito.mockStatic(NetworkInterface.class);
+            MockedStatic<InetAddress> inetMocked = Mockito.mockStatic(InetAddress.class)) {
+            nicMocked.when(NetworkInterface::getNetworkInterfaces)
+                .thenThrow(new SocketException("forced"));
+            inetMocked.when(InetAddress::getLocalHost).thenReturn(local);
+            InetAddress result = InetUtils.findFirstNonLoopbackAddress();
+            assertEquals(local, result);
+        }
+    }
+
+    @Test
+    void testFindFirstNonLoopbackAddressReturnsNullWhenLocalHostFails() {
+        try (MockedStatic<NetworkInterface> nicMocked = Mockito.mockStatic(NetworkInterface.class);
+            MockedStatic<InetAddress> inetMocked = Mockito.mockStatic(InetAddress.class)) {
+            nicMocked.when(NetworkInterface::getNetworkInterfaces)
+                .thenThrow(new SocketException("forced"));
+            inetMocked.when(InetAddress::getLocalHost)
+                .thenThrow(new UnknownHostException("forced"));
+            assertNull(InetUtils.findFirstNonLoopbackAddress());
+        }
+    }
+
+    private static void invokeRefreshIp() throws Exception {
+        Method refreshIp = InetUtils.class.getDeclaredMethod("refreshIp");
+        refreshIp.setAccessible(true);
+        refreshIp.invoke(null);
+    }
+
+    private static String invokeGetPreferHostnameOverIp() throws Exception {
+        Method method = InetUtils.class.getDeclaredMethod("getPreferHostnameOverIP");
+        method.setAccessible(true);
+        return (String) method.invoke(null);
+    }
+
+    @Test
+    void testRefreshIpWithIpv6Bracketed() throws Exception {
+        boolean original = setPreferIpv6(true);
+        System.setProperty(NACOS_SERVER_IP, "240e:3a1:8170:6c00:8c80:9aff:fe33:5d2c");
+        try {
+            invokeRefreshIp();
+            String selfIp = InetUtils.getSelfIP();
+            assertNotNull(selfIp);
+            assertTrue(selfIp.startsWith(InternetAddressUtil.IPV6_START_MARK));
+            assertTrue(selfIp.endsWith(InternetAddressUtil.IPV6_END_MARK));
+        } finally {
+            setPreferIpv6(original);
+            System.setProperty(NACOS_SERVER_IP, "1.1.1.1");
+            invokeRefreshIp();
+        }
+    }
+
+    @Test
+    void testRefreshIpWithIpv6PercentScopeStripped() throws Exception {
+        boolean original = setPreferIpv6(true);
+        System.setProperty(NACOS_SERVER_IP, "fe80::1%en0");
+        try {
+            invokeRefreshIp();
+            String selfIp = InetUtils.getSelfIP();
+            assertNotNull(selfIp);
+            assertFalse(selfIp.contains(InternetAddressUtil.PERCENT_SIGN_IN_IPV6));
+            assertTrue(selfIp.endsWith(InternetAddressUtil.IPV6_END_MARK));
+        } finally {
+            setPreferIpv6(original);
+            System.setProperty(NACOS_SERVER_IP, "1.1.1.1");
+            invokeRefreshIp();
+        }
+    }
+
+    @Test
+    void testFindFirstNonLoopbackAddressSkipsHigherIndexInterface() throws Exception {
+        Inet4Address inet4 = mock(Inet4Address.class);
+        when(inet4.isLoopbackAddress()).thenReturn(false);
+        when(inet4.getHostAddress()).thenReturn("10.0.0.1");
+
+        NetworkInterface lowIfc = mock(NetworkInterface.class);
+        when(lowIfc.getIndex()).thenReturn(1);
+        when(lowIfc.isUp()).thenReturn(true);
+        when(lowIfc.getDisplayName()).thenReturn("eth0");
+        when(lowIfc.getInetAddresses())
+            .thenReturn(Collections.enumeration(Collections.singletonList(inet4)));
+
+        NetworkInterface highIfc = mock(NetworkInterface.class);
+        when(highIfc.getIndex()).thenReturn(99);
+        when(highIfc.isUp()).thenReturn(true);
+        when(highIfc.getDisplayName()).thenReturn("eth99");
+        // not iterated because isHigher && result != null
+
+        Enumeration<NetworkInterface> enumeration =
+            Collections.enumeration(java.util.Arrays.asList(lowIfc, highIfc));
+        try (MockedStatic<NetworkInterface> nicMocked =
+            Mockito.mockStatic(NetworkInterface.class)) {
+            nicMocked.when(NetworkInterface::getNetworkInterfaces).thenReturn(enumeration);
+            InetAddress result = InetUtils.findFirstNonLoopbackAddress();
+            assertEquals(inet4, result);
+            verify(highIfc, Mockito.never()).getInetAddresses();
+        }
+    }
+
+    @Test
+    void testFindFirstNonLoopbackAddressReturnsIpv6WhenPreferred() throws Exception {
+        boolean original = setPreferIpv6(true);
+        try {
+            Inet6Address inet6 = mock(Inet6Address.class);
+            when(inet6.isLoopbackAddress()).thenReturn(false);
+            when(inet6.getHostAddress()).thenReturn("fe80::1");
+
+            NetworkInterface ifc = mock(NetworkInterface.class);
+            when(ifc.getIndex()).thenReturn(1);
+            when(ifc.isUp()).thenReturn(true);
+            when(ifc.getDisplayName()).thenReturn("eth0");
+            when(ifc.getInetAddresses())
+                .thenReturn(Collections.enumeration(Collections.singletonList(inet6)));
+
+            try (MockedStatic<NetworkInterface> nicMocked =
+                Mockito.mockStatic(NetworkInterface.class)) {
+                nicMocked.when(NetworkInterface::getNetworkInterfaces)
+                    .thenReturn(Collections.enumeration(Collections.singletonList(ifc)));
+                InetAddress result = InetUtils.findFirstNonLoopbackAddress();
+                assertEquals(inet6, result);
+            }
+        } finally {
+            setPreferIpv6(original);
+        }
+    }
+
+    private static boolean setPreferIpv6(boolean value) throws Exception {
+        Field theUnsafeField = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe");
+        theUnsafeField.setAccessible(true);
+        Object unsafe = theUnsafeField.get(null);
+        Class<?> unsafeClass = unsafe.getClass();
+        Field field = InternetAddressUtil.class.getDeclaredField("PREFER_IPV6_ADDRESSES");
+        Object base = unsafeClass.getMethod("staticFieldBase", Field.class).invoke(unsafe, field);
+        long offset =
+            (long) unsafeClass.getMethod("staticFieldOffset", Field.class).invoke(unsafe, field);
+        boolean original = field.getBoolean(null);
+        unsafeClass.getMethod("putBoolean", Object.class, long.class, boolean.class)
+            .invoke(unsafe, base, offset, value);
+        return original;
+    }
 }

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/InetUtilsTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/InetUtilsTest.java
@@ -219,21 +219,21 @@ class InetUtilsTest {
         InetUtils.IPChangeEvent event = new InetUtils.IPChangeEvent();
         event.setOldIP("192.168.1.1");
         event.setNewIP("192.168.1.2");
-
+        
         // 测试 getter 方法 (lines 292, 300)
         assertEquals("192.168.1.1", event.getOldIP());
         assertEquals("192.168.1.2", event.getNewIP());
-
+        
         // 测试 toString 方法 (line 309)
         String expected = "IPChangeEvent{oldIP='192.168.1.1', newIP='192.168.1.2'}";
         assertEquals(expected, event.toString());
     }
-
+    
     @Test
     void testConstructor() {
         new InetUtils();
     }
-
+    
     @Test
     void testRefreshIpWithSystemPreferHostnameOverIp() throws Exception {
         System.clearProperty(NACOS_SERVER_IP);
@@ -247,7 +247,7 @@ class InetUtilsTest {
             ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
         }
     }
-
+    
     @Test
     void testRefreshIpWithEnvPreferHostnameOverIp() throws Exception {
         System.clearProperty(NACOS_SERVER_IP);
@@ -263,7 +263,7 @@ class InetUtilsTest {
             ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
         }
     }
-
+    
     @Test
     void testGetPreferHostnameOverIpWhenHostnameDiffersFromCanonical() throws Exception {
         System.setProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP, "true");
@@ -279,7 +279,7 @@ class InetUtilsTest {
             ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
         }
     }
-
+    
     @Test
     void testGetPreferHostnameOverIpWhenHostnameEqualsCanonical() throws Exception {
         System.setProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP, "true");
@@ -295,7 +295,7 @@ class InetUtilsTest {
             ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
         }
     }
-
+    
     @Test
     void testGetPreferHostnameOverIpWhenLookupFails() throws Exception {
         System.setProperty(SYSTEM_PREFER_HOSTNAME_OVER_IP, "true");
@@ -308,7 +308,7 @@ class InetUtilsTest {
             ReflectionTestUtils.setField(InetUtils.class, "preferHostnameOverIP", false);
         }
     }
-
+    
     @Test
     void testFindFirstNonLoopbackAddressFallbackToLocalHost() throws Exception {
         InetAddress local = mock(InetAddress.class);
@@ -322,7 +322,7 @@ class InetUtilsTest {
             assertEquals(local, result);
         }
     }
-
+    
     @Test
     void testFindFirstNonLoopbackAddressReturnsNullWhenLocalHostFails() {
         try (MockedStatic<NetworkInterface> nicMocked = Mockito.mockStatic(NetworkInterface.class);
@@ -334,19 +334,19 @@ class InetUtilsTest {
             assertNull(InetUtils.findFirstNonLoopbackAddress());
         }
     }
-
+    
     private static void invokeRefreshIp() throws Exception {
         Method refreshIp = InetUtils.class.getDeclaredMethod("refreshIp");
         refreshIp.setAccessible(true);
         refreshIp.invoke(null);
     }
-
+    
     private static String invokeGetPreferHostnameOverIp() throws Exception {
         Method method = InetUtils.class.getDeclaredMethod("getPreferHostnameOverIP");
         method.setAccessible(true);
         return (String) method.invoke(null);
     }
-
+    
     @Test
     void testRefreshIpWithIpv6Bracketed() throws Exception {
         boolean original = setPreferIpv6(true);
@@ -363,7 +363,7 @@ class InetUtilsTest {
             invokeRefreshIp();
         }
     }
-
+    
     @Test
     void testRefreshIpWithIpv6PercentScopeStripped() throws Exception {
         boolean original = setPreferIpv6(true);
@@ -380,26 +380,26 @@ class InetUtilsTest {
             invokeRefreshIp();
         }
     }
-
+    
     @Test
     void testFindFirstNonLoopbackAddressSkipsHigherIndexInterface() throws Exception {
         Inet4Address inet4 = mock(Inet4Address.class);
         when(inet4.isLoopbackAddress()).thenReturn(false);
         when(inet4.getHostAddress()).thenReturn("10.0.0.1");
-
+        
         NetworkInterface lowIfc = mock(NetworkInterface.class);
         when(lowIfc.getIndex()).thenReturn(1);
         when(lowIfc.isUp()).thenReturn(true);
         when(lowIfc.getDisplayName()).thenReturn("eth0");
         when(lowIfc.getInetAddresses())
             .thenReturn(Collections.enumeration(Collections.singletonList(inet4)));
-
+        
         NetworkInterface highIfc = mock(NetworkInterface.class);
         when(highIfc.getIndex()).thenReturn(99);
         when(highIfc.isUp()).thenReturn(true);
         when(highIfc.getDisplayName()).thenReturn("eth99");
         // not iterated because isHigher && result != null
-
+        
         Enumeration<NetworkInterface> enumeration =
             Collections.enumeration(java.util.Arrays.asList(lowIfc, highIfc));
         try (MockedStatic<NetworkInterface> nicMocked =
@@ -410,7 +410,7 @@ class InetUtilsTest {
             verify(highIfc, Mockito.never()).getInetAddresses();
         }
     }
-
+    
     @Test
     void testFindFirstNonLoopbackAddressReturnsIpv6WhenPreferred() throws Exception {
         boolean original = setPreferIpv6(true);
@@ -418,14 +418,14 @@ class InetUtilsTest {
             Inet6Address inet6 = mock(Inet6Address.class);
             when(inet6.isLoopbackAddress()).thenReturn(false);
             when(inet6.getHostAddress()).thenReturn("fe80::1");
-
+            
             NetworkInterface ifc = mock(NetworkInterface.class);
             when(ifc.getIndex()).thenReturn(1);
             when(ifc.isUp()).thenReturn(true);
             when(ifc.getDisplayName()).thenReturn("eth0");
             when(ifc.getInetAddresses())
                 .thenReturn(Collections.enumeration(Collections.singletonList(inet6)));
-
+            
             try (MockedStatic<NetworkInterface> nicMocked =
                 Mockito.mockStatic(NetworkInterface.class)) {
                 nicMocked.when(NetworkInterface::getNetworkInterfaces)
@@ -437,7 +437,7 @@ class InetUtilsTest {
             setPreferIpv6(original);
         }
     }
-
+    
     private static boolean setPreferIpv6(boolean value) throws Exception {
         Field theUnsafeField = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe");
         theUnsafeField.setAccessible(true);

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/PropertiesUtilTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/PropertiesUtilTest.java
@@ -70,14 +70,14 @@ class PropertiesUtilTest {
         Map properties = PropertiesUtil.handleSpringBinder(environment, "nacos.prefix", Map.class);
         assertEquals(3, properties.size());
     }
-
+    
     @Test
     void testHandleSpringBinderWithDotEndingPrefix() {
         Map properties =
             PropertiesUtil.handleSpringBinder(environment, "nacos.prefix.", Map.class);
         assertEquals(3, properties.size());
     }
-
+    
     @Test
     void testConstructor() {
         new PropertiesUtil();

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/PropertiesUtilTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/PropertiesUtilTest.java
@@ -70,4 +70,16 @@ class PropertiesUtilTest {
         Map properties = PropertiesUtil.handleSpringBinder(environment, "nacos.prefix", Map.class);
         assertEquals(3, properties.size());
     }
+
+    @Test
+    void testHandleSpringBinderWithDotEndingPrefix() {
+        Map properties =
+            PropertiesUtil.handleSpringBinder(environment, "nacos.prefix.", Map.class);
+        assertEquals(3, properties.size());
+    }
+
+    @Test
+    void testConstructor() {
+        new PropertiesUtil();
+    }
 }

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/TimerContextTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/TimerContextTest.java
@@ -126,4 +126,9 @@ class TimerContextTest {
         verify(consumer).accept(o);
         verify(logger).debug(anyString(), any(Object[].class));
     }
+
+    @Test
+    void testConstructor() {
+        new TimerContext();
+    }
 }

--- a/sys/src/test/java/com/alibaba/nacos/sys/utils/TimerContextTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/utils/TimerContextTest.java
@@ -126,7 +126,7 @@ class TimerContextTest {
         verify(consumer).accept(o);
         verify(logger).debug(anyString(), any(Object[].class));
     }
-
+    
     @Test
     void testConstructor() {
         new TimerContext();

--- a/sys/src/test/resources/META-INF/services/com.alibaba.nacos.sys.module.ModuleStateBuilder
+++ b/sys/src/test/resources/META-INF/services/com.alibaba.nacos.sys.module.ModuleStateBuilder
@@ -17,3 +17,5 @@
 com.alibaba.nacos.sys.module.mock.MockModuleStateBuilder
 com.alibaba.nacos.sys.module.mock.ExceptionMockModuleStateBuilder
 com.alibaba.nacos.sys.module.mock.MockRebuildModuleStateBuilder
+com.alibaba.nacos.sys.module.mock.IgnoreMockModuleStateBuilder
+com.alibaba.nacos.sys.module.mock.NonMatchDeploymentMockModuleStateBuilder


### PR DESCRIPTION
## Summary

- Adds 38 unit tests covering previously-untested branches in `DiskUtils`, `EnvUtil`, `InetUtils`, `PropertiesUtil`, `TimerContext`, `ModuleStateHolder`, and `WatchFileCenter`
- Lifts `sys` module line coverage from ~91.4% to **99.59%** (973/977 lines)
- All 254 tests pass; 0 Checkstyle violations

## Coverage by package

| Package | Before | After |
|---|---|---|
| `module` | 96.8% | **100%** |
| `filter` | 100% | **100%** |
| `env` | 98.6% | 99.7% |
| `utils` | 91.4% | 99.8% |
| `file` | 89.7% | 98.5% |

## Remaining 4 lines (documented as unreachable / impractical)

| Class:Line | Why it isn't covered |
|---|---|
| `DiskUtils.java:224` | Trailing `decoder.flush` loop body. UTF-8 is stateless, so `flush()` never emits residual chars on well-formed input. Effectively defensive dead code. |
| `OperatingSystemBeanManager.java:68` | `static {}` IBM-JDK fallback (`getTotalPhysicalMemory`). HotSpot always exposes `getTotalPhysicalMemorySize`, so the false branch is unreachable on the test platform. |
| `OperatingSystemBeanManager.java:110` | `if (Objects.isNull(OPERATING_SYSTEM_BEAN_CLASS)) return null;` — same root cause; HotSpot always loads `com.sun.management.OperatingSystemMXBean`. |
| `WatchFileCenter.java:192-193` | `catch (Throwable)` around `FILE_SYSTEM.newWatchService()`. Triggering it requires swapping a `static final FileSystem` reference; `sun.misc.Unsafe.putObject` does not reliably take effect on JDK 17 reference fields, and ByteBuddy / agent-based instrumentation is too costly for this single branch. |

## Test plan

- [x] `mvn -pl sys clean test` — 254 tests pass, 0 failures
- [x] `mvn -pl sys checkstyle:check` — 0 violations
- [x] JaCoCo report regenerated and verified at `sys/target/site/jacoco/jacoco.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)