### PR TITLE
fix(ai): default unlisted resources to base64 to avoid utf-8 corruption

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecZipParser.java
@@ -36,12 +36,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * AgentSpec zip parser utility. Mirrors {@link SkillZipParser} for HiClaw Worker packages.
@@ -63,13 +60,6 @@ public class AgentSpecZipParser {
     
     private static final String SLASH = "/";
     
-    private static final String DOT = ".";
-    
-    /** Metadata key for binary resources: value "base64" means content is Base64-encoded. */
-    private static final String METADATA_ENCODING = "encoding";
-    
-    private static final String METADATA_ENCODING_BASE64 = "base64";
-    
     /**
      * Maximum total decompressed size allowed (50MB). Prevents Zip Bomb attacks.
      */
@@ -79,26 +69,6 @@ public class AgentSpecZipParser {
      * Maximum number of entries allowed in a ZIP file. Prevents entry-count flooding attacks.
      */
     private static final int MAX_ZIP_ENTRIES = 500;
-    
-    /** File extensions treated as binary; content will be stored as Base64. */
-    private static final Set<String> BINARY_EXTENSIONS = new HashSet<>();
-    
-    static {
-        BINARY_EXTENSIONS.add("ttf");
-        BINARY_EXTENSIONS.add("otf");
-        BINARY_EXTENSIONS.add("woff");
-        BINARY_EXTENSIONS.add("woff2");
-        BINARY_EXTENSIONS.add("eot");
-        BINARY_EXTENSIONS.add("png");
-        BINARY_EXTENSIONS.add("jpg");
-        BINARY_EXTENSIONS.add("jpeg");
-        BINARY_EXTENSIONS.add("gif");
-        BINARY_EXTENSIONS.add("webp");
-        BINARY_EXTENSIONS.add("ico");
-        BINARY_EXTENSIONS.add("cur");
-        BINARY_EXTENSIONS.add("pdf");
-        BINARY_EXTENSIONS.add("bin");
-    }
     
     /**
      * Parse AgentSpec from zip file bytes. Zip size must not exceed {@link Constants.AgentSpecs#MAX_UPLOAD_ZIP_BYTES}.
@@ -332,21 +302,14 @@ public class AgentSpecZipParser {
                 resourceName = parts[parts.length - 1];
             }
             
-            boolean isBinary = isBinaryResource(resourceName);
-            String content;
-            Map<String, Object> metadata = new HashMap<>(4);
-            if (isBinary) {
-                content = Base64.getEncoder().encodeToString(entry.data);
-                metadata.put(METADATA_ENCODING, METADATA_ENCODING_BASE64);
-            } else {
-                content = new String(entry.data, StandardCharsets.UTF_8);
-            }
+            ResourceContentEncoder.EncodedContent encoded =
+                ResourceContentEncoder.encode(entry.data, resourceName);
             
             AgentSpecResource resource = new AgentSpecResource();
             resource.setName(resourceName);
             resource.setType(type);
-            resource.setContent(content);
-            resource.setMetadata(metadata.isEmpty() ? null : metadata);
+            resource.setContent(encoded.getContent());
+            resource.setMetadata(encoded.getMetadata());
             String key = AgentSpecUtils.generateResourceId(type, resourceName);
             resources.put(key, resource);
         }
@@ -365,15 +328,6 @@ public class AgentSpecZipParser {
             return "tool-analysis";
         }
         return "";
-    }
-    
-    private static boolean isBinaryResource(String fileName) {
-        if (StringUtils.isBlank(fileName) || !fileName.contains(DOT)) {
-            return false;
-        }
-        String ext =
-            fileName.substring(fileName.lastIndexOf(DOT.charAt(0)) + 1).trim().toLowerCase();
-        return BINARY_EXTENSIONS.contains(ext);
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/ResourceContentEncoder.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/ResourceContentEncoder.java
@@ -54,40 +54,39 @@ public final class ResourceContentEncoder {
     static {
         Set<String> exts = new HashSet<>();
         Collections.addAll(exts,
-                // Markup / docs
-                "md", "markdown", "mdx", "txt", "rst", "adoc", "asciidoc",
-                // Structured data / config
-                "json", "json5", "yaml", "yml", "xml", "html", "htm", "css", "scss", "sass", "less",
-                "properties", "conf", "cfg", "ini", "toml", "env", "tpl", "tmpl", "j2", "mustache", "hbs",
-                // Common script / source code
-                "js", "mjs", "cjs", "ts", "tsx", "jsx", "vue", "svelte",
-                "py", "java", "kt", "kts", "scala", "groovy", "go", "rs", "rb", "php",
-                "swift", "m", "mm", "c", "h", "cpp", "cc", "cxx", "hpp", "hh", "hxx",
-                "cs", "fs", "fsx", "vb", "lua", "r", "pl", "pm", "ex", "exs", "erl",
-                "dart", "zig", "nim", "jl", "clj", "cljs", "edn", "elm",
-                // Shell / build
-                "sh", "bash", "zsh", "fish", "ps1", "psm1", "bat", "cmd",
-                "gradle", "sbt", "make", "mk",
-                // Data / log
-                "sql", "graphql", "gql", "csv", "tsv", "log", "diff", "patch",
-                // Misc text
-                "proto", "thrift", "ipynb"
-        );
+            // Markup / docs
+            "md", "markdown", "mdx", "txt", "rst", "adoc", "asciidoc",
+            // Structured data / config
+            "json", "json5", "yaml", "yml", "xml", "html", "htm", "css", "scss", "sass", "less",
+            "properties", "conf", "cfg", "ini", "toml", "env", "tpl", "tmpl", "j2", "mustache",
+            "hbs",
+            // Common script / source code
+            "js", "mjs", "cjs", "ts", "tsx", "jsx", "vue", "svelte",
+            "py", "java", "kt", "kts", "scala", "groovy", "go", "rs", "rb", "php",
+            "swift", "m", "mm", "c", "h", "cpp", "cc", "cxx", "hpp", "hh", "hxx",
+            "cs", "fs", "fsx", "vb", "lua", "r", "pl", "pm", "ex", "exs", "erl",
+            "dart", "zig", "nim", "jl", "clj", "cljs", "edn", "elm",
+            // Shell / build
+            "sh", "bash", "zsh", "fish", "ps1", "psm1", "bat", "cmd",
+            "gradle", "sbt", "make", "mk",
+            // Data / log
+            "sql", "graphql", "gql", "csv", "tsv", "log", "diff", "patch",
+            // Misc text
+            "proto", "thrift", "ipynb");
         TEXT_EXTENSIONS = Collections.unmodifiableSet(exts);
         
         Set<String> names = new HashSet<>();
         Collections.addAll(names,
-                // Common no-extension text files (case-insensitive match)
-                "dockerfile", "containerfile", "makefile", "rakefile", "gemfile", "gemfile.lock",
-                "jenkinsfile", "vagrantfile", "procfile", "brewfile",
-                "license", "license.txt", "notice", "readme", "changelog", "authors",
-                "contributors", "maintainers", "codeowners", "version", "manifest",
-                // Dotfiles
-                ".gitignore", ".gitattributes", ".gitmodules", ".gitkeep",
-                ".dockerignore", ".editorconfig", ".env", ".envrc",
-                ".npmrc", ".nvmrc", ".yarnrc", ".prettierrc", ".eslintrc",
-                ".babelrc", ".browserslistrc", ".stylelintrc"
-        );
+            // Common no-extension text files (case-insensitive match)
+            "dockerfile", "containerfile", "makefile", "rakefile", "gemfile", "gemfile.lock",
+            "jenkinsfile", "vagrantfile", "procfile", "brewfile",
+            "license", "license.txt", "notice", "readme", "changelog", "authors",
+            "contributors", "maintainers", "codeowners", "version", "manifest",
+            // Dotfiles
+            ".gitignore", ".gitattributes", ".gitmodules", ".gitkeep",
+            ".dockerignore", ".editorconfig", ".env", ".envrc",
+            ".npmrc", ".nvmrc", ".yarnrc", ".prettierrc", ".eslintrc",
+            ".babelrc", ".browserslistrc", ".stylelintrc");
         TEXT_FILE_NAMES = Collections.unmodifiableSet(names);
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/ResourceContentEncoder.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/ResourceContentEncoder.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.utils;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Resource content encoder shared by Skill and AgentSpec zip parsers.
+ *
+ * <p>Decision policy: a file is treated as plain text only when its name (or extension)
+ * matches the text whitelist; everything else is encoded as Base64 with metadata
+ * {@code encoding=base64}. The detection contract used at download time
+ * ({@code metadata.encoding == "base64"}) is unchanged, so legacy resources written
+ * without metadata continue to be decoded as UTF-8 text.
+ *
+ * @author nacos
+ */
+public final class ResourceContentEncoder {
+    
+    /** Metadata key indicating the resource content encoding. */
+    public static final String METADATA_ENCODING = "encoding";
+    
+    /** Metadata value meaning the content is Base64-encoded binary data. */
+    public static final String METADATA_ENCODING_BASE64 = "base64";
+    
+    /** File extensions whose content is safe to store as UTF-8 text. */
+    private static final Set<String> TEXT_EXTENSIONS;
+    
+    /** Lower-cased file names (no extension or with leading dot) that are always text. */
+    private static final Set<String> TEXT_FILE_NAMES;
+    
+    static {
+        Set<String> exts = new HashSet<>();
+        Collections.addAll(exts,
+                // Markup / docs
+                "md", "markdown", "mdx", "txt", "rst", "adoc", "asciidoc",
+                // Structured data / config
+                "json", "json5", "yaml", "yml", "xml", "html", "htm", "css", "scss", "sass", "less",
+                "properties", "conf", "cfg", "ini", "toml", "env", "tpl", "tmpl", "j2", "mustache", "hbs",
+                // Common script / source code
+                "js", "mjs", "cjs", "ts", "tsx", "jsx", "vue", "svelte",
+                "py", "java", "kt", "kts", "scala", "groovy", "go", "rs", "rb", "php",
+                "swift", "m", "mm", "c", "h", "cpp", "cc", "cxx", "hpp", "hh", "hxx",
+                "cs", "fs", "fsx", "vb", "lua", "r", "pl", "pm", "ex", "exs", "erl",
+                "dart", "zig", "nim", "jl", "clj", "cljs", "edn", "elm",
+                // Shell / build
+                "sh", "bash", "zsh", "fish", "ps1", "psm1", "bat", "cmd",
+                "gradle", "sbt", "make", "mk",
+                // Data / log
+                "sql", "graphql", "gql", "csv", "tsv", "log", "diff", "patch",
+                // Misc text
+                "proto", "thrift", "ipynb"
+        );
+        TEXT_EXTENSIONS = Collections.unmodifiableSet(exts);
+        
+        Set<String> names = new HashSet<>();
+        Collections.addAll(names,
+                // Common no-extension text files (case-insensitive match)
+                "dockerfile", "containerfile", "makefile", "rakefile", "gemfile", "gemfile.lock",
+                "jenkinsfile", "vagrantfile", "procfile", "brewfile",
+                "license", "license.txt", "notice", "readme", "changelog", "authors",
+                "contributors", "maintainers", "codeowners", "version", "manifest",
+                // Dotfiles
+                ".gitignore", ".gitattributes", ".gitmodules", ".gitkeep",
+                ".dockerignore", ".editorconfig", ".env", ".envrc",
+                ".npmrc", ".nvmrc", ".yarnrc", ".prettierrc", ".eslintrc",
+                ".babelrc", ".browserslistrc", ".stylelintrc"
+        );
+        TEXT_FILE_NAMES = Collections.unmodifiableSet(names);
+    }
+    
+    private ResourceContentEncoder() {
+    }
+    
+    /**
+     * Decide whether the given file should be persisted as UTF-8 text.
+     * Text whitelist matches by exact filename (for files with no extension or leading dot)
+     * and by lower-cased extension. Anything not matched is treated as binary.
+     *
+     * @param fileName file name including extension (path prefix is allowed)
+     * @return {@code true} if the file is recognized as plain text
+     */
+    public static boolean isText(String fileName) {
+        if (StringUtils.isBlank(fileName)) {
+            return false;
+        }
+        String pureName = stripDirectory(fileName).trim();
+        if (pureName.isEmpty()) {
+            return false;
+        }
+        String lower = pureName.toLowerCase();
+        if (TEXT_FILE_NAMES.contains(lower)) {
+            return true;
+        }
+        int dot = lower.lastIndexOf('.');
+        // No extension, or trailing dot: rely solely on the filename whitelist above.
+        if (dot <= 0 || dot == lower.length() - 1) {
+            return false;
+        }
+        String ext = lower.substring(dot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+    
+    /**
+     * Convenience inverse of {@link #isText(String)}.
+     *
+     * @param fileName file name including extension
+     * @return {@code true} when the file is not in the text whitelist
+     */
+    public static boolean isBinary(String fileName) {
+        return !isText(fileName);
+    }
+    
+    /**
+     * Encode raw resource bytes for storage.
+     * Text files are stored as UTF-8 strings with no encoding metadata; binary files are
+     * stored as Base64 strings with {@code metadata.encoding=base64} so download paths
+     * can restore the original bytes via {@code SkillUtils.resolveResourceBytes}.
+     *
+     * @param data     raw bytes; {@code null} is treated as empty content
+     * @param fileName file name used to look up the text whitelist
+     * @return immutable encoded content holder
+     */
+    public static EncodedContent encode(byte[] data, String fileName) {
+        if (data == null || data.length == 0) {
+            return new EncodedContent("", null);
+        }
+        if (isText(fileName)) {
+            return new EncodedContent(new String(data, StandardCharsets.UTF_8), null);
+        }
+        Map<String, Object> metadata = new HashMap<>(2);
+        metadata.put(METADATA_ENCODING, METADATA_ENCODING_BASE64);
+        return new EncodedContent(Base64.getEncoder().encodeToString(data), metadata);
+    }
+    
+    /**
+     * Build a metadata map flagging Base64 encoding. Used by storage-side reconstruction
+     * paths that already hold a content string and only need to attach the encoding hint.
+     *
+     * @return mutable metadata map containing only the Base64 encoding flag
+     */
+    public static Map<String, Object> base64Metadata() {
+        Map<String, Object> metadata = new HashMap<>(2);
+        metadata.put(METADATA_ENCODING, METADATA_ENCODING_BASE64);
+        return metadata;
+    }
+    
+    private static String stripDirectory(String name) {
+        int slash = name.lastIndexOf('/');
+        if (slash >= 0) {
+            return name.substring(slash + 1);
+        }
+        int back = name.lastIndexOf('\\');
+        return back >= 0 ? name.substring(back + 1) : name;
+    }
+    
+    /**
+     * Immutable holder describing an encoded resource: the textual content and optional metadata.
+     * Metadata is {@code null} when no special encoding hint is needed (plain text).
+     */
+    public static final class EncodedContent {
+        
+        private final String content;
+        
+        private final Map<String, Object> metadata;
+        
+        EncodedContent(String content, Map<String, Object> metadata) {
+            this.content = content;
+            this.metadata = metadata;
+        }
+        
+        public String getContent() {
+            return content;
+        }
+        
+        public Map<String, Object> getMetadata() {
+            return metadata;
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
@@ -74,7 +74,8 @@ public class SkillZipParser {
      */
     public static final String METADATA_ENCODING = ResourceContentEncoder.METADATA_ENCODING;
     
-    public static final String METADATA_ENCODING_BASE64 = ResourceContentEncoder.METADATA_ENCODING_BASE64;
+    public static final String METADATA_ENCODING_BASE64 =
+        ResourceContentEncoder.METADATA_ENCODING_BASE64;
     
     /**
      * Maximum total decompressed size allowed (50MB). Prevents Zip Bomb attacks.

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
@@ -33,7 +33,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -67,12 +66,15 @@ public class SkillZipParser {
     private static final String ESCAPED_DOUBLE_QUOTE = "\\\"";
     private static final String SLASH = "/";
     private static final String DOT = ".";
-    /** Metadata key for binary resources: value "base64" means content is Base64-encoded. */
-    public static final String METADATA_ENCODING = "encoding";
-    public static final String METADATA_ENCODING_BASE64 = "base64";
+    /**
+     * Metadata key for binary resources: value "base64" means content is Base64-encoded.
+     * Kept as constants on this class for backward compatibility with existing callers
+     * (e.g. {@code SkillOperationServiceImpl}); the canonical definition lives on
+     * {@link ResourceContentEncoder}.
+     */
+    public static final String METADATA_ENCODING = ResourceContentEncoder.METADATA_ENCODING;
     
-    /** File extensions treated as binary; content will be stored as Base64. */
-    private static final Set<String> BINARY_EXTENSIONS = new HashSet<>();
+    public static final String METADATA_ENCODING_BASE64 = ResourceContentEncoder.METADATA_ENCODING_BASE64;
     
     /**
      * Maximum total decompressed size allowed (50MB). Prevents Zip Bomb attacks.
@@ -83,23 +85,6 @@ public class SkillZipParser {
      * Maximum number of entries allowed in a ZIP file.
      */
     private static final int MAX_ZIP_ENTRIES = 500;
-    
-    static {
-        BINARY_EXTENSIONS.add("ttf");
-        BINARY_EXTENSIONS.add("otf");
-        BINARY_EXTENSIONS.add("woff");
-        BINARY_EXTENSIONS.add("woff2");
-        BINARY_EXTENSIONS.add("eot");
-        BINARY_EXTENSIONS.add("png");
-        BINARY_EXTENSIONS.add("jpg");
-        BINARY_EXTENSIONS.add("jpeg");
-        BINARY_EXTENSIONS.add("gif");
-        BINARY_EXTENSIONS.add("webp");
-        BINARY_EXTENSIONS.add("ico");
-        BINARY_EXTENSIONS.add("cur");
-        BINARY_EXTENSIONS.add("pdf");
-        BINARY_EXTENSIONS.add("bin");
-    }
     
     private static final Pattern YAML_FRONT_MATTER = Pattern.compile(
         "^---\\s*\\n(.*?)\\n---\\s*\\n(.*)$", Pattern.DOTALL);
@@ -568,21 +553,14 @@ public class SkillZipParser {
                 continue;
             }
             
-            boolean isBinary = isBinaryResource(resourceName);
-            String content;
-            Map<String, Object> metadata = new HashMap<>(4);
-            if (isBinary) {
-                content = Base64.getEncoder().encodeToString(entry.data);
-                metadata.put(METADATA_ENCODING, METADATA_ENCODING_BASE64);
-            } else {
-                content = new String(entry.data, StandardCharsets.UTF_8);
-            }
+            ResourceContentEncoder.EncodedContent encoded =
+                ResourceContentEncoder.encode(entry.data, resourceName);
             
             SkillResource resource = new SkillResource();
             resource.setName(resourceName);
             resource.setType(type);
-            resource.setContent(content);
-            resource.setMetadata(metadata.isEmpty() ? null : metadata);
+            resource.setContent(encoded.getContent());
+            resource.setMetadata(encoded.getMetadata());
             // Use same key as getSkillDetail so resource map is consistent when skill is read back
             String key = SkillUtils.generateResourceId(type, resourceName);
             resources.put(key, resource);
@@ -592,17 +570,14 @@ public class SkillZipParser {
     }
     
     /**
-     * check is binary
-     * @param fileName file name
-     * @return
+     * Check whether a resource should be persisted as Base64-encoded binary content.
+     * Backward-compatible facade over {@link ResourceContentEncoder#isBinary(String)}.
+     *
+     * @param fileName resource file name (with extension)
+     * @return {@code true} when the file is not in the text whitelist
      */
     public static boolean isBinaryResource(String fileName) {
-        if (StringUtils.isBlank(fileName) || !fileName.contains(DOT)) {
-            return false;
-        }
-        String ext =
-            fileName.substring(fileName.lastIndexOf(DOT.charAt(0)) + 1).trim().toLowerCase();
-        return BINARY_EXTENSIONS.contains(ext);
+        return ResourceContentEncoder.isBinary(fileName);
     }
     
     private static final class ZipEntryData {

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/ResourceContentEncoderTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/ResourceContentEncoderTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResourceContentEncoderTest {
+    
+    @Test
+    void isTextShouldRecognizeCommonTextExtensions() {
+        for (String name : Arrays.asList("SKILL.md", "manifest.json", "config.yaml",
+                "README.txt", "build.gradle", "schema.proto", "script.py", "service.go",
+                "Main.java", "index.ts", "styles.css", "query.sql")) {
+            assertTrue(ResourceContentEncoder.isText(name), name + " should be text");
+        }
+    }
+    
+    @Test
+    void isTextShouldRejectKnownBinaryExtensions() {
+        for (String name : Arrays.asList("logo.png", "preview.jpg", "icon.ico",
+                "doc.pdf", "font.ttf", "font.woff2", "blob.bin")) {
+            assertFalse(ResourceContentEncoder.isText(name), name + " should be binary");
+        }
+    }
+    
+    @Test
+    void isTextShouldRejectUnlistedBinaryExtensions() {
+        // Files previously slipping through the legacy binary whitelist now fall back to binary.
+        for (String name : Arrays.asList("payload.zip", "lib.jar", "audio.mp3",
+                "video.mp4", "module.wasm", "report.docx", "deck.pptx", "data.xlsx")) {
+            assertFalse(ResourceContentEncoder.isText(name), name + " should be binary");
+        }
+    }
+    
+    @Test
+    void isTextShouldRecognizeWellKnownNoExtensionFiles() {
+        for (String name : Arrays.asList("Dockerfile", "Makefile", "Jenkinsfile",
+                "LICENSE", "NOTICE", "README", "CHANGELOG")) {
+            assertTrue(ResourceContentEncoder.isText(name), name + " should be text");
+        }
+    }
+    
+    @Test
+    void isTextShouldRecognizeCommonDotfiles() {
+        for (String name : Arrays.asList(".gitignore", ".gitattributes", ".dockerignore",
+                ".editorconfig", ".env", ".npmrc", ".prettierrc")) {
+            assertTrue(ResourceContentEncoder.isText(name), name + " should be text");
+        }
+    }
+    
+    @Test
+    void isTextShouldBeCaseInsensitive() {
+        assertTrue(ResourceContentEncoder.isText("README.MD"));
+        assertTrue(ResourceContentEncoder.isText("DOCKERFILE"));
+        assertTrue(ResourceContentEncoder.isText("Notes.JSON"));
+    }
+    
+    @Test
+    void isTextShouldStripPathPrefix() {
+        assertTrue(ResourceContentEncoder.isText("skill-name/scripts/run.sh"));
+        assertTrue(ResourceContentEncoder.isText("nested/dir/Dockerfile"));
+        assertFalse(ResourceContentEncoder.isText("assets/images/logo.png"));
+    }
+    
+    @Test
+    void isTextShouldRejectBlankAndNoExtensionUnknownFiles() {
+        assertFalse(ResourceContentEncoder.isText(null));
+        assertFalse(ResourceContentEncoder.isText(""));
+        assertFalse(ResourceContentEncoder.isText("   "));
+        // Unknown file with no extension and not in the dotfile/no-ext whitelist
+        assertFalse(ResourceContentEncoder.isText("randomfile"));
+        assertFalse(ResourceContentEncoder.isText("script."));
+    }
+    
+    @Test
+    void isBinaryShouldBeInverseOfIsText() {
+        assertTrue(ResourceContentEncoder.isBinary("logo.png"));
+        assertTrue(ResourceContentEncoder.isBinary("payload.zip"));
+        assertFalse(ResourceContentEncoder.isBinary("README.md"));
+        assertFalse(ResourceContentEncoder.isBinary("Dockerfile"));
+    }
+    
+    @Test
+    void encodeShouldReturnUtf8StringWithoutMetadataForTextFiles() {
+        byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+        ResourceContentEncoder.EncodedContent encoded =
+                ResourceContentEncoder.encode(data, "notes.md");
+        assertEquals("hello world", encoded.getContent());
+        assertNull(encoded.getMetadata());
+    }
+    
+    @Test
+    void encodeShouldReturnBase64StringWithMetadataForBinaryFiles() {
+        byte[] data = new byte[]{0x00, 0x01, (byte) 0xFF, (byte) 0xFE, 0x42};
+        ResourceContentEncoder.EncodedContent encoded =
+                ResourceContentEncoder.encode(data, "blob.bin");
+        assertEquals(Base64.getEncoder().encodeToString(data), encoded.getContent());
+        Map<String, Object> meta = encoded.getMetadata();
+        assertNotNull(meta);
+        assertEquals(ResourceContentEncoder.METADATA_ENCODING_BASE64,
+                meta.get(ResourceContentEncoder.METADATA_ENCODING));
+    }
+    
+    @Test
+    void encodeShouldRoundTripBinaryBytes() {
+        byte[] original = new byte[256];
+        for (int i = 0; i < original.length; i++) {
+            original[i] = (byte) i;
+        }
+        ResourceContentEncoder.EncodedContent encoded =
+                ResourceContentEncoder.encode(original, "payload.zip");
+        byte[] decoded = Base64.getDecoder().decode(encoded.getContent());
+        assertArrayEquals(original, decoded);
+    }
+    
+    @Test
+    void encodeShouldHandleNullAndEmptyData() {
+        ResourceContentEncoder.EncodedContent forNull =
+                ResourceContentEncoder.encode(null, "notes.md");
+        assertEquals("", forNull.getContent());
+        assertNull(forNull.getMetadata());
+        
+        ResourceContentEncoder.EncodedContent forEmpty =
+                ResourceContentEncoder.encode(new byte[0], "blob.bin");
+        assertEquals("", forEmpty.getContent());
+        assertNull(forEmpty.getMetadata());
+    }
+    
+    @Test
+    void base64MetadataShouldContainOnlyEncodingFlag() {
+        Map<String, Object> meta = ResourceContentEncoder.base64Metadata();
+        assertEquals(1, meta.size());
+        assertEquals(ResourceContentEncoder.METADATA_ENCODING_BASE64,
+                meta.get(ResourceContentEncoder.METADATA_ENCODING));
+    }
+    
+    @Test
+    void publicMetadataConstantsShouldUseExpectedValues() {
+        assertEquals("encoding", ResourceContentEncoder.METADATA_ENCODING);
+        assertEquals("base64", ResourceContentEncoder.METADATA_ENCODING_BASE64);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/ResourceContentEncoderTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/ResourceContentEncoderTest.java
@@ -35,8 +35,8 @@ class ResourceContentEncoderTest {
     @Test
     void isTextShouldRecognizeCommonTextExtensions() {
         for (String name : Arrays.asList("SKILL.md", "manifest.json", "config.yaml",
-                "README.txt", "build.gradle", "schema.proto", "script.py", "service.go",
-                "Main.java", "index.ts", "styles.css", "query.sql")) {
+            "README.txt", "build.gradle", "schema.proto", "script.py", "service.go",
+            "Main.java", "index.ts", "styles.css", "query.sql")) {
             assertTrue(ResourceContentEncoder.isText(name), name + " should be text");
         }
     }
@@ -44,7 +44,7 @@ class ResourceContentEncoderTest {
     @Test
     void isTextShouldRejectKnownBinaryExtensions() {
         for (String name : Arrays.asList("logo.png", "preview.jpg", "icon.ico",
-                "doc.pdf", "font.ttf", "font.woff2", "blob.bin")) {
+            "doc.pdf", "font.ttf", "font.woff2", "blob.bin")) {
             assertFalse(ResourceContentEncoder.isText(name), name + " should be binary");
         }
     }
@@ -53,7 +53,7 @@ class ResourceContentEncoderTest {
     void isTextShouldRejectUnlistedBinaryExtensions() {
         // Files previously slipping through the legacy binary whitelist now fall back to binary.
         for (String name : Arrays.asList("payload.zip", "lib.jar", "audio.mp3",
-                "video.mp4", "module.wasm", "report.docx", "deck.pptx", "data.xlsx")) {
+            "video.mp4", "module.wasm", "report.docx", "deck.pptx", "data.xlsx")) {
             assertFalse(ResourceContentEncoder.isText(name), name + " should be binary");
         }
     }
@@ -61,7 +61,7 @@ class ResourceContentEncoderTest {
     @Test
     void isTextShouldRecognizeWellKnownNoExtensionFiles() {
         for (String name : Arrays.asList("Dockerfile", "Makefile", "Jenkinsfile",
-                "LICENSE", "NOTICE", "README", "CHANGELOG")) {
+            "LICENSE", "NOTICE", "README", "CHANGELOG")) {
             assertTrue(ResourceContentEncoder.isText(name), name + " should be text");
         }
     }
@@ -69,7 +69,7 @@ class ResourceContentEncoderTest {
     @Test
     void isTextShouldRecognizeCommonDotfiles() {
         for (String name : Arrays.asList(".gitignore", ".gitattributes", ".dockerignore",
-                ".editorconfig", ".env", ".npmrc", ".prettierrc")) {
+            ".editorconfig", ".env", ".npmrc", ".prettierrc")) {
             assertTrue(ResourceContentEncoder.isText(name), name + " should be text");
         }
     }
@@ -110,21 +110,21 @@ class ResourceContentEncoderTest {
     void encodeShouldReturnUtf8StringWithoutMetadataForTextFiles() {
         byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
         ResourceContentEncoder.EncodedContent encoded =
-                ResourceContentEncoder.encode(data, "notes.md");
+            ResourceContentEncoder.encode(data, "notes.md");
         assertEquals("hello world", encoded.getContent());
         assertNull(encoded.getMetadata());
     }
     
     @Test
     void encodeShouldReturnBase64StringWithMetadataForBinaryFiles() {
-        byte[] data = new byte[]{0x00, 0x01, (byte) 0xFF, (byte) 0xFE, 0x42};
+        byte[] data = new byte[] {0x00, 0x01, (byte) 0xFF, (byte) 0xFE, 0x42};
         ResourceContentEncoder.EncodedContent encoded =
-                ResourceContentEncoder.encode(data, "blob.bin");
+            ResourceContentEncoder.encode(data, "blob.bin");
         assertEquals(Base64.getEncoder().encodeToString(data), encoded.getContent());
         Map<String, Object> meta = encoded.getMetadata();
         assertNotNull(meta);
         assertEquals(ResourceContentEncoder.METADATA_ENCODING_BASE64,
-                meta.get(ResourceContentEncoder.METADATA_ENCODING));
+            meta.get(ResourceContentEncoder.METADATA_ENCODING));
     }
     
     @Test
@@ -134,7 +134,7 @@ class ResourceContentEncoderTest {
             original[i] = (byte) i;
         }
         ResourceContentEncoder.EncodedContent encoded =
-                ResourceContentEncoder.encode(original, "payload.zip");
+            ResourceContentEncoder.encode(original, "payload.zip");
         byte[] decoded = Base64.getDecoder().decode(encoded.getContent());
         assertArrayEquals(original, decoded);
     }
@@ -142,12 +142,12 @@ class ResourceContentEncoderTest {
     @Test
     void encodeShouldHandleNullAndEmptyData() {
         ResourceContentEncoder.EncodedContent forNull =
-                ResourceContentEncoder.encode(null, "notes.md");
+            ResourceContentEncoder.encode(null, "notes.md");
         assertEquals("", forNull.getContent());
         assertNull(forNull.getMetadata());
         
         ResourceContentEncoder.EncodedContent forEmpty =
-                ResourceContentEncoder.encode(new byte[0], "blob.bin");
+            ResourceContentEncoder.encode(new byte[0], "blob.bin");
         assertEquals("", forEmpty.getContent());
         assertNull(forEmpty.getMetadata());
     }
@@ -157,7 +157,7 @@ class ResourceContentEncoderTest {
         Map<String, Object> meta = ResourceContentEncoder.base64Metadata();
         assertEquals(1, meta.size());
         assertEquals(ResourceContentEncoder.METADATA_ENCODING_BASE64,
-                meta.get(ResourceContentEncoder.METADATA_ENCODING));
+            meta.get(ResourceContentEncoder.METADATA_ENCODING));
     }
     
     @Test


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

default unlisted resources to base64 to avoid utf-8 corruption

## Brief changelog

- Extract ResourceContentEncoder shared by Skill and AgentSpec zip parsers, switching upload policy from a binary blacklist to a text whitelist.
- Files outside the text whitelist (zip/jar/mp3/etc.) are now stored as Base64 with metadata.encoding=base64 instead of being decoded as UTF-8, which previously corrupted the bytes.
- Detection contract on download (metadata.encoding == "base64") is unchanged, so legacy resources keep working without migration.
- Recognize well-known no-extension files (Dockerfile/Makefile/.gitignore ...) as text so they stop being unnecessarily Base64-encoded.
- Add ResourceContentEncoderTest covering text whitelist, binary fallback, no-extension/dotfile cases and full byte-level round-trip.

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

