### PR TITLE
[ISSUE #14816] Add Nacos specification documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,25 @@ Every new source file **must** include the Apache License 2.0 header. CI enforce
 
 ## API Standards
 
-Nacos v3 APIs follow strict conventions. AI agents **must** comply with these standards when generating controller code.
+Nacos v3 APIs follow strict conventions. AI agents **must** comply with these
+standards when generating controller code.
+
+Authoritative HTTP API specs live under [`specs/`](./specs/README.md). English:
+
+- [HTTP API Spec](./specs/en/http-api/api-spec.md)
+- [Authorization Spec](./specs/en/http-api/authorization-spec.md)
+- [Response And Error Spec](./specs/en/http-api/response-error-spec.md)
+- [V3 API Surface](./specs/en/http-api/v3-api-surface.md)
+
+Simplified Chinese:
+
+- [HTTP API 规范](./specs/zh-cn/http-api/api-spec.md)
+- [鉴权规范](./specs/zh-cn/http-api/authorization-spec.md)
+- [响应与错误规范](./specs/zh-cn/http-api/response-error-spec.md)
+- [V3 API 范围](./specs/zh-cn/http-api/v3-api-surface.md)
+
+This section is a quick implementation checklist for agents. If it conflicts
+with the specs, follow the specs and update this checklist.
 
 ### URL Path Patterns
 
@@ -114,6 +132,7 @@ Nacos v3 APIs follow strict conventions. AI agents **must** comply with these st
 | **Open API** | `/v3/client/{module}/...` | Client-facing operations | `/v3/client/ns/instance` |
 | **Admin API** | `/v3/admin/{module}/...` | Administrative operations | `/v3/admin/ns/service` |
 | **Console API** | `/v3/console/{module}/...` | Web console operations | `/v3/console/cs/config` |
+| **Auth API** | `/v3/auth/{resource}/...` | Plugin-provided auth operations | `/v3/auth/user` |
 
 ### Module Names
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,12 +108,16 @@ Every new source file **must** include the Apache License 2.0 header. CI enforce
 Nacos v3 APIs follow strict conventions. AI agents **must** comply with these
 standards when generating controller code.
 
-Authoritative HTTP API specs live under [`specs/`](./specs/README.md). English:
+Authoritative API and SDK specs live under [`specs/`](./specs/README.md).
+English:
 
 - [HTTP API Spec](./specs/en/http-api/api-spec.md)
 - [Authorization Spec](./specs/en/http-api/authorization-spec.md)
 - [Response And Error Spec](./specs/en/http-api/response-error-spec.md)
 - [V3 API Surface](./specs/en/http-api/v3-api-surface.md)
+- [gRPC API Spec](./specs/en/grpc-api/api-spec.md)
+- [SDK Spec](./specs/en/sdk/sdk-spec.md)
+- [Java SDK Implementation Spec](./specs/en/sdk/sdk-java-impl-spec.md)
 
 Simplified Chinese:
 
@@ -121,6 +125,9 @@ Simplified Chinese:
 - [鉴权规范](./specs/zh-cn/http-api/authorization-spec.md)
 - [响应与错误规范](./specs/zh-cn/http-api/response-error-spec.md)
 - [V3 API 范围](./specs/zh-cn/http-api/v3-api-surface.md)
+- [gRPC API 规范](./specs/zh-cn/grpc-api/api-spec.md)
+- [SDK 规范](./specs/zh-cn/sdk/sdk-spec.md)
+- [Java SDK 实现规范](./specs/zh-cn/sdk/sdk-java-impl-spec.md)
 
 This section is a quick implementation checklist for agents. If it conflicts
 with the specs, follow the specs and update this checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Key modules and their roles:
 - **core**: Core server infrastructure (cluster, distributed consensus)
 - **consistency**: JRaft-based CP protocol + custom Distro AP protocol
 - **auth**: Authentication and authorization
-- **plugin / plugin-default-impl**: Extensible plugin system (Java SPI). Types: auth, encryption, datasource, control, trace, config, environment
+- **plugin / plugin-default-impl**: Extensible plugin system (Java SPI). Types: auth, visibility, datasource dialect, config change, encryption, trace, environment, control, AI pipeline, AI storage
 - **console / console-ui**: Web UI backend (Spring Boot) and frontend (React)
 - **ai / copilot / ai-registry-adaptor**: AI Agent support, Copilot integration, and AI registry adaptor
 - **sys**: System environment utilities and JVM parameter management
@@ -113,6 +113,11 @@ English:
 
 - [Nacos Design Spec](./specs/en/design/nacos-design-spec.md)
 - [Resource Model Spec](./specs/en/design/resource-model-spec.md)
+- [Plugin Spec](./specs/en/plugin/plugin-spec.md)
+- [Auth And Permission Spec](./specs/en/auth/auth-permission-spec.md)
+- [Auth Plugin Spec](./specs/en/auth/auth-plugin-spec.md)
+- [Visibility Plugin Spec](./specs/en/auth/visibility-plugin-spec.md)
+- [Default Auth Plugin Implementation Spec](./specs/en/auth/default-auth-plugin-spec.md)
 - [HTTP API Spec](./specs/en/http-api/api-spec.md)
 - [Authorization Spec](./specs/en/http-api/authorization-spec.md)
 - [Response And Error Spec](./specs/en/http-api/response-error-spec.md)
@@ -125,6 +130,11 @@ Simplified Chinese:
 
 - [Nacos 设计规范](./specs/zh-cn/design/nacos-design-spec.md)
 - [资源模型规范](./specs/zh-cn/design/resource-model-spec.md)
+- [插件化规范](./specs/zh-cn/plugin/plugin-spec.md)
+- [鉴权与权限规范](./specs/zh-cn/auth/auth-permission-spec.md)
+- [鉴权插件规范](./specs/zh-cn/auth/auth-plugin-spec.md)
+- [可见性插件规范](./specs/zh-cn/auth/visibility-plugin-spec.md)
+- [默认鉴权插件实现规范](./specs/zh-cn/auth/default-auth-plugin-spec.md)
 - [HTTP API 规范](./specs/zh-cn/http-api/api-spec.md)
 - [鉴权规范](./specs/zh-cn/http-api/authorization-spec.md)
 - [响应与错误规范](./specs/zh-cn/http-api/response-error-spec.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,8 @@ standards when generating controller code.
 Authoritative API and SDK specs live under [`specs/`](./specs/README.md).
 English:
 
+- [Nacos Design Spec](./specs/en/design/nacos-design-spec.md)
+- [Resource Model Spec](./specs/en/design/resource-model-spec.md)
 - [HTTP API Spec](./specs/en/http-api/api-spec.md)
 - [Authorization Spec](./specs/en/http-api/authorization-spec.md)
 - [Response And Error Spec](./specs/en/http-api/response-error-spec.md)
@@ -121,6 +123,8 @@ English:
 
 Simplified Chinese:
 
+- [Nacos 设计规范](./specs/zh-cn/design/nacos-design-spec.md)
+- [资源模型规范](./specs/zh-cn/design/resource-model-spec.md)
 - [HTTP API 规范](./specs/zh-cn/http-api/api-spec.md)
 - [鉴权规范](./specs/zh-cn/http-api/authorization-spec.md)
 - [响应与错误规范](./specs/zh-cn/http-api/response-error-spec.md)

--- a/specs/README.md
+++ b/specs/README.md
@@ -21,6 +21,24 @@ the source for implementation, tests, and user-facing documentation alignment.
 
 本目录包含 Nacos 行为的设计级规范说明。规范用于对齐实现、测试和面向用户的文档。
 
+Spec hierarchy:
+
+```text
+Nacos design
+  -> Resource model
+  -> Domain specs
+  -> HTTP / gRPC / SDK interface specs
+```
+
+规范层次：
+
+```text
+Nacos 顶层设计
+  -> 资源模型
+  -> 领域规范
+  -> HTTP / gRPC / SDK 接口规范
+```
+
 Available languages:
 
 - [English](en/README.md)

--- a/specs/README.md
+++ b/specs/README.md
@@ -26,6 +26,7 @@ Spec hierarchy:
 ```text
 Nacos design
   -> Resource model
+  -> Plugin model
   -> Domain specs
   -> HTTP / gRPC / SDK interface specs
 ```
@@ -35,6 +36,7 @@ Nacos design
 ```text
 Nacos 顶层设计
   -> 资源模型
+  -> 插件化模型
   -> 领域规范
   -> HTTP / gRPC / SDK 接口规范
 ```

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,27 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos Specs
+
+This directory contains design-level specifications for Nacos behavior. Specs are
+the source for implementation, tests, and user-facing documentation alignment.
+
+本目录包含 Nacos 行为的设计级规范说明。规范用于对齐实现、测试和面向用户的文档。
+
+Available languages:
+
+- [English](en/README.md)
+- [简体中文](zh-cn/README.md)

--- a/specs/en/README.md
+++ b/specs/en/README.md
@@ -1,0 +1,25 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos Specs
+
+Current specs:
+
+- [HTTP API Spec](http-api/api-spec.md)
+
+Agent guidance files such as [AGENTS.md](../../AGENTS.md) should summarize these
+specs for local execution. The specs remain the rule source when API guidance is
+used by humans, AI agents, templates, or validation tools.

--- a/specs/en/README.md
+++ b/specs/en/README.md
@@ -18,6 +18,8 @@
 
 Current specs:
 
+- [Nacos Design Spec](design/nacos-design-spec.md)
+- [Resource Model Spec](design/resource-model-spec.md)
 - [HTTP API Spec](http-api/api-spec.md)
 - [gRPC API Spec](grpc-api/api-spec.md)
 - [SDK Spec](sdk/sdk-spec.md)

--- a/specs/en/README.md
+++ b/specs/en/README.md
@@ -19,6 +19,9 @@
 Current specs:
 
 - [HTTP API Spec](http-api/api-spec.md)
+- [gRPC API Spec](grpc-api/api-spec.md)
+- [SDK Spec](sdk/sdk-spec.md)
+- [Java SDK Implementation Spec](sdk/sdk-java-impl-spec.md)
 
 Agent guidance files such as [AGENTS.md](../../AGENTS.md) should summarize these
 specs for local execution. The specs remain the rule source when API guidance is

--- a/specs/en/README.md
+++ b/specs/en/README.md
@@ -20,6 +20,11 @@ Current specs:
 
 - [Nacos Design Spec](design/nacos-design-spec.md)
 - [Resource Model Spec](design/resource-model-spec.md)
+- [Plugin Spec](plugin/plugin-spec.md)
+- [Auth And Permission Spec](auth/auth-permission-spec.md)
+- [Auth Plugin Spec](auth/auth-plugin-spec.md)
+- [Visibility Plugin Spec](auth/visibility-plugin-spec.md)
+- [Default Auth Plugin Implementation Spec](auth/default-auth-plugin-spec.md)
 - [HTTP API Spec](http-api/api-spec.md)
 - [gRPC API Spec](grpc-api/api-spec.md)
 - [SDK Spec](sdk/sdk-spec.md)

--- a/specs/en/auth/auth-permission-spec.md
+++ b/specs/en/auth/auth-permission-spec.md
@@ -1,0 +1,203 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Auth And Permission Spec
+
+## Scope
+
+This document defines the Nacos authentication and permission model shared by
+HTTP APIs, gRPC APIs, plugin APIs, and server-internal calls. Transport-specific
+details are defined by the HTTP and gRPC API specs.
+
+Nacos authorization is modeled as:
+
+```text
+request identity -> authenticated subject -> roles -> permissions -> resource/action
+```
+
+The built-in implementation uses RBAC. Custom auth plugins may connect to other
+identity systems, but they must still evaluate Nacos requests through identity,
+resource, and action semantics.
+
+## Auth Plugin And Visibility Plugin
+
+Nacos separates request-level authorization from data-level visibility.
+
+| Layer | Main question | Typical SPI | Scope |
+|-------|---------------|-------------|-------|
+| Auth plugin | Can this caller invoke this API for the parsed resource/action? | `AuthPluginService` | Request admission and permission decision. |
+| Visibility plugin | Can this caller see or modify this concrete resource, or which resources should a range query return? | `VisibilityService` | Resource instance visibility and query planning. |
+
+The two layers are orthogonal:
+
+- An auth plugin can exist without a visibility plugin.
+- A visibility plugin can exist independently, but each domain must define what
+  happens when no request identity is available.
+- A visibility plugin may reuse the identity produced by the auth plugin and may
+  delegate explicit resource permission checks back to the selected auth plugin.
+- Passing `@Secured` auth does not automatically make every matching data row
+  visible.
+
+For visibility-aware resources, the recommended request flow is:
+
+```text
+@Secured + AuthPlugin -> VisibilityService -> business operation
+```
+
+Single-resource reads may return not found when visibility is denied in order to
+hide resource existence. Writes should return access denied when the caller can
+address the resource but cannot modify it. List and search APIs must apply
+visibility before pagination and total count are produced.
+
+## RBAC Model
+
+The default permission model contains:
+
+| Concept | Meaning |
+|---------|---------|
+| User | Authenticated subject that can log in or call APIs. |
+| Role | Named permission group assigned to users. |
+| Permission | A role's allowed action on a Nacos resource. |
+| Resource | A Nacos object identified by namespace, group or resource type, name, and domain type. |
+| Action | Operation type, currently read or write. |
+
+`ROLE_ADMIN` is the global administrator role. A global administrator bypasses
+normal resource permission checks.
+
+## Core Concepts
+
+### `ApiType`
+
+`ApiType` describes the API audience and the auth scope switch that applies to
+the request.
+
+| Value | Meaning |
+|-------|---------|
+| `OPEN_API` | Client-facing API for application or SDK access. |
+| `ADMIN_API` | Administrative API for maintainers, tools, and gateways. |
+| `CONSOLE_API` | API used by the Nacos web console. |
+| `INNER_API` | Server-internal API, usually protected by server identity. |
+
+### `SignType`
+
+`SignType` identifies the domain used to parse and authorize resources.
+
+| Value | Meaning |
+|-------|---------|
+| `CONFIG` | Configuration resources. |
+| `NAMING` | Naming and service discovery resources. |
+| `AI` | AI registry resources such as MCP, prompts, agents, and tools. |
+| `CONSOLE` | Console management resources such as users, roles, and permissions. |
+| `LOCK` | Lock resources. |
+| `SPECIFIED` | Explicit resource string supplied by the secured endpoint. |
+
+### `ActionTypes`
+
+| Value | Stored value | Semantics |
+|-------|--------------|-----------|
+| `READ` | `r` | Query, list, detail, subscribe, watch, or read-only inspection. |
+| `WRITE` | `w` | Create, update, delete, publish, register, deregister, or state change. |
+
+An implementation may store combined actions such as `rw`, but endpoint
+annotations must use the explicit action that matches the API behavior.
+
+### `@Secured`
+
+`@Secured` is the endpoint-level declaration that binds a controller or request
+handler to the auth model.
+
+| Field | Purpose |
+|-------|---------|
+| `action` | Required action, usually `READ` or `WRITE`. |
+| `resource` | Explicit resource name, mainly for `SPECIFIED` or console resources. |
+| `signType` | Domain used for resource parsing and permission evaluation. |
+| `parser` | Custom resource parser when the default parser is not enough. |
+| `tags` | Additional metadata copied into `Resource.properties`. |
+| `apiType` | API audience and auth scope. |
+
+Every non-public v3 HTTP API and gRPC request handler must declare the intended
+auth metadata. Public endpoints must be explicitly documented by their owning
+spec.
+
+## Authorization Flow
+
+The common auth flow is:
+
+1. Locate the request's `@Secured` metadata.
+2. Build `IdentityContext` from headers, parameters, tokens, certificates, or
+   connector metadata.
+3. Parse the Nacos `Resource` from request parameters or from the explicit
+   resource declared by `@Secured`.
+4. Ask the selected auth plugin whether auth is enabled for the action and
+   domain.
+5. Validate identity.
+6. Validate authority for the `Permission(resource, action)`.
+
+Server-internal requests may also require the configured server identity key and
+value before normal request handling continues.
+
+## Resource Permission Names
+
+Nacos permissions are evaluated against resources derived from the resource
+model:
+
+```text
+NamespaceId -> Group or resourceType -> resourceName
+```
+
+Standard resource forms are:
+
+| Domain | Permission resource form |
+|--------|--------------------------|
+| Config | `{namespaceId}:{group}:config/{dataId}` |
+| Naming | `{namespaceId}:{group}:naming/{serviceName}` |
+| AI | `{namespaceId}:{group}:ai/{resourceName}` plus AI resource metadata. |
+| Console | `console/{managementResource}` |
+| Explicit | The string supplied by `@Secured(resource = ...)`. |
+
+The default auth implementation supports `*` wildcards in permission resources.
+The resource model spec remains authoritative for the meaning of namespace,
+group, resource type, and resource name.
+
+## Auth Scope Switches
+
+Auth enablement is scoped by API audience:
+
+| Configuration | Scope |
+|---------------|-------|
+| `nacos.core.auth.enabled` | Enables auth for Open APIs and the general auth system. |
+| `nacos.core.auth.admin.enabled` | Enables auth for Admin APIs. |
+| `nacos.core.auth.console.enabled` | Enables auth for Console APIs and login behavior. |
+
+The selected auth plugin is named by `nacos.core.auth.system.type`.
+
+## Plugin APIs
+
+Auth-related HTTP APIs under `/v3/auth/*` are plugin-provided APIs. The default
+Nacos auth plugin provides user, role, permission, and login endpoints. These
+endpoints are not Open, Admin, or Console APIs by path, but they must still
+follow the Nacos v3 API response, error, and authorization conventions.
+
+## Public Endpoints
+
+An endpoint may be intentionally unauthenticated only when the owning spec and
+documentation say so. Typical examples are login, one-time administrator
+initialization guarded by server-side state, and health or status endpoints that
+are designed for unauthenticated probes.
+
+When an endpoint is public for compatibility rather than by current design, the
+new documented API should be the primary API and the old endpoint should remain
+only as a compatibility surface.

--- a/specs/en/auth/auth-plugin-spec.md
+++ b/specs/en/auth/auth-plugin-spec.md
@@ -1,0 +1,127 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Auth Plugin Spec
+
+## Scope
+
+The auth plugin category lets Nacos replace the authentication and authorization
+implementation without changing API controllers or resource parsers. The common
+contract is:
+
+```text
+IdentityContext + Resource + Action -> allowed or rejected
+```
+
+The auth plugin does not own Nacos resource modeling. It consumes resources
+created by Nacos controllers, protocol filters, and resource parsers.
+
+## Server SPI
+
+A server auth plugin implements `AuthPluginService`.
+
+| Method | Requirement |
+|--------|-------------|
+| `getAuthServiceName()` | Return the stable plugin name selected by `nacos.core.auth.system.type`. |
+| `identityNames()` | Declare identity fields that may be extracted from requests. |
+| `enableAuth(action, type)` | Decide whether this plugin requires auth for the action and sign type. |
+| `validateIdentity(identityContext, resource)` | Authenticate the caller and enrich identity metadata. |
+| `validateAuthority(identityContext, permission)` | Authorize the caller for the target resource and action. |
+| `isLoginEnabled()` | Declare whether plugin-provided login should be exposed. |
+| `isAdminRequest()` | Declare whether the current request should be treated as administrator bootstrap flow. |
+
+The plugin must throw or return Nacos auth exceptions for rejected identities or
+permissions so that the protocol layer can map them to standard API errors.
+
+## Client SPI
+
+Client-side auth plugins provide request identity material. A client plugin must
+inject only the credentials or tokens required by the selected server plugin and
+must not alter the semantic request payload.
+
+The Java client must support the built-in username/password and token flow. A
+custom client auth plugin may provide access keys, signatures, certificates, or
+external tokens, but it must keep compatibility with the server-side identity
+names declared by the matching auth plugin.
+
+## Selection And State
+
+The selected auth implementation is named by:
+
+```properties
+nacos.core.auth.system.type=nacos
+```
+
+Auth plugins are also registered in the core plugin system with type `auth`.
+Only the selected and enabled auth plugin may handle requests. If a plugin is
+loaded but disabled by plugin state, it must not be used for auth decisions.
+
+## Identity Context
+
+`IdentityContext` is the transport-neutral caller description. It may contain:
+
+- Built-in fields such as remote IP.
+- Headers or parameters such as `Authorization`, `accessToken`, `username`, and
+  `password`.
+- Plugin-defined fields such as access key, signature, tenant claim, or
+  external principal.
+- Auth result metadata such as authenticated username, user id, or global admin
+  marker.
+
+Identity names are part of the plugin contract. Server and client plugin
+implementations must agree on those names.
+
+## Resource And Permission
+
+Auth plugins receive Nacos `Resource` and `Permission` objects. The plugin may
+map those objects to an external permission system, but it must preserve:
+
+- Namespace isolation.
+- Group or resource type semantics.
+- Resource name semantics.
+- `READ` and `WRITE` action semantics.
+- Explicit resources declared with `SignType.SPECIFIED`.
+
+## Plugin APIs
+
+If an auth plugin exposes HTTP APIs, those APIs must:
+
+- Use the `/v3/auth/{resource}` path family.
+- Use `Result<T>` as the response envelope.
+- Use standard Nacos error codes and exception handling.
+- Add `@Secured` to protected management endpoints.
+- Document any intentionally public endpoint, such as login or bootstrap.
+
+The default Nacos auth plugin is the reference implementation for the current
+`/v3/auth/user`, `/v3/auth/role`, and `/v3/auth/permission` surface.
+
+## Relationship With Visibility
+
+Auth answers who the caller is and whether the caller has permission for a
+resource/action pair. Visibility answers which resources should be visible in a
+single-resource operation or range query.
+
+Visibility plugins may delegate explicit permission checks back to the selected
+auth plugin. Auth plugins must therefore keep permission evaluation stable for
+explicit resources as well as domain resources.
+
+## Safety Requirements
+
+The built-in Nacos auth plugin is designed for trusted internal networks and is
+not a complete strong-auth solution for hostile public networks. Deployments
+that require stronger authentication should provide or select an auth plugin
+that matches their security requirements.
+

--- a/specs/en/auth/default-auth-plugin-spec.md
+++ b/specs/en/auth/default-auth-plugin-spec.md
@@ -1,0 +1,177 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Default Auth Plugin Implementation Spec
+
+## Scope
+
+The default auth implementation package provides the `nacos` and `ldap` auth
+plugins. The `nacos` plugin provides username/password login, token
+authentication, RBAC permission management, and the default visibility
+integration used by AI resources.
+
+The default implementation is intended to reduce accidental misuse in trusted
+internal networks. It is not a full strong-auth solution for hostile public
+networks. Public exposure requires an external security boundary or a stronger
+auth plugin.
+
+## Required Configuration
+
+| Configuration | Purpose |
+|---------------|---------|
+| `nacos.core.auth.enabled` | Enable the general auth system and Open API auth. |
+| `nacos.core.auth.admin.enabled` | Enable Admin API auth. |
+| `nacos.core.auth.console.enabled` | Enable Console API auth and default login behavior. |
+| `nacos.core.auth.system.type` | Select the auth plugin, default `nacos`. |
+| `nacos.core.auth.plugin.nacos.token.secret.key` | Secret key used to sign default tokens. Must be configured by deployments. |
+| `nacos.core.auth.plugin.nacos.token.expire.seconds` | Token expiration time. |
+| `nacos.core.auth.plugin.nacos.token.cache.enable` | Enable token parse and validation cache. |
+| `nacos.core.auth.server.identity.key` | Server-to-server identity key. |
+| `nacos.core.auth.server.identity.value` | Server-to-server identity value. |
+| `nacos.core.auth.caching.enabled` | Enable user, role, and permission cache. |
+| `nacos.core.auth.nacos.anonymous.ai.enabled` | Allow anonymous AI access when an endpoint explicitly opts in. |
+
+Token secrets and server identity values must be deployment-specific. A default
+or shared value is unsafe.
+
+The `ldap` plugin variant additionally uses the `nacos.core.auth.ldap.*`
+configuration family. LDAP changes identity authentication only; authorization
+continues to use Nacos roles and permissions.
+
+## Identity
+
+The plugin accepts these identity inputs:
+
+| Input | Usage |
+|-------|-------|
+| `Authorization: Bearer ...` | Token authentication. |
+| `accessToken` | Token authentication through request parameter or header. |
+| `username` and `password` | Login or direct username/password authentication. |
+| Server identity key/value | Server-to-server request identity. |
+
+After successful authentication, the plugin enriches `IdentityContext` with the
+authenticated Nacos user and user id. Global administrator status is derived from
+the user role model.
+
+Anonymous AI access is allowed only when all of these are true:
+
+- The endpoint marks the request as allowing anonymous access.
+- `nacos.core.auth.nacos.anonymous.ai.enabled` is enabled.
+- The default plugin accepts the request as the built-in anonymous identity.
+
+When anonymous AI access is enabled, the implementation initializes the reserved
+anonymous user and role with read permission on `public:*:ai/*`.
+
+## RBAC Storage Model
+
+The default plugin stores:
+
+| Object | Meaning |
+|--------|---------|
+| `User` | Username and password identity. |
+| `RoleInfo` | Role assigned to a username. |
+| `PermissionInfo` | Resource and action assigned to a role. |
+
+`ROLE_ADMIN` is the global administrator role. Users with this role may access
+all resources and console management operations.
+
+## Permission Resource Format
+
+Default resource permissions use:
+
+```text
+{namespaceId}:{group}:{signType}/{resourceName}
+```
+
+Examples:
+
+| Resource | Example |
+|----------|---------|
+| Config data | `public:DEFAULT_GROUP:config/example.properties` |
+| Naming service | `public:DEFAULT_GROUP:naming/com.example.Service` |
+| Console users | `console/users` |
+| Console roles | `console/roles` |
+| Console permissions | `console/permissions` |
+| Visibility permission | `@@visibility/public/mcp/example-mcp` |
+
+Rules:
+
+- `*` may be used as a wildcard in permission resources.
+- If group is empty, the permission check uses `*` for the group segment.
+- If resource name is empty, the resource name segment becomes `*`.
+- A stored resource that starts with `:` is interpreted with the default
+  namespace `public`.
+- `SPECIFIED` resources use the explicit resource string directly.
+- Stored actions may include `r`, `w`, or `rw`.
+
+Non-admin roles must not manage console users, roles, or permissions.
+
+## Default Auth APIs
+
+The default plugin owns these v3 API families:
+
+| Path | Purpose |
+|------|---------|
+| `/v3/auth/user` | User management and password update. |
+| `/v3/auth/user/login` | Login and token issuance. |
+| `/v3/auth/user/admin` | Administrator bootstrap when no global admin exists. |
+| `/v3/auth/role` | Role management. |
+| `/v3/auth/permission` | Permission management. |
+
+Management endpoints must be protected by console-scoped `@Secured` resources
+such as `console/users`, `console/roles`, `console/permissions`, and
+`console/user/password`.
+
+Login is intentionally public. Administrator bootstrap is intentionally exposed
+only for the no-admin initialization state and must be rejected after a global
+administrator exists.
+
+## Default Visibility Implementation
+
+The default visibility implementation is also named `nacos` and is currently
+used by AI resources.
+
+Default behavior:
+
+- New resources default to `PRIVATE` unless the domain supplies another scope.
+- Global administrators can read and write all visibility-aware resources.
+- A resource owner can read and write the resource.
+- `PUBLIC` resources can be read by non-owners.
+- Explicit visibility permission can grant access through the auth plugin.
+- Anonymous AI read access is allowed only through the anonymous AI opt-in path.
+- Denied reads may be reported as not found to hide resource existence.
+- Denied writes are reported as access denied.
+
+Explicit visibility permission resources use:
+
+```text
+@@visibility/{namespaceId}/{resourceType}/{resourceName}
+```
+
+Range queries must combine the base visibility predicate with explicitly
+authorized resources. The current default implementation exposes the structure
+for explicit authorized resources; API and storage integrations must use it as
+that integration is completed.
+
+For AI list and search paths, visibility must be converted into repository query
+conditions before count and page queries run. This keeps `totalCount` aligned
+with the visible resource set and avoids full-load in-memory filtering.
+
+## Compatibility
+
+Legacy or compatibility endpoints may remain for existing clients, but new
+documentation and new development should target the v3 auth API and the plugin
+contracts defined here.

--- a/specs/en/auth/visibility-plugin-spec.md
+++ b/specs/en/auth/visibility-plugin-spec.md
@@ -1,0 +1,155 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Visibility Plugin Spec
+
+## Scope
+
+The visibility plugin category controls whether a resource is visible to a
+caller. It is separate from auth:
+
+- Auth decides identity and permission for a target resource/action.
+- Visibility decides whether the target resource, or a resource in a range
+  query, should be visible to that identity.
+
+Visibility is especially important for AI registry resources, where users may
+create resources that are private to an owner, public to readers, or visible
+through explicit authorization.
+
+Visibility must be applied at data-query time. List and search APIs must not
+page over the raw candidate set and then filter the page in memory, because that
+produces incorrect `totalCount`, empty pages, and unpredictable latency.
+
+## Resource Model
+
+A visibility-aware resource must provide:
+
+| Field | Meaning |
+|-------|---------|
+| `namespaceId` | Namespace that owns the resource. |
+| `resourceType` | Resource category inside the namespace. |
+| `resourceName` | Stable resource name inside the type. |
+| `scope` | Visibility scope, currently `PUBLIC` or `PRIVATE`. |
+| `owner` | Identity that owns the resource. |
+
+This follows the Nacos resource hierarchy:
+
+```text
+NamespaceId -> resourceType -> resourceName
+```
+
+## Visibility SPI
+
+A visibility plugin implements `VisibilityService`.
+
+| Method | Requirement |
+|--------|-------------|
+| `getVisibilityServiceName()` | Return the stable plugin name. |
+| `init(properties)` | Initialize plugin-specific properties. |
+| `resolveDefaultScopeForCreate(identity, apiType, resourceType)` | Decide the default scope when a resource is created without an explicit scope. |
+| `validateVisibility(identity, action, apiType, resource)` | Validate visibility for one resource. |
+| `adviseQuery(identity, action, apiType, queryContext)` | Return query predicates and explicit resources for range queries. |
+
+The plugin is discovered by SPI and registered with plugin type `visibility`.
+The configured visibility service name is selected by:
+
+```properties
+nacos.plugin.visibility.type=nacos
+```
+
+## Actions
+
+Visibility uses the same read/write vocabulary as auth:
+
+| Action | Meaning |
+|--------|---------|
+| `r` | Read or list visible resources. |
+| `w` | Create, update, delete, or change visibility-sensitive resource state. |
+
+Write visibility must be stricter than read visibility. Public read access does
+not imply public write access.
+
+## Query Advisory
+
+Range queries must not load all resources and filter only in memory when the
+storage layer can apply visibility predicates. `QueryAdvisor` carries:
+
+| Field | Purpose |
+|-------|---------|
+| `BaseVisibilityPredicate` | Base predicate such as all resources, public only, owner only, or public plus owner. |
+| `AuthorizedResources` | Explicitly authorized resource names that should be included. |
+
+The API or storage adapter that lists resources must combine both parts without
+leaking private resources.
+
+The default AI integration converts `QueryAdvisor` to repository `QueryCondition`
+before count and page queries run. The base predicate maps as follows:
+
+| Predicate | Query behavior |
+|-----------|----------------|
+| `ALL` | Add no visibility condition. |
+| `PUBLIC` | Restrict to `scope=PUBLIC`, or empty result if the caller requested a conflicting scope. |
+| `OWNER` | Restrict to `owner=identity`, or empty result if identity is absent or conflicts. |
+| `PUBLIC_AND_OWNER` | Restrict to `scope=PUBLIC OR owner=identity`; anonymous callers degrade to public-only. |
+
+If `AuthorizedResources` is populated, it is added as an OR branch with the base
+predicate. The default implementation currently leaves this list empty and keeps
+the field as the extension point for explicit resource grants.
+
+## Plugin State And Configuration
+
+Visibility plugin enablement is controlled by the visibility plugin manager and
+the core plugin state checker. The global visibility plugin switch is:
+
+```properties
+nacos.plugin.visibility.enabled=true
+```
+
+Plugin-specific properties use the prefix:
+
+```properties
+nacos.plugin.visibility.{serviceName}.*
+```
+
+If visibility is disabled, the owning domain must define whether it behaves as
+fully visible or whether it rejects visibility-sensitive operations. The default
+AI visibility implementation treats disabled auth as allowing visibility.
+
+## Relationship With Auth
+
+A visibility plugin may delegate explicit permission checks to the selected auth
+plugin. Explicit visibility permission resources use a domain-owned resource
+string and `SignType.SPECIFIED`; the default implementation uses:
+
+```text
+@@visibility/{namespaceId}/{resourceType}/{resourceName}
+```
+
+This preserves the separation of concerns: visibility decides candidate
+resources, while auth remains the source of permission decisions.
+
+## API Requirements
+
+Any API that returns visibility-aware resources must:
+
+- Validate single-resource read/write operations with `validateVisibility`.
+- Apply `adviseQuery` to list or search operations before returning data.
+- Preserve owner and scope metadata when resources are created or updated.
+- Avoid exposing private resource names through counts, errors, or partial list
+  responses.
+- Return not found for denied single-resource reads when the API needs to hide
+  resource existence.
+- Return access denied for denied writes.

--- a/specs/en/design/nacos-design-spec.md
+++ b/specs/en/design/nacos-design-spec.md
@@ -107,6 +107,19 @@ not an optional add-on:
 
 ## 4. Domain Responsibilities
 
+Nacos domains should be organized around the unified resource hierarchy:
+
+```text
+NamespaceId -> Group/resourceType -> resourceName
+```
+
+`NamespaceId` is the isolation boundary. `Group/resourceType` is the
+second-level classifier: microservice resources use `Group`, while AI Registry
+resources use `resourceType`. `resourceName` is the concrete domain resource
+name. Domain specs may further define governance attributes such as version,
+label, status, and visibility, but they should not break this top-level
+hierarchy.
+
 ### 4.1 Configuration Domain
 
 The configuration domain manages dynamic configuration resources identified by
@@ -124,9 +137,11 @@ service-change push.
 ### 4.3 AI Registry Domain
 
 The AI registry domain manages AI resources such as MCP Server, A2A AgentCard,
-Prompt, Skill, and AgentSpec. It owns AI resource metadata, versions, labels,
-visibility, endpoints, tool or skill descriptors, publish pipeline state,
-download/distribution, and audit-oriented trace information.
+Prompt, Skill, and AgentSpec. AI resources use
+`NamespaceId -> resourceType -> resourceName` as their top-level identity. The
+domain owns AI resource metadata, versions, labels, visibility, endpoints, tool
+or skill descriptors, publish pipeline state, download/distribution, and
+audit-oriented trace information.
 
 AI Registry is not a separate product model inside Nacos. It is a first-class
 Nacos domain that uses the same namespace, API, SDK, auth, plugin, and resource

--- a/specs/en/design/nacos-design-spec.md
+++ b/specs/en/design/nacos-design-spec.md
@@ -1,0 +1,223 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos Design Spec
+
+This document defines the top-level design intent for Nacos. Lower-level specs
+for APIs, SDKs, resources, modules, plugins, and compatibility should follow
+this design intent.
+
+## 1. Positioning
+
+Nacos is a dynamic service discovery, configuration management, service
+management, and AI agent management platform for cloud-native and AI-native
+applications.
+
+Nacos is infrastructure for service-centered application architectures. A
+service may be a microservice, RPC service, DNS-discoverable endpoint, gateway
+backend, MCP Server, A2A Agent, Prompt, Skill, AgentSpec, or another runtime
+resource that needs discovery, dynamic configuration, lifecycle management,
+governance, and secure distribution.
+
+## 2. Design Goals
+
+Nacos should:
+
+- make runtime resources easy to register, discover, configure, govern, and
+  observe;
+- let applications change configuration, routing, discovery, and AI resource
+  selection without redeployment;
+- provide a unified control plane for configuration, naming, service metadata,
+  and AI registry resources;
+- support multi-tenant and multi-environment isolation through namespaces and
+  permission boundaries;
+- remain production-grade for large-scale clusters and high-concurrency
+  workloads;
+- preserve an open ecosystem through standard protocols, SDKs, APIs, and plugin
+  extension points.
+
+## 3. Design Principles
+
+### 3.1 Easy To Use
+
+Nacos should provide simple APIs, SDKs, command-line tools, and console
+workflows for common runtime and management tasks. A user should not need to
+understand internal storage, consensus, or transport details to use Nacos
+correctly.
+
+### 3.2 Standards Oriented
+
+Nacos should align with widely used standards and ecosystem protocols where
+they exist, including cloud-native service discovery, HTTP APIs, gRPC transport,
+MCP, A2A, and Kubernetes/Spring/Dubbo/Spring AI integration patterns.
+
+When Nacos adds a protocol adaptation layer, the Nacos resource model remains
+the internal source of semantic truth and protocol models are adapters over that
+model.
+
+### 3.3 Runtime Dynamic
+
+Nacos resources are expected to change at runtime. Configuration content,
+service instances, endpoints, AI resources, labels, visibility, and metadata may
+change without requiring application redeployment.
+
+Runtime-facing APIs and SDKs should support subscription, push, local cache, and
+safe fallback where the domain requires them.
+
+### 3.4 High Availability
+
+Nacos should support standalone mode for local development and test scenarios,
+and cluster mode for production scenarios. Cluster mode should provide
+availability and horizontal scalability through the appropriate consistency and
+replication mechanisms for each domain.
+
+### 3.5 Extensible
+
+Nacos should keep module boundaries clear and expose plugin extension points for
+cross-cutting concerns such as authentication, visibility, datasource,
+encryption, tracing, control, environment, and AI publish pipelines.
+
+Extensions must not redefine core resource identity, API response semantics, or
+authorization boundaries.
+
+### 3.6 Secure And Governable
+
+Nacos manages sensitive runtime and AI assets. Security is part of the design,
+not an optional add-on:
+
+- authentication and authorization should be enabled and explicit for protected
+  APIs;
+- AI resources should support ownership, visibility, version governance,
+  review, distribution, and auditability;
+- broad read and management APIs belong to admin or maintainer surfaces;
+- runtime client surfaces should expose least-privilege capabilities.
+
+## 4. Domain Responsibilities
+
+### 4.1 Configuration Domain
+
+The configuration domain manages dynamic configuration resources identified by
+namespace, group, and dataId. It owns configuration content, type, md5, metadata,
+listeners, fuzzy watch, gray/beta release, history, rollback, dump, and
+failover-related behavior.
+
+### 4.2 Naming Domain
+
+The naming domain manages service discovery resources identified by namespace,
+group, and service name. It owns service metadata, instances, clusters, health
+status, ephemeral and persistent semantics, subscribers, client views, and
+service-change push.
+
+### 4.3 AI Registry Domain
+
+The AI registry domain manages AI resources such as MCP Server, A2A AgentCard,
+Prompt, Skill, and AgentSpec. It owns AI resource metadata, versions, labels,
+visibility, endpoints, tool or skill descriptors, publish pipeline state,
+download/distribution, and audit-oriented trace information.
+
+AI Registry is not a separate product model inside Nacos. It is a first-class
+Nacos domain that uses the same namespace, API, SDK, auth, plugin, and resource
+governance principles.
+
+### 4.4 Core And Operation Domain
+
+The core domain owns namespace management, cluster members, server state,
+readiness/liveness, connection management, log-level operations, plugin state,
+and other server control-plane resources.
+
+These capabilities are administrative by nature and should be exposed through
+Admin API, Console API, or Maintainer SDK surfaces rather than runtime Client
+SDK surfaces.
+
+### 4.5 Security And Visibility Domain
+
+The security domain owns authentication, authorization, identity propagation,
+API classification, action classification, and visibility enforcement. It
+should apply consistently across HTTP APIs, gRPC calls, SDKs, console actions,
+and plugin-provided APIs.
+
+## 5. Interface Architecture
+
+Nacos exposes the same resource semantics through multiple interface families:
+
+- HTTP APIs for Open, Admin, Console, Auth, and plugin APIs;
+- gRPC APIs for high-frequency runtime communication, push, subscription, and
+  client-server control messages;
+- Client SDKs for runtime applications and agent frameworks;
+- Maintainer SDKs for management, UI, gateway, and operation integrations;
+- console and CLI tools for human and automation workflows.
+
+Interfaces may use different transport models, but they must preserve the same
+resource identity, validation, authorization, lifecycle, and error semantics.
+
+## 6. Module Architecture
+
+Nacos modules should follow these ownership rules:
+
+- `api`, `client`, and `client-basic` define public client models, SDK
+  interfaces, and transport contracts.
+- `config`, `naming`, and `ai` own domain behavior for their resources.
+- `core` owns cluster, namespace, server, plugin, and operation fundamentals.
+- `auth` and plugin modules own extensible security and policy behavior.
+- `maintainer-client` exposes typed Java management entry points over Admin API
+  semantics.
+- `console` exposes UI-oriented backend APIs and should not redefine domain
+  semantics independently.
+
+Shared models should live where their API compatibility requirement is clear.
+Server-only implementation details should not leak into public SDK contracts.
+
+## 7. Consistency And Storage
+
+Each domain should choose consistency and storage behavior according to resource
+semantics:
+
+- configuration resources require durable storage, version/history awareness,
+  and reliable change notification;
+- naming resources require fast runtime updates, health-driven availability,
+  and clear ephemeral/persistent semantics;
+- AI resources require durable metadata, immutable published versions where
+  applicable, label-based routing, visibility, and review/audit metadata;
+- server and cluster resources require explicit administrative control and
+  operational safety.
+
+The implementation may use database persistence, local cache, Distro, Raft, or
+other mechanisms, but public semantics must be expressed in domain specs rather
+than storage implementation details.
+
+## 8. New Feature Design Rules
+
+Every new Nacos feature should define:
+
+- the domain that owns the feature;
+- the resource type and resource identity;
+- whether the feature is runtime-facing, management-facing, or both;
+- the API audience: Open, Admin, Console, Auth, plugin, gRPC, Client SDK, or
+  Maintainer SDK;
+- namespace, group, version, label, status, and visibility behavior if relevant;
+- authentication, authorization, and audit requirements;
+- compatibility and deprecation impact for existing APIs and SDKs;
+- tests or validation rules that keep the spec enforceable.
+
+If a feature cannot answer these questions, it is not ready to become a stable
+Nacos contract.
+
+## 9. Related Specs
+
+- [Resource Model Spec](./resource-model-spec.md)
+- [HTTP API Spec](../http-api/api-spec.md)
+- [gRPC API Spec](../grpc-api/api-spec.md)
+- [SDK Spec](../sdk/sdk-spec.md)

--- a/specs/en/design/resource-model-spec.md
+++ b/specs/en/design/resource-model-spec.md
@@ -1,0 +1,257 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos Resource Model Spec
+
+This document defines the shared resource model for Nacos. It is the semantic
+source for HTTP APIs, gRPC APIs, SDKs, console workflows, persistence models, and
+documentation.
+
+## 1. Resource Envelope
+
+Every Nacos resource should be described by a common envelope:
+
+| Field | Requirement | Meaning |
+| --- | --- | --- |
+| `namespaceId` | Required for tenant-scoped resources | Isolation boundary for tenants, teams, and environments. |
+| `resourceType` | Required when multiple resource kinds share a store or API surface | Domain type such as config, service, mcp, a2a, prompt, skill, or agentspec. |
+| `resourceName` | Required | Stable name that identifies the resource within its scope and type. |
+| `group` | Optional, domain-specific | Secondary grouping used by configuration and naming resources. |
+| `version` | Optional, versioned resources only | Immutable or lifecycle-managed version identifier. |
+| `labels` | Optional, versioned resources only | Named route aliases such as `latest`, `stable`, or custom labels. |
+| `status` | Optional, domain-specific | Resource or version lifecycle state. |
+| `metadata` | Optional | User or system metadata that does not change identity. |
+| `visibility` | Optional, visibility-aware resources | Access scope and owner information. |
+
+The historical Nacos data model is a tuple of namespace, group, and resource
+name. This tuple remains valid for configuration and naming resources. AI
+resources extend the same idea with `resourceType`, `version`, `labels`, and
+visibility governance.
+
+## 2. Namespace
+
+Namespace is the primary isolation boundary. It separates tenants, teams,
+environments, or other administrative scopes.
+
+| Concept | Canonical name | Compatibility names |
+| --- | --- | --- |
+| Namespace id | `namespaceId` or `namespace` | `tenant`, `tenantId` |
+| Display name | `namespaceShowName` | `tenantName` |
+| Description | `namespaceDesc` | `tenantDesc` |
+
+The default namespace id is `public`. Historical code may use `tenant` or
+`tenantId`; new public APIs and specs should use `namespaceId` unless an
+existing compatibility contract requires another name.
+
+Cross-namespace operations are administrative operations and must use Admin API,
+Console API, or Maintainer SDK surfaces.
+
+## 3. Group
+
+Group is a domain-specific secondary scope. It is required for configuration and
+naming identity and defaults to `DEFAULT_GROUP` when omitted by supported
+interfaces.
+
+Group is not a universal Nacos resource field. AI resources should not invent a
+group field unless a domain spec explicitly defines its semantics.
+
+## 4. Resource Identity Rules
+
+| Resource | Canonical identity | Notes |
+| --- | --- | --- |
+| Namespace | `namespaceId` | Root isolation resource. |
+| Config | `namespaceId + group + dataId` | `tenant` is the historical storage/API name for namespace. |
+| Naming service | `namespaceId + group + serviceName` | Internal grouped names may use `group@@serviceName`. |
+| Naming cluster | `namespaceId + group + serviceName + clusterName` | Cluster is subordinate to a service. |
+| Naming instance | `namespaceId + group + serviceName + clusterName + ip + port` | `instanceId` may be generated or provided as a runtime identifier. |
+| Naming client | `clientId` or connection id | Runtime view, not a user-created domain resource. |
+| AI resource | `namespaceId + resourceType + name` | Shared model for Prompt, Skill, AgentSpec, and similar governed resources. |
+| AI resource version | `namespaceId + resourceType + name + version` | Version state is managed separately from resource metadata. |
+| MCP Server | `namespaceId + name` plus optional `id` | `id` may represent registry/import identity; `name` remains the user-facing resource name. |
+| A2A AgentCard | `namespaceId + registrationType + name + version` | Registration type participates in lookup semantics. |
+| Prompt | `namespaceId + promptKey + version` | Legacy Prompt data may be mirrored as config data. |
+| Skill | `namespaceId + name + version` | Labels map route names to versions. |
+| AgentSpec | `namespaceId + name + version` | AgentSpec may reference other AI resources. |
+| Plugin | `pluginType + pluginName` | Plugin state is server-control-plane metadata. |
+
+Resource identity fields must not be treated as mutable metadata. Updating a
+resource identity is a delete-and-create or clone operation unless a domain spec
+defines a migration operation.
+
+## 5. Config Resource
+
+A config resource is identified by `namespaceId + group + dataId`.
+
+Config owns:
+
+- content and md5;
+- config type;
+- description, tags, and app name metadata;
+- publish, CAS publish, delete, and query semantics;
+- listener and fuzzy-watch semantics;
+- gray/beta publication state;
+- history, rollback, dump, and failover data.
+
+`dataId` is the resource name for configuration. Config metadata such as
+`appName`, `type`, `desc`, and `configTags` does not change identity.
+
+Prompt has a legacy compatibility mapping to config storage with fixed group
+`nacos-ai-prompt` and dataId `{promptKey}.json`; this mapping must not make
+Prompt a normal config resource in new specs.
+
+## 6. Naming Resource
+
+A naming service is identified by `namespaceId + group + serviceName`.
+
+Naming owns:
+
+- service metadata and selector information;
+- ephemeral or persistent service semantics;
+- clusters and health-check configuration;
+- instances with `ip`, `port`, `clusterName`, `weight`, `healthy`, `enabled`,
+  `ephemeral`, `metadata`, and optional `instanceId`;
+- subscribers, publishers, and client connection views;
+- service and instance change events.
+
+An instance is subordinate to a service. An instance must not be interpreted
+without its service scope.
+
+Ephemeral and persistent semantics affect lifecycle and consistency behavior.
+They must be preserved across HTTP, gRPC, SDK, and storage models.
+
+## 7. AI Resource
+
+AI resources use a shared governance model:
+
+- resource metadata row: `namespaceId + type + name`;
+- version row: `namespaceId + type + name + version`;
+- labels: name-to-version mappings, including `latest`;
+- meta status: enable or disable;
+- version status: draft, reviewing, reviewed, online, or offline;
+- optional owner and visibility scope: `PUBLIC` or `PRIVATE`;
+- optional publish pipeline state: in progress, approved, or rejected;
+- optional business tags, extension metadata, source, and download count.
+
+Published AI versions should be treated as immutable unless a domain spec
+explicitly defines a safe mutation. Changes should create a new draft version,
+pass review if required, and then publish or relabel.
+
+### 7.1 MCP Server
+
+MCP Server resources describe MCP-capable services. They may be created from
+new MCP servers, imported external MCP servers, or existing HTTP/RPC services
+adapted into MCP services.
+
+MCP Server identity is based on `namespaceId + name`, with optional registry
+`id`. MCP-specific metadata includes protocol, front protocol, repository,
+packages, icons, website URL, local or remote server config, endpoint spec, tool
+spec, status, and discovered capabilities.
+
+Supported protocol values include stdio, SSE-style MCP, streamable HTTP, HTTP,
+and Dubbo-compatible forms as defined by the AI domain.
+
+### 7.2 A2A AgentCard
+
+A2A AgentCard resources describe agent capabilities, skills, supported
+interfaces, provider information, security schemes, signatures, and endpoint
+metadata.
+
+AgentCard lookup is scoped by namespace, registration type, agent name, and
+version. Endpoint registration is subordinate to the owning agent card and may
+be client-owned at runtime.
+
+### 7.3 Prompt
+
+Prompt resources are identified by prompt key and version within a namespace.
+A Prompt contains template content, variables, md5, and version metadata.
+
+Runtime Prompt lookup should resolve by explicit version, then label, then
+`latest` according to the relevant API or SDK contract.
+
+### 7.4 Skill
+
+Skill resources represent reusable AI Agent capabilities. A Skill contains
+metadata, instruction content, optional resources, versions, labels, visibility,
+and publish pipeline metadata.
+
+A Skill version moves through draft/review/publish/offline states. Only online
+versions should be returned to runtime clients unless a management API
+explicitly requests other states.
+
+### 7.5 AgentSpec
+
+AgentSpec resources assemble agent configuration by referencing prompts, skills,
+MCP servers, A2A agents, or other required resources. AgentSpec identity follows
+`namespaceId + name + version` and should use labels for runtime routing.
+
+AgentSpec should reference other resources by stable identity and version or
+label, not by storage implementation details.
+
+## 8. Visibility And Ownership
+
+Resources that support visibility must expose:
+
+- `namespaceId`;
+- stable resource name;
+- resource type;
+- scope, currently `PUBLIC` or `PRIVATE`;
+- owner identity.
+
+Visibility affects discovery, detail viewing, download, and write operations.
+It complements authorization and must not replace permission checks.
+
+## 9. Status And Lifecycle
+
+Status values are domain-specific but must be explicit and documented.
+
+- Config resources use publication, gray/beta, history, and listener state.
+- Naming resources use service, instance, health, enabled, and ephemeral state.
+- AI resources use metadata status, version status, labels, pipeline state, and
+  visibility state.
+- Core resources use server, member, readiness, liveness, plugin, and connection
+  state.
+
+Runtime APIs should return only states intended for runtime consumers.
+Management APIs may return draft, review, offline, internal, or operational
+states when authorized.
+
+## 10. API Representation Rules
+
+All API families must preserve the same resource identity:
+
+- HTTP path and parameter names should use the canonical resource terms from
+  this spec.
+- gRPC request objects should carry the same identity fields even when the
+  transport payload is JSON encoded.
+- Client SDKs should expose runtime-safe resource operations.
+- Maintainer SDKs should expose broad management resource operations.
+- Console APIs may shape data for UI, but must not redefine resource identity.
+
+If a historical API uses a compatibility name, the implementation should map it
+to the canonical resource term internally and document the alias.
+
+## 11. New Resource Checklist
+
+Every new resource type must define:
+
+- owning domain and module;
+- canonical identity fields;
+- namespace and group behavior;
+- version, label, status, and visibility behavior;
+- runtime API, management API, and SDK exposure;
+- authorization and audit requirements;
+- persistence and cache expectations;
+- compatibility aliases, if any.

--- a/specs/en/design/resource-model-spec.md
+++ b/specs/en/design/resource-model-spec.md
@@ -20,30 +20,41 @@ This document defines the shared resource model for Nacos. It is the semantic
 source for HTTP APIs, gRPC APIs, SDKs, console workflows, persistence models, and
 documentation.
 
-## 1. Resource Envelope
+## 1. Top-level Resource Hierarchy
 
-Every Nacos resource should be described by a common envelope:
+Nacos top-level resource identity has three layers:
 
-| Field | Requirement | Meaning |
+```text
+NamespaceId -> Group/resourceType -> resourceName
+```
+
+The layers mean:
+
+| Layer | Meaning | Scope |
 | --- | --- | --- |
-| `namespaceId` | Required for tenant-scoped resources | Isolation boundary for tenants, teams, and environments. |
-| `resourceType` | Required when multiple resource kinds share a store or API surface | Domain type such as config, service, mcp, a2a, prompt, skill, or agentspec. |
-| `resourceName` | Required | Stable name that identifies the resource within its scope and type. |
-| `group` | Optional, domain-specific | Secondary grouping used by configuration and naming resources. |
-| `version` | Optional, versioned resources only | Immutable or lifecycle-managed version identifier. |
-| `labels` | Optional, versioned resources only | Named route aliases such as `latest`, `stable`, or custom labels. |
-| `status` | Optional, domain-specific | Resource or version lifecycle state. |
-| `metadata` | Optional | User or system metadata that does not change identity. |
-| `visibility` | Optional, visibility-aware resources | Access scope and owner information. |
+| `NamespaceId` | Isolation boundary for tenants, teams, environments, or management domains. | All tenant-scoped resources. |
+| `Group/resourceType` | The second-level classifier. Microservice resources use `group`; AI resources use `resourceType`. | Domain-specific. |
+| `resourceName` | Stable name that identifies a concrete resource within the parent scope. | All named resources. |
 
-The historical Nacos data model is a tuple of namespace, group, and resource
-name. This tuple remains valid for configuration and naming resources. AI
-resources extend the same idea with `resourceType`, `version`, `labels`, and
-visibility governance.
+`group` and `resourceType` must not be treated as the same field:
 
-## 2. Namespace
+- `group` is a business grouping for microservice resources, mainly used by
+  configuration and naming resources.
+- `resourceType` is a type classifier for resources that share a governance
+  model, mainly used by AI Registry resources.
 
-Namespace is the primary isolation boundary. It separates tenants, teams,
+Therefore, Nacos has two primary resource-model branches:
+
+- **Microservice resource model**: `NamespaceId -> Group -> resourceName`.
+- **AI resource model**: `NamespaceId -> resourceType -> resourceName`.
+
+Version, labels, status, visibility, owner, and metadata are governance
+attributes of a resource. They are not part of the top-level three-layer
+identity unless a domain spec explicitly says so.
+
+## 2. NamespaceId
+
+NamespaceId is the primary isolation boundary. It separates tenants, teams,
 environments, or other administrative scopes.
 
 | Concept | Canonical name | Compatibility names |
@@ -59,41 +70,70 @@ existing compatibility contract requires another name.
 Cross-namespace operations are administrative operations and must use Admin API,
 Console API, or Maintainer SDK surfaces.
 
-## 3. Group
+## 3. Second Layer: Group Or resourceType
 
-Group is a domain-specific secondary scope. It is required for configuration and
-naming identity and defaults to `DEFAULT_GROUP` when omitted by supported
-interfaces.
+The second layer further classifies resources inside a namespace, but the
+semantics are domain-specific.
 
-Group is not a universal Nacos resource field. AI resources should not invent a
-group field unless a domain spec explicitly defines its semantics.
+### 3.1 Group
 
-## 4. Resource Identity Rules
+Group is the business grouping for microservice resources. It is part of
+configuration and naming identity and defaults to `DEFAULT_GROUP` when omitted
+by supported interfaces.
 
-| Resource | Canonical identity | Notes |
-| --- | --- | --- |
-| Namespace | `namespaceId` | Root isolation resource. |
-| Config | `namespaceId + group + dataId` | `tenant` is the historical storage/API name for namespace. |
-| Naming service | `namespaceId + group + serviceName` | Internal grouped names may use `group@@serviceName`. |
-| Naming cluster | `namespaceId + group + serviceName + clusterName` | Cluster is subordinate to a service. |
-| Naming instance | `namespaceId + group + serviceName + clusterName + ip + port` | `instanceId` may be generated or provided as a runtime identifier. |
-| Naming client | `clientId` or connection id | Runtime view, not a user-created domain resource. |
-| AI resource | `namespaceId + resourceType + name` | Shared model for Prompt, Skill, AgentSpec, and similar governed resources. |
-| AI resource version | `namespaceId + resourceType + name + version` | Version state is managed separately from resource metadata. |
-| MCP Server | `namespaceId + name` plus optional `id` | `id` may represent registry/import identity; `name` remains the user-facing resource name. |
-| A2A AgentCard | `namespaceId + registrationType + name + version` | Registration type participates in lookup semantics. |
-| Prompt | `namespaceId + promptKey + version` | Legacy Prompt data may be mirrored as config data. |
-| Skill | `namespaceId + name + version` | Labels map route names to versions. |
-| AgentSpec | `namespaceId + name + version` | AgentSpec may reference other AI resources. |
-| Plugin | `pluginType + pluginName` | Plugin state is server-control-plane metadata. |
+Group is suitable for business isolation inside the same resource family, such
+as application, business line, environment-local grouping, or user-defined
+grouping. Group does not express resource type, so a config and a service may
+exist under the same group.
 
-Resource identity fields must not be treated as mutable metadata. Updating a
-resource identity is a delete-and-create or clone operation unless a domain spec
-defines a migration operation.
+### 3.2 resourceType
 
-## 5. Config Resource
+resourceType is a type classifier. It is suitable for shared governance models
+that contain multiple resource types, such as AI Registry resource types:
+`mcp`, `a2a`, `prompt`, `skill`, and `agentspec`.
 
-A config resource is identified by `namespaceId + group + dataId`.
+resourceType is not a business grouping. AI resources should not introduce a
+group identity field unless a domain spec explicitly defines additional
+semantics.
+
+## 4. Third Layer: resourceName
+
+resourceName is the stable name of a resource under
+`NamespaceId + Group/resourceType`.
+
+Different domains expose domain-specific names:
+
+| Domain | Concrete resourceName |
+| --- | --- |
+| Config | `dataId` |
+| Naming service | `serviceName` |
+| MCP Server | `name` or `mcpName` |
+| A2A AgentCard | `name` or `agentName` |
+| Prompt | `promptKey` |
+| Skill | `name` |
+| AgentSpec | `name` |
+
+resourceName is an identity field and should not be modified as ordinary
+metadata. Updating a resourceName is a delete-and-create or clone operation
+unless a domain spec defines a migration operation.
+
+## 5. Microservice Resource Model
+
+The microservice resource model uses:
+
+```text
+NamespaceId -> Group -> resourceName
+```
+
+It covers the traditional Nacos configuration and naming capabilities.
+
+### 5.1 Config Resource
+
+Config resource identity is:
+
+```text
+namespaceId -> group -> dataId
+```
 
 Config owns:
 
@@ -105,115 +145,176 @@ Config owns:
 - gray/beta publication state;
 - history, rollback, dump, and failover data.
 
-`dataId` is the resource name for configuration. Config metadata such as
-`appName`, `type`, `desc`, and `configTags` does not change identity.
+`dataId` is the resourceName for Config. Config metadata such as `appName`,
+`type`, `desc`, and `configTags` does not change identity.
 
 Prompt has a legacy compatibility mapping to config storage with fixed group
-`nacos-ai-prompt` and dataId `{promptKey}.json`; this mapping must not make
-Prompt a normal config resource in new specs.
+`nacos-ai-prompt` and dataId `{promptKey}.json`. This mapping is a compatibility
+storage shape and must not make Prompt a normal Config resource in new specs.
 
-## 6. Naming Resource
+### 5.2 Naming Service Resource
 
-A naming service is identified by `namespaceId + group + serviceName`.
+Naming service resource identity is:
 
-Naming owns:
+```text
+namespaceId -> group -> serviceName
+```
+
+Naming service owns:
 
 - service metadata and selector information;
 - ephemeral or persistent service semantics;
 - clusters and health-check configuration;
-- instances with `ip`, `port`, `clusterName`, `weight`, `healthy`, `enabled`,
-  `ephemeral`, `metadata`, and optional `instanceId`;
 - subscribers, publishers, and client connection views;
 - service and instance change events.
 
-An instance is subordinate to a service. An instance must not be interpreted
-without its service scope.
+Internal grouped names may use `group@@serviceName`, but public APIs and specs
+should prefer separate `group` and `serviceName` fields.
+
+### 5.3 Cluster And Instance
+
+Cluster and Instance are subordinate resources of a service. They do not change
+the top-level three-layer model.
+
+```text
+namespaceId -> group -> serviceName -> clusterName -> instance
+```
+
+Instance identity is usually determined by service scope, `clusterName`, `ip`,
+and `port`; `instanceId` may be generated or provided as a runtime identifier.
+
+Instance contains `ip`, `port`, `clusterName`, `weight`, `healthy`, `enabled`,
+`ephemeral`, `metadata`, and optional `instanceId`. An instance must not be
+interpreted without its service scope.
 
 Ephemeral and persistent semantics affect lifecycle and consistency behavior.
 They must be preserved across HTTP, gRPC, SDK, and storage models.
 
-## 7. AI Resource
+## 6. AI Resource Model
 
-AI resources use a shared governance model:
+The AI resource model uses:
 
-- resource metadata row: `namespaceId + type + name`;
-- version row: `namespaceId + type + name + version`;
-- labels: name-to-version mappings, including `latest`;
-- meta status: enable or disable;
-- version status: draft, reviewing, reviewed, online, or offline;
-- optional owner and visibility scope: `PUBLIC` or `PRIVATE`;
-- optional publish pipeline state: in progress, approved, or rejected;
-- optional business tags, extension metadata, source, and download count.
+```text
+NamespaceId -> resourceType -> resourceName
+```
+
+It covers AI Registry resources such as MCP Server, A2A AgentCard, Prompt,
+Skill, and AgentSpec.
+
+AI resources share governance attributes:
+
+| Attribute | Meaning |
+| --- | --- |
+| `version` | Resource version, forming `NamespaceId + resourceType + resourceName + version`. |
+| `labels` | Label-to-version mappings such as `latest` or `stable`. |
+| `status` | Resource or version lifecycle state. |
+| `visibility` | Visibility scope, such as `PUBLIC` or `PRIVATE`. |
+| `owner` | Owner identity. |
+| `bizTags` / `metadata` / `ext` | Business or extension metadata that does not participate in identity. |
+| `pipeline` | Publish review or automation state. |
+
+AI resource metadata identity is `namespaceId + resourceType + resourceName`.
+AI resource version identity is
+`namespaceId + resourceType + resourceName + version`.
 
 Published AI versions should be treated as immutable unless a domain spec
 explicitly defines a safe mutation. Changes should create a new draft version,
 pass review if required, and then publish or relabel.
 
-### 7.1 MCP Server
+### 6.1 MCP Server
 
-MCP Server resources describe MCP-capable services. They may be created from
-new MCP servers, imported external MCP servers, or existing HTTP/RPC services
+MCP Server canonical resource identity is:
+
+```text
+namespaceId -> mcp -> mcpName
+```
+
+MCP Server resources describe MCP-capable services. They may be created from new
+MCP servers, imported external MCP servers, or existing HTTP/RPC services
 adapted into MCP services.
 
-MCP Server identity is based on `namespaceId + name`, with optional registry
-`id`. MCP-specific metadata includes protocol, front protocol, repository,
-packages, icons, website URL, local or remote server config, endpoint spec, tool
-spec, status, and discovered capabilities.
+MCP Server may carry a registry `id`, but `mcpName` remains the user-facing
+resourceName. MCP-specific metadata includes protocol, front protocol,
+repository, packages, icons, website URL, local or remote server config,
+endpoint spec, tool spec, status, and discovered capabilities.
 
-Supported protocol values include stdio, SSE-style MCP, streamable HTTP, HTTP,
-and Dubbo-compatible forms as defined by the AI domain.
+### 6.2 A2A AgentCard
 
-### 7.2 A2A AgentCard
+A2A AgentCard canonical resource identity is:
 
-A2A AgentCard resources describe agent capabilities, skills, supported
-interfaces, provider information, security schemes, signatures, and endpoint
-metadata.
+```text
+namespaceId -> a2a -> agentName
+```
 
-AgentCard lookup is scoped by namespace, registration type, agent name, and
-version. Endpoint registration is subordinate to the owning agent card and may
-be client-owned at runtime.
+AgentCard resources describe agent capabilities, skills, supported interfaces,
+provider information, security schemes, signatures, and endpoint metadata.
 
-### 7.3 Prompt
+`registrationType` participates in AgentCard lookup and compatibility
+semantics, but it is not the top-level second-layer field. Its relation with
+resourceName, version, and endpoint should be defined by a specific A2A domain
+spec.
 
-Prompt resources are identified by prompt key and version within a namespace.
+### 6.3 Prompt
+
+Prompt canonical resource identity is:
+
+```text
+namespaceId -> prompt -> promptKey
+```
+
+Prompt version identity is:
+
+```text
+namespaceId -> prompt -> promptKey -> version
+```
+
 A Prompt contains template content, variables, md5, and version metadata.
-
 Runtime Prompt lookup should resolve by explicit version, then label, then
 `latest` according to the relevant API or SDK contract.
 
-### 7.4 Skill
+### 6.4 Skill
 
-Skill resources represent reusable AI Agent capabilities. A Skill contains
-metadata, instruction content, optional resources, versions, labels, visibility,
-and publish pipeline metadata.
+Skill canonical resource identity is:
 
-A Skill version moves through draft/review/publish/offline states. Only online
-versions should be returned to runtime clients unless a management API
-explicitly requests other states.
+```text
+namespaceId -> skill -> skillName
+```
 
-### 7.5 AgentSpec
+Skill represents reusable AI Agent capability. A Skill contains metadata,
+instruction content, optional resources, versions, labels, visibility, and
+publish pipeline metadata.
 
-AgentSpec resources assemble agent configuration by referencing prompts, skills,
-MCP servers, A2A agents, or other required resources. AgentSpec identity follows
-`namespaceId + name + version` and should use labels for runtime routing.
+A Skill version moves through draft, reviewing, reviewed, online, and offline
+states. Only online versions should be returned to runtime clients unless a
+management API explicitly requests other states.
 
-AgentSpec should reference other resources by stable identity and version or
-label, not by storage implementation details.
+### 6.5 AgentSpec
 
-## 8. Visibility And Ownership
+AgentSpec canonical resource identity is:
+
+```text
+namespaceId -> agentspec -> agentSpecName
+```
+
+AgentSpec assembles agent configuration by referencing prompts, skills, MCP
+servers, A2A agents, or other required resources. AgentSpec should reference
+other resources by stable identity and version or label, not by storage
+implementation details.
+
+## 7. Visibility And Ownership
 
 Resources that support visibility must expose:
 
 - `namespaceId`;
-- stable resource name;
-- resource type;
+- `resourceType`;
+- stable resourceName;
 - scope, currently `PUBLIC` or `PRIVATE`;
 - owner identity.
 
 Visibility affects discovery, detail viewing, download, and write operations.
 It complements authorization and must not replace permission checks.
 
-## 9. Status And Lifecycle
+## 8. Status And Lifecycle
 
 Status values are domain-specific but must be explicit and documented.
 
@@ -228,7 +329,7 @@ Runtime APIs should return only states intended for runtime consumers.
 Management APIs may return draft, review, offline, internal, or operational
 states when authorized.
 
-## 10. API Representation Rules
+## 9. API Representation Rules
 
 All API families must preserve the same resource identity:
 
@@ -243,13 +344,14 @@ All API families must preserve the same resource identity:
 If a historical API uses a compatibility name, the implementation should map it
 to the canonical resource term internally and document the alias.
 
-## 11. New Resource Checklist
+## 10. New Resource Checklist
 
 Every new resource type must define:
 
 - owning domain and module;
 - canonical identity fields;
-- namespace and group behavior;
+- whether the second layer is `Group` or `resourceType`;
+- concrete business name for resourceName;
 - version, label, status, and visibility behavior;
 - runtime API, management API, and SDK exposure;
 - authorization and audit requirements;

--- a/specs/en/grpc-api/api-spec.md
+++ b/specs/en/grpc-api/api-spec.md
@@ -1,0 +1,232 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos gRPC API Spec
+
+This document defines the Nacos gRPC API model used by Java SDKs, Nacos server
+nodes, and remote module handlers. Unlike the HTTP API, Nacos gRPC has a small
+fixed proto surface and a Java payload type surface.
+
+## 1. Design Model
+
+Nacos gRPC is the primary remote protocol for SDK runtime traffic and server
+cluster traffic. The proto file defines only transport-level methods:
+
+| Service | Method | Shape | Purpose |
+| --- | --- | --- | --- |
+| `Request` | `request(Payload) returns (Payload)` | unary | Client or peer sends one request and receives one response. |
+| `BiRequestStream` | `requestBiStream(stream Payload) returns (stream Payload)` | bidirectional stream | Connection setup, server push, and ack responses. |
+
+Business operations are selected by `Payload.metadata.type`, not by separate
+proto RPC methods. The value is the Java simple class name of a registered
+`Request` or `Response` payload type.
+
+### 1.1 Why Payload Uses JSON Objects
+
+Nacos does not model every gRPC business request and response as a dedicated
+protobuf message. Instead, the fixed protobuf `Payload` wraps JSON-serialized
+Java semantic objects.
+
+This is an intentional design choice:
+
+- Nacos HTTP APIs and gRPC APIs can share the same semantic object definitions
+  and validation model instead of maintaining two independent DTO families.
+- During the original RPC selection, gRPC was compared with other RPC protocols
+  and connector styles, including RSocket-like options. The remote layer was
+  designed so a connector could be switched or made compatible without changing
+  every business request object. gRPC later became the practical choice because
+  of ecosystem activity, multi-language support, and operational maturity, but
+  the connector abstraction remained.
+
+The community accepts the trade-off. JSON inside protobuf introduces additional
+serialization and deserialization CPU cost, and it cannot fully use protobuf's
+safer schema model or native multi-language object generation. This cost is part
+of the compatibility and abstraction decision.
+
+## 2. Wire Contract
+
+`Payload` contains:
+
+| Field | Meaning |
+| --- | --- |
+| `metadata.type` | Java simple class name used by `PayloadRegistry`. |
+| `metadata.clientIp` | Client IP set by the sender. Server-side request context uses connection metadata as the trusted source. |
+| `metadata.headers` | Case-insensitive logical request headers copied to `Request.headers`. |
+| `body.value` | JSON bytes of the Java request or response object. |
+
+Payload classes must be registered through
+`META-INF/services/com.alibaba.nacos.api.remote.Payload`; otherwise the receiver
+cannot parse `metadata.type`.
+
+Rules:
+
+- Do not add one proto service method per business operation.
+- Do not use Java package names in `metadata.type`; use the simple class name.
+- Request and response classes must remain JSON-serializable.
+- Request headers are transported through `metadata.headers`, not inside the JSON
+  body.
+- New request classes must define the module through `Request#getModule()`.
+
+## 3. Ports And Connection Sources
+
+Nacos starts two gRPC servers by default:
+
+| Server | Default port | Source label | Caller |
+| --- | --- | --- | --- |
+| SDK gRPC server | `${server.port} + 1000` | `sdk` | SDK clients |
+| Cluster gRPC server | `${server.port} + 1001` | `cluster` | Nacos server nodes |
+
+The Java client may override the port offset with
+`nacos.server.grpc.port.offset`. Server-side SDK and cluster servers use their
+own default offsets.
+
+Some handlers are annotated with `@InvokeSource`. When present, only the listed
+source labels may invoke that payload type.
+
+## 4. Connection Lifecycle
+
+1. A client opens `BiRequestStream.requestBiStream`.
+2. The first stream payload should be `ConnectionSetupRequest`.
+3. Server creates a `Connection` using the connection id, remote address, client
+   version, namespace, labels, and ability table.
+4. If the client sends an ability table, the server replies with
+   `SetupAckRequest` containing server abilities.
+5. The client calls unary `ServerCheckRequest` to verify that the connection is
+   usable. The server replies with `ServerCheckResponse`.
+6. Unary business requests are accepted only after the connection is registered.
+7. Server push requests are sent over the stream and clients answer with response
+   payloads such as `NotifySubscriberResponse`, `ConfigChangeNotifyResponse`, or
+   `PushAckRequest`-related responses.
+
+If the server is starting, the connection is unregistered, the request type is
+unknown, parsing fails, or a handler throws, the server returns `ErrorResponse`.
+
+## 5. Response And Error Contract
+
+All gRPC responses extend `com.alibaba.nacos.api.remote.response.Response`:
+
+| Field | Meaning |
+| --- | --- |
+| `resultCode` | `200` for success, `500` or an error code for failure. |
+| `errorCode` | Nacos error code when failed. |
+| `message` | Error or diagnostic message. |
+| `requestId` | Request correlation id when available. |
+
+`Response#isSuccess()` is true only when `resultCode == 200`.
+
+`ErrorResponse` is used for transport and handler errors. For `NacosException`
+and `NacosRuntimeException`, `errorCode` is copied from the exception. For other
+throwables, `errorCode` falls back to `500`.
+
+## 6. Authorization
+
+gRPC authorization is applied by `RemoteRequestAuthFilter`.
+
+Handlers should annotate `handle(...)` with `@Secured` when the operation needs
+identity, authority, or server identity validation. The filter:
+
+- copies `@Secured.apiType()` into the request context;
+- skips non-inner authorization when auth is disabled;
+- always checks inner API server identity when inner auth is enabled;
+- parses identity and resource from request headers and payload;
+- validates identity and action permission.
+
+Inner cluster APIs should use `ApiType.INNER_API` and restrict invocation with
+`@InvokeSource(source = {RemoteConstants.LABEL_SOURCE_CLUSTER})`.
+
+## 7. Payload Inventory
+
+### 7.1 Common And Core
+
+| Request type | Response type | Direction | Auth/source | Contract |
+| --- | --- | --- | --- | --- |
+| `ConnectionSetupRequest` | `SetupAckRequest` | stream | connection bootstrap | Register a gRPC connection with client version, namespace, labels, and ability table. |
+| `ServerCheckRequest` | `ServerCheckResponse` | unary | registered connection | Verify the selected server connection and return connection id and ability negotiation support. |
+| `HealthCheckRequest` | `HealthCheckResponse` | unary | none | Keep-alive health check. |
+| `ClientDetectionRequest` | `ClientDetectionResponse` | stream push | none | Server-side client detection. |
+| `ConnectResetRequest` | `ConnectResetResponse` | stream push | none | Ask the client to reconnect to a target server. |
+| `ServerReloadRequest` | `ServerReloadResponse` | unary | inner, cluster source | Reload server remote context on a peer. |
+| `ServerLoaderInfoRequest` | `ServerLoaderInfoResponse` | unary | inner, cluster source | Query server loader metrics from a peer. |
+| `MemberReportRequest` | `MemberReportResponse` | unary | inner, cluster source | Report member metadata and update server member state. |
+| `PluginAvailabilityRequest` | `PluginAvailabilityResponse` | unary | handler exists | Query plugin availability on a node. Current code has a handler, but the payload is not listed in the core payload SPI file, so it must be registered before becoming an active gRPC contract. |
+
+### 7.2 Config
+
+| Request type | Response type | Action | Main fields | Contract |
+| --- | --- | --- | --- | --- |
+| `ConfigQueryRequest` | `ConfigQueryResponse` | read | `dataId`, `group`, `tenant`, `tag` | Query config content, md5, type, encrypted key, beta/tag metadata. |
+| `ConfigPublishRequest` | `ConfigPublishResponse` | write | `dataId`, `group`, `tenant`, `content`, `casMd5`, `additionMap` | Publish or CAS-publish config. |
+| `ConfigRemoveRequest` | `ConfigRemoveResponse` | write | `dataId`, `group`, `tenant`, `tag` | Remove config. |
+| `ConfigBatchListenRequest` | `ConfigChangeBatchListenResponse` | read | `listen`, `ConfigListenContext[]` | Add or remove config listeners and return changed configs. |
+| `ConfigChangeNotifyRequest` | `ConfigChangeNotifyResponse` | server push | `dataId`, `group`, `tenant` | Notify client that a config changed. |
+| `ConfigFuzzyWatchRequest` | `ConfigFuzzyWatchResponse` | read | `groupKeyPattern`, `receivedGroupKeys`, `watchType`, `isInitializing` | Add or cancel fuzzy watch for config group keys. |
+| `ConfigFuzzyWatchChangeNotifyRequest` | `ConfigFuzzyWatchChangeNotifyResponse` | server push | `groupKey`, `changeType` | Notify client of fuzzy-watch resource changes. |
+| `ConfigFuzzyWatchSyncRequest` | `ConfigFuzzyWatchSyncResponse` | server push | `syncType`, `groupKeyPattern`, `contexts`, `totalBatch`, `currentBatch` | Sync fuzzy-watch initial or diff state. |
+| `ClientConfigMetricRequest` | `ClientConfigMetricResponse` | read | `metricsKeys` | Query client config metrics. |
+| `ConfigChangeClusterSyncRequest` | `ConfigChangeClusterSyncResponse` | inner | `dataId`, `group`, `tenant`, `lastModified`, `isBeta`, `tag`, `grayName` | Sync config change events between server nodes. |
+
+### 7.3 Naming
+
+| Request type | Response type | Action | Main fields | Contract |
+| --- | --- | --- | --- | --- |
+| `InstanceRequest` | `InstanceResponse` | write | `namespace`, `groupName`, `serviceName`, `type`, `instance` | Register or deregister an ephemeral instance. |
+| `PersistentInstanceRequest` | `InstanceResponse` | write | `namespace`, `groupName`, `serviceName`, `type`, `instance` | Register or deregister a persistent instance. |
+| `BatchInstanceRequest` | `BatchInstanceResponse` | write | `namespace`, `groupName`, `serviceName`, `type`, `instances` | Batch register or deregister instances. |
+| `ServiceQueryRequest` | `QueryServiceResponse` | read | `namespace`, `groupName`, `serviceName`, `cluster`, `healthyOnly`, `udpPort` | Query service instances. |
+| `ServiceListRequest` | `ServiceListResponse` | read | `namespace`, `groupName`, `pageNo`, `pageSize`, `selector` | List service names. |
+| `SubscribeServiceRequest` | `SubscribeServiceResponse` | read | `namespace`, `groupName`, `serviceName`, `clusters`, `subscribe` | Subscribe or unsubscribe a service. |
+| `NotifySubscriberRequest` | `NotifySubscriberResponse` | server push | `namespace`, `groupName`, `serviceName`, `serviceInfo` | Push service info changes to subscribers. |
+| `NamingFuzzyWatchRequest` | `NamingFuzzyWatchResponse` | read | `namespace`, `groupKeyPattern`, `receivedGroupKeys`, `watchType`, `isInitializing` | Add or cancel fuzzy watch for service keys. |
+| `NamingFuzzyWatchChangeNotifyRequest` | `NamingFuzzyWatchChangeNotifyResponse` | server push | `serviceKey`, `changedType` | Notify client of fuzzy-watch service changes. |
+| `NamingFuzzyWatchSyncRequest` | `NamingFuzzyWatchSyncResponse` | server push | `groupKeyPattern`, `contexts`, `totalBatch`, `currentBatch` | Sync fuzzy-watch initial or diff state. |
+| `DistroDataRequest` | `DistroDataResponse` | inner | `distroData`, `dataOperation` | Distro AP protocol data transport between server nodes. |
+
+### 7.4 AI
+
+| Request type | Response type | Action | Main fields | Contract |
+| --- | --- | --- | --- | --- |
+| `QueryMcpServerRequest` | `QueryMcpServerResponse` | read | `namespace`, `mcpName`, `version` | Query MCP server detail. |
+| `ReleaseMcpServerRequest` | `ReleaseMcpServerResponse` | write | `serverSpecification`, `toolSpecification`, `resourceSpecification`, `endpointSpecification` | Release MCP server or a new version. |
+| `McpServerEndpointRequest` | `McpServerEndpointResponse` | write | `mcpName`, `address`, `port`, `version`, `type` | Register or deregister an MCP endpoint. |
+| `QueryAgentCardRequest` | `QueryAgentCardResponse` | read | `namespace`, `agentName`, `version`, `registrationType` | Query A2A AgentCard detail. |
+| `ReleaseAgentCardRequest` | `ReleaseAgentCardResponse` | write | `agentCard`, `registrationType`, `setAsLatest` | Release an AgentCard or a new version. |
+| `AgentEndpointRequest` | `AgentEndpointResponse` | write | `agentName`, `endpoint`, `type` | Register or deregister one Agent endpoint. |
+| `BatchAgentEndpointRequest` | `AgentEndpointResponse` | write | `agentName`, `endpoints` | Replace this client's endpoints for an Agent. |
+| `QueryPromptRequest` | `QueryPromptResponse` | read | `namespace`, `promptKey`, `version`, `label`, `md5` | Query Prompt by version, label, latest, or md5. |
+
+Skill ZIP download and AgentSpec assembly are Java SDK interface capabilities,
+but current Java client implementation uses HTTP/config composition rather than a
+dedicated gRPC payload.
+
+### 7.5 Lock
+
+| Request type | Response type | Action | Main fields | Contract |
+| --- | --- | --- | --- | --- |
+| `LockOperationRequest` | `LockOperationResponse` | none in handler | `lockInstance`, `lockOperationEnum` | Try lock or release a Nacos distributed lock. |
+
+## 8. Rules For Adding Or Changing gRPC APIs
+
+1. Add a concrete `Request` and `Response` type, or reuse an existing type only
+   when the operation is the same semantic contract.
+2. Register both payload classes in the correct
+   `META-INF/services/com.alibaba.nacos.api.remote.Payload` file.
+3. Add a `RequestHandler<Request, Response>` bean and document its action,
+   module, and source.
+4. Add `@Secured` for SDK-facing or inner protected operations.
+5. Add `@InvokeSource` for cluster-only payloads.
+6. Keep request fields explicit and JSON-compatible.
+7. Update this spec and the SDK interface spec when the operation is exposed
+   through a public SDK interface.

--- a/specs/en/http-api/api-spec.md
+++ b/specs/en/http-api/api-spec.md
@@ -1,0 +1,171 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos HTTP API Spec
+
+This document defines the common design model for Nacos HTTP APIs. It is the
+entry point for API design rules. Detailed current surfaces, authorization rules,
+and response rules are maintained in linked documents.
+
+## 1. Design Motivation
+
+Nacos uses gRPC as the primary client communication protocol for high-frequency
+runtime traffic. HTTP APIs still exist because they serve different needs:
+
+- language-neutral access for clients that cannot use the official SDK or gRPC;
+- operational access for administrators and maintenance tools;
+- web-console access for UI workflows;
+- compatibility and migration paths for existing Nacos users;
+- easy inspection, scripting, and integration with common HTTP infrastructure.
+
+The HTTP API design therefore separates audiences before it separates resources.
+A client-facing API, an operator API, and a console API may operate on similar
+domain objects, but they do not have the same compatibility promise, permission
+model, or response expectations.
+
+## 2. Design Principles
+
+### 2.1 Audience First
+
+Every HTTP API must first declare its audience:
+
+| Audience | Path prefix | Intended caller |
+| --- | --- | --- |
+| Open API | `/v3/client` | SDKs and custom runtime clients |
+| Admin API | `/v3/admin` | operators and maintainer tooling |
+| Console API | `/v3/console` | Nacos console UI |
+| Auth API | `/v3/auth` | plugin-provided auth APIs and bootstrap flows |
+
+An endpoint should not be documented as an Open API only because it is reachable
+over HTTP. Open APIs carry a stronger compatibility expectation than Admin or
+Console APIs.
+
+### 2.2 Stable Resource Shape
+
+HTTP paths should follow this shape after the Nacos server context path:
+
+```text
+/v3/{audience}/{module}/{resource}[/{subResource}]
+```
+
+Current module names include:
+
+| Module | Meaning |
+| --- | --- |
+| `core` | cluster, namespace, server state, plugin, and operations |
+| `cs` | configuration service |
+| `ns` | naming service |
+| `ai` | MCP, A2A, Prompt, Skill, AgentSpec, and Pipeline |
+| `auth` | user, role, and permission |
+| `copilot` | console copilot features |
+
+The deployment context path, usually `/nacos`, is outside the controller mapping.
+User-facing examples may include it, but code-level path definitions should not.
+
+### 2.3 HTTP Method Semantics
+
+V3 HTTP APIs use methods according to operation semantics:
+
+| Method | Meaning |
+| --- | --- |
+| `GET` | Query or download data. |
+| `POST` | Create, publish, register, upload, submit, or trigger work. |
+| `PUT` | Update existing state or set idempotent mutable state. |
+| `DELETE` | Remove, deregister, or delete bindings and drafts. |
+
+Any exception should be recorded in the endpoint-specific spec before it is
+treated as intentional behavior.
+
+### 2.4 Consistent Response Contract
+
+JSON HTTP APIs should return `com.alibaba.nacos.api.model.v2.Result<T>` unless
+there is a deliberate response-shape reason not to. Downloads, streaming APIs,
+and health probes are common exceptions.
+
+Detailed response and error rules are defined in
+[Response And Error Spec](response-error-spec.md).
+
+### 2.5 Explicit Authorization
+
+HTTP APIs should declare authorization through `@Secured` unless the endpoint is
+explicitly public, bootstrap-only, or health-oriented. Authorization must reflect
+the API audience, resource domain, and action.
+
+Detailed rules are defined in [Authorization Spec](authorization-spec.md).
+
+### 2.6 Compatibility Is Part Of The API
+
+Open APIs must be reviewed as long-lived compatibility surfaces. Admin and Console
+APIs may evolve faster, but incompatible changes still need deprecation notes or
+migration guidance when documented users can depend on them.
+
+Deprecated endpoints should stay documented in a compatibility section instead of
+being silently removed from docs while code still supports them.
+
+### 2.7 Documentation Follows Spec
+
+User-facing documentation should be generated from, or manually checked against,
+the spec and implementation. When code and documentation differ, the difference
+must be classified before it is resolved:
+
+- `Normative Spec`: behavior Nacos intentionally promises.
+- `Current Behavior`: behavior currently implemented but not yet confirmed as a
+  long-term contract.
+- `Spec Decision Required`: behavior that must not be treated as promised until
+  the spec is updated.
+
+### 2.8 Agent Guidance And Automated Validation
+
+Agent guidance files, AI skills, controller templates, and API compliance
+checkers should treat this spec family as their source of truth.
+
+They may keep short implementation checklists for local context, but they must
+not define conflicting API rules. If an agent guide, template, checker, website
+document, or implementation disagrees with the spec, the disagreement should be
+resolved by updating the incorrect artifact or by explicitly updating the spec.
+
+Automated validation should map findings to concrete spec rules, including:
+
+- audience and path prefix;
+- module and resource naming;
+- HTTP method semantics;
+- `Result<T>` response shape and documented exceptions;
+- `@Secured` declaration, action, sign type, and API type;
+- deprecated compatibility endpoints and their migration status.
+
+## 3. Current V3 Documents
+
+The current v3 HTTP API surface is recorded in [V3 API Surface](v3-api-surface.md).
+
+Additional detail specs:
+
+- [Authorization Spec](authorization-spec.md)
+- [Response And Error Spec](response-error-spec.md)
+
+## 4. Rules For Adding Or Changing HTTP APIs
+
+1. Pick the audience first: Open, Admin, Console, or Auth.
+2. Choose the module and resource path using the stable path shape.
+3. Use HTTP methods according to section 2.3.
+4. Declare authorization and action semantics.
+5. Use `Result<T>` for JSON responses unless a documented exception applies.
+6. Put validation in a form object or dedicated validator.
+7. Add route, validation, auth, and response-shape tests for meaningful changes.
+8. Update the matching spec and website documentation in the same change.
+
+New Open APIs require an explicit compatibility note. New Admin or Console APIs
+require an explicit authorization note. New non-`Result<T>` APIs require an
+explicit response-shape note.

--- a/specs/en/http-api/authorization-spec.md
+++ b/specs/en/http-api/authorization-spec.md
@@ -16,6 +16,12 @@
 
 # HTTP API Authorization Spec
 
+This document defines how the Nacos auth model is applied to v3 HTTP APIs. The
+shared auth domain model is defined by
+[Auth And Permission Spec](../auth/auth-permission-spec.md), and plugin
+contracts are defined by [Auth Plugin Spec](../auth/auth-plugin-spec.md) and
+[Visibility Plugin Spec](../auth/visibility-plugin-spec.md).
+
 ## 1. Authorization Tuple
 
 The effective authorization tuple for v3 HTTP APIs is:

--- a/specs/en/http-api/authorization-spec.md
+++ b/specs/en/http-api/authorization-spec.md
@@ -1,0 +1,95 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# HTTP API Authorization Spec
+
+## 1. Authorization Tuple
+
+The effective authorization tuple for v3 HTTP APIs is:
+
+```text
+apiType + signType + resource + action + tags
+```
+
+Where:
+
+- `apiType` separates `OPEN_API`, `ADMIN_API`, `CONSOLE_API`, and inner APIs.
+- `signType` identifies the resource domain, such as `CONFIG`, `NAMING`, `AI`,
+  or `CONSOLE`.
+- `resource` identifies the protected resource path or logical resource name.
+- `action` is usually `READ` or `WRITE`.
+- `tags` adds special behavior such as `ONLY_IDENTITY` or `ALLOW_ANONYMOUS`.
+
+## 2. Filter Split
+
+Current code dispatches auth by `apiType`:
+
+- `AuthAdminFilter` handles methods whose `@Secured.apiType()` is
+  `ApiType.ADMIN_API`.
+- `AuthFilter` handles secured APIs whose `apiType()` is not `ADMIN_API`,
+  including `OPEN_API`, `CONSOLE_API`, and inner APIs.
+
+## 3. Required Annotation
+
+V3 HTTP APIs should declare `@Secured` unless the endpoint is explicitly:
+
+- public;
+- bootstrap-only;
+- health-oriented;
+- handled by a documented compatibility path.
+
+Admin APIs should use `ApiType.ADMIN_API`. Console APIs should use
+`ApiType.CONSOLE_API`. Open APIs should use `ApiType.OPEN_API`.
+
+## 4. Public And Bootstrap Endpoints
+
+Endpoints may omit `@Secured` only when they are intentionally public,
+bootstrap-only, health-oriented, or compatibility-only. Public endpoints must be
+documented as public and must not expose sensitive operational details.
+
+Implemented public endpoints include:
+
+- `GET /v3/admin/core/state`
+- `GET /v3/admin/core/state/liveness`
+- `GET /v3/admin/core/state/readiness`
+- `GET /v3/console/server/state`
+- `GET /v3/console/server/announcement`
+- `GET /v3/console/server/guide`
+- `GET /v3/console/health/liveness`
+- `GET /v3/console/health/readiness`
+
+The corresponding Admin API and Console API docs mark these endpoints as public
+and requiring no identity information.
+
+Bootstrap behavior:
+
+- `/v3/auth/user/admin` can create the first admin user when no global admin
+  exists and the auth system is `NACOS`.
+
+## 5. Plugin-Provided Auth APIs
+
+The `/v3/auth/*` API surface belongs to auth plugins. The default Nacos auth
+plugin is shipped with Nacos and must follow the Nacos HTTP API rules for path
+shape, response shape, validation, and error behavior.
+
+Third-party auth plugins should follow the same rules when exposing HTTP APIs
+through Nacos.
+
+## 6. Implemented Exceptions
+
+Implemented behavior that needs endpoint-level documentation:
+
+- Some AI client endpoints allow anonymous access through `ALLOW_ANONYMOUS`.

--- a/specs/en/http-api/response-error-spec.md
+++ b/specs/en/http-api/response-error-spec.md
@@ -1,0 +1,83 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# HTTP API Response And Error Spec
+
+## 1. JSON Response Envelope
+
+The default v3 JSON response envelope is
+`com.alibaba.nacos.api.model.v2.Result<T>`:
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {}
+}
+```
+
+Endpoint docs must state the `data` type and any non-default HTTP status.
+
+## 2. Response Exceptions
+
+Current intentional response-shape exceptions:
+
+- File download endpoints may return `ResponseEntity<byte[]>`.
+- Streaming copilot endpoints return Server-Sent Events.
+- Health readiness may return HTTP 500 with a `Result<String>` body when not
+  ready.
+- Some legacy or operational endpoints may return plain text. These should be
+  kept only when confirmed as compatibility behavior.
+
+## 3. Error Handling
+
+Controllers annotated with `@NacosApi` use `NacosApiExceptionHandler` for common
+v3 errors:
+
+| Exception type | HTTP status | Result code source |
+| --- | --- | --- |
+| `NacosApiException` | exception error code | detailed API error code |
+| `NacosException` | exception error code | `SERVER_ERROR` |
+| missing request parameter | 400 | `PARAMETER_MISSING` |
+| invalid argument or number format | 400 | `PARAMETER_VALIDATE_ERROR` |
+| media type errors | 400 | `MEDIA_TYPE_ERROR` |
+| `AccessException` | 403 | `ACCESS_DENIED` |
+| data access, servlet, or IO failures | 500 | `DATA_ACCESS_ERROR` |
+| unhandled exceptions | 500 | generic failure |
+
+## 4. Exception Handler Convergence
+
+Nacos-owned v3 HTTP APIs should converge on `@NacosApi` and
+`NacosApiExceptionHandler` for unified exception handling. Module-level exception
+handlers that predate the v3 API model should not define a different response
+shape for v3 APIs.
+
+Plugin-style modules may keep their own exception handler when they intentionally
+own a separate API surface. `PrometheusApiExceptionHandler` is an example of this
+kind of plugin-style exception handler.
+
+Known convergence items:
+
+- `config/server/exception/GlobalExceptionHandler` still applies to
+  `com.alibaba.nacos.config.server` and can return plain text
+  `ResponseEntity<String>`.
+- `naming/exception/ResponseExceptionHandler` still applies to
+  `com.alibaba.nacos.naming` and can return plain text `ResponseEntity<String>`.
+- `ConfigOpenApiController` imports `NacosApi` but is not currently annotated
+  with `@NacosApi`.
+
+These items should be treated as pending cleanup so Config and Naming v3 APIs use
+the same `Result<T>` error contract as other Nacos v3 APIs.

--- a/specs/en/http-api/v3-api-surface.md
+++ b/specs/en/http-api/v3-api-surface.md
@@ -1,0 +1,207 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# V3 HTTP API Surface
+
+This document describes the current v3 HTTP API coverage. It complements
+[HTTP API Spec](api-spec.md), which defines the design rules.
+
+## 1. Scope
+
+This document covers HTTP endpoints whose paths start with one of the following
+v3 prefixes after the Nacos web context path:
+
+| Prefix | API type | Primary users | Current auth scope |
+| --- | --- | --- | --- |
+| `/v3/client` | Open API | SDKs and custom clients | `ApiType.OPEN_API` |
+| `/v3/admin` | Admin API | operators and maintainer tooling | `ApiType.ADMIN_API` |
+| `/v3/console` | Console API | Nacos console UI backend calls | `ApiType.CONSOLE_API` |
+| `/v3/auth` | Auth plugin API | plugin-provided auth and bootstrap APIs | default auth plugin |
+
+This document does not cover:
+
+- v1/v2 compatibility APIs;
+- gRPC request and response contracts;
+- internal cluster APIs that are not exposed as v3 HTTP controllers;
+- the AI Registry adaptor API, which has a separate compatibility surface.
+
+## 2. Current Source Of Truth
+
+The v3 HTTP behavior is currently defined by these source locations:
+
+| Area | Code source |
+| --- | --- |
+| Admin core | `core/src/main/java/com/alibaba/nacos/core/controller/v3` |
+| Admin config | `config/src/main/java/com/alibaba/nacos/config/server/controller/v3` |
+| Admin naming | `naming/src/main/java/com/alibaba/nacos/naming/controllers/v3` |
+| Admin AI | `ai/src/main/java/com/alibaba/nacos/ai/controller` |
+| Console | `console/src/main/java/com/alibaba/nacos/console/controller/v3` |
+| Auth v3 | `plugin-default-impl/nacos-default-auth-plugin/src/main/java/.../controller/v3` |
+| Path constants | `Commons`, config `Constants`, naming `UtilsAndCommons`, AI `Constants`, `AuthConstants` |
+
+The corresponding website source files are:
+
+- `admin/admin-api.md`
+- `admin/console-api.md`
+- `user/open-api.md`
+
+## 3. Current API Families
+
+This section captures current implemented families. Counts are a script-assisted
+inventory of Spring mappings in `src/main/java` and should be used as a review
+guide, not as a final OpenAPI export.
+
+| Family | Approx. mappings | Methods | Notes |
+| --- | ---: | --- | --- |
+| `/v3/client/cs/config` | 1 | GET | Query config for custom HTTP clients. |
+| `/v3/client/ns/instance` | 3 | GET, POST, DELETE | Register, heartbeat, deregister, and list service instances. |
+| `/v3/client/ai/prompt` | 1 | GET | Runtime prompt query. |
+| `/v3/client/ai/skills` | 1 | GET | Runtime skill zip download. |
+| `/v3/client/ai/agentspecs` | 2 | GET | Runtime AgentSpec get and search. |
+| `/v3/admin/core/*` | 25 | GET, POST, PUT, DELETE | Loader, cluster, ops, namespace, state, plugin. |
+| `/v3/admin/cs/*` | 25 | GET, POST, PUT, DELETE | Config CRUD, history, listener, capacity, metrics, ops. |
+| `/v3/admin/ns/*` | 29 | GET, POST, PUT, DELETE | Service, instance, client, cluster, health, ops. |
+| `/v3/admin/ai/*` | 71 | GET, POST, PUT, DELETE | MCP, A2A, Prompt, Skill, AgentSpec, Pipeline. |
+| `/v3/console/core/*` | 7 | GET, POST, PUT, DELETE | Cluster and namespace console operations. |
+| `/v3/console/cs/*` | 17 | GET, POST, DELETE | Config and history console operations. |
+| `/v3/console/ns/*` | 11 | GET, POST, PUT, DELETE | Naming console service and instance operations. |
+| `/v3/console/ai/*` | 67 | GET, POST, PUT, DELETE | Console AI management, imports, lifecycle, pipelines. |
+| `/v3/console/copilot/*` | 6 | GET, POST | Config plus SSE copilot operations. |
+| `/v3/auth/user` | 7 | GET, POST, PUT, DELETE | User login and management in default auth plugin. |
+| `/v3/auth/role` | 4 | GET, POST, DELETE | Role management in default auth plugin. |
+| `/v3/auth/permission` | 4 | GET, POST, DELETE | Permission management in default auth plugin. |
+
+## 4. Open API Implemented Behavior
+
+Implemented Open API surface:
+
+| Endpoint | Behavior |
+| --- | --- |
+| `GET /v3/client/cs/config` | Query a single config. It does not provide HTTP long polling. |
+| `POST /v3/client/ns/instance` | Register an instance, or send heartbeat when `heartBeat=true`. |
+| `DELETE /v3/client/ns/instance` | Deregister an instance. Missing instance is still successful. |
+| `GET /v3/client/ns/instance/list` | List enabled instances for a service. Disabled instances are filtered out. |
+| `GET /v3/client/ai/prompt` | Query prompt by version, label, or latest. |
+| `GET /v3/client/ai/skills` | Download online skill package as a zip response. |
+| `GET /v3/client/ai/agentspecs` | Query AgentSpec by version, label, or latest. May allow anonymous access. |
+| `GET /v3/client/ai/agentspecs/search` | Search enabled AgentSpecs for runtime use. |
+
+## 5. Admin API Implemented Behavior
+
+Admin APIs are operator-oriented and default to `ApiType.ADMIN_API`. Existing docs
+state that v3 Admin API is not compatible with v1/v2 Admin API, and that v1/v2
+Admin API compatibility requires `nacos.core.auth.admin.enabled=true`.
+
+Current modules:
+
+- `core`: connection loader, cluster node data, Raft and ID ops, namespace,
+  plugin, and server state.
+- `cs`: config CRUD, metadata, batch operations, history, listener, capacity,
+  metrics, and ops.
+- `ns`: service, instance, cluster, health, client, and naming ops.
+- `ai`: MCP, A2A, Prompt, Skill, AgentSpec, and Pipeline management.
+
+Implemented behavior to document more explicitly:
+
+- Naming service creation creates persistent service metadata.
+- Open naming instance heartbeat uses the same `POST /v3/client/ns/instance`
+  endpoint and returns `INSTANCE_NOT_FOUND` when re-registration is needed.
+- Config query decrypts encrypted content before returning Admin API detail.
+- Config publish encrypts content when no encrypted data key is supplied and the
+  configured encryption handler applies.
+- AI Prompt contains deprecated compatibility endpoints and newer lifecycle
+  endpoints in the same controller.
+
+## 6. Console API Implemented Behavior
+
+Console APIs serve the Nacos web console and are not the same stability surface
+as Open APIs. They default to `ApiType.CONSOLE_API` and often use console-specific
+resource names, `ONLY_IDENTITY`, or UI-oriented response models.
+
+Console API modules mirror Admin modules where the UI needs them:
+
+- server state and health;
+- core cluster, namespace, and plugin;
+- config and history;
+- naming service and instance;
+- AI resources and copilot.
+
+Console API docs should avoid presenting console-only endpoints as recommended
+automation APIs. Automation users should prefer Admin APIs unless a feature is
+intentionally console-only.
+
+## 7. Auth API Implemented Behavior
+
+The v3 auth API lives in the default auth plugin, not in core:
+
+```text
+/v3/auth/user
+/v3/auth/role
+/v3/auth/permission
+```
+
+Implemented behavior:
+
+- user management supports create, delete, password update, login, list, and
+  search.
+- role management supports add, delete, list, and search.
+- permission management supports add, delete, and list.
+- first-admin bootstrap is implemented by `POST /v3/auth/user/admin`.
+
+The default auth plugin is shipped with Nacos, so its v3 auth endpoints should
+follow the Nacos HTTP API rules.
+
+## 8. Documentation Gap Notes
+
+This is not a bug list. It records places where the current documentation and
+code appear to describe different surfaces.
+
+- Admin AI Prompt lifecycle: code adds `/governance`, `/version`, `/draft`,
+  `/submit`, `/publish`, `/force-publish`, `/online`, `/offline`, `/labels`,
+  `/description`, and `/biz-tags`; docs mostly cover legacy `/detail`, `/label`,
+  `/metadata`, plus list and versions.
+- Console AI Prompt lifecycle: console code mirrors the Admin lifecycle under
+  `/v3/console/ai/prompt`; docs mostly cover legacy `/detail`, `/label`, and
+  `/metadata`.
+- Pipeline list/detail: code exposes `/v3/*/ai/pipelines/list`, `/detail`, and
+  `/{pipelineId}`; docs show `/v3/*/ai/pipelines` and `/{pipelineId}`.
+- Force publish: code has `POST /force-publish` for Prompt, Skill, and
+  AgentSpec; docs do not consistently describe the privileged operation.
+- AgentSpec version meta: code has `GET /v3/admin/ai/agentspecs/version/meta`;
+  it is not documented in the admin API doc.
+- Auth v3: code exposes `/v3/auth/user`, `/role`, and `/permission`; the three
+  website API files do not cover this API surface.
+- Config Open API exception handling: `ConfigOpenApiController` lacks
+  `@NacosApi` while most v3 controllers have it; Open API docs assume unified
+  response.
+- Config and Naming exception handlers: Config and Naming still have historical
+  module-level `ControllerAdvice` classes that may return plain text error
+  bodies. They should converge to `NacosApiExceptionHandler` for v3 APIs.
+
+## 9. Deprecated Compatibility Notes
+
+Some v3 AI APIs were released before this spec existed and were later replaced by
+clearer lifecycle or REST-style APIs. These old endpoints should be treated as
+deprecated compatibility APIs:
+
+- AI Prompt legacy endpoints such as `/detail`, `/label`, and `/metadata`.
+- Pipeline legacy REST-style endpoints that do not match the current `/list` and
+  `/detail` shape.
+
+Compatibility endpoints may remain available for a transition period, but the
+user-facing documentation should describe the new APIs as the primary contract.
+Deprecated endpoints should be documented only in compatibility sections with
+migration guidance.

--- a/specs/en/plugin/plugin-spec.md
+++ b/specs/en/plugin/plugin-spec.md
@@ -1,0 +1,170 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos Plugin Spec
+
+## Purpose
+
+Nacos uses plugins to keep cross-cutting infrastructure and replaceable domain
+capabilities outside the fixed server core. A plugin may provide authentication,
+resource visibility, data source dialects, encryption, tracing, flow control,
+environment adaptation, AI pipeline behavior, or AI storage behavior.
+
+The plugin mechanism must let Nacos keep a stable core model while allowing
+deployments to choose an implementation that matches their identity system,
+database, observability stack, or extension scenario.
+
+## Plugin Identity
+
+Every plugin is identified by:
+
+- `pluginType`: the extension category, such as `auth` or `visibility`.
+- `pluginName`: the implementation name inside that category, such as `nacos`.
+- `pluginId`: the runtime identifier in the form `{pluginType}:{pluginName}`.
+
+The `pluginId` is the value used by the admin plugin API, cluster state
+synchronization, persisted plugin state, and user-facing diagnostics.
+
+## Plugin Types
+
+The current plugin type registry is defined by `PluginType`.
+
+| Type | Purpose |
+|------|---------|
+| `auth` | Authentication and authorization implementation. |
+| `visibility` | Resource visibility and query visibility advisory. |
+| `datasource-dialect` | Database dialect and persistence adaptation. |
+| `config-change` | Configuration change extension. |
+| `encryption` | Encryption and decryption extension. |
+| `trace` | Trace and observability extension. |
+| `environment` | Environment adaptation extension. |
+| `control` | Traffic and control extension. |
+| `ai-pipeline` | AI registry pipeline extension. |
+| `ai-storage` | AI registry storage extension. |
+
+Domain-specific plugin contracts are defined by their own specs. This document
+defines the common runtime contract shared by all plugin categories.
+
+## Execution Modes
+
+Plugin categories do not all execute in the same shape. A plugin type must
+define its execution mode explicitly.
+
+| Mode | Meaning | Examples |
+|------|---------|----------|
+| Exclusive selection | One implementation is selected for the process or request scope. Other loaded implementations remain inactive for that decision. | `auth`, `datasource-dialect` |
+| Configured single service | Multiple implementations may be loaded, while a domain chooses one service by configuration or request context. | `visibility` |
+| Ordered chain | Multiple matching plugins are invoked in a stable order. Each node may contribute a result, and the domain defines whether failure stops the chain. | `ai-pipeline`, `config-change` |
+| Subscriber or broadcast | Multiple subscribers observe the same event or trace point without owning the primary decision. | `trace`, event-style extensions |
+
+For chained plugins, the domain SPI must define:
+
+- How candidate plugins are selected for a resource or pointcut.
+- Which field controls ordering, such as `getPreferOrder()` or `getOrder()`.
+- Whether execution is serial or parallel.
+- Whether a failed plugin stops the chain or only records a failed result.
+- How partial results are persisted and exposed.
+
+The core plugin manager records loaded and enabled plugins; it does not by
+itself define the execution mode. Domain managers are responsible for applying
+the mode consistently.
+
+## SPI Layers
+
+Nacos plugins have two related SPI layers:
+
+1. Domain SPI, such as `AuthPluginService` or `VisibilityService`, defines the
+   behavior required by the owning domain.
+2. Core plugin SPI, `PluginProvider`, exposes plugin instances to the core
+   plugin manager for listing, status management, configuration, and
+   observability.
+
+A plugin that needs dynamic configuration implements `PluginConfigSpec`. A
+plugin category that supports enable or disable checks must use
+`PluginStateCheckerHolder` rather than keeping an independent status source.
+
+## Loading And Lifecycle
+
+Plugin implementations are discovered with the Nacos SPI loader. Deployments may
+provide plugins from the classpath or from the server plugin directory. The
+plugin implementation must be loadable without changing Nacos server code.
+
+The core `PluginManager` discovers `PluginProvider` implementations after the
+server application is ready. Domain managers may also load their domain services
+through SPI, but availability decisions must still respect the plugin state held
+by the core plugin manager.
+
+Plugin startup must be deterministic:
+
+- A plugin type and name pair must map to one runtime plugin instance.
+- Duplicate plugin names in the same type are invalid for stable operation.
+- Plugin implementations must not change the meaning of shared Nacos resource
+  identifiers, response envelopes, or error conventions.
+
+## State And Configuration
+
+Plugin state has two levels:
+
+- Loaded: the implementation exists in the runtime.
+- Enabled: the implementation may participate in request handling.
+
+Most plugin types are enabled by default after loading. Exclusive plugin types
+select one default implementation:
+
+| Type | Default selection rule |
+|------|------------------------|
+| `auth` | The implementation named by `nacos.core.auth.system.type`, default `nacos`. |
+| `datasource-dialect` | The configured SQL platform, default `derby`. |
+
+Critical plugins cannot be disabled while the server depends on them. The
+current critical set includes built-in data source dialects and the default AI
+storage plugin required by the server.
+
+Plugins with `PluginConfigSpec` expose config definitions, current config, and
+config application behavior. Cluster-wide status or config changes must be
+synchronized through the plugin state operation path unless the request is
+explicitly local only.
+
+## Admin API
+
+The core plugin admin API is:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/v3/admin/core/plugin/list` | List loaded plugins, optionally filtered by type. |
+| `GET` | `/v3/admin/core/plugin/detail` | Read one plugin detail. |
+| `PUT` | `/v3/admin/core/plugin/status` | Enable or disable a plugin. |
+| `PUT` | `/v3/admin/core/plugin/config` | Update plugin configuration. |
+
+These endpoints are Admin APIs and require console-scoped authorization. Plugin
+management must use the standard v3 response and error model.
+
+## Design Requirements
+
+Plugin implementations must follow these rules:
+
+- Use existing Nacos resource identifiers and domain models instead of inventing
+  an incompatible model for the same resource.
+- Preserve v3 API response, error, and authorization conventions for any
+  plugin-provided HTTP APIs.
+- Expose only plugin-owned configuration through `PluginConfigSpec`.
+- Keep cluster-wide state changes synchronized unless the caller explicitly
+  requests a local-only operation for diagnosis or emergency handling.
+- Document security-sensitive defaults and deployment requirements in the
+  plugin implementation spec.
+
+The plugin mechanism is an extension boundary, not a license to bypass Nacos
+resource, API, or security rules.

--- a/specs/en/sdk/sdk-java-impl-spec.md
+++ b/specs/en/sdk/sdk-java-impl-spec.md
@@ -1,0 +1,240 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos Java SDK Implementation Spec
+
+This document defines how the Java SDK implements the shared
+[SDK Spec](./sdk-spec.md). It covers both the Java Client SDK and the Java
+Maintainer SDK.
+
+## 1. Scope
+
+The Java SDK has two public families:
+
+- Java Client SDK, provided mainly by `nacos-client` and the public interfaces
+  under the `api` module.
+- Java Maintainer SDK, provided by `nacos-maintainer-client` and the public
+  interfaces under the `maintainer-client` module.
+
+The Java Client SDK is the baseline for existing runtime application behavior.
+The Java Maintainer SDK is the preferred Java entry point for management, UI,
+gateway, and operation scenarios.
+
+## 2. Java Client SDK Factories and Lifecycle
+
+| Interface | Factory | Shutdown method |
+| --- | --- | --- |
+| `ConfigService` | `NacosFactory.createConfigService(...)` | `shutDown()` |
+| `NamingService` | `NacosFactory.createNamingService(...)` | `shutDown()` |
+| `AiService` | `AiFactory.createAiService(Properties)` | `shutdown()` |
+| `LockService` | `NacosLockFactory.createLockService(Properties)` or `NacosFactory.createLockService(Properties)` | `shutdown()` |
+| `NamingMaintainService` | `NacosFactory.createMaintainService(...)` | `shutDown()` |
+
+`NamingMaintainService` is deprecated after 3.3.0. New management integrations
+should use `nacos-maintainer-client`.
+
+One Java SDK instance is bound to one namespace. Applications that need multiple
+namespaces should create separate SDK instances and close them when no longer
+used.
+
+## 3. Java Client SDK Configuration
+
+Java Client SDK configuration is represented by `NacosClientProperties`.
+
+The default lookup order is:
+
+```text
+Properties -> JVM system properties -> environment variables -> defaults
+```
+
+The first lookup source can be changed by `nacos.env.first` or
+`NACOS_ENV_FIRST`.
+
+Common properties include:
+
+| Property | Scope | Meaning |
+| --- | --- | --- |
+| `serverAddr` | common | Nacos server address list. |
+| `contextPath` | common | Server context path, defaulting to `nacos`. |
+| `endpoint` and endpoint-related properties | common | Dynamic server address endpoint. |
+| `namespace` | common | Namespace id bound to the SDK instance. |
+| `username`, `password` | common | Login credentials when authentication is enabled. |
+| `accessKey`, `secretKey`, `ramRoleName`, `signatureRegionId` | common | RAM-style authentication properties. |
+| `configRequestTimeout` | config | Config RPC request timeout override. |
+| `namingRequestTimeout` | naming | Naming RPC request timeout override. |
+| `nacos.server.grpc.port.offset` | connection | gRPC port offset used by the Java client. |
+
+Deprecated historical properties should remain compatible, but new behavior
+should not depend on them.
+
+## 4. Java Client SDK Interfaces
+
+### 4.1 ConfigService
+
+| Capability | Methods | Contract |
+| --- | --- | --- |
+| Query config | `getConfig`, `getConfigWithResult` | Query one known config by `dataId` and `group`; `getConfigWithResult` also returns md5 for CAS. |
+| Query and listen | `getConfigAndSignListener` | Query current config and register the same listener for later changes. |
+| Listen | `addListener`, `removeListener` | Add or remove a listener. Callback should prefer the executor supplied by the listener. |
+| Publish | `publishConfig`, `publishConfigCas` | Compatibility write surface for creating or updating config. CAS publish must compare the previous md5. |
+| Delete | `removeConfig` | Compatibility write surface for deleting config. Existing user docs define deleting a missing config as success. |
+| Filter | `addConfigFilter` | Add a client-side config filter. |
+| Fuzzy watch | `fuzzyWatch`, `fuzzyWatchWithGroupKeys`, `cancelFuzzyWatch` | Watch config keys by group or dataId pattern and receive key change events. |
+| Status and lifecycle | `getServerStatus`, `shutDown` | Query status and release resources. |
+
+Config identity follows the user-facing constraints for `dataId`, `group`, and
+content size. New broad config management APIs should be added to the Maintainer
+SDK instead of `ConfigService`.
+
+### 4.2 NamingService
+
+| Capability | Methods | Contract |
+| --- | --- | --- |
+| Register | `registerInstance`, `batchRegisterInstance` | Register one or more instances under a service and group. |
+| Deregister | `deregisterInstance`, `batchDeregisterInstance` | Remove one or more instances. |
+| Query instances | `getAllInstances`, `selectInstances`, `selectOneHealthyInstance` | Query cached or remote service information by cluster, health, and subscribe options. |
+| Subscribe | `subscribe`, `unsubscribe` | Receive service instance change events. Unsubscribe requires the same listener instance. |
+| Fuzzy watch | `fuzzyWatch`, `fuzzyWatchWithServiceKeys`, `cancelFuzzyWatch` | Watch service keys by group or service pattern and receive service-level events. |
+| List services | `getServicesOfServer` | Compatibility broad query surface. New broad listing should use the Maintainer SDK. |
+| Local status | `getSubscribeServices`, `getServerStatus`, `shutDown` | Query subscribed services, status, and release resources. |
+
+The selector overload of `getServicesOfServer` is deprecated and remains only as
+a compatibility surface.
+
+### 4.3 AiService and A2aService
+
+`AiService` extends `A2aService`.
+
+| Capability | Methods | Contract |
+| --- | --- | --- |
+| MCP query | `getMcpServer` | Query MCP Server details by name and optional version. |
+| MCP release | `releaseMcpServer` | Create an MCP Server or release a new version. Existing same-version data remains idempotent. |
+| MCP endpoint | `registerMcpServerEndpoint`, `deregisterMcpServerEndpoint` | Register or remove endpoints owned by the current client. |
+| MCP subscription | `subscribeMcpServer`, `unsubscribeMcpServer` | Subscribe to MCP detail changes. |
+| A2A AgentCard query | `getAgentCard` | Query an AgentCard by name, optional version, and registration type. |
+| A2A AgentCard release | `releaseAgentCard` | Create an AgentCard or release a new version; `setAsLatest` only affects the new version. |
+| A2A endpoint | `registerAgentEndpoint`, `deregisterAgentEndpoint` | Register or remove endpoints owned by the current client. Batch registration replaces endpoints previously registered by this client for the same agent. |
+| A2A subscription | `subscribeAgentCard`, `unsubscribeAgentCard` | Subscribe to AgentCard changes. |
+| Skill | `downloadSkillZip`, `downloadSkillZipByVersion`, `downloadSkillZipByLabel` | Download Skill zip bytes by latest, version, or label. |
+| AgentSpec | `loadAgentSpec`, `subscribeAgentSpec`, `unsubscribeAgentSpec` | Load assembled AgentSpec and subscribe to changes. |
+| Prompt | `getPrompt`, `getPromptByVersion`, `getPromptByLabel`, `subscribePrompt`, `unsubscribePrompt` | Query and subscribe to Prompt resources by key, version, or label. |
+
+The Java implementation may mix gRPC, HTTP, and config assembly behind the
+interface. The public interface contract should stay independent from transport
+details.
+
+### 4.4 LockService
+
+| Capability | Methods | Contract |
+| --- | --- | --- |
+| User lock | `lock` | Acquire a lock through `LockInstance#lock`. |
+| User unlock | `unLock` | Release a lock through `LockInstance#unLock`. |
+| Remote lock | `remoteTryLock` | Send a gRPC lock operation request. |
+| Remote unlock | `remoteReleaseLock` | Send a gRPC unlock operation request. |
+| Lifecycle | `shutdown` | Release client resources. |
+
+## 5. Java Maintainer SDK Factories and Lifecycle
+
+| Interface | Factory | Shutdown method |
+| --- | --- | --- |
+| `ConfigMaintainerService` | `NacosMaintainerFactory.createConfigMaintainerService(...)` or `ConfigMaintainerFactory.createConfigMaintainerService(...)` | `close()` |
+| `NamingMaintainerService` | `NamingMaintainerFactory.createNamingMaintainerService(...)` | `close()` |
+| `AiMaintainerService` | `AiMaintainerFactory.createAiMaintainerService(...)` | Not exposed by the current interface |
+
+Maintainer services inherit `CoreMaintainerService` where applicable. They are
+higher-privilege clients and should be configured with management credentials.
+
+## 6. Java Maintainer SDK Interfaces
+
+### 6.1 CoreMaintainerService
+
+`CoreMaintainerService` exposes server and cluster maintenance capabilities:
+
+- server state, liveness, readiness, id-generator status, and loader metrics;
+- log-level updates;
+- cluster node listing and lookup mode updates;
+- current client connection inspection and client reload operations;
+- namespace listing, query, create, update, delete, and existence check;
+- raft operation forwarding for administrative scenarios.
+
+These APIs are administrative by definition and must not be copied into the
+Client SDK.
+
+### 6.2 ConfigMaintainerService
+
+`ConfigMaintainerService` includes:
+
+- get, publish, delete, and batch delete config;
+- list and search configs with namespace, dataId, group, type, tag, and app
+  filters where supported;
+- clone and import/export style management models;
+- beta and gray release operations through `BetaConfigMaintainerService`;
+- history query and rollback-related access through
+  `ConfigHistoryMaintainerService`;
+- dump, listener, log, and operation endpoints through
+  `ConfigOpsMaintainerService`;
+- metadata update for configuration descriptions and tags.
+
+Management writes and broad queries should be added here instead of expanding
+`ConfigService`.
+
+### 6.3 NamingMaintainerService
+
+`NamingMaintainerService` includes:
+
+- service create, update, remove, detail query, and list operations;
+- instance register, deregister, update, list, and metadata maintenance;
+- subscriber and client query operations through `NamingClientMaintainerService`;
+- naming metrics and log-level operations;
+- persistent instance health-status updates;
+- health checker listing and cluster metadata updates.
+
+Runtime instance registration remains available in `NamingService`, but service
+administration, broad listing, subscriber inspection, and health-check
+maintenance belong to the Maintainer SDK.
+
+### 6.4 AiMaintainerService
+
+`AiMaintainerService` exposes typed delegates:
+
+- `mcp()` for MCP Server list, search, detail, create, update, and delete;
+- `a2a()` for AgentCard register, query, update, delete, version, search, and
+  list operations;
+- `prompt()` for Prompt management;
+- `skill()` for Skill management;
+- `agentSpec()` for AgentSpec management;
+- `pipeline()` for Pipeline management.
+
+Runtime AI registration and subscription can remain in `AiService`; broad AI
+resource management belongs to `AiMaintainerService`.
+
+## 7. Java Compatibility Rules
+
+- `api`, `client`, and `plugin` modules remain Java 8 compatible unless the
+  module policy changes.
+- Server-side and maintainer modules follow the repository Java version policy.
+- Deprecated Client SDK methods should keep binary compatibility when possible,
+  but new designs should point callers to the Maintainer SDK.
+- Public model changes should preserve source and binary compatibility where
+  practical, especially for objects shared with HTTP and gRPC APIs.
+
+## 8. Documentation References
+
+- Java Client SDK user docs:
+  `src/content/docs/next/zh-cn/manual/user/java-sdk` in the Nacos docs project.
+- Java Maintainer SDK user docs:
+  `src/content/docs/next/zh-cn/manual/admin/maintainer-sdk.md` in the Nacos docs
+  project.

--- a/specs/en/sdk/sdk-spec.md
+++ b/specs/en/sdk/sdk-spec.md
@@ -1,0 +1,137 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos SDK Spec
+
+This document defines the shared SDK design rules for Nacos. Language-specific
+SDKs may use idiomatic names, async primitives, and packaging, but their public
+capability boundaries should follow this document.
+
+## 1. SDK Families
+
+Nacos SDKs are divided into two families:
+
+- **Client SDK**: used by microservice applications, agent frameworks, and
+  other runtime workloads that consume Nacos capabilities during normal service
+  execution.
+- **Maintainer SDK**: used by operation tools, consoles, gateways, management
+  platforms, and other applications that need administrative access without
+  manually integrating Nacos Admin HTTP APIs.
+
+The two families can share model objects, authentication primitives, retry
+rules, and connection infrastructure, but they must not blur their user
+audience or permission boundary.
+
+## 2. Client SDK Scope
+
+The Client SDK is designed for application runtime access. It should expose only
+the capabilities that a runtime application normally needs:
+
+- read known configuration items and subscribe to their changes;
+- register and deregister the current application instance;
+- query and subscribe to known services used by the application;
+- register, resolve, and subscribe to runtime AI resources, such as MCP
+  endpoints, A2A agent endpoints, Prompt, Skill, and AgentSpec resources;
+- use optional runtime primitives such as distributed lock when the language SDK
+  supports them;
+- manage its own lifecycle, local cache, listeners, and connections.
+
+The Client SDK should avoid broad management capabilities, including:
+
+- cluster control, server state mutation, log level changes, or traffic reloads;
+- listing all namespaces, all configurations, all services, or all clients;
+- querying history, audit-oriented metadata, dump data, or subscriber lists;
+- batch deletion, cross-namespace management, and other high-impact operations;
+- introducing new write APIs whose main user is an operator instead of a runtime
+  application.
+
+Some historical Client SDK interfaces may already contain write or broad query
+methods, such as configuration publish/delete or service list operations. These
+APIs are compatibility surfaces. New SDK designs should not expand this surface;
+management-oriented use cases should be implemented through the Maintainer SDK
+or Admin APIs.
+
+## 3. Maintainer SDK Scope
+
+The Maintainer SDK is designed for administrative integration. It may expose
+capabilities that are intentionally absent from the Client SDK:
+
+- namespace, cluster, server state, readiness/liveness, and log-level
+  maintenance;
+- broad configuration listing, searching, publishing, deletion, history, beta,
+  dump, and metadata operations;
+- service, instance, cluster metadata, subscriber, client, and health-check
+  maintenance;
+- AI resource management for MCP, A2A, Prompt, Skill, AgentSpec, and Pipeline
+  resources;
+- paginated and filterable access to large management datasets.
+
+The Maintainer SDK should be treated as a typed facade over the Nacos Admin API
+surface. When a capability is only useful for management, UI, gateway, or
+operation tools, it belongs here instead of the Client SDK.
+
+## 4. Security Rules
+
+SDK capability design must follow least privilege:
+
+- Client SDK credentials should be scoped to runtime resources and should not
+  require broad read or write permissions.
+- Maintainer SDK credentials are higher privilege and must be clearly separated
+  from Client SDK credentials in documentation and examples.
+- Broad read APIs must support explicit filters and pagination. They must not
+  silently perform unbounded full-cluster reads.
+- Cross-namespace operations belong to the Maintainer SDK and should require an
+  explicit namespace parameter.
+- SDK documentation should make data-leakage risks visible when an API can list
+  or export a large amount of configuration, service, client, or metadata.
+
+## 5. Transport and API Alignment
+
+The SDK contract is a semantic contract, not a transport contract:
+
+- Client SDKs may use gRPC, HTTP Open APIs, local cache files, or a mix of
+  transports, as long as the public SDK behavior remains stable.
+- Maintainer SDKs should align with Nacos Admin API semantics and result models,
+  even if the implementation later changes transport details.
+- SDK model objects should align with the HTTP and gRPC semantic objects so the
+  same business meaning is not redefined differently per transport.
+- SDK errors should map Nacos error codes and validation failures into
+  language-idiomatic exceptions or result types without hiding server-side
+  semantics.
+
+## 6. Multi-language Alignment
+
+Java is currently the baseline implementation for defining shared SDK
+semantics. Other language SDKs should align with the same capability families:
+
+- initialization, namespace binding, authentication, and lifecycle shutdown;
+- Client SDK configuration, naming, AI, and optional lock runtime capabilities;
+- Maintainer SDK core, configuration, naming, and AI management capabilities;
+- consistent data identity rules, such as namespace, group, dataId, service
+  name, cluster, version, and label;
+- consistent listener, subscription, retry, timeout, and local cache behavior
+  where the language runtime supports them.
+
+Language SDKs may expose futures, promises, streams, coroutines, callbacks, or
+context cancellation according to local conventions. These differences should be
+documented in language implementation specs without changing the shared SDK
+scope.
+
+## 7. Related Specs
+
+- [Java SDK Implementation Spec](./sdk-java-impl-spec.md)
+- [HTTP API Spec](../http-api/api-spec.md)
+- [gRPC API Spec](../grpc-api/api-spec.md)

--- a/specs/zh-cn/README.md
+++ b/specs/zh-cn/README.md
@@ -1,0 +1,24 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos 规范说明
+
+当前规范：
+
+- [HTTP API 规范](http-api/api-spec.md)
+
+[AGENTS.md](../../AGENTS.md) 等 Agent 指南文件应只摘要这些规范以便本地执行。
+当人、AI agent、模板或校验工具使用 API 指南时，规范仍然是规则来源。

--- a/specs/zh-cn/README.md
+++ b/specs/zh-cn/README.md
@@ -19,6 +19,9 @@
 当前规范：
 
 - [HTTP API 规范](http-api/api-spec.md)
+- [gRPC API 规范](grpc-api/api-spec.md)
+- [SDK 规范](sdk/sdk-spec.md)
+- [Java SDK 实现规范](sdk/sdk-java-impl-spec.md)
 
 [AGENTS.md](../../AGENTS.md) 等 Agent 指南文件应只摘要这些规范以便本地执行。
 当人、AI agent、模板或校验工具使用 API 指南时，规范仍然是规则来源。

--- a/specs/zh-cn/README.md
+++ b/specs/zh-cn/README.md
@@ -20,6 +20,11 @@
 
 - [Nacos 设计规范](design/nacos-design-spec.md)
 - [资源模型规范](design/resource-model-spec.md)
+- [插件化规范](plugin/plugin-spec.md)
+- [鉴权与权限规范](auth/auth-permission-spec.md)
+- [鉴权插件规范](auth/auth-plugin-spec.md)
+- [可见性插件规范](auth/visibility-plugin-spec.md)
+- [默认鉴权插件实现规范](auth/default-auth-plugin-spec.md)
 - [HTTP API 规范](http-api/api-spec.md)
 - [gRPC API 规范](grpc-api/api-spec.md)
 - [SDK 规范](sdk/sdk-spec.md)

--- a/specs/zh-cn/README.md
+++ b/specs/zh-cn/README.md
@@ -18,6 +18,8 @@
 
 当前规范：
 
+- [Nacos 设计规范](design/nacos-design-spec.md)
+- [资源模型规范](design/resource-model-spec.md)
 - [HTTP API 规范](http-api/api-spec.md)
 - [gRPC API 规范](grpc-api/api-spec.md)
 - [SDK 规范](sdk/sdk-spec.md)

--- a/specs/zh-cn/auth/auth-permission-spec.md
+++ b/specs/zh-cn/auth/auth-permission-spec.md
@@ -1,0 +1,181 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# 鉴权与权限规范
+
+## 范围
+
+本文档定义 Nacos HTTP API、gRPC API、插件 API 和服务端内部调用共享的认证与权限模型。
+传输协议相关细节由 HTTP API 和 gRPC API 规范定义。
+
+Nacos 授权模型可以表示为：
+
+```text
+请求身份 -> 已认证主体 -> 角色 -> 权限 -> 资源/动作
+```
+
+内置实现采用 RBAC。自定义鉴权插件可以接入其他身份系统，但仍必须通过身份、资源和动作
+语义来评估 Nacos 请求。
+
+## 鉴权插件与可见性插件
+
+Nacos 将请求级授权和数据级可见性分开处理。
+
+| 层次 | 主要问题 | 典型 SPI | 范围 |
+|------|----------|----------|------|
+| 鉴权插件 | 该调用方是否可以针对解析出的资源/动作调用这个 API？ | `AuthPluginService` | 请求准入与权限判断。 |
+| 可见性插件 | 该调用方是否可以看见或修改这个具体资源，或范围查询应该返回哪些资源？ | `VisibilityService` | 资源实例可见性与查询计划。 |
+
+这两层是正交关系：
+
+- 鉴权插件可以在没有可见性插件的情况下存在。
+- 可见性插件也可以独立存在，但每个领域必须定义没有请求身份时的行为。
+- 可见性插件可以复用鉴权插件产出的身份，也可以把显式资源权限检查委托回当前选中的鉴权插件。
+- 通过 `@Secured` 鉴权，只代表请求级准入通过，不代表所有匹配数据行都可见。
+
+对于具备可见性语义的资源，推荐请求流程为：
+
+```text
+@Secured + AuthPlugin -> VisibilityService -> 业务操作
+```
+
+单资源读在可见性拒绝时可以返回 not found，以隐藏资源存在性。写操作在调用方能定位资源但
+不能修改时应返回 access denied。列表和搜索 API 必须在产生分页数据和总数前应用可见性。
+
+## RBAC 模型
+
+默认权限模型包含：
+
+| 概念 | 含义 |
+|------|------|
+| 用户 | 可以登录或调用 API 的认证主体。 |
+| 角色 | 分配给用户的命名权限组。 |
+| 权限 | 某个角色对某个 Nacos 资源允许执行的动作。 |
+| 资源 | 由命名空间、分组或资源类型、资源名和领域类型共同标识的 Nacos 对象。 |
+| 动作 | 操作类型，目前为读或写。 |
+
+`ROLE_ADMIN` 是全局管理员角色。全局管理员会跳过普通资源权限检查。
+
+## 核心概念
+
+### `ApiType`
+
+`ApiType` 描述 API 受众，以及请求适用的鉴权开关范围。
+
+| 值 | 含义 |
+|----|------|
+| `OPEN_API` | 面向应用或 SDK 的客户端 API。 |
+| `ADMIN_API` | 面向维护者、工具和网关的管理 API。 |
+| `CONSOLE_API` | Nacos 控制台使用的 API。 |
+| `INNER_API` | 服务端内部 API，通常由服务端身份保护。 |
+
+### `SignType`
+
+`SignType` 标识用于解析和授权资源的领域。
+
+| 值 | 含义 |
+|----|------|
+| `CONFIG` | 配置资源。 |
+| `NAMING` | 服务发现和注册资源。 |
+| `AI` | MCP、Prompt、Agent、Tool 等 AI 注册中心资源。 |
+| `CONSOLE` | 用户、角色、权限等控制台管理资源。 |
+| `LOCK` | 锁资源。 |
+| `SPECIFIED` | 由受保护端点显式提供的资源字符串。 |
+
+### `ActionTypes`
+
+| 值 | 存储值 | 语义 |
+|----|--------|------|
+| `READ` | `r` | 查询、列表、详情、订阅、监听或只读查看。 |
+| `WRITE` | `w` | 创建、更新、删除、发布、注册、注销或状态变更。 |
+
+实现可以存储 `rw` 这类组合动作，但端点注解必须使用与 API 行为匹配的明确动作。
+
+### `@Secured`
+
+`@Secured` 是端点级声明，用于把 Controller 或请求处理器绑定到鉴权模型。
+
+| 字段 | 目的 |
+|------|------|
+| `action` | 需要的动作，通常为 `READ` 或 `WRITE`。 |
+| `resource` | 显式资源名，主要用于 `SPECIFIED` 或控制台资源。 |
+| `signType` | 用于资源解析和权限判断的领域。 |
+| `parser` | 默认解析器不足时使用的自定义资源解析器。 |
+| `tags` | 复制到 `Resource.properties` 的附加元数据。 |
+| `apiType` | API 受众与鉴权范围。 |
+
+每个非公开的 v3 HTTP API 和 gRPC 请求处理器都必须声明预期的鉴权元数据。公开端点必须由
+所属规范明确记录。
+
+## 授权流程
+
+通用鉴权流程如下：
+
+1. 定位请求的 `@Secured` 元数据。
+2. 从 header、参数、token、证书或连接器元数据中构造 `IdentityContext`。
+3. 从请求参数或 `@Secured` 显式资源中解析 Nacos `Resource`。
+4. 询问选中的鉴权插件，该动作和领域是否启用鉴权。
+5. 校验身份。
+6. 针对 `Permission(resource, action)` 校验权限。
+
+服务端内部请求在继续处理前，还可能要求配置的服务端身份 key 和 value 校验通过。
+
+## 资源权限名
+
+Nacos 权限基于资源模型派生的资源进行评估：
+
+```text
+NamespaceId -> Group 或 resourceType -> resourceName
+```
+
+标准资源形式如下：
+
+| 领域 | 权限资源形式 |
+|------|--------------|
+| 配置 | `{namespaceId}:{group}:config/{dataId}` |
+| 注册发现 | `{namespaceId}:{group}:naming/{serviceName}` |
+| AI | `{namespaceId}:{group}:ai/{resourceName}`，并携带 AI 资源元数据。 |
+| 控制台 | `console/{managementResource}` |
+| 显式资源 | `@Secured(resource = ...)` 提供的字符串。 |
+
+默认鉴权实现支持在权限资源中使用 `*` 通配符。命名空间、分组、资源类型和资源名的含义以
+资源模型规范为准。
+
+## 鉴权开关范围
+
+鉴权启用状态按 API 受众划分：
+
+| 配置 | 范围 |
+|------|------|
+| `nacos.core.auth.enabled` | 启用 Open API 和通用鉴权系统。 |
+| `nacos.core.auth.admin.enabled` | 启用 Admin API 鉴权。 |
+| `nacos.core.auth.console.enabled` | 启用 Console API 和登录行为鉴权。 |
+
+选中的鉴权插件由 `nacos.core.auth.system.type` 指定。
+
+## 插件 API
+
+`/v3/auth/*` 下的鉴权相关 HTTP API 属于插件提供的 API。默认 Nacos 鉴权插件提供用户、
+角色、权限和登录端点。这些端点按路径不归属于 Open、Admin 或 Console API，但仍必须遵守
+Nacos v3 API 的响应、错误和鉴权约定。
+
+## 公开端点
+
+端点只有在所属规范和文档明确说明时，才可以被设计为无需鉴权。典型例子包括登录、由服务端
+状态保护的一次性管理员初始化，以及为未认证探测而设计的健康检查或状态端点。
+
+当某个端点因兼容性而公开，而不是当前设计要求公开时，新文档化 API 应作为主 API，旧端点
+只作为兼容面保留。

--- a/specs/zh-cn/auth/auth-plugin-spec.md
+++ b/specs/zh-cn/auth/auth-plugin-spec.md
@@ -1,0 +1,114 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# 鉴权插件规范
+
+## 范围
+
+鉴权插件类别允许 Nacos 在不修改 API Controller 或资源解析器的情况下替换认证与授权实现。
+通用契约为：
+
+```text
+IdentityContext + Resource + Action -> 允许或拒绝
+```
+
+鉴权插件不拥有 Nacos 资源模型。它消费由 Nacos Controller、协议过滤器和资源解析器创建的
+资源。
+
+## 服务端 SPI
+
+服务端鉴权插件实现 `AuthPluginService`。
+
+| 方法 | 要求 |
+|------|------|
+| `getAuthServiceName()` | 返回稳定的插件名称，由 `nacos.core.auth.system.type` 选择。 |
+| `identityNames()` | 声明可以从请求中提取的身份字段。 |
+| `enableAuth(action, type)` | 判断该动作和 SignType 是否需要鉴权。 |
+| `validateIdentity(identityContext, resource)` | 认证调用方，并补充身份元数据。 |
+| `validateAuthority(identityContext, permission)` | 校验调用方是否拥有目标资源和动作的权限。 |
+| `isLoginEnabled()` | 声明是否暴露插件提供的登录能力。 |
+| `isAdminRequest()` | 声明当前请求是否属于管理员初始化流程。 |
+
+当身份或权限被拒绝时，插件必须抛出或返回 Nacos 鉴权异常，使协议层可以映射为标准 API
+错误。
+
+## 客户端 SPI
+
+客户端鉴权插件负责提供请求身份材料。客户端插件只能注入所选服务端插件需要的凭据或 token，
+不得改变请求载荷的语义。
+
+Java 客户端必须支持内置用户名/密码和 token 流程。自定义客户端鉴权插件可以提供 AK、
+签名、证书或外部 token，但必须与匹配的服务端鉴权插件声明的身份字段保持兼容。
+
+## 选择与状态
+
+选中的鉴权实现由以下配置指定：
+
+```properties
+nacos.core.auth.system.type=nacos
+```
+
+鉴权插件同时以 `auth` 类型注册到核心插件系统。只有被选中且处于启用状态的鉴权插件可以
+处理请求。如果插件已加载但被插件状态禁用，则不得参与鉴权判断。
+
+## 身份上下文
+
+`IdentityContext` 是与传输协议无关的调用方描述。它可以包含：
+
+- 远端 IP 等内置字段。
+- `Authorization`、`accessToken`、`username`、`password` 等 header 或参数。
+- AK、签名、租户声明、外部主体等插件自定义字段。
+- 已认证用户名、用户 ID、全局管理员标记等认证结果元数据。
+
+身份字段名属于插件契约的一部分。服务端和客户端插件实现必须对这些名称达成一致。
+
+## 资源与权限
+
+鉴权插件接收 Nacos `Resource` 和 `Permission` 对象。插件可以将这些对象映射到外部权限
+系统，但必须保留：
+
+- 命名空间隔离。
+- 分组或资源类型语义。
+- 资源名语义。
+- `READ` 和 `WRITE` 动作语义。
+- 通过 `SignType.SPECIFIED` 声明的显式资源。
+
+## 插件 API
+
+如果鉴权插件暴露 HTTP API，这些 API 必须：
+
+- 使用 `/v3/auth/{resource}` 路径族。
+- 使用 `Result<T>` 作为响应封装。
+- 使用标准 Nacos 错误码和异常处理。
+- 为受保护的管理端点添加 `@Secured`。
+- 记录登录、初始化等有意公开的端点。
+
+默认 Nacos 鉴权插件是当前 `/v3/auth/user`、`/v3/auth/role` 和
+`/v3/auth/permission` API 的参考实现。
+
+## 与可见性的关系
+
+鉴权回答调用方是谁，以及调用方是否拥有某个资源/动作的权限。可见性回答单资源操作或范围
+查询中哪些资源应对调用方可见。
+
+可见性插件可以将显式权限检查委托回当前选中的鉴权插件。因此鉴权插件必须让显式资源和领域
+资源的权限判断都保持稳定。
+
+## 安全要求
+
+内置 Nacos 鉴权插件面向可信内网环境设计，并不是针对恶意公网环境的完整强鉴权方案。需要
+更强认证能力的部署，应提供或选择符合自身安全要求的鉴权插件。
+

--- a/specs/zh-cn/auth/default-auth-plugin-spec.md
+++ b/specs/zh-cn/auth/default-auth-plugin-spec.md
@@ -1,0 +1,160 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# 默认鉴权插件实现规范
+
+## 范围
+
+默认鉴权实现包提供 `nacos` 和 `ldap` 两个鉴权插件。`nacos` 插件提供用户名/密码登录、
+token 认证、RBAC 权限管理，以及 AI 资源使用的默认可见性集成。
+
+默认实现用于在可信内网环境中降低误用风险。它不是面向恶意公网环境的完整强鉴权方案。
+如果需要暴露到公网，应使用外部安全边界，或选择更强的鉴权插件。
+
+## 必要配置
+
+| 配置 | 目的 |
+|------|------|
+| `nacos.core.auth.enabled` | 启用通用鉴权系统和 Open API 鉴权。 |
+| `nacos.core.auth.admin.enabled` | 启用 Admin API 鉴权。 |
+| `nacos.core.auth.console.enabled` | 启用 Console API 鉴权和默认登录行为。 |
+| `nacos.core.auth.system.type` | 选择鉴权插件，默认 `nacos`。 |
+| `nacos.core.auth.plugin.nacos.token.secret.key` | 默认 token 签名密钥，部署时必须配置。 |
+| `nacos.core.auth.plugin.nacos.token.expire.seconds` | token 过期时间。 |
+| `nacos.core.auth.plugin.nacos.token.cache.enable` | 启用 token 解析和校验缓存。 |
+| `nacos.core.auth.server.identity.key` | 服务端之间调用的身份 key。 |
+| `nacos.core.auth.server.identity.value` | 服务端之间调用的身份 value。 |
+| `nacos.core.auth.caching.enabled` | 启用用户、角色和权限缓存。 |
+| `nacos.core.auth.nacos.anonymous.ai.enabled` | 当端点明确选择匿名访问时，允许匿名 AI 访问。 |
+
+token 密钥和服务端身份值必须由部署环境独立配置。使用默认值或共享值是不安全的。
+
+`ldap` 插件变体额外使用 `nacos.core.auth.ldap.*` 配置族。LDAP 只改变身份认证方式，授权仍然
+使用 Nacos 角色和权限。
+
+## 身份
+
+插件接受以下身份输入：
+
+| 输入 | 用途 |
+|------|------|
+| `Authorization: Bearer ...` | token 认证。 |
+| `accessToken` | 通过请求参数或 header 进行 token 认证。 |
+| `username` 和 `password` | 登录或直接用户名/密码认证。 |
+| 服务端身份 key/value | 服务端之间调用的身份。 |
+
+认证成功后，插件会向 `IdentityContext` 补充已认证的 Nacos 用户和用户 ID。全局管理员状态由
+用户角色模型推导。
+
+匿名 AI 访问只有在以下条件同时满足时才允许：
+
+- 端点标记该请求允许匿名访问。
+- `nacos.core.auth.nacos.anonymous.ai.enabled` 已启用。
+- 默认插件将请求接受为内置匿名身份。
+
+当匿名 AI 访问启用时，实现会初始化保留的匿名用户和角色，并授予 `public:*:ai/*` 读权限。
+
+## RBAC 存储模型
+
+默认插件存储：
+
+| 对象 | 含义 |
+|------|------|
+| `User` | 用户名和密码身份。 |
+| `RoleInfo` | 分配给用户名的角色。 |
+| `PermissionInfo` | 分配给角色的资源和动作。 |
+
+`ROLE_ADMIN` 是全局管理员角色。拥有该角色的用户可以访问所有资源和控制台管理操作。
+
+## 权限资源格式
+
+默认资源权限使用：
+
+```text
+{namespaceId}:{group}:{signType}/{resourceName}
+```
+
+示例：
+
+| 资源 | 示例 |
+|------|------|
+| 配置数据 | `public:DEFAULT_GROUP:config/example.properties` |
+| 注册发现服务 | `public:DEFAULT_GROUP:naming/com.example.Service` |
+| 控制台用户 | `console/users` |
+| 控制台角色 | `console/roles` |
+| 控制台权限 | `console/permissions` |
+| 可见性权限 | `@@visibility/public/mcp/example-mcp` |
+
+规则：
+
+- 权限资源中可以使用 `*` 作为通配符。
+- group 为空时，权限检查会在 group 段使用 `*`。
+- resource name 为空时，资源名段会变成 `*`。
+- 存储资源以 `:` 开头时，会补充默认命名空间 `public`。
+- `SPECIFIED` 资源直接使用显式资源字符串。
+- 存储动作可以是 `r`、`w` 或 `rw`。
+
+非管理员角色不得管理控制台用户、角色或权限。
+
+## 默认鉴权 API
+
+默认插件拥有以下 v3 API 族：
+
+| 路径 | 目的 |
+|------|------|
+| `/v3/auth/user` | 用户管理和密码更新。 |
+| `/v3/auth/user/login` | 登录和 token 签发。 |
+| `/v3/auth/user/admin` | 当不存在全局管理员时进行管理员初始化。 |
+| `/v3/auth/role` | 角色管理。 |
+| `/v3/auth/permission` | 权限管理。 |
+
+管理端点必须使用控制台域的 `@Secured` 资源保护，例如 `console/users`、
+`console/roles`、`console/permissions` 和 `console/user/password`。
+
+登录端点是有意公开的。管理员初始化端点只在无管理员初始化状态下有意暴露；一旦全局管理员
+已经存在，必须拒绝该端点。
+
+## 默认可见性实现
+
+默认可见性实现名称同样为 `nacos`，当前用于 AI 资源。
+
+默认行为：
+
+- 除非领域提供其他 scope，新资源默认 `PRIVATE`。
+- 全局管理员可以读写所有具备可见性语义的资源。
+- 资源 owner 可以读写该资源。
+- `PUBLIC` 资源可以被非 owner 读取。
+- 显式可见性权限可以通过鉴权插件授予访问。
+- 匿名 AI 读访问只能通过匿名 AI 显式选择路径开启。
+- 读拒绝可以返回 not found，以隐藏资源存在性。
+- 写拒绝返回 access denied。
+
+显式可见性权限资源使用：
+
+```text
+@@visibility/{namespaceId}/{resourceType}/{resourceName}
+```
+
+范围查询必须组合基础可见性谓词和显式授权资源。当前默认实现已经暴露显式授权资源结构；
+API 和存储集成在补齐后必须使用该结构。
+
+对于 AI 列表和搜索路径，可见性必须在 count 和分页查询前转换为仓储层查询条件。这可以让
+`totalCount` 与可见资源集合保持一致，并避免全量加载后在内存中过滤。
+
+## 兼容性
+
+旧端点或兼容端点可以为已有客户端保留，但新的文档和新的开发应以 v3 鉴权 API 以及本文档
+定义的插件契约为准。

--- a/specs/zh-cn/auth/visibility-plugin-spec.md
+++ b/specs/zh-cn/auth/visibility-plugin-spec.md
@@ -1,0 +1,142 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# 可见性插件规范
+
+## 范围
+
+可见性插件类别控制某个资源对调用方是否可见。它与鉴权相互独立：
+
+- 鉴权判断目标资源/动作上的身份和权限。
+- 可见性判断目标资源，或范围查询中的某个资源，是否应该对该身份可见。
+
+可见性对于 AI 注册中心资源尤其重要，因为用户可能创建仅 owner 可见、读者公开可见，或通过
+显式授权可见的资源。
+
+可见性必须在数据查询阶段生效。列表和搜索 API 不得先对原始候选集合分页，再只在内存中过滤
+当前页，因为这会产生错误的 `totalCount`、空页和不可控延迟。
+
+## 资源模型
+
+具备可见性语义的资源必须提供：
+
+| 字段 | 含义 |
+|------|------|
+| `namespaceId` | 资源所属命名空间。 |
+| `resourceType` | 命名空间内的资源类别。 |
+| `resourceName` | 资源类型内稳定的资源名。 |
+| `scope` | 可见性范围，目前为 `PUBLIC` 或 `PRIVATE`。 |
+| `owner` | 资源所有者身份。 |
+
+这遵循 Nacos 资源层次：
+
+```text
+NamespaceId -> resourceType -> resourceName
+```
+
+## 可见性 SPI
+
+可见性插件实现 `VisibilityService`。
+
+| 方法 | 要求 |
+|------|------|
+| `getVisibilityServiceName()` | 返回稳定的插件名称。 |
+| `init(properties)` | 初始化插件自身属性。 |
+| `resolveDefaultScopeForCreate(identity, apiType, resourceType)` | 当创建资源未显式指定 scope 时，决定默认 scope。 |
+| `validateVisibility(identity, action, apiType, resource)` | 校验单个资源的可见性。 |
+| `adviseQuery(identity, action, apiType, queryContext)` | 为范围查询返回查询谓词和显式授权资源。 |
+
+该插件通过 SPI 发现，并以 `visibility` 类型注册到插件系统。
+配置的可见性服务名称由以下配置选择：
+
+```properties
+nacos.plugin.visibility.type=nacos
+```
+
+## 动作
+
+可见性使用与鉴权一致的读写语义：
+
+| 动作 | 含义 |
+|------|------|
+| `r` | 读取或列出可见资源。 |
+| `w` | 创建、更新、删除或改变可见性敏感的资源状态。 |
+
+写可见性必须严于读可见性。公开读权限不意味着公开写权限。
+
+## 查询建议
+
+当存储层可以应用可见性条件时，范围查询不应先加载所有资源再只在内存中做过滤。
+`QueryAdvisor` 携带：
+
+| 字段 | 目的 |
+|------|------|
+| `BaseVisibilityPredicate` | 基础谓词，例如所有资源、仅公开资源、仅 owner 资源，或公开加 owner 资源。 |
+| `AuthorizedResources` | 需要额外包含的显式授权资源名。 |
+
+列出资源的 API 或存储适配层必须组合这两部分，且不得泄漏私有资源。
+
+默认 AI 集成会在执行 count 和分页查询前，将 `QueryAdvisor` 转换为仓储层
+`QueryCondition`。基础谓词映射如下：
+
+| 谓词 | 查询行为 |
+|------|----------|
+| `ALL` | 不追加可见性条件。 |
+| `PUBLIC` | 限制为 `scope=PUBLIC`；如果调用方请求了冲突 scope，则返回空集。 |
+| `OWNER` | 限制为 `owner=identity`；如果身份为空或 owner 冲突，则返回空集。 |
+| `PUBLIC_AND_OWNER` | 限制为 `scope=PUBLIC OR owner=identity`；匿名调用方退化为仅公开资源。 |
+
+如果 `AuthorizedResources` 被填充，它应作为与基础谓词并列的 OR 分支加入查询。默认实现当前
+保持该列表为空，并将该字段作为显式资源授权的扩展点。
+
+## 插件状态与配置
+
+可见性插件的启用状态由可见性插件管理器和核心插件状态检查器共同控制。全局开关为：
+
+```properties
+nacos.plugin.visibility.enabled=true
+```
+
+插件自身属性使用前缀：
+
+```properties
+nacos.plugin.visibility.{serviceName}.*
+```
+
+当可见性被关闭时，所属领域必须定义行为是全部可见，还是拒绝可见性敏感操作。默认 AI
+可见性实现会在鉴权未启用时允许可见。
+
+## 与鉴权的关系
+
+可见性插件可以将显式权限检查委托给当前选中的鉴权插件。显式可见性权限资源使用领域自己
+拥有的资源字符串和 `SignType.SPECIFIED`；默认实现使用：
+
+```text
+@@visibility/{namespaceId}/{resourceType}/{resourceName}
+```
+
+这保留了职责分离：可见性决定候选资源，鉴权仍然是权限判断来源。
+
+## API 要求
+
+任何返回具备可见性语义资源的 API 都必须：
+
+- 对单资源读写操作调用 `validateVisibility`。
+- 在列表或搜索操作返回数据前应用 `adviseQuery`。
+- 在资源创建或更新时保留 owner 和 scope 元数据。
+- 避免通过数量、错误信息或部分列表响应暴露私有资源名。
+- 当 API 需要隐藏资源存在性时，单资源读拒绝应返回 not found。
+- 写拒绝应返回 access denied。

--- a/specs/zh-cn/design/nacos-design-spec.md
+++ b/specs/zh-cn/design/nacos-design-spec.md
@@ -1,0 +1,182 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos 设计规范
+
+本文档定义 Nacos 的顶层设计意图。API、SDK、资源模型、模块、插件和兼容性等
+更细粒度规范都应遵循本文档。
+
+## 1. 定位
+
+Nacos 是面向云原生和 AI 原生应用的动态服务发现、配置管理、服务管理和
+AI Agent 管理平台。
+
+Nacos 是以服务为中心的应用架构基础设施。这里的服务可以是微服务、RPC 服务、
+DNS 可发现端点、网关后端、MCP Server、A2A Agent、Prompt、Skill、AgentSpec，
+也可以是其他需要发现、动态配置、生命周期管理、治理和安全分发的运行时资源。
+
+## 2. 设计目标
+
+Nacos 应做到：
+
+- 让运行时资源易于注册、发现、配置、治理和观测；
+- 让应用无需重新部署即可改变配置、路由、发现结果和 AI 资源选择；
+- 为配置、注册中心、服务元数据和 AI Registry 资源提供统一控制面；
+- 通过 namespace 和权限边界支持多租户、多环境隔离；
+- 在大规模集群和高并发工作负载下保持生产级可用性；
+- 通过标准协议、SDK、API 和插件扩展点保持开放生态。
+
+## 3. 设计原则
+
+### 3.1 易于使用
+
+Nacos 应为常见运行时和管理任务提供简单 API、SDK、命令行工具和控制台流程。
+用户不应为了正确使用 Nacos 而理解内部存储、一致性协议或传输细节。
+
+### 3.2 面向标准
+
+Nacos 应尽量对齐广泛使用的标准和生态协议，包括云原生服务发现、HTTP API、
+gRPC 传输、MCP、A2A，以及 Kubernetes、Spring、Dubbo、Spring AI 等集成模式。
+
+当 Nacos 增加协议适配层时，Nacos 资源模型仍然是内部语义来源，协议模型只是
+该资源模型上的适配。
+
+### 3.3 运行时动态
+
+Nacos 资源预期会在运行时发生变化。配置内容、服务实例、端点、AI 资源、标签、
+可见性和元数据都可以在不重新部署应用的情况下变化。
+
+面向运行时的 API 和 SDK 应在领域需要时支持订阅、推送、本地缓存和安全回退。
+
+### 3.4 高可用
+
+Nacos 应支持面向本地开发和测试的单机模式，也应支持面向生产环境的集群模式。
+集群模式应根据不同领域的资源语义，通过合适的一致性和复制机制提供可用性与
+水平扩展能力。
+
+### 3.5 方便扩展
+
+Nacos 应保持清晰模块边界，并为鉴权、可见性、数据源、加密、链路追踪、控制、
+环境和 AI 发布流水线等横切能力提供插件扩展点。
+
+扩展不应重新定义核心资源身份、API 响应语义或鉴权边界。
+
+### 3.6 安全可治理
+
+Nacos 管理敏感的运行时资产和 AI 资产。安全是设计的一部分，而不是可选附加项：
+
+- 受保护 API 应显式启用鉴权和授权；
+- AI 资源应支持 owner、可见性、版本治理、审核、分发和审计追溯；
+- 大范围读取和管理 API 应属于 admin 或 maintainer 能力面；
+- 运行时 client 能力面应只暴露最小权限能力。
+
+## 4. 领域职责
+
+### 4.1 配置领域
+
+配置领域管理由 namespace、group 和 dataId 标识的动态配置资源。它负责配置内容、
+type、md5、元数据、监听、模糊订阅、灰度/beta 发布、历史、回滚、dump 和
+failover 相关行为。
+
+### 4.2 注册中心领域
+
+注册中心领域管理由 namespace、group 和 service name 标识的服务发现资源。它负责
+服务元数据、实例、集群、健康状态、临时和持久化语义、订阅者、客户端视图和
+服务变化推送。
+
+### 4.3 AI Registry 领域
+
+AI Registry 领域管理 MCP Server、A2A AgentCard、Prompt、Skill 和 AgentSpec 等
+AI 资源。它负责 AI 资源元数据、版本、标签、可见性、端点、工具或 Skill 描述、
+发布流水线状态、下载分发和面向审计的追踪信息。
+
+AI Registry 不是 Nacos 内部的独立产品模型，而是 Nacos 的一等领域，使用同一套
+namespace、API、SDK、鉴权、插件和资源治理原则。
+
+### 4.4 Core 和运维领域
+
+Core 领域负责 namespace 管理、集群成员、服务端状态、readiness/liveness、连接
+管理、日志级别操作、插件状态和其他服务端控制面资源。
+
+这些能力天然属于管理能力，应通过 Admin API、Console API 或 Maintainer SDK 暴露，
+而不是通过运行时 Client SDK 暴露。
+
+### 4.5 安全和可见性领域
+
+安全领域负责认证、授权、身份传递、API 分类、动作分类和可见性校验。它应一致
+作用于 HTTP API、gRPC 调用、SDK、控制台行为以及插件提供的 API。
+
+## 5. 接口架构
+
+Nacos 通过多类接口暴露同一套资源语义：
+
+- HTTP API，用于 Open、Admin、Console、Auth 和插件 API；
+- gRPC API，用于高频运行时通信、推送、订阅和客户端-服务端控制消息；
+- Client SDK，用于运行时应用和 Agent Framework；
+- Maintainer SDK，用于管理、UI、网关和运维接入；
+- 控制台和 CLI，用于人和自动化流程。
+
+不同接口可以使用不同传输模型，但必须保持一致的资源身份、校验、鉴权、生命周期
+和错误语义。
+
+## 6. 模块架构
+
+Nacos 模块应遵循以下职责边界：
+
+- `api`、`client` 和 `client-basic` 定义公开客户端模型、SDK interface 和传输契约。
+- `config`、`naming` 和 `ai` 负责各自领域资源行为。
+- `core` 负责集群、namespace、服务端、插件和运维基础能力。
+- `auth` 和 plugin 模块负责可扩展的安全与策略行为。
+- `maintainer-client` 基于 Admin API 语义暴露类型化 Java 管理入口。
+- `console` 暴露面向 UI 的后端 API，不应独立重新定义领域语义。
+
+共享模型应放在 API 兼容要求清晰的位置。服务端内部实现细节不应泄露到公开 SDK
+契约中。
+
+## 7. 一致性和存储
+
+每个领域应根据资源语义选择一致性和存储行为：
+
+- 配置资源需要持久存储、版本/历史感知和可靠变更通知；
+- 注册中心资源需要快速运行时更新、健康状态驱动的可用性以及清晰的临时/持久化语义；
+- AI 资源需要持久元数据、适用场景下不可变的已发布版本、基于标签的路由、可见性
+  和审核/审计元数据；
+- 服务端和集群资源需要显式管理控制和运维安全。
+
+实现可以使用数据库持久化、本地缓存、Distro、Raft 或其他机制，但公开语义必须
+通过领域规范表达，而不是通过存储实现细节表达。
+
+## 8. 新功能设计规则
+
+每个 Nacos 新功能都应定义：
+
+- 功能所属领域；
+- 资源类型和资源身份；
+- 功能面向运行时、管理侧，还是两者都面向；
+- API 受众：Open、Admin、Console、Auth、plugin、gRPC、Client SDK 或 Maintainer SDK；
+- namespace、group、version、label、status 和 visibility 行为；
+- 认证、授权和审计要求；
+- 对已有 API 和 SDK 的兼容及废弃影响；
+- 能让规范可执行的测试或校验规则。
+
+如果一个功能无法回答这些问题，它还不应成为稳定的 Nacos 契约。
+
+## 9. 相关规范
+
+- [资源模型规范](./resource-model-spec.md)
+- [HTTP API 规范](../http-api/api-spec.md)
+- [gRPC API 规范](../grpc-api/api-spec.md)
+- [SDK 规范](../sdk/sdk-spec.md)

--- a/specs/zh-cn/design/nacos-design-spec.md
+++ b/specs/zh-cn/design/nacos-design-spec.md
@@ -85,6 +85,17 @@ Nacos 管理敏感的运行时资产和 AI 资产。安全是设计的一部分�
 
 ## 4. 领域职责
 
+Nacos 领域应围绕统一资源层次组织：
+
+```text
+NamespaceId -> Group/resourceType -> resourceName
+```
+
+其中 `NamespaceId` 是隔离边界；`Group/resourceType` 是第二层分类，微服务应用资源
+使用 `Group`，AI Registry 资源使用 `resourceType`；`resourceName` 是领域内具体
+资源名称。领域规范可以继续定义 version、label、status、visibility 等治理属性，
+但不应打破这个顶层层次。
+
 ### 4.1 配置领域
 
 配置领域管理由 namespace、group 和 dataId 标识的动态配置资源。它负责配置内容、
@@ -100,8 +111,9 @@ failover 相关行为。
 ### 4.3 AI Registry 领域
 
 AI Registry 领域管理 MCP Server、A2A AgentCard、Prompt、Skill 和 AgentSpec 等
-AI 资源。它负责 AI 资源元数据、版本、标签、可见性、端点、工具或 Skill 描述、
-发布流水线状态、下载分发和面向审计的追踪信息。
+AI 资源。AI 资源使用 `NamespaceId -> resourceType -> resourceName` 作为顶层身份。
+它负责 AI 资源元数据、版本、标签、可见性、端点、工具或 Skill 描述、发布流水线
+状态、下载分发和面向审计的追踪信息。
 
 AI Registry 不是 Nacos 内部的独立产品模型，而是 Nacos 的一等领域，使用同一套
 namespace、API、SDK、鉴权、插件和资源治理原则。

--- a/specs/zh-cn/design/resource-model-spec.md
+++ b/specs/zh-cn/design/resource-model-spec.md
@@ -19,29 +19,39 @@
 本文档定义 Nacos 共享资源模型，是 HTTP API、gRPC API、SDK、控制台流程、持久化
 模型和用户文档的语义来源。
 
-## 1. 资源信封
+## 1. 顶层资源层次
 
-每个 Nacos 资源都应能用一组通用信封字段描述：
+Nacos 顶层资源身份由三层组成：
 
-| 字段 | 要求 | 含义 |
+```text
+NamespaceId -> Group/resourceType -> resourceName
+```
+
+三层含义如下：
+
+| 层级 | 含义 | 适用范围 |
 | --- | --- | --- |
-| `namespaceId` | 租户域资源必需 | 租户、团队和环境的隔离边界。 |
-| `resourceType` | 多类资源共用存储或 API 面时必需 | 资源类型，例如 config、service、mcp、a2a、prompt、skill、agentspec。 |
-| `resourceName` | 必需 | 在所属 scope 和 type 内稳定标识资源的名称。 |
-| `group` | 可选，领域特定 | 配置和注册中心使用的二级分组。 |
-| `version` | 可选，仅版本化资源 | 不可变或受生命周期管理的版本标识。 |
-| `labels` | 可选，仅版本化资源 | `latest`、`stable` 或自定义标签等命名路由别名。 |
-| `status` | 可选，领域特定 | 资源或版本生命周期状态。 |
-| `metadata` | 可选 | 不改变资源身份的用户或系统元数据。 |
-| `visibility` | 可选，支持可见性的资源 | 访问范围和 owner 信息。 |
+| `NamespaceId` | 租户、团队、环境或管理域隔离边界。 | 所有租户域资源。 |
+| `Group/resourceType` | 第二层分类。微服务应用资源使用 `group`；AI 资源使用 `resourceType`。 | 由领域决定。 |
+| `resourceName` | 在上层 scope 内标识具体资源的稳定名称。 | 所有可命名资源。 |
 
-历史 Nacos 数据模型是 namespace、group 和 resource name 三元组。该三元组仍然
-适用于配置和注册中心资源。AI 资源在同一思路上扩展了 `resourceType`、`version`、
-`labels` 和可见性治理。
+`group` 和 `resourceType` 不应被混为同一个字段：
 
-## 2. Namespace
+- `group` 是微服务应用资源的业务分组，主要用于配置和注册中心资源。
+- `resourceType` 是资源类型分组，主要用于 AI Registry 等多类型资源共享同一套
+  治理模型的场景。
 
-Namespace 是最主要的隔离边界，用于隔离租户、团队、环境或其他管理范围。
+因此，Nacos 的资源模型可以按领域分为两类主干：
+
+- **微服务资源模型**：`NamespaceId -> Group -> resourceName`。
+- **AI 资源模型**：`NamespaceId -> resourceType -> resourceName`。
+
+版本、标签、状态、可见性、owner、元数据等字段属于资源的治理属性，除非领域规范
+明确说明，否则不参与顶层三层身份。
+
+## 2. NamespaceId
+
+NamespaceId 是最主要的隔离边界，用于隔离租户、团队、环境或其他管理范围。
 
 | 概念 | 标准名称 | 兼容名称 |
 | --- | --- | --- |
@@ -55,39 +65,63 @@ API 和规范应使用 `namespaceId`，除非已有兼容契约要求继续使�
 跨 namespace 操作属于管理操作，必须通过 Admin API、Console API 或 Maintainer SDK
 能力面暴露。
 
-## 3. Group
+## 3. 第二层：Group 或 resourceType
 
-Group 是领域特定的二级 scope。它是配置和注册中心资源身份的一部分，在支持省略的
-接口中默认值为 `DEFAULT_GROUP`。
+第二层用于在 namespace 内继续划分资源，但不同领域使用不同语义。
 
-Group 不是所有 Nacos 资源的通用字段。AI 资源不应引入 group 字段，除非对应领域
-规范明确给出语义。
+### 3.1 Group
 
-## 4. 资源身份规则
+Group 是微服务应用资源的业务分组。它是配置和注册中心资源身份的一部分，在支持
+省略的接口中默认值为 `DEFAULT_GROUP`。
 
-| 资源 | 标准身份 | 说明 |
-| --- | --- | --- |
-| Namespace | `namespaceId` | 根隔离资源。 |
-| Config | `namespaceId + group + dataId` | `tenant` 是 namespace 的历史存储/API 名称。 |
-| Naming service | `namespaceId + group + serviceName` | 内部 grouped name 可以使用 `group@@serviceName`。 |
-| Naming cluster | `namespaceId + group + serviceName + clusterName` | Cluster 从属于 service。 |
-| Naming instance | `namespaceId + group + serviceName + clusterName + ip + port` | `instanceId` 可以生成或由用户提供，作为运行时标识。 |
-| Naming client | `clientId` 或 connection id | 运行时视图，不是用户创建的领域资源。 |
-| AI resource | `namespaceId + resourceType + name` | Prompt、Skill、AgentSpec 等治理资源的共享模型。 |
-| AI resource version | `namespaceId + resourceType + name + version` | 版本状态独立于资源元数据管理。 |
-| MCP Server | `namespaceId + name`，可附带 `id` | `id` 可表示 registry/import 身份；`name` 是面向用户的资源名。 |
-| A2A AgentCard | `namespaceId + registrationType + name + version` | registration type 参与查询语义。 |
-| Prompt | `namespaceId + promptKey + version` | 旧 Prompt 数据可以镜像为 config 数据。 |
-| Skill | `namespaceId + name + version` | labels 映射路由名到版本。 |
-| AgentSpec | `namespaceId + name + version` | AgentSpec 可以引用其他 AI 资源。 |
-| Plugin | `pluginType + pluginName` | 插件状态是服务端控制面元数据。 |
+Group 适合表达同一类微服务资源的业务隔离，例如应用、业务线、环境内分组或用户
+自定义分组。Group 不表达资源类型，因此同一 group 下可以存在配置和服务等不同
+领域资源。
 
-资源身份字段不应被当作可变元数据。除非领域规范定义迁移操作，否则修改资源身份
-应视为删除并创建，或 clone 操作。
+### 3.2 resourceType
 
-## 5. Config 资源
+resourceType 是资源类型分组。它适合表达一类共享治理模型中的不同资源类型，例如
+AI Registry 中的 `mcp`、`a2a`、`prompt`、`skill`、`agentspec`。
 
-Config 资源由 `namespaceId + group + dataId` 标识。
+resourceType 不表达业务分组。AI 资源不应再引入 group 作为身份字段，除非对应领域
+规范明确给出额外语义。
+
+## 4. 第三层：resourceName
+
+resourceName 是在 `NamespaceId + Group/resourceType` 下稳定标识资源的名称。
+
+不同领域会使用更贴近业务的名称：
+
+| 领域 | resourceName 的具体名称 |
+| --- | --- |
+| Config | `dataId` |
+| Naming service | `serviceName` |
+| MCP Server | `name` 或 `mcpName` |
+| A2A AgentCard | `name` 或 `agentName` |
+| Prompt | `promptKey` |
+| Skill | `name` |
+| AgentSpec | `name` |
+
+resourceName 是身份字段，不应被当作普通元数据修改。除非领域规范定义迁移操作，
+否则修改 resourceName 应视为删除并创建，或 clone 操作。
+
+## 5. 微服务资源模型
+
+微服务资源模型使用：
+
+```text
+NamespaceId -> Group -> resourceName
+```
+
+它覆盖 Nacos 传统配置中心和注册中心能力。
+
+### 5.1 Config 资源
+
+Config 资源身份为：
+
+```text
+namespaceId -> group -> dataId
+```
 
 Config 负责：
 
@@ -99,104 +133,164 @@ Config 负责：
 - gray/beta 发布状态；
 - history、rollback、dump 和 failover 数据。
 
-`dataId` 是配置资源名。`appName`、`type`、`desc` 和 `configTags` 等元数据不改变
-资源身份。
+`dataId` 是 Config 的 resourceName。`appName`、`type`、`desc` 和 `configTags` 等
+元数据不改变资源身份。
 
 Prompt 存在旧兼容映射：固定 group 为 `nacos-ai-prompt`，dataId 为
-`{promptKey}.json`。该映射不应让 Prompt 在新规范中被视为普通 Config 资源。
+`{promptKey}.json`。该映射是兼容存储形态，不应让 Prompt 在新规范中被视为普通
+Config 资源。
 
-## 6. Naming 资源
+### 5.2 Naming service 资源
 
-Naming service 由 `namespaceId + group + serviceName` 标识。
+Naming service 资源身份为：
 
-Naming 负责：
+```text
+namespaceId -> group -> serviceName
+```
+
+Naming service 负责：
 
 - 服务元数据和 selector 信息；
 - 临时或持久化服务语义；
 - cluster 和健康检查配置；
-- instance，包含 `ip`、`port`、`clusterName`、`weight`、`healthy`、`enabled`、
-  `ephemeral`、`metadata` 和可选 `instanceId`；
 - subscriber、publisher 和 client connection 视图；
 - service 和 instance 变更事件。
 
-Instance 从属于 service。脱离 service scope 的 instance 不应被单独解释。
+内部 grouped name 可以使用 `group@@serviceName` 表达，但公开 API 和规范应优先
+使用独立的 `group` 与 `serviceName` 字段。
+
+### 5.3 Cluster 和 Instance
+
+Cluster 和 Instance 是 service 的下级资源，不改变顶层三层模型。
+
+```text
+namespaceId -> group -> serviceName -> clusterName -> instance
+```
+
+Instance 身份通常由 service scope、`clusterName`、`ip` 和 `port` 共同确定；
+`instanceId` 可以生成或由用户提供，作为运行时标识。
+
+Instance 包含 `ip`、`port`、`clusterName`、`weight`、`healthy`、`enabled`、
+`ephemeral`、`metadata` 和可选 `instanceId`。脱离 service scope 的 instance 不应
+被单独解释。
 
 临时和持久化语义会影响生命周期和一致性行为。HTTP、gRPC、SDK 和存储模型都必须
 保留该语义。
 
-## 7. AI 资源
+## 6. AI 资源模型
 
-AI 资源使用共享治理模型：
+AI 资源模型使用：
 
-- 资源元数据行：`namespaceId + type + name`；
-- 版本行：`namespaceId + type + name + version`；
-- 标签：名称到版本的映射，包括 `latest`；
-- 元数据状态：enable 或 disable；
-- 版本状态：draft、reviewing、reviewed、online 或 offline；
-- 可选 owner 和可见性范围：`PUBLIC` 或 `PRIVATE`；
-- 可选发布流水线状态：in progress、approved 或 rejected；
-- 可选业务标签、扩展元数据、来源和下载次数。
+```text
+NamespaceId -> resourceType -> resourceName
+```
+
+它覆盖 MCP Server、A2A AgentCard、Prompt、Skill、AgentSpec 等 AI Registry 资源。
+
+AI 资源共享一套治理属性：
+
+| 属性 | 含义 |
+| --- | --- |
+| `version` | 资源版本，形成 `NamespaceId + resourceType + resourceName + version`。 |
+| `labels` | 标签到版本的映射，例如 `latest`、`stable`。 |
+| `status` | 资源或版本状态。 |
+| `visibility` | 资源可见性，例如 `PUBLIC` 或 `PRIVATE`。 |
+| `owner` | 资源所有者 identity。 |
+| `bizTags` / `metadata` / `ext` | 不参与身份的业务或扩展元数据。 |
+| `pipeline` | 发布审核或自动化处理状态。 |
+
+AI 资源元数据身份为 `namespaceId + resourceType + resourceName`。AI 资源版本身份为
+`namespaceId + resourceType + resourceName + version`。
 
 已发布 AI 版本应视为不可变，除非领域规范显式定义安全修改方式。变更应创建新的
 draft 版本，在需要时通过审核，然后发布或调整 label。
 
-### 7.1 MCP Server
+### 6.1 MCP Server
+
+MCP Server 的标准资源身份为：
+
+```text
+namespaceId -> mcp -> mcpName
+```
 
 MCP Server 资源描述具备 MCP 能力的服务。它可以来自新构建的 MCP Server、导入的
 外部 MCP Server，也可以来自通过适配声明转换而来的存量 HTTP/RPC 服务。
 
-MCP Server 身份基于 `namespaceId + name`，并可带有 registry `id`。MCP 特有元数据
-包括 protocol、front protocol、repository、packages、icons、website URL、本地或
-远程 server config、endpoint spec、tool spec、status 和自动发现的 capabilities。
+MCP Server 可带有 registry `id`，但 `mcpName` 仍是面向用户的 resourceName。
+MCP 特有元数据包括 protocol、front protocol、repository、packages、icons、
+website URL、本地或远程 server config、endpoint spec、tool spec、status 和自动
+发现的 capabilities。
 
-支持的协议值包括 stdio、SSE 风格 MCP、streamable HTTP、HTTP 和 Dubbo 兼容形态，
-具体由 AI 领域定义。
+### 6.2 A2A AgentCard
 
-### 7.2 A2A AgentCard
+A2A AgentCard 的标准资源身份为：
 
-A2A AgentCard 资源描述 Agent 的能力、skills、supported interfaces、provider 信息、
+```text
+namespaceId -> a2a -> agentName
+```
+
+AgentCard 资源描述 Agent 的能力、skills、supported interfaces、provider 信息、
 security schemes、signatures 和 endpoint 元数据。
 
-AgentCard 查询按 namespace、registration type、agent name 和 version 确定范围。
-Endpoint registration 从属于对应 AgentCard，并且在运行时可能由客户端拥有。
+`registrationType` 参与 AgentCard 查询和兼容语义，但它不是顶层第二层字段。需要
+在具体 A2A 领域规范中定义它与 resourceName、version 和 endpoint 的关系。
 
-### 7.3 Prompt
+### 6.3 Prompt
 
-Prompt 资源在 namespace 内由 prompt key 和 version 标识。Prompt 包含 template
-内容、variables、md5 和版本元数据。
+Prompt 的标准资源身份为：
 
-运行时 Prompt 查询应按照对应 API 或 SDK 契约，通过显式 version、label、`latest`
-的顺序进行解析。
+```text
+namespaceId -> prompt -> promptKey
+```
 
-### 7.4 Skill
+Prompt version 形成：
 
-Skill 资源表示 AI Agent 的可复用能力。Skill 包含元数据、指令内容、可选资源、
-版本、标签、可见性和发布流水线元数据。
+```text
+namespaceId -> prompt -> promptKey -> version
+```
 
-Skill version 会经历 draft、review、publish、offline 等状态。除非管理 API 显式
-请求其他状态，否则运行时客户端只应获得 online version。
+Prompt 包含 template 内容、variables、md5 和版本元数据。运行时查询应按照对应
+API 或 SDK 契约，通过显式 version、label、`latest` 的顺序进行解析。
 
-### 7.5 AgentSpec
+### 6.4 Skill
 
-AgentSpec 资源通过引用 Prompt、Skill、MCP Server、A2A Agent 或其他必要资源来组装
-Agent 配置。AgentSpec 身份遵循 `namespaceId + name + version`，运行时路由应使用
-labels。
+Skill 的标准资源身份为：
 
-AgentSpec 应通过稳定身份和 version 或 label 引用其他资源，不应引用存储实现细节。
+```text
+namespaceId -> skill -> skillName
+```
 
-## 8. 可见性和 Owner
+Skill 表示 AI Agent 的可复用能力，包含元数据、指令内容、可选资源、版本、标签、
+可见性和发布流水线元数据。
+
+Skill version 会经历 draft、reviewing、reviewed、online、offline 等状态。除非
+管理 API 显式请求其他状态，否则运行时客户端只应获得 online version。
+
+### 6.5 AgentSpec
+
+AgentSpec 的标准资源身份为：
+
+```text
+namespaceId -> agentspec -> agentSpecName
+```
+
+AgentSpec 通过引用 Prompt、Skill、MCP Server、A2A Agent 或其他必要资源来组装
+Agent 配置。AgentSpec 应通过稳定身份和 version 或 label 引用其他资源，不应引用
+存储实现细节。
+
+## 7. 可见性和 Owner
 
 支持可见性的资源必须暴露：
 
 - `namespaceId`；
-- 稳定资源名；
-- 资源类型；
+- `resourceType`；
+- 稳定 resourceName；
 - scope，目前为 `PUBLIC` 或 `PRIVATE`；
 - owner identity。
 
 可见性影响发现、详情查看、下载和写入操作。它补充授权逻辑，但不能替代权限校验。
 
-## 9. 状态和生命周期
+## 8. 状态和生命周期
 
 状态值是领域特定的，但必须显式定义并记录：
 
@@ -209,7 +303,7 @@ AgentSpec 应通过稳定身份和 version 或 label 引用其他资源，不应
 运行时 API 应只返回运行时消费者需要的状态。管理 API 在授权后可以返回 draft、
 review、offline、internal 或 operational 状态。
 
-## 10. API 表达规则
+## 9. API 表达规则
 
 所有 API 家族必须保持相同的资源身份：
 
@@ -221,13 +315,14 @@ review、offline、internal 或 operational 状态。
 
 如果历史 API 使用兼容名称，实现应在内部映射到标准资源术语，并记录该别名。
 
-## 11. 新资源检查项
+## 10. 新资源检查项
 
 每个新的资源类型都必须定义：
 
 - 所属领域和模块；
 - 标准身份字段；
-- namespace 和 group 行为；
+- 使用 `Group` 还是 `resourceType` 作为第二层；
+- resourceName 的具体业务名称；
 - version、label、status 和 visibility 行为；
 - runtime API、management API 和 SDK 暴露方式；
 - 授权和审计要求；

--- a/specs/zh-cn/design/resource-model-spec.md
+++ b/specs/zh-cn/design/resource-model-spec.md
@@ -1,0 +1,235 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos 资源模型规范
+
+本文档定义 Nacos 共享资源模型，是 HTTP API、gRPC API、SDK、控制台流程、持久化
+模型和用户文档的语义来源。
+
+## 1. 资源信封
+
+每个 Nacos 资源都应能用一组通用信封字段描述：
+
+| 字段 | 要求 | 含义 |
+| --- | --- | --- |
+| `namespaceId` | 租户域资源必需 | 租户、团队和环境的隔离边界。 |
+| `resourceType` | 多类资源共用存储或 API 面时必需 | 资源类型，例如 config、service、mcp、a2a、prompt、skill、agentspec。 |
+| `resourceName` | 必需 | 在所属 scope 和 type 内稳定标识资源的名称。 |
+| `group` | 可选，领域特定 | 配置和注册中心使用的二级分组。 |
+| `version` | 可选，仅版本化资源 | 不可变或受生命周期管理的版本标识。 |
+| `labels` | 可选，仅版本化资源 | `latest`、`stable` 或自定义标签等命名路由别名。 |
+| `status` | 可选，领域特定 | 资源或版本生命周期状态。 |
+| `metadata` | 可选 | 不改变资源身份的用户或系统元数据。 |
+| `visibility` | 可选，支持可见性的资源 | 访问范围和 owner 信息。 |
+
+历史 Nacos 数据模型是 namespace、group 和 resource name 三元组。该三元组仍然
+适用于配置和注册中心资源。AI 资源在同一思路上扩展了 `resourceType`、`version`、
+`labels` 和可见性治理。
+
+## 2. Namespace
+
+Namespace 是最主要的隔离边界，用于隔离租户、团队、环境或其他管理范围。
+
+| 概念 | 标准名称 | 兼容名称 |
+| --- | --- | --- |
+| Namespace id | `namespaceId` 或 `namespace` | `tenant`, `tenantId` |
+| 展示名称 | `namespaceShowName` | `tenantName` |
+| 描述 | `namespaceDesc` | `tenantDesc` |
+
+默认 namespace id 是 `public`。历史代码可能使用 `tenant` 或 `tenantId`；新的公开
+API 和规范应使用 `namespaceId`，除非已有兼容契约要求继续使用其他名称。
+
+跨 namespace 操作属于管理操作，必须通过 Admin API、Console API 或 Maintainer SDK
+能力面暴露。
+
+## 3. Group
+
+Group 是领域特定的二级 scope。它是配置和注册中心资源身份的一部分，在支持省略的
+接口中默认值为 `DEFAULT_GROUP`。
+
+Group 不是所有 Nacos 资源的通用字段。AI 资源不应引入 group 字段，除非对应领域
+规范明确给出语义。
+
+## 4. 资源身份规则
+
+| 资源 | 标准身份 | 说明 |
+| --- | --- | --- |
+| Namespace | `namespaceId` | 根隔离资源。 |
+| Config | `namespaceId + group + dataId` | `tenant` 是 namespace 的历史存储/API 名称。 |
+| Naming service | `namespaceId + group + serviceName` | 内部 grouped name 可以使用 `group@@serviceName`。 |
+| Naming cluster | `namespaceId + group + serviceName + clusterName` | Cluster 从属于 service。 |
+| Naming instance | `namespaceId + group + serviceName + clusterName + ip + port` | `instanceId` 可以生成或由用户提供，作为运行时标识。 |
+| Naming client | `clientId` 或 connection id | 运行时视图，不是用户创建的领域资源。 |
+| AI resource | `namespaceId + resourceType + name` | Prompt、Skill、AgentSpec 等治理资源的共享模型。 |
+| AI resource version | `namespaceId + resourceType + name + version` | 版本状态独立于资源元数据管理。 |
+| MCP Server | `namespaceId + name`，可附带 `id` | `id` 可表示 registry/import 身份；`name` 是面向用户的资源名。 |
+| A2A AgentCard | `namespaceId + registrationType + name + version` | registration type 参与查询语义。 |
+| Prompt | `namespaceId + promptKey + version` | 旧 Prompt 数据可以镜像为 config 数据。 |
+| Skill | `namespaceId + name + version` | labels 映射路由名到版本。 |
+| AgentSpec | `namespaceId + name + version` | AgentSpec 可以引用其他 AI 资源。 |
+| Plugin | `pluginType + pluginName` | 插件状态是服务端控制面元数据。 |
+
+资源身份字段不应被当作可变元数据。除非领域规范定义迁移操作，否则修改资源身份
+应视为删除并创建，或 clone 操作。
+
+## 5. Config 资源
+
+Config 资源由 `namespaceId + group + dataId` 标识。
+
+Config 负责：
+
+- content 和 md5；
+- config type；
+- description、tags 和 app name 元数据；
+- 发布、CAS 发布、删除和查询语义；
+- listener 和 fuzzy-watch 语义；
+- gray/beta 发布状态；
+- history、rollback、dump 和 failover 数据。
+
+`dataId` 是配置资源名。`appName`、`type`、`desc` 和 `configTags` 等元数据不改变
+资源身份。
+
+Prompt 存在旧兼容映射：固定 group 为 `nacos-ai-prompt`，dataId 为
+`{promptKey}.json`。该映射不应让 Prompt 在新规范中被视为普通 Config 资源。
+
+## 6. Naming 资源
+
+Naming service 由 `namespaceId + group + serviceName` 标识。
+
+Naming 负责：
+
+- 服务元数据和 selector 信息；
+- 临时或持久化服务语义；
+- cluster 和健康检查配置；
+- instance，包含 `ip`、`port`、`clusterName`、`weight`、`healthy`、`enabled`、
+  `ephemeral`、`metadata` 和可选 `instanceId`；
+- subscriber、publisher 和 client connection 视图；
+- service 和 instance 变更事件。
+
+Instance 从属于 service。脱离 service scope 的 instance 不应被单独解释。
+
+临时和持久化语义会影响生命周期和一致性行为。HTTP、gRPC、SDK 和存储模型都必须
+保留该语义。
+
+## 7. AI 资源
+
+AI 资源使用共享治理模型：
+
+- 资源元数据行：`namespaceId + type + name`；
+- 版本行：`namespaceId + type + name + version`；
+- 标签：名称到版本的映射，包括 `latest`；
+- 元数据状态：enable 或 disable；
+- 版本状态：draft、reviewing、reviewed、online 或 offline；
+- 可选 owner 和可见性范围：`PUBLIC` 或 `PRIVATE`；
+- 可选发布流水线状态：in progress、approved 或 rejected；
+- 可选业务标签、扩展元数据、来源和下载次数。
+
+已发布 AI 版本应视为不可变，除非领域规范显式定义安全修改方式。变更应创建新的
+draft 版本，在需要时通过审核，然后发布或调整 label。
+
+### 7.1 MCP Server
+
+MCP Server 资源描述具备 MCP 能力的服务。它可以来自新构建的 MCP Server、导入的
+外部 MCP Server，也可以来自通过适配声明转换而来的存量 HTTP/RPC 服务。
+
+MCP Server 身份基于 `namespaceId + name`，并可带有 registry `id`。MCP 特有元数据
+包括 protocol、front protocol、repository、packages、icons、website URL、本地或
+远程 server config、endpoint spec、tool spec、status 和自动发现的 capabilities。
+
+支持的协议值包括 stdio、SSE 风格 MCP、streamable HTTP、HTTP 和 Dubbo 兼容形态，
+具体由 AI 领域定义。
+
+### 7.2 A2A AgentCard
+
+A2A AgentCard 资源描述 Agent 的能力、skills、supported interfaces、provider 信息、
+security schemes、signatures 和 endpoint 元数据。
+
+AgentCard 查询按 namespace、registration type、agent name 和 version 确定范围。
+Endpoint registration 从属于对应 AgentCard，并且在运行时可能由客户端拥有。
+
+### 7.3 Prompt
+
+Prompt 资源在 namespace 内由 prompt key 和 version 标识。Prompt 包含 template
+内容、variables、md5 和版本元数据。
+
+运行时 Prompt 查询应按照对应 API 或 SDK 契约，通过显式 version、label、`latest`
+的顺序进行解析。
+
+### 7.4 Skill
+
+Skill 资源表示 AI Agent 的可复用能力。Skill 包含元数据、指令内容、可选资源、
+版本、标签、可见性和发布流水线元数据。
+
+Skill version 会经历 draft、review、publish、offline 等状态。除非管理 API 显式
+请求其他状态，否则运行时客户端只应获得 online version。
+
+### 7.5 AgentSpec
+
+AgentSpec 资源通过引用 Prompt、Skill、MCP Server、A2A Agent 或其他必要资源来组装
+Agent 配置。AgentSpec 身份遵循 `namespaceId + name + version`，运行时路由应使用
+labels。
+
+AgentSpec 应通过稳定身份和 version 或 label 引用其他资源，不应引用存储实现细节。
+
+## 8. 可见性和 Owner
+
+支持可见性的资源必须暴露：
+
+- `namespaceId`；
+- 稳定资源名；
+- 资源类型；
+- scope，目前为 `PUBLIC` 或 `PRIVATE`；
+- owner identity。
+
+可见性影响发现、详情查看、下载和写入操作。它补充授权逻辑，但不能替代权限校验。
+
+## 9. 状态和生命周期
+
+状态值是领域特定的，但必须显式定义并记录：
+
+- Config 资源使用发布、gray/beta、history 和 listener 状态；
+- Naming 资源使用 service、instance、health、enabled 和 ephemeral 状态；
+- AI 资源使用 metadata status、version status、labels、pipeline state 和 visibility
+  state；
+- Core 资源使用 server、member、readiness、liveness、plugin 和 connection 状态。
+
+运行时 API 应只返回运行时消费者需要的状态。管理 API 在授权后可以返回 draft、
+review、offline、internal 或 operational 状态。
+
+## 10. API 表达规则
+
+所有 API 家族必须保持相同的资源身份：
+
+- HTTP path 和参数名应使用本规范中的标准资源术语。
+- gRPC request 对象即使使用 JSON payload，也应携带同样的身份字段。
+- Client SDK 应暴露运行时安全的资源操作。
+- Maintainer SDK 应暴露大范围管理资源操作。
+- Console API 可以为 UI 调整数据形态，但不能重新定义资源身份。
+
+如果历史 API 使用兼容名称，实现应在内部映射到标准资源术语，并记录该别名。
+
+## 11. 新资源检查项
+
+每个新的资源类型都必须定义：
+
+- 所属领域和模块；
+- 标准身份字段；
+- namespace 和 group 行为；
+- version、label、status 和 visibility 行为；
+- runtime API、management API 和 SDK 暴露方式；
+- 授权和审计要求；
+- 持久化和缓存预期；
+- 兼容别名，如存在。

--- a/specs/zh-cn/grpc-api/api-spec.md
+++ b/specs/zh-cn/grpc-api/api-spec.md
@@ -1,0 +1,219 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos gRPC API 规范
+
+本文档定义 Nacos gRPC API 模型，用于 Java SDK、Nacos Server 节点和各模块
+远程处理器。与 HTTP API 不同，Nacos gRPC 只有很小的固定 proto 传输面，
+业务 API 由 Java payload 类型表达。
+
+## 1. 设计模型
+
+Nacos gRPC 是 SDK 运行时流量和服务端集群流量的主要远程协议。proto 文件
+只定义传输级方法：
+
+| Service | Method | 形态 | 用途 |
+| --- | --- | --- | --- |
+| `Request` | `request(Payload) returns (Payload)` | unary | 客户端或对端发送一次请求并接收一次响应。 |
+| `BiRequestStream` | `requestBiStream(stream Payload) returns (stream Payload)` | 双向流 | 建连、服务端推送和 ack 响应。 |
+
+业务操作由 `Payload.metadata.type` 选择，而不是由独立 proto RPC 方法选择。
+该值是已注册 `Request` 或 `Response` payload 类型的 Java 简单类名。
+
+### 1.1 为什么 Payload 使用 JSON 对象
+
+Nacos 没有把每个 gRPC 业务请求和响应都建模成独立 protobuf message，而是
+使用固定 protobuf `Payload` 包装 JSON 序列化后的 Java 语义对象。
+
+这是一个有意的设计选择：
+
+- Nacos HTTP API 和 gRPC API 可以复用同一套语义对象定义和校验模型，而不是
+  维护两套独立 DTO。
+- 最初进行 RPC 选型时，gRPC 曾和其他 RPC 协议及 connector 形态进行过对比，
+  包括类似 RSocket 的方案。远程层设计上期望 connector 可以切换或兼容，而
+  不需要改动所有业务请求对象。后来因为生态活跃度、多语言支持度和运维成熟度
+  等原因，gRPC 成为实际选择，但 connector 抽象被保留了下来。
+
+社区知道这个选择存在代价。protobuf 内再承载 JSON 会带来额外的序列化和反
+序列化 CPU 开销，也无法完全利用 protobuf 更安全的 schema 模型和原生多语言
+对象生成能力。这是兼容性和抽象能力取舍的一部分。
+
+## 2. 传输契约
+
+`Payload` 包含：
+
+| 字段 | 含义 |
+| --- | --- |
+| `metadata.type` | `PayloadRegistry` 使用的 Java 简单类名。 |
+| `metadata.clientIp` | 发送方设置的客户端 IP。服务端请求上下文以连接元数据作为可信来源。 |
+| `metadata.headers` | 逻辑请求头，复制到 `Request.headers`。 |
+| `body.value` | Java 请求或响应对象的 JSON 字节。 |
+
+Payload 类必须通过
+`META-INF/services/com.alibaba.nacos.api.remote.Payload` 注册，否则接收方无法
+解析 `metadata.type`。
+
+规则：
+
+- 不为每个业务操作新增一个 proto service method。
+- `metadata.type` 不使用 Java 包名，只使用简单类名。
+- Request 和 Response 类必须保持 JSON 可序列化。
+- 请求头通过 `metadata.headers` 传输，不放在 JSON body 中。
+- 新增 Request 类必须通过 `Request#getModule()` 定义模块。
+
+## 3. 端口和调用来源
+
+Nacos 默认启动两个 gRPC Server：
+
+| Server | 默认端口 | 来源标签 | 调用方 |
+| --- | --- | --- | --- |
+| SDK gRPC server | `${server.port} + 1000` | `sdk` | SDK 客户端 |
+| Cluster gRPC server | `${server.port} + 1001` | `cluster` | Nacos Server 节点 |
+
+Java 客户端可通过 `nacos.server.grpc.port.offset` 覆盖端口偏移。服务端 SDK
+和 cluster gRPC Server 使用各自的默认偏移。
+
+部分处理器带有 `@InvokeSource` 注解。存在该注解时，只有列出的来源标签可以
+调用对应 payload 类型。
+
+## 4. 连接生命周期
+
+1. 客户端打开 `BiRequestStream.requestBiStream`。
+2. 流上的第一个 payload 应为 `ConnectionSetupRequest`。
+3. 服务端根据 connection id、远端地址、客户端版本、命名空间、labels 和
+   ability table 创建 `Connection`。
+4. 如果客户端发送 ability table，服务端返回包含服务端能力的
+   `SetupAckRequest`。
+5. 客户端通过 unary `ServerCheckRequest` 校验连接可用性，服务端返回
+   `ServerCheckResponse`。
+6. unary 业务请求只有在连接已注册后才会被接受。
+7. 服务端推送请求通过双向流发送，客户端以 `NotifySubscriberResponse`、
+   `ConfigChangeNotifyResponse` 或与 `PushAckRequest` 相关的响应返回 ack。
+
+当服务端仍在启动、连接未注册、请求类型未知、解析失败或处理器抛出异常时，
+服务端返回 `ErrorResponse`。
+
+## 5. 响应和错误契约
+
+所有 gRPC 响应都继承 `com.alibaba.nacos.api.remote.response.Response`：
+
+| 字段 | 含义 |
+| --- | --- |
+| `resultCode` | 成功为 `200`，失败为 `500` 或具体错误码。 |
+| `errorCode` | 失败时的 Nacos 错误码。 |
+| `message` | 错误或诊断信息。 |
+| `requestId` | 可用时的请求关联 id。 |
+
+只有 `resultCode == 200` 时，`Response#isSuccess()` 才为 true。
+
+`ErrorResponse` 用于传输层和处理器错误。对于 `NacosException` 和
+`NacosRuntimeException`，`errorCode` 来自异常；其他异常回退为 `500`。
+
+## 6. 鉴权
+
+gRPC 鉴权由 `RemoteRequestAuthFilter` 执行。
+
+需要身份、权限或服务端身份校验的处理器，应在 `handle(...)` 上添加
+`@Secured`。该 filter 会：
+
+- 将 `@Secured.apiType()` 写入请求上下文；
+- 当非 inner API 且鉴权关闭时跳过鉴权；
+- 当 inner auth 开启时始终校验 inner API 服务端身份；
+- 从请求头和 payload 中解析身份和资源；
+- 校验身份和 action 权限。
+
+集群内部 API 应使用 `ApiType.INNER_API`，并通过
+`@InvokeSource(source = {RemoteConstants.LABEL_SOURCE_CLUSTER})` 限制调用来源。
+
+## 7. Payload 清单
+
+### 7.1 通用和 Core
+
+| Request type | Response type | 方向 | 鉴权/来源 | 契约 |
+| --- | --- | --- | --- | --- |
+| `ConnectionSetupRequest` | `SetupAckRequest` | stream | 建连 | 使用客户端版本、命名空间、labels 和 ability table 注册 gRPC 连接。 |
+| `ServerCheckRequest` | `ServerCheckResponse` | unary | 已注册连接 | 校验当前连接并返回 connection id 和能力协商支持情况。 |
+| `HealthCheckRequest` | `HealthCheckResponse` | unary | 无 | keep-alive 健康检查。 |
+| `ClientDetectionRequest` | `ClientDetectionResponse` | stream push | 无 | 服务端发起客户端探测。 |
+| `ConnectResetRequest` | `ConnectResetResponse` | stream push | 无 | 要求客户端重连到目标服务端。 |
+| `ServerReloadRequest` | `ServerReloadResponse` | unary | inner，cluster 来源 | 在对端重新加载远程上下文。 |
+| `ServerLoaderInfoRequest` | `ServerLoaderInfoResponse` | unary | inner，cluster 来源 | 查询对端 server loader 指标。 |
+| `MemberReportRequest` | `MemberReportResponse` | unary | inner，cluster 来源 | 上报成员信息并更新成员状态。 |
+| `PluginAvailabilityRequest` | `PluginAvailabilityResponse` | unary | 已有 handler | 查询节点上的插件可用性。当前代码已有 handler，但 payload 未列入 core payload SPI 文件；注册前不应视为已生效的 gRPC 契约。 |
+
+### 7.2 Config
+
+| Request type | Response type | 动作 | 主要字段 | 契约 |
+| --- | --- | --- | --- | --- |
+| `ConfigQueryRequest` | `ConfigQueryResponse` | read | `dataId`, `group`, `tenant`, `tag` | 查询配置内容、md5、类型、加密 key、beta/tag 元数据。 |
+| `ConfigPublishRequest` | `ConfigPublishResponse` | write | `dataId`, `group`, `tenant`, `content`, `casMd5`, `additionMap` | 发布配置或 CAS 发布配置。 |
+| `ConfigRemoveRequest` | `ConfigRemoveResponse` | write | `dataId`, `group`, `tenant`, `tag` | 删除配置。 |
+| `ConfigBatchListenRequest` | `ConfigChangeBatchListenResponse` | read | `listen`, `ConfigListenContext[]` | 添加或移除配置监听，并返回发生变化的配置。 |
+| `ConfigChangeNotifyRequest` | `ConfigChangeNotifyResponse` | server push | `dataId`, `group`, `tenant` | 通知客户端配置发生变化。 |
+| `ConfigFuzzyWatchRequest` | `ConfigFuzzyWatchResponse` | read | `groupKeyPattern`, `receivedGroupKeys`, `watchType`, `isInitializing` | 添加或取消配置 group key 模糊订阅。 |
+| `ConfigFuzzyWatchChangeNotifyRequest` | `ConfigFuzzyWatchChangeNotifyResponse` | server push | `groupKey`, `changeType` | 通知客户端模糊订阅资源变化。 |
+| `ConfigFuzzyWatchSyncRequest` | `ConfigFuzzyWatchSyncResponse` | server push | `syncType`, `groupKeyPattern`, `contexts`, `totalBatch`, `currentBatch` | 同步模糊订阅初始化或 diff 状态。 |
+| `ClientConfigMetricRequest` | `ClientConfigMetricResponse` | read | `metricsKeys` | 查询客户端配置指标。 |
+| `ConfigChangeClusterSyncRequest` | `ConfigChangeClusterSyncResponse` | inner | `dataId`, `group`, `tenant`, `lastModified`, `isBeta`, `tag`, `grayName` | 在服务端节点之间同步配置变更事件。 |
+
+### 7.3 Naming
+
+| Request type | Response type | 动作 | 主要字段 | 契约 |
+| --- | --- | --- | --- | --- |
+| `InstanceRequest` | `InstanceResponse` | write | `namespace`, `groupName`, `serviceName`, `type`, `instance` | 注册或注销临时实例。 |
+| `PersistentInstanceRequest` | `InstanceResponse` | write | `namespace`, `groupName`, `serviceName`, `type`, `instance` | 注册或注销持久实例。 |
+| `BatchInstanceRequest` | `BatchInstanceResponse` | write | `namespace`, `groupName`, `serviceName`, `type`, `instances` | 批量注册或注销实例。 |
+| `ServiceQueryRequest` | `QueryServiceResponse` | read | `namespace`, `groupName`, `serviceName`, `cluster`, `healthyOnly`, `udpPort` | 查询服务实例。 |
+| `ServiceListRequest` | `ServiceListResponse` | read | `namespace`, `groupName`, `pageNo`, `pageSize`, `selector` | 列举服务名。 |
+| `SubscribeServiceRequest` | `SubscribeServiceResponse` | read | `namespace`, `groupName`, `serviceName`, `clusters`, `subscribe` | 订阅或取消订阅服务。 |
+| `NotifySubscriberRequest` | `NotifySubscriberResponse` | server push | `namespace`, `groupName`, `serviceName`, `serviceInfo` | 向订阅者推送服务信息变化。 |
+| `NamingFuzzyWatchRequest` | `NamingFuzzyWatchResponse` | read | `namespace`, `groupKeyPattern`, `receivedGroupKeys`, `watchType`, `isInitializing` | 添加或取消服务 key 模糊订阅。 |
+| `NamingFuzzyWatchChangeNotifyRequest` | `NamingFuzzyWatchChangeNotifyResponse` | server push | `serviceKey`, `changedType` | 通知客户端模糊订阅服务变化。 |
+| `NamingFuzzyWatchSyncRequest` | `NamingFuzzyWatchSyncResponse` | server push | `groupKeyPattern`, `contexts`, `totalBatch`, `currentBatch` | 同步模糊订阅初始化或 diff 状态。 |
+| `DistroDataRequest` | `DistroDataResponse` | inner | `distroData`, `dataOperation` | 服务端节点之间的 Distro AP 协议数据传输。 |
+
+### 7.4 AI
+
+| Request type | Response type | 动作 | 主要字段 | 契约 |
+| --- | --- | --- | --- | --- |
+| `QueryMcpServerRequest` | `QueryMcpServerResponse` | read | `namespace`, `mcpName`, `version` | 查询 MCP Server 详情。 |
+| `ReleaseMcpServerRequest` | `ReleaseMcpServerResponse` | write | `serverSpecification`, `toolSpecification`, `resourceSpecification`, `endpointSpecification` | 发布 MCP Server 或新版本。 |
+| `McpServerEndpointRequest` | `McpServerEndpointResponse` | write | `mcpName`, `address`, `port`, `version`, `type` | 注册或注销 MCP endpoint。 |
+| `QueryAgentCardRequest` | `QueryAgentCardResponse` | read | `namespace`, `agentName`, `version`, `registrationType` | 查询 A2A AgentCard 详情。 |
+| `ReleaseAgentCardRequest` | `ReleaseAgentCardResponse` | write | `agentCard`, `registrationType`, `setAsLatest` | 发布 AgentCard 或新版本。 |
+| `AgentEndpointRequest` | `AgentEndpointResponse` | write | `agentName`, `endpoint`, `type` | 注册或注销一个 Agent endpoint。 |
+| `BatchAgentEndpointRequest` | `AgentEndpointResponse` | write | `agentName`, `endpoints` | 替换当前客户端为某个 Agent 注册的 endpoints。 |
+| `QueryPromptRequest` | `QueryPromptResponse` | read | `namespace`, `promptKey`, `version`, `label`, `md5` | 按版本、标签、latest 或 md5 查询 Prompt。 |
+
+Skill ZIP 下载和 AgentSpec 组装属于 Java SDK interface 能力，但当前 Java 客户端
+实现使用 HTTP/config 组合，不对应专用 gRPC payload。
+
+### 7.5 Lock
+
+| Request type | Response type | 动作 | 主要字段 | 契约 |
+| --- | --- | --- | --- | --- |
+| `LockOperationRequest` | `LockOperationResponse` | handler 未声明 | `lockInstance`, `lockOperationEnum` | 尝试获取或释放 Nacos 分布式锁。 |
+
+## 8. 新增或变更 gRPC API 的规则
+
+1. 新增具体 `Request` 和 `Response` 类型；只有语义契约相同的操作才复用类型。
+2. 在正确的 `META-INF/services/com.alibaba.nacos.api.remote.Payload` 文件中注册
+   请求和响应 payload。
+3. 新增 `RequestHandler<Request, Response>` bean，并记录 action、module 和 source。
+4. 面向 SDK 或受保护的 inner 操作应添加 `@Secured`。
+5. cluster-only payload 应添加 `@InvokeSource`。
+6. 请求字段保持显式且 JSON 兼容。
+7. 当操作暴露为公开 SDK interface 时，同步更新本规范和 SDK interface 规范。

--- a/specs/zh-cn/http-api/api-spec.md
+++ b/specs/zh-cn/http-api/api-spec.md
@@ -1,0 +1,157 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos HTTP API 规范
+
+本文档定义 Nacos HTTP API 的通用设计模型，是 API 设计规则的入口。当前
+API 范围、鉴权规则、响应规则等细节维护在关联文档中。
+
+## 1. 设计动机
+
+Nacos 使用 gRPC 作为高频运行时流量的主要客户端通信协议。HTTP API 仍然
+存在，是因为它服务于不同的需求：
+
+- 为无法使用官方 SDK 或 gRPC 的客户端提供语言无关的访问方式；
+- 为管理员和运维工具提供运维访问能力；
+- 为 Nacos 控制台提供 UI 工作流访问能力；
+- 为现有 Nacos 用户提供兼容和迁移路径；
+- 便于通过常见 HTTP 基础设施进行检查、脚本化和集成。
+
+因此，HTTP API 的设计首先区分调用者受众，再区分资源。客户端 API、运维
+API 和控制台 API 可能操作相似的领域对象，但它们的兼容性承诺、权限模型
+和响应预期并不相同。
+
+## 2. 设计原则
+
+### 2.1 受众优先
+
+每个 HTTP API 必须先声明它的调用者受众：
+
+| 受众 | 路径前缀 | 预期调用方 |
+| --- | --- | --- |
+| Open API | `/v3/client` | SDK 和自定义运行时客户端 |
+| Admin API | `/v3/admin` | 运维人员和维护工具 |
+| Console API | `/v3/console` | Nacos 控制台 UI |
+| Auth API | `/v3/auth` | 插件提供的鉴权 API 和初始化流程 |
+
+不能仅因为某个端点可以通过 HTTP 访问，就把它记录为 Open API。Open API
+比 Admin API 或 Console API 承担更强的兼容性预期。
+
+### 2.2 稳定的资源路径形态
+
+HTTP 路径在 Nacos Server context path 之后应遵循以下形态：
+
+```text
+/v3/{audience}/{module}/{resource}[/{subResource}]
+```
+
+当前模块名包括：
+
+| 模块 | 含义 |
+| --- | --- |
+| `core` | 集群、命名空间、服务端状态、插件和运维操作 |
+| `cs` | 配置中心 |
+| `ns` | 注册中心 |
+| `ai` | MCP、A2A、Prompt、Skill、AgentSpec 和 Pipeline |
+| `auth` | 用户、角色和权限 |
+| `copilot` | 控制台 Copilot 功能 |
+
+部署 context path 通常为 `/nacos`，它不属于 Controller 映射。面向用户的
+示例可以包含它，但代码级路径定义不应包含它。
+
+### 2.3 HTTP Method 语义
+
+V3 HTTP API 按操作语义使用 HTTP Method：
+
+| Method | 含义 |
+| --- | --- |
+| `GET` | 查询或下载数据。 |
+| `POST` | 创建、发布、注册、上传、提交或触发任务。 |
+| `PUT` | 更新已有状态，或设置幂等的可变状态。 |
+| `DELETE` | 删除、注销，或删除绑定和草稿。 |
+
+任何例外都应先记录到端点级规范中，再被视为有意设计的行为。
+
+### 2.4 一致的响应契约
+
+JSON HTTP API 应返回 `com.alibaba.nacos.api.model.v2.Result<T>`，除非存在
+明确的响应形态理由。下载、流式 API 和健康检查是常见例外。
+
+详细响应和错误规则见 [响应与错误规范](response-error-spec.md)。
+
+### 2.5 显式鉴权
+
+HTTP API 应通过 `@Secured` 声明鉴权，除非端点被明确设计为公开端点、初始化
+端点或健康检查端点。鉴权声明必须反映 API 受众、资源领域和操作动作。
+
+详细规则见 [鉴权规范](authorization-spec.md)。
+
+### 2.6 兼容性是 API 的一部分
+
+Open API 必须作为长期兼容面进行审查。Admin API 和 Console API 可以演进
+得更快，但当文档化用户可能依赖它们时，不兼容变更仍需要废弃说明或迁移指引。
+
+已废弃端点应保留在兼容性章节中，而不是在代码仍支持它们时从文档中静默删除。
+
+### 2.7 文档跟随规范
+
+面向用户的文档应由规范生成，或至少根据规范和实现进行人工校验。当代码和
+文档不一致时，应先分类再解决：
+
+- `Normative Spec`：Nacos 有意承诺的行为。
+- `Current Behavior`：当前已经实现，但尚未确认长期契约的行为。
+- `Spec Decision Required`：在规范更新前，不应视为已承诺的行为。
+
+### 2.8 Agent 指南与自动校验
+
+Agent 指南文件、AI skill、Controller 模板和 API 合规校验工具，应把本规范
+体系作为规则来源。
+
+这些工具可以保留简短的实现检查清单，方便在本地上下文中使用，但不应定义
+与规范冲突的 API 规则。如果 Agent 指南、模板、校验工具、网站文档或实现
+与规范不一致，应修正错误的一方，或显式更新规范。
+
+自动校验应将检查结果映射到具体规范规则，包括：
+
+- 受众和路径前缀；
+- 模块和资源命名；
+- HTTP Method 语义；
+- `Result<T>` 响应形态和已记录的例外；
+- `@Secured` 声明、action、sign type 和 API type；
+- 已废弃兼容端点及其迁移状态。
+
+## 3. 当前 V3 文档
+
+当前 v3 HTTP API 范围记录在 [V3 API 范围](v3-api-surface.md) 中。
+
+更多细节规范：
+
+- [鉴权规范](authorization-spec.md)
+- [响应与错误规范](response-error-spec.md)
+
+## 4. 新增或变更 HTTP API 的规则
+
+1. 先选择受众：Open、Admin、Console 或 Auth。
+2. 按稳定路径形态选择模块和资源路径。
+3. 按第 2.3 节的语义使用 HTTP Method。
+4. 声明鉴权和动作语义。
+5. JSON 响应使用 `Result<T>`，除非存在已记录的例外。
+6. 在 form 对象或专用 validator 中实现参数校验。
+7. 对有意义的变更增加路由、校验、鉴权和响应形态测试。
+8. 在同一个变更中更新对应规范和网站文档。
+
+新增 Open API 需要明确的兼容性说明。新增 Admin API 或 Console API 需要
+明确的鉴权说明。新增非 `Result<T>` API 需要明确的响应形态说明。

--- a/specs/zh-cn/http-api/authorization-spec.md
+++ b/specs/zh-cn/http-api/authorization-spec.md
@@ -1,0 +1,90 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# HTTP API 鉴权规范
+
+## 1. 鉴权元组
+
+V3 HTTP API 的有效鉴权元组为：
+
+```text
+apiType + signType + resource + action + tags
+```
+
+其中：
+
+- `apiType` 区分 `OPEN_API`、`ADMIN_API`、`CONSOLE_API` 和内部 API。
+- `signType` 标识资源领域，例如 `CONFIG`、`NAMING`、`AI` 或 `CONSOLE`。
+- `resource` 标识受保护的资源路径或逻辑资源名。
+- `action` 通常为 `READ` 或 `WRITE`。
+- `tags` 增加特殊行为，例如 `ONLY_IDENTITY` 或 `ALLOW_ANONYMOUS`。
+
+## 2. Filter 分流
+
+当前代码按 `apiType` 分发鉴权：
+
+- `AuthAdminFilter` 处理 `@Secured.apiType()` 为 `ApiType.ADMIN_API` 的方法。
+- `AuthFilter` 处理 `apiType()` 不是 `ADMIN_API` 的受保护 API，包括
+  `OPEN_API`、`CONSOLE_API` 和内部 API。
+
+## 3. 必要注解
+
+V3 HTTP API 应声明 `@Secured`，除非该端点被明确设计为：
+
+- 公开端点；
+- 初始化端点；
+- 健康检查端点；
+- 已记录的兼容路径。
+
+Admin API 应使用 `ApiType.ADMIN_API`。Console API 应使用
+`ApiType.CONSOLE_API`。Open API 应使用 `ApiType.OPEN_API`。
+
+## 4. 公开端点和初始化端点
+
+端点只有在被明确设计为公开端点、初始化端点、健康检查端点或兼容端点时，
+才可以不声明 `@Secured`。公开端点必须在文档中标记为公开，并且不得暴露
+敏感运维细节。
+
+已实现的公开端点包括：
+
+- `GET /v3/admin/core/state`
+- `GET /v3/admin/core/state/liveness`
+- `GET /v3/admin/core/state/readiness`
+- `GET /v3/console/server/state`
+- `GET /v3/console/server/announcement`
+- `GET /v3/console/server/guide`
+- `GET /v3/console/health/liveness`
+- `GET /v3/console/health/readiness`
+
+对应的 Admin API 和 Console API 文档已将这些端点标记为公开接口，无需身份信息。
+
+初始化行为：
+
+- `/v3/auth/user/admin` 可以在不存在全局管理员，且鉴权系统为 `NACOS` 时
+  创建第一个管理员用户。
+
+## 5. 插件提供的 Auth API
+
+`/v3/auth/*` API 面属于鉴权插件。Nacos 默认鉴权插件随 Nacos 一起发布，
+必须遵循 Nacos HTTP API 对路径形态、响应形态、参数校验和错误行为的规范。
+
+第三方鉴权插件通过 Nacos 暴露 HTTP API 时，也建议遵循同一套规则。
+
+## 6. 已实现例外
+
+以下已实现行为需要在端点级文档中说明：
+
+- 部分 AI 客户端端点通过 `ALLOW_ANONYMOUS` 允许匿名访问。

--- a/specs/zh-cn/http-api/authorization-spec.md
+++ b/specs/zh-cn/http-api/authorization-spec.md
@@ -16,6 +16,11 @@
 
 # HTTP API 鉴权规范
 
+本文档定义 Nacos 鉴权模型如何应用到 v3 HTTP API。共享鉴权领域模型由
+[鉴权与权限规范](../auth/auth-permission-spec.md) 定义，插件契约由
+[鉴权插件规范](../auth/auth-plugin-spec.md) 和
+[可见性插件规范](../auth/visibility-plugin-spec.md) 定义。
+
 ## 1. 鉴权元组
 
 V3 HTTP API 的有效鉴权元组为：

--- a/specs/zh-cn/http-api/response-error-spec.md
+++ b/specs/zh-cn/http-api/response-error-spec.md
@@ -1,0 +1,77 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# HTTP API 响应与错误规范
+
+## 1. JSON 响应包装
+
+V3 JSON 响应默认使用 `com.alibaba.nacos.api.model.v2.Result<T>`：
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {}
+}
+```
+
+端点文档必须说明 `data` 类型以及任何非默认 HTTP 状态。
+
+## 2. 响应例外
+
+当前有意设计的响应形态例外：
+
+- 文件下载端点可以返回 `ResponseEntity<byte[]>`。
+- Copilot 流式端点返回 Server-Sent Events。
+- 健康检查 readiness 在未就绪时可以返回 HTTP 500，并携带
+  `Result<String>` 响应体。
+- 部分遗留或运维端点可以返回纯文本。只有在确认属于兼容行为后，才应保留。
+
+## 3. 错误处理
+
+标注 `@NacosApi` 的 Controller 使用 `NacosApiExceptionHandler` 处理常见
+v3 错误：
+
+| 异常类型 | HTTP 状态 | Result code 来源 |
+| --- | --- | --- |
+| `NacosApiException` | 异常错误码 | 详细 API 错误码 |
+| `NacosException` | 异常错误码 | `SERVER_ERROR` |
+| 缺少请求参数 | 400 | `PARAMETER_MISSING` |
+| 非法参数或数字格式错误 | 400 | `PARAMETER_VALIDATE_ERROR` |
+| Media type 错误 | 400 | `MEDIA_TYPE_ERROR` |
+| `AccessException` | 403 | `ACCESS_DENIED` |
+| 数据访问、Servlet 或 IO 失败 | 500 | `DATA_ACCESS_ERROR` |
+| 未处理异常 | 500 | 通用失败 |
+
+## 4. ExceptionHandler 收敛
+
+Nacos 自有的 v3 HTTP API 应收敛到 `@NacosApi` 和
+`NacosApiExceptionHandler`，以获得统一异常处理。早于 v3 API 模型存在的
+模块级 ExceptionHandler，不应为 v3 API 定义不同的响应形态。
+
+插件性质的模块如果有意维护独立 API 面，可以保留自己的 ExceptionHandler。
+`PrometheusApiExceptionHandler` 是这类插件式 ExceptionHandler 的例子。
+
+已知待处理项：
+
+- `config/server/exception/GlobalExceptionHandler` 仍作用于
+  `com.alibaba.nacos.config.server`，并可能返回纯文本 `ResponseEntity<String>`。
+- `naming/exception/ResponseExceptionHandler` 仍作用于
+  `com.alibaba.nacos.naming`，并可能返回纯文本 `ResponseEntity<String>`。
+- `ConfigOpenApiController` 引入了 `NacosApi`，但当前没有标注 `@NacosApi`。
+
+这些项应作为待处理的收敛问题，使 Config 和 Naming 的 v3 API 使用与其他
+Nacos v3 API 一致的 `Result<T>` 错误契约。

--- a/specs/zh-cn/http-api/v3-api-surface.md
+++ b/specs/zh-cn/http-api/v3-api-surface.md
@@ -1,0 +1,194 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# V3 HTTP API 范围
+
+本文档说明当前 v3 HTTP API 覆盖范围。它补充
+[HTTP API 规范](api-spec.md)，后者定义通用设计规则。
+
+## 1. 范围
+
+本文档覆盖在 Nacos Web context path 之后，以以下 v3 前缀开头的 HTTP
+端点：
+
+| 前缀 | API 类型 | 主要用户 | 当前鉴权范围 |
+| --- | --- | --- | --- |
+| `/v3/client` | Open API | SDK 和自定义客户端 | `ApiType.OPEN_API` |
+| `/v3/admin` | Admin API | 运维人员和维护工具 | `ApiType.ADMIN_API` |
+| `/v3/console` | Console API | Nacos 控制台 UI 后端调用 | `ApiType.CONSOLE_API` |
+| `/v3/auth` | Auth plugin API | 插件提供的鉴权和初始化 API | 默认鉴权插件 |
+
+本文档不覆盖：
+
+- v1/v2 兼容 API；
+- gRPC 请求和响应契约；
+- 未作为 v3 HTTP Controller 暴露的内部集群 API；
+- AI Registry adaptor API，它有独立的兼容性边界。
+
+## 2. 当前事实来源
+
+V3 HTTP 行为当前由以下代码位置定义：
+
+| 领域 | 代码来源 |
+| --- | --- |
+| Admin core | `core/src/main/java/com/alibaba/nacos/core/controller/v3` |
+| Admin config | `config/src/main/java/com/alibaba/nacos/config/server/controller/v3` |
+| Admin naming | `naming/src/main/java/com/alibaba/nacos/naming/controllers/v3` |
+| Admin AI | `ai/src/main/java/com/alibaba/nacos/ai/controller` |
+| Console | `console/src/main/java/com/alibaba/nacos/console/controller/v3` |
+| Auth v3 | `plugin-default-impl/nacos-default-auth-plugin/src/main/java/.../controller/v3` |
+| 路径常量 | `Commons`、config `Constants`、naming `UtilsAndCommons`、AI `Constants`、`AuthConstants` |
+
+对应的网站源文件：
+
+- `admin/admin-api.md`
+- `admin/console-api.md`
+- `user/open-api.md`
+
+## 3. 当前 API 家族
+
+本节记录当前已经实现的 API 家族。数量来自对 `src/main/java` 中 Spring
+映射的脚本辅助盘点，应作为核对参考，而不是最终 OpenAPI 导出。
+
+| 家族 | 近似映射数 | Method | 说明 |
+| --- | ---: | --- | --- |
+| `/v3/client/cs/config` | 1 | GET | 供自定义 HTTP 客户端查询配置。 |
+| `/v3/client/ns/instance` | 3 | GET, POST, DELETE | 注册、心跳、注销和查询服务实例。 |
+| `/v3/client/ai/prompt` | 1 | GET | 运行时 Prompt 查询。 |
+| `/v3/client/ai/skills` | 1 | GET | 运行时 Skill zip 下载。 |
+| `/v3/client/ai/agentspecs` | 2 | GET | 运行时 AgentSpec 获取和搜索。 |
+| `/v3/admin/core/*` | 25 | GET, POST, PUT, DELETE | Loader、集群、ops、命名空间、状态、插件。 |
+| `/v3/admin/cs/*` | 25 | GET, POST, PUT, DELETE | 配置 CRUD、历史、监听者、容量、指标、ops。 |
+| `/v3/admin/ns/*` | 29 | GET, POST, PUT, DELETE | 服务、实例、客户端、集群、健康状态、ops。 |
+| `/v3/admin/ai/*` | 71 | GET, POST, PUT, DELETE | MCP、A2A、Prompt、Skill、AgentSpec、Pipeline。 |
+| `/v3/console/core/*` | 7 | GET, POST, PUT, DELETE | 控制台集群和命名空间操作。 |
+| `/v3/console/cs/*` | 17 | GET, POST, DELETE | 控制台配置和历史操作。 |
+| `/v3/console/ns/*` | 11 | GET, POST, PUT, DELETE | 控制台服务和实例操作。 |
+| `/v3/console/ai/*` | 67 | GET, POST, PUT, DELETE | 控制台 AI 管理、导入、生命周期、Pipeline。 |
+| `/v3/console/copilot/*` | 6 | GET, POST | 配置和 SSE Copilot 操作。 |
+| `/v3/auth/user` | 7 | GET, POST, PUT, DELETE | 默认鉴权插件中的用户登录和管理。 |
+| `/v3/auth/role` | 4 | GET, POST, DELETE | 默认鉴权插件中的角色管理。 |
+| `/v3/auth/permission` | 4 | GET, POST, DELETE | 默认鉴权插件中的权限管理。 |
+
+## 4. Open API 已实现行为
+
+已实现的 Open API 范围：
+
+| 端点 | 行为 |
+| --- | --- |
+| `GET /v3/client/cs/config` | 查询单个配置。不提供 HTTP 长轮询。 |
+| `POST /v3/client/ns/instance` | 注册实例，或在 `heartBeat=true` 时发送心跳。 |
+| `DELETE /v3/client/ns/instance` | 注销实例。实例不存在时仍视为成功。 |
+| `GET /v3/client/ns/instance/list` | 查询服务的启用实例列表。会过滤 disabled 实例。 |
+| `GET /v3/client/ai/prompt` | 按版本、标签或 latest 查询 Prompt。 |
+| `GET /v3/client/ai/skills` | 以 zip 响应下载在线 Skill 包。 |
+| `GET /v3/client/ai/agentspecs` | 按版本、标签或 latest 查询 AgentSpec。可能允许匿名访问。 |
+| `GET /v3/client/ai/agentspecs/search` | 搜索运行时可用的已启用 AgentSpec。 |
+
+## 5. Admin API 已实现行为
+
+Admin API 面向运维人员，默认使用 `ApiType.ADMIN_API`。现有文档说明 v3
+Admin API 不兼容 v1/v2 Admin API；如果必须使用 v1/v2 Admin API 兼容能力，
+需要设置 `nacos.core.auth.admin.enabled=true`。
+
+当前模块：
+
+- `core`：连接 loader、集群节点数据、Raft 和 ID 运维、命名空间、插件和
+  服务端状态。
+- `cs`：配置 CRUD、元数据、批量操作、历史、监听者、容量、指标和 ops。
+- `ns`：服务、实例、集群、健康状态、客户端和注册中心 ops。
+- `ai`：MCP、A2A、Prompt、Skill、AgentSpec 和 Pipeline 管理。
+
+需要更明确文档化的已实现行为：
+
+- Naming service 创建会创建持久化服务元数据。
+- Open naming instance 心跳复用 `POST /v3/client/ns/instance` 端点，并在
+  需要重新注册时返回 `INSTANCE_NOT_FOUND`。
+- Config 查询在返回 Admin API 详情前会解密加密内容。
+- Config 发布在未提供 encrypted data key 且适用加密处理器时会加密内容。
+- AI Prompt 在同一个 Controller 中同时包含已废弃兼容端点和新的生命周期端点。
+
+## 6. Console API 已实现行为
+
+Console API 服务于 Nacos Web 控制台，它不是 Open API 的同一稳定性边界。
+它默认使用 `ApiType.CONSOLE_API`，并经常使用控制台专用资源名、
+`ONLY_IDENTITY` 或面向 UI 的响应模型。
+
+Console API 模块在 UI 需要时会镜像 Admin 模块：
+
+- 服务端状态和健康检查；
+- core 集群、命名空间和插件；
+- 配置和历史；
+- 注册中心服务和实例；
+- AI 资源和 Copilot。
+
+Console API 文档应避免把控制台专用端点呈现为推荐的自动化 API。自动化用户
+应优先使用 Admin API，除非某个功能被明确设计为仅控制台可用。
+
+## 7. Auth API 已实现行为
+
+V3 Auth API 位于默认鉴权插件中，而不是 core 模块中：
+
+```text
+/v3/auth/user
+/v3/auth/role
+/v3/auth/permission
+```
+
+已实现行为：
+
+- 用户管理支持创建、删除、密码更新、登录、列表和搜索。
+- 角色管理支持添加、删除、列表和搜索。
+- 权限管理支持添加、删除和列表。
+- 第一个管理员初始化由 `POST /v3/auth/user/admin` 实现。
+
+默认鉴权插件随 Nacos 一起发布，因此它的 v3 auth 端点应遵循 Nacos HTTP
+API 规范。
+
+## 8. 文档 Gap 记录
+
+这不是 bug 列表，而是记录当前文档和代码可能描述了不同 API 面的地方。
+
+- Admin AI Prompt 生命周期：代码增加 `/governance`、`/version`、`/draft`、
+  `/submit`、`/publish`、`/force-publish`、`/online`、`/offline`、`/labels`、
+  `/description` 和 `/biz-tags`；文档主要覆盖旧的 `/detail`、`/label`、
+  `/metadata`，以及 list 和 versions。
+- Console AI Prompt 生命周期：控制台代码在 `/v3/console/ai/prompt` 下镜像
+  Admin 生命周期；文档主要覆盖旧的 `/detail`、`/label` 和 `/metadata`。
+- Pipeline list/detail：代码暴露 `/v3/*/ai/pipelines/list`、`/detail` 和
+  `/{pipelineId}`；文档展示 `/v3/*/ai/pipelines` 和 `/{pipelineId}`。
+- Force publish：代码中 Prompt、Skill 和 AgentSpec 都有 `POST /force-publish`；
+  文档没有一致描述这个高权限操作。
+- AgentSpec version meta：代码中有
+  `GET /v3/admin/ai/agentspecs/version/meta`；admin API 文档未记录。
+- Auth v3：代码暴露 `/v3/auth/user`、`/role` 和 `/permission`；三份网站
+  API 文档未覆盖这个 API 面。
+- Config Open API 异常处理：`ConfigOpenApiController` 没有 `@NacosApi`，
+  而大多数 v3 Controller 都有；Open API 文档假设统一响应。
+- Config 和 Naming ExceptionHandler：Config 和 Naming 仍有历史模块级
+  `ControllerAdvice`，可能返回纯文本错误体。它们应在 v3 API 上收敛到
+  `NacosApiExceptionHandler`。
+
+## 9. 废弃兼容说明
+
+部分 v3 AI API 在本规范建立之前已经发布，后续又被更清晰的生命周期 API 或
+REST 风格 API 替代。这些旧端点应视为废弃兼容 API：
+
+- AI Prompt legacy 端点，例如 `/detail`、`/label` 和 `/metadata`。
+- Pipeline 中不符合当前 `/list` 和 `/detail` 形态的 legacy REST 风格端点。
+
+兼容端点可以在过渡期内继续保留，但面向用户的文档应以新 API 作为主要契约。
+废弃端点只应出现在兼容章节中，并提供迁移说明。

--- a/specs/zh-cn/plugin/plugin-spec.md
+++ b/specs/zh-cn/plugin/plugin-spec.md
@@ -1,0 +1,149 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos 插件化规范
+
+## 目的
+
+Nacos 使用插件机制，将横切基础能力和可替换的领域能力从固定的服务端核心中拆出。
+插件可以提供鉴权、资源可见性、数据源方言、加解密、链路追踪、流量控制、环境适配、
+AI pipeline 或 AI 存储等能力。
+
+插件机制的目标，是在保持 Nacos 核心模型稳定的同时，让不同部署环境可以选择符合自身
+身份系统、数据库、观测体系或扩展场景的实现。
+
+## 插件身份
+
+每个插件由以下字段唯一标识：
+
+- `pluginType`：扩展类别，例如 `auth` 或 `visibility`。
+- `pluginName`：该类别下的实现名称，例如 `nacos`。
+- `pluginId`：运行时标识，格式为 `{pluginType}:{pluginName}`。
+
+`pluginId` 用于管理 API、集群状态同步、插件状态持久化和面向用户的诊断信息。
+
+## 插件类型
+
+当前插件类型注册表由 `PluginType` 定义。
+
+| 类型 | 目的 |
+|------|------|
+| `auth` | 认证与授权实现。 |
+| `visibility` | 资源可见性与查询可见性建议。 |
+| `datasource-dialect` | 数据库方言与持久化适配。 |
+| `config-change` | 配置变更扩展。 |
+| `encryption` | 加解密扩展。 |
+| `trace` | 链路追踪与观测扩展。 |
+| `environment` | 环境适配扩展。 |
+| `control` | 流量与控制扩展。 |
+| `ai-pipeline` | AI 注册中心 pipeline 扩展。 |
+| `ai-storage` | AI 注册中心存储扩展。 |
+
+各插件类别的领域契约由对应规范定义。本文档定义所有插件类别共享的运行时契约。
+
+## 执行形态
+
+插件类别并不都以同一种形态执行。每个插件类型都必须明确自身执行形态。
+
+| 形态 | 含义 | 示例 |
+|------|------|------|
+| 互斥选择 | 在进程或请求范围内选择一个实现，其他已加载实现不参与该次判断。 | `auth`、`datasource-dialect` |
+| 配置选择的单服务 | 可以加载多个实现，但领域根据配置或请求上下文选择一个服务。 | `visibility` |
+| 有序链式执行 | 多个匹配插件按稳定顺序执行。每个节点可以贡献结果，失败是否中断由领域定义。 | `ai-pipeline`、`config-change` |
+| 订阅或广播 | 多个订阅者观察同一个事件或 trace 点，不拥有主决策权。 | `trace`、事件型扩展 |
+
+对于链式插件，领域 SPI 必须定义：
+
+- 如何根据资源或 pointcut 选择候选插件。
+- 哪个字段控制顺序，例如 `getPreferOrder()` 或 `getOrder()`。
+- 执行方式是串行还是并行。
+- 某个插件失败时，是中断链路还是只记录失败结果。
+- 如何持久化和暴露部分执行结果。
+
+核心插件管理器记录插件的加载状态和启用状态，本身不定义执行形态。领域管理器负责稳定地
+应用对应执行形态。
+
+## SPI 层次
+
+Nacos 插件包含两个相关的 SPI 层次：
+
+1. 领域 SPI，例如 `AuthPluginService` 或 `VisibilityService`，定义所属领域需要的行为。
+2. 核心插件 SPI，即 `PluginProvider`，将插件实例暴露给核心插件管理器，用于列表查询、
+   状态管理、配置管理和运行时观测。
+
+需要动态配置的插件应实现 `PluginConfigSpec`。支持启停状态判断的插件类别，应通过
+`PluginStateCheckerHolder` 获取状态，而不是维护一套独立状态来源。
+
+## 加载与生命周期
+
+插件实现通过 Nacos SPI 加载。部署时可以从 classpath 或服务端插件目录提供插件。
+插件实现必须能在不修改 Nacos 服务端代码的情况下被加载。
+
+核心 `PluginManager` 会在服务端应用就绪后发现 `PluginProvider` 实现。领域管理器也可以
+通过 SPI 加载自身领域服务，但是否可参与请求处理，仍必须遵守核心插件管理器维护的启停
+状态。
+
+插件启动必须具备确定性：
+
+- 一个插件类型和插件名称组合只能对应一个运行时插件实例。
+- 同一插件类型下重复的插件名称不适合稳定运行。
+- 插件实现不得改变 Nacos 共享资源标识、响应封装或错误约定的含义。
+
+## 状态与配置
+
+插件状态分为两个层次：
+
+- 已加载：实现存在于运行时。
+- 已启用：实现可以参与请求处理。
+
+大多数插件类型在加载后默认启用。互斥插件类型会选择一个默认实现：
+
+| 类型 | 默认选择规则 |
+|------|--------------|
+| `auth` | 由 `nacos.core.auth.system.type` 指定，默认 `nacos`。 |
+| `datasource-dialect` | 由 SQL platform 配置指定，默认 `derby`。 |
+
+当服务端依赖某些插件维持基本运行能力时，这些插件不能被禁用。当前关键插件集合包括内置
+数据源方言，以及服务端需要的默认 AI 存储插件。
+
+实现 `PluginConfigSpec` 的插件应暴露配置定义、当前配置和配置应用行为。除非请求明确
+声明为仅本机生效，否则集群级状态或配置变更必须通过插件状态操作链路进行同步。
+
+## 管理 API
+
+核心插件管理 API 如下：
+
+| 方法 | 路径 | 目的 |
+|------|------|------|
+| `GET` | `/v3/admin/core/plugin/list` | 查询已加载插件，可按类型过滤。 |
+| `GET` | `/v3/admin/core/plugin/detail` | 查询单个插件详情。 |
+| `PUT` | `/v3/admin/core/plugin/status` | 启用或禁用插件。 |
+| `PUT` | `/v3/admin/core/plugin/config` | 更新插件配置。 |
+
+这些端点属于 Admin API，并要求控制台域的鉴权。插件管理 API 必须使用标准 v3 响应和错误
+模型。
+
+## 设计要求
+
+插件实现必须遵守以下规则：
+
+- 使用已有 Nacos 资源标识和领域模型，不为同一资源发明不兼容的新模型。
+- 插件提供的 HTTP API 必须保持 v3 API 响应、错误和鉴权约定。
+- 仅通过 `PluginConfigSpec` 暴露插件自身拥有的配置。
+- 除调用方明确要求本机操作用于诊断或应急处理外，集群级状态变更必须保持同步。
+- 安全敏感的默认值和部署要求必须在插件实现规范中说明。
+
+插件机制是扩展边界，不是绕过 Nacos 资源、API 或安全规则的通道。

--- a/specs/zh-cn/sdk/sdk-java-impl-spec.md
+++ b/specs/zh-cn/sdk/sdk-java-impl-spec.md
@@ -1,0 +1,222 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos Java SDK 实现规范
+
+本文档定义 Java SDK 如何实现共享的 [SDK 规范](./sdk-spec.md)，覆盖 Java
+Client SDK 和 Java Maintainer SDK。
+
+## 1. 范围
+
+Java SDK 当前包含两类公开能力：
+
+- Java Client SDK，主要由 `nacos-client` artifact 和 `api` 模块中的公开
+  interface 提供。
+- Java Maintainer SDK，由 `nacos-maintainer-client` artifact 和
+  `maintainer-client` 模块中的公开 interface 提供。
+
+Java Client SDK 是现有运行时应用行为的基准。Java Maintainer SDK 是管理、
+UI、网关和运维场景的推荐 Java 接入方式。
+
+## 2. Java Client SDK Factory 和生命周期
+
+| Interface | Factory | 生命周期关闭方法 |
+| --- | --- | --- |
+| `ConfigService` | `NacosFactory.createConfigService(...)` | `shutDown()` |
+| `NamingService` | `NacosFactory.createNamingService(...)` | `shutDown()` |
+| `AiService` | `AiFactory.createAiService(Properties)` | `shutdown()` |
+| `LockService` | `NacosLockFactory.createLockService(Properties)` 或 `NacosFactory.createLockService(Properties)` | `shutdown()` |
+| `NamingMaintainService` | `NacosFactory.createMaintainService(...)` | `shutDown()` |
+
+`NamingMaintainService` 在 3.3.0 后已废弃。新的管理类接入应使用
+`nacos-maintainer-client`。
+
+一个 Java SDK 实例绑定一个命名空间。需要访问多个命名空间的应用应创建多个
+SDK 实例，并在不再使用时关闭实例。
+
+## 3. Java Client SDK 配置模型
+
+Java Client SDK 配置由 `NacosClientProperties` 表达。
+
+默认配置查找顺序为：
+
+```text
+Properties -> JVM system properties -> environment variables -> defaults
+```
+
+第一个查找来源可通过 `nacos.env.first` 或 `NACOS_ENV_FIRST` 调整。
+
+常见配置项包括：
+
+| 配置项 | 范围 | 含义 |
+| --- | --- | --- |
+| `serverAddr` | 通用 | Nacos Server 地址列表。 |
+| `contextPath` | 通用 | 服务端 context path，默认 `nacos`。 |
+| `endpoint` 及 endpoint 相关配置 | 通用 | 动态服务端地址接入点。 |
+| `namespace` | 通用 | 当前 SDK 实例绑定的命名空间 id。 |
+| `username`, `password` | 通用 | 开启鉴权时的登录凭据。 |
+| `accessKey`, `secretKey`, `ramRoleName`, `signatureRegionId` | 通用 | RAM 风格鉴权参数。 |
+| `configRequestTimeout` | config | Config RPC 请求超时覆盖值。 |
+| `namingRequestTimeout` | naming | Naming RPC 请求超时覆盖值。 |
+| `nacos.server.grpc.port.offset` | 连接 | Java 客户端使用的 gRPC 端口偏移。 |
+
+已废弃的历史配置项应继续兼容，但新增代码不应依赖这些配置引入新行为。
+
+## 4. Java Client SDK Interface
+
+### 4.1 ConfigService
+
+| 能力 | 方法 | 契约 |
+| --- | --- | --- |
+| 查询配置 | `getConfig`, `getConfigWithResult` | 按 `dataId` 和 `group` 查询单个已知配置；`getConfigWithResult` 额外返回 md5，用于 CAS。 |
+| 查询并监听 | `getConfigAndSignListener` | 查询当前配置，并注册同一个 listener 接收后续变更。 |
+| 监听 | `addListener`, `removeListener` | 添加或移除监听器。回调应优先使用 listener 提供的 executor。 |
+| 发布 | `publishConfig`, `publishConfigCas` | 用于创建或更新配置的兼容写入面。CAS 发布必须比较上一次 md5。 |
+| 删除 | `removeConfig` | 用于删除配置的兼容写入面。用户文档定义删除不存在的配置也视为成功。 |
+| Filter | `addConfigFilter` | 添加客户端侧配置 filter。 |
+| 模糊订阅 | `fuzzyWatch`, `fuzzyWatchWithGroupKeys`, `cancelFuzzyWatch` | 按 group 或 dataId pattern 订阅配置 key，接收 key 变更事件。 |
+| 状态/生命周期 | `getServerStatus`, `shutDown` | 查询状态并释放资源。 |
+
+配置标识遵循用户文档中对 `dataId`、`group` 和配置内容大小的约束。新的大范围
+配置管理 API 应加入 Maintainer SDK，而不是扩展 `ConfigService`。
+
+### 4.2 NamingService
+
+| 能力 | 方法 | 契约 |
+| --- | --- | --- |
+| 注册 | `registerInstance`, `batchRegisterInstance` | 在 service 和 group 下注册一个或多个实例。 |
+| 注销 | `deregisterInstance`, `batchDeregisterInstance` | 移除一个或多个实例。 |
+| 查询实例 | `getAllInstances`, `selectInstances`, `selectOneHealthyInstance` | 按 cluster、health、subscribe 等选项查询缓存或远端服务信息。 |
+| 订阅 | `subscribe`, `unsubscribe` | 接收服务实例变化事件。取消订阅需要使用同一个 listener 实例。 |
+| 模糊订阅 | `fuzzyWatch`, `fuzzyWatchWithServiceKeys`, `cancelFuzzyWatch` | 按 group 或 service pattern 订阅服务 key，接收服务级事件。 |
+| 列举服务 | `getServicesOfServer` | 兼容性大范围查询面。新的大范围列举应使用 Maintainer SDK。 |
+| 本地状态 | `getSubscribeServices`, `getServerStatus`, `shutDown` | 查询已订阅服务、状态并释放资源。 |
+
+`getServicesOfServer` 的 selector overload 已废弃，仅作为兼容面保留。
+
+### 4.3 AiService 和 A2aService
+
+`AiService` 继承 `A2aService`。
+
+| 能力 | 方法 | 契约 |
+| --- | --- | --- |
+| MCP 查询 | `getMcpServer` | 按名称和可选版本查询 MCP Server 详情。 |
+| MCP 发布 | `releaseMcpServer` | 创建 MCP Server 或发布新版本。同版本已存在时保持幂等。 |
+| MCP endpoint | `registerMcpServerEndpoint`, `deregisterMcpServerEndpoint` | 注册或移除当前客户端拥有的 endpoint。 |
+| MCP 订阅 | `subscribeMcpServer`, `unsubscribeMcpServer` | 订阅 MCP 详情变化。 |
+| A2A AgentCard 查询 | `getAgentCard` | 按名称、可选版本和 registration type 查询 AgentCard。 |
+| A2A AgentCard 发布 | `releaseAgentCard` | 创建 AgentCard 或发布新版本；`setAsLatest` 只影响新版本。 |
+| A2A endpoint | `registerAgentEndpoint`, `deregisterAgentEndpoint` | 注册或移除当前客户端拥有的 endpoint。批量注册会替换当前客户端此前为该 Agent 注册的 endpoints。 |
+| A2A 订阅 | `subscribeAgentCard`, `unsubscribeAgentCard` | 订阅 AgentCard 变化。 |
+| Skill | `downloadSkillZip`, `downloadSkillZipByVersion`, `downloadSkillZipByLabel` | 按 latest、版本或标签下载 Skill zip 字节。 |
+| AgentSpec | `loadAgentSpec`, `subscribeAgentSpec`, `unsubscribeAgentSpec` | 加载组装后的 AgentSpec，并订阅其变化。 |
+| Prompt | `getPrompt`, `getPromptByVersion`, `getPromptByLabel`, `subscribePrompt`, `unsubscribePrompt` | 按 key、版本或标签查询和订阅 Prompt。 |
+
+当前 Java 实现在 interface 背后可以混合使用 gRPC、HTTP 和 config 组装。公开
+interface 契约应独立于具体传输方式保持稳定。
+
+### 4.4 LockService
+
+| 能力 | 方法 | 契约 |
+| --- | --- | --- |
+| 用户加锁 | `lock` | 通过 `LockInstance#lock` 获取锁。 |
+| 用户解锁 | `unLock` | 通过 `LockInstance#unLock` 释放锁。 |
+| 远程加锁 | `remoteTryLock` | 发送 gRPC lock operation 请求。 |
+| 远程解锁 | `remoteReleaseLock` | 发送 gRPC unlock operation 请求。 |
+| 生命周期 | `shutdown` | 释放客户端资源。 |
+
+## 5. Java Maintainer SDK Factory 和生命周期
+
+| Interface | Factory | 生命周期关闭方法 |
+| --- | --- | --- |
+| `ConfigMaintainerService` | `NacosMaintainerFactory.createConfigMaintainerService(...)` 或 `ConfigMaintainerFactory.createConfigMaintainerService(...)` | `close()` |
+| `NamingMaintainerService` | `NamingMaintainerFactory.createNamingMaintainerService(...)` | `close()` |
+| `AiMaintainerService` | `AiMaintainerFactory.createAiMaintainerService(...)` | 当前 interface 未暴露 |
+
+Maintainer service 在适用场景下继承 `CoreMaintainerService`。它们属于高权限
+客户端，应使用管理类凭据进行配置。
+
+## 6. Java Maintainer SDK Interface
+
+### 6.1 CoreMaintainerService
+
+`CoreMaintainerService` 暴露服务端和集群维护能力：
+
+- 服务端状态、liveness、readiness、ID 生成器状态和 loader metrics；
+- 日志级别更新；
+- 集群节点列表和 lookup mode 更新；
+- 当前客户端连接查看和客户端 reload 操作；
+- 命名空间列表、查询、创建、更新、删除和存在性检查；
+- 面向管理场景的 raft operation 转发。
+
+这些 API 本质上属于管理能力，不应复制到 Client SDK。
+
+### 6.2 ConfigMaintainerService
+
+`ConfigMaintainerService` 包含：
+
+- 配置获取、发布、删除和批量删除；
+- 按 namespace、dataId、group、type、tag、app 等条件进行配置列表和搜索；
+- clone、import/export 等管理模型；
+- 通过 `BetaConfigMaintainerService` 提供 beta 和灰度发布能力；
+- 通过 `ConfigHistoryMaintainerService` 提供历史查询和回滚相关访问；
+- 通过 `ConfigOpsMaintainerService` 提供 dump、listener、log 和操作端点；
+- 配置描述、标签等元数据更新。
+
+管理类写入和大范围查询应加入这里，而不是继续扩展 `ConfigService`。
+
+### 6.3 NamingMaintainerService
+
+`NamingMaintainerService` 包含：
+
+- 服务创建、更新、删除、详情查询和列表查询；
+- 实例注册、注销、更新、列表和元数据维护；
+- 通过 `NamingClientMaintainerService` 提供订阅者和客户端查询；
+- 注册中心 metrics 和日志级别操作；
+- 持久化实例健康状态更新；
+- 健康检查器列表和集群元数据更新。
+
+运行时实例注册仍可保留在 `NamingService` 中，但服务管理、大范围列表、订阅者
+查看和健康检查维护属于 Maintainer SDK。
+
+### 6.4 AiMaintainerService
+
+`AiMaintainerService` 暴露类型化 delegate：
+
+- `mcp()`：MCP Server 列表、搜索、详情、创建、更新和删除；
+- `a2a()`：AgentCard 注册、查询、更新、删除、版本、搜索和列表；
+- `prompt()`：Prompt 管理；
+- `skill()`：Skill 管理；
+- `agentSpec()`：AgentSpec 管理；
+- `pipeline()`：Pipeline 管理。
+
+运行时 AI 注册和订阅可以继续保留在 `AiService`；大范围 AI 资源管理属于
+`AiMaintainerService`。
+
+## 7. Java 兼容规则
+
+- `api`、`client` 和 `plugin` 模块保持 Java 8 兼容，除非模块策略发生变化。
+- 服务端和 maintainer 模块遵循仓库 Java 版本策略。
+- 已废弃的 Client SDK 方法应尽量保持二进制兼容，但新的设计应引导调用方使用
+  Maintainer SDK。
+- 公开模型变更应尽量保持源码和二进制兼容，尤其是 HTTP 和 gRPC API 共享的对象。
+
+## 8. 文档参考
+
+- Java Client SDK 用户文档：Nacos 文档项目中的
+  `src/content/docs/next/zh-cn/manual/user/java-sdk`。
+- Java Maintainer SDK 用户文档：Nacos 文档项目中的
+  `src/content/docs/next/zh-cn/manual/admin/maintainer-sdk.md`。

--- a/specs/zh-cn/sdk/sdk-spec.md
+++ b/specs/zh-cn/sdk/sdk-spec.md
@@ -1,0 +1,114 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Nacos SDK 规范
+
+本文档定义 Nacos SDK 的通用设计规范。不同语言 SDK 可以采用符合语言习惯的
+命名、异步模型和包结构，但公开能力边界应遵循本文档。
+
+## 1. SDK 分类
+
+Nacos SDK 分为两类：
+
+- **Client SDK**：面向微服务应用、Agent Framework 以及其他运行时工作负载，
+  用于在应用正常运行过程中消费 Nacos 能力。
+- **Maintainer SDK**：面向运维工具、控制台、网关、管理平台以及其他需要管理
+  Nacos 的应用，避免这些应用自行拼装和调用 Nacos Admin HTTP API。
+
+两类 SDK 可以复用模型对象、鉴权参数、重试规则和连接基础设施，但不应混淆
+目标用户和权限边界。
+
+## 2. Client SDK 范围
+
+Client SDK 面向应用运行时访问，应只暴露运行时应用通常需要的能力：
+
+- 读取已知配置项，并订阅这些配置的变更；
+- 注册和注销当前应用实例；
+- 查询和订阅应用已知依赖的服务；
+- 注册、解析和订阅运行时 AI 资源，例如 MCP endpoint、A2A agent endpoint、
+  Prompt、Skill 和 AgentSpec；
+- 在语言 SDK 支持时，提供分布式锁等可选运行时原语；
+- 管理自身生命周期、本地缓存、监听器和连接。
+
+Client SDK 应避免暴露大范围管理能力，包括：
+
+- 集群控制、服务端状态变更、日志级别变更、连接或流量重载；
+- 列举全部命名空间、全部配置、全部服务或全部客户端；
+- 查询历史、审计类元数据、dump 数据或订阅者列表；
+- 批量删除、跨命名空间管理以及其他高影响操作；
+- 新增主要面向运维人员而非运行时应用的写入 API。
+
+部分历史 Client SDK interface 已经包含写入或大范围查询能力，例如配置发布、
+配置删除或服务列表查询。这些 API 属于兼容面。新的 SDK 设计不应继续扩大这类
+能力；管理类场景应转向 Maintainer SDK 或 Admin API。
+
+## 3. Maintainer SDK 范围
+
+Maintainer SDK 面向管理接入，可以暴露 Client SDK 有意不包含的能力：
+
+- 命名空间、集群、服务端状态、readiness/liveness、日志级别等维护能力；
+- 配置的列表、搜索、发布、删除、历史、beta、dump 和元数据管理；
+- 服务、实例、集群元数据、订阅者、客户端、健康检查等注册中心维护能力；
+- MCP、A2A、Prompt、Skill、AgentSpec 和 Pipeline 等 AI 资源管理；
+- 对大规模管理数据提供分页和过滤能力。
+
+Maintainer SDK 应被视为 Nacos Admin API 能力面的类型化门面。只对管理、UI、
+网关或运维工具有意义的能力，应归入 Maintainer SDK，而不是 Client SDK。
+
+## 4. 安全规则
+
+SDK 能力设计必须遵循最小权限原则：
+
+- Client SDK 凭据应限制在运行时资源范围内，不应要求大范围读写权限。
+- Maintainer SDK 凭据权限更高，文档和示例必须与 Client SDK 凭据明确区分。
+- 大范围读取 API 必须提供显式过滤和分页，不应静默执行无边界的全量集群读取。
+- 跨命名空间操作属于 Maintainer SDK，并应要求显式传入 namespace。
+- 当 API 可以列举或导出大量配置、服务、客户端或元数据时，SDK 文档应明确说明
+  可能的数据泄露风险。
+
+## 5. 传输和 API 对齐
+
+SDK 契约是语义契约，而不是传输契约：
+
+- Client SDK 可以使用 gRPC、HTTP Open API、本地缓存文件或多种传输组合，只要
+  公开 SDK 行为保持稳定。
+- Maintainer SDK 应与 Nacos Admin API 的语义和结果模型对齐，即使实现细节未来
+  更换传输方式。
+- SDK 模型对象应与 HTTP 和 gRPC 的语义对象对齐，避免同一个业务含义在不同
+  传输中被重复定义。
+- SDK 错误应将 Nacos 错误码和校验失败映射为符合语言习惯的异常或结果类型，
+  同时保留服务端语义。
+
+## 6. 多语言 SDK 对齐
+
+Java 目前是定义共享 SDK 语义的基准实现。其他语言 SDK 应对齐相同的能力分类：
+
+- 初始化、命名空间绑定、鉴权和生命周期关闭；
+- Client SDK 的配置、注册中心、AI 以及可选分布式锁运行时能力；
+- Maintainer SDK 的 Core、配置、注册中心和 AI 管理能力；
+- namespace、group、dataId、service name、cluster、version、label 等一致的
+  数据标识规则；
+- 在语言运行时支持时，保持一致的监听、订阅、重试、超时和本地缓存行为。
+
+语言 SDK 可以按照语言习惯暴露 future、promise、stream、coroutine、callback
+或 context cancellation。这些差异应记录在语言实现规范中，而不是改变共享 SDK
+范围。
+
+## 7. 相关规范
+
+- [Java SDK 实现规范](./sdk-java-impl-spec.md)
+- [HTTP API 规范](../http-api/api-spec.md)
+- [gRPC API 规范](../grpc-api/api-spec.md)


### PR DESCRIPTION
## Summary
- Add bilingual Nacos plugin specs, including plugin identity, runtime state, execution modes, and admin APIs.
- Add bilingual auth and permission specs covering RBAC, AuthPlugin, VisibilityPlugin, default auth implementation, and visibility query planning.
- Link the new specs from spec indexes, HTTP authorization specs, and AGENTS.md.

## Related Issue
Related to #14816

## Testing
- git diff --check