### PR TITLE
test(client): raise client module line coverage to 95.93%

### DIFF
--- a/client/src/test/java/com/alibaba/nacos/client/ai/NacosAiServiceTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/NacosAiServiceTest.java
@@ -17,21 +17,37 @@
 package com.alibaba.nacos.client.ai;
 
 import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosAgentCardListener;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosAgentSpecListener;
 import com.alibaba.nacos.api.ai.listener.AbstractNacosMcpServerListener;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosPromptListener;
+import com.alibaba.nacos.api.ai.listener.NacosAgentCardEvent;
+import com.alibaba.nacos.api.ai.listener.NacosAgentSpecEvent;
 import com.alibaba.nacos.api.ai.listener.NacosMcpServerEvent;
+import com.alibaba.nacos.api.ai.listener.NacosPromptEvent;
 import com.alibaba.nacos.api.ai.model.a2a.AgentCard;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
 import com.alibaba.nacos.api.ai.model.a2a.AgentEndpoint;
 import com.alibaba.nacos.api.ai.model.a2a.AgentInterface;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.ai.model.prompt.Prompt;
 import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.client.ai.cache.NacosAgentCardCacheHolder;
+import com.alibaba.nacos.client.ai.cache.NacosAgentSpecCacheHolder;
 import com.alibaba.nacos.client.ai.cache.NacosMcpServerCacheHolder;
+import com.alibaba.nacos.client.ai.cache.NacosPromptCacheHolder;
+import com.alibaba.nacos.client.ai.event.AgentCardListenerInvoker;
+import com.alibaba.nacos.client.ai.event.AgentSpecListenerInvoker;
 import com.alibaba.nacos.client.ai.event.AiChangeNotifier;
 import com.alibaba.nacos.client.ai.event.McpServerListenerInvoker;
+import com.alibaba.nacos.client.ai.event.PromptListenerInvoker;
+import com.alibaba.nacos.client.ai.remote.AiClientProxy;
 import com.alibaba.nacos.client.ai.remote.AiGrpcClient;
 import com.alibaba.nacos.client.ai.remote.AiHttpClientProxy;
 import org.junit.jupiter.api.AfterEach;
@@ -52,6 +68,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -71,6 +88,21 @@ class NacosAiServiceTest {
     
     @Mock
     private NacosAgentCardCacheHolder agentCardCacheHolder;
+    
+    @Mock
+    private NacosPromptCacheHolder promptCacheHolder;
+    
+    @Mock
+    private NacosAgentSpecCacheHolder agentSpecCacheHolder;
+    
+    @Mock
+    private AiHttpClientProxy httpProxy;
+    
+    @Mock
+    private AiClientProxy aiClientProxy;
+    
+    @Mock
+    private ConfigService skillConfigService;
     
     @Mock
     private AiChangeNotifier aiChangeNotifier;
@@ -354,6 +386,471 @@ class NacosAiServiceTest {
             () -> nacosAiService.registerAgentEndpoint("testAgent", endpoints));
     }
     
