### PR TITLE
fix(console): resolve controller mapping with request context path

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
+++ b/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
@@ -21,10 +21,12 @@ import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.common.packagescan.DefaultPackageScan;
 import com.alibaba.nacos.common.utils.ArrayUtils;
 import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.core.code.RequestMappingInfo.RequestMappingInfoComparator;
 import com.alibaba.nacos.core.code.condition.ParamRequestCondition;
 import com.alibaba.nacos.core.code.condition.PathRequestCondition;
 import com.alibaba.nacos.sys.env.EnvUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -36,7 +38,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -70,8 +71,8 @@ public class ControllerMethodsCache {
     public Method getMethod(HttpServletRequest request) {
         String path = getPath(request);
         String httpMethod = request.getMethod();
-        String urlKey =
-            httpMethod + REQUEST_PATH_SEPARATOR + path.replaceFirst(EnvUtil.getContextPath(), "");
+        String urlKey = httpMethod + REQUEST_PATH_SEPARATOR
+            + stripContextPath(path, resolveContextPath(request));
         List<RequestMappingInfo> requestMappingInfos = urlLookup.get(urlKey);
         if (CollectionUtils.isEmpty(requestMappingInfos)) {
             return null;
@@ -94,6 +95,23 @@ public class ControllerMethodsCache {
             }
         }
         return methods.get(bestMatch);
+    }
+    
+    private String resolveContextPath(HttpServletRequest request) {
+        String requestContextPath = request.getContextPath();
+        return StringUtils.isEmpty(requestContextPath) ? EnvUtil.getContextPath()
+            : requestContextPath;
+    }
+    
+    private String stripContextPath(String path, String contextPath) {
+        if (StringUtils.isEmpty(path) || StringUtils.isEmpty(contextPath)) {
+            return path;
+        }
+        if (path.startsWith(contextPath)) {
+            String stripped = path.substring(contextPath.length());
+            return StringUtils.isEmpty(stripped) ? StringUtils.EMPTY : stripped;
+        }
+        return path;
     }
     
     private String getPath(HttpServletRequest request) {

--- a/core/src/test/java/com/alibaba/nacos/core/code/ControllerMethodsCacheTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/code/ControllerMethodsCacheTest.java
@@ -136,6 +136,18 @@ class ControllerMethodsCacheTest {
     }
     
     @Test
+    void getMethodWithRequestSpecificContextPathResolvesConsolePath() throws Exception {
+        cache.initClassMethod(Collections.singleton(ConsolePathController.class));
+        MockHttpServletRequest request =
+            new MockHttpServletRequest("POST", "/src/v3/console/ai/skills/draft");
+        request.setContextPath("/src");
+        request.setRequestURI("/src/v3/console/ai/skills/draft");
+        Method method = cache.getMethod(request);
+        assertNotNull(method);
+        assertEquals("createDraft", method.getName());
+    }
+    
+    @Test
     void ambiguousMappingThrowsIllegalStateException() {
         cache.initClassMethod(Collections.singleton(AmbiguousController.class));
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/ambig/same");
@@ -340,5 +352,14 @@ class ControllerMethodsCacheTest {
         @GetMapping("/info")
         public void info() {
         }
+    }
+    
+    @RequestMapping("/v3/console/ai/skills")
+    public static class ConsolePathController {
+        
+        @PostMapping("/draft")
+        public void createDraft() {
+        }
+        
     }
 }


### PR DESCRIPTION
issue: #15166

## What is the purpose of the change

修复 Nacos 3.2.1 配置 nacos.console.contextPath 后，通过 Console 手动创建 Skill 时，创建成功但后续查询详情返回 Skill not found 的问题。

问题根因是 ControllerMethodsCache 在解析请求对应的 Controller 方法时，使用了全局的 EnvUtil.getContextPath() 来剥离请求前缀，而不是优先使用当前请求的 request.getContextPath()。

当 Console 配置了非空前缀，例如 /src 时，请求路径会变成 /src/v3/console/...。此时如果前缀没有被正确剥离，AbstractWebAuthFilter 就无法匹配到目标方法，从而跳过认证上下文构建，导致 Skill 创建时 owner 为空。后续查询 Skill 详情时，由于可见性校验失败，被包装成 not found 返回。

本次修改使 Controller 方法解析优先使用当前请求的 contextPath，并在请求没有 contextPath 时回退到 EnvUtil.getContextPath()，从而兼容原有行为并修复该问题。


## Brief changelog

- 修改 ControllerMethodsCache#getMethod(HttpServletRequest) 中 URL key 的构造逻辑，优先使用 request.getContextPath() 剥离当前请求前缀。
- 保留向后兼容逻辑：当 request.getContextPath() 为空时，仍回退使用 EnvUtil.getContextPath()。
- 增加回归测试，验证在 nacos.console.contextPath=/src 场景下，Console 请求能够正确匹配到对应 Controller 方法。
- 保留并验证原有默认 context path 场景下的方法匹配行为不受影响。

## Verifying this change

人工验证结果：

- 配置 nacos.console.contextPath=/src
- 通过 Console 手动创建 Skill 成功
- 后续查询 Skill 详情不再返回 Skill not found

