### PR TITLE
[ISSUE #14997] fix(skill): keep SKILL.md indent and validate version

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -292,20 +292,33 @@ public class SkillOperationServiceImpl implements SkillOperationService {
     /**
      * Resolve the upload version.
      * Priority: SKILL.md YAML front-matter (version / metadata.version) -> meta.json in ZIP -> user-specified targetVersion -> default "0.0.1".
+     * Rejects non-{@code x.y.z}/{@code vN} versions from any source so invalid values cannot reach storage.
      */
-    private String resolveUploadVersion(String skillMd, byte[] zipBytes, String targetVersion) {
+    private String resolveUploadVersion(String skillMd, byte[] zipBytes, String targetVersion)
+        throws NacosApiException {
         String versionFromSkillMd = resolveVersionFromSkillMd(skillMd);
         if (StringUtils.isNotBlank(versionFromSkillMd)) {
-            return versionFromSkillMd;
+            return validateUploadVersionFormat(versionFromSkillMd, "SKILL.md frontmatter");
         }
         String versionFromMetaJson = SkillZipParser.resolveVersionFromZip(zipBytes);
         if (StringUtils.isNotBlank(versionFromMetaJson)) {
-            return versionFromMetaJson;
+            return validateUploadVersionFormat(versionFromMetaJson, "_meta.json");
         }
         if (StringUtils.isNotBlank(targetVersion)) {
-            return targetVersion.trim();
+            return validateUploadVersionFormat(targetVersion.trim(), "targetVersion parameter");
         }
         return DEFAULT_INITIAL_UPLOAD_VERSION;
+    }
+    
+    private static String validateUploadVersionFormat(String version, String source)
+        throws NacosApiException {
+        if (!VersionUtils.isSupportedVersionFormat(version)) {
+            throw new NacosApiException(NacosException.INVALID_PARAM,
+                ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "Invalid version from " + source + ": '" + version
+                    + "', expected x.y.z or vN");
+        }
+        return version;
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillRequestUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillRequestUtil.java
@@ -181,7 +181,12 @@ public class SkillRequestUtil {
         for (String line : lines) {
             int colonIdx = line.indexOf(':');
             if (colonIdx > 0 && line.substring(0, colonIdx).trim().equals(field)) {
-                sb.append(field).append(": ").append(value);
+                int indentLen = 0;
+                while (indentLen < line.length() && Character.isWhitespace(
+                    line.charAt(indentLen))) {
+                    indentLen++;
+                }
+                sb.append(line, 0, indentLen).append(field).append(": ").append(value);
                 found = true;
             } else {
                 sb.append(line);

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
@@ -397,7 +397,7 @@ class SkillOperationServiceImplTest {
     @Test
     void testUploadSkillFromZipUsesFrontmatterMetadataVersion() throws NacosException, IOException {
         String namespaceId = "test-namespace";
-        byte[] zipBytes = createZipBytesWithNestedMetadataVersion("1.0");
+        byte[] zipBytes = createZipBytesWithNestedMetadataVersion("1.0.0");
         when(aiResourcePersistService.find(eq(namespaceId), anyString(), anyString()))
             .thenReturn(null);
         
@@ -405,7 +405,32 @@ class SkillOperationServiceImplTest {
         
         assertEquals("test-skill", result);
         verify(aiResourceVersionPersistService).insert(argThat(inserted -> inserted != null
-            && "1.0".equals(inserted.getVersion())));
+            && "1.0.0".equals(inserted.getVersion())));
+    }
+    
+    @Test
+    void testUploadSkillFromZipRejectsInvalidFrontmatterMetadataVersion() throws IOException {
+        String namespaceId = "test-namespace";
+        byte[] zipBytes = createZipBytesWithNestedMetadataVersion("latest");
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> skillOperationService.uploadSkillFromZip(namespaceId, zipBytes, false));
+        assertTrue(exception.getErrMsg().contains("SKILL.md frontmatter"),
+            "error should identify the frontmatter as the source");
+        assertTrue(exception.getErrMsg().contains("latest"),
+            "error should include the offending value");
+    }
+    
+    @Test
+    void testUploadSkillFromZipRejectsInvalidTargetVersion() throws IOException {
+        String namespaceId = "test-namespace";
+        byte[] zipBytes = createZipBytesWithoutVersion();
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> skillOperationService.uploadSkillFromZip(namespaceId, zipBytes, false,
+                "not-a-version"));
+        assertTrue(exception.getErrMsg().contains("targetVersion"),
+            "error should identify targetVersion as the source");
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillRequestUtilTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillRequestUtilTest.java
@@ -125,6 +125,39 @@ class SkillRequestUtilTest {
         assertEquals("test", SkillRequestUtil.parseFrontmatterField(result, "name"));
     }
     
+    @Test
+    void testUpdateFrontmatterFieldPreservesNestedIndent() {
+        // Issue #14997: nested `metadata.version` lost its indent and was promoted to a top-level key.
+        String md = "---\nname: hello-world\nmetadata:\n  version: latest\n  openclaw:\n"
+            + "    emoji: 👋\n---\n# Body";
+        String result = SkillRequestUtil.updateFrontmatterField(md, "version", "latest");
+        assertTrue(result.contains("\n  version: latest\n"),
+            "Nested version should keep its 2-space indent");
+        assertTrue(!result.contains("\nversion: latest\n"),
+            "Nested version must not be promoted to a top-level key");
+        assertTrue(result.contains("\n  openclaw:\n    emoji: 👋\n"),
+            "Sibling nested keys must remain intact");
+    }
+    
+    @Test
+    void testUpdateFrontmatterFieldUpdatesNestedValuePreservingIndent() {
+        String md = "---\nname: my-skill\nmetadata:\n  version: 1.0.0\n---\n# Body";
+        String result = SkillRequestUtil.updateFrontmatterField(md, "version", "2.0.0");
+        assertTrue(result.contains("\n  version: 2.0.0\n"),
+            "Nested version value should be updated while preserving indent");
+        assertTrue(!result.contains("\nversion: 2.0.0\n"));
+    }
+    
+    @Test
+    void testUpdateFrontmatterFieldKeepsTopLevelBehavior() {
+        String md = "---\nname: my-skill\nversion: 0.0.1\n---\n# Body";
+        String result = SkillRequestUtil.updateFrontmatterField(md, "version", "2.0.0");
+        assertTrue(result.contains("\nversion: 2.0.0\n"),
+            "Top-level version must remain at the top level after update");
+        assertTrue(!result.contains("  version: 2.0.0"),
+            "Top-level version must not gain unexpected indentation");
+    }
+    
     // ========== normalizeSkillFrontmatter — first create ==========
     
     @Test


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fix issue #14997: after uploading a SKILL.md with YAML frontmatter and downloading it back, nested keys lose their indentation and get promoted to top-level keys (e.g. `metadata.version` becomes a top-level `version`), breaking the YAML hierarchy. While investigating, also close a related inconsistency in the upload path: version values sourced from the SKILL.md frontmatter, the bundled `_meta.json`, or the `targetVersion` request parameter were never format-checked, so non-semver values like `latest` could silently land in storage — even though the same value supplied through `resolveSpecifiedDraftVersion` was already rejected.

## Brief changelog

- `SkillRequestUtil#updateFrontmatterField` now preserves the matched line's leading whitespace when rewriting, so nested keys are no longer promoted to top-level.
- `SkillOperationServiceImpl#resolveUploadVersion` calls a new `validateUploadVersionFormat` helper before returning at every source (frontmatter `version`, `metadata.version`, `_meta.json`, `targetVersion`).
- Invalid versions throw `NacosApiException(INVALID_PARAM, PARAMETER_VALIDATE_ERROR)`; the error message identifies the source (`SKILL.md frontmatter` / `_meta.json` / `targetVersion parameter`) and includes the offending value.
- Added 5 unit tests (3 in `SkillRequestUtilTest` covering nested indent preservation, nested value update, and top-level regression guard; 2 in `SkillOperationServiceImplTest` covering invalid frontmatter and invalid `targetVersion` rejection). Corrected the existing `testUploadSkillFromZipUsesFrontmatterMetadataVersion` to use a valid `1.0.0` instead of the malformed `1.0`.

## Verifying this change

- `mvn -pl ai test -Dtest=SkillRequestUtilTest` — 28 tests pass (25 existing + 3 new)
- `mvn -pl ai test -Dtest=SkillOperationServiceImplTest` — 66 tests pass (64 existing + 2 new)
- `mvn -pl ai spotless:check checkstyle:check` — pass

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.