### PR TITLE
feat(ai): parallelize AgentSpec storage writes aligned with Skill

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -31,6 +31,7 @@ import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.ai.utils.AgentSpecSeedArchiveReader;
 import com.alibaba.nacos.ai.utils.AgentSpecZipParser;
+import com.alibaba.nacos.ai.utils.ExecutorUtils;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecBasicInfo;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecMeta;
@@ -61,6 +62,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 
 /**
  * AgentSpec operation service implementation. Mirrors {@code SkillOperationServiceImpl} with AgentSpec types.
@@ -125,29 +129,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         long uniformId = System.currentTimeMillis();
         String currentUser = VisibilityHelper.resolveCurrentIdentity();
         
-        // 1) write storage for draft version
-        byte[] mainContent = buildMainContent(agentSpec, uniformId);
-        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(resolveStorageProvider(),
-            namespaceId,
-            NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC, agentSpecName, version,
-            NacosConfigAiResourceStorage.getMainFilePath(AgentSpecUtils.AGENTSPEC_MAIN_DATA_ID));
-        storageRouter.route(mainKey).save(mainKey, mainContent);
-        
-        if (agentSpec.getResource() != null && !agentSpec.getResource().isEmpty()) {
-            for (Map.Entry<String, AgentSpecResource> entry : agentSpec.getResource().entrySet()) {
-                AgentSpecResource resource = entry.getValue();
-                String path =
-                    NacosConfigAiResourceStorage.getAgentSpecResourceFilePath(resource.getType(),
-                        resource.getName());
-                byte[] resourceContent = buildResourceContent(resource, uniformId);
-                StorageKey resourceKey =
-                    NacosConfigAiResourceStorage.buildStorageKey(resolveStorageProvider(),
-                        namespaceId, NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC,
-                        agentSpecName, version,
-                        path);
-                storageRouter.route(resourceKey).save(resourceKey, resourceContent);
-            }
-        }
+        // 1) write storage for draft version (main config + resources persisted concurrently)
+        saveAgentSpecFilesConcurrently(namespaceId, agentSpec, version, uniformId);
         
         // 2) insert draft version row
         resourceManager.insertVersionRow(namespaceId, agentSpecName, RESOURCE_TYPE_AGENTSPEC,
@@ -1151,18 +1134,45 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
      * Write all AgentSpec files (main config + resources) to storage.
      * Main config is serialized as JSON containing name, description, content, and resource references.
      * Each resource file is serialized as JSON with a uniformId for consistency tracking.
+     *
+     * <p>Files are persisted concurrently via a dedicated IO executor to reduce latency
+     * when AgentSpec contains multiple resource files. Mirrors the Skill implementation.</p>
      */
     private void writeAgentSpecToStorage(String namespaceId, AgentSpec agentSpec, String version,
         long uniformId)
         throws NacosException {
-        // Step 1: Serialize and store main config file (manifest.json), containing name/description/content and resource reference list
+        saveAgentSpecFilesConcurrently(namespaceId, agentSpec, version, uniformId);
+    }
+    
+    /**
+     * Persist AgentSpec main config (manifest.json) and all resource files concurrently.
+     *
+     * <p>Each file (main + N resources) is submitted to {@link ExecutorUtils#getAgentSpecStorageIoExecutor()}
+     * and waited on via {@link CompletableFuture#allOf}. Underlying {@link NacosException}s thrown from
+     * individual save tasks are unwrapped from {@link CompletionException} and rethrown to keep the
+     * original exception semantics aligned with the previous serial implementation.</p>
+     */
+    private void saveAgentSpecFilesConcurrently(String namespaceId, AgentSpec agentSpec,
+        String version, long uniformId) throws NacosException {
+        String provider = resolveStorageProvider();
+        String agentSpecName = agentSpec.getName();
+        Executor executor = ExecutorUtils.getAgentSpecStorageIoExecutor();
+        List<CompletableFuture<Void>> tasks = new ArrayList<>();
+        
+        // 1) Main config file (manifest.json)
         byte[] mainContent = buildMainContent(agentSpec, uniformId);
-        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(resolveStorageProvider(),
-            namespaceId,
-            NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC, agentSpec.getName(), version,
+        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId,
+            NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC, agentSpecName, version,
             NacosConfigAiResourceStorage.getMainFilePath(AgentSpecUtils.AGENTSPEC_MAIN_DATA_ID));
-        storageRouter.route(mainKey).save(mainKey, mainContent);
-        // Step 2: Serialize and store each resource file (each resource carries a uniformId for consistency tracking)
+        tasks.add(CompletableFuture.runAsync(() -> {
+            try {
+                storageRouter.route(mainKey).save(mainKey, mainContent);
+            } catch (NacosException e) {
+                throw new CompletionException(e);
+            }
+        }, executor));
+        
+        // 2) Resource files (each carries a uniformId for consistency tracking)
         if (agentSpec.getResource() != null && !agentSpec.getResource().isEmpty()) {
             for (Map.Entry<String, AgentSpecResource> entry : agentSpec.getResource().entrySet()) {
                 AgentSpecResource resource = entry.getValue();
@@ -1170,13 +1180,27 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
                     NacosConfigAiResourceStorage.getAgentSpecResourceFilePath(resource.getType(),
                         resource.getName());
                 byte[] content = buildResourceContent(resource, uniformId);
-                StorageKey resourceKey =
-                    NacosConfigAiResourceStorage.buildStorageKey(resolveStorageProvider(),
-                        namespaceId, NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC,
-                        agentSpec.getName(),
-                        version, path);
-                storageRouter.route(resourceKey).save(resourceKey, content);
+                StorageKey resourceKey = NacosConfigAiResourceStorage.buildStorageKey(provider,
+                    namespaceId, NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC,
+                    agentSpecName, version, path);
+                tasks.add(CompletableFuture.runAsync(() -> {
+                    try {
+                        storageRouter.route(resourceKey).save(resourceKey, content);
+                    } catch (NacosException e) {
+                        throw new CompletionException(e);
+                    }
+                }, executor));
             }
+        }
+        
+        try {
+            CompletableFuture.allOf(tasks.toArray(new CompletableFuture[0])).join();
+        } catch (CompletionException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof NacosException) {
+                throw (NacosException) cause;
+            }
+            throw ex;
         }
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/ExecutorUtils.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/ExecutorUtils.java
@@ -38,16 +38,34 @@ public final class ExecutorUtils {
         "nacos.ai.skill.storage.io.concurrency";
     
     /**
+     * System config key for async concurrency when persisting AgentSpec resource files to storage.
+     */
+    public static final String AGENTSPEC_STORAGE_IO_CONCURRENCY_CONFIG_KEY =
+        "nacos.ai.agentspec.storage.io.concurrency";
+    
+    /**
      * Default concurrency for async skill resource persistence.
      */
     private static final int DEFAULT_SKILL_STORAGE_IO_CONCURRENCY =
         PropertyUtils.getProcessorsCount();
     
+    /**
+     * Default concurrency for async AgentSpec resource persistence.
+     */
+    private static final int DEFAULT_AGENTSPEC_STORAGE_IO_CONCURRENCY =
+        PropertyUtils.getProcessorsCount();
+    
     private static final ExecutorService SKILL_STORAGE_IO_EXECUTOR =
         ExecutorFactory.Managed.newFixedExecutorService(
             ExecutorUtils.class.getCanonicalName(),
-            resolveStorageIoConcurrency(),
+            resolveSkillStorageIoConcurrency(),
             new NameThreadFactory("com.alibaba.nacos.ai.skill.storage-io"));
+    
+    private static final ExecutorService AGENTSPEC_STORAGE_IO_EXECUTOR =
+        ExecutorFactory.Managed.newFixedExecutorService(
+            ExecutorUtils.class.getCanonicalName(),
+            resolveAgentSpecStorageIoConcurrency(),
+            new NameThreadFactory("com.alibaba.nacos.ai.agentspec.storage-io"));
     
     /**
      * Executor for async storage IO of skill resources.
@@ -56,13 +74,30 @@ public final class ExecutorUtils {
         return SKILL_STORAGE_IO_EXECUTOR;
     }
     
-    private static int resolveStorageIoConcurrency() {
+    /**
+     * Executor for async storage IO of AgentSpec resources.
+     */
+    public static ExecutorService getAgentSpecStorageIoExecutor() {
+        return AGENTSPEC_STORAGE_IO_EXECUTOR;
+    }
+    
+    private static int resolveSkillStorageIoConcurrency() {
         String val = EnvUtil.getProperty(SKILL_STORAGE_IO_CONCURRENCY_CONFIG_KEY,
             String.valueOf(DEFAULT_SKILL_STORAGE_IO_CONCURRENCY));
         try {
             return Integer.max(1, Integer.parseInt(val));
         } catch (Exception ignored) {
             return DEFAULT_SKILL_STORAGE_IO_CONCURRENCY;
+        }
+    }
+    
+    private static int resolveAgentSpecStorageIoConcurrency() {
+        String val = EnvUtil.getProperty(AGENTSPEC_STORAGE_IO_CONCURRENCY_CONFIG_KEY,
+            String.valueOf(DEFAULT_AGENTSPEC_STORAGE_IO_CONCURRENCY));
+        try {
+            return Integer.max(1, Integer.parseInt(val));
+        } catch (Exception ignored) {
+            return DEFAULT_AGENTSPEC_STORAGE_IO_CONCURRENCY;
         }
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecConcurrentSaveTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecConcurrentSaveTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agentspecs;
+
+import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
+import com.alibaba.nacos.ai.pipeline.PublishPipelineManager;
+import com.alibaba.nacos.ai.pipeline.config.PipelineConfigProvider;
+import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
+import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
+import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
+import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.service.resource.AiResourceManager;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecResource;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
+import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests guarding the concurrent save behaviour introduced in
+ * {@link AgentSpecOperationServiceImpl#saveAgentSpecFilesConcurrently}.
+ *
+ * <p>The tests directly drive the private helper through reflection so that they
+ * remain insulated from the surrounding draft / publish business logic. Each test
+ * pins one invariant of the refactor: write count, executor isolation, and exception
+ * unwrapping. Together they ensure the parallelization does not regress correctness
+ * compared to the previous serial implementation.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class AgentSpecConcurrentSaveTest {
+    
+    @Mock
+    private AiResourceStorage storage;
+    
+    @Mock
+    private AiResourcePersistService aiResourcePersistService;
+    
+    @Mock
+    private AiResourceVersionPersistService aiResourceVersionPersistService;
+    
+    @Mock
+    private PipelineConfigProvider pipelineConfigProvider;
+    
+    @Mock
+    private PipelineExecutionRepository pipelineExecutionRepository;
+    
+    private AgentSpecOperationServiceImpl service;
+    
+    private static final org.springframework.core.env.ConfigurableEnvironment CACHED_ENVIRONMENT =
+        EnvUtil.getEnvironment();
+    
+    @BeforeAll
+    static void initEnvBeforeClassLoad() {
+        // ExecutorUtils' static initializer reads EnvUtil during class loading; if EnvUtil
+        // has not been primed beforehand, the <clinit> will throw NPE and permanently mark
+        // the class as NoClassDefFoundError, breaking every subsequent test in the JVM.
+        EnvUtil.setEnvironment(new StandardEnvironment());
+    }
+    
+    @AfterAll
+    static void restoreEnv() {
+        EnvUtil.setEnvironment(CACHED_ENVIRONMENT);
+    }
+    
+    @BeforeEach
+    void setUp() {
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        AiResourceStorageRouter.reset();
+        lenient().when(storage.type()).thenReturn("nacos_config");
+        AiResourceStorageRouter.join(storage);
+        PipelineConfig disabledConfig = new PipelineConfig();
+        disabledConfig.setEnabled(false);
+        lenient().when(pipelineConfigProvider.getConfig()).thenReturn(disabledConfig);
+        PublishPipelineExecutor publishPipelineExecutor = new PublishPipelineExecutor(
+            new PublishPipelineManager(), pipelineConfigProvider, pipelineExecutionRepository,
+            Executors.newSingleThreadExecutor());
+        service = new AgentSpecOperationServiceImpl(aiResourcePersistService,
+            aiResourceVersionPersistService, publishPipelineExecutor,
+            new AiResourceManager(aiResourcePersistService, aiResourceVersionPersistService,
+                pipelineExecutionRepository));
+    }
+    
+    @AfterEach
+    void tearDown() {
+        AiResourceStorageRouter.reset();
+        EnvUtil.setEnvironment(CACHED_ENVIRONMENT);
+    }
+    
+    @Test
+    void saveAgentSpecWithoutResourcesShouldPersistOnlyManifest() throws Exception {
+        AgentSpec agentSpec = new AgentSpec();
+        agentSpec.setName("only-main-agent");
+        agentSpec.setDescription("manifest only");
+        
+        invokeConcurrentSave("public", agentSpec, "v1", System.currentTimeMillis());
+        
+        verify(storage, org.mockito.Mockito.times(1))
+            .save(any(StorageKey.class), any(byte[].class));
+    }
+    
+    @Test
+    void saveAgentSpecWithMultipleResourcesShouldPersistMainAndAllResources() throws Exception {
+        AgentSpec agentSpec = new AgentSpec();
+        agentSpec.setName("multi-resource-agent");
+        agentSpec.setDescription("with resources");
+        Map<String, AgentSpecResource> resources = new LinkedHashMap<>();
+        resources.put("res-a", buildResource("res-a", "config", "alpha"));
+        resources.put("res-b", buildResource("res-b", "skill", "beta"));
+        resources.put("res-c", buildResource("res-c", "other", "gamma"));
+        agentSpec.setResource(resources);
+        
+        Set<String> capturedKeys = new HashSet<>();
+        lenient().doAnswer(invocation -> {
+            StorageKey key = invocation.getArgument(0);
+            capturedKeys.add(key.getKey());
+            return null;
+        }).when(storage).save(any(StorageKey.class), any(byte[].class));
+        
+        invokeConcurrentSave("public", agentSpec, "v1", System.currentTimeMillis());
+        
+        verify(storage, org.mockito.Mockito.times(4))
+            .save(any(StorageKey.class), any(byte[].class));
+        // Each StorageKey must be unique to avoid resources stomping each other when
+        // running concurrently in production.
+        assertEquals(4, capturedKeys.size(),
+            "Each saved file must use a distinct StorageKey, captured: " + capturedKeys);
+    }
+    
+    @Test
+    void allSavesShouldRunOnAgentSpecStorageIoExecutor() throws Exception {
+        AgentSpec agentSpec = new AgentSpec();
+        agentSpec.setName("threading-agent");
+        Map<String, AgentSpecResource> resources = new LinkedHashMap<>();
+        resources.put("a", buildResource("a", "config", "x"));
+        resources.put("b", buildResource("b", "config", "y"));
+        agentSpec.setResource(resources);
+        
+        ConcurrentLinkedQueue<String> threadNames = new ConcurrentLinkedQueue<>();
+        lenient().doAnswer(invocation -> {
+            threadNames.add(Thread.currentThread().getName());
+            return null;
+        }).when(storage).save(any(StorageKey.class), any(byte[].class));
+        
+        invokeConcurrentSave("public", agentSpec, "v1", System.currentTimeMillis());
+        
+        // 1 manifest + 2 resources = 3 save invocations, all routed to the dedicated executor.
+        assertEquals(3, threadNames.size());
+        for (String name : threadNames) {
+            assertNotNull(name);
+            assertTrue(name.startsWith("com.alibaba.nacos.ai.agentspec.storage-io"),
+                "save() must run on the AgentSpec storage IO executor, but got: " + name);
+        }
+    }
+    
+    @Test
+    void nacosExceptionFromSaveTaskShouldBeUnwrapped() throws Exception {
+        AgentSpec agentSpec = new AgentSpec();
+        agentSpec.setName("failing-agent");
+        Map<String, AgentSpecResource> resources = new LinkedHashMap<>();
+        resources.put("boom", buildResource("boom", "config", "payload"));
+        agentSpec.setResource(resources);
+        
+        NacosException expected = new NacosException(NacosException.SERVER_ERROR, "boom");
+        lenient().doThrow(expected).when(storage).save(any(StorageKey.class), any(byte[].class));
+        
+        InvocationTargetException ite = assertThrows(InvocationTargetException.class,
+            () -> invokeConcurrentSave("public", agentSpec, "v1", System.currentTimeMillis()));
+        Throwable cause = ite.getCause();
+        assertNotNull(cause, "Reflection invocation must propagate the underlying cause");
+        assertTrue(cause instanceof NacosException,
+            "Expected NacosException unwrapped from CompletionException, got: " + cause);
+        assertSame(expected, cause,
+            "The NacosException raised by storage.save must be propagated as-is");
+    }
+    
+    private AgentSpecResource buildResource(String name, String type, String content) {
+        AgentSpecResource resource = new AgentSpecResource();
+        resource.setName(name);
+        resource.setType(type);
+        resource.setContent(content);
+        resource.setMetadata(new HashMap<>());
+        return resource;
+    }
+    
+    private void invokeConcurrentSave(String namespaceId, AgentSpec agentSpec, String version,
+        long uniformId) throws Exception {
+        Method method = AgentSpecOperationServiceImpl.class
+            .getDeclaredMethod("saveAgentSpecFilesConcurrently", String.class, AgentSpec.class,
+                String.class, long.class);
+        method.setAccessible(true);
+        method.invoke(service, namespaceId, agentSpec, version, uniformId);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/ExecutorUtilsTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/ExecutorUtilsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.utils;
+
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ExecutorUtils} that guard the dedicated IO executors used
+ * by Skill and AgentSpec storage write paths.
+ *
+ * <p>These tests pin the contract relied upon by the concurrent save implementation
+ * in {@code AgentSpecOperationServiceImpl} / {@code SkillOperationServiceImpl}: each
+ * resource type owns an isolated executor, so contention from one resource type
+ * cannot starve the other.</p>
+ */
+class ExecutorUtilsTest {
+    
+    private static ConfigurableEnvironment cachedEnvironment;
+    
+    @BeforeAll
+    static void initEnvBeforeClassLoad() {
+        // ExecutorUtils' static initializer reads EnvUtil; it must be primed before
+        // the test methods trigger class loading, otherwise <clinit> will fail.
+        cachedEnvironment = EnvUtil.getEnvironment();
+        EnvUtil.setEnvironment(new StandardEnvironment());
+    }
+    
+    @AfterAll
+    static void restoreEnv() {
+        if (cachedEnvironment != null) {
+            EnvUtil.setEnvironment(cachedEnvironment);
+        }
+    }
+    
+    @Test
+    void agentSpecExecutorShouldBeAvailable() {
+        ExecutorService executor = ExecutorUtils.getAgentSpecStorageIoExecutor();
+        assertNotNull(executor, "AgentSpec storage IO executor must be initialized");
+    }
+    
+    @Test
+    void agentSpecAndSkillExecutorsShouldBeIsolated() {
+        ExecutorService agentSpecExecutor = ExecutorUtils.getAgentSpecStorageIoExecutor();
+        ExecutorService skillExecutor = ExecutorUtils.getSkillStorageIoExecutor();
+        assertNotNull(agentSpecExecutor);
+        assertNotNull(skillExecutor);
+        assertNotSame(skillExecutor, agentSpecExecutor,
+            "AgentSpec and Skill executors must not share the same underlying pool");
+    }
+    
+    @Test
+    void agentSpecExecutorThreadNameShouldUseDedicatedPrefix() throws Exception {
+        AtomicReference<String> capturedName = new AtomicReference<>();
+        ExecutorUtils.getAgentSpecStorageIoExecutor().submit(() -> {
+            capturedName.set(Thread.currentThread().getName());
+        }).get();
+        String name = capturedName.get();
+        assertNotNull(name);
+        assertTrue(name.startsWith("com.alibaba.nacos.ai.agentspec.storage-io"),
+            "Unexpected thread name for AgentSpec storage IO executor: " + name);
+    }
+    
+    @Test
+    void skillExecutorThreadNameShouldRemainUnchanged() throws Exception {
+        AtomicReference<String> capturedName = new AtomicReference<>();
+        ExecutorUtils.getSkillStorageIoExecutor().submit(() -> {
+            capturedName.set(Thread.currentThread().getName());
+        }).get();
+        String name = capturedName.get();
+        assertNotNull(name);
+        assertTrue(name.startsWith("com.alibaba.nacos.ai.skill.storage-io"),
+            "Skill storage IO executor thread name should remain stable: " + name);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

When publishing or updating an AgentSpec that contains multiple resource files,
`AgentSpecOperationServiceImpl` previously serialized all storage writes
(manifest.json + N resources) into a single `for` loop on the caller thread.
Each write goes through `NacosConfigAiResourceStorage` and ultimately becomes a
`publishConfig` round-trip, so end-to-end latency grew linearly with the number
of resources in an AgentSpec.

This PR aligns AgentSpec writes with the existing `SkillOperationServiceImpl`
implementation by persisting all files concurrently on a dedicated executor,
preserving the original exception semantics.

## Brief changelog

- `ai/utils/ExecutorUtils`
  - Add `AGENTSPEC_STORAGE_IO_EXECUTOR`, a fixed-size pool isolated from the
    Skill executor.
  - Add config key `nacos.ai.agentspec.storage.io.concurrency`
    (default = available processors, min = 1).
  - Rename the previous `resolveStorageIoConcurrency` to
    `resolveSkillStorageIoConcurrency`; add the AgentSpec counterpart.
- `ai/service/agentspecs/AgentSpecOperationServiceImpl`
  - Extract `saveAgentSpecFilesConcurrently(namespaceId, agentSpec, version,
    uniformId)` and replace the serial loop in both
    `createDraftWithAgentSpec` and `writeAgentSpecToStorage`.
  - Each save task is submitted via `CompletableFuture.runAsync` on the
    dedicated executor; tasks wrap the underlying `NacosException` in a
    `CompletionException`, which is unwrapped after `allOf().join()` so the
    outward exception contract is identical to the previous serial code.
  - `resolveStorageProvider()` is now invoked once per call instead of once
    per file.
- Tests
  - `ai/utils/ExecutorUtilsTest`: pin executor isolation, non-null contract,
    and the dedicated `com.alibaba.nacos.ai.agentspec.storage-io` thread name
    prefix.
  - `ai/service/agentspecs/AgentSpecConcurrentSaveTest`: pin save count for
    manifest-only and multi-resource cases, distinct StorageKeys, executor
    membership, and `NacosException` propagation.

## Verifying this change

- `mvn -pl ai -am test -Dtest='ExecutorUtilsTest,AgentSpecConcurrentSaveTest'
  -Dsurefire.failIfNoSpecifiedTests=false` → 8/8 pass.
- `mvn -pl ai -am test` (full AI module): AgentSpec suites 141/141 pass,
  Skill suites 66/66 pass, `SkillAdminControllerTest` 24/24 pass — no
  regression on existing tests.
- `mvn -pl ai -am checkstyle:check`: pass.
- Read/delete paths in `AgentSpecOperationServiceImpl` are intentionally left
  serial (matches Skill behavior).

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