+    @Test
+    void releaseAgentCardWithInvalidInterfaceShouldUseLegacyValidation() {
+        // V1 interface fails validation (missing protocolVersion), legacy fields also missing
+        AgentCard agentCard = new AgentCard();
+        agentCard.setName("testAgent");
+        agentCard.setVersion("1.0.0");
+        AgentInterface invalid = new AgentInterface();
+        invalid.setUrl("http://127.0.0.1:8080");
+        invalid.setProtocolBinding("JSONRPC");
+        // No protocolVersion → invalid → hasValidV1Interfaces returns false (line 417)
+        agentCard.setSupportedInterfaces(Collections.singletonList(invalid));
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.releaseAgentCard(agentCard, "service", true));
+    }
+    
+    @Test
+    void getAgentCard() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AgentCardDetailInfo expected = new AgentCardDetailInfo();
+        when(grpcClient.getAgentCard("agentName", "1.0.0", "service")).thenReturn(expected);
+        AgentCardDetailInfo actual = nacosAiService.getAgentCard("agentName", "1.0.0", "service");
+        assertEquals(expected, actual);
+    }
+    
+    @Test
+    void getAgentCardWithBlankName() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.getAgentCard("", "1.0.0", "service"));
+    }
+    
+    @Test
+    void releaseAgentCardWithoutRegistrationTypeShouldUseDefault()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AgentCard agentCard = new AgentCard();
+        agentCard.setName("testAgent");
+        agentCard.setVersion("1.0.0");
+        AgentInterface ai = new AgentInterface();
+        ai.setUrl("http://127.0.0.1:8080");
+        ai.setProtocolBinding("JSONRPC");
+        ai.setProtocolVersion("1.0");
+        agentCard.setSupportedInterfaces(Collections.singletonList(ai));
+        nacosAiService.releaseAgentCard(agentCard, "", true);
+        verify(grpcClient).releaseAgentCard(eq(agentCard), eq(
+            com.alibaba.nacos.api.ai.constant.AiConstants.A2a.A2A_ENDPOINT_TYPE_SERVICE), eq(true));
+    }
+    
+    @Test
+    void releaseAgentCardWithNullAgentCard() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.releaseAgentCard(null, "service", true));
+    }
+    
+    @Test
+    void releaseAgentCardWithBlankName() {
+        AgentCard agentCard = new AgentCard();
+        // missing name
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.releaseAgentCard(agentCard, "service", true));
+    }
+    
+    @Test
+    void registerAgentEndpoint()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AgentEndpoint endpoint = new AgentEndpoint();
+        endpoint.setAddress("1.1.1.1");
+        endpoint.setPort(8080);
+        endpoint.setVersion("1.0.0");
+        nacosAiService.registerAgentEndpoint("testAgent", endpoint);
+        verify(grpcClient).registerAgentEndpoint("testAgent", endpoint);
+    }
+    
+    @Test
+    void registerAgentEndpointWithBlankAgentName() {
+        AgentEndpoint endpoint = new AgentEndpoint();
+        endpoint.setAddress("1.1.1.1");
+        endpoint.setPort(8080);
+        endpoint.setVersion("1.0.0");
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.registerAgentEndpoint("", endpoint));
+    }
+    
+    @Test
+    void registerAgentEndpointWithNullEndpoint() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.registerAgentEndpoint("testAgent", (AgentEndpoint) null));
+    }
+    
+    @Test
+    void deregisterAgentEndpoint()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AgentEndpoint endpoint = new AgentEndpoint();
+        endpoint.setAddress("1.1.1.1");
+        endpoint.setPort(8080);
+        endpoint.setVersion("1.0.0");
+        nacosAiService.deregisterAgentEndpoint("testAgent", endpoint);
+        verify(grpcClient).deregisterAgentEndpoint("testAgent", endpoint);
+    }
+    
+    @Test
+    void deregisterAgentEndpointWithBlankAgentName() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.deregisterAgentEndpoint("", new AgentEndpoint()));
+    }
+    
+    @Test
+    void subscribeAgentCard() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AbstractNacosAgentCardListener listener =
+            Mockito.mock(AbstractNacosAgentCardListener.class);
+        AgentCardDetailInfo expected = new AgentCardDetailInfo();
+        when(grpcClient.subscribeAgentCard("agentName", "1.0.0")).thenReturn(expected);
+        AgentCardDetailInfo actual =
+            nacosAiService.subscribeAgentCard("agentName", "1.0.0", listener);
+        assertEquals(expected, actual);
+        verify(aiChangeNotifier).registerListener(eq("agentName"), eq("1.0.0"),
+            any(AgentCardListenerInvoker.class));
+        verify(listener).onEvent(any(NacosAgentCardEvent.class));
+    }
+    
+    @Test
+    void subscribeAgentCardWithBlankName() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.subscribeAgentCard("", "1.0.0", null));
+    }
+    
+    @Test
+    void subscribeAgentCardWithNullListener() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.subscribeAgentCard("agentName", "1.0.0", null));
+    }
+    
+    @Test
+    void unsubscribeAgentCard()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AbstractNacosAgentCardListener listener =
+            Mockito.mock(AbstractNacosAgentCardListener.class);
+        nacosAiService.unsubscribeAgentCard("agentName", "1.0.0", listener);
+        verify(aiChangeNotifier).deregisterListener(eq("agentName"), eq("1.0.0"),
+            any(AgentCardListenerInvoker.class));
+        verify(grpcClient).unsubscribeAgentCard("agentName", "1.0.0");
+    }
+    
+    @Test
+    void unsubscribeAgentCardWithRemainingListeners()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        when(aiChangeNotifier.isAgentCardSubscribed("agentName", "1.0.0")).thenReturn(true);
+        AbstractNacosAgentCardListener listener =
+            Mockito.mock(AbstractNacosAgentCardListener.class);
+        nacosAiService.unsubscribeAgentCard("agentName", "1.0.0", listener);
+        verify(aiChangeNotifier).deregisterListener(eq("agentName"), eq("1.0.0"),
+            any(AgentCardListenerInvoker.class));
+        verify(grpcClient, never()).unsubscribeAgentCard("agentName", "1.0.0");
+    }
+    
+    @Test
+    void unsubscribeAgentCardWithNullListener()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        nacosAiService.unsubscribeAgentCard("agentName", "1.0.0", null);
+        verify(aiChangeNotifier, never()).deregisterListener(eq("agentName"), eq("1.0.0"),
+            any(AgentCardListenerInvoker.class));
+        verify(grpcClient, never()).unsubscribeAgentCard("agentName", "1.0.0");
+    }
+    
+    @Test
+    void unsubscribeAgentCardWithBlankName() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.unsubscribeAgentCard("", null, null));
+    }
+    
+    @Test
+    void downloadSkillZip() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        byte[] zipBytes = new byte[] {1, 2, 3};
+        when(httpProxy.downloadSkillZip("skillName", null, null)).thenReturn(zipBytes);
+        assertEquals(zipBytes, nacosAiService.downloadSkillZip("skillName"));
+    }
+    
+    @Test
+    void downloadSkillZipWithBlankName() {
+        assertThrows(NacosApiException.class, () -> nacosAiService.downloadSkillZip(""));
+    }
+    
+    @Test
+    void downloadSkillZipByVersion()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        byte[] zipBytes = new byte[] {4, 5, 6};
+        when(httpProxy.downloadSkillZip("skillName", "1.0.0", null)).thenReturn(zipBytes);
+        assertEquals(zipBytes, nacosAiService.downloadSkillZipByVersion("skillName", "1.0.0"));
+    }
+    
+    @Test
+    void downloadSkillZipByVersionWithBlankName() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.downloadSkillZipByVersion("", "1.0.0"));
+    }
+    
+    @Test
+    void downloadSkillZipByLabel()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        byte[] zipBytes = new byte[] {7, 8, 9};
+        when(httpProxy.downloadSkillZip("skillName", null, "stable")).thenReturn(zipBytes);
+        assertEquals(zipBytes, nacosAiService.downloadSkillZipByLabel("skillName", "stable"));
+    }
+    
+    @Test
+    void downloadSkillZipByLabelWithBlankName() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.downloadSkillZipByLabel("", "stable"));
+    }
+    
+    @Test
+    void loadAgentSpec() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AgentSpec expected = new AgentSpec();
+        when(agentSpecCacheHolder.queryAgentSpec("specName")).thenReturn(expected);
+        assertEquals(expected, nacosAiService.loadAgentSpec("specName"));
+    }
+    
+    @Test
+    void loadAgentSpecWithBlankName() {
+        assertThrows(NacosApiException.class, () -> nacosAiService.loadAgentSpec(""));
+    }
+    
+    @Test
+    void subscribeAgentSpec() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AbstractNacosAgentSpecListener listener =
+            Mockito.mock(AbstractNacosAgentSpecListener.class);
+        AgentSpec expected = new AgentSpec();
+        when(agentSpecCacheHolder.subscribeAgentSpec("specName")).thenReturn(expected);
+        AgentSpec actual = nacosAiService.subscribeAgentSpec("specName", listener);
+        assertEquals(expected, actual);
+        verify(aiChangeNotifier).registerListener(eq("specName"),
+            any(AgentSpecListenerInvoker.class));
+        verify(listener).onEvent(any(NacosAgentSpecEvent.class));
+    }
+    
+    @Test
+    void subscribeAgentSpecWithBlankName() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.subscribeAgentSpec("", null));
+    }
+    
+    @Test
+    void subscribeAgentSpecWithNullListener() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.subscribeAgentSpec("specName", null));
+    }
+    
+    @Test
+    void unsubscribeAgentSpec()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AbstractNacosAgentSpecListener listener =
+            Mockito.mock(AbstractNacosAgentSpecListener.class);
+        nacosAiService.unsubscribeAgentSpec("specName", listener);
+        verify(aiChangeNotifier).deregisterListener(eq("specName"),
+            any(AgentSpecListenerInvoker.class));
+        verify(agentSpecCacheHolder).unsubscribeAgentSpec("specName");
+    }
+    
+    @Test
+    void unsubscribeAgentSpecWithRemainingListeners()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        when(aiChangeNotifier.isAgentSpecSubscribed("specName")).thenReturn(true);
+        AbstractNacosAgentSpecListener listener =
+            Mockito.mock(AbstractNacosAgentSpecListener.class);
+        nacosAiService.unsubscribeAgentSpec("specName", listener);
+        verify(aiChangeNotifier).deregisterListener(eq("specName"),
+            any(AgentSpecListenerInvoker.class));
+        verify(agentSpecCacheHolder, never()).unsubscribeAgentSpec("specName");
+    }
+    
+    @Test
+    void unsubscribeAgentSpecWithNullListener()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        nacosAiService.unsubscribeAgentSpec("specName", null);
+        verify(aiChangeNotifier, never()).deregisterListener(eq("specName"),
+            any(AgentSpecListenerInvoker.class));
+        verify(agentSpecCacheHolder, never()).unsubscribeAgentSpec("specName");
+    }
+    
+    @Test
+    void unsubscribeAgentSpecWithBlankName() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.unsubscribeAgentSpec("", null));
+    }
+    
+    @Test
+    void getPrompt() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        Prompt expected = new Prompt("p1", "1.0.0", "tpl");
+        when(aiClientProxy.queryPrompt("p1", null, null, null)).thenReturn(expected);
+        assertEquals(expected, nacosAiService.getPrompt("p1"));
+    }
+    
+    @Test
+    void getPromptWithBlankKey() {
+        assertThrows(NacosApiException.class, () -> nacosAiService.getPrompt(""));
+    }
+    
+    @Test
+    void getPromptByVersion()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        Prompt expected = new Prompt("p1", "1.0.0", "tpl");
+        when(aiClientProxy.queryPrompt("p1", "1.0.0", null, null)).thenReturn(expected);
+        assertEquals(expected, nacosAiService.getPromptByVersion("p1", "1.0.0"));
+    }
+    
+    @Test
+    void getPromptByVersionWithBlankVersion()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        Prompt expected = new Prompt("p1", "1.0.0", "tpl");
+        when(aiClientProxy.queryPrompt("p1", null, null, null)).thenReturn(expected);
+        assertEquals(expected, nacosAiService.getPromptByVersion("p1", ""));
+    }
+    
+    @Test
+    void getPromptByVersionWithBlankKey() {
+        assertThrows(NacosApiException.class, () -> nacosAiService.getPromptByVersion("", "1.0.0"));
+    }
+    
+    @Test
+    void getPromptByLabel() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        Prompt expected = new Prompt("p1", "1.0.0", "tpl");
+        when(aiClientProxy.queryPrompt("p1", null, "prod", null)).thenReturn(expected);
+        assertEquals(expected, nacosAiService.getPromptByLabel("p1", "prod"));
+    }
+    
+    @Test
+    void getPromptByLabelWithBlankKey() {
+        assertThrows(NacosApiException.class, () -> nacosAiService.getPromptByLabel("", "prod"));
+    }
+    
+    @Test
+    void getPromptByLabelWithBlankLabel() {
+        assertThrows(NacosApiException.class, () -> nacosAiService.getPromptByLabel("p1", ""));
+    }
+    
+    @Test
+    void subscribePrompt() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AbstractNacosPromptListener listener = Mockito.mock(AbstractNacosPromptListener.class);
+        Prompt expected = new Prompt("p1", "1.0.0", "tpl");
+        when(promptCacheHolder.subscribePrompt("p1", "1.0.0", null)).thenReturn(expected);
+        Prompt actual = nacosAiService.subscribePrompt("p1", "1.0.0", null, listener);
+        assertEquals(expected, actual);
+        verify(aiChangeNotifier).registerListener(eq("p1"), eq("1.0.0"), isNull(),
+            any(PromptListenerInvoker.class));
+        verify(listener).onEvent(any(NacosPromptEvent.class));
+    }
+    
+    @Test
+    void subscribePromptWithBlankKey() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.subscribePrompt("", null, null, null));
+    }
+    
+    @Test
+    void subscribePromptWithNullListener() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.subscribePrompt("p1", null, null, null));
+    }
+    
+    @Test
+    void subscribePromptWithNullResult()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AbstractNacosPromptListener listener = Mockito.mock(AbstractNacosPromptListener.class);
+        when(promptCacheHolder.subscribePrompt("p1", "1.0.0", null)).thenReturn(null);
+        Prompt actual = nacosAiService.subscribePrompt("p1", "1.0.0", null, listener);
+        assertNull(actual);
+        verify(listener, never()).onEvent(any(NacosPromptEvent.class));
+    }
+    
+    @Test
+    void unsubscribePrompt() throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        AbstractNacosPromptListener listener = Mockito.mock(AbstractNacosPromptListener.class);
+        nacosAiService.unsubscribePrompt("p1", "1.0.0", null, listener);
+        verify(aiChangeNotifier).deregisterListener(eq("p1"), eq("1.0.0"), isNull(),
+            any(PromptListenerInvoker.class));
+        verify(promptCacheHolder).unsubscribePrompt("p1", "1.0.0", null);
+    }
+    
+    @Test
+    void unsubscribePromptWithRemainingListeners()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        when(aiChangeNotifier.isPromptSubscribed("p1", "1.0.0", null)).thenReturn(true);
+        AbstractNacosPromptListener listener = Mockito.mock(AbstractNacosPromptListener.class);
+        nacosAiService.unsubscribePrompt("p1", "1.0.0", null, listener);
+        verify(aiChangeNotifier).deregisterListener(eq("p1"), eq("1.0.0"), isNull(),
+            any(PromptListenerInvoker.class));
+        verify(promptCacheHolder, never()).unsubscribePrompt("p1", "1.0.0", null);
+    }
+    
+    @Test
+    void unsubscribePromptWithNullListener()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        nacosAiService.unsubscribePrompt("p1", "1.0.0", null, null);
+        verify(aiChangeNotifier, never()).deregisterListener(eq("p1"), eq("1.0.0"), isNull(),
+            any(PromptListenerInvoker.class));
+        verify(promptCacheHolder, never()).unsubscribePrompt("p1", "1.0.0", null);
+    }
+    
+    @Test
+    void unsubscribePromptWithBlankKey() {
+        assertThrows(NacosApiException.class,
+            () -> nacosAiService.unsubscribePrompt("", null, null, null));
+    }
+    
+    @Test
+    void shutdownInvokesAllChildShutdowns()
+        throws NoSuchFieldException, IllegalAccessException, NacosException {
+        injectMocks();
+        nacosAiService.shutdown();
+        verify(grpcClient).shutdown();
+        verify(httpProxy).shutdown();
+        verify(skillConfigService).shutDown();
+        verify(mcpServerCacheHolder).shutdown();
+        verify(promptCacheHolder).shutdown();
+        verify(agentSpecCacheHolder).shutdown();
+        // null out so AfterEach doesn't run shutdown again
+        nacosAiService = null;
+    }
+    
+    @Test
+    void constructorHttpTransportMode() throws NacosException {
+        Properties properties = new Properties();
+        properties.put(PropertyKeyConst.SERVER_ADDR, "127.0.0.1");
+        properties.put(com.alibaba.nacos.api.ai.constant.AiConstants.AI_TRANSPORT_MODE,
+            com.alibaba.nacos.api.ai.constant.AiConstants.AI_TRANSPORT_MODE_HTTP);
+        NacosAiService aiService = null;
+        try {
+            aiService = new NacosAiService(properties);
+            // Verify aiClientProxy field is set to httpProxy
+            Field clientProxyField = NacosAiService.class.getDeclaredField("aiClientProxy");
+            clientProxyField.setAccessible(true);
+            Field httpProxyField = NacosAiService.class.getDeclaredField("httpProxy");
+            httpProxyField.setAccessible(true);
+            assertEquals(httpProxyField.get(aiService), clientProxyField.get(aiService));
+        } catch (NoSuchFieldException | IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        } finally {
+            if (aiService != null) {
+                aiService.shutdown();
+            }
+        }
+    }
+    
     private void injectMocks() throws NoSuchFieldException, IllegalAccessException {
         Field field = NacosAiService.class.getDeclaredField("grpcClient");
         field.setAccessible(true);
@@ -362,9 +859,10 @@ class NacosAiServiceTest {
         field = NacosAiService.class.getDeclaredField("httpProxy");
         field.setAccessible(true);
         final AiHttpClientProxy autoBuildHttpProxy = (AiHttpClientProxy) field.get(nacosAiService);
+        field.set(nacosAiService, httpProxy);
         field = NacosAiService.class.getDeclaredField("aiClientProxy");
         field.setAccessible(true);
-        field.set(nacosAiService, grpcClient);
+        field.set(nacosAiService, aiClientProxy);
         field = NacosAiService.class.getDeclaredField("mcpServerCacheHolder");
         field.setAccessible(true);
         NacosMcpServerCacheHolder autoBuildCacheHolder =
@@ -375,6 +873,20 @@ class NacosAiServiceTest {
         NacosAgentCardCacheHolder autoBuildAgentCacheHolder =
             (NacosAgentCardCacheHolder) field.get(nacosAiService);
         field.set(nacosAiService, agentCardCacheHolder);
+        field = NacosAiService.class.getDeclaredField("promptCacheHolder");
+        field.setAccessible(true);
+        NacosPromptCacheHolder autoBuildPromptCacheHolder =
+            (NacosPromptCacheHolder) field.get(nacosAiService);
+        field.set(nacosAiService, promptCacheHolder);
+        field = NacosAiService.class.getDeclaredField("agentSpecCacheHolder");
+        field.setAccessible(true);
+        NacosAgentSpecCacheHolder autoBuildAgentSpecCacheHolder =
+            (NacosAgentSpecCacheHolder) field.get(nacosAiService);
+        field.set(nacosAiService, agentSpecCacheHolder);
+        field = NacosAiService.class.getDeclaredField("skillConfigService");
+        field.setAccessible(true);
+        ConfigService autoBuildConfigService = (ConfigService) field.get(nacosAiService);
+        field.set(nacosAiService, skillConfigService);
         field = NacosAiService.class.getDeclaredField("aiChangeNotifier");
         field.setAccessible(true);
         field.set(nacosAiService, aiChangeNotifier);
@@ -383,6 +895,9 @@ class NacosAiServiceTest {
             autoBuildHttpProxy.shutdown();
             autoBuildCacheHolder.shutdown();
             autoBuildAgentCacheHolder.shutdown();
+            autoBuildPromptCacheHolder.shutdown();
+            autoBuildAgentSpecCacheHolder.shutdown();
+            autoBuildConfigService.shutDown();
         } catch (NacosException ignored) {
         }
     }

--- a/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentCardCacheHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentCardCacheHolderTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.client.ai.cache;
 
 import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
 import com.alibaba.nacos.api.ai.model.a2a.AgentInterface;
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.client.ai.event.AgentCardChangedEvent;
 import com.alibaba.nacos.client.ai.remote.AiGrpcClient;
 import com.alibaba.nacos.client.env.NacosClientProperties;
@@ -30,18 +31,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NacosAgentCardCacheHolderTest {
@@ -221,6 +228,107 @@ class NacosAgentCardCacheHolderTest {
         cacheHolder.processAgentCardDetailInfo(detailInfo);
         assertNotNull(cacheHolder.getAgentCard("test-agent", "1.0"));
         assertNull(cacheHolder.getAgentCard("test-agent", null));
+    }
+    
+    @SuppressWarnings("unchecked")
+    private static <T> T readField(Object target, String name) throws Exception {
+        Field field = findField(target.getClass(), name);
+        field.setAccessible(true);
+        return (T) field.get(target);
+    }
+    
+    private static Field findField(Class<?> clazz, String name) throws NoSuchFieldException {
+        Class<?> c = clazz;
+        while (c != null) {
+            for (Field f : c.getDeclaredFields()) {
+                if (f.getName().equals(name)) {
+                    return f;
+                }
+            }
+            c = c.getSuperclass();
+        }
+        throw new NoSuchFieldException(name);
+    }
+    
+    @Test
+    void testAddAndRemoveAgentCardUpdateTask() throws Exception {
+        cacheHolder.addAgentCardUpdateTask("test-agent", "1.0");
+        Map<String, ?> taskMap = readField(cacheHolder, "updateTaskMap");
+        assertNotNull(taskMap);
+        assertEquals(1, taskMap.size());
+        // adding same key is a no-op (computeIfAbsent)
+        cacheHolder.addAgentCardUpdateTask("test-agent", "1.0");
+        assertEquals(1, taskMap.size());
+        cacheHolder.removeAgentCardUpdateTask("test-agent", "1.0");
+        assertEquals(0, taskMap.size());
+    }
+    
+    @Test
+    void testRemoveAgentCardUpdateTaskNonExistentNoOp() throws Exception {
+        // No task registered → remove should be a no-op
+        cacheHolder.removeAgentCardUpdateTask("non-existent", "1.0");
+        Map<String, ?> taskMap = readField(cacheHolder, "updateTaskMap");
+        assertEquals(0, taskMap.size());
+    }
+    
+    @Test
+    void testAgentCardUpdaterRunFetchesAndProcesses() throws Exception {
+        AgentCardDetailInfo detailInfo = buildDetailInfo("test-agent", "1.0", true);
+        when(aiGrpcClient.getAgentCard(anyString(), anyString(), anyString()))
+            .thenReturn(detailInfo);
+        Runnable updater = newUpdater("test-agent", "1.0");
+        updater.run();
+        // After run, the detail info should be in the cache
+        assertNotNull(cacheHolder.getAgentCard("test-agent", "1.0"));
+    }
+    
+    @Test
+    void testAgentCardUpdaterRunSwallowsNotFound() throws Exception {
+        when(aiGrpcClient.getAgentCard(anyString(), anyString(), anyString()))
+            .thenThrow(new NacosException(NacosException.NOT_FOUND, "missing"));
+        Runnable updater = newUpdater("test-agent", "1.0");
+        updater.run();
+        // Should not throw and the cache stays empty
+        assertNull(cacheHolder.getAgentCard("test-agent", "1.0"));
+    }
+    
+    @Test
+    void testAgentCardUpdaterRunSwallowsOtherException() throws Exception {
+        when(aiGrpcClient.getAgentCard(anyString(), anyString(), anyString()))
+            .thenThrow(new RuntimeException("boom"));
+        Runnable updater = newUpdater("test-agent", "1.0");
+        // Should not throw, caught and rescheduled
+        updater.run();
+    }
+    
+    @Test
+    void testAgentCardUpdaterCancelExitsEarly() throws Exception {
+        Runnable updater = newUpdater("test-agent", "1.0");
+        AtomicBoolean cancel = readField(updater, "cancel");
+        cancel.set(true);
+        // Should not call aiGrpcClient at all because cancel=true
+        updater.run();
+        org.mockito.Mockito.verifyNoInteractions(aiGrpcClient);
+    }
+    
+    @Test
+    void testAgentCardUpdaterCancelMethod() throws Exception {
+        Runnable updater = newUpdater("test-agent", "1.0");
+        AtomicBoolean cancel = readField(updater, "cancel");
+        assertFalse(cancel.get());
+        Method cancelMethod = updater.getClass().getDeclaredMethod("cancel");
+        cancelMethod.setAccessible(true);
+        cancelMethod.invoke(updater);
+        assertTrue(cancel.get());
+    }
+    
+    private Runnable newUpdater(String agentName, String version) throws Exception {
+        Class<?> updaterClass = Class.forName(
+            "com.alibaba.nacos.client.ai.cache.NacosAgentCardCacheHolder$AgentCardUpdater");
+        java.lang.reflect.Constructor<?> ctor = updaterClass.getDeclaredConstructor(
+            NacosAgentCardCacheHolder.class, String.class, String.class);
+        ctor.setAccessible(true);
+        return (Runnable) ctor.newInstance(cacheHolder, agentName, version);
     }
     
     private AgentCardDetailInfo buildDetailInfo(String name, String version, boolean isLatest) {

--- a/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentSpecCacheHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentSpecCacheHolderTest.java
@@ -1,0 +1,488 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.ai.cache;
+
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecUtils;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.config.listener.Listener;
+import com.alibaba.nacos.api.exception.NacosException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class NacosAgentSpecCacheHolderTest {
+    
+    private static final String SPEC_NAME = "test-agent";
+    
+    private static final String VERSION = "v1";
+    
+    private static final String NAMESPACE = "ns";
+    
+    @Mock
+    private ConfigService configService;
+    
+    private NacosAgentSpecCacheHolder cacheHolder;
+    
+    @BeforeEach
+    void setUp() {
+        cacheHolder = new NacosAgentSpecCacheHolder(configService, NAMESPACE);
+    }
+    
+    @AfterEach
+    void tearDown() throws Exception {
+        cacheHolder.shutdown();
+    }
+    
+    @SuppressWarnings("unchecked")
+    private static <T> T readField(Object target, String name) throws Exception {
+        Class<?> c = target.getClass();
+        while (c != null) {
+            for (Field f : c.getDeclaredFields()) {
+                if (f.getName().equals(name)) {
+                    f.setAccessible(true);
+                    return (T) f.get(target);
+                }
+            }
+            c = c.getSuperclass();
+        }
+        throw new NoSuchFieldException(name);
+    }
+    
+    private void mockIndex(String agentSpecName, String json) throws NacosException {
+        String group = AgentSpecUtils.buildAgentSpecGroup(agentSpecName);
+        when(configService.getConfig(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID), eq(group),
+            anyLong())).thenReturn(json);
+    }
+    
+    private void mockResource(String agentSpecName, String version, String filePath,
+        String content) throws NacosException {
+        String versionGroup = AgentSpecUtils.buildAgentSpecVersionGroup(agentSpecName, version);
+        when(configService.getConfig(eq(filePath), eq(versionGroup), anyLong()))
+            .thenReturn(content);
+    }
+    
+    @Test
+    void testQueryAgentSpecReturnsNullWhenIndexBlank() throws NacosException {
+        mockIndex(SPEC_NAME, null);
+        assertNull(cacheHolder.queryAgentSpec(SPEC_NAME));
+    }
+    
+    @Test
+    void testQueryAgentSpecReturnsNullWhenIndexInvalidJson() throws NacosException {
+        mockIndex(SPEC_NAME, "not-json{");
+        assertNull(cacheHolder.queryAgentSpec(SPEC_NAME));
+    }
+    
+    @Test
+    void testQueryAgentSpecReturnsNullWhenIndexHasNoFiles() throws NacosException {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[]}");
+        assertNull(cacheHolder.queryAgentSpec(SPEC_NAME));
+    }
+    
+    @Test
+    void testQueryAgentSpecReturnsNullWhenIndexBlankVersion() throws NacosException {
+        mockIndex(SPEC_NAME, "{\"version\":\"\",\"files\":[\"a\"]}");
+        assertNull(cacheHolder.queryAgentSpec(SPEC_NAME));
+    }
+    
+    @Test
+    void testQueryAgentSpecBuildsAgentSpecFromManifest() throws NacosException {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"manifest.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "manifest.json",
+            "{\"name\":\"manifest.json\",\"content\":\""
+                + "{\\\"name\\\":\\\"my-agent\\\",\\\"description\\\":\\\"d\\\"}\"}");
+        AgentSpec spec = cacheHolder.queryAgentSpec(SPEC_NAME);
+        assertNotNull(spec);
+        assertEquals(NAMESPACE, spec.getNamespaceId());
+        assertEquals("my-agent", spec.getName());
+        assertEquals("d", spec.getDescription());
+    }
+    
+    @Test
+    void testQueryAgentSpecSkipsBlankResourceContent() throws NacosException {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"manifest.json\",\"f.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "manifest.json",
+            "{\"name\":\"manifest.json\",\"content\":\"{}\"}");
+        mockResource(SPEC_NAME, VERSION, "f.json", "");
+        AgentSpec spec = cacheHolder.queryAgentSpec(SPEC_NAME);
+        assertNotNull(spec);
+        assertEquals(0, spec.getResource().size());
+    }
+    
+    @Test
+    void testQueryAgentSpecSkipsBlankResourceContent2() throws NacosException {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"f.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "f.json", "   ");
+        AgentSpec spec = cacheHolder.queryAgentSpec(SPEC_NAME);
+        assertNotNull(spec);
+        assertEquals(0, spec.getResource().size());
+    }
+    
+    @Test
+    void testQueryAgentSpecAddsNonManifestResource() throws NacosException {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"r1.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "r1.json",
+            "{\"name\":\"toolA.txt\",\"type\":\"tool\",\"content\":\"x\"}");
+        AgentSpec spec = cacheHolder.queryAgentSpec(SPEC_NAME);
+        assertNotNull(spec);
+        assertEquals(1, spec.getResource().size());
+    }
+    
+    @Test
+    void testQueryAgentSpecManifestWithMalformedContent() throws NacosException {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"manifest.json\"]}");
+        // content is non-blank but not parseable as Map → caught and warned
+        mockResource(SPEC_NAME, VERSION, "manifest.json",
+            "{\"name\":\"manifest.json\",\"content\":\"not-json{\"}");
+        AgentSpec spec = cacheHolder.queryAgentSpec(SPEC_NAME);
+        assertNotNull(spec);
+    }
+    
+    @Test
+    void testSubscribeAgentSpecBlankNameThrows() {
+        NacosException ex = assertThrows(NacosException.class,
+            () -> cacheHolder.subscribeAgentSpec(""));
+        assertEquals(NacosException.INVALID_PARAM, ex.getErrCode());
+    }
+    
+    @Test
+    void testSubscribeAgentSpecRegistersListenerAndCachesSpec() throws Exception {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"manifest.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "manifest.json",
+            "{\"name\":\"manifest.json\",\"content\":\"{}\"}");
+        AgentSpec spec = cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        assertNotNull(spec);
+        // manifest listener registered
+        verify(configService, times(1)).addListener(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), any(Listener.class));
+        // resource listener registered
+        verify(configService, times(1)).addListener(eq("manifest.json"),
+            eq(AgentSpecUtils.buildAgentSpecVersionGroup(SPEC_NAME, VERSION)), any(Listener.class));
+    }
+    
+    @Test
+    void testSubscribeAgentSpecIdempotent() throws Exception {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"f.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "f.json",
+            "{\"name\":\"r1\",\"type\":\"tool\",\"content\":\"x\"}");
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        // Second call should hit subscriptionMap.containsKey and return cached spec
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        verify(configService, times(1)).addListener(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), any(Listener.class));
+    }
+    
+    @Test
+    void testSubscribeAgentSpecHandlesNoIndex() throws Exception {
+        mockIndex(SPEC_NAME, null);
+        AgentSpec spec = cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        assertNull(spec);
+        // Manifest listener is added even without index
+        verify(configService, times(1)).addListener(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), any(Listener.class));
+    }
+    
+    @Test
+    void testUnsubscribeAgentSpecBlankNameNoOp() {
+        cacheHolder.unsubscribeAgentSpec(null);
+        verify(configService, never()).removeListener(anyString(), anyString(), any());
+    }
+    
+    @Test
+    void testUnsubscribeAgentSpecRemovesListeners() throws Exception {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"f.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "f.json",
+            "{\"name\":\"r1\",\"type\":\"tool\",\"content\":\"x\"}");
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        cacheHolder.unsubscribeAgentSpec(SPEC_NAME);
+        verify(configService, times(1)).removeListener(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), any(Listener.class));
+        // resource listener also removed
+        verify(configService, times(1)).removeListener(eq("f.json"),
+            eq(AgentSpecUtils.buildAgentSpecVersionGroup(SPEC_NAME, VERSION)),
+            any(Listener.class));
+    }
+    
+    @Test
+    void testUnsubscribeAgentSpecNotSubscribedNoOp() {
+        cacheHolder.unsubscribeAgentSpec("nonexistent-spec");
+        verify(configService, never()).removeListener(anyString(), anyString(), any());
+    }
+    
+    @Test
+    void testShutdownUnsubscribesAll() throws Exception {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[]}");
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        cacheHolder.shutdown();
+        // After shutdown subscription map is cleared
+        Map<String, ?> subs = readField(cacheHolder, "subscriptionMap");
+        assertEquals(0, subs.size());
+    }
+    
+    @Test
+    void testManifestListenerVersionChangeReSubscribesResources() throws Exception {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"f1.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "f1.json",
+            "{\"name\":\"r1\",\"type\":\"tool\",\"content\":\"x\"}");
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        
+        // Capture the manifest listener
+        ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+        verify(configService).addListener(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), listenerCaptor.capture());
+        Listener manifestListener = listenerCaptor.getValue();
+        
+        // Switch to v2 with new file
+        when(configService.getConfig(eq("f2.json"),
+            eq(AgentSpecUtils.buildAgentSpecVersionGroup(SPEC_NAME, "v2")), anyLong()))
+            .thenReturn("{\"name\":\"r2\",\"type\":\"tool\",\"content\":\"y\"}");
+        when(configService.getConfig(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), anyLong()))
+            .thenReturn("{\"version\":\"v2\",\"files\":[\"f2.json\"]}");
+        
+        manifestListener.receiveConfigInfo(
+            "{\"version\":\"v2\",\"files\":[\"f2.json\"]}");
+        // f1 listener removed, f2 listener added
+        verify(configService, times(1)).removeListener(eq("f1.json"),
+            eq(AgentSpecUtils.buildAgentSpecVersionGroup(SPEC_NAME, VERSION)),
+            any(Listener.class));
+        verify(configService, times(1)).addListener(eq("f2.json"),
+            eq(AgentSpecUtils.buildAgentSpecVersionGroup(SPEC_NAME, "v2")),
+            any(Listener.class));
+    }
+    
+    @Test
+    void testManifestListenerNoSubscriptionEarlyReturn() throws Exception {
+        Method onManifestChanged = NacosAgentSpecCacheHolder.class.getDeclaredMethod(
+            "onManifestChanged", String.class, String.class);
+        onManifestChanged.setAccessible(true);
+        // Should not throw and not interact with configService
+        onManifestChanged.invoke(cacheHolder, "no-such-spec", "{}");
+    }
+    
+    @Test
+    void testParseAgentSpecIndexBlank() throws Exception {
+        Method m = NacosAgentSpecCacheHolder.class.getDeclaredMethod("parseAgentSpecIndex",
+            String.class);
+        m.setAccessible(true);
+        assertNull(m.invoke(null, ""));
+        assertNull(m.invoke(null, (String) null));
+    }
+    
+    @Test
+    void testParseAgentSpecIndexInvalidJson() throws Exception {
+        Method m = NacosAgentSpecCacheHolder.class.getDeclaredMethod("parseAgentSpecIndex",
+            String.class);
+        m.setAccessible(true);
+        assertNull(m.invoke(null, "not-json{"));
+    }
+    
+    @Test
+    void testIsAgentSpecChangedNullOldReturnsTrue() throws Exception {
+        Method m = NacosAgentSpecCacheHolder.class.getDeclaredMethod("isAgentSpecChanged",
+            AgentSpec.class, AgentSpec.class);
+        m.setAccessible(true);
+        AgentSpec n = new AgentSpec();
+        n.setName("a");
+        assertTrue((boolean) m.invoke(cacheHolder, null, n));
+    }
+    
+    @Test
+    void testIsAgentSpecChangedSameReturnsFalse() throws Exception {
+        Method m = NacosAgentSpecCacheHolder.class.getDeclaredMethod("isAgentSpecChanged",
+            AgentSpec.class, AgentSpec.class);
+        m.setAccessible(true);
+        AgentSpec o = new AgentSpec();
+        o.setName("a");
+        AgentSpec n = new AgentSpec();
+        n.setName("a");
+        assertTrue(!(boolean) m.invoke(cacheHolder, o, n));
+    }
+    
+    @Test
+    void testIsAgentSpecChangedDifferentReturnsTrue() throws Exception {
+        Method m = NacosAgentSpecCacheHolder.class.getDeclaredMethod("isAgentSpecChanged",
+            AgentSpec.class, AgentSpec.class);
+        m.setAccessible(true);
+        AgentSpec o = new AgentSpec();
+        o.setName("a");
+        AgentSpec n = new AgentSpec();
+        n.setName("b");
+        assertTrue((boolean) m.invoke(cacheHolder, o, n));
+    }
+    
+    @Test
+    void testManifestListenerVersionGoesNull() throws Exception {
+        // Set up subscription with v1 + a file
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"f1.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "f1.json",
+            "{\"name\":\"r1\",\"type\":\"tool\",\"content\":\"x\"}");
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        // Now invoke onManifestChanged with empty index → version cleared, resources unsubscribed
+        Method onManifestChanged = NacosAgentSpecCacheHolder.class.getDeclaredMethod(
+            "onManifestChanged", String.class, String.class);
+        onManifestChanged.setAccessible(true);
+        onManifestChanged.invoke(cacheHolder, SPEC_NAME, "");
+    }
+    
+    @Test
+    void testManifestListenerExceptionPath() throws Exception {
+        // First create a subscription so onManifestChanged finds a sub
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"f1.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "f1.json",
+            "{\"name\":\"r1\",\"type\":\"tool\",\"content\":\"x\"}");
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        // Make configService throw on subsequent getConfig to push into the catch block
+        when(configService.getConfig(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), anyLong()))
+            .thenThrow(new NacosException(500, "boom"));
+        Method onManifestChanged = NacosAgentSpecCacheHolder.class.getDeclaredMethod(
+            "onManifestChanged", String.class, String.class);
+        onManifestChanged.setAccessible(true);
+        // Should not throw — Exception is caught
+        onManifestChanged.invoke(cacheHolder, SPEC_NAME, "{\"version\":\"v2\",\"files\":[]}");
+    }
+    
+    @Test
+    void testReloadAndPublishRemovesWhenNewSpecIsNull() throws Exception {
+        // Pre-cache a spec via subscribe + valid index
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"manifest.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "manifest.json",
+            "{\"name\":\"manifest.json\",\"content\":\"{}\"}");
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        // Now invalidate index so loadAgentSpecFromConfig returns null
+        when(configService.getConfig(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), anyLong()))
+            .thenReturn("");
+        Method reloadAndPublish = NacosAgentSpecCacheHolder.class.getDeclaredMethod(
+            "reloadAndPublish", String.class);
+        reloadAndPublish.setAccessible(true);
+        reloadAndPublish.invoke(cacheHolder, SPEC_NAME);
+    }
+    
+    @Test
+    void testReloadAndPublishExceptionSwallowed() throws Exception {
+        // configService returns a value but JacksonUtils throws on toObj path → exception via load
+        when(configService.getConfig(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), anyLong()))
+            .thenThrow(new NacosException(500, "fail"));
+        Method reloadAndPublish = NacosAgentSpecCacheHolder.class.getDeclaredMethod(
+            "reloadAndPublish", String.class);
+        reloadAndPublish.setAccessible(true);
+        // Should not throw (catch (Exception e))
+        reloadAndPublish.invoke(cacheHolder, SPEC_NAME);
+    }
+    
+    @Test
+    void testSubscribeResourcesAddListenerThrowsSwallowed() throws Exception {
+        // Mock addListener to throw NacosException for resource subscription
+        when(configService.getConfig(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), anyLong()))
+            .thenReturn("{\"version\":\"v1\",\"files\":[\"f.json\"]}");
+        when(configService.getConfig(eq("f.json"),
+            eq(AgentSpecUtils.buildAgentSpecVersionGroup(SPEC_NAME, VERSION)), anyLong()))
+            .thenReturn("{\"name\":\"r1\",\"type\":\"tool\",\"content\":\"x\"}");
+        org.mockito.Mockito.doThrow(new NacosException(500, "fail")).when(configService)
+            .addListener(eq("f.json"),
+                eq(AgentSpecUtils.buildAgentSpecVersionGroup(SPEC_NAME, VERSION)),
+                any(Listener.class));
+        // Should not throw — internal try/catch swallows
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+    }
+    
+    @Test
+    void testManifestListenerGetExecutorReturnsNull() throws Exception {
+        mockIndex(SPEC_NAME, "{\"version\":\"v1\",\"files\":[\"f1.json\"]}");
+        mockResource(SPEC_NAME, VERSION, "f1.json",
+            "{\"name\":\"r1\",\"type\":\"tool\",\"content\":\"x\"}");
+        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        // Capture manifest listener and call its getExecutor + receiveConfigInfo
+        org.mockito.ArgumentCaptor<Listener> captor =
+            org.mockito.ArgumentCaptor.forClass(Listener.class);
+        verify(configService).addListener(eq(AgentSpecUtils.AGENTSPEC_INDEX_DATA_ID),
+            eq(AgentSpecUtils.buildAgentSpecGroup(SPEC_NAME)), captor.capture());
+        Listener manifestListener = captor.getValue();
+        assertNull(manifestListener.getExecutor());
+        // Capture resource listener (file f1.json) and call its getExecutor + receive
+        org.mockito.ArgumentCaptor<Listener> resCap =
+            org.mockito.ArgumentCaptor.forClass(Listener.class);
+        verify(configService).addListener(eq("f1.json"),
+            eq(AgentSpecUtils.buildAgentSpecVersionGroup(SPEC_NAME, VERSION)), resCap.capture());
+        Listener resourceListener = resCap.getValue();
+        assertNull(resourceListener.getExecutor());
+        // receiveConfigInfo on resource listener triggers onResourceChanged → reloadAndPublish
+        resourceListener.receiveConfigInfo("{}");
+    }
+    
+    @Test
+    void testIsAgentSpecChangedNullOldLogsAndReturnsTrue() throws Exception {
+        // Already covered by testIsAgentSpecChangedNullOldReturnsTrue but ensure newJson log path
+        Method m = NacosAgentSpecCacheHolder.class.getDeclaredMethod("isAgentSpecChanged",
+            AgentSpec.class, AgentSpec.class);
+        m.setAccessible(true);
+        // Pass null new and null old → newJson="null", returns true
+        assertTrue((boolean) m.invoke(cacheHolder, null, null));
+    }
+    
+    @Test
+    void testAgentSpecIndexInnerGettersAndSetters() throws Exception {
+        Class<?> indexClass = Class.forName(
+            "com.alibaba.nacos.client.ai.cache.NacosAgentSpecCacheHolder$AgentSpecIndex");
+        java.lang.reflect.Constructor<?> ctor = indexClass.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        Object idx = ctor.newInstance();
+        Method setVersion = indexClass.getDeclaredMethod("setVersion", String.class);
+        setVersion.setAccessible(true);
+        setVersion.invoke(idx, "v1");
+        Method getVersion = indexClass.getDeclaredMethod("getVersion");
+        getVersion.setAccessible(true);
+        assertEquals("v1", getVersion.invoke(idx));
+        Method setFiles = indexClass.getDeclaredMethod("setFiles", java.util.List.class);
+        setFiles.setAccessible(true);
+        setFiles.invoke(idx, java.util.Collections.singletonList("a.json"));
+        Method getFiles = indexClass.getDeclaredMethod("getFiles");
+        getFiles.setAccessible(true);
+        assertEquals(java.util.Collections.singletonList("a.json"), getFiles.invoke(idx));
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/ai/event/AgentCardChangedEventTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/event/AgentCardChangedEventTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.ai.event;
+
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
+import com.alibaba.nacos.client.ai.utils.CacheKeyUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class AgentCardChangedEventTest {
+    
+    @Test
+    void testGettersWithLatestVersion() {
+        AgentCardDetailInfo info = new AgentCardDetailInfo();
+        info.setName("agentX");
+        info.setLatestVersion(true);
+        info.setVersion("1.0");
+        AgentCardChangedEvent event = new AgentCardChangedEvent(info);
+        assertEquals("agentX", event.getAgentName());
+        assertEquals(CacheKeyUtils.LATEST_VERSION, event.getVersion());
+        assertSame(info, event.getAgentCard());
+    }
+    
+    @Test
+    void testGettersWithSpecifiedVersion() {
+        AgentCardDetailInfo info = new AgentCardDetailInfo();
+        info.setName("agentX");
+        info.setLatestVersion(false);
+        info.setVersion("v2");
+        AgentCardChangedEvent event = new AgentCardChangedEvent(info);
+        assertEquals("agentX", event.getAgentName());
+        assertEquals("v2", event.getVersion());
+        assertSame(info, event.getAgentCard());
+    }
+    
+    @Test
+    void testGettersWithNullLatestVersion() {
+        AgentCardDetailInfo info = new AgentCardDetailInfo();
+        info.setName("agentX");
+        info.setLatestVersion(null);
+        info.setVersion("v3");
+        AgentCardChangedEvent event = new AgentCardChangedEvent(info);
+        assertEquals("agentX", event.getAgentName());
+        assertEquals(CacheKeyUtils.LATEST_VERSION, event.getVersion());
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/ai/event/AgentCardListenerInvokerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/event/AgentCardListenerInvokerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.ai.event;
+
+import com.alibaba.nacos.api.ai.listener.AbstractNacosAgentCardListener;
+import com.alibaba.nacos.api.ai.listener.NacosAgentCardEvent;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AgentCardListenerInvokerTest {
+    
+    @Mock
+    AbstractNacosAgentCardListener listener;
+    
+    AgentCardListenerInvoker invoker;
+    
+    @BeforeEach
+    void setUp() {
+        invoker = new AgentCardListenerInvoker(listener);
+    }
+    
+    @Test
+    void invokeDirect() {
+        AgentCardDetailInfo agentCard = new AgentCardDetailInfo();
+        agentCard.setName("agent");
+        NacosAgentCardEvent event = new NacosAgentCardEvent(agentCard);
+        invoker.invoke(event);
+        verify(listener).onEvent(any(NacosAgentCardEvent.class));
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/ai/event/AiChangeNotifierTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/event/AiChangeNotifierTest.java
@@ -16,10 +16,20 @@
 
 package com.alibaba.nacos.client.ai.event;
 
+import com.alibaba.nacos.api.ai.listener.AbstractNacosAgentCardListener;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosAgentSpecListener;
 import com.alibaba.nacos.api.ai.listener.AbstractNacosMcpServerListener;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosPromptListener;
+import com.alibaba.nacos.api.ai.listener.NacosAgentCardEvent;
+import com.alibaba.nacos.api.ai.listener.NacosAgentSpecEvent;
 import com.alibaba.nacos.api.ai.listener.NacosMcpServerEvent;
+import com.alibaba.nacos.api.ai.listener.NacosPromptEvent;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.ai.model.prompt.Prompt;
+import com.alibaba.nacos.client.ai.utils.CacheKeyUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -159,5 +169,158 @@ class AiChangeNotifierTest {
         McpServerListenerInvoker invoker = new McpServerListenerInvoker(listener);
         changeNotifier.deregisterListener("test", null, invoker);
         assertFalse(changeNotifier.isMcpServerSubscribed("test", ""));
+    }
+    
+    @Test
+    void agentCardRegisterAndOnEvent() {
+        AgentCardDetailInfo detail = new AgentCardDetailInfo();
+        detail.setName("ag");
+        detail.setVersion("1.0");
+        detail.setLatestVersion(true);
+        AbstractNacosAgentCardListener listener = new AbstractNacosAgentCardListener() {
+            
+            @Override
+            public void onEvent(NacosAgentCardEvent event) {
+                invokedMark.set(true);
+            }
+        };
+        AgentCardListenerInvoker invoker = new AgentCardListenerInvoker(listener);
+        // null invoker is a no-op (early return)
+        changeNotifier.registerListener("ag", null, (AgentCardListenerInvoker) null);
+        assertFalse(changeNotifier.isAgentCardSubscribed("ag",
+            CacheKeyUtils.LATEST_VERSION));
+        // real invoker is registered and triggered
+        changeNotifier.registerListener("ag", null, invoker);
+        assertTrue(changeNotifier.isAgentCardSubscribed("ag", CacheKeyUtils.LATEST_VERSION));
+        changeNotifier.onEvent(new AgentCardChangedEvent(detail));
+        assertTrue(invokedMark.get());
+    }
+    
+    @Test
+    void agentCardOnEventNoListenerEarlyReturn() {
+        AgentCardDetailInfo detail = new AgentCardDetailInfo();
+        detail.setName("ag-no-sub");
+        detail.setVersion("1.0");
+        detail.setLatestVersion(true);
+        // Without a registered listener, onEvent should early-return
+        assertDoesNotThrow(
+            () -> changeNotifier.onEvent(new AgentCardChangedEvent(detail)));
+    }
+    
+    @Test
+    void agentCardDeregisterListener() {
+        AbstractNacosAgentCardListener l =
+            Mockito.mock(AbstractNacosAgentCardListener.class);
+        AgentCardListenerInvoker invoker = new AgentCardListenerInvoker(l);
+        // null invoker is no-op
+        changeNotifier.deregisterListener("ag", null, (AgentCardListenerInvoker) null);
+        // dereg before register also no-op
+        changeNotifier.deregisterListener("ag", null, invoker);
+        assertFalse(changeNotifier.isAgentCardSubscribed("ag",
+            CacheKeyUtils.LATEST_VERSION));
+        // register then dereg empties the set
+        changeNotifier.registerListener("ag", null, invoker);
+        changeNotifier.deregisterListener("ag", null, invoker);
+        assertFalse(changeNotifier.isAgentCardSubscribed("ag",
+            CacheKeyUtils.LATEST_VERSION));
+    }
+    
+    @Test
+    void promptRegisterAndOnEvent() {
+        AbstractNacosPromptListener listener = new AbstractNacosPromptListener() {
+            
+            @Override
+            public void onEvent(NacosPromptEvent event) {
+                invokedMark.set(true);
+            }
+        };
+        PromptListenerInvoker invoker = new PromptListenerInvoker(listener);
+        // null invoker is no-op
+        changeNotifier.registerListener("p", "1.0", null, (PromptListenerInvoker) null);
+        assertFalse(changeNotifier.isPromptSubscribed("p", "1.0", null));
+        changeNotifier.registerListener("p", "1.0", null, invoker);
+        assertTrue(changeNotifier.isPromptSubscribed("p", "1.0", null));
+        Prompt prompt = new Prompt("p", "1.0", "tpl");
+        String cacheKey = CacheKeyUtils.buildPromptKey("p", "1.0", null);
+        changeNotifier.onEvent(new PromptChangedEvent("p", cacheKey, prompt));
+        assertTrue(invokedMark.get());
+    }
+    
+    @Test
+    void promptOnEventNoListenerEarlyReturn() {
+        Prompt prompt = new Prompt("p2", "1.0", "tpl");
+        String cacheKey = CacheKeyUtils.buildPromptKey("p2", "1.0", null);
+        assertDoesNotThrow(
+            () -> changeNotifier.onEvent(new PromptChangedEvent("p2", cacheKey, prompt)));
+    }
+    
+    @Test
+    void promptDeregisterListener() {
+        AbstractNacosPromptListener l = Mockito.mock(AbstractNacosPromptListener.class);
+        PromptListenerInvoker invoker = new PromptListenerInvoker(l);
+        // null invoker no-op
+        changeNotifier.deregisterListener("p", "1.0", null, (PromptListenerInvoker) null);
+        // dereg before register no-op
+        changeNotifier.deregisterListener("p", "1.0", null, invoker);
+        assertFalse(changeNotifier.isPromptSubscribed("p", "1.0", null));
+        changeNotifier.registerListener("p", "1.0", null, invoker);
+        changeNotifier.deregisterListener("p", "1.0", null, invoker);
+        assertFalse(changeNotifier.isPromptSubscribed("p", "1.0", null));
+    }
+    
+    @Test
+    void agentSpecRegisterAndOnEvent() {
+        AbstractNacosAgentSpecListener listener = new AbstractNacosAgentSpecListener() {
+            
+            @Override
+            public void onEvent(NacosAgentSpecEvent event) {
+                invokedMark.set(true);
+            }
+        };
+        AgentSpecListenerInvoker invoker = new AgentSpecListenerInvoker(listener);
+        // null invoker no-op
+        changeNotifier.registerListener("spec", (AgentSpecListenerInvoker) null);
+        assertFalse(changeNotifier.isAgentSpecSubscribed("spec"));
+        changeNotifier.registerListener("spec", invoker);
+        assertTrue(changeNotifier.isAgentSpecSubscribed("spec"));
+        AgentSpec spec = new AgentSpec();
+        spec.setName("spec");
+        changeNotifier.onEvent(new AgentSpecChangedEvent("spec", spec));
+        assertTrue(invokedMark.get());
+    }
+    
+    @Test
+    void agentSpecOnEventNoListenerEarlyReturn() {
+        AgentSpec spec = new AgentSpec();
+        spec.setName("spec-no");
+        assertDoesNotThrow(
+            () -> changeNotifier.onEvent(new AgentSpecChangedEvent("spec-no", spec)));
+    }
+    
+    @Test
+    void agentSpecDeregisterListener() {
+        AbstractNacosAgentSpecListener l =
+            Mockito.mock(AbstractNacosAgentSpecListener.class);
+        AgentSpecListenerInvoker invoker = new AgentSpecListenerInvoker(l);
+        // null invoker no-op
+        changeNotifier.deregisterListener("spec", (AgentSpecListenerInvoker) null);
+        // dereg before register no-op
+        changeNotifier.deregisterListener("spec", invoker);
+        assertFalse(changeNotifier.isAgentSpecSubscribed("spec"));
+        changeNotifier.registerListener("spec", invoker);
+        changeNotifier.deregisterListener("spec", invoker);
+        assertFalse(changeNotifier.isAgentSpecSubscribed("spec"));
+    }
+    
+    @Test
+    void subscribeTypesContainsAllFour() {
+        assertTrue(changeNotifier.subscribeTypes()
+            .contains(McpServerChangedEvent.class));
+        assertTrue(changeNotifier.subscribeTypes()
+            .contains(AgentCardChangedEvent.class));
+        assertTrue(changeNotifier.subscribeTypes()
+            .contains(PromptChangedEvent.class));
+        assertTrue(changeNotifier.subscribeTypes()
+            .contains(AgentSpecChangedEvent.class));
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/ai/remote/AiGrpcClientTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/remote/AiGrpcClientTest.java
@@ -20,7 +20,9 @@ import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.ability.constant.AbilityKey;
 import com.alibaba.nacos.api.ability.constant.AbilityStatus;
 import com.alibaba.nacos.api.ai.model.a2a.AgentCard;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
 import com.alibaba.nacos.api.ai.model.a2a.AgentCapabilities;
+import com.alibaba.nacos.api.ai.model.a2a.AgentEndpoint;
 import com.alibaba.nacos.api.ai.model.a2a.AgentInterface;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
@@ -28,11 +30,16 @@ import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
 import com.alibaba.nacos.api.ai.model.prompt.Prompt;
 import com.alibaba.nacos.api.ai.remote.AiRemoteConstants;
+import com.alibaba.nacos.api.ai.remote.request.AgentEndpointRequest;
+import com.alibaba.nacos.api.ai.remote.request.BatchAgentEndpointRequest;
 import com.alibaba.nacos.api.ai.remote.request.McpServerEndpointRequest;
+import com.alibaba.nacos.api.ai.remote.request.QueryAgentCardRequest;
 import com.alibaba.nacos.api.ai.remote.request.QueryMcpServerRequest;
 import com.alibaba.nacos.api.ai.remote.request.QueryPromptRequest;
 import com.alibaba.nacos.api.ai.remote.request.ReleaseAgentCardRequest;
 import com.alibaba.nacos.api.ai.remote.request.ReleaseMcpServerRequest;
+import com.alibaba.nacos.api.ai.remote.response.AgentEndpointResponse;
+import com.alibaba.nacos.api.ai.remote.response.QueryAgentCardResponse;
 import com.alibaba.nacos.api.ai.remote.response.ReleaseAgentCardResponse;
 import com.alibaba.nacos.api.ai.remote.response.McpServerEndpointResponse;
 import com.alibaba.nacos.api.ai.remote.response.QueryMcpServerResponse;
@@ -63,6 +70,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Collections;
 import java.util.Map;
@@ -492,6 +500,325 @@ class AiGrpcClientTest {
             assertInstanceOf(NacosException.class, targetException);
             assertEquals(400, ((NacosException) targetException).getErrCode());
         }
+    }
+    
+    @Test
+    void queryPromptThreeArgOverloadDelegates() throws Exception {
+        injectMock();
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        QueryPromptResponse response = new QueryPromptResponse();
+        response.setPromptInfo(new Prompt("p1", "1.0.0", "tpl"));
+        when(rpcClient.request(any(QueryPromptRequest.class))).thenReturn(response);
+        Prompt actual = aiGrpcClient.queryPrompt("p1", "1.0.0", "stable");
+        assertEquals("p1", actual.getPromptKey());
+    }
+    
+    @Test
+    void subscribeMcpServerSwallowsNotFound() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_MCP_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        Response notFound = ErrorResponse.build(NacosException.NOT_FOUND, "missing");
+        when(rpcClient.request(any(QueryMcpServerRequest.class))).thenReturn(notFound);
+        // NOT_FOUND is swallowed; addMcpServerUpdateTask is still called
+        assertDoesNotThrow(() -> aiGrpcClient.subscribeMcpServer("test", null));
+        verify(mcpServerCacheHolder).addMcpServerUpdateTask("test", null);
+    }
+    
+    @Test
+    void subscribeMcpServerRethrowsOnNonNotFound() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_MCP_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        Response other = ErrorResponse.build(NacosException.SERVER_ERROR, "boom");
+        when(rpcClient.request(any(QueryMcpServerRequest.class))).thenReturn(other);
+        assertThrows(NacosException.class,
+            () -> aiGrpcClient.subscribeMcpServer("test", null));
+        verify(mcpServerCacheHolder, never()).addMcpServerUpdateTask("test", null);
+    }
+    
+    @Test
+    void getAgentCardSendsRequest() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        QueryAgentCardResponse response = new QueryAgentCardResponse();
+        AgentCardDetailInfo detail = new AgentCardDetailInfo();
+        response.setAgentCardDetailInfo(detail);
+        when(rpcClient.request(any(QueryAgentCardRequest.class))).thenReturn(response);
+        AgentCardDetailInfo actual = aiGrpcClient.getAgentCard("ag", "1.0", "service");
+        assertEquals(detail, actual);
+        ArgumentCaptor<QueryAgentCardRequest> cap =
+            ArgumentCaptor.forClass(QueryAgentCardRequest.class);
+        verify(rpcClient).request(cap.capture());
+        assertEquals("ag", cap.getValue().getAgentName());
+        assertEquals("1.0", cap.getValue().getVersion());
+        assertEquals("service", cap.getValue().getRegistrationType());
+    }
+    
+    @Test
+    void releaseAgentCardSuccessNoLegacyRetry() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_CARD_V1))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        ReleaseAgentCardResponse success = new ReleaseAgentCardResponse();
+        when(rpcClient.request(any(ReleaseAgentCardRequest.class))).thenReturn(success);
+        aiGrpcClient.releaseAgentCard(buildV1AgentCard(), "service", false);
+        verify(rpcClient, org.mockito.Mockito.times(1))
+            .request(any(ReleaseAgentCardRequest.class));
+    }
+    
+    @Test
+    void releaseAgentCardRethrowsOnNonLegacyError() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_CARD_V1))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        Response error = ErrorResponse.build(NacosException.INVALID_PARAM,
+            "totally unrelated parameter error");
+        when(rpcClient.request(any(ReleaseAgentCardRequest.class))).thenReturn(error);
+        assertThrows(NacosException.class,
+            () -> aiGrpcClient.releaseAgentCard(buildV1AgentCard(), "service", false));
+        verify(rpcClient, org.mockito.Mockito.times(1))
+            .request(any(ReleaseAgentCardRequest.class));
+    }
+    
+    @Test
+    void releaseAgentCardRetriesOnPreferredTransportError() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_CARD_V1))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        Response error = ErrorResponse.build(NacosException.INVALID_PARAM,
+            "Required parameter `agentCard.preferredTransport` not present");
+        ReleaseAgentCardResponse success = new ReleaseAgentCardResponse();
+        when(rpcClient.request(any(ReleaseAgentCardRequest.class))).thenReturn(error)
+            .thenReturn(success);
+        aiGrpcClient.releaseAgentCard(buildV1AgentCard(), "service", false);
+        verify(rpcClient, org.mockito.Mockito.times(2))
+            .request(any(ReleaseAgentCardRequest.class));
+    }
+    
+    @Test
+    void releaseAgentCardRetriesOnUrlError() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_CARD_V1))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        Response error = ErrorResponse.build(NacosException.INVALID_PARAM,
+            "Required parameter `agentCard.url` not present");
+        ReleaseAgentCardResponse success = new ReleaseAgentCardResponse();
+        when(rpcClient.request(any(ReleaseAgentCardRequest.class))).thenReturn(error)
+            .thenReturn(success);
+        aiGrpcClient.releaseAgentCard(buildV1AgentCard(), "service", false);
+        verify(rpcClient, org.mockito.Mockito.times(2))
+            .request(any(ReleaseAgentCardRequest.class));
+    }
+    
+    @Test
+    void shouldRetryWithLegacyFormatNonInvalidParam() throws Exception {
+        Method m = AiGrpcClient.class.getDeclaredMethod("shouldRetryWithLegacyFormat",
+            NacosException.class);
+        m.setAccessible(true);
+        // Non INVALID_PARAM: returns false
+        assertFalse((boolean) m.invoke(aiGrpcClient, new NacosException(500, "x")));
+        // INVALID_PARAM but null msg: returns false
+        assertFalse((boolean) m.invoke(aiGrpcClient,
+            new NacosException(NacosException.INVALID_PARAM, "")));
+    }
+    
+    @Test
+    void registerAgentEndpoint() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        AgentEndpointResponse response = new AgentEndpointResponse();
+        when(rpcClient.request(any(AgentEndpointRequest.class))).thenReturn(response);
+        AgentEndpoint endpoint = new AgentEndpoint();
+        endpoint.setAddress("127.0.0.1");
+        endpoint.setPort(8080);
+        aiGrpcClient.registerAgentEndpoint("ag", endpoint);
+        verify(redoService).cachedAgentEndpointForRedo(org.mockito.ArgumentMatchers.eq("ag"),
+            any());
+        verify(redoService).agentEndpointRegistered("ag");
+    }
+    
+    @Test
+    void registerAgentEndpointsBatch() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        AgentEndpointResponse response = new AgentEndpointResponse();
+        when(rpcClient.request(any(BatchAgentEndpointRequest.class))).thenReturn(response);
+        AgentEndpoint e1 = new AgentEndpoint();
+        e1.setAddress("127.0.0.1");
+        e1.setPort(8080);
+        AgentEndpoint e2 = new AgentEndpoint();
+        e2.setAddress("127.0.0.1");
+        e2.setPort(8081);
+        aiGrpcClient.registerAgentEndpoints("ag", Arrays.asList(e1, e2));
+        verify(redoService).cachedAgentEndpointForRedo(org.mockito.ArgumentMatchers.eq("ag"),
+            any());
+        verify(redoService).agentEndpointRegistered("ag");
+    }
+    
+    @Test
+    void deregisterAgentEndpoint() throws Exception {
+        injectMock();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        AgentEndpointResponse response = new AgentEndpointResponse();
+        when(rpcClient.request(any(AgentEndpointRequest.class))).thenReturn(response);
+        AgentEndpoint endpoint = new AgentEndpoint();
+        endpoint.setAddress("127.0.0.1");
+        endpoint.setPort(8080);
+        aiGrpcClient.deregisterAgentEndpoint("ag", endpoint);
+        verify(redoService).agentEndpointDeregister("ag");
+        verify(redoService).agentEndpointDeregistered("ag");
+    }
+    
+    @Test
+    void subscribeAgentCardCachedReturnsImmediately() throws Exception {
+        injectMockWithAgentCardCache();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        AgentCardDetailInfo cached = new AgentCardDetailInfo();
+        when(agentCardCacheHolder.getAgentCard("ag", null)).thenReturn(cached);
+        AgentCardDetailInfo actual = aiGrpcClient.subscribeAgentCard("ag", null);
+        assertEquals(cached, actual);
+        verify(rpcClient, never()).request(any(QueryAgentCardRequest.class));
+    }
+    
+    @Test
+    void subscribeAgentCardFetchesAndCaches() throws Exception {
+        injectMockWithAgentCardCache();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        QueryAgentCardResponse response = new QueryAgentCardResponse();
+        AgentCardDetailInfo fetched = new AgentCardDetailInfo();
+        response.setAgentCardDetailInfo(fetched);
+        when(rpcClient.request(any(QueryAgentCardRequest.class))).thenReturn(response);
+        aiGrpcClient.subscribeAgentCard("ag", null);
+        verify(agentCardCacheHolder).processAgentCardDetailInfo(fetched);
+        verify(agentCardCacheHolder).addAgentCardUpdateTask("ag", null);
+    }
+    
+    @Test
+    void subscribeAgentCardSwallowsNotFound() throws Exception {
+        injectMockWithAgentCardCache();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        Response notFound = ErrorResponse.build(NacosException.NOT_FOUND, "missing");
+        when(rpcClient.request(any(QueryAgentCardRequest.class))).thenReturn(notFound);
+        assertDoesNotThrow(() -> aiGrpcClient.subscribeAgentCard("ag", null));
+        verify(agentCardCacheHolder).addAgentCardUpdateTask("ag", null);
+    }
+    
+    @Test
+    void subscribeAgentCardRethrowsOnNonNotFound() throws Exception {
+        injectMockWithAgentCardCache();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        Response other = ErrorResponse.build(NacosException.SERVER_ERROR, "boom");
+        when(rpcClient.request(any(QueryAgentCardRequest.class))).thenReturn(other);
+        assertThrows(NacosException.class,
+            () -> aiGrpcClient.subscribeAgentCard("ag", null));
+        verify(agentCardCacheHolder, never()).addAgentCardUpdateTask("ag", null);
+    }
+    
+    @Test
+    void unsubscribeAgentCard() throws Exception {
+        injectMockWithAgentCardCache();
+        when(rpcClient.isRunning()).thenReturn(true);
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_AGENT_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        aiGrpcClient.unsubscribeAgentCard("ag", null);
+        verify(agentCardCacheHolder).removeAgentCardUpdateTask("ag", null);
+    }
+    
+    @Test
+    void isAbilitySupportedByServer() throws Exception {
+        injectMock();
+        when(rpcClient.getConnectionAbility(AbilityKey.SERVER_MCP_REGISTRY))
+            .thenReturn(AbilityStatus.SUPPORTED);
+        assertTrue(aiGrpcClient.isAbilitySupportedByServer(AbilityKey.SERVER_MCP_REGISTRY));
+    }
+    
+    @Test
+    void buildLegacyCompatibleAgentCardWithMultipleInterfaces() throws Exception {
+        Method m = AiGrpcClient.class.getDeclaredMethod("buildLegacyCompatibleAgentCard",
+            AgentCard.class);
+        m.setAccessible(true);
+        AgentCard card = new AgentCard();
+        card.setName("multi");
+        card.setVersion("1.0");
+        AgentInterface i1 = new AgentInterface();
+        i1.setUrl("u1");
+        i1.setProtocolBinding("b1");
+        i1.setProtocolVersion("v1");
+        AgentInterface i2 = new AgentInterface();
+        i2.setUrl("u2");
+        i2.setProtocolBinding("b2");
+        i2.setProtocolVersion("v2");
+        card.setSupportedInterfaces(Arrays.asList(i1, i2));
+        AgentCard converted = (AgentCard) m.invoke(aiGrpcClient, card);
+        assertEquals("u1", converted.getUrl());
+        assertEquals(1, converted.getAdditionalInterfaces().size());
+    }
+    
+    @Test
+    void requestToServerWithExplicitTimeout() throws Exception {
+        // Set a positive requestTimeout to take the timeout branch
+        Field tf = AiGrpcClient.class.getDeclaredField("requestTimeout");
+        tf.setAccessible(true);
+        tf.set(aiGrpcClient, 5000L);
+        injectMock();
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        QueryPromptResponse response = new QueryPromptResponse();
+        response.setPromptInfo(new Prompt("p", "1.0", "tpl"));
+        when(rpcClient.request(any(QueryPromptRequest.class),
+            org.mockito.ArgumentMatchers.eq(5000L)))
+            .thenReturn(response);
+        assertDoesNotThrow(() -> aiGrpcClient.queryPrompt("p", "1.0", null, null));
+        verify(rpcClient).request(any(QueryPromptRequest.class),
+            org.mockito.ArgumentMatchers.eq(5000L));
+    }
+    
+    @Test
+    void buildRequestResourceWithNullName() throws Exception {
+        Method m = AiGrpcClient.class.getDeclaredMethod("buildRequestResource", String.class,
+            String.class);
+        m.setAccessible(true);
+        // Should not throw and should return a resource even with null name
+        Object resource = m.invoke(aiGrpcClient, "ns", null);
+        assertTrue(resource != null);
+    }
+    
+    private void injectMockWithAgentCardCache()
+        throws NoSuchFieldException, IllegalAccessException {
+        injectMock();
+        Field field = AiGrpcClient.class.getDeclaredField("agentCardCacheHolder");
+        field.setAccessible(true);
+        field.set(aiGrpcClient, agentCardCacheHolder);
     }
     
     private void injectMock() throws NoSuchFieldException, IllegalAccessException {

--- a/client/src/test/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxyTest.java
@@ -33,20 +33,29 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -163,6 +172,206 @@ class AiHttpClientProxyTest {
         
         assertNotNull(actual);
         assertEquals("test-key", actual.getPromptKey());
+    }
+    
+    @Test
+    void queryPromptWithNullKeyUsesEmptyResource() throws Exception {
+        Prompt p = new Prompt("k", "v", "tpl");
+        Result<Prompt> r = Result.success(p);
+        HttpRestResult<String> httpResult = new HttpRestResult<>();
+        httpResult.setCode(200);
+        httpResult.setData(JacksonUtils.toJson(r));
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doReturn(httpResult).when(nacosRestTemplate).get(anyString(), any(Header.class),
+            any(Query.class), eq(String.class));
+        // Pass null promptKey to exercise StringUtils.EMPTY branch (line 130)
+        Prompt actual = httpClientProxy.queryPrompt(null, null, null, null);
+        assertNotNull(actual);
+    }
+    
+    @Test
+    void queryPromptForbiddenTriggersReLogin() throws Exception {
+        HttpRestResult<String> httpResult = new HttpRestResult<>();
+        httpResult.setCode(HttpURLConnection.HTTP_FORBIDDEN);
+        httpResult.setMessage("forbidden");
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doReturn(httpResult).when(nacosRestTemplate).get(anyString(), any(Header.class),
+            any(Query.class), eq(String.class));
+        assertThrows(NacosException.class,
+            () -> httpClientProxy.queryPrompt("k", null, null, null));
+        verify(securityProxy, times(3)).reLogin();
+    }
+    
+    @Test
+    void queryPromptNonNacosExceptionWrapped() throws Exception {
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doThrow(new RuntimeException("boom")).when(nacosRestTemplate).get(anyString(),
+            any(Header.class), any(Query.class), eq(String.class));
+        NacosException ex = assertThrows(NacosException.class,
+            () -> httpClientProxy.queryPrompt("k", null, null, null));
+        assertEquals(NacosException.SERVER_ERROR, ex.getErrCode());
+    }
+    
+    @Test
+    void downloadSkillZipSuccess() throws Exception {
+        byte[] zip = buildEmptyZip();
+        HttpRestResult<byte[]> httpResult = new HttpRestResult<>();
+        httpResult.setCode(200);
+        httpResult.setData(zip);
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doReturn(httpResult).when(nacosRestTemplate).get(anyString(), any(Header.class),
+            any(Query.class), eq(byte[].class));
+        byte[] result = httpClientProxy.downloadSkillZip("skill-a", "1.0", "stable");
+        assertArrayEquals(zip, result);
+    }
+    
+    @Test
+    void downloadSkillZipNullNameUsesEmptyResource() throws Exception {
+        byte[] zip = buildEmptyZip();
+        HttpRestResult<byte[]> httpResult = new HttpRestResult<>();
+        httpResult.setCode(200);
+        httpResult.setData(zip);
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doReturn(httpResult).when(nacosRestTemplate).get(anyString(), any(Header.class),
+            any(Query.class), eq(byte[].class));
+        byte[] result = httpClientProxy.downloadSkillZip(null, null, null);
+        assertNotNull(result);
+    }
+    
+    @Test
+    void downloadSkillZipUnsafeEntryWrapped() throws Exception {
+        // Create a zip with a path traversal entry to trigger SecurityException on validation
+        byte[] zip = buildZipWithEntry("../escape.txt");
+        HttpRestResult<byte[]> httpResult = new HttpRestResult<>();
+        httpResult.setCode(200);
+        httpResult.setData(zip);
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doReturn(httpResult).when(nacosRestTemplate).get(anyString(), any(Header.class),
+            any(Query.class), eq(byte[].class));
+        NacosException ex = assertThrows(NacosException.class,
+            () -> httpClientProxy.downloadSkillZip("s", null, null));
+        assertEquals(NacosException.SERVER_ERROR, ex.getErrCode());
+        assertTrue(ex.getErrMsg().contains("unsafe entry paths"));
+    }
+    
+    @Test
+    void downloadSkillZipNoServer() {
+        when(serverListManager.getServerList()).thenReturn(Collections.emptyList());
+        NacosException ex = assertThrows(NacosException.class,
+            () -> httpClientProxy.downloadSkillZip("s", null, null));
+        assertEquals(NacosException.INVALID_PARAM, ex.getErrCode());
+    }
+    
+    @Test
+    void downloadSkillZipServerError() throws Exception {
+        HttpRestResult<byte[]> httpResult = new HttpRestResult<>();
+        httpResult.setCode(500);
+        httpResult.setMessage("Internal Server Error");
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doReturn(httpResult).when(nacosRestTemplate).get(anyString(), any(Header.class),
+            any(Query.class), eq(byte[].class));
+        NacosException ex = assertThrows(NacosException.class,
+            () -> httpClientProxy.downloadSkillZip("s", null, null));
+        assertEquals(500, ex.getErrCode());
+    }
+    
+    @Test
+    void downloadSkillZipForbiddenTriggersReLogin() throws Exception {
+        HttpRestResult<byte[]> httpResult = new HttpRestResult<>();
+        httpResult.setCode(HttpURLConnection.HTTP_FORBIDDEN);
+        httpResult.setMessage("forbidden");
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doReturn(httpResult).when(nacosRestTemplate).get(anyString(), any(Header.class),
+            any(Query.class), eq(byte[].class));
+        assertThrows(NacosException.class,
+            () -> httpClientProxy.downloadSkillZip("s", null, null));
+        verify(securityProxy, times(3)).reLogin();
+    }
+    
+    @Test
+    void downloadSkillZipNonNacosExceptionWrapped() throws Exception {
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doThrow(new RuntimeException("boom")).when(nacosRestTemplate).get(anyString(),
+            any(Header.class), any(Query.class), eq(byte[].class));
+        NacosException ex = assertThrows(NacosException.class,
+            () -> httpClientProxy.downloadSkillZip("s", null, null));
+        assertEquals(NacosException.SERVER_ERROR, ex.getErrCode());
+    }
+    
+    @Test
+    void buildUrlWithExplicitHttpPrefix() throws Exception {
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        Method m = AiHttpClientProxy.class.getDeclaredMethod("buildUrl", String.class,
+            String.class);
+        m.setAccessible(true);
+        String url = (String) m.invoke(httpClientProxy, "http://1.2.3.4:8848", "/v3/path");
+        assertEquals("http://1.2.3.4:8848/nacos/v3/path", url);
+    }
+    
+    @Test
+    void buildUrlWithExplicitHttpsPrefix() throws Exception {
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        Method m = AiHttpClientProxy.class.getDeclaredMethod("buildUrl", String.class,
+            String.class);
+        m.setAccessible(true);
+        String url = (String) m.invoke(httpClientProxy, "https://1.2.3.4:8848", "/v3/path");
+        assertEquals("https://1.2.3.4:8848/nacos/v3/path", url);
+    }
+    
+    @Test
+    void buildUrlWithoutPrefixAddsHttp() throws Exception {
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        Method m = AiHttpClientProxy.class.getDeclaredMethod("buildUrl", String.class,
+            String.class);
+        m.setAccessible(true);
+        String url = (String) m.invoke(httpClientProxy, "1.2.3.4:8848", "/v3/path");
+        // ENABLE_HTTPS defaults to false; expect http:// prepended
+        assertTrue(url.startsWith("http://1.2.3.4:8848"));
+    }
+    
+    @Test
+    void shutdownIsIdempotent() throws Exception {
+        httpClientProxy.shutdown();
+        // Calling shutdown a second time should also be safe
+        httpClientProxy.shutdown();
+    }
+    
+    private static byte[] buildEmptyZip() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("safe.txt"));
+            zos.write(new byte[] {1, 2, 3});
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+    
+    private static byte[] buildZipWithEntry(String entryName) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry(entryName));
+            zos.write(new byte[] {1});
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
     }
     
     private AiHttpClientProxy createProxyWithMocks() throws Exception {

--- a/client/src/test/java/com/alibaba/nacos/client/ai/remote/redo/AgentEndpointRedoDataTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/remote/redo/AgentEndpointRedoDataTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.ai.remote.redo;
+
+import com.alibaba.nacos.api.ai.model.a2a.AgentEndpoint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class AgentEndpointRedoDataTest {
+    
+    private AgentEndpoint newEndpoint(String address, int port) {
+        AgentEndpoint endpoint = new AgentEndpoint();
+        endpoint.setAddress(address);
+        endpoint.setPort(port);
+        return endpoint;
+    }
+    
+    @Test
+    void testGetAgentName() {
+        AgentEndpointWrapper wrapper = AgentEndpointWrapper.wrap(newEndpoint("127.0.0.1", 8080));
+        AgentEndpointRedoData data = new AgentEndpointRedoData("agentX", wrapper);
+        assertEquals("agentX", data.getAgentName());
+        assertSame(wrapper, data.get());
+    }
+    
+    @Test
+    void testEquals() {
+        AgentEndpointWrapper wrapper = AgentEndpointWrapper.wrap(newEndpoint("127.0.0.1", 8080));
+        AgentEndpointRedoData data = new AgentEndpointRedoData("agentX", wrapper);
+        assertEquals(data, data);
+        assertNotEquals(data, null);
+        assertNotEquals(data, new Object());
+        
+        AgentEndpointRedoData same = new AgentEndpointRedoData("agentX", wrapper);
+        assertEquals(data, same);
+        assertEquals(data.hashCode(), same.hashCode());
+        
+        AgentEndpointRedoData diffName = new AgentEndpointRedoData("agentY", wrapper);
+        assertNotEquals(data, diffName);
+        
+        AgentEndpointWrapper otherWrapper =
+            AgentEndpointWrapper.wrap(newEndpoint("127.0.0.2", 9090));
+        AgentEndpointRedoData diffWrapper = new AgentEndpointRedoData("agentX", otherWrapper);
+        assertNotEquals(data, diffWrapper);
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/ai/remote/redo/AgentEndpointWrapperTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/remote/redo/AgentEndpointWrapperTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.ai.remote.redo;
+
+import com.alibaba.nacos.api.ai.model.a2a.AgentEndpoint;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentEndpointWrapperTest {
+    
+    private AgentEndpoint newEndpoint(String address, int port) {
+        AgentEndpoint endpoint = new AgentEndpoint();
+        endpoint.setAddress(address);
+        endpoint.setPort(port);
+        return endpoint;
+    }
+    
+    @Test
+    void testWrapSingle() {
+        AgentEndpoint endpoint = newEndpoint("127.0.0.1", 8080);
+        AgentEndpointWrapper wrapper = AgentEndpointWrapper.wrap(endpoint);
+        assertFalse(wrapper.isBatch());
+        assertSame(endpoint, wrapper.getData());
+        assertThrows(UnsupportedOperationException.class, wrapper::getBatchData);
+    }
+    
+    @Test
+    void testWrapBatch() {
+        Collection<AgentEndpoint> list =
+            Arrays.asList(newEndpoint("127.0.0.1", 8080), newEndpoint("127.0.0.2", 9090));
+        AgentEndpointWrapper wrapper = AgentEndpointWrapper.wrap(list);
+        assertTrue(wrapper.isBatch());
+        assertEquals(2, wrapper.getBatchData().size());
+        assertThrows(UnsupportedOperationException.class, wrapper::getData);
+    }
+    
+    @Test
+    void testEquals() {
+        AgentEndpoint e1 = newEndpoint("127.0.0.1", 8080);
+        AgentEndpointWrapper wrapper1 = AgentEndpointWrapper.wrap(e1);
+        AgentEndpointWrapper wrapper2 = AgentEndpointWrapper.wrap(e1);
+        assertEquals(wrapper1, wrapper1);
+        assertNotEquals(wrapper1, null);
+        assertNotEquals(wrapper1, new Object());
+        assertEquals(wrapper1, wrapper2);
+        assertEquals(wrapper1.hashCode(), wrapper2.hashCode());
+        
+        AgentEndpointWrapper diffData = AgentEndpointWrapper.wrap(newEndpoint("127.0.0.2", 9090));
+        assertNotEquals(wrapper1, diffData);
+        
+        AgentEndpointWrapper batch = AgentEndpointWrapper.wrap(Arrays.asList(e1));
+        assertNotEquals(wrapper1, batch);
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/ai/remote/redo/AiGrpcRedoServiceTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/remote/redo/AiGrpcRedoServiceTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -112,6 +113,24 @@ class AiGrpcRedoServiceTest {
         redoService.removeAgentEndpointForRedo("testAgent");
         Set<RedoData<AgentEndpointWrapper>> redoDatas = redoService.findAgentEndpointRedoData();
         assertTrue(redoDatas.isEmpty());
+    }
+    
+    @Test
+    void getAgentEndpointReturnsCachedWrapper() {
+        AgentEndpoint endpoint = new AgentEndpoint();
+        endpoint.setAddress("127.0.0.1");
+        endpoint.setPort(8080);
+        AgentEndpointWrapper wrapper = AgentEndpointWrapper.wrap(endpoint);
+        redoService.cachedAgentEndpointForRedo("testAgent", wrapper);
+        AgentEndpointWrapper actual = redoService.getAgentEndpoint("testAgent");
+        assertNotNull(actual);
+        assertFalse(actual.isBatch());
+        assertEquals("127.0.0.1", actual.getData().getAddress());
+    }
+    
+    @Test
+    void getAgentEndpointReturnsNullWhenNotCached() {
+        assertNull(redoService.getAgentEndpoint("missing"));
     }
     
     @Test

--- a/client/src/test/java/com/alibaba/nacos/client/ai/utils/CacheKeyUtilsTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/utils/CacheKeyUtilsTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.client.ai.utils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class CacheKeyUtilsTest {
     
@@ -44,5 +45,36 @@ class CacheKeyUtilsTest {
     void buildAgentSpecKeyShouldReturnNameItself() {
         String key = CacheKeyUtils.buildAgentSpecKey("my-agent-spec");
         assertEquals("my-agent-spec", key);
+    }
+    
+    @Test
+    void buildSkillKeyShouldReturnNameItself() {
+        String key = CacheKeyUtils.buildSkillKey("my-skill");
+        assertEquals("my-skill", key);
+    }
+    
+    @Test
+    void buildPromptKeySingleArgShouldReturnKeyItself() {
+        String key = CacheKeyUtils.buildPromptKey("p1");
+        assertEquals("p1", key);
+    }
+    
+    @Test
+    void buildMcpServerKeyWithBlankVersion() {
+        assertEquals("mcp::latest", CacheKeyUtils.buildMcpServerKey("mcp", null));
+        assertEquals("mcp::latest", CacheKeyUtils.buildMcpServerKey("mcp", ""));
+        assertEquals("mcp::1.0.0", CacheKeyUtils.buildMcpServerKey("mcp", "1.0.0"));
+    }
+    
+    @Test
+    void buildAgentCardKeyWithBlankVersion() {
+        assertEquals("a1::latest", CacheKeyUtils.buildAgentCardKey("a1", null));
+        assertEquals("a1::1.0.0", CacheKeyUtils.buildAgentCardKey("a1", "1.0.0"));
+    }
+    
+    @Test
+    void constructorIsAccessible() {
+        // Ensure default constructor counts toward class coverage.
+        assertNotNull(new CacheKeyUtils());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/NacosConfigServiceTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/NacosConfigServiceTest.java
@@ -551,4 +551,114 @@ class NacosConfigServiceTest {
             nacosConfigService.shutDown();
         });
     }
+    
+    @Test
+    void testGetConfigWithResultFromServer() throws NacosException {
+        ConfigResponse response = new ConfigResponse();
+        response.setContent("server-content");
+        response.setMd5("md5val");
+        response.setConfigType("yaml");
+        response.setEncryptedDataKey("ek");
+        Mockito.when(mockWoker.getServerConfig("d", "g", "public", 3000, false))
+            .thenReturn(response);
+        com.alibaba.nacos.api.config.ConfigQueryResult result =
+            nacosConfigService.getConfigWithResult("d", "g", 3000);
+        assertEquals("server-content", result.getContent());
+        assertEquals("md5val", result.getMd5());
+        assertEquals("yaml", result.getConfigType());
+        assertEquals("ek", result.getEncryptedDataKey());
+    }
+    
+    @Test
+    void testGetConfigWithResultFromFailover() throws NacosException {
+        try (MockedStatic<LocalConfigInfoProcessor> processor =
+            Mockito.mockStatic(LocalConfigInfoProcessor.class)) {
+            processor.when(() -> LocalConfigInfoProcessor.getFailover(any(),
+                eq("dfo"), eq("g"), eq("public"))).thenReturn("failover-content");
+            com.alibaba.nacos.api.config.ConfigQueryResult result =
+                nacosConfigService.getConfigWithResult("dfo", "g", 3000);
+            assertEquals("failover-content", result.getContent());
+        }
+    }
+    
+    @Test
+    void testGetConfigWithResultFromSnapshot() throws NacosException {
+        try (MockedStatic<LocalConfigInfoProcessor> processor =
+            Mockito.mockStatic(LocalConfigInfoProcessor.class)) {
+            processor.when(() -> LocalConfigInfoProcessor.getFailover(any(),
+                eq("dsnap"), eq("g"), eq("public"))).thenReturn(null);
+            processor.when(() -> LocalConfigInfoProcessor.getSnapshot(any(),
+                eq("dsnap"), eq("g"), eq("public"))).thenReturn("snapshot-content");
+            Mockito.when(mockWoker.getServerConfig("dsnap", "g", "public", 3000, false))
+                .thenThrow(new NacosException(500, "down"));
+            com.alibaba.nacos.api.config.ConfigQueryResult result =
+                nacosConfigService.getConfigWithResult("dsnap", "g", 3000);
+            assertEquals("snapshot-content", result.getContent());
+        }
+    }
+    
+    @Test
+    void testGetConfigWithResultThrowsOnNoRight() throws NacosException {
+        try (MockedStatic<LocalConfigInfoProcessor> processor =
+            Mockito.mockStatic(LocalConfigInfoProcessor.class)) {
+            processor.when(() -> LocalConfigInfoProcessor.getFailover(any(),
+                eq("dnr"), eq("g"), eq("public"))).thenReturn(null);
+            Mockito.when(mockWoker.getServerConfig("dnr", "g", "public", 3000, false))
+                .thenThrow(new NacosException(NacosException.NO_RIGHT, "no right"));
+            NacosException ex = Assertions.assertThrows(NacosException.class,
+                () -> nacosConfigService.getConfigWithResult("dnr", "g", 3000));
+            assertEquals(NacosException.NO_RIGHT, ex.getErrCode());
+        }
+    }
+    
+    @Test
+    void testCancelFuzzyWatchWithNullWatcher() throws NacosException {
+        // null watcher → early return; should not call worker
+        nacosConfigService.cancelFuzzyWatch("g*", (FuzzyWatchEventWatcher) null);
+        Mockito.verify(mockWoker, Mockito.never())
+            .removeFuzzyListenListener(anyString(), anyString(), any());
+    }
+    
+    @Test
+    void testCancelFuzzyWatchWithWatcherDelegates() throws NacosException {
+        FuzzyWatchEventWatcher watcher = new FuzzyWatchEventWatcher() {
+            
+            @Override
+            public void onEvent(ConfigFuzzyWatchChangeEvent event) {
+            }
+            
+            @Override
+            public Executor getExecutor() {
+                return null;
+            }
+        };
+        nacosConfigService.cancelFuzzyWatch("g*", watcher);
+        Mockito.verify(mockWoker, Mockito.times(1))
+            .removeFuzzyListenListener(ALL_PATTERN, "g*", watcher);
+    }
+    
+    @Test
+    void testCancelFuzzyWatchWithDataIdPattern() throws NacosException {
+        FuzzyWatchEventWatcher watcher = new FuzzyWatchEventWatcher() {
+            
+            @Override
+            public void onEvent(ConfigFuzzyWatchChangeEvent event) {
+            }
+            
+            @Override
+            public Executor getExecutor() {
+                return null;
+            }
+        };
+        nacosConfigService.cancelFuzzyWatch("d*", "g*", watcher);
+        Mockito.verify(mockWoker, Mockito.times(1))
+            .removeFuzzyListenListener("d*", "g*", watcher);
+    }
+    
+    @Test
+    void testAddConfigFilterDelegates() {
+        com.alibaba.nacos.api.config.filter.IConfigFilter filter =
+            Mockito.mock(com.alibaba.nacos.api.config.filter.IConfigFilter.class);
+        Assertions.assertDoesNotThrow(() -> nacosConfigService.addConfigFilter(filter));
+    }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/common/ConfigConstantsTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/common/ConfigConstantsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.config.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ConfigConstantsTest {
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new ConfigConstants());
+    }
+    
+    @Test
+    void testFields() {
+        assertEquals("tenant", ConfigConstants.TENANT);
+        assertEquals("dataId", ConfigConstants.DATA_ID);
+        assertEquals("group", ConfigConstants.GROUP);
+        assertEquals("content", ConfigConstants.CONTENT);
+        assertEquals("configType", ConfigConstants.CONFIG_TYPE);
+        assertEquals("encryptedDataKey", ConfigConstants.ENCRYPTED_DATA_KEY);
+        assertEquals("type", ConfigConstants.TYPE);
+        assertEquals("md5", ConfigConstants.MD5);
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/config/common/GroupKeyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/common/GroupKeyTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GroupKeyTest {
@@ -83,5 +84,10 @@ class GroupKeyTest {
         assertThrows(IllegalArgumentException.class, () -> {
             GroupKey.getKey("a", "");
         });
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new GroupKey());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/filter/impl/ConfigResponseTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/filter/impl/ConfigResponseTest.java
@@ -74,4 +74,11 @@ class ConfigResponseTest {
         IConfigContext configContext = configResponse.getConfigContext();
         assertNotNull(configContext);
     }
+    
+    @Test
+    void testMd5GetterAndSetter() {
+        ConfigResponse configResponse = new ConfigResponse();
+        configResponse.setMd5("md5-hash");
+        assertEquals("md5-hash", configResponse.getMd5());
+    }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ChangeNotifyBlockEventTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ChangeNotifyBlockEventTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.config.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChangeNotifyBlockEventTest {
+    
+    @Test
+    void testGettersAndSetters() {
+        ChangeNotifyBlockEvent event = new ChangeNotifyBlockEvent("listener", "dataId", "group",
+            "tenant", 1L, 2L, "stack");
+        assertEquals("dataId", event.getDataId());
+        assertEquals("group", event.getGroup());
+        assertEquals("tenant", event.getTenant());
+        assertEquals(1L, event.getStartTime());
+        assertEquals(2L, event.getCurrentTime());
+        assertEquals("stack", event.getBlockStack());
+        
+        event.setDataId("dataId2");
+        event.setGroup("group2");
+        event.setTenant("tenant2");
+        event.setStartTime(10L);
+        event.setCurrentTime(20L);
+        event.setBlockStack("stack2");
+        
+        assertEquals("dataId2", event.getDataId());
+        assertEquals("group2", event.getGroup());
+        assertEquals("tenant2", event.getTenant());
+        assertEquals(10L, event.getStartTime());
+        assertEquals(20L, event.getCurrentTime());
+        assertEquals("stack2", event.getBlockStack());
+    }
+    
+    @Test
+    void testToString() {
+        ChangeNotifyBlockEvent event = new ChangeNotifyBlockEvent("listener", "dataId", "group",
+            "tenant", 1L, 2L, "stack");
+        String s = event.toString();
+        assertTrue(s.contains("dataId='dataId'"));
+        assertTrue(s.contains("group='group'"));
+        assertTrue(s.contains("tenant='tenant'"));
+        assertTrue(s.contains("listener='listener'"));
+        assertTrue(s.contains("blockStack='stack'"));
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ClientFuzzyWatchNotifyRequestHandlerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ClientFuzzyWatchNotifyRequestHandlerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.config.impl;
+
+import com.alibaba.nacos.api.config.remote.request.ConfigFuzzyWatchChangeNotifyRequest;
+import com.alibaba.nacos.api.config.remote.request.ConfigFuzzyWatchSyncRequest;
+import com.alibaba.nacos.api.config.remote.response.ConfigFuzzyWatchChangeNotifyResponse;
+import com.alibaba.nacos.api.config.remote.response.ConfigFuzzyWatchSyncResponse;
+import com.alibaba.nacos.api.remote.request.HealthCheckRequest;
+import com.alibaba.nacos.api.remote.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClientFuzzyWatchNotifyRequestHandlerTest {
+    
+    @Mock
+    ConfigFuzzyWatchGroupKeyHolder configFuzzyWatchGroupKeyHolder;
+    
+    ClientFuzzyWatchNotifyRequestHandler handler;
+    
+    @BeforeEach
+    void setUp() {
+        handler = new ClientFuzzyWatchNotifyRequestHandler(configFuzzyWatchGroupKeyHolder);
+    }
+    
+    @Test
+    void requestReplyWithSyncRequest() {
+        ConfigFuzzyWatchSyncRequest request = new ConfigFuzzyWatchSyncRequest();
+        ConfigFuzzyWatchSyncResponse response = new ConfigFuzzyWatchSyncResponse();
+        when(configFuzzyWatchGroupKeyHolder.handleFuzzyWatchSyncNotifyRequest(request))
+            .thenReturn(response);
+        Response actual = handler.requestReply(request, null);
+        assertSame(response, actual);
+    }
+    
+    @Test
+    void requestReplyWithChangeRequest() {
+        ConfigFuzzyWatchChangeNotifyRequest request = new ConfigFuzzyWatchChangeNotifyRequest();
+        ConfigFuzzyWatchChangeNotifyResponse response = new ConfigFuzzyWatchChangeNotifyResponse();
+        when(configFuzzyWatchGroupKeyHolder.handlerFuzzyWatchChangeNotifyRequest(request))
+            .thenReturn(response);
+        Response actual = handler.requestReply(request, null);
+        assertSame(response, actual);
+    }
+    
+    @Test
+    void requestReplyWithUnknownRequest() {
+        Response response = handler.requestReply(new HealthCheckRequest(), null);
+        assertNull(response);
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigChangeHandlerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigChangeHandlerTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConfigChangeHandlerTest {
     
@@ -38,5 +39,12 @@ class ConfigChangeHandlerTest {
         Map properties = ConfigChangeHandler.getInstance().parseChangeData("",
             "app:\n  name: nacos", "yaml");
         assertEquals("nacos", ((ConfigChangeItem) properties.get("app.name")).getNewValue());
+    }
+    
+    @Test
+    void testParseUnsupportedTypeReturnsEmpty() throws IOException {
+        Map properties = ConfigChangeHandler.getInstance().parseChangeData("", "foo=bar",
+            "unsupported-type-xx");
+        assertTrue(properties.isEmpty());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolderTest.java
@@ -57,7 +57,6 @@ import static com.alibaba.nacos.api.model.v2.ErrorCode.FUZZY_WATCH_PATTERN_MATCH
 import static com.alibaba.nacos.api.model.v2.ErrorCode.FUZZY_WATCH_PATTERN_OVER_LIMIT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -79,7 +78,7 @@ public class ConfigFuzzyWatchGroupKeyHolderTest {
     void before() {
         configFuzzyWatchGroupKeyHolder =
             new ConfigFuzzyWatchGroupKeyHolder(rpcTransportClient, clientId);
-        doReturn(true).when(rpcTransportClient)
+        Mockito.lenient().doReturn(true).when(rpcTransportClient)
             .isAbilitySupportedByServer(AbilityKey.SERVER_FUZZY_WATCH);
     }
     
@@ -453,5 +452,155 @@ public class ConfigFuzzyWatchGroupKeyHolderTest {
                     }
                 });
         });
+    }
+    
+    @Test
+    void testRegisterFuzzyWatcherWithExistingReceivedKeysPublishesInitEvents()
+        throws InterruptedException {
+        when(rpcTransportClient.getTenant()).thenReturn(tenant);
+        // First register and seed received group keys via change notify
+        AtomicInteger watcherFlag = new AtomicInteger(0);
+        AbstractFuzzyWatchEventWatcher watcher = new AbstractFuzzyWatchEventWatcher() {
+            
+            @Override
+            public void onEvent(ConfigFuzzyWatchChangeEvent event) {
+                watcherFlag.incrementAndGet();
+            }
+        };
+        ConfigFuzzyWatchContext ctx =
+            configFuzzyWatchGroupKeyHolder.registerFuzzyWatcher("d*", "group", watcher);
+        // Inject a received group key
+        String groupKey = GroupKey.getKeyTenant("d1", "group", tenant);
+        configFuzzyWatchGroupKeyHolder.handlerFuzzyWatchChangeNotifyRequest(
+            new ConfigFuzzyWatchChangeNotifyRequest(groupKey, ADD_CONFIG));
+        awaitCondition(() -> ctx.getReceivedGroupKeys().contains(groupKey), 3000L,
+            "received group key should be added");
+        // Now register a NEW watcher that should receive init events for existing keys
+        AtomicInteger watcher2Flag = new AtomicInteger(0);
+        AbstractFuzzyWatchEventWatcher watcher2 = new AbstractFuzzyWatchEventWatcher() {
+            
+            @Override
+            public void onEvent(ConfigFuzzyWatchChangeEvent event) {
+                watcher2Flag.incrementAndGet();
+            }
+        };
+        configFuzzyWatchGroupKeyHolder.registerFuzzyWatcher("d*", "group", watcher2);
+        awaitCondition(() -> watcher2Flag.get() >= 1, 3000L,
+            "watcher2 should be init-notified for existing key");
+    }
+    
+    @Test
+    void testHandleFuzzyWatchSyncNotifyRequestDefaultCase() throws Exception {
+        when(rpcTransportClient.getTenant()).thenReturn(tenant);
+        // Register a watcher to create a context
+        configFuzzyWatchGroupKeyHolder.registerFuzzyWatcher("foo*", "group",
+            new AbstractFuzzyWatchEventWatcher() {
+                
+                @Override
+                public void onEvent(ConfigFuzzyWatchChangeEvent event) {
+                }
+            });
+        String pattern = FuzzyGroupKeyPattern.generatePattern("foo*", "group", tenant);
+        // Build a sync request with an unknown change type to hit the default branch
+        Set<ConfigFuzzyWatchSyncRequest.Context> contexts = new HashSet<>();
+        contexts.add(ConfigFuzzyWatchSyncRequest.Context.build(
+            GroupKey.getKeyTenant("foo1", "group", tenant), "UNKNOWN_TYPE"));
+        ConfigFuzzyWatchSyncRequest request = ConfigFuzzyWatchSyncRequest.buildSyncRequest(
+            FUZZY_WATCH_DIFF_SYNC_NOTIFY, contexts, pattern, 1, 1);
+        // Should not throw; default branch just warns
+        configFuzzyWatchGroupKeyHolder.handleFuzzyWatchSyncNotifyRequest(request);
+    }
+    
+    @Test
+    void testRemoveFuzzyWatcherNoContextNoOp() {
+        // No registered watcher → context is null, removeFuzzyWatcher is a no-op
+        configFuzzyWatchGroupKeyHolder.removeFuzzyWatcher("nonexist*", "group", null);
+    }
+    
+    @Test
+    void testHandlerFuzzyWatchChangeNotifyRequestDeleteWithReceived()
+        throws InterruptedException {
+        when(rpcTransportClient.getTenant()).thenReturn(tenant);
+        AtomicInteger watcherFlag = new AtomicInteger(0);
+        ConfigFuzzyWatchContext ctx = configFuzzyWatchGroupKeyHolder.registerFuzzyWatcher("d*",
+            "group", new AbstractFuzzyWatchEventWatcher() {
+                
+                @Override
+                public void onEvent(ConfigFuzzyWatchChangeEvent event) {
+                    watcherFlag.incrementAndGet();
+                }
+            });
+        String groupKey = GroupKey.getKeyTenant("d1", "group", tenant);
+        // Add then delete
+        configFuzzyWatchGroupKeyHolder.handlerFuzzyWatchChangeNotifyRequest(
+            new ConfigFuzzyWatchChangeNotifyRequest(groupKey, ADD_CONFIG));
+        awaitCondition(() -> ctx.getReceivedGroupKeys().contains(groupKey), 3000L,
+            "received group key should be added");
+        configFuzzyWatchGroupKeyHolder.handlerFuzzyWatchChangeNotifyRequest(
+            new ConfigFuzzyWatchChangeNotifyRequest(groupKey, DELETE_CONFIG));
+        awaitCondition(() -> !ctx.getReceivedGroupKeys().contains(groupKey), 3000L,
+            "received group key should be removed after DELETE_CONFIG");
+    }
+    
+    @Test
+    void testOnEventDifferentClientUuidEarlyReturn() {
+        // Build event with a different clientUuid; onEvent should early return
+        ConfigFuzzyWatchNotifyEvent ev = ConfigFuzzyWatchNotifyEvent.buildEvent(
+            "g:d:t", "p", ADD_CONFIG, FUZZY_WATCH_INIT_NOTIFY, "other-uuid");
+        Assertions.assertDoesNotThrow(() -> configFuzzyWatchGroupKeyHolder.onEvent(ev));
+        ConfigFuzzyWatchLoadEvent loadEv = ConfigFuzzyWatchLoadEvent.buildEvent(
+            FUZZY_WATCH_PATTERN_OVER_LIMIT.getCode(), "p", "other-uuid");
+        Assertions.assertDoesNotThrow(
+            () -> configFuzzyWatchGroupKeyHolder.onEvent(loadEv));
+    }
+    
+    @Test
+    void testOnEventContextNullEarlyReturn() {
+        // Same clientUuid but no matching context → early return
+        ConfigFuzzyWatchNotifyEvent ev = ConfigFuzzyWatchNotifyEvent.buildEvent(
+            "g:d:t", "no-such-pattern", ADD_CONFIG, FUZZY_WATCH_INIT_NOTIFY,
+            clientId);
+        Assertions.assertDoesNotThrow(() -> configFuzzyWatchGroupKeyHolder.onEvent(ev));
+        ConfigFuzzyWatchLoadEvent loadEv = ConfigFuzzyWatchLoadEvent.buildEvent(
+            FUZZY_WATCH_PATTERN_OVER_LIMIT.getCode(), "no-such-pattern", clientId);
+        Assertions.assertDoesNotThrow(
+            () -> configFuzzyWatchGroupKeyHolder.onEvent(loadEv));
+    }
+    
+    @Test
+    void testExecuteFuzzyWatchRequestServerError() throws NacosException {
+        AbstractFuzzyWatchEventWatcher watcher = new AbstractFuzzyWatchEventWatcher() {
+            
+            @Override
+            public void onEvent(ConfigFuzzyWatchChangeEvent event) {
+            }
+        };
+        ConfigFuzzyWatchContext ctx = configFuzzyWatchGroupKeyHolder.registerFuzzyWatcher(
+            "ee*", "group", watcher);
+        RpcClient rpcClient = Mockito.mock(RpcClient.class);
+        ConfigFuzzyWatchResponse errorResponse = new ConfigFuzzyWatchResponse();
+        errorResponse.setErrorInfo(NacosException.SERVER_ERROR, "boom");
+        when(rpcTransportClient.requestProxy(eq(rpcClient), any(ConfigFuzzyWatchRequest.class)))
+            .thenReturn(errorResponse);
+        // Should not throw; just logs the error
+        configFuzzyWatchGroupKeyHolder.executeFuzzyWatchRequest(ctx, rpcClient);
+        Assertions.assertFalse(ctx.isConsistentWithServer());
+    }
+    
+    @Test
+    void testExecuteFuzzyWatchRequestNonOverLimitNacosException() throws NacosException {
+        AbstractFuzzyWatchEventWatcher watcher = new AbstractFuzzyWatchEventWatcher() {
+            
+            @Override
+            public void onEvent(ConfigFuzzyWatchChangeEvent event) {
+            }
+        };
+        ConfigFuzzyWatchContext ctx = configFuzzyWatchGroupKeyHolder.registerFuzzyWatcher(
+            "ff*", "group", watcher);
+        RpcClient rpcClient = Mockito.mock(RpcClient.class);
+        when(rpcTransportClient.requestProxy(eq(rpcClient), any(ConfigFuzzyWatchRequest.class)))
+            .thenThrow(new NacosException(NacosException.SERVER_ERROR, "boom"));
+        // Should not throw; should retry via notifyFuzzyWatchSync
+        configFuzzyWatchGroupKeyHolder.executeFuzzyWatchRequest(ctx, rpcClient);
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchLoadEventTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchLoadEventTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.config.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ConfigFuzzyWatchLoadEventTest {
+    
+    @Test
+    void testDefaultConstructor() {
+        ConfigFuzzyWatchLoadEvent event = new ConfigFuzzyWatchLoadEvent();
+        assertNotNull(event);
+        assertEquals(0, event.getCode());
+        assertNull(event.getGroupKeyPattern());
+        assertNull(event.getClientUuid());
+    }
+    
+    @Test
+    void testBuildEvent() {
+        ConfigFuzzyWatchLoadEvent event = ConfigFuzzyWatchLoadEvent.buildEvent(42, "pattern",
+            "clientUuid");
+        assertEquals(42, event.getCode());
+        assertEquals("pattern", event.getGroupKeyPattern());
+        assertEquals("clientUuid", event.getClientUuid());
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchNotifyEventTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchNotifyEventTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.config.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ConfigFuzzyWatchNotifyEventTest {
+    
+    @Test
+    void testDefaultConstructor() {
+        ConfigFuzzyWatchNotifyEvent event = new ConfigFuzzyWatchNotifyEvent();
+        assertNotNull(event);
+        assertNull(event.getGroupKey());
+        assertNull(event.getGroupKeyPattern());
+        assertNull(event.getChangedType());
+        assertNull(event.getSyncType());
+        assertNull(event.getClientUuid());
+        assertNull(event.getWatcherUuid());
+    }
+    
+    @Test
+    void testBuildEventWithoutWatcher() {
+        ConfigFuzzyWatchNotifyEvent event = ConfigFuzzyWatchNotifyEvent.buildEvent("groupKey",
+            "pattern", "ADD", "FULL", "clientUuid");
+        assertEquals("groupKey", event.getGroupKey());
+        assertEquals("pattern", event.getGroupKeyPattern());
+        assertEquals("ADD", event.getChangedType());
+        assertEquals("FULL", event.getSyncType());
+        assertEquals("clientUuid", event.getClientUuid());
+        assertNull(event.getWatcherUuid());
+    }
+    
+    @Test
+    void testBuildEventWithWatcher() {
+        ConfigFuzzyWatchNotifyEvent event = ConfigFuzzyWatchNotifyEvent.buildEvent("groupKey",
+            "pattern", "ADD", "FULL", "clientUuid", "watcherUuid");
+        assertEquals("watcherUuid", event.getWatcherUuid());
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatcherWrapperTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatcherWrapperTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.config.impl;
+
+import com.alibaba.nacos.api.config.listener.FuzzyWatchEventWatcher;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigFuzzyWatcherWrapperTest {
+    
+    @Test
+    void testGetUuidAndSyncGroupKeys() {
+        FuzzyWatchEventWatcher watcher = Mockito.mock(FuzzyWatchEventWatcher.class);
+        ConfigFuzzyWatcherWrapper wrapper = new ConfigFuzzyWatcherWrapper(watcher);
+        assertNotNull(wrapper.getUuid());
+        assertTrue(wrapper.getSyncGroupKeys().isEmpty());
+    }
+    
+    @Test
+    void testEqualsAndHashCode() {
+        FuzzyWatchEventWatcher watcher = Mockito.mock(FuzzyWatchEventWatcher.class);
+        ConfigFuzzyWatcherWrapper wrapper = new ConfigFuzzyWatcherWrapper(watcher);
+        assertEquals(wrapper, wrapper);
+        assertNotEquals(wrapper, null);
+        assertNotEquals(wrapper, new Object());
+        
+        // different uuid means not equal even for same watcher
+        ConfigFuzzyWatcherWrapper other = new ConfigFuzzyWatcherWrapper(watcher);
+        assertNotEquals(wrapper, other);
+        assertNotEquals(wrapper.hashCode(), other.hashCode());
+        
+        // same uuid, same watcher => equal
+        ConfigFuzzyWatcherWrapper sameRef = new ConfigFuzzyWatcherWrapper(watcher);
+        sameRef.uuid = wrapper.getUuid();
+        assertEquals(wrapper, sameRef);
+        assertEquals(wrapper.hashCode(), sameRef.hashCode());
+        
+        // different watcher => not equal
+        FuzzyWatchEventWatcher watcher2 = Mockito.mock(FuzzyWatchEventWatcher.class);
+        ConfigFuzzyWatcherWrapper diffWatcher = new ConfigFuzzyWatcherWrapper(watcher2);
+        diffWatcher.uuid = wrapper.getUuid();
+        assertNotEquals(wrapper, diffWatcher);
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigHttpClientManagerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigHttpClientManagerTest.java
@@ -16,12 +16,28 @@
 
 package com.alibaba.nacos.client.config.impl;
 
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.http.HttpClientBeanHolder;
+import com.alibaba.nacos.common.http.client.HttpClientRequestInterceptor;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
+import com.alibaba.nacos.common.http.client.response.HttpClientResponse;
+import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.model.RequestHttpEntity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
 
 class ConfigHttpClientManagerTest {
     
@@ -45,4 +61,91 @@ class ConfigHttpClientManagerTest {
         });
     }
     
+    @Test
+    void testGetNacosRestTemplateAddsLimiterInterceptorOnce() {
+        ConfigHttpClientManager instance = ConfigHttpClientManager.getInstance();
+        // first call adds interceptor
+        NacosRestTemplate t1 = instance.getNacosRestTemplate();
+        int afterFirst = t1.getInterceptors().size();
+        // second call should not add a duplicate
+        NacosRestTemplate t2 = instance.getNacosRestTemplate();
+        assertEquals(afterFirst, t2.getInterceptors().size());
+    }
+    
+    @Test
+    void testShutdownSwallowsException() {
+        try (MockedStatic<HttpClientBeanHolder> mocked =
+            Mockito.mockStatic(HttpClientBeanHolder.class)) {
+            mocked.when(() -> HttpClientBeanHolder.shutdownNacosSyncRest(anyString()))
+                .thenThrow(new RuntimeException("forced"));
+            Assertions.assertDoesNotThrow(() -> ConfigHttpClientManager.getInstance().shutdown());
+        }
+    }
+    
+    @Test
+    void testConfigHttpClientFactoryInternalsViaReflection() throws Exception {
+        java.lang.reflect.Field f =
+            ConfigHttpClientManager.class.getDeclaredField("HTTP_CLIENT_FACTORY");
+        f.setAccessible(true);
+        Object factory = f.get(null);
+        Method buildConfig = factory.getClass().getDeclaredMethod("buildHttpClientConfig");
+        buildConfig.setAccessible(true);
+        assertNotNull(buildConfig.invoke(factory));
+        Method assignLogger = factory.getClass().getDeclaredMethod("assignLogger");
+        assignLogger.setAccessible(true);
+        assertNotNull(assignLogger.invoke(factory));
+    }
+    
+    @Test
+    void testLimiterHttpClientRequestInterceptorIsInterceptDelegatesToLimiter() throws Exception {
+        Class<?> interceptorClass = Class.forName(
+            "com.alibaba.nacos.client.config.impl.ConfigHttpClientManager$"
+                + "LimiterHttpClientRequestInterceptor");
+        Constructor<?> ctor = interceptorClass.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        HttpClientRequestInterceptor interceptor =
+            (HttpClientRequestInterceptor) ctor.newInstance();
+        URI uri = new URI("http://example.com/path");
+        // Empty body branch
+        RequestHttpEntity emptyEntity = new RequestHttpEntity(Header.newInstance(), null);
+        // Returns boolean depending on Limiter; we just verify it runs without throwing
+        Assertions.assertDoesNotThrow(() -> interceptor.isIntercept(uri, "GET", emptyEntity));
+    }
+    
+    @Test
+    void testLimiterHttpClientRequestInterceptorIntercept() throws Exception {
+        Class<?> interceptorClass = Class.forName(
+            "com.alibaba.nacos.client.config.impl.ConfigHttpClientManager$"
+                + "LimiterHttpClientRequestInterceptor");
+        Constructor<?> ctor = interceptorClass.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        HttpClientRequestInterceptor interceptor =
+            (HttpClientRequestInterceptor) ctor.newInstance();
+        HttpClientResponse response = interceptor.intercept();
+        assertNotNull(response);
+        assertEquals(NacosException.CLIENT_OVER_THRESHOLD, response.getStatusCode());
+        assertEquals(Header.EMPTY, response.getHeaders());
+        assertNull(response.getStatusText());
+        try (InputStream body = response.getBody()) {
+            byte[] buf = new byte[256];
+            int n = body.read(buf);
+            String content = new String(buf, 0, n, StandardCharsets.UTF_8);
+            assertEquals("More than client-side current limit threshold", content);
+        }
+        Assertions.assertDoesNotThrow(response::close);
+    }
+    
+    @Test
+    void testLimiterInterceptorHandlesNonEmptyBody() throws Exception {
+        Class<?> interceptorClass = Class.forName(
+            "com.alibaba.nacos.client.config.impl.ConfigHttpClientManager$"
+                + "LimiterHttpClientRequestInterceptor");
+        Constructor<?> ctor = interceptorClass.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        HttpClientRequestInterceptor interceptor =
+            (HttpClientRequestInterceptor) ctor.newInstance();
+        URI uri = new URI("http://example.com/x");
+        RequestHttpEntity entity = new RequestHttpEntity(Header.newInstance(), "non-empty-body");
+        Assertions.assertDoesNotThrow(() -> interceptor.isIntercept(uri, "POST", entity));
+    }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigServerListManagerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigServerListManagerTest.java
@@ -461,6 +461,31 @@ class ConfigServerListManagerTest {
     }
     
     @Test
+    void testIteratorWithEmptyServerListLogsError()
+        throws NacosException, NoSuchFieldException, IllegalAccessException {
+        Properties properties = new Properties();
+        properties.setProperty(PropertyKeyConst.SERVER_ADDR, "1.1.1.1:8848");
+        final NacosClientProperties clientProperties =
+            NacosClientProperties.PROTOTYPE.derive(properties);
+        ConfigServerListManager mgr = new ConfigServerListManager(clientProperties);
+        mgr.start();
+        // Replace the underlying server list with an empty list to drive the LOGGER.error branch
+        Field providerField =
+            AbstractServerListManager.class.getDeclaredField("serverListProvider");
+        providerField.setAccessible(true);
+        ServerListProvider originalProvider = (ServerListProvider) providerField.get(mgr);
+        ServerListProvider empty = mock(ServerListProvider.class);
+        when(empty.getServerList()).thenReturn(java.util.Collections.emptyList());
+        providerField.set(mgr, empty);
+        try {
+            // Calling iterator() on an empty list logs the error but does not throw
+            assertThrows(NoSuchElementException.class, () -> mgr.iterator().next());
+        } finally {
+            providerField.set(mgr, originalProvider);
+        }
+    }
+    
+    @Test
     void testGenNextServerWithMockConcurrent()
         throws NacosException, NoSuchFieldException, IllegalAccessException {
         Properties properties = new Properties();

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/LimiterTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/LimiterTest.java
@@ -16,9 +16,14 @@
 
 package com.alibaba.nacos.client.config.impl;
 
+import com.google.common.cache.Cache;
+import com.google.common.util.concurrent.RateLimiter;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LimiterTest {
@@ -36,4 +41,27 @@ class LimiterTest {
         // assert  < limit 5qps
         assertTrue(elapse > 980);
     }
+    
+    @Test
+    void testIsLimitConstructor() {
+        // class loading; ensure default ctor is exercised for coverage.
+        assertNotNull(new Limiter());
+    }
+    
+    @Test
+    void testIsLimitTriggered() throws Exception {
+        // Replace cache with a low-rate limiter so a rapid burst triggers the limited path
+        Field cacheField = Limiter.class.getDeclaredField("CACHE");
+        cacheField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Cache<String, RateLimiter> cache = (Cache<String, RateLimiter>) cacheField.get(null);
+        cache.invalidateAll();
+        // Use very small rate so subsequent acquires get limited
+        RateLimiter slowLimiter = RateLimiter.create(0.0001);
+        cache.put("limited-key", slowLimiter);
+        // Drain initial permit; subsequent call should be limited
+        slowLimiter.tryAcquire();
+        assertTrue(Limiter.isLimit("limited-key"));
+    }
+    
 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/LocalConfigInfoProcessorTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/LocalConfigInfoProcessorTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.config.impl;
+
+import com.alibaba.nacos.client.config.utils.JvmUtil;
+import com.alibaba.nacos.client.config.utils.SnapShotSwitch;
+import com.alibaba.nacos.client.utils.ConcurrentDiskUtil;
+import com.alibaba.nacos.common.utils.IoUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalConfigInfoProcessorTest {
+    
+    private String envName;
+    
+    @BeforeEach
+    void setUp() {
+        envName = "envtest-" + UUID.randomUUID();
+        SnapShotSwitch.setIsSnapShot(true);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        LocalConfigInfoProcessor.cleanAllSnapshot();
+        SnapShotSwitch.setIsSnapShot(true);
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new LocalConfigInfoProcessor());
+    }
+    
+    @Test
+    void testGetFailoverNoFile() {
+        assertNull(LocalConfigInfoProcessor.getFailover(envName, "d", "g", null));
+    }
+    
+    @Test
+    void testGetFailoverWithFile() throws Exception {
+        File f = LocalConfigInfoProcessor.getFailoverFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "failover-content".getBytes(StandardCharsets.UTF_8));
+        assertEquals("failover-content",
+            LocalConfigInfoProcessor.getFailover(envName, "d", "g", null));
+    }
+    
+    @Test
+    void testGetFailoverWithTenant() throws Exception {
+        File f = LocalConfigInfoProcessor.getFailoverFile(envName, "d", "g", "tenant1");
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "failover-tenant".getBytes(StandardCharsets.UTF_8));
+        assertEquals("failover-tenant",
+            LocalConfigInfoProcessor.getFailover(envName, "d", "g", "tenant1"));
+    }
+    
+    @Test
+    void testGetSnapshotSnapShotSwitchOff() {
+        SnapShotSwitch.setIsSnapShot(false);
+        assertNull(LocalConfigInfoProcessor.getSnapshot(envName, "d", "g", null));
+    }
+    
+    @Test
+    void testGetSnapshotNoFile() {
+        assertNull(LocalConfigInfoProcessor.getSnapshot(envName, "d", "g", null));
+    }
+    
+    @Test
+    void testGetSnapshotWithFile() throws Exception {
+        File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "snap-content".getBytes(StandardCharsets.UTF_8));
+        assertEquals("snap-content",
+            LocalConfigInfoProcessor.getSnapshot(envName, "d", "g", null));
+    }
+    
+    @Test
+    void testGetSnapshotWithTenant() throws Exception {
+        File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", "tenant1");
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "snap-tenant".getBytes(StandardCharsets.UTF_8));
+        assertEquals("snap-tenant",
+            LocalConfigInfoProcessor.getSnapshot(envName, "d", "g", "tenant1"));
+    }
+    
+    @Test
+    void testReadFileMultiInstance() throws Exception {
+        File f = File.createTempFile("nacos-cfg-multi-", ".tmp");
+        f.deleteOnExit();
+        Files.write(f.toPath(), "multi".getBytes(StandardCharsets.UTF_8));
+        try (MockedStatic<JvmUtil> jvmMock = Mockito.mockStatic(JvmUtil.class)) {
+            jvmMock.when(JvmUtil::isMultiInstance).thenReturn(true);
+            try (MockedStatic<ConcurrentDiskUtil> diskMock =
+                Mockito.mockStatic(ConcurrentDiskUtil.class)) {
+                diskMock.when(() -> ConcurrentDiskUtil.getFileContent(Mockito.any(File.class),
+                    Mockito.anyString())).thenReturn("multi-via-cdu");
+                Method m = LocalConfigInfoProcessor.class.getDeclaredMethod("readFile",
+                    File.class);
+                m.setAccessible(true);
+                assertEquals("multi-via-cdu", m.invoke(null, f));
+            }
+        }
+    }
+    
+    @Test
+    void testReadFileNonExistReturnsNull() throws Exception {
+        Method m = LocalConfigInfoProcessor.class.getDeclaredMethod("readFile", File.class);
+        m.setAccessible(true);
+        File missing = new File("/non/existent/path/nacos-test-" + UUID.randomUUID());
+        assertNull(m.invoke(null, missing));
+    }
+    
+    @Test
+    void testSaveSnapshotSwitchOff() {
+        SnapShotSwitch.setIsSnapShot(false);
+        LocalConfigInfoProcessor.saveSnapshot(envName, "d", "g", null, "x");
+        // file should not be written
+        File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", null);
+        assertTrue(!f.exists());
+    }
+    
+    @Test
+    void testSaveSnapshotWithContent() {
+        LocalConfigInfoProcessor.saveSnapshot(envName, "d", "g", null, "save-me");
+        File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", null);
+        assertTrue(f.exists());
+    }
+    
+    @Test
+    void testSaveSnapshotMultiInstance() {
+        try (MockedStatic<JvmUtil> jvmMock = Mockito.mockStatic(JvmUtil.class)) {
+            jvmMock.when(JvmUtil::isMultiInstance).thenReturn(true);
+            LocalConfigInfoProcessor.saveSnapshot(envName, "d", "g", null, "save-multi");
+            File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", null);
+            assertTrue(f.exists());
+        }
+    }
+    
+    @Test
+    void testSaveSnapshotWithNullDeletes() throws Exception {
+        File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        assertTrue(f.exists());
+        LocalConfigInfoProcessor.saveSnapshot(envName, "d", "g", null, null);
+        assertTrue(!f.exists());
+    }
+    
+    @Test
+    void testCleanAllSnapshot() throws Exception {
+        File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        assertTrue(f.exists());
+        LocalConfigInfoProcessor.cleanAllSnapshot();
+        assertTrue(!f.exists());
+    }
+    
+    @Test
+    void testCleanEnvSnapshot() throws Exception {
+        File f = new File(LocalConfigInfoProcessor.LOCAL_SNAPSHOT_PATH,
+            envName + "_nacos/snapshot/test.txt");
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        LocalConfigInfoProcessor.cleanEnvSnapshot(envName);
+        assertTrue(!f.exists());
+    }
+    
+    @Test
+    void testGetFailoverIoExceptionReturnsNull() throws Exception {
+        File f = LocalConfigInfoProcessor.getFailoverFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        try (MockedStatic<JvmUtil> jvmMock = Mockito.mockStatic(JvmUtil.class)) {
+            jvmMock.when(JvmUtil::isMultiInstance).thenReturn(true);
+            try (MockedStatic<ConcurrentDiskUtil> cd =
+                Mockito.mockStatic(ConcurrentDiskUtil.class)) {
+                cd.when(() -> ConcurrentDiskUtil.getFileContent(Mockito.any(File.class),
+                    Mockito.anyString())).thenThrow(new IOException("forced"));
+                assertNull(LocalConfigInfoProcessor.getFailover(envName, "d", "g", null));
+            }
+        }
+    }
+    
+    @Test
+    void testGetSnapshotIoExceptionReturnsNull() throws Exception {
+        File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        try (MockedStatic<JvmUtil> jvmMock = Mockito.mockStatic(JvmUtil.class)) {
+            jvmMock.when(JvmUtil::isMultiInstance).thenReturn(true);
+            try (MockedStatic<ConcurrentDiskUtil> cd =
+                Mockito.mockStatic(ConcurrentDiskUtil.class)) {
+                cd.when(() -> ConcurrentDiskUtil.getFileContent(Mockito.any(File.class),
+                    Mockito.anyString())).thenThrow(new IOException("forced"));
+                assertNull(LocalConfigInfoProcessor.getSnapshot(envName, "d", "g", null));
+            }
+        }
+    }
+    
+    @Test
+    void testSaveSnapshotDeleteIoExceptionSwallowed() throws Exception {
+        // Pre-create file
+        File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        try (MockedStatic<IoUtils> ioMock = Mockito.mockStatic(IoUtils.class)) {
+            ioMock.when(() -> IoUtils.delete(Mockito.any(File.class)))
+                .thenThrow(new IOException("forced"));
+            // Should swallow the IOException
+            LocalConfigInfoProcessor.saveSnapshot(envName, "d", "g", null, null);
+        }
+    }
+    
+    @Test
+    void testSaveSnapshotWriteIoExceptionSwallowed() throws Exception {
+        try (MockedStatic<IoUtils> ioMock = Mockito.mockStatic(IoUtils.class)) {
+            ioMock
+                .when(() -> IoUtils.writeStringToFile(Mockito.any(File.class), Mockito.anyString(),
+                    Mockito.anyString()))
+                .thenThrow(new IOException("forced"));
+            // Should swallow the IOException
+            LocalConfigInfoProcessor.saveSnapshot(envName, "d", "g", null, "content");
+        }
+    }
+    
+    @Test
+    void testCleanAllSnapshotIoExceptionSwallowed() throws Exception {
+        // Pre-create a snapshot directory ending with SUFFIX so listFiles is non-empty
+        File f = LocalConfigInfoProcessor.getSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        try (MockedStatic<IoUtils> ioMock = Mockito.mockStatic(IoUtils.class)) {
+            ioMock.when(() -> IoUtils.cleanDirectory(Mockito.any(File.class)))
+                .thenThrow(new IOException("forced"));
+            // Should swallow the IOException
+            LocalConfigInfoProcessor.cleanAllSnapshot();
+        }
+    }
+    
+    @Test
+    void testCleanEnvSnapshotIoExceptionSwallowed() throws Exception {
+        try (MockedStatic<IoUtils> ioMock = Mockito.mockStatic(IoUtils.class)) {
+            ioMock.when(() -> IoUtils.cleanDirectory(Mockito.any(File.class)))
+                .thenThrow(new IOException("forced"));
+            // Should swallow the IOException
+            LocalConfigInfoProcessor.cleanEnvSnapshot(envName);
+        }
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/LocalEncryptedDataKeyProcessorTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/LocalEncryptedDataKeyProcessorTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.config.impl;
+
+import com.alibaba.nacos.client.config.utils.JvmUtil;
+import com.alibaba.nacos.client.config.utils.SnapShotSwitch;
+import com.alibaba.nacos.client.utils.ConcurrentDiskUtil;
+import com.alibaba.nacos.common.utils.IoUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalEncryptedDataKeyProcessorTest {
+    
+    private String envName;
+    
+    @BeforeEach
+    void setUp() {
+        envName = "envenc-" + UUID.randomUUID();
+        SnapShotSwitch.setIsSnapShot(true);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        LocalConfigInfoProcessor.cleanAllSnapshot();
+        SnapShotSwitch.setIsSnapShot(true);
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new LocalEncryptedDataKeyProcessor());
+    }
+    
+    private File invokePrivateGetFailoverFile(String env, String dataId, String group,
+        String tenant) throws Exception {
+        Method m = LocalEncryptedDataKeyProcessor.class.getDeclaredMethod(
+            "getEncryptDataKeyFailoverFile", String.class, String.class, String.class,
+            String.class);
+        m.setAccessible(true);
+        return (File) m.invoke(null, env, dataId, group, tenant);
+    }
+    
+    private File invokePrivateGetSnapshotFile(String env, String dataId, String group,
+        String tenant) throws Exception {
+        Method m = LocalEncryptedDataKeyProcessor.class.getDeclaredMethod(
+            "getEncryptDataKeySnapshotFile", String.class, String.class, String.class,
+            String.class);
+        m.setAccessible(true);
+        return (File) m.invoke(null, env, dataId, group, tenant);
+    }
+    
+    @Test
+    void testGetEncryptDataKeyFailoverNoFile() {
+        assertNull(LocalEncryptedDataKeyProcessor.getEncryptDataKeyFailover(envName, "d", "g",
+            null));
+    }
+    
+    @Test
+    void testGetEncryptDataKeyFailoverWithFile() throws Exception {
+        File f = invokePrivateGetFailoverFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "ek-failover".getBytes(StandardCharsets.UTF_8));
+        assertEquals("ek-failover",
+            LocalEncryptedDataKeyProcessor.getEncryptDataKeyFailover(envName, "d", "g", null));
+    }
+    
+    @Test
+    void testGetEncryptDataKeyFailoverWithTenant() throws Exception {
+        File f = invokePrivateGetFailoverFile(envName, "d", "g", "tenantA");
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "ek-failover-t".getBytes(StandardCharsets.UTF_8));
+        assertEquals("ek-failover-t",
+            LocalEncryptedDataKeyProcessor.getEncryptDataKeyFailover(envName, "d", "g",
+                "tenantA"));
+    }
+    
+    @Test
+    void testGetEncryptDataKeySnapshotSwitchOff() {
+        SnapShotSwitch.setIsSnapShot(false);
+        assertNull(LocalEncryptedDataKeyProcessor.getEncryptDataKeySnapshot(envName, "d", "g",
+            null));
+    }
+    
+    @Test
+    void testGetEncryptDataKeySnapshotNoFile() {
+        assertNull(LocalEncryptedDataKeyProcessor.getEncryptDataKeySnapshot(envName, "d", "g",
+            null));
+    }
+    
+    @Test
+    void testGetEncryptDataKeySnapshotWithFile() throws Exception {
+        File f = invokePrivateGetSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "ek-snap".getBytes(StandardCharsets.UTF_8));
+        assertEquals("ek-snap",
+            LocalEncryptedDataKeyProcessor.getEncryptDataKeySnapshot(envName, "d", "g", null));
+    }
+    
+    @Test
+    void testGetEncryptDataKeySnapshotWithTenant() throws Exception {
+        File f = invokePrivateGetSnapshotFile(envName, "d", "g", "tenantA");
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "ek-snap-t".getBytes(StandardCharsets.UTF_8));
+        assertEquals("ek-snap-t",
+            LocalEncryptedDataKeyProcessor.getEncryptDataKeySnapshot(envName, "d", "g",
+                "tenantA"));
+    }
+    
+    @Test
+    void testSaveEncryptDataKeySnapshotSwitchOff() throws Exception {
+        SnapShotSwitch.setIsSnapShot(false);
+        LocalEncryptedDataKeyProcessor.saveEncryptDataKeySnapshot(envName, "d", "g", null, "ek");
+        File f = invokePrivateGetSnapshotFile(envName, "d", "g", null);
+        assertTrue(!f.exists());
+    }
+    
+    @Test
+    void testSaveEncryptDataKeySnapshotWithContent() throws Exception {
+        LocalEncryptedDataKeyProcessor.saveEncryptDataKeySnapshot(envName, "d", "g", null,
+            "save-ek");
+        File f = invokePrivateGetSnapshotFile(envName, "d", "g", null);
+        assertTrue(f.exists());
+    }
+    
+    @Test
+    void testSaveEncryptDataKeySnapshotWithContentMultiInstance() throws Exception {
+        try (MockedStatic<JvmUtil> jvmMock = Mockito.mockStatic(JvmUtil.class)) {
+            jvmMock.when(JvmUtil::isMultiInstance).thenReturn(true);
+            LocalEncryptedDataKeyProcessor.saveEncryptDataKeySnapshot(envName, "d", "g", null,
+                "save-multi");
+            File f = invokePrivateGetSnapshotFile(envName, "d", "g", null);
+            assertTrue(f.exists());
+        }
+    }
+    
+    @Test
+    void testSaveEncryptDataKeySnapshotWithNullDeletes() throws Exception {
+        File f = invokePrivateGetSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        assertTrue(f.exists());
+        LocalEncryptedDataKeyProcessor.saveEncryptDataKeySnapshot(envName, "d", "g", null, null);
+        assertTrue(!f.exists());
+    }
+    
+    @Test
+    void testSaveEncryptDataKeySnapshotWithTenant() throws Exception {
+        LocalEncryptedDataKeyProcessor.saveEncryptDataKeySnapshot(envName, "d", "g", "tenantA",
+            "save-with-tenant");
+        File f = invokePrivateGetSnapshotFile(envName, "d", "g", "tenantA");
+        assertTrue(f.exists());
+    }
+    
+    @Test
+    void testGetEncryptDataKeyFailoverIoExceptionReturnsNull() throws Exception {
+        File f = invokePrivateGetFailoverFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        try (MockedStatic<JvmUtil> jvmMock = Mockito.mockStatic(JvmUtil.class)) {
+            jvmMock.when(JvmUtil::isMultiInstance).thenReturn(true);
+            try (MockedStatic<ConcurrentDiskUtil> cd =
+                Mockito.mockStatic(ConcurrentDiskUtil.class)) {
+                cd.when(() -> ConcurrentDiskUtil.getFileContent(Mockito.any(File.class),
+                    Mockito.anyString())).thenThrow(new IOException("forced"));
+                assertNull(LocalEncryptedDataKeyProcessor.getEncryptDataKeyFailover(envName, "d",
+                    "g", null));
+            }
+        }
+    }
+    
+    @Test
+    void testGetEncryptDataKeySnapshotIoExceptionReturnsNull() throws Exception {
+        File f = invokePrivateGetSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        try (MockedStatic<JvmUtil> jvmMock = Mockito.mockStatic(JvmUtil.class)) {
+            jvmMock.when(JvmUtil::isMultiInstance).thenReturn(true);
+            try (MockedStatic<ConcurrentDiskUtil> cd =
+                Mockito.mockStatic(ConcurrentDiskUtil.class)) {
+                cd.when(() -> ConcurrentDiskUtil.getFileContent(Mockito.any(File.class),
+                    Mockito.anyString())).thenThrow(new IOException("forced"));
+                assertNull(LocalEncryptedDataKeyProcessor.getEncryptDataKeySnapshot(envName,
+                    "d", "g", null));
+            }
+        }
+    }
+    
+    @Test
+    void testSaveEncryptDataKeySnapshotDeleteIoExceptionSwallowed() throws Exception {
+        File f = invokePrivateGetSnapshotFile(envName, "d", "g", null);
+        f.getParentFile().mkdirs();
+        Files.write(f.toPath(), "x".getBytes(StandardCharsets.UTF_8));
+        try (MockedStatic<IoUtils> ioMock = Mockito.mockStatic(IoUtils.class)) {
+            ioMock.when(() -> IoUtils.delete(Mockito.any(File.class)))
+                .thenThrow(new IOException("forced"));
+            // Null content takes the delete branch
+            LocalEncryptedDataKeyProcessor.saveEncryptDataKeySnapshot(envName, "d", "g", null,
+                null);
+        }
+    }
+    
+    @Test
+    void testSaveEncryptDataKeySnapshotWriteIoExceptionSwallowed() throws Exception {
+        try (MockedStatic<IoUtils> ioMock = Mockito.mockStatic(IoUtils.class)) {
+            ioMock
+                .when(() -> IoUtils.writeStringToFile(Mockito.any(File.class), Mockito.anyString(),
+                    Mockito.anyString()))
+                .thenThrow(new IOException("forced"));
+            LocalEncryptedDataKeyProcessor.saveEncryptDataKeySnapshot(envName, "d", "g", null,
+                "ek-content");
+        }
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/YmlChangeParserTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/YmlChangeParserTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,6 +89,40 @@ class YmlChangeParserTest {
                     + "    !!java.net.URL [\"http://[yourhost]:[port]/yaml-payload.jar\"]\n"
                     + "  ]]\n" + "]",
                 type);
+        });
+    }
+    
+    @Test
+    void testEmptyCollectionValue() throws IOException {
+        // collection value empty -> falls into the `result.put(key, "")` branch.
+        Map<String, ConfigChangeItem> map = parser.doParse("", "list: []\n", type);
+        assertNotNull(map.get("list"));
+        assertEquals("", map.get("list").getNewValue());
+    }
+    
+    @Test
+    void testNonStringScalarValue() throws IOException {
+        // numeric scalar -> falls into the `else { result.put(key, e.getValue()) }` branch.
+        Map<String, ConfigChangeItem> map = parser.doParse("", "count: 123\n", type);
+        assertNotNull(map.get("count"));
+        assertEquals("123", map.get("count").getNewValue());
+    }
+    
+    @Test
+    void testCollectionOfScalars() throws IOException {
+        Map<String, ConfigChangeItem> map = parser.doParse("",
+            "items:\n  - 1\n  - 2\n  - 3\n", type);
+        assertNotNull(map.get("items[0]"));
+        assertEquals("1", map.get("items[0]").getNewValue());
+        assertEquals("2", map.get("items[1]").getNewValue());
+        assertEquals("3", map.get("items[2]").getNewValue());
+    }
+    
+    @Test
+    void testInvalidYamlSyntaxRethrown() {
+        // a MarkedYAMLException whose message does NOT match constructor error => rethrown as-is.
+        assertThrows(org.yaml.snakeyaml.error.MarkedYAMLException.class, () -> {
+            parser.doParse("", "a: : :\n", type);
         });
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/lock/core/NLockFactoryTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/lock/core/NLockFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,33 @@
  * limitations under the License.
  */
 
-package com.alibaba.nacos.client.utils;
+package com.alibaba.nacos.client.lock.core;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-class PreInitUtilsTest {
-    
-    @Test
-    void testAsyncPreLoadCostComponent() throws InterruptedException {
-        // There is no things need to be assert.
-        // The method will called when nacos-client init to async to load some components to reduce the sync load time.
-        PreInitUtils.asyncPreLoadCostComponent();
-        // No exception is ok.
-        // Let async thread run completed
-        TimeUnit.SECONDS.sleep(2);
-    }
+class NLockFactoryTest {
     
     @Test
     void testConstructor() {
-        assertNotNull(new PreInitUtils());
+        assertNotNull(new NLockFactory());
+    }
+    
+    @Test
+    void testGetLockWithoutExpireTime() {
+        NLock lock = NLockFactory.getLock("k");
+        assertNotNull(lock);
+        assertEquals("k", lock.getKey());
+        assertEquals(-1L, lock.getExpiredTime());
+    }
+    
+    @Test
+    void testGetLockWithExpireTime() {
+        NLock lock = NLockFactory.getLock("k", 1000L);
+        assertNotNull(lock);
+        assertEquals("k", lock.getKey());
+        assertEquals(1000L, lock.getExpiredTime());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/logging/NacosLoggingTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/logging/NacosLoggingTest.java
@@ -19,19 +19,29 @@
 package com.alibaba.nacos.client.logging;
 
 import com.alibaba.nacos.common.logging.NacosLoggingAdapter;
+import com.alibaba.nacos.common.logging.NacosLoggingAdapterBuilder;
 import com.alibaba.nacos.common.logging.NacosLoggingProperties;
+import com.alibaba.nacos.common.spi.NacosServiceLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NacosLoggingTest {
@@ -82,6 +92,66 @@ class NacosLoggingTest {
             // without exception thrown
         } finally {
             nacosLoggingField.set(instance, cachedLogging);
+        }
+    }
+    
+    @Test
+    void testInitLoggingAdapterMatchesBuilder() throws Exception {
+        NacosLoggingAdapter mockAdapter = mock(NacosLoggingAdapter.class);
+        when(mockAdapter.isEnabled()).thenReturn(true);
+        when(mockAdapter.isAdaptedLogger(any())).thenReturn(true);
+        when(mockAdapter.getDefaultConfigLocation()).thenReturn("test.xml");
+        NacosLoggingAdapterBuilder builder = mock(NacosLoggingAdapterBuilder.class);
+        when(builder.build()).thenReturn(mockAdapter);
+        try (MockedStatic<NacosServiceLoader> mocked =
+            Mockito.mockStatic(NacosServiceLoader.class)) {
+            mocked.when(() -> NacosServiceLoader.load(NacosLoggingAdapterBuilder.class))
+                .thenReturn(Collections.singletonList(builder));
+            Constructor<NacosLogging> ctor = NacosLogging.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            NacosLogging fresh = ctor.newInstance();
+            Field adapterField = NacosLogging.class.getDeclaredField("loggingAdapter");
+            adapterField.setAccessible(true);
+            assertSame(mockAdapter, adapterField.get(fresh));
+            Field propsField = NacosLogging.class.getDeclaredField("loggingProperties");
+            propsField.setAccessible(true);
+            assertNotNull(propsField.get(fresh));
+        }
+    }
+    
+    @Test
+    void testInitLoggingAdapterDisabledAdapterIgnored() throws Exception {
+        NacosLoggingAdapter mockAdapter = mock(NacosLoggingAdapter.class);
+        when(mockAdapter.isEnabled()).thenReturn(false);
+        NacosLoggingAdapterBuilder builder = mock(NacosLoggingAdapterBuilder.class);
+        when(builder.build()).thenReturn(mockAdapter);
+        try (MockedStatic<NacosServiceLoader> mocked =
+            Mockito.mockStatic(NacosServiceLoader.class)) {
+            mocked.when(() -> NacosServiceLoader.load(NacosLoggingAdapterBuilder.class))
+                .thenReturn(Collections.singletonList(builder));
+            Constructor<NacosLogging> ctor = NacosLogging.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            NacosLogging fresh = ctor.newInstance();
+            Field adapterField = NacosLogging.class.getDeclaredField("loggingAdapter");
+            adapterField.setAccessible(true);
+            assertNull(adapterField.get(fresh));
+        }
+    }
+    
+    @Test
+    void testInitLoggingAdapterBuilderThrows() throws Exception {
+        NacosLoggingAdapterBuilder builder = mock(NacosLoggingAdapterBuilder.class);
+        when(builder.build()).thenThrow(new RuntimeException("forced"));
+        try (MockedStatic<NacosServiceLoader> mocked =
+            Mockito.mockStatic(NacosServiceLoader.class)) {
+            mocked.when(() -> NacosServiceLoader.load(NacosLoggingAdapterBuilder.class))
+                .thenReturn(Collections.singletonList(builder));
+            Constructor<NacosLogging> ctor = NacosLogging.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            NacosLogging fresh = ctor.newInstance();
+            Field adapterField = NacosLogging.class.getDeclaredField("loggingAdapter");
+            adapterField.setAccessible(true);
+            assertNull(adapterField.get(fresh));
         }
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/monitor/MetricsMonitorTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/monitor/MetricsMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,16 @@
  * limitations under the License.
  */
 
-package com.alibaba.nacos.client.utils;
+package com.alibaba.nacos.client.monitor;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-class PreInitUtilsTest {
-    
-    @Test
-    void testAsyncPreLoadCostComponent() throws InterruptedException {
-        // There is no things need to be assert.
-        // The method will called when nacos-client init to async to load some components to reduce the sync load time.
-        PreInitUtils.asyncPreLoadCostComponent();
-        // No exception is ok.
-        // Let async thread run completed
-        TimeUnit.SECONDS.sleep(2);
-    }
+class MetricsMonitorTest {
     
     @Test
     void testConstructor() {
-        assertNotNull(new PreInitUtils());
+        assertNotNull(new MetricsMonitor());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/NacosNamingServiceTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/NacosNamingServiceTest.java
@@ -22,9 +22,12 @@ import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.listener.EventListener;
+import com.alibaba.nacos.api.naming.listener.FuzzyWatchEventWatcher;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
 import com.alibaba.nacos.api.selector.AbstractSelector;
+import com.alibaba.nacos.client.naming.cache.NamingFuzzyWatchContext;
+import com.alibaba.nacos.client.naming.cache.NamingFuzzyWatchServiceListHolder;
 import com.alibaba.nacos.client.naming.cache.ServiceInfoHolder;
 import com.alibaba.nacos.client.naming.event.InstancesChangeEvent;
 import com.alibaba.nacos.client.naming.event.InstancesChangeNotifier;
@@ -1283,5 +1286,181 @@ class NacosNamingServiceTest {
         instance.setClusterName(clusterName);
         instance.setHealthy(healthy);
         return instance;
+    }
+    
+    @Test
+    void testSelectInstancesEmptyServiceInfoReturnsEmptyList() throws NacosException {
+        String serviceName = "service-empty";
+        when(proxy.queryInstancesOfService(serviceName, Constants.DEFAULT_GROUP, "", false))
+            .thenReturn(null);
+        List<Instance> result = client.selectInstances(serviceName, true, false);
+        assertTrue(result.isEmpty());
+    }
+    
+    @Test
+    void testSelectInstancesFromFailover() throws NacosException {
+        String serviceName = "svc-failover";
+        ServiceInfo failoverInfo = new ServiceInfo();
+        failoverInfo.setName(serviceName);
+        failoverInfo.addHost(mockInstance(Constants.DEFAULT_CLUSTER_NAME, true));
+        when(serviceInfoHolder.isFailoverSwitch()).thenReturn(true);
+        when(serviceInfoHolder.getFailoverServiceInfo(serviceName, Constants.DEFAULT_GROUP))
+            .thenReturn(failoverInfo);
+        List<Instance> result = client.selectInstances(serviceName, true);
+        assertEquals(1, result.size());
+        verify(proxy, never()).subscribe(anyString(), anyString(), anyString());
+    }
+    
+    @Test
+    void testSelectInstancesFailoverEmptyFallsBackToSubscribe() throws NacosException {
+        String serviceName = "svc-failover-empty";
+        ServiceInfo emptyFailover = new ServiceInfo();
+        emptyFailover.setName(serviceName);
+        when(serviceInfoHolder.isFailoverSwitch()).thenReturn(true);
+        when(serviceInfoHolder.getFailoverServiceInfo(serviceName, Constants.DEFAULT_GROUP))
+            .thenReturn(emptyFailover);
+        ServiceInfo subscribed = new ServiceInfo();
+        subscribed.setName(serviceName);
+        subscribed.addHost(mockInstance(Constants.DEFAULT_CLUSTER_NAME, true));
+        when(proxy.subscribe(serviceName, Constants.DEFAULT_GROUP, "")).thenReturn(subscribed);
+        List<Instance> result = client.selectInstances(serviceName, true);
+        assertEquals(1, result.size());
+    }
+    
+    @Test
+    void testTryToSubscribeUsesCacheWhenAlreadySubscribed() throws NacosException {
+        String serviceName = "svc-cached";
+        ServiceInfo cached = new ServiceInfo();
+        cached.setName(serviceName);
+        cached.addHost(mockInstance(Constants.DEFAULT_CLUSTER_NAME, true));
+        when(serviceInfoHolder.getServiceInfo(serviceName, Constants.DEFAULT_GROUP))
+            .thenReturn(cached);
+        when(proxy.isSubscribed(serviceName, Constants.DEFAULT_GROUP, "")).thenReturn(true);
+        List<Instance> result = client.selectInstances(serviceName, true);
+        assertEquals(1, result.size());
+        verify(proxy, never()).subscribe(anyString(), anyString(), anyString());
+    }
+    
+    @Test
+    void testTryToSubscribeSwallowsSubscribeFailureAndUsesCache() throws NacosException {
+        String serviceName = "svc-cached-not-subscribed";
+        ServiceInfo cached = new ServiceInfo();
+        cached.setName(serviceName);
+        cached.addHost(mockInstance(Constants.DEFAULT_CLUSTER_NAME, true));
+        when(serviceInfoHolder.getServiceInfo(serviceName, Constants.DEFAULT_GROUP))
+            .thenReturn(cached);
+        when(proxy.isSubscribed(serviceName, Constants.DEFAULT_GROUP, "")).thenReturn(false);
+        when(proxy.subscribe(serviceName, Constants.DEFAULT_GROUP, ""))
+            .thenThrow(new NacosException(500, "boom"));
+        List<Instance> result = client.selectInstances(serviceName, true);
+        assertEquals(1, result.size());
+    }
+    
+    @Test
+    void testFuzzyWatchWithFixedGroupName() throws Exception {
+        NamingFuzzyWatchServiceListHolder holder =
+            org.mockito.Mockito.mock(NamingFuzzyWatchServiceListHolder.class);
+        NamingFuzzyWatchContext ctx = org.mockito.Mockito.mock(NamingFuzzyWatchContext.class);
+        when(holder.registerFuzzyWatcher(anyString(),
+            org.mockito.ArgumentMatchers.any(FuzzyWatchEventWatcher.class))).thenReturn(ctx);
+        Field f = NacosNamingService.class.getDeclaredField("namingFuzzyWatchServiceListHolder");
+        f.setAccessible(true);
+        f.set(client, holder);
+        FuzzyWatchEventWatcher watcher =
+            org.mockito.Mockito.mock(FuzzyWatchEventWatcher.class);
+        client.fuzzyWatch("test-group", watcher);
+        verify(holder).registerFuzzyWatcher(anyString(), eq(watcher));
+    }
+    
+    @Test
+    void testFuzzyWatchWithPatterns() throws Exception {
+        NamingFuzzyWatchServiceListHolder holder =
+            org.mockito.Mockito.mock(NamingFuzzyWatchServiceListHolder.class);
+        NamingFuzzyWatchContext ctx = org.mockito.Mockito.mock(NamingFuzzyWatchContext.class);
+        when(holder.registerFuzzyWatcher(anyString(),
+            org.mockito.ArgumentMatchers.any(FuzzyWatchEventWatcher.class))).thenReturn(ctx);
+        Field f = NacosNamingService.class.getDeclaredField("namingFuzzyWatchServiceListHolder");
+        f.setAccessible(true);
+        f.set(client, holder);
+        FuzzyWatchEventWatcher watcher =
+            org.mockito.Mockito.mock(FuzzyWatchEventWatcher.class);
+        client.fuzzyWatch("svc-*", "grp-*", watcher);
+        verify(holder).registerFuzzyWatcher(anyString(), eq(watcher));
+    }
+    
+    @Test
+    void testFuzzyWatchWithKeysReturnsFuture() throws Exception {
+        NamingFuzzyWatchServiceListHolder holder =
+            org.mockito.Mockito.mock(NamingFuzzyWatchServiceListHolder.class);
+        NamingFuzzyWatchContext ctx = org.mockito.Mockito.mock(NamingFuzzyWatchContext.class);
+        when(holder.registerFuzzyWatcher(anyString(),
+            org.mockito.ArgumentMatchers.any(FuzzyWatchEventWatcher.class))).thenReturn(ctx);
+        when(ctx.createNewFuture())
+            .thenReturn(org.mockito.Mockito.mock(java.util.concurrent.Future.class));
+        Field f = NacosNamingService.class.getDeclaredField("namingFuzzyWatchServiceListHolder");
+        f.setAccessible(true);
+        f.set(client, holder);
+        FuzzyWatchEventWatcher watcher =
+            org.mockito.Mockito.mock(FuzzyWatchEventWatcher.class);
+        assertNotNull(client.fuzzyWatchWithServiceKeys("test-grp", watcher));
+        assertNotNull(client.fuzzyWatchWithServiceKeys("svc-*", "grp-*", watcher));
+    }
+    
+    @Test
+    void testFuzzyWatchNullWatcherReturnsNullFuture() throws Exception {
+        // null watcher means doFuzzyWatch returns null
+        java.util.concurrent.Future<?> result =
+            client.fuzzyWatchWithServiceKeys("group", null);
+        assertEquals(null, result);
+    }
+    
+    @Test
+    void testCancelFuzzyWatchWithFixedGroup() throws Exception {
+        NamingFuzzyWatchServiceListHolder holder =
+            org.mockito.Mockito.mock(NamingFuzzyWatchServiceListHolder.class);
+        NamingFuzzyWatchContext ctx = org.mockito.Mockito.mock(NamingFuzzyWatchContext.class);
+        when(holder.getFuzzyWatchContext(anyString())).thenReturn(ctx);
+        Field f = NacosNamingService.class.getDeclaredField("namingFuzzyWatchServiceListHolder");
+        f.setAccessible(true);
+        f.set(client, holder);
+        FuzzyWatchEventWatcher watcher =
+            org.mockito.Mockito.mock(FuzzyWatchEventWatcher.class);
+        client.cancelFuzzyWatch("group", watcher);
+        verify(ctx).removeWatcher(watcher);
+    }
+    
+    @Test
+    void testCancelFuzzyWatchWithPatterns() throws Exception {
+        NamingFuzzyWatchServiceListHolder holder =
+            org.mockito.Mockito.mock(NamingFuzzyWatchServiceListHolder.class);
+        NamingFuzzyWatchContext ctx = org.mockito.Mockito.mock(NamingFuzzyWatchContext.class);
+        when(holder.getFuzzyWatchContext(anyString())).thenReturn(ctx);
+        Field f = NacosNamingService.class.getDeclaredField("namingFuzzyWatchServiceListHolder");
+        f.setAccessible(true);
+        f.set(client, holder);
+        FuzzyWatchEventWatcher watcher =
+            org.mockito.Mockito.mock(FuzzyWatchEventWatcher.class);
+        client.cancelFuzzyWatch("svc-*", "grp-*", watcher);
+        verify(ctx).removeWatcher(watcher);
+    }
+    
+    @Test
+    void testCancelFuzzyWatchNullWatcherNoOp() throws Exception {
+        client.cancelFuzzyWatch("group", null);
+        // No exception, no interaction expected
+    }
+    
+    @Test
+    void testCancelFuzzyWatchNoContextNoOp() throws Exception {
+        NamingFuzzyWatchServiceListHolder holder =
+            org.mockito.Mockito.mock(NamingFuzzyWatchServiceListHolder.class);
+        when(holder.getFuzzyWatchContext(anyString())).thenReturn(null);
+        Field f = NacosNamingService.class.getDeclaredField("namingFuzzyWatchServiceListHolder");
+        f.setAccessible(true);
+        f.set(client, holder);
+        FuzzyWatchEventWatcher watcher =
+            org.mockito.Mockito.mock(FuzzyWatchEventWatcher.class);
+        client.cancelFuzzyWatch("group", watcher);
+        // No NPE on null context
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/cache/DiskCacheTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/cache/DiskCacheTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -157,5 +158,10 @@ class DiskCacheTest {
     void testGetLineSeparator() {
         String lineSeparator = DiskCache.getLineSeparator();
         assertTrue(lineSeparator.length() > 0);
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new DiskCache());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/cache/FuzzyWatchEventWatcherWrapperTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/cache/FuzzyWatchEventWatcherWrapperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.naming.cache;
+
+import com.alibaba.nacos.api.naming.listener.FuzzyWatchEventWatcher;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FuzzyWatchEventWatcherWrapperTest {
+    
+    @Test
+    void testGetUuidAndSyncServiceKeys() {
+        FuzzyWatchEventWatcher watcher = Mockito.mock(FuzzyWatchEventWatcher.class);
+        FuzzyWatchEventWatcherWrapper wrapper = new FuzzyWatchEventWatcherWrapper(watcher);
+        assertNotNull(wrapper.getUuid());
+        assertTrue(wrapper.getSyncServiceKeys().isEmpty());
+    }
+    
+    @Test
+    void testEqualsAndHashCode() {
+        FuzzyWatchEventWatcher watcher = Mockito.mock(FuzzyWatchEventWatcher.class);
+        FuzzyWatchEventWatcherWrapper wrapper = new FuzzyWatchEventWatcherWrapper(watcher);
+        assertEquals(wrapper, wrapper);
+        assertNotEquals(wrapper, null);
+        assertNotEquals(wrapper, new Object());
+        
+        // equals only compares the watcher reference
+        FuzzyWatchEventWatcherWrapper sameWatcher = new FuzzyWatchEventWatcherWrapper(watcher);
+        assertEquals(wrapper, sameWatcher);
+        assertEquals(wrapper.hashCode(), sameWatcher.hashCode());
+        
+        FuzzyWatchEventWatcher otherWatcher = Mockito.mock(FuzzyWatchEventWatcher.class);
+        FuzzyWatchEventWatcherWrapper diff = new FuzzyWatchEventWatcherWrapper(otherWatcher);
+        assertNotEquals(wrapper, diff);
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/naming/core/BalancerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/core/BalancerTest.java
@@ -66,4 +66,11 @@ class BalancerTest {
         });
         assertTrue(exception.getMessage().contains("no host to srv for serviceInfo: null"));
     }
+    
+    @Test
+    void testDefaultConstructors() {
+        // exercise default constructors so JaCoCo accounts for the class declaration lines
+        org.junit.jupiter.api.Assertions.assertNotNull(new Balancer());
+        org.junit.jupiter.api.Assertions.assertNotNull(new Balancer.RandomByWeight());
+    }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/event/InstancesChangeNotifierTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/event/InstancesChangeNotifierTest.java
@@ -173,4 +173,23 @@ class InstancesChangeNotifierTest {
     void testSubscribeType() {
         assertEquals(InstancesChangeEvent.class, instancesChangeNotifier.subscribeType());
     }
+    
+    @Test
+    void testRegisterListenerWithNullWrapper() {
+        instancesChangeNotifier.registerListener(GROUP_CASE, SERVICE_NAME_CASE, null);
+        assertFalse(instancesChangeNotifier.isSubscribed(GROUP_CASE, SERVICE_NAME_CASE));
+    }
+    
+    @Test
+    void testDeregisterListenerWithNullWrapper() {
+        instancesChangeNotifier.deregisterListener(GROUP_CASE, SERVICE_NAME_CASE, null);
+        assertFalse(instancesChangeNotifier.isSubscribed(GROUP_CASE, SERVICE_NAME_CASE));
+    }
+    
+    @Test
+    void testJustForTestConstructor() {
+        InstancesChangeNotifier notifier = new InstancesChangeNotifier();
+        // event scope is generated and not null
+        assertEquals(InstancesChangeEvent.class, notifier.subscribeType());
+    }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/event/NamingFuzzyWatchNotifyEventTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/event/NamingFuzzyWatchNotifyEventTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.naming.event;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class NamingFuzzyWatchNotifyEventTest {
+    
+    @Test
+    void buildWithoutWatcherUuid() {
+        NamingFuzzyWatchNotifyEvent event = NamingFuzzyWatchNotifyEvent.build("scope", "pattern",
+            "serviceKey", "ADD", "FULL");
+        assertEquals("scope", event.scope());
+        assertEquals("scope", event.getScope());
+        assertEquals("pattern", event.getPattern());
+        assertEquals("serviceKey", event.getServiceKey());
+        assertEquals("ADD", event.getChangedType());
+        assertEquals("FULL", event.getSyncType());
+        assertNull(event.getWatcherUuid());
+    }
+    
+    @Test
+    void buildWithWatcherUuid() {
+        NamingFuzzyWatchNotifyEvent event = NamingFuzzyWatchNotifyEvent.build("scope", "pattern",
+            "serviceKey", "ADD", "FULL", "watcher-1");
+        assertEquals("watcher-1", event.getWatcherUuid());
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/redo/data/BatchInstanceRedoDataTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/remote/gprc/redo/data/BatchInstanceRedoDataTest.java
@@ -53,4 +53,14 @@ class BatchInstanceRedoDataTest {
         redoData2.getInstances().get(0).setIp("1.1.1.1");
         assertNotEquals(redoData1.hashCode(), redoData2.hashCode());
     }
+    
+    @Test
+    @SuppressWarnings("all")
+    void testEqualsWithDifferentType() {
+        BatchInstanceRedoData redoData = new BatchInstanceRedoData("a", "b");
+        redoData.setInstances(Collections.singletonList(new Instance()));
+        // not a BatchInstanceRedoData -> equals returns false at the early instanceof check
+        assertNotEquals(redoData, new Object());
+        assertNotEquals(redoData, "string");
+    }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/selector/NamingListenerInvokerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/selector/NamingListenerInvokerTest.java
@@ -83,5 +83,18 @@ public class NamingListenerInvokerTest {
         assertNotEquals(invoker1, invoker3);
         assertNotEquals(null, invoker1);
         assertEquals(invoker1, invoker1);
+        // different concrete class -> not equal
+        assertNotEquals(invoker1, new Object());
+    }
+    
+    @Test
+    public void testInvokeWithExecutor() {
+        AbstractEventListener listener = mock(AbstractEventListener.class);
+        java.util.concurrent.Executor executor = mock(java.util.concurrent.Executor.class);
+        org.mockito.Mockito.when(listener.getExecutor()).thenReturn(executor);
+        NamingListenerInvoker listenerInvoker = new NamingListenerInvoker(listener);
+        NamingEvent event = new NamingEvent("serviceName", Collections.emptyList());
+        listenerInvoker.invoke(event);
+        verify(executor).execute(org.mockito.ArgumentMatchers.any(Runnable.class));
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/selector/NamingSelectorFactoryTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/selector/NamingSelectorFactoryTest.java
@@ -173,6 +173,27 @@ public class NamingSelectorFactoryTest {
     }
     
     @Test
+    public void testNewIpSelectorWithNullRegex() {
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+            () -> NamingSelectorFactory.newIpSelector(null));
+    }
+    
+    @Test
+    public void testNewMetadataSelectorWithNullMetadata() {
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+            () -> NamingSelectorFactory.newMetadataSelector(null));
+    }
+    
+    @Test
+    public void testClusterSelectorEqualsNullAndOther() {
+        NamingSelector selector =
+            NamingSelectorFactory.newClusterSelector(Collections.singletonList("a"));
+        assertNotEquals(selector, null);
+        assertNotEquals(selector, new Object());
+        assertEquals(selector, selector);
+    }
+    
+    @Test
     public void testEmptySelector() {
         Instance ins1 = new Instance();
         Instance ins2 = new Instance();

--- a/client/src/test/java/com/alibaba/nacos/client/naming/selector/NamingSelectorWrapperTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/selector/NamingSelectorWrapperTest.java
@@ -107,4 +107,49 @@ public class NamingSelectorWrapperTest {
         selectorWrapper.notifyListener(event);
         verify(listener).onEvent(argThat(Objects::nonNull));
     }
+    
+    @Test
+    public void testCallableWithNullEvent() {
+        NamingSelectorWrapper selectorWrapper = new NamingSelectorWrapper(null, null);
+        assertFalse(selectorWrapper.isCallable(null));
+    }
+    
+    @Test
+    public void testBuildListenerEventWithModifiedInstances() {
+        EventListener listener = mock(EventListener.class);
+        NamingSelectorWrapper selectorWrapper = new NamingSelectorWrapper("svc", "grp", "cl",
+            new DefaultNamingSelector(instance -> true), listener);
+        InstancesDiff diff = new InstancesDiff();
+        diff.setModifiedInstances(Collections.singletonList(new Instance()));
+        InstancesChangeEvent event =
+            new InstancesChangeEvent(null, "svc", "grp", "cl",
+                Collections.singletonList(new Instance()), diff);
+        selectorWrapper.notifyListener(event);
+        verify(listener).onEvent(argThat(e -> {
+            NamingChangeEvent ce = (NamingChangeEvent) e;
+            return ce.getModifiedInstances() != null && !ce.getModifiedInstances().isEmpty();
+        }));
+    }
+    
+    @Test
+    public void testInnerNamingContextGetters() {
+        EventListener listener = mock(EventListener.class);
+        NamingSelector selector = mock(NamingSelector.class);
+        com.alibaba.nacos.api.naming.selector.NamingResult emptyResult =
+            () -> Collections.emptyList();
+        org.mockito.Mockito.when(selector.select(org.mockito.ArgumentMatchers.any()))
+            .thenReturn(emptyResult);
+        NamingSelectorWrapper wrapper =
+            new NamingSelectorWrapper("svc", "grp", "cl", selector, listener);
+        InstancesDiff diff =
+            new InstancesDiff(null, Collections.singletonList(new Instance()), null);
+        InstancesChangeEvent event =
+            new InstancesChangeEvent(null, "svc", "grp", "cl",
+                Collections.singletonList(new Instance()), diff);
+        wrapper.notifyListener(event);
+        verify(selector, org.mockito.Mockito.atLeastOnce())
+            .select(argThat(ctx -> "svc".equals(ctx.getServiceName())
+                && "grp".equals(ctx.getGroupName()) && "cl".equals(ctx.getClusters())
+                && ctx.getInstances() != null));
+    }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/utils/CacheDirUtilTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/utils/CacheDirUtilTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class CacheDirUtilTest {
     
@@ -77,5 +78,10 @@ class CacheDirUtilTest {
         properties.setProperty(PropertyKeyConst.NAMING_CACHE_REGISTRY_DIR, "custom");
         String actual = CacheDirUtil.initCacheDir("test", properties);
         assertEquals("/home/snapshot/nacos/custom/naming/test", actual);
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new CacheDirUtil());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/utils/ChooserTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/utils/ChooserTest.java
@@ -154,6 +154,20 @@ class ChooserTest {
         assertEquals(ref, ref2);
     }
     
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void testEqualsExplicitNullAndOtherType() {
+        // Explicitly trigger equals(null) and equals(other-type) for both Chooser and Ref so the
+        // null/getClass branches are reached (assertNotEquals(null, x) shortcuts via Objects.equals)
+        List<Pair<String>> list = new LinkedList<>();
+        list.add(new Pair<>("test", 1));
+        Chooser<String, String> chooser = new Chooser<>("test", list);
+        assertTrue(!chooser.equals(null));
+        assertTrue(!chooser.equals("not a chooser"));
+        Chooser.Ref ref = chooser.getRef();
+        assertTrue(!ref.equals(null));
+    }
+    
     private List<Instance> getInstanceList() {
         List<Instance> list = new ArrayList<>();
         int size = ThreadLocalRandom.current().nextInt(0, 1000);

--- a/client/src/test/java/com/alibaba/nacos/client/naming/utils/ConcurrentDiskUtilTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/utils/ConcurrentDiskUtilTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -109,5 +110,10 @@ class ConcurrentDiskUtilTest {
                 throw e.getCause();
             }
         });
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new ConcurrentDiskUtil());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/utils/InitUtilsTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/utils/InitUtilsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class InitUtilsTest {
     
@@ -145,5 +146,10 @@ class InitUtilsTest {
         assertEquals("/nacos", UtilAndComs.webContext);
         assertEquals("/nacos/v1/ns", UtilAndComs.nacosUrlBase);
         assertEquals("/nacos/v1/ns/instance", UtilAndComs.nacosUrlInstance);
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new InitUtils());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/naming/utils/UtilAndComsTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/utils/UtilAndComsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,26 @@
  * limitations under the License.
  */
 
-package com.alibaba.nacos.client.utils;
+package com.alibaba.nacos.client.naming.utils;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-class PreInitUtilsTest {
-    
-    @Test
-    void testAsyncPreLoadCostComponent() throws InterruptedException {
-        // There is no things need to be assert.
-        // The method will called when nacos-client init to async to load some components to reduce the sync load time.
-        PreInitUtils.asyncPreLoadCostComponent();
-        // No exception is ok.
-        // Let async thread run completed
-        TimeUnit.SECONDS.sleep(2);
-    }
+class UtilAndComsTest {
     
     @Test
     void testConstructor() {
-        assertNotNull(new PreInitUtils());
+        assertNotNull(new UtilAndComs());
+    }
+    
+    @Test
+    void testFields() {
+        assertEquals("/nacos", UtilAndComs.webContext);
+        assertEquals("/nacos/v1/ns", UtilAndComs.nacosUrlBase);
+        assertEquals("/nacos/v1/ns/instance", UtilAndComs.nacosUrlInstance);
+        assertEquals("/nacos/v1/ns/service", UtilAndComs.nacosUrlService);
+        assertEquals("envList", UtilAndComs.ENV_LIST_KEY);
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/utils/EnvUtilTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/EnvUtilTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 class EnvUtilTest {
@@ -70,5 +71,10 @@ class EnvUtilTest {
         assertNull(EnvUtil.getSelfAmoryTag());
         assertNull(EnvUtil.getSelfVipserverTag());
         assertNull(EnvUtil.getSelfLocationTag());
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new EnvUtil());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/utils/LogUtilsTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/LogUtilsTest.java
@@ -29,4 +29,9 @@ class LogUtilsTest {
         assertNotNull(logger);
     }
     
+    @Test
+    void testConstructor() {
+        assertNotNull(new LogUtils());
+    }
+    
 }

--- a/client/src/test/java/com/alibaba/nacos/client/utils/ParamUtilTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/ParamUtilTest.java
@@ -28,6 +28,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ParamUtilTest {
@@ -144,5 +145,10 @@ class ParamUtilTest {
     void testSimplyEnvNameNotOverLimit() {
         String expect = "test";
         assertEquals(expect, ParamUtil.simplyEnvNameIfOverLimit(expect));
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new ParamUtil());
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/utils/ValidatorUtilsTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/ValidatorUtilsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ValidatorUtilsTest {
@@ -82,5 +83,10 @@ class ValidatorUtilsTest {
                 NacosClientProperties.PROTOTYPE.derive(properties);
             ValidatorUtils.checkInitParam(nacosClientProperties);
         });
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new ValidatorUtils());
     }
 }


### PR DESCRIPTION
## Summary

- Raise `client` module line coverage from **84.91%** baseline → **95.93%** (989 tests passing).
- Follow-up to PR #15139 (client-basic), completes the two-PR client coverage strategy.
- Skip async gRPC connection lifecycle and background-executor catch-and-retry blocks where mocking would require timing-coupled tests, per project's coverage-pragmatism guidance.

### Coverage breakdown

| Metric | Before | After |
|---|---|---|
| Lines covered | 5898 / 6946 (84.91%) | 6663 / 6946 (95.93%) |
| Lines missed | 1048 | 283 |

### Targeted classes

Highest-impact additions:

- **AI module** — `AiHttpClientProxy` (57.78% → ~98%), `AiGrpcClient` (73.21% → ~98%), `AiChangeNotifier` (73.19% → ~99%), `NacosAgentSpecCacheHolder` (new, 91.41%), `NacosAgentCardCacheHolder` (extended)
- **Config fuzzy-watch** — `ConfigFuzzyWatchGroupKeyHolder`, `LocalConfigInfoProcessor`, `LocalEncryptedDataKeyProcessor` IO error paths via `MockedStatic<IoUtils>` / `<JvmUtil>` / `<ConcurrentDiskUtil>`
- **Naming** — `NacosNamingService` failover/fuzzy-watch/cancelFuzzyWatch paths, `Balancer`, `InstancesChangeNotifier`, `NamingSelectorFactory/Wrapper`
- **Lock / Monitor / Logging** — new `NLockFactoryTest`, `MetricsMonitorTest`, extended `NacosLoggingTest`
- **0%-coverage trivial classes** — `ConfigConstantsTest`, `UtilAndComsTest`, plus 17 new event/wrapper tests

### Residual uncovered (~283 lines, accepted as practical)

- ~80 lines in `ClientWorker$ConfigRpcTransportClient` — async gRPC connection lifecycle (would need real gRPC channel)
- ~20 lines in `ClientWorker$ConfigRpcTransportClient$1` — anonymous `Subscriber<ServerListChangeEvent>` callback (4.76%)
- ~25 lines across fuzzy-watch executor `try { ... } catch (Throwable) { Thread.sleep; notifySync }` blocks
- ~15 lines of `Listener` lambda `getExecutor()` returns / `receiveConfigInfo` resource-listener bodies
- Long tail of 1-3 line defensive null-checks across ~50 classes

## Test plan

- [x] `mvn -B -pl client clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests` passes
- [x] `mvn -pl client test` — 989 tests pass (excluding 2 pre-existing flaky tests: `NamingGrpcClientProxyTest#testServerListChanged`, `FailoverReactorTest#testIsFailoverSwitchByServiceNameWhenServiceHasInstances`)
- [x] No production code changes — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)