### PR TITLE
[ISSUE #15160] Fix config change pointcut routing for missing srcType

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspect.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspect.java
@@ -24,6 +24,9 @@ import com.alibaba.nacos.config.server.model.gray.BetaGrayRule;
 import com.alibaba.nacos.config.server.model.gray.TagGrayRule;
 import com.alibaba.nacos.config.server.utils.ConfigExecutor;
 import com.alibaba.nacos.config.server.utils.TimeUtils;
+import com.alibaba.nacos.core.context.RequestContext;
+import com.alibaba.nacos.core.context.RequestContextHolder;
+import com.alibaba.nacos.core.context.addition.BasicContext;
 import com.alibaba.nacos.plugin.config.ConfigChangePluginManager;
 import com.alibaba.nacos.plugin.config.constants.ConfigChangeConstants;
 import com.alibaba.nacos.plugin.config.constants.ConfigChangeExecuteTypes;
@@ -44,6 +47,7 @@ import java.util.Locale;
 import java.util.Properties;
 
 import static com.alibaba.nacos.config.server.constant.Constants.HTTP;
+import static com.alibaba.nacos.config.server.constant.Constants.RPC;
 
 /**
  * Config change pointcut aspect,which config change plugin services will pointcut.
@@ -112,14 +116,8 @@ public class ConfigChangeAspect {
             grayRuleExp = tag;
         }
         
-        ConfigChangePointCutTypes configChangePointCutType = null;
-        if (HTTP.equals(scrType)) {
-            // via console or api calls
-            configChangePointCutType = ConfigChangePointCutTypes.PUBLISH_BY_HTTP;
-        } else {
-            // via sdk rpc calls
-            configChangePointCutType = ConfigChangePointCutTypes.PUBLISH_BY_RPC;
-        }
+        ConfigChangePointCutTypes configChangePointCutType =
+            resolvePublishPointCutType(scrType);
         final List<ConfigChangePluginService> pluginServices = getPluginServices(
             configChangePointCutType);
         // didn't enabled or add relative plugin
@@ -158,14 +156,8 @@ public class ConfigChangeAspect {
         final String srcUser = (String) args[5];
         final String scrType = (String) args[6];
         
-        ConfigChangePointCutTypes configChangePointCutType = null;
-        if (HTTP.equals(scrType)) {
-            // via console or api calls
-            configChangePointCutType = ConfigChangePointCutTypes.PUBLISH_BY_HTTP;
-        } else {
-            // via sdk rpc calls
-            configChangePointCutType = ConfigChangePointCutTypes.PUBLISH_BY_RPC;
-        }
+        ConfigChangePointCutTypes configChangePointCutType =
+            resolveRemovePointCutType(scrType);
         final List<ConfigChangePluginService> pluginServices =
             getPluginServices(configChangePointCutType);
         // didn't enabled or add relative plugin
@@ -273,6 +265,64 @@ public class ConfigChangeAspect {
             }
         }
         return new ArrayList<>();
+    }
+    
+    private ConfigChangePointCutTypes resolvePublishPointCutType(String srcType) {
+        String resolvedSourceType = resolveSourceType(srcType);
+        if (HTTP.equals(resolvedSourceType)) {
+            // via console or api calls
+            return ConfigChangePointCutTypes.PUBLISH_BY_HTTP;
+        }
+        if (RPC.equals(resolvedSourceType)) {
+            // via sdk rpc calls
+            return ConfigChangePointCutTypes.PUBLISH_BY_RPC;
+        }
+        logUnknownSourceType(srcType);
+        return ConfigChangePointCutTypes.PUBLISH_BY_UNKNOWN;
+    }
+    
+    private ConfigChangePointCutTypes resolveRemovePointCutType(String srcType) {
+        String resolvedSourceType = resolveSourceType(srcType);
+        if (HTTP.equals(resolvedSourceType)) {
+            // via console or api calls
+            return ConfigChangePointCutTypes.REMOVE_BY_HTTP;
+        }
+        if (RPC.equals(resolvedSourceType)) {
+            // via sdk rpc calls
+            return ConfigChangePointCutTypes.REMOVE_BY_RPC;
+        }
+        logUnknownSourceType(srcType);
+        return ConfigChangePointCutTypes.REMOVE_BY_UNKNOWN;
+    }
+    
+    private String resolveSourceType(String srcType) {
+        RequestContext requestContext = RequestContextHolder.getContext();
+        if (requestContext != null) {
+            String requestProtocol = requestContext.getBasicContext().getRequestProtocol();
+            if (BasicContext.HTTP_PROTOCOL.equals(requestProtocol)) {
+                return HTTP;
+            }
+            if (BasicContext.GRPC_PROTOCOL.equals(requestProtocol)) {
+                return RPC;
+            }
+        }
+        if (HTTP.equals(srcType) || RPC.equals(srcType)) {
+            return srcType;
+        }
+        return null;
+    }
+    
+    private void logUnknownSourceType(String srcType) {
+        RequestContext requestContext = RequestContextHolder.getContext();
+        String requestProtocol = null;
+        String requestTarget = null;
+        if (requestContext != null) {
+            requestProtocol = requestContext.getBasicContext().getRequestProtocol();
+            requestTarget = requestContext.getBasicContext().getRequestTarget();
+        }
+        LOGGER.warn(
+            "Use unknown config change pointcut due to unknown source type: {}, requestProtocol: {}, requestTarget: {}",
+            srcType, requestProtocol, requestTarget);
     }
     
     private boolean isEnabled(ConfigChangePluginService configChangePluginService) {

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3.java
@@ -229,6 +229,7 @@ public class ConfigControllerV3 {
         
         ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
         configRequestInfo.setSrcIp(RequestUtil.getRemoteIp(request));
+        configRequestInfo.setSrcType(Constants.HTTP);
         configRequestInfo.setRequestIpApp(RequestUtil.getAppName(request));
         configRequestInfo.setBetaIps(request.getHeader("betaIps"));
         configRequestInfo.setCasMd5(request.getHeader("casMd5"));

--- a/config/src/test/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspectTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspectTest.java
@@ -22,6 +22,8 @@ import com.alibaba.nacos.config.server.configuration.ConfigChangeConfigs;
 import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
 import com.alibaba.nacos.config.server.model.form.ConfigForm;
 import com.alibaba.nacos.config.server.utils.RequestUtil;
+import com.alibaba.nacos.core.context.RequestContextHolder;
+import com.alibaba.nacos.core.context.addition.BasicContext;
 import com.alibaba.nacos.plugin.config.ConfigChangePluginManager;
 import com.alibaba.nacos.plugin.config.constants.ConfigChangeConstants;
 import com.alibaba.nacos.plugin.config.constants.ConfigChangeExecuteTypes;
@@ -80,6 +82,9 @@ class ConfigChangeAspectTest {
     
     @BeforeEach
     void before() {
+        RequestContextHolder.getContext().getBasicContext().setRequestProtocol(null);
+        RequestContextHolder.getContext().getBasicContext().setRequestTarget(null);
+        
         //mock config change service enabled.
         propertiesStatic = Mockito.mockStatic(PropertiesUtil.class);
         requestUtilMockedStatic = Mockito.mockStatic(RequestUtil.class);
@@ -105,6 +110,9 @@ class ConfigChangeAspectTest {
     
     @AfterEach
     void after() {
+        RequestContextHolder.getContext().getBasicContext().setRequestProtocol(null);
+        RequestContextHolder.getContext().getBasicContext().setRequestTarget(null);
+        
         propertiesStatic.close();
         requestUtilMockedStatic.close();
         ConfigChangePluginManager.reset();
@@ -269,6 +277,114 @@ class ConfigChangeAspectTest {
     }
     
     @Test
+    void testRequestProtocolTakesPrecedenceOverSourceTypeForPublish() throws Throwable {
+        RequestContextHolder.getContext().getBasicContext()
+            .setRequestProtocol(BasicContext.HTTP_PROTOCOL);
+        RequestContextHolder.getContext().getBasicContext().setRequestTarget("POST /v3/cs/config");
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        when(pjp.getArgs()).thenReturn(new Object[] {configForm, configRequestInfo});
+        when(configRequestInfo.getSrcType()).thenReturn("rpc");
+        when(configForm.getDataId()).thenReturn("dataId");
+        when(pjp.proceed(any())).thenReturn("Success");
+        
+        configChangeAspect.publishOrUpdateConfigAround(pjp);
+        
+        ArgumentCaptor<ConfigChangeRequest> requestCaptor =
+            ArgumentCaptor.forClass(ConfigChangeRequest.class);
+        verify(configChangePluginService).execute(requestCaptor.capture(), any());
+        assertEquals(ConfigChangePointCutTypes.PUBLISH_BY_HTTP,
+            requestCaptor.getValue().getRequestType());
+    }
+    
+    @Test
+    void testRequestProtocolTakesPrecedenceOverSourceTypeForRemove() throws Throwable {
+        RequestContextHolder.getContext().getBasicContext()
+            .setRequestProtocol(BasicContext.GRPC_PROTOCOL);
+        RequestContextHolder.getContext().getBasicContext().setRequestTarget("ConfigRemoveRequest");
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        when(pjp.getArgs()).thenReturn(
+            new Object[] {"dataId", "group", "namespaceId", null, "127.0.0.1", "nacos", "http"});
+        when(pjp.proceed(any())).thenReturn("Success");
+        
+        configChangeAspect.removeConfigByIdAround(pjp);
+        
+        ArgumentCaptor<ConfigChangeRequest> requestCaptor =
+            ArgumentCaptor.forClass(ConfigChangeRequest.class);
+        verify(configChangePluginService).execute(requestCaptor.capture(), any());
+        assertEquals(ConfigChangePointCutTypes.REMOVE_BY_RPC,
+            requestCaptor.getValue().getRequestType());
+    }
+    
+    @Test
+    void testPublishWithUnknownSourceTypeUsesUnknownPointcut() throws Throwable {
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        when(pjp.getArgs()).thenReturn(new Object[] {configForm, configRequestInfo});
+        when(configRequestInfo.getSrcType()).thenReturn(null);
+        when(configForm.getDataId()).thenReturn("dataId");
+        when(pjp.proceed(any())).thenReturn("Success");
+        
+        configChangeAspect.publishOrUpdateConfigAround(pjp);
+        
+        ArgumentCaptor<ConfigChangeRequest> requestCaptor =
+            ArgumentCaptor.forClass(ConfigChangeRequest.class);
+        verify(configChangePluginService).execute(requestCaptor.capture(), any());
+        assertEquals(ConfigChangePointCutTypes.PUBLISH_BY_UNKNOWN,
+            requestCaptor.getValue().getRequestType());
+    }
+    
+    @Test
+    void testRemoveWithUnknownSourceTypeUsesUnknownPointcut() throws Throwable {
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        when(pjp.getArgs()).thenReturn(
+            new Object[] {"dataId", "group", "namespaceId", null, "127.0.0.1", "nacos", null});
+        when(pjp.proceed(any())).thenReturn("Success");
+        
+        configChangeAspect.removeConfigByIdAround(pjp);
+        
+        ArgumentCaptor<ConfigChangeRequest> requestCaptor =
+            ArgumentCaptor.forClass(ConfigChangeRequest.class);
+        verify(configChangePluginService).execute(requestCaptor.capture(), any());
+        assertEquals(ConfigChangePointCutTypes.REMOVE_BY_UNKNOWN,
+            requestCaptor.getValue().getRequestType());
+    }
+    
+    @Test
+    void testRemoveHttpSourceTypeUsesRemovePointcut() throws Throwable {
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        when(pjp.getArgs()).thenReturn(
+            new Object[] {"dataId", "group", "namespaceId", null, "127.0.0.1", "nacos", "http"});
+        when(pjp.proceed(any())).thenReturn("Success");
+        
+        configChangeAspect.removeConfigByIdAround(pjp);
+        ArgumentCaptor<ConfigChangeRequest> requestCaptor =
+            ArgumentCaptor.forClass(ConfigChangeRequest.class);
+        verify(configChangePluginService).execute(requestCaptor.capture(), any());
+        assertEquals(ConfigChangePointCutTypes.REMOVE_BY_HTTP,
+            requestCaptor.getValue().getRequestType());
+    }
+    
+    @Test
+    void testRemoveRpcSourceTypeUsesRemovePointcut() throws Throwable {
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        when(pjp.getArgs()).thenReturn(
+            new Object[] {"dataId", "group", "namespaceId", null, "127.0.0.1", "nacos", "rpc"});
+        when(pjp.proceed(any())).thenReturn("Success");
+        
+        configChangeAspect.removeConfigByIdAround(pjp);
+        ArgumentCaptor<ConfigChangeRequest> requestCaptor =
+            ArgumentCaptor.forClass(ConfigChangeRequest.class);
+        verify(configChangePluginService).execute(requestCaptor.capture(), any());
+        assertEquals(ConfigChangePointCutTypes.REMOVE_BY_RPC,
+            requestCaptor.getValue().getRequestType());
+    }
+    
+    @Test
     void testPublishConfigWithBetaIps() throws Throwable {
         Mockito.when(configChangePluginService.executeType())
             .thenReturn(ConfigChangeExecuteTypes.EXECUTE_AFTER_TYPE);
@@ -325,7 +441,7 @@ class ConfigChangeAspectTest {
         ArgumentCaptor<ConfigChangeRequest> captor =
             ArgumentCaptor.forClass(ConfigChangeRequest.class);
         verify(configChangePluginService).execute(captor.capture(), any());
-        assertEquals(ConfigChangePointCutTypes.PUBLISH_BY_RPC,
+        assertEquals(ConfigChangePointCutTypes.REMOVE_BY_RPC,
             captor.getValue().getRequestType());
     }
     

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
@@ -134,6 +134,7 @@ public class ConsoleConfigController {
         
         ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
         configRequestInfo.setSrcIp(RequestUtil.getRemoteIp(request));
+        configRequestInfo.setSrcType(Constants.HTTP);
         configRequestInfo.setRequestIpApp(RequestUtil.getAppName(request));
         configRequestInfo.setBetaIps(request.getHeader("betaIps"));
         configRequestInfo.setCasMd5(request.getHeader("casMd5"));

--- a/plugin/config/src/main/java/com/alibaba/nacos/plugin/config/constants/ConfigChangePointCutTypes.java
+++ b/plugin/config/src/main/java/com/alibaba/nacos/plugin/config/constants/ConfigChangePointCutTypes.java
@@ -32,6 +32,10 @@ public enum ConfigChangePointCutTypes {
      */
     PUBLISH_BY_RPC("publishOrUpdateByRpc"),
     /**
+     * Publish config with unknown source type.
+     */
+    PUBLISH_BY_UNKNOWN("publishOrUpdateByUnknown"),
+    /**
      * Remove by id through http.
      */
     REMOVE_BY_HTTP("removeSingleByHttp"),
@@ -39,6 +43,10 @@ public enum ConfigChangePointCutTypes {
      * Remove through rpc.
      */
     REMOVE_BY_RPC("removeSingleByRpc"),
+    /**
+     * Remove with unknown source type.
+     */
+    REMOVE_BY_UNKNOWN("removeSingleByUnknown"),
     /**
      * Import config file through http/console.
      */


### PR DESCRIPTION
Route missing config change source types to unknown pointcuts instead of treating them as RPC, and use remove pointcuts for delete operations.

Assisted-by: Codex

Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

This PR fixes config-change pointcut routing when `ConfigRequestInfo.srcType` is missing, empty, or not recognized.
本 PR 修复 `ConfigRequestInfo.srcType` 缺失、为空或无法识别时的配置变更切点路由问题。

Before this change, a config change without an explicit `srcType` could be treated as an RPC change.
在本次修改前，没有显式 `srcType` 的配置变更可能会被当作 RPC 变更处理。

This can affect config-change plugins that intentionally skip RPC events.
这会影响那些有意跳过 RPC 事件的配置变更插件。

For example, when a config publish operation is triggered from the console but is classified as RPC, a file-format config-change plugin may skip validation and allow invalid config content to pass.
例如，当配置发布操作从控制台触发但被识别为 RPC 时，文件格式校验插件可能会跳过校验，导致错误配置内容被放行。

This PR also fixes delete operation routing so that delete operations use remove pointcuts instead of publish pointcuts.
本 PR 同时修正删除操作的切点路由，使删除操作使用 remove pointcut，而不是 publish pointcut。

AI-related config operation call paths are not assigned a new explicit source type in this PR.
本 PR 没有为 AI 相关配置操作调用路径新增显式来源类型。

The `srcType` of AI entry points is not changed in this PR.
本 PR 未调整 AI 入口的 `srcType`。

Some AI paths currently construct an empty `ConfigRequestInfo`, and their caller context does not always identify a single HTTP or RPC source at that layer.
当前部分 AI 路径会构造空的 `ConfigRequestInfo`，并且在这些调用层级上并不总能确定单一的 HTTP 或 RPC 来源。

These paths remain unclassified instead of being treated as RPC.
这些路径保持未分类状态，而不是被当作 RPC 处理。

## Brief changelog

- Add unknown config-change pointcut types for unclassified publish and delete operations.
- 为未分类的发布和删除操作增加 unknown 配置变更切点类型。

- Route missing, empty, or unrecognized `srcType` values to unknown pointcuts instead of RPC pointcuts.
- 将缺失、为空或无法识别的 `srcType` 路由到 unknown pointcut，而不是 RPC pointcut。

- Route delete operations to remove pointcuts.
- 将删除操作路由到 remove pointcut。

- Set HTTP `srcType` in HTTP config publish entry points.
- 在 HTTP 配置发布入口设置 HTTP `srcType`。

- Add unit tests for RPC, HTTP remove, and unknown source routing behavior.
- 为 RPC、HTTP 删除以及 unknown 来源路由行为增加单元测试。

## Verifying this change

The following checks were run locally:
本地已执行以下检查：

```bash
.\mvnw -q -pl config -am '-Dtest=ConfigChangeAspectTest' '-Dsurefire.failIfNoSpecifiedTests=false' test
.\mvnw -q -pl plugin/config,config,console,ai -am -DskipTests compile
git diff --check
```

The full test suite was not completed locally because some tests in this repository are written for Unix-like environments and cannot pass in my local Windows environment.
本地没有完整执行全部 test suite，因为仓库中部分测试按类 Unix 环境编写，在我的 Windows 本地环境中无法通过。

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
