### PR TITLE
[ISSUE #15136] Fix change password menu item not opening dialog in new console

### DIFF
--- a/console-ui-next/src/components/layout/__tests__/change-password-dialog.test.ts
+++ b/console-ui-next/src/components/layout/__tests__/change-password-dialog.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, '../change-password-dialog.tsx'),
+  'utf-8',
+);
+
+const EN_LOCALE = fs.readFileSync(
+  path.resolve(__dirname, '../../../locales/en-US.json'),
+  'utf-8',
+);
+
+const ZH_LOCALE = fs.readFileSync(
+  path.resolve(__dirname, '../../../locales/zh-CN.json'),
+  'utf-8',
+);
+
+describe('ChangePasswordDialog', () => {
+  it('exposes a controlled open/onOpenChange interface', () => {
+    expect(SOURCE).toContain('interface ChangePasswordDialogProps {');
+    expect(SOURCE).toContain('open: boolean;');
+    expect(SOURCE).toContain('onOpenChange: (open: boolean) => void;');
+  });
+
+  it('reads the current username from the auth store', () => {
+    expect(SOURCE).toContain("import { useAuthStore } from '@/stores/auth-store'");
+    expect(SOURCE).toContain('useAuthStore((state) => state.username)');
+  });
+
+  it('delegates field validation to the shared helper before submitting', () => {
+    expect(SOURCE).toContain(
+      "import { validateChangePasswordForm } from '@/lib/change-password'",
+    );
+    expect(SOURCE).toContain('validateChangePasswordForm(newPassword, confirmPassword)');
+    expect(SOURCE).toContain('if (!validation.valid)');
+  });
+
+  it('persists the new password through authApi.resetPassword', () => {
+    expect(SOURCE).toContain("import { authApi } from '@/api/auth'");
+    expect(SOURCE).toContain(
+      'authApi.resetPassword({ username, newPassword: newPassword.trim() })',
+    );
+  });
+
+  it('reports success and closes the dialog on a successful update', () => {
+    expect(SOURCE).toContain("toast.success(t('authority.resetPasswordSuccess'))");
+    expect(SOURCE).toContain('closeDialog(false)');
+  });
+
+  it('clears local state when the dialog is dismissed', () => {
+    expect(SOURCE).toContain('const resetFields = ()');
+    expect(SOURCE).toContain('setNewPassword(\'\')');
+    expect(SOURCE).toContain('setConfirmPassword(\'\')');
+    expect(SOURCE).toContain('resetFields();');
+  });
+
+  it('renders the change-password title using the shared i18n key', () => {
+    expect(SOURCE).toContain("t('header.changePassword')");
+    expect(EN_LOCALE).toContain('"changePassword": "Modify Password"');
+    expect(ZH_LOCALE).toContain('"changePassword": "修改密码"');
+  });
+});

--- a/console-ui-next/src/components/layout/__tests__/header-change-password.test.ts
+++ b/console-ui-next/src/components/layout/__tests__/header-change-password.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const HEADER_SOURCE = fs.readFileSync(
+  path.resolve(__dirname, '../header.tsx'),
+  'utf-8',
+);
+
+describe('Header change-password wiring', () => {
+  it('imports the ChangePasswordDialog from the layout folder', () => {
+    expect(HEADER_SOURCE).toContain(
+      "import { ChangePasswordDialog } from '@/components/layout/change-password-dialog'",
+    );
+  });
+
+  it('manages dialog visibility with local component state', () => {
+    expect(HEADER_SOURCE).toContain(
+      'const [changePasswordOpen, setChangePasswordOpen] = useState(false);',
+    );
+  });
+
+  it('opens the dialog when the change-password menu item is selected', () => {
+    const menuItemBlock = HEADER_SOURCE.slice(
+      HEADER_SOURCE.indexOf("t('header.changePassword')") - 400,
+      HEADER_SOURCE.indexOf("t('header.changePassword')") + 80,
+    );
+
+    expect(menuItemBlock).toContain('setChangePasswordOpen(true)');
+    expect(menuItemBlock).toContain('event.preventDefault()');
+  });
+
+  it('renders the dialog only when auth is enabled and the user is not OIDC', () => {
+    expect(HEADER_SOURCE).toContain('{authEnabled && !isOidcUser() && (');
+    expect(HEADER_SOURCE).toContain(
+      '<ChangePasswordDialog open={changePasswordOpen} onOpenChange={setChangePasswordOpen} />',
+    );
+  });
+});

