### PR TITLE
Prevent PostgreSQL tenant nulls from turning config sync into row explosion

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
@@ -87,7 +87,8 @@ public class ConfigOperationService {
      */
     public Boolean publishConfig(ConfigForm configForm, ConfigRequestInfo configRequestInfo,
         String encryptedDataKey) throws NacosException {
-        configForm.setNamespaceId(NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId()));
+        configForm
+            .setNamespaceId(NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId()));
         Map<String, Object> configAdvanceInfo = getConfigAdvanceInfo(configForm);
         ParamUtils.checkParam(configAdvanceInfo);
         
@@ -201,7 +202,8 @@ public class ConfigOperationService {
     private Boolean publishConfigGray(String grayType, ConfigForm configForm,
         ConfigRequestInfo configRequestInfo)
         throws NacosException {
-        configForm.setNamespaceId(NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId()));
+        configForm
+            .setNamespaceId(NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId()));
         
         Map<String, Object> configAdvanceInfo = getConfigAdvanceInfo(configForm);
         ParamUtils.checkParam(configAdvanceInfo);
@@ -327,7 +329,7 @@ public class ConfigOperationService {
             clientIp, persistEvent,
             ConfigTraceService.PERSISTENCE_TYPE_REMOVE, null);
         ConfigChangePublisher.notifyConfigChange(
-                new ConfigDataChangeEvent(dataId, group, namespaceId, grayName, time.getTime()));
+            new ConfigDataChangeEvent(dataId, group, namespaceId, grayName, time.getTime()));
         return true;
     }
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.MapUtil;
+import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.common.utils.NumberUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
@@ -86,6 +87,7 @@ public class ConfigOperationService {
      */
     public Boolean publishConfig(ConfigForm configForm, ConfigRequestInfo configRequestInfo,
         String encryptedDataKey) throws NacosException {
+        configForm.setNamespaceId(normalizeNamespaceId(configForm.getNamespaceId()));
         Map<String, Object> configAdvanceInfo = getConfigAdvanceInfo(configForm);
         ParamUtils.checkParam(configAdvanceInfo);
         
@@ -199,6 +201,7 @@ public class ConfigOperationService {
     private Boolean publishConfigGray(String grayType, ConfigForm configForm,
         ConfigRequestInfo configRequestInfo)
         throws NacosException {
+        configForm.setNamespaceId(normalizeNamespaceId(configForm.getNamespaceId()));
         
         Map<String, Object> configAdvanceInfo = getConfigAdvanceInfo(configForm);
         ParamUtils.checkParam(configAdvanceInfo);
@@ -303,6 +306,7 @@ public class ConfigOperationService {
     public Boolean deleteConfig(String dataId, String group, String namespaceId, String grayName,
         String clientIp,
         String srcUser, String srcType) {
+        namespaceId = normalizeNamespaceId(namespaceId);
         String persistEvent = ConfigTraceService.PERSISTENCE_EVENT;
         if (StringUtils.isBlank(grayName)) {
             configInfoPersistService.removeConfigInfo(dataId, group, namespaceId, clientIp,
@@ -323,8 +327,18 @@ public class ConfigOperationService {
             clientIp, persistEvent,
             ConfigTraceService.PERSISTENCE_TYPE_REMOVE, null);
         ConfigChangePublisher.notifyConfigChange(
-            new ConfigDataChangeEvent(dataId, group, namespaceId, grayName, time.getTime()));
+                new ConfigDataChangeEvent(dataId, group, namespaceId, grayName, time.getTime()));
         return true;
+    }
+
+    String normalizeNamespaceId(String namespaceId) {
+        if (namespaceId == null) {
+            return NamespaceUtil.processNamespaceParameter(namespaceId);
+        }
+        if (StringUtils.equals(namespaceId, StringUtils.EMPTY)) {
+            return StringUtils.EMPTY;
+        }
+        return NamespaceUtil.processNamespaceParameter(namespaceId);
     }
     
     public Map<String, Object> getConfigAdvanceInfo(ConfigForm configForm) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
@@ -87,7 +87,7 @@ public class ConfigOperationService {
      */
     public Boolean publishConfig(ConfigForm configForm, ConfigRequestInfo configRequestInfo,
         String encryptedDataKey) throws NacosException {
-        configForm.setNamespaceId(normalizeNamespaceId(configForm.getNamespaceId()));
+        configForm.setNamespaceId(NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId()));
         Map<String, Object> configAdvanceInfo = getConfigAdvanceInfo(configForm);
         ParamUtils.checkParam(configAdvanceInfo);
         
@@ -201,7 +201,7 @@ public class ConfigOperationService {
     private Boolean publishConfigGray(String grayType, ConfigForm configForm,
         ConfigRequestInfo configRequestInfo)
         throws NacosException {
-        configForm.setNamespaceId(normalizeNamespaceId(configForm.getNamespaceId()));
+        configForm.setNamespaceId(NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId()));
         
         Map<String, Object> configAdvanceInfo = getConfigAdvanceInfo(configForm);
         ParamUtils.checkParam(configAdvanceInfo);
@@ -306,7 +306,7 @@ public class ConfigOperationService {
     public Boolean deleteConfig(String dataId, String group, String namespaceId, String grayName,
         String clientIp,
         String srcUser, String srcType) {
-        namespaceId = normalizeNamespaceId(namespaceId);
+        namespaceId = NamespaceUtil.processNamespaceParameter(namespaceId);
         String persistEvent = ConfigTraceService.PERSISTENCE_EVENT;
         if (StringUtils.isBlank(grayName)) {
             configInfoPersistService.removeConfigInfo(dataId, group, namespaceId, clientIp,
@@ -329,16 +329,6 @@ public class ConfigOperationService {
         ConfigChangePublisher.notifyConfigChange(
                 new ConfigDataChangeEvent(dataId, group, namespaceId, grayName, time.getTime()));
         return true;
-    }
-
-    String normalizeNamespaceId(String namespaceId) {
-        if (namespaceId == null) {
-            return NamespaceUtil.processNamespaceParameter(namespaceId);
-        }
-        if (StringUtils.equals(namespaceId, StringUtils.EMPTY)) {
-            return StringUtils.EMPTY;
-        }
-        return NamespaceUtil.processNamespaceParameter(namespaceId);
     }
     
     public Map<String, Object> getConfigAdvanceInfo(ConfigForm configForm) {

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigOperationServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigOperationServiceTest.java
@@ -273,7 +273,7 @@ class ConfigOperationServiceTest {
         assertTrue(bResult);
         configRequestInfo.setCasMd5("");
     }
-
+    
     @Test
     void testPublishConfigNormalizesNullNamespaceIdToDefault() throws NacosException {
         ConfigForm configForm = new ConfigForm();
@@ -283,16 +283,17 @@ class ConfigOperationServiceTest {
         configForm.setContent("test content");
         ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
         ArgumentCaptor<ConfigInfo> configInfoCaptor = ArgumentCaptor.forClass(ConfigInfo.class);
-        when(configInfoPersistService.insertOrUpdate(any(), any(), configInfoCaptor.capture(), any()))
+        when(configInfoPersistService.insertOrUpdate(any(), any(), configInfoCaptor.capture(),
+            any()))
             .thenReturn(new ConfigOperateResult());
-
+        
         Boolean result = configOperationService.publishConfig(configForm, configRequestInfo, "");
-
+        
         assertTrue(result);
         assertEquals(Constants.DEFAULT_NAMESPACE_ID, configInfoCaptor.getValue().getTenant());
         assertEquals(Constants.DEFAULT_NAMESPACE_ID, configForm.getNamespaceId());
     }
-
+    
     @Test
     void testPublishConfigNormalizesBlankNamespaceIdThroughNamespaceUtil() throws NacosException {
         ConfigForm configForm = new ConfigForm();
@@ -302,16 +303,17 @@ class ConfigOperationServiceTest {
         configForm.setContent("test content");
         ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
         ArgumentCaptor<ConfigInfo> configInfoCaptor = ArgumentCaptor.forClass(ConfigInfo.class);
-        when(configInfoPersistService.insertOrUpdate(any(), any(), configInfoCaptor.capture(), any()))
+        when(configInfoPersistService.insertOrUpdate(any(), any(), configInfoCaptor.capture(),
+            any()))
             .thenReturn(new ConfigOperateResult());
-
+        
         Boolean result = configOperationService.publishConfig(configForm, configRequestInfo, "");
-
+        
         assertTrue(result);
         assertEquals(Constants.DEFAULT_NAMESPACE_ID, configInfoCaptor.getValue().getTenant());
         assertEquals(Constants.DEFAULT_NAMESPACE_ID, configForm.getNamespaceId());
     }
-
+    
     @Test
     void testPublishConfigPreservesExplicitCompatibilityEmptyNamespaceId() throws NacosException {
         ConfigForm configForm = new ConfigForm();
@@ -321,11 +323,12 @@ class ConfigOperationServiceTest {
         configForm.setContent("test content");
         ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
         ArgumentCaptor<ConfigInfo> configInfoCaptor = ArgumentCaptor.forClass(ConfigInfo.class);
-        when(configInfoPersistService.insertOrUpdate(any(), any(), configInfoCaptor.capture(), any()))
+        when(configInfoPersistService.insertOrUpdate(any(), any(), configInfoCaptor.capture(),
+            any()))
             .thenReturn(new ConfigOperateResult());
-
+        
         Boolean result = configOperationService.publishConfig(configForm, configRequestInfo, "");
-
+        
         assertTrue(result);
         assertEquals("", configInfoCaptor.getValue().getTenant());
         assertEquals("", configForm.getNamespaceId());
@@ -423,7 +426,7 @@ class ConfigOperationServiceTest {
             "test", "http");
         assertTrue(bResult);
     }
-
+    
     @Test
     void testDeleteConfigNormalizesNullNamespaceIdToDefault() {
         Boolean result = configOperationService.deleteConfig("test", "test", null, "", "1.1.1.1",

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigOperationServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigOperationServiceTest.java
@@ -315,7 +315,7 @@ class ConfigOperationServiceTest {
     }
     
     @Test
-    void testPublishConfigPreservesExplicitCompatibilityEmptyNamespaceId() throws NacosException {
+    void testPublishConfigNormalizesExplicitEmptyNamespaceIdToDefault() throws NacosException {
         ConfigForm configForm = new ConfigForm();
         configForm.setDataId("test");
         configForm.setGroup("test");
@@ -330,8 +330,8 @@ class ConfigOperationServiceTest {
         Boolean result = configOperationService.publishConfig(configForm, configRequestInfo, "");
         
         assertTrue(result);
-        assertEquals("", configInfoCaptor.getValue().getTenant());
-        assertEquals("", configForm.getNamespaceId());
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, configInfoCaptor.getValue().getTenant());
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, configForm.getNamespaceId());
     }
     
     @Test
@@ -418,8 +418,8 @@ class ConfigOperationServiceTest {
         // if tag is blank
         Boolean aResult =
             configOperationService.deleteConfig("test", "test", "", "", "1.1.1.1", "test", "http");
-        verify(configInfoPersistService).removeConfigInfo(eq("test"), eq("test"), eq(""), any(),
-            any());
+        verify(configInfoPersistService).removeConfigInfo(eq("test"), eq("test"),
+            eq(Constants.DEFAULT_NAMESPACE_ID), any(), any());
         assertTrue(aResult);
         // if tag is not blank
         Boolean bResult = configOperationService.deleteConfig("test", "test", "", "test", "1.1.1.1",
@@ -463,7 +463,7 @@ class ConfigOperationServiceTest {
             "test", "test", "", "beta", "1.1.1.1", "user", "http");
         assertTrue(result);
         verify(configInfoGrayPersistService).removeConfigInfoGray(
-            eq("test"), eq("test"), eq(""), eq("beta"), any(), any());
+            eq("test"), eq("test"), eq(Constants.DEFAULT_NAMESPACE_ID), eq("beta"), any(), any());
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigOperationServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigOperationServiceTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.config.server.service;
 
+import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
@@ -272,6 +273,63 @@ class ConfigOperationServiceTest {
         assertTrue(bResult);
         configRequestInfo.setCasMd5("");
     }
+
+    @Test
+    void testPublishConfigNormalizesNullNamespaceIdToDefault() throws NacosException {
+        ConfigForm configForm = new ConfigForm();
+        configForm.setDataId("test");
+        configForm.setGroup("test");
+        configForm.setNamespaceId(null);
+        configForm.setContent("test content");
+        ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
+        ArgumentCaptor<ConfigInfo> configInfoCaptor = ArgumentCaptor.forClass(ConfigInfo.class);
+        when(configInfoPersistService.insertOrUpdate(any(), any(), configInfoCaptor.capture(), any()))
+            .thenReturn(new ConfigOperateResult());
+
+        Boolean result = configOperationService.publishConfig(configForm, configRequestInfo, "");
+
+        assertTrue(result);
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, configInfoCaptor.getValue().getTenant());
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, configForm.getNamespaceId());
+    }
+
+    @Test
+    void testPublishConfigNormalizesBlankNamespaceIdThroughNamespaceUtil() throws NacosException {
+        ConfigForm configForm = new ConfigForm();
+        configForm.setDataId("test");
+        configForm.setGroup("test");
+        configForm.setNamespaceId("   ");
+        configForm.setContent("test content");
+        ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
+        ArgumentCaptor<ConfigInfo> configInfoCaptor = ArgumentCaptor.forClass(ConfigInfo.class);
+        when(configInfoPersistService.insertOrUpdate(any(), any(), configInfoCaptor.capture(), any()))
+            .thenReturn(new ConfigOperateResult());
+
+        Boolean result = configOperationService.publishConfig(configForm, configRequestInfo, "");
+
+        assertTrue(result);
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, configInfoCaptor.getValue().getTenant());
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, configForm.getNamespaceId());
+    }
+
+    @Test
+    void testPublishConfigPreservesExplicitCompatibilityEmptyNamespaceId() throws NacosException {
+        ConfigForm configForm = new ConfigForm();
+        configForm.setDataId("test");
+        configForm.setGroup("test");
+        configForm.setNamespaceId("");
+        configForm.setContent("test content");
+        ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
+        ArgumentCaptor<ConfigInfo> configInfoCaptor = ArgumentCaptor.forClass(ConfigInfo.class);
+        when(configInfoPersistService.insertOrUpdate(any(), any(), configInfoCaptor.capture(), any()))
+            .thenReturn(new ConfigOperateResult());
+
+        Boolean result = configOperationService.publishConfig(configForm, configRequestInfo, "");
+
+        assertTrue(result);
+        assertEquals("", configInfoCaptor.getValue().getTenant());
+        assertEquals("", configForm.getNamespaceId());
+    }
     
     @Test
     void testUpdateForExistTrue() throws Exception {
@@ -364,6 +422,17 @@ class ConfigOperationServiceTest {
         Boolean bResult = configOperationService.deleteConfig("test", "test", "", "test", "1.1.1.1",
             "test", "http");
         assertTrue(bResult);
+    }
+
+    @Test
+    void testDeleteConfigNormalizesNullNamespaceIdToDefault() {
+        Boolean result = configOperationService.deleteConfig("test", "test", null, "", "1.1.1.1",
+            "test", "http");
+        verify(configInfoPersistService).removeConfigInfo(eq("test"), eq("test"),
+            eq(Constants.DEFAULT_NAMESPACE_ID), any(), any());
+        verify(configMigrateService).removeConfigInfoMigrate(eq("test"), eq("test"),
+            eq(Constants.DEFAULT_NAMESPACE_ID), any(), any());
+        assertTrue(result);
     }
     
     @Test

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImpl.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImpl.java
@@ -62,12 +62,12 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
     private static final int DB_MASTER_SELECT_THRESHOLD = 1;
     
     private static final String DB_LOAD_ERROR_MSG = "[db-load-error]load jdbc.properties error";
-
+    
     private static final String POSTGRESQL = "postgresql";
-
+    
     private static final String POSTGRESQL_NULL_TENANT_MIGRATION_SCRIPT =
         "META-INF/pg-upgrade-null-tenant-id.sql";
-
+    
     private static final String[] POSTGRESQL_CONFIG_TENANT_TABLES = {"config_info",
         "config_info_gray", "config_tags_relation", "his_config_info"};
     
@@ -247,20 +247,20 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
     public String getDataSourceType() {
         return dataSourceType;
     }
-
+    
     void validatePostgresqlTenantSchema() {
         if (!POSTGRESQL.equalsIgnoreCase(dataSourceType) || null == jt.getDataSource()) {
             return;
         }
         validatePostgresqlTenantSchema(jt);
     }
-
+    
     void validatePostgresqlTenantSchema(JdbcTemplate jdbcTemplate) {
         for (String tableName : POSTGRESQL_CONFIG_TENANT_TABLES) {
             validatePostgresqlTenantColumn(jdbcTemplate, tableName);
         }
     }
-
+    
     private void validatePostgresqlTenantColumn(JdbcTemplate jdbcTemplate, String tableName) {
         String sql = "SELECT is_nullable, column_default FROM information_schema.columns "
             + "WHERE table_schema = current_schema() AND table_name = ? AND column_name = 'tenant_id'";
@@ -274,17 +274,20 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
                 throwIncompatiblePostgresqlTenantSchema(tableName);
             }
         } catch (DataAccessException e) {
-            throw new IllegalStateException(buildIncompatiblePostgresqlTenantSchemaMessage(tableName), e);
+            throw new IllegalStateException(
+                buildIncompatiblePostgresqlTenantSchemaMessage(tableName), e);
         }
     }
-
+    
     private void throwIncompatiblePostgresqlTenantSchema(String tableName) {
         throw new IllegalStateException(buildIncompatiblePostgresqlTenantSchemaMessage(tableName));
     }
-
+    
     private String buildIncompatiblePostgresqlTenantSchemaMessage(String tableName) {
-        return "PostgreSQL schema is incompatible for table '" + tableName + "': column 'tenant_id' must be "
-            + "NOT NULL DEFAULT ''. Apply the migration script " + POSTGRESQL_NULL_TENANT_MIGRATION_SCRIPT
+        return "PostgreSQL schema is incompatible for table '" + tableName
+            + "': column 'tenant_id' must be "
+            + "NOT NULL DEFAULT ''. Apply the migration script "
+            + POSTGRESQL_NULL_TENANT_MIGRATION_SCRIPT
             + " before starting Nacos.";
     }
     

--- a/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImpl.java
+++ b/persistence/src/main/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImpl.java
@@ -39,6 +39,7 @@ import javax.sql.DataSource;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -61,6 +62,14 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
     private static final int DB_MASTER_SELECT_THRESHOLD = 1;
     
     private static final String DB_LOAD_ERROR_MSG = "[db-load-error]load jdbc.properties error";
+
+    private static final String POSTGRESQL = "postgresql";
+
+    private static final String POSTGRESQL_NULL_TENANT_MIGRATION_SCRIPT =
+        "META-INF/pg-upgrade-null-tenant-id.sql";
+
+    private static final String[] POSTGRESQL_CONFIG_TENANT_TABLES = {"config_info",
+        "config_info_gray", "config_tags_relation", "his_config_info"};
     
     private List<HikariDataSource> dataSourceList = new ArrayList<>();
     
@@ -151,6 +160,7 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
             testJtList = testJtListNew;
             isHealthList = isHealthListNew;
             new SelectMasterTask().run();
+            validatePostgresqlTenantSchema();
             new CheckDbHealthTask().run();
             
             //close old datasource.
@@ -164,6 +174,8 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
                     oldJdbc.setDataSource(null);
                 }
             }
+        } catch (IllegalStateException e) {
+            throw e;
         } catch (RuntimeException e) {
             LOGGER.error(DB_LOAD_ERROR_MSG, e);
             throw new IOException(e);
@@ -234,6 +246,46 @@ public class ExternalDataSourceServiceImpl implements DataSourceService {
     @Override
     public String getDataSourceType() {
         return dataSourceType;
+    }
+
+    void validatePostgresqlTenantSchema() {
+        if (!POSTGRESQL.equalsIgnoreCase(dataSourceType) || null == jt.getDataSource()) {
+            return;
+        }
+        validatePostgresqlTenantSchema(jt);
+    }
+
+    void validatePostgresqlTenantSchema(JdbcTemplate jdbcTemplate) {
+        for (String tableName : POSTGRESQL_CONFIG_TENANT_TABLES) {
+            validatePostgresqlTenantColumn(jdbcTemplate, tableName);
+        }
+    }
+
+    private void validatePostgresqlTenantColumn(JdbcTemplate jdbcTemplate, String tableName) {
+        String sql = "SELECT is_nullable, column_default FROM information_schema.columns "
+            + "WHERE table_schema = current_schema() AND table_name = ? AND column_name = 'tenant_id'";
+        try {
+            Map<String, Object> columnInfo = jdbcTemplate.queryForMap(sql, tableName);
+            String isNullable = null == columnInfo.get("is_nullable") ? StringUtils.EMPTY
+                : String.valueOf(columnInfo.get("is_nullable"));
+            String columnDefault = null == columnInfo.get("column_default") ? StringUtils.EMPTY
+                : String.valueOf(columnInfo.get("column_default"));
+            if (!"NO".equalsIgnoreCase(isNullable) || !StringUtils.contains(columnDefault, "''")) {
+                throwIncompatiblePostgresqlTenantSchema(tableName);
+            }
+        } catch (DataAccessException e) {
+            throw new IllegalStateException(buildIncompatiblePostgresqlTenantSchemaMessage(tableName), e);
+        }
+    }
+
+    private void throwIncompatiblePostgresqlTenantSchema(String tableName) {
+        throw new IllegalStateException(buildIncompatiblePostgresqlTenantSchemaMessage(tableName));
+    }
+
+    private String buildIncompatiblePostgresqlTenantSchemaMessage(String tableName) {
+        return "PostgreSQL schema is incompatible for table '" + tableName + "': column 'tenant_id' must be "
+            + "NOT NULL DEFAULT ''. Apply the migration script " + POSTGRESQL_NULL_TENANT_MIGRATION_SCRIPT
+            + " before starting Nacos.";
     }
     
     class SelectMasterTask implements Runnable {

--- a/persistence/src/test/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImplTest.java
+++ b/persistence/src/test/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImplTest.java
@@ -157,7 +157,7 @@ class ExternalDataSourceServiceImplTest {
             EnvUtil.setEnvironment(null);
         }
     }
-
+    
     @Test
     void testReloadPropagatesIllegalStateException() {
         try {
@@ -327,24 +327,24 @@ class ExternalDataSourceServiceImplTest {
                 new NJdbcException("test"));
         assertDoesNotThrow(() -> service.new SelectMasterTask().run());
     }
-
+    
     @Test
     void testValidatePostgresqlTenantSchemaSuccess() {
         Map<String, Object> columnInfo = new HashMap<>();
         columnInfo.put("is_nullable", "NO");
         columnInfo.put("column_default", "''::character varying");
         when(jt.queryForMap(anyString(), any())).thenReturn(columnInfo);
-
+        
         assertDoesNotThrow(() -> service.validatePostgresqlTenantSchema(jt));
     }
-
+    
     @Test
     void testValidatePostgresqlTenantSchemaFailWhenNullable() {
         Map<String, Object> columnInfo = new HashMap<>();
         columnInfo.put("is_nullable", "YES");
         columnInfo.put("column_default", null);
         when(jt.queryForMap(anyString(), any())).thenReturn(columnInfo);
-
+        
         assertThrows(IllegalStateException.class, () -> service.validatePostgresqlTenantSchema(jt));
     }
 }

--- a/persistence/src/test/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImplTest.java
+++ b/persistence/src/test/java/com/alibaba/nacos/persistence/datasource/ExternalDataSourceServiceImplTest.java
@@ -39,7 +39,9 @@ import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -50,7 +52,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -148,6 +152,28 @@ class ExternalDataSourceServiceImplTest {
             verify(jt).setDataSource(any(DataSource.class));
             verify(oldJt).setDataSource(null);
             verify(dataSource).close();
+        } finally {
+            DatasourceConfiguration.setUseExternalDb(false);
+            EnvUtil.setEnvironment(null);
+        }
+    }
+
+    @Test
+    void testReloadPropagatesIllegalStateException() {
+        try {
+            MockEnvironment environment = new MockEnvironment();
+            EnvUtil.setEnvironment(environment);
+            environment.setProperty("db.num", "1");
+            environment.setProperty("db.user", "user");
+            environment.setProperty("db.password", "password");
+            environment.setProperty("db.url.0", "1.1.1.1");
+            environment.setProperty("db.pool.config.driverClassName",
+                "com.alibaba.nacos.persistence.datasource.mock.MockDriver");
+            DatasourceConfiguration.setUseExternalDb(true);
+            ExternalDataSourceServiceImpl spyService = spy(service);
+            doThrow(new IllegalStateException("invalid postgresql schema")).when(spyService)
+                .validatePostgresqlTenantSchema();
+            assertThrows(IllegalStateException.class, spyService::reload);
         } finally {
             DatasourceConfiguration.setUseExternalDb(false);
             EnvUtil.setEnvironment(null);
@@ -300,5 +326,25 @@ class ExternalDataSourceServiceImplTest {
             .thenThrow(
                 new NJdbcException("test"));
         assertDoesNotThrow(() -> service.new SelectMasterTask().run());
+    }
+
+    @Test
+    void testValidatePostgresqlTenantSchemaSuccess() {
+        Map<String, Object> columnInfo = new HashMap<>();
+        columnInfo.put("is_nullable", "NO");
+        columnInfo.put("column_default", "''::character varying");
+        when(jt.queryForMap(anyString(), any())).thenReturn(columnInfo);
+
+        assertDoesNotThrow(() -> service.validatePostgresqlTenantSchema(jt));
+    }
+
+    @Test
+    void testValidatePostgresqlTenantSchemaFailWhenNullable() {
+        Map<String, Object> columnInfo = new HashMap<>();
+        columnInfo.put("is_nullable", "YES");
+        columnInfo.put("column_default", null);
+        when(jt.queryForMap(anyString(), any())).thenReturn(columnInfo);
+
+        assertThrows(IllegalStateException.class, () -> service.validatePostgresqlTenantSchema(jt));
     }
 }

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-schema.sql
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-schema.sql
@@ -29,7 +29,7 @@ CREATE TABLE "config_info" (
   "src_user" text ,
   "src_ip" varchar(20) ,
   "app_name" varchar(128) ,
-  "tenant_id" varchar(128) ,
+  "tenant_id" varchar(128) NOT NULL DEFAULT '',
   "c_desc" varchar(256) ,
   "c_use" varchar(64) ,
   "effect" varchar(64) ,
@@ -66,7 +66,7 @@ CREATE TABLE "config_info_gray" (
   "gmt_create" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   "gmt_modified" timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   "app_name" varchar(128),
-  "tenant_id" varchar(128) DEFAULT '',
+  "tenant_id" varchar(128) NOT NULL DEFAULT '',
   "gray_name" varchar(128) NOT NULL,
   "gray_rule" text NOT NULL,
   "encrypted_data_key" varchar(256) NOT NULL DEFAULT ''
@@ -112,7 +112,7 @@ CREATE TABLE "config_tags_relation" (
   "tag_type" varchar(64) ,
   "data_id" varchar(255)  NOT NULL,
   "group_id" varchar(128)  NOT NULL,
-  "tenant_id" varchar(128) ,
+  "tenant_id" varchar(128) NOT NULL DEFAULT '',
   "nid" bigserial NOT NULL
 )
 ;
@@ -182,7 +182,7 @@ CREATE TABLE "his_config_info" (
   "src_user" text ,
   "src_ip" varchar(20) ,
   "op_type" char(10) ,
-  "tenant_id" varchar(128) ,
+  "tenant_id" varchar(128) NOT NULL DEFAULT '',
   "encrypted_data_key" text  NOT NULL,
   "publish_type" varchar(50) DEFAULT 'formal',
   "gray_name" varchar(50),

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-upgrade-null-tenant-id.sql
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-upgrade-null-tenant-id.sql
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- PostgreSQL upgrade script for deployments that still contain nullable tenant_id
+-- values in config-related tables.
+--
+-- IMPORTANT:
+-- 1. Review and clean duplicate logical rows before replacing NULL tenant_id
+--    values with '' on config_info, otherwise the UPDATE may conflict with the
+--    existing unique index on (data_id, group_id, tenant_id).
+-- 2. Apply this script before upgrading to a Nacos build that validates the
+--    PostgreSQL tenant schema on startup.
+--
+-- Suggested pre-check for duplicate logical config rows:
+-- SELECT data_id, group_id, COUNT(*)
+-- FROM config_info
+-- WHERE tenant_id IS NULL
+-- GROUP BY data_id, group_id
+-- HAVING COUNT(*) > 1;
+
+ALTER TABLE config_info ALTER COLUMN tenant_id SET DEFAULT '';
+UPDATE config_info SET tenant_id = '' WHERE tenant_id IS NULL;
+ALTER TABLE config_info ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE config_info_gray ALTER COLUMN tenant_id SET DEFAULT '';
+UPDATE config_info_gray SET tenant_id = '' WHERE tenant_id IS NULL;
+ALTER TABLE config_info_gray ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE config_tags_relation ALTER COLUMN tenant_id SET DEFAULT '';
+UPDATE config_tags_relation SET tenant_id = '' WHERE tenant_id IS NULL;
+ALTER TABLE config_tags_relation ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE his_config_info ALTER COLUMN tenant_id SET DEFAULT '';
+UPDATE his_config_info SET tenant_id = '' WHERE tenant_id IS NULL;
+ALTER TABLE his_config_info ALTER COLUMN tenant_id SET NOT NULL;

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/PostgresqlTenantMigrationScriptTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/PostgresqlTenantMigrationScriptTest.java
@@ -26,17 +26,22 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PostgresqlTenantMigrationScriptTest {
-
+    
     @Test
     void testMigrationScriptExistsAndCoversAllTenantTables() throws IOException {
         try (InputStream inputStream =
-                     getClass().getClassLoader().getResourceAsStream("META-INF/pg-upgrade-null-tenant-id.sql")) {
+            getClass().getClassLoader()
+                .getResourceAsStream("META-INF/pg-upgrade-null-tenant-id.sql")) {
             assertNotNull(inputStream);
             String sql = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-            assertTrue(sql.contains("ALTER TABLE config_info ALTER COLUMN tenant_id SET DEFAULT ''"));
-            assertTrue(sql.contains("ALTER TABLE config_info_gray ALTER COLUMN tenant_id SET DEFAULT ''"));
-            assertTrue(sql.contains("ALTER TABLE config_tags_relation ALTER COLUMN tenant_id SET DEFAULT ''"));
-            assertTrue(sql.contains("ALTER TABLE his_config_info ALTER COLUMN tenant_id SET DEFAULT ''"));
+            assertTrue(
+                sql.contains("ALTER TABLE config_info ALTER COLUMN tenant_id SET DEFAULT ''"));
+            assertTrue(
+                sql.contains("ALTER TABLE config_info_gray ALTER COLUMN tenant_id SET DEFAULT ''"));
+            assertTrue(sql.contains(
+                "ALTER TABLE config_tags_relation ALTER COLUMN tenant_id SET DEFAULT ''"));
+            assertTrue(
+                sql.contains("ALTER TABLE his_config_info ALTER COLUMN tenant_id SET DEFAULT ''"));
         }
     }
 }

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/PostgresqlTenantMigrationScriptTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/PostgresqlTenantMigrationScriptTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.impl.postgresql;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostgresqlTenantMigrationScriptTest {
+
+    @Test
+    void testMigrationScriptExistsAndCoversAllTenantTables() throws IOException {
+        try (InputStream inputStream =
+                     getClass().getClassLoader().getResourceAsStream("META-INF/pg-upgrade-null-tenant-id.sql")) {
+            assertNotNull(inputStream);
+            String sql = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            assertTrue(sql.contains("ALTER TABLE config_info ALTER COLUMN tenant_id SET DEFAULT ''"));
+            assertTrue(sql.contains("ALTER TABLE config_info_gray ALTER COLUMN tenant_id SET DEFAULT ''"));
+            assertTrue(sql.contains("ALTER TABLE config_tags_relation ALTER COLUMN tenant_id SET DEFAULT ''"));
+            assertTrue(sql.contains("ALTER TABLE his_config_info ALTER COLUMN tenant_id SET DEFAULT ''"));
+        }
+    }
+}

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/PostgresqlTenantSchemaResourceTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/PostgresqlTenantSchemaResourceTest.java
@@ -28,13 +28,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class PostgresqlTenantSchemaResourceTest {
-
+    
     @Test
     void testTenantColumnsAreHardenedInSchemaResource() throws IOException {
-        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("META-INF/pg-schema.sql")) {
+        try (InputStream inputStream =
+            getClass().getClassLoader().getResourceAsStream("META-INF/pg-schema.sql")) {
             assertNotNull(inputStream);
             String schema = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-            Matcher matcher = Pattern.compile("\"tenant_id\" varchar\\(128\\) NOT NULL DEFAULT ''").matcher(schema);
+            Matcher matcher = Pattern.compile("\"tenant_id\" varchar\\(128\\) NOT NULL DEFAULT ''")
+                .matcher(schema);
             int count = 0;
             while (matcher.find()) {
                 count++;

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/PostgresqlTenantSchemaResourceTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/postgresql/PostgresqlTenantSchemaResourceTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.impl.postgresql;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class PostgresqlTenantSchemaResourceTest {
+
+    @Test
+    void testTenantColumnsAreHardenedInSchemaResource() throws IOException {
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("META-INF/pg-schema.sql")) {
+            assertNotNull(inputStream);
+            String schema = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            Matcher matcher = Pattern.compile("\"tenant_id\" varchar\\(128\\) NOT NULL DEFAULT ''").matcher(schema);
+            int count = 0;
+            while (matcher.find()) {
+                count++;
+            }
+            assertEquals(4, count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR hardens PostgreSQL tenant handling in config persistence so that nullable `tenant_id` values can no longer bypass the config uniqueness model and explode `config_info`.

## Production incident background

A production incident was triggered after configuration data was imported from MySQL into PostgreSQL.

In the original implementation:

- MySQL schemas used `tenant_id DEFAULT ''` for the affected config tables.
- PostgreSQL schemas did not enforce equivalent `NOT NULL DEFAULT ''` constraints.
- Several persistence and row-mapping paths still tolerated `null` / blank tenant values instead of normalizing them consistently.

Once namespace compatibility sync (`public <-> ''`) kept mirroring default-namespace records, PostgreSQL accepted `NULL tenant_id` rows that bypassed the `(data_id, group_id, tenant_id)` uniqueness model, which led to a production `config_info` explosion.

## Root cause

The incident was caused by the combination of:

1. Missing PostgreSQL schema validation / tenant constraints after MySQL-to-PostgreSQL data import.
2. Missing PostgreSQL edge-case handling for `null` / blank tenant values in code.
3. Ongoing namespace compatibility sync continuing to amplify the bad rows once they existed.

## Fix

This change closes the gap from both the code side and the PostgreSQL schema side:

- Normalize storage-layer tenant values before they are written into config, gray, beta, tag, migrate, and history persistence paths.
- Normalize JDBC-mapped tenant values when reading rows back from the database.
- Normalize tag relation writes and reads so auxiliary config metadata cannot keep a separate null-tenant path alive.
- Harden PostgreSQL schema artifacts so the affected `tenant_id` columns are `NOT NULL DEFAULT ''`.
- Add PostgreSQL startup validation that fails fast if the runtime schema is still incompatible.

## Verification

- `git diff --cached --check`
- `./mvnw -pl config,persistence,plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql -am -DskipITs -DskipTests compile`
- `./mvnw -pl config -am -DskipITs -Dtest=ConfigStorageTenantUtilTest,ConfigRowMapperInjectorTest,EmbeddedConfigInfoPersistServiceImplTest,ExternalConfigInfoPersistServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl persistence -am -DskipITs -Dtest=ExternalDataSourceServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql -am -DskipITs -Dtest=PostgresqlSchemaTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Upgrade note

Production environments still need to:

- clean the existing `NULL tenant_id` / duplicate rows, and
- apply the PostgreSQL schema migration

before rolling out the fixed server version.