--- a/console-ui-next/src/components/layout/change-password-dialog.tsx
+++ b/console-ui-next/src/components/layout/change-password-dialog.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+
+import { authApi } from '@/api/auth';
+import { useAuthStore } from '@/stores/auth-store';
+import { validateChangePasswordForm } from '@/lib/change-password';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface ChangePasswordDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialogProps) {
+  const { t } = useTranslation();
+  const username = useAuthStore((state) => state.username) || '';
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const resetFields = () => {
+    setNewPassword('');
+    setConfirmPassword('');
+  };
+
+  const closeDialog = (next: boolean) => {
+    if (!next) {
+      resetFields();
+    }
+    onOpenChange(next);
+  };
+
+  const handleSubmit = async () => {
+    const validation = validateChangePasswordForm(newPassword, confirmPassword);
+    if (!validation.valid) {
+      toast.error(t(validation.errorKey ?? 'authority.passwordRequired'));
+      return;
+    }
+    setSaving(true);
+    try {
+      await authApi.resetPassword({ username, newPassword: newPassword.trim() });
+      toast.success(t('authority.resetPasswordSuccess'));
+      closeDialog(false);
+    } catch {
+      // Error toasts are already handled by the global axios interceptor.
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const submitDisabled = saving || !newPassword || newPassword !== confirmPassword;
+
+  return (
+    <Dialog open={open} onOpenChange={closeDialog}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('header.changePassword')}</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label>{t('authority.username')}</Label>
+            <Input value={username} disabled />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label>
+              {t('authority.newPassword')}
+              <span className="text-destructive ml-1">*</span>
+            </Label>
+            <Input
+              type="password"
+              placeholder={t('authority.newPasswordPlaceholder')}
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label>
+              {t('authority.confirmPassword')}
+              <span className="text-destructive ml-1">*</span>
+            </Label>
+            <Input
+              type="password"
+              placeholder={t('authority.newPasswordPlaceholder')}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+            />
+            {confirmPassword && newPassword !== confirmPassword && (
+              <p className="text-xs text-destructive">{t('authority.passwordMismatch')}</p>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => closeDialog(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitDisabled}>
+            {saving ? t('common.loading') : t('common.confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/console-ui-next/src/components/layout/header.tsx
+++ b/console-ui-next/src/components/layout/header.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Sun,
@@ -31,6 +32,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
+import { ChangePasswordDialog } from '@/components/layout/change-password-dialog';
 
 function getBaseUrl(language: string) {
   return language.toLowerCase() === 'en-us' ? 'https://nacos.io/en/' : 'https://nacos.io/';
@@ -65,6 +67,7 @@ export function Header() {
   const { username, logout, isOidcUser } = useAuthStore();
   const { currentNamespace, namespaces, setNamespace } = useNamespaceStore();
   const { authEnabled } = useServerStore();
+  const [changePasswordOpen, setChangePasswordOpen] = useState(false);
 
   const baseUrl = getBaseUrl(language);
 
@@ -164,6 +167,9 @@ export function Header() {
         </Tooltip>
 
         {/* User menu */}
+        {authEnabled && !isOidcUser() && (
+          <ChangePasswordDialog open={changePasswordOpen} onOpenChange={setChangePasswordOpen} />
+        )}
         {authEnabled && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -181,7 +187,13 @@ export function Header() {
             <DropdownMenuSeparator />
             {!isOidcUser() && (
               <>
-                <DropdownMenuItem className="gap-2 text-xs">
+                <DropdownMenuItem
+                  className="gap-2 text-xs"
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    setChangePasswordOpen(true);
+                  }}
+                >
                   <KeyRound size={14} />
                   {t('header.changePassword')}
                 </DropdownMenuItem>

--- a/console-ui-next/src/lib/__tests__/change-password.test.ts
+++ b/console-ui-next/src/lib/__tests__/change-password.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateChangePasswordForm } from '../change-password';
+
+describe('validateChangePasswordForm', () => {
+  it('rejects an empty new password', () => {
+    expect(validateChangePasswordForm('', '')).toEqual({
+      valid: false,
+      errorKey: 'authority.passwordRequired',
+    });
+  });
+
+  it('rejects a whitespace-only new password', () => {
+    expect(validateChangePasswordForm('   ', '   ')).toEqual({
+      valid: false,
+      errorKey: 'authority.passwordRequired',
+    });
+  });
+
+  it('rejects a confirm password that does not match', () => {
+    expect(validateChangePasswordForm('Secret1!', 'Secret2!')).toEqual({
+      valid: false,
+      errorKey: 'authority.passwordMismatch',
+    });
+  });
+
+  it('accepts a non-empty new password that matches the confirmation', () => {
+    expect(validateChangePasswordForm('Secret1!', 'Secret1!')).toEqual({
+      valid: true,
+    });
+  });
+
+  it('treats the password as significant when only the confirmation is blank', () => {
+    expect(validateChangePasswordForm('Secret1!', '')).toEqual({
+      valid: false,
+      errorKey: 'authority.passwordMismatch',
+    });
+  });
+});

--- a/console-ui-next/src/lib/change-password.ts
+++ b/console-ui-next/src/lib/change-password.ts
@@ -1,0 +1,22 @@
+/*
+ * Validation helpers for the self-service change-password flow rendered in the
+ * console header. Extracted so the rules can be unit-tested without rendering
+ * the dialog component.
+ */
+export interface ChangePasswordValidation {
+  valid: boolean;
+  errorKey?: string;
+}
+
+export function validateChangePasswordForm(
+  newPassword: string,
+  confirmPassword: string,
+): ChangePasswordValidation {
+  if (!newPassword || !newPassword.trim()) {
+    return { valid: false, errorKey: 'authority.passwordRequired' };
+  }
+  if (newPassword !== confirmPassword) {
+    return { valid: false, errorKey: 'authority.passwordMismatch' };
+  }
+  return { valid: true };
+}


### PR DESCRIPTION
Closes #15136

## What is the purpose of the change

In the new Nacos console (`console-ui-next`), the "Modify Password" entry in the user dropdown rendered without an `onClick` handler, so clicking it produced no visible reaction. Users were forced to switch back to the legacy console to change their own password.

This PR restores the missing self-service flow so the menu item opens a password-change dialog that behaves consistently with the legacy console.

## Brief changelog

- Add `console-ui-next/src/lib/change-password.ts` with a `validateChangePasswordForm` helper covering empty / whitespace / mismatched / valid inputs.
- Add `console-ui-next/src/components/layout/change-password-dialog.tsx`, a small controlled dialog that:
  - reads the current username from the existing auth store,
  - validates the new + confirm password through the shared helper,
  - persists the change through `authApi.resetPassword` (the same `PUT /v3/auth/user` endpoint that already powers the admin reset-password flow in the User Management page),
  - reports success via `sonner` toast and resets local state when dismissed.
- Wire the existing "Modify Password" `DropdownMenuItem` in `header.tsx` to open the dialog via `onSelect`, and render `ChangePasswordDialog` once per session. The dialog (like the menu item) is gated behind `authEnabled && !isOidcUser()`, so OIDC users — whose identity is owned by the IdP — still don't see it.
- No new i18n keys are introduced; the existing `header.changePassword`, `authority.*` and `common.*` keys cover the dialog copy.

## Verifying this change

Run the new tests in the `console-ui-next` workspace:

```bash
cd console-ui-next
npm install
npx vitest run \
  src/lib/__tests__/change-password.test.ts \
  src/components/layout/__tests__/change-password-dialog.test.ts \
  src/components/layout/__tests__/header-change-password.test.ts
# Test Files  3 passed (3)
# Tests       16 passed (16)
```

Manual verification:

1. Start the new console (`npm run dev`) and log in with a Nacos-auth user.
2. Open the avatar dropdown in the top-right corner and click **Modify Password** — the dialog now opens (previously: no reaction).
3. Submit with mismatched / empty inputs → the inline error and toast surface using the existing i18n keys.
4. Submit with matching inputs → success toast appears, dialog closes, and the new password is accepted on the next login.
5. Log in as an OIDC user → the menu item and dialog stay hidden as before.

Build / type-check / lint were exercised through `npx tsc -b` and `npx vite build`; no new errors are introduced relative to `upstream/develop`.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass. *(Frontend-only change; backend Maven checks are not exercised by this PR.)*