### PR TITLE
[ISSUE #15164] Make skill ZIP entry and size limits configurable

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -150,7 +150,13 @@ public class Constants {
         public static final String SKILL_DEFAULT_NAMESPACE = "public";
         
         /**
-         * Max allowed size for skill zip upload (10MB). Exceeding this will result in a clear error.
+         * Default max allowed size for skill zip upload (10MB).
+         *
+         * <p>Runtime callers should use
+         * {@code com.alibaba.nacos.ai.utils.SkillZipParser#resolveMaxUploadBytes()} instead, which
+         * honors the {@code nacos.ai.skill.zip.max-upload-size-mb} property when an operator
+         * needs to raise this cap. This constant is preserved as the historical default and for
+         * backward compatibility with callers outside the skill upload path.
          */
         public static final long MAX_UPLOAD_ZIP_BYTES = 10L * 1024 * 1024;
     }

--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -176,7 +176,13 @@ public class Constants {
         public static final String AGENTSPEC_MAIN_DATA_ID = "manifest.json";
         
         /**
-         * Max allowed size for agentspec zip upload (50MB). Exceeding this will result in a clear error.
+         * Default max allowed size for agentspec zip upload (50MB).
+         *
+         * <p>Runtime callers should use
+         * {@code com.alibaba.nacos.ai.utils.AgentSpecZipParser#resolveMaxUploadBytes()} instead,
+         * which honors the {@code nacos.ai.agentspec.zip.max-upload-size-mb} property when an
+         * operator needs to raise this cap. This constant is preserved as the historical default
+         * and for backward compatibility with callers outside the AgentSpec upload path.
          */
         public static final long MAX_UPLOAD_ZIP_BYTES = 50L * 1024 * 1024;
         

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecRequestUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecRequestUtil.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.nacos.ai.utils;
 
-import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.form.agentspecs.admin.AgentSpecDetailForm;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.exception.NacosException;
@@ -98,11 +97,12 @@ public class AgentSpecRequestUtil {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.DATA_EMPTY,
                 "File is required");
         }
-        if (file.getSize() > Constants.AgentSpecs.MAX_UPLOAD_ZIP_BYTES) {
+        long maxUploadBytes = AgentSpecZipParser.resolveMaxUploadBytes();
+        if (file.getSize() > maxUploadBytes) {
             throw new NacosApiException(NacosException.INVALID_PARAM,
                 ErrorCode.PARAMETER_VALIDATE_ERROR,
                 "AgentSpec zip size must not exceed "
-                    + (Constants.AgentSpecs.MAX_UPLOAD_ZIP_BYTES / 1024 / 1024)
+                    + (maxUploadBytes / 1024 / 1024)
                     + "MB, current: " + (file.getSize() / 1024 / 1024) + "MB");
         }
         try {

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentSpecZipParser.java
@@ -26,6 +26,7 @@ import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.slf4j.Logger;
@@ -61,17 +62,50 @@ public class AgentSpecZipParser {
     private static final String SLASH = "/";
     
     /**
-     * Maximum total decompressed size allowed (50MB). Prevents Zip Bomb attacks.
+     * Default maximum compressed (upload) size in MB for an AgentSpec ZIP. Derived from the
+     * historical {@link Constants.AgentSpecs#MAX_UPLOAD_ZIP_BYTES} so the public constant remains
+     * the single source of truth; runtime callers should consult {@link #resolveMaxUploadBytes()}
+     * which honors the {@value #CONFIG_MAX_UPLOAD_SIZE_MB} override.
      */
-    private static final long MAX_TOTAL_UNCOMPRESSED_BYTES = 50L * 1024 * 1024;
+    static final int DEFAULT_MAX_UPLOAD_SIZE_MB =
+        (int) (Constants.AgentSpecs.MAX_UPLOAD_ZIP_BYTES / 1024L / 1024L);
     
     /**
-     * Maximum number of entries allowed in a ZIP file. Prevents entry-count flooding attacks.
+     * Default maximum number of entries allowed in an AgentSpec ZIP. Overridable via the
+     * {@value #CONFIG_MAX_ZIP_ENTRIES} property when users legitimately upload larger specs.
      */
-    private static final int MAX_ZIP_ENTRIES = 500;
+    static final int DEFAULT_MAX_ZIP_ENTRIES = 500;
     
     /**
-     * Parse AgentSpec from zip file bytes. Zip size must not exceed {@link Constants.AgentSpecs#MAX_UPLOAD_ZIP_BYTES}.
+     * Default maximum total decompressed size (in MB) for an AgentSpec ZIP. Prevents Zip Bomb
+     * attacks while still permitting legitimate uploads. Overridable via the
+     * {@value #CONFIG_MAX_UNCOMPRESSED_SIZE_MB} property.
+     */
+    static final int DEFAULT_MAX_UNCOMPRESSED_SIZE_MB = 50;
+    
+    /**
+     * Property key for overriding {@link #DEFAULT_MAX_UPLOAD_SIZE_MB}. The value is in megabytes
+     * and applies to the raw compressed AgentSpec ZIP before parsing. Non-positive values are
+     * ignored.
+     */
+    static final String CONFIG_MAX_UPLOAD_SIZE_MB =
+        "nacos.ai.agentspec.zip.max-upload-size-mb";
+    
+    /**
+     * Property key for overriding {@link #DEFAULT_MAX_ZIP_ENTRIES}. Non-positive values are ignored.
+     */
+    static final String CONFIG_MAX_ZIP_ENTRIES = "nacos.ai.agentspec.zip.max-entries";
+    
+    /**
+     * Property key for overriding {@link #DEFAULT_MAX_UNCOMPRESSED_SIZE_MB}. The value is in
+     * megabytes. Non-positive values are ignored.
+     */
+    static final String CONFIG_MAX_UNCOMPRESSED_SIZE_MB =
+        "nacos.ai.agentspec.zip.max-uncompressed-size-mb";
+    
+    /**
+     * Parse AgentSpec from zip file bytes. Zip size must not exceed the limit returned by
+     * {@link #resolveMaxUploadBytes()} (configurable via {@value #CONFIG_MAX_UPLOAD_SIZE_MB}).
      * Looks for manifest.json as the main metadata, extracts worker.suggested_name as the AgentSpec name.
      * Other entries become AgentSpecResource instances. Binary files are Base64 encoded.
      * macOS metadata files (__MACOSX/*, .DS_Store, ._*) are filtered out.
@@ -88,11 +122,12 @@ public class AgentSpecZipParser {
                 ErrorCode.PARAMETER_VALIDATE_ERROR,
                 "AgentSpec zip file is empty");
         }
-        if (zipBytes.length > Constants.AgentSpecs.MAX_UPLOAD_ZIP_BYTES) {
+        long maxUploadBytes = resolveMaxUploadBytes();
+        if (zipBytes.length > maxUploadBytes) {
             throw new NacosApiException(NacosApiException.INVALID_PARAM,
                 ErrorCode.PARAMETER_VALIDATE_ERROR,
                 "AgentSpec zip size must not exceed "
-                    + (Constants.AgentSpecs.MAX_UPLOAD_ZIP_BYTES / 1024 / 1024)
+                    + (maxUploadBytes / 1024 / 1024)
                     + "MB, current: " + (zipBytes.length / 1024 / 1024) + "MB");
         }
         try {
@@ -140,9 +175,11 @@ public class AgentSpecZipParser {
      * <ul>
      *   <li>Rejects entries with path traversal sequences (..) or absolute paths via
      *       {@link SkillUtils#validatePathSafety(String)}</li>
-     *   <li>Enforces maximum total decompressed size ({@link #MAX_TOTAL_UNCOMPRESSED_BYTES})
-     *       to prevent Zip Bomb attacks</li>
-     *   <li>Enforces maximum number of entries ({@link #MAX_ZIP_ENTRIES})
+     *   <li>Enforces maximum total decompressed size (configurable via
+     *       {@value #CONFIG_MAX_UNCOMPRESSED_SIZE_MB}, default
+     *       {@link #DEFAULT_MAX_UNCOMPRESSED_SIZE_MB} MB) to prevent Zip Bomb attacks</li>
+     *   <li>Enforces maximum number of entries (configurable via
+     *       {@value #CONFIG_MAX_ZIP_ENTRIES}, default {@link #DEFAULT_MAX_ZIP_ENTRIES})
      *       to prevent entry-count flooding attacks</li>
      * </ul>
      *
@@ -152,6 +189,8 @@ public class AgentSpecZipParser {
      * for the HTTP layer.
      */
     private static List<ZipEntryData> unzipToEntries(byte[] zipBytes) throws IOException {
+        final int maxEntries = resolveMaxZipEntries();
+        final long maxUncompressedBytes = resolveMaxUncompressedBytes();
         List<ZipEntryData> result = new ArrayList<>();
         long totalSize = 0;
         try (ZipArchiveInputStream zis =
@@ -169,19 +208,19 @@ public class AgentSpecZipParser {
                 if (name != null && (name.startsWith("__MACOSX/") || name.contains("/__MACOSX/"))) {
                     continue;
                 }
-                if (result.size() >= MAX_ZIP_ENTRIES) {
+                if (result.size() >= maxEntries) {
                     throw new NacosRuntimeException(ErrorCode.PARAMETER_VALIDATE_ERROR.getCode(),
-                        "ZIP file contains too many entries (max " + MAX_ZIP_ENTRIES + ")");
+                        "ZIP file contains too many entries (max " + maxEntries + ")");
                 }
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 int n;
                 while ((n = zis.read(buffer)) != -1) {
                     totalSize += n;
-                    if (totalSize > MAX_TOTAL_UNCOMPRESSED_BYTES) {
+                    if (totalSize > maxUncompressedBytes) {
                         throw new NacosRuntimeException(
                             ErrorCode.PARAMETER_VALIDATE_ERROR.getCode(),
                             "ZIP decompressed size exceeds limit ("
-                                + (MAX_TOTAL_UNCOMPRESSED_BYTES / 1024 / 1024) + "MB)");
+                                + (maxUncompressedBytes / 1024 / 1024) + "MB)");
                     }
                     out.write(buffer, 0, n);
                 }
@@ -189,6 +228,52 @@ public class AgentSpecZipParser {
             }
         }
         return result;
+    }
+    
+    /**
+     * Resolve the maximum compressed (upload) size in bytes, honoring the
+     * {@value #CONFIG_MAX_UPLOAD_SIZE_MB} override (interpreted in megabytes) when present and
+     * positive. Returns {@link #DEFAULT_MAX_UPLOAD_SIZE_MB} MB otherwise. Keep this in sync with
+     * the Spring multipart cap; the multipart filter rejects oversize uploads first.
+     */
+    static long resolveMaxUploadBytes() {
+        int mb = resolvePositiveIntProperty(CONFIG_MAX_UPLOAD_SIZE_MB, DEFAULT_MAX_UPLOAD_SIZE_MB);
+        return (long) mb * 1024L * 1024L;
+    }
+    
+    /**
+     * Resolve the maximum number of ZIP entries allowed, honoring the
+     * {@value #CONFIG_MAX_ZIP_ENTRIES} override when present and positive.
+     * Returns {@link #DEFAULT_MAX_ZIP_ENTRIES} when no override is configured or when the
+     * Nacos environment has not been initialized (e.g. in unit tests that bypass Spring boot-up).
+     */
+    static int resolveMaxZipEntries() {
+        return resolvePositiveIntProperty(CONFIG_MAX_ZIP_ENTRIES, DEFAULT_MAX_ZIP_ENTRIES);
+    }
+    
+    /**
+     * Resolve the maximum total decompressed size in bytes, honoring the
+     * {@value #CONFIG_MAX_UNCOMPRESSED_SIZE_MB} override (interpreted in megabytes) when present
+     * and positive. Returns {@link #DEFAULT_MAX_UNCOMPRESSED_SIZE_MB} MB otherwise.
+     */
+    static long resolveMaxUncompressedBytes() {
+        int mb = resolvePositiveIntProperty(
+            CONFIG_MAX_UNCOMPRESSED_SIZE_MB, DEFAULT_MAX_UNCOMPRESSED_SIZE_MB);
+        return (long) mb * 1024L * 1024L;
+    }
+    
+    /**
+     * Read an int-valued property from {@link EnvUtil}, returning {@code defaultValue} whenever
+     * the override is missing, non-positive, or the environment has not yet been initialized.
+     * Non-positive overrides are deliberately rejected so misconfiguration cannot silently
+     * disable the underlying security guards.
+     */
+    private static int resolvePositiveIntProperty(String key, int defaultValue) {
+        if (EnvUtil.getEnvironment() == null) {
+            return defaultValue;
+        }
+        Integer configured = EnvUtil.getProperty(key, Integer.class);
+        return configured != null && configured > 0 ? configured : defaultValue;
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillRequestUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillRequestUtil.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.nacos.ai.utils;
 
-import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.form.skills.admin.SkillDetailForm;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
@@ -329,11 +328,12 @@ public class SkillRequestUtil {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.DATA_EMPTY,
                 "File is required");
         }
-        if (file.getSize() > Constants.Skills.MAX_UPLOAD_ZIP_BYTES) {
+        long maxUploadBytes = SkillZipParser.resolveMaxUploadBytes();
+        if (file.getSize() > maxUploadBytes) {
             throw new NacosApiException(NacosException.INVALID_PARAM,
                 ErrorCode.PARAMETER_VALIDATE_ERROR,
                 "Skill zip size must not exceed "
-                    + (Constants.Skills.MAX_UPLOAD_ZIP_BYTES / 1024 / 1024)
+                    + (maxUploadBytes / 1024 / 1024)
                     + "MB, current: " + (file.getSize() / 1024 / 1024) + "MB");
         }
         try {

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
@@ -79,6 +79,13 @@ public class SkillZipParser {
         ResourceContentEncoder.METADATA_ENCODING_BASE64;
     
     /**
+     * Default maximum compressed (upload) size in MB for a skill ZIP. Mirrors the historical
+     * {@link Constants.Skills#MAX_UPLOAD_ZIP_BYTES} value; the public constant is kept for
+     * backward compatibility but runtime callers should consult {@link #resolveMaxUploadBytes()}.
+     */
+    static final int DEFAULT_MAX_UPLOAD_SIZE_MB = 10;
+    
+    /**
      * Default maximum number of entries allowed in a skill ZIP. Overridable via the
      * {@value #CONFIG_MAX_ZIP_ENTRIES} property when users legitimately upload larger skills.
      */
@@ -90,6 +97,12 @@ public class SkillZipParser {
      * {@value #CONFIG_MAX_UNCOMPRESSED_SIZE_MB} property.
      */
     static final int DEFAULT_MAX_UNCOMPRESSED_SIZE_MB = 50;
+    
+    /**
+     * Property key for overriding {@link #DEFAULT_MAX_UPLOAD_SIZE_MB}. The value is in megabytes
+     * and applies to the raw compressed skill ZIP before parsing. Non-positive values are ignored.
+     */
+    static final String CONFIG_MAX_UPLOAD_SIZE_MB = "nacos.ai.skill.zip.max-upload-size-mb";
     
     /**
      * Property key for overriding {@link #DEFAULT_MAX_ZIP_ENTRIES}. Non-positive values are ignored.
@@ -177,7 +190,8 @@ public class SkillZipParser {
     }
     
     /**
-     * Parse skill from zip file bytes. Zip size must not exceed {@link Constants.Skills#MAX_UPLOAD_ZIP_BYTES}.
+     * Parse skill from zip file bytes. Zip size must not exceed the limit returned by
+     * {@link #resolveMaxUploadBytes()} (configurable via {@value #CONFIG_MAX_UPLOAD_SIZE_MB}).
      * Text files are decoded as UTF-8; binary files (by extension) are stored as Base64 with metadata encoding=base64.
      *
      * @param zipBytes zip file bytes
@@ -192,11 +206,12 @@ public class SkillZipParser {
                 ErrorCode.PARAMETER_VALIDATE_ERROR,
                 "Skill zip file is empty");
         }
-        if (zipBytes.length > Constants.Skills.MAX_UPLOAD_ZIP_BYTES) {
+        long maxUploadBytes = resolveMaxUploadBytes();
+        if (zipBytes.length > maxUploadBytes) {
             throw new NacosApiException(NacosApiException.INVALID_PARAM,
                 ErrorCode.PARAMETER_VALIDATE_ERROR,
                 "Skill zip size must not exceed "
-                    + (Constants.Skills.MAX_UPLOAD_ZIP_BYTES / 1024 / 1024) + "MB, current: "
+                    + (maxUploadBytes / 1024 / 1024) + "MB, current: "
                     + (zipBytes.length / 1024 / 1024) + "MB");
         }
         try {
@@ -265,11 +280,12 @@ public class SkillZipParser {
                 ErrorCode.PARAMETER_VALIDATE_ERROR,
                 "Skill zip file is empty");
         }
-        if (zipBytes.length > Constants.Skills.MAX_UPLOAD_ZIP_BYTES) {
+        long maxUploadBytes = resolveMaxUploadBytes();
+        if (zipBytes.length > maxUploadBytes) {
             throw new NacosApiException(NacosApiException.INVALID_PARAM,
                 ErrorCode.PARAMETER_VALIDATE_ERROR,
                 "Skill zip size must not exceed "
-                    + (Constants.Skills.MAX_UPLOAD_ZIP_BYTES / 1024 / 1024) + "MB, current: "
+                    + (maxUploadBytes / 1024 / 1024) + "MB, current: "
                     + (zipBytes.length / 1024 / 1024) + "MB");
         }
         try {
@@ -480,6 +496,19 @@ public class SkillZipParser {
             }
         }
         return result;
+    }
+    
+    /**
+     * Resolve the maximum compressed (upload) size in bytes, honoring the
+     * {@value #CONFIG_MAX_UPLOAD_SIZE_MB} override (interpreted in megabytes) when present and
+     * positive. Returns {@link #DEFAULT_MAX_UPLOAD_SIZE_MB} MB otherwise. Keep this in sync with
+     * the Spring multipart cap ({@code spring.servlet.multipart.max-file-size}); the multipart
+     * filter rejects oversize uploads first, but operators raising the multipart cap also need
+     * to raise this property for the change to take effect on the skill upload pipeline.
+     */
+    static long resolveMaxUploadBytes() {
+        int mb = resolvePositiveIntProperty(CONFIG_MAX_UPLOAD_SIZE_MB, DEFAULT_MAX_UPLOAD_SIZE_MB);
+        return (long) mb * 1024L * 1024L;
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
@@ -79,11 +79,13 @@ public class SkillZipParser {
         ResourceContentEncoder.METADATA_ENCODING_BASE64;
     
     /**
-     * Default maximum compressed (upload) size in MB for a skill ZIP. Mirrors the historical
-     * {@link Constants.Skills#MAX_UPLOAD_ZIP_BYTES} value; the public constant is kept for
-     * backward compatibility but runtime callers should consult {@link #resolveMaxUploadBytes()}.
+     * Default maximum compressed (upload) size in MB for a skill ZIP. Derived from the historical
+     * {@link Constants.Skills#MAX_UPLOAD_ZIP_BYTES} so the public constant remains the single
+     * source of truth; runtime callers should consult {@link #resolveMaxUploadBytes()} which
+     * honors the {@value #CONFIG_MAX_UPLOAD_SIZE_MB} override.
      */
-    static final int DEFAULT_MAX_UPLOAD_SIZE_MB = 10;
+    static final int DEFAULT_MAX_UPLOAD_SIZE_MB =
+        (int) (Constants.Skills.MAX_UPLOAD_ZIP_BYTES / 1024L / 1024L);
     
     /**
      * Default maximum number of entries allowed in a skill ZIP. Overridable via the

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
@@ -489,11 +489,7 @@ public class SkillZipParser {
      * Nacos environment has not been initialized (e.g. in unit tests that bypass Spring boot-up).
      */
     static int resolveMaxZipEntries() {
-        if (EnvUtil.getEnvironment() == null) {
-            return DEFAULT_MAX_ZIP_ENTRIES;
-        }
-        Integer configured = EnvUtil.getProperty(CONFIG_MAX_ZIP_ENTRIES, Integer.class);
-        return configured != null && configured > 0 ? configured : DEFAULT_MAX_ZIP_ENTRIES;
+        return resolvePositiveIntProperty(CONFIG_MAX_ZIP_ENTRIES, DEFAULT_MAX_ZIP_ENTRIES);
     }
     
     /**
@@ -502,15 +498,23 @@ public class SkillZipParser {
      * and positive. Returns {@link #DEFAULT_MAX_UNCOMPRESSED_SIZE_MB} MB otherwise.
      */
     static long resolveMaxUncompressedBytes() {
-        int mb = DEFAULT_MAX_UNCOMPRESSED_SIZE_MB;
-        if (EnvUtil.getEnvironment() != null) {
-            Integer configured =
-                EnvUtil.getProperty(CONFIG_MAX_UNCOMPRESSED_SIZE_MB, Integer.class);
-            if (configured != null && configured > 0) {
-                mb = configured;
-            }
-        }
+        int mb = resolvePositiveIntProperty(
+            CONFIG_MAX_UNCOMPRESSED_SIZE_MB, DEFAULT_MAX_UNCOMPRESSED_SIZE_MB);
         return (long) mb * 1024L * 1024L;
+    }
+    
+    /**
+     * Read an int-valued property from {@link EnvUtil}, returning {@code defaultValue} whenever
+     * the override is missing, non-positive, or the environment has not yet been initialized.
+     * Non-positive overrides are deliberately rejected so misconfiguration cannot silently
+     * disable the underlying security guards.
+     */
+    private static int resolvePositiveIntProperty(String key, int defaultValue) {
+        if (EnvUtil.getEnvironment() == null) {
+            return defaultValue;
+        }
+        Integer configured = EnvUtil.getProperty(key, Integer.class);
+        return configured != null && configured > 0 ? configured : defaultValue;
     }
     
     private static ZipEntryData findSkillMdEntry(List<ZipEntryData> entries) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/SkillZipParser.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,14 +79,29 @@ public class SkillZipParser {
         ResourceContentEncoder.METADATA_ENCODING_BASE64;
     
     /**
-     * Maximum total decompressed size allowed (50MB). Prevents Zip Bomb attacks.
+     * Default maximum number of entries allowed in a skill ZIP. Overridable via the
+     * {@value #CONFIG_MAX_ZIP_ENTRIES} property when users legitimately upload larger skills.
      */
-    private static final long MAX_TOTAL_UNCOMPRESSED_BYTES = 50L * 1024 * 1024;
+    static final int DEFAULT_MAX_ZIP_ENTRIES = 500;
     
     /**
-     * Maximum number of entries allowed in a ZIP file.
+     * Default maximum total decompressed size (in MB) for a skill ZIP. Prevents Zip Bomb attacks
+     * while still permitting legitimate uploads. Overridable via the
+     * {@value #CONFIG_MAX_UNCOMPRESSED_SIZE_MB} property.
      */
-    private static final int MAX_ZIP_ENTRIES = 500;
+    static final int DEFAULT_MAX_UNCOMPRESSED_SIZE_MB = 50;
+    
+    /**
+     * Property key for overriding {@link #DEFAULT_MAX_ZIP_ENTRIES}. Non-positive values are ignored.
+     */
+    static final String CONFIG_MAX_ZIP_ENTRIES = "nacos.ai.skill.zip.max-entries";
+    
+    /**
+     * Property key for overriding {@link #DEFAULT_MAX_UNCOMPRESSED_SIZE_MB}. The value is in megabytes.
+     * Non-positive values are ignored.
+     */
+    static final String CONFIG_MAX_UNCOMPRESSED_SIZE_MB =
+        "nacos.ai.skill.zip.max-uncompressed-size-mb";
     
     private static final Pattern YAML_FRONT_MATTER = Pattern.compile(
         "^---\\s*\\n(.*?)\\n---\\s*\\n(.*)$", Pattern.DOTALL);
@@ -410,8 +426,11 @@ public class SkillZipParser {
      * <p>Security hardening:
      * <ul>
      *   <li>Rejects entries with path traversal sequences (..) or absolute paths</li>
-     *   <li>Enforces maximum total decompressed size ({@link #MAX_TOTAL_UNCOMPRESSED_BYTES})</li>
-     *   <li>Enforces maximum number of entries ({@link #MAX_ZIP_ENTRIES})</li>
+     *   <li>Enforces maximum total decompressed size (configurable via
+     *       {@value #CONFIG_MAX_UNCOMPRESSED_SIZE_MB}, default
+     *       {@link #DEFAULT_MAX_UNCOMPRESSED_SIZE_MB} MB)</li>
+     *   <li>Enforces maximum number of entries (configurable via
+     *       {@value #CONFIG_MAX_ZIP_ENTRIES}, default {@link #DEFAULT_MAX_ZIP_ENTRIES})</li>
      * </ul>
      *
      * <p>Security-limit violations are reported as {@link NacosRuntimeException} (not {@link IOException})
@@ -420,6 +439,8 @@ public class SkillZipParser {
      * for the HTTP layer.
      */
     private static List<ZipEntryData> unzipToEntries(byte[] zipBytes) throws IOException {
+        final int maxEntries = resolveMaxZipEntries();
+        final long maxUncompressedBytes = resolveMaxUncompressedBytes();
         List<ZipEntryData> result = new ArrayList<>();
         long totalSize = 0;
         try (ZipArchiveInputStream zis =
@@ -439,19 +460,19 @@ public class SkillZipParser {
                 if (isMacOsxEntry) {
                     continue;
                 }
-                if (result.size() >= MAX_ZIP_ENTRIES) {
+                if (result.size() >= maxEntries) {
                     throw new NacosRuntimeException(ErrorCode.PARAMETER_VALIDATE_ERROR.getCode(),
-                        "ZIP file contains too many entries (max " + MAX_ZIP_ENTRIES + ")");
+                        "ZIP file contains too many entries (max " + maxEntries + ")");
                 }
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 int n;
                 while ((n = zis.read(buffer)) != -1) {
                     totalSize += n;
-                    if (totalSize > MAX_TOTAL_UNCOMPRESSED_BYTES) {
+                    if (totalSize > maxUncompressedBytes) {
                         throw new NacosRuntimeException(
                             ErrorCode.PARAMETER_VALIDATE_ERROR.getCode(),
                             "ZIP decompressed size exceeds limit ("
-                                + (MAX_TOTAL_UNCOMPRESSED_BYTES / 1024 / 1024) + "MB)");
+                                + (maxUncompressedBytes / 1024 / 1024) + "MB)");
                     }
                     out.write(buffer, 0, n);
                 }
@@ -459,6 +480,37 @@ public class SkillZipParser {
             }
         }
         return result;
+    }
+    
+    /**
+     * Resolve the maximum number of ZIP entries allowed, honoring the
+     * {@value #CONFIG_MAX_ZIP_ENTRIES} override when present and positive.
+     * Returns {@link #DEFAULT_MAX_ZIP_ENTRIES} when no override is configured or when the
+     * Nacos environment has not been initialized (e.g. in unit tests that bypass Spring boot-up).
+     */
+    static int resolveMaxZipEntries() {
+        if (EnvUtil.getEnvironment() == null) {
+            return DEFAULT_MAX_ZIP_ENTRIES;
+        }
+        Integer configured = EnvUtil.getProperty(CONFIG_MAX_ZIP_ENTRIES, Integer.class);
+        return configured != null && configured > 0 ? configured : DEFAULT_MAX_ZIP_ENTRIES;
+    }
+    
+    /**
+     * Resolve the maximum total decompressed size in bytes, honoring the
+     * {@value #CONFIG_MAX_UNCOMPRESSED_SIZE_MB} override (interpreted in megabytes) when present
+     * and positive. Returns {@link #DEFAULT_MAX_UNCOMPRESSED_SIZE_MB} MB otherwise.
+     */
+    static long resolveMaxUncompressedBytes() {
+        int mb = DEFAULT_MAX_UNCOMPRESSED_SIZE_MB;
+        if (EnvUtil.getEnvironment() != null) {
+            Integer configured =
+                EnvUtil.getProperty(CONFIG_MAX_UNCOMPRESSED_SIZE_MB, Integer.class);
+            if (configured != null && configured > 0) {
+                mb = configured;
+            }
+        }
+        return (long) mb * 1024L * 1024L;
     }
     
     private static ZipEntryData findSkillMdEntry(List<ZipEntryData> entries) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentSpecZipParserLimitsConfigTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentSpecZipParserLimitsConfigTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.utils;
+
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Random;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies that {@link AgentSpecZipParser} honors the configurable upper bounds for upload size,
+ * ZIP entry count, and total decompressed size while preserving the historical defaults
+ * (50 MB / 500 entries / 50 MB) when no override is set. Mirrors
+ * {@code SkillZipParserLimitsConfigTest} so the two zip parsers stay symmetric.
+ */
+class AgentSpecZipParserLimitsConfigTest {
+    
+    private static final String NAMESPACE_ID = "test-ns";
+    
+    private static final String VALID_MANIFEST = "{\"worker\":{\"suggested_name\":\"sample\"}}";
+    
+    private ConfigurableEnvironment previousEnvironment;
+    
+    @BeforeEach
+    void setUp() {
+        previousEnvironment = EnvUtil.getEnvironment();
+        EnvUtil.setEnvironment(new MockEnvironment());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(previousEnvironment);
+    }
+    
+    @Test
+    void resolveMaxUploadBytesReturnsDefaultWhenUnset() {
+        long expectedBytes =
+            (long) AgentSpecZipParser.DEFAULT_MAX_UPLOAD_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, AgentSpecZipParser.resolveMaxUploadBytes());
+    }
+    
+    @Test
+    void resolveMaxUploadBytesHonorsPositiveOverride() {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(AgentSpecZipParser.CONFIG_MAX_UPLOAD_SIZE_MB, "200");
+        assertEquals(200L * 1024L * 1024L, AgentSpecZipParser.resolveMaxUploadBytes());
+    }
+    
+    @Test
+    void resolveMaxUploadBytesIgnoresNonPositiveOverride() {
+        MockEnvironment env = (MockEnvironment) EnvUtil.getEnvironment();
+        env.setProperty(AgentSpecZipParser.CONFIG_MAX_UPLOAD_SIZE_MB, "0");
+        long expectedBytes =
+            (long) AgentSpecZipParser.DEFAULT_MAX_UPLOAD_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, AgentSpecZipParser.resolveMaxUploadBytes());
+    }
+    
+    @Test
+    void resolveMaxUploadBytesFallsBackToDefaultWhenEnvironmentMissing() {
+        EnvUtil.setEnvironment(null);
+        long expectedBytes =
+            (long) AgentSpecZipParser.DEFAULT_MAX_UPLOAD_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, AgentSpecZipParser.resolveMaxUploadBytes());
+    }
+    
+    @Test
+    void resolveMaxZipEntriesReturnsDefaultWhenUnset() {
+        assertEquals(AgentSpecZipParser.DEFAULT_MAX_ZIP_ENTRIES,
+            AgentSpecZipParser.resolveMaxZipEntries());
+    }
+    
+    @Test
+    void resolveMaxZipEntriesHonorsPositiveOverride() {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(AgentSpecZipParser.CONFIG_MAX_ZIP_ENTRIES, "2000");
+        assertEquals(2000, AgentSpecZipParser.resolveMaxZipEntries());
+    }
+    
+    @Test
+    void resolveMaxZipEntriesIgnoresNonPositiveOverride() {
+        MockEnvironment env = (MockEnvironment) EnvUtil.getEnvironment();
+        env.setProperty(AgentSpecZipParser.CONFIG_MAX_ZIP_ENTRIES, "0");
+        assertEquals(AgentSpecZipParser.DEFAULT_MAX_ZIP_ENTRIES,
+            AgentSpecZipParser.resolveMaxZipEntries());
+        
+        env.setProperty(AgentSpecZipParser.CONFIG_MAX_ZIP_ENTRIES, "-10");
+        assertEquals(AgentSpecZipParser.DEFAULT_MAX_ZIP_ENTRIES,
+            AgentSpecZipParser.resolveMaxZipEntries());
+    }
+    
+    @Test
+    void resolveMaxZipEntriesFallsBackToDefaultWhenEnvironmentMissing() {
+        EnvUtil.setEnvironment(null);
+        assertEquals(AgentSpecZipParser.DEFAULT_MAX_ZIP_ENTRIES,
+            AgentSpecZipParser.resolveMaxZipEntries());
+    }
+    
+    @Test
+    void resolveMaxUncompressedBytesReturnsDefaultWhenUnset() {
+        long expectedBytes =
+            (long) AgentSpecZipParser.DEFAULT_MAX_UNCOMPRESSED_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, AgentSpecZipParser.resolveMaxUncompressedBytes());
+    }
+    
+    @Test
+    void resolveMaxUncompressedBytesHonorsPositiveOverride() {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(AgentSpecZipParser.CONFIG_MAX_UNCOMPRESSED_SIZE_MB, "200");
+        assertEquals(200L * 1024L * 1024L, AgentSpecZipParser.resolveMaxUncompressedBytes());
+    }
+    
+    @Test
+    void resolveMaxUncompressedBytesIgnoresNonPositiveOverride() {
+        MockEnvironment env = (MockEnvironment) EnvUtil.getEnvironment();
+        env.setProperty(AgentSpecZipParser.CONFIG_MAX_UNCOMPRESSED_SIZE_MB, "0");
+        long expectedBytes =
+            (long) AgentSpecZipParser.DEFAULT_MAX_UNCOMPRESSED_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, AgentSpecZipParser.resolveMaxUncompressedBytes());
+    }
+    
+    @Test
+    void resolveMaxUncompressedBytesFallsBackToDefaultWhenEnvironmentMissing() {
+        EnvUtil.setEnvironment(null);
+        long expectedBytes =
+            (long) AgentSpecZipParser.DEFAULT_MAX_UNCOMPRESSED_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, AgentSpecZipParser.resolveMaxUncompressedBytes());
+    }
+    
+    @Test
+    void parseAgentSpecFromZipUsesConfiguredEntryLimit() throws IOException {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(AgentSpecZipParser.CONFIG_MAX_ZIP_ENTRIES, "3");
+        byte[] zipBytes = buildZipWithEntryCount(5);
+        
+        try {
+            AgentSpecZipParser.parseAgentSpecFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the configured-entry-limit guard to reject this zip");
+        } catch (NacosApiException e) {
+            assertTrue(e.getMessage().contains("too many entries"),
+                "NacosApiException should describe the entry-count violation, got: "
+                    + e.getMessage());
+            assertTrue(e.getMessage().contains("max 3"),
+                "Error message should report the configured maximum (3), got: " + e.getMessage());
+        }
+    }
+    
+    @Test
+    void unzipToEntriesAcceptsEntryCountAboveDefaultWhenLimitRaised() throws Exception {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(AgentSpecZipParser.CONFIG_MAX_ZIP_ENTRIES, "1000");
+        byte[] zipBytes = buildZipWithEntryCount(600);
+        
+        List<?> entries = invokeUnzipToEntries(zipBytes);
+        
+        // 600 added entries plus the manifest.json header entry built by the helper.
+        assertEquals(601, entries.size(),
+            "Raising the entry-count limit must allow all 600 + manifest entries through, "
+                + "but got: " + entries.size());
+    }
+    
+    @Test
+    void parseAgentSpecFromZipUsesConfiguredUncompressedSizeLimit() throws IOException {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(AgentSpecZipParser.CONFIG_MAX_UNCOMPRESSED_SIZE_MB, "1");
+        // ~2 MB of decompressed payload — should be rejected at the 1 MB configured limit.
+        byte[] zipBytes = buildZipWithOneMbEntries(2);
+        
+        try {
+            AgentSpecZipParser.parseAgentSpecFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the configured uncompressed-size limit to reject this zip");
+        } catch (NacosApiException e) {
+            assertNotNull(e.getMessage(), "NacosApiException message must not be null");
+            assertTrue(e.getMessage().contains("decompressed size exceeds limit"),
+                "Error message should describe the decompressed-size violation, got: "
+                    + e.getMessage());
+            assertTrue(e.getMessage().contains("1MB"),
+                "Error message should report the configured maximum (1MB), got: "
+                    + e.getMessage());
+        }
+    }
+    
+    @Test
+    void parseAgentSpecFromZipUsesConfiguredUploadLimit() throws IOException {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(AgentSpecZipParser.CONFIG_MAX_UPLOAD_SIZE_MB, "1");
+        byte[] zipBytes = buildZipWithIncompressiblePayloadMb(2);
+        
+        try {
+            AgentSpecZipParser.parseAgentSpecFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the configured upload-size limit to reject this zip");
+        } catch (NacosApiException e) {
+            assertTrue(e.getMessage().contains("AgentSpec zip size must not exceed"),
+                "NacosApiException should describe the upload-size violation, got: "
+                    + e.getMessage());
+            assertTrue(e.getMessage().contains("1MB"),
+                "Error message should report the configured maximum (1MB), got: "
+                    + e.getMessage());
+        }
+    }
+    
+    // -------- Helpers --------
+    
+    @SuppressWarnings("unchecked")
+    private static List<Object> invokeUnzipToEntries(byte[] zipBytes) throws Exception {
+        Method unzip = AgentSpecZipParser.class.getDeclaredMethod("unzipToEntries", byte[].class);
+        unzip.setAccessible(true);
+        return (List<Object>) unzip.invoke(null, (Object) zipBytes);
+    }
+    
+    private static byte[] buildZipWithEntryCount(int entryCount) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            addZipEntry(zos, "manifest.json", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+            byte[] small = "x".getBytes(StandardCharsets.UTF_8);
+            for (int i = 0; i < entryCount; i++) {
+                addZipEntry(zos, "assets/entry_" + i + ".txt", small);
+            }
+        }
+        return baos.toByteArray();
+    }
+    
+    private static byte[] buildZipWithOneMbEntries(int count) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            addZipEntry(zos, "manifest.json", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+            byte[] oneMegabyteOfZeros = new byte[1024 * 1024];
+            for (int i = 0; i < count; i++) {
+                addZipEntry(zos, "assets/blob_" + i + ".bin", oneMegabyteOfZeros);
+            }
+        }
+        return baos.toByteArray();
+    }
+    
+    private static byte[] buildZipWithIncompressiblePayloadMb(int targetMb) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            addZipEntry(zos, "manifest.json", VALID_MANIFEST.getBytes(StandardCharsets.UTF_8));
+            byte[] payload = new byte[targetMb * 1024 * 1024];
+            new Random(42).nextBytes(payload);
+            addZipEntry(zos, "assets/random.bin", payload);
+        }
+        return baos.toByteArray();
+    }
+    
+    private static void addZipEntry(ZipOutputStream zos, String name, byte[] data)
+        throws IOException {
+        ZipEntry entry = new ZipEntry(name);
+        zos.putNextEntry(entry);
+        zos.write(data);
+        zos.closeEntry();
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserLimitsConfigTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserLimitsConfigTest.java
@@ -26,7 +26,9 @@ import org.springframework.mock.env.MockEnvironment;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -113,6 +115,14 @@ class SkillZipParserLimitsConfigTest {
     }
     
     @Test
+    void resolveMaxUncompressedBytesFallsBackToDefaultWhenEnvironmentMissing() {
+        EnvUtil.setEnvironment(null);
+        long expectedBytes =
+            (long) SkillZipParser.DEFAULT_MAX_UNCOMPRESSED_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, SkillZipParser.resolveMaxUncompressedBytes());
+    }
+    
+    @Test
     void parseSkillFromZipUsesConfiguredEntryLimit() throws IOException {
         ((MockEnvironment) EnvUtil.getEnvironment())
             .setProperty(SkillZipParser.CONFIG_MAX_ZIP_ENTRIES, "3");
@@ -131,21 +141,20 @@ class SkillZipParserLimitsConfigTest {
     }
     
     @Test
-    void parseSkillFromZipAcceptsLargeEntryCountWhenLimitRaised() throws Exception {
-        // 600 entries exceeds DEFAULT_MAX_ZIP_ENTRIES (=500), but a raised limit must accept it.
+    void unzipToEntriesAcceptsEntryCountAboveDefaultWhenLimitRaised() throws Exception {
+        // 600 entries exceeds DEFAULT_MAX_ZIP_ENTRIES (=500), but the configured cap (1000) is
+        // higher, so the entry-count guard must let every entry through. We invoke the private
+        // {@code unzipToEntries} directly so the assertion targets the guard, not later parsing.
         ((MockEnvironment) EnvUtil.getEnvironment())
             .setProperty(SkillZipParser.CONFIG_MAX_ZIP_ENTRIES, "1000");
         byte[] zipBytes = buildZipWithEntryCount(600);
         
-        // parseSkillFromZip succeeds (returns a skill) or fails on a non-limit reason.
-        // We only assert that NO entry-count exception is raised at the configured higher limit.
-        try {
-            SkillZipParser.parseSkillFromZip(zipBytes, NAMESPACE_ID);
-        } catch (NacosApiException e) {
-            assertTrue(!e.getMessage().contains("too many entries"),
-                "Raising the limit must lift the entry-count guard, but message was: "
-                    + e.getMessage());
-        }
+        List<?> entries = invokeUnzipToEntries(zipBytes);
+        
+        // 600 added entries plus the SKILL.md header entry built by the helper.
+        assertEquals(601, entries.size(),
+            "Raising the entry-count limit must allow all 600 + SKILL.md entries through, "
+                + "but got: " + entries.size());
     }
     
     @Test
@@ -170,6 +179,18 @@ class SkillZipParserLimitsConfigTest {
     }
     
     // -------- Helpers --------
+    
+    /**
+     * Reflectively invoke {@code SkillZipParser#unzipToEntries(byte[])} so tests can assert
+     * directly against the entry-count / size guards without going through the rest of the
+     * {@code parseSkillFromZip} pipeline (which would obscure why the parse passed or failed).
+     */
+    @SuppressWarnings("unchecked")
+    private static List<Object> invokeUnzipToEntries(byte[] zipBytes) throws Exception {
+        Method unzip = SkillZipParser.class.getDeclaredMethod("unzipToEntries", byte[].class);
+        unzip.setAccessible(true);
+        return (List<Object>) unzip.invoke(null, (Object) zipBytes);
+    }
     
     private static byte[] buildZipWithEntryCount(int entryCount) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserLimitsConfigTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserLimitsConfigTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.utils;
+
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies that {@link SkillZipParser} honors the configurable upper bounds for
+ * ZIP entry count and total decompressed size while preserving the historical defaults
+ * (500 entries / 50 MB) when no override is set. The configurability was added in response
+ * to legitimately-large skill uploads that hit the previously hard-coded limits.
+ */
+class SkillZipParserLimitsConfigTest {
+    
+    private static final String VALID_SKILL_MD =
+        "---\nname: sample\ndescription: sample skill\n---\n\nbody\n";
+    
+    private static final String NAMESPACE_ID = "test-ns";
+    
+    private ConfigurableEnvironment previousEnvironment;
+    
+    @BeforeEach
+    void setUp() {
+        previousEnvironment = EnvUtil.getEnvironment();
+        EnvUtil.setEnvironment(new MockEnvironment());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(previousEnvironment);
+    }
+    
+    @Test
+    void resolveMaxZipEntriesReturnsDefaultWhenUnset() {
+        assertEquals(SkillZipParser.DEFAULT_MAX_ZIP_ENTRIES, SkillZipParser.resolveMaxZipEntries());
+    }
+    
+    @Test
+    void resolveMaxZipEntriesHonorsPositiveOverride() {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(SkillZipParser.CONFIG_MAX_ZIP_ENTRIES, "2000");
+        assertEquals(2000, SkillZipParser.resolveMaxZipEntries());
+    }
+    
+    @Test
+    void resolveMaxZipEntriesIgnoresNonPositiveOverride() {
+        MockEnvironment env = (MockEnvironment) EnvUtil.getEnvironment();
+        env.setProperty(SkillZipParser.CONFIG_MAX_ZIP_ENTRIES, "0");
+        assertEquals(SkillZipParser.DEFAULT_MAX_ZIP_ENTRIES, SkillZipParser.resolveMaxZipEntries());
+        
+        env.setProperty(SkillZipParser.CONFIG_MAX_ZIP_ENTRIES, "-10");
+        assertEquals(SkillZipParser.DEFAULT_MAX_ZIP_ENTRIES, SkillZipParser.resolveMaxZipEntries());
+    }
+    
+    @Test
+    void resolveMaxZipEntriesFallsBackToDefaultWhenEnvironmentMissing() {
+        EnvUtil.setEnvironment(null);
+        assertEquals(SkillZipParser.DEFAULT_MAX_ZIP_ENTRIES, SkillZipParser.resolveMaxZipEntries());
+    }
+    
+    @Test
+    void resolveMaxUncompressedBytesReturnsDefaultWhenUnset() {
+        long expectedBytes =
+            (long) SkillZipParser.DEFAULT_MAX_UNCOMPRESSED_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, SkillZipParser.resolveMaxUncompressedBytes());
+    }
+    
+    @Test
+    void resolveMaxUncompressedBytesHonorsPositiveOverride() {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(SkillZipParser.CONFIG_MAX_UNCOMPRESSED_SIZE_MB, "200");
+        assertEquals(200L * 1024L * 1024L, SkillZipParser.resolveMaxUncompressedBytes());
+    }
+    
+    @Test
+    void resolveMaxUncompressedBytesIgnoresNonPositiveOverride() {
+        MockEnvironment env = (MockEnvironment) EnvUtil.getEnvironment();
+        env.setProperty(SkillZipParser.CONFIG_MAX_UNCOMPRESSED_SIZE_MB, "0");
+        long expectedBytes =
+            (long) SkillZipParser.DEFAULT_MAX_UNCOMPRESSED_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, SkillZipParser.resolveMaxUncompressedBytes());
+    }
+    
+    @Test
+    void parseSkillFromZipUsesConfiguredEntryLimit() throws IOException {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(SkillZipParser.CONFIG_MAX_ZIP_ENTRIES, "3");
+        byte[] zipBytes = buildZipWithEntryCount(5);
+        
+        try {
+            SkillZipParser.parseSkillFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the configured-entry-limit guard to reject this zip");
+        } catch (NacosApiException e) {
+            assertTrue(e.getMessage().contains("too many entries"),
+                "NacosApiException should describe the entry-count violation, got: "
+                    + e.getMessage());
+            assertTrue(e.getMessage().contains("max 3"),
+                "Error message should report the configured maximum (3), got: " + e.getMessage());
+        }
+    }
+    
+    @Test
+    void parseSkillFromZipAcceptsLargeEntryCountWhenLimitRaised() throws Exception {
+        // 600 entries exceeds DEFAULT_MAX_ZIP_ENTRIES (=500), but a raised limit must accept it.
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(SkillZipParser.CONFIG_MAX_ZIP_ENTRIES, "1000");
+        byte[] zipBytes = buildZipWithEntryCount(600);
+        
+        // parseSkillFromZip succeeds (returns a skill) or fails on a non-limit reason.
+        // We only assert that NO entry-count exception is raised at the configured higher limit.
+        try {
+            SkillZipParser.parseSkillFromZip(zipBytes, NAMESPACE_ID);
+        } catch (NacosApiException e) {
+            assertTrue(!e.getMessage().contains("too many entries"),
+                "Raising the limit must lift the entry-count guard, but message was: "
+                    + e.getMessage());
+        }
+    }
+    
+    @Test
+    void parseSkillFromZipUsesConfiguredUncompressedSizeLimit() throws IOException {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(SkillZipParser.CONFIG_MAX_UNCOMPRESSED_SIZE_MB, "1");
+        // ~2 MB of decompressed payload — should be rejected at the 1 MB configured limit.
+        byte[] zipBytes = buildZipWithOneMbEntries(2);
+        
+        try {
+            SkillZipParser.parseSkillFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the configured uncompressed-size limit to reject this zip");
+        } catch (NacosApiException e) {
+            assertNotNull(e.getMessage(), "NacosApiException message must not be null");
+            assertTrue(e.getMessage().contains("decompressed size exceeds limit"),
+                "Error message should describe the decompressed-size violation, got: "
+                    + e.getMessage());
+            assertTrue(e.getMessage().contains("1MB"),
+                "Error message should report the configured maximum (1MB), got: "
+                    + e.getMessage());
+        }
+    }
+    
+    // -------- Helpers --------
+    
+    private static byte[] buildZipWithEntryCount(int entryCount) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            addZipEntry(zos, "SKILL.md", VALID_SKILL_MD.getBytes(StandardCharsets.UTF_8));
+            byte[] small = "x".getBytes(StandardCharsets.UTF_8);
+            for (int i = 0; i < entryCount; i++) {
+                addZipEntry(zos, "assets/entry_" + i + ".txt", small);
+            }
+        }
+        return baos.toByteArray();
+    }
+    
+    private static byte[] buildZipWithOneMbEntries(int count) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            addZipEntry(zos, "SKILL.md", VALID_SKILL_MD.getBytes(StandardCharsets.UTF_8));
+            byte[] oneMegabyteOfZeros = new byte[1024 * 1024];
+            for (int i = 0; i < count; i++) {
+                addZipEntry(zos, "assets/blob_" + i + ".bin", oneMegabyteOfZeros);
+            }
+        }
+        return baos.toByteArray();
+    }
+    
+    private static void addZipEntry(ZipOutputStream zos, String name, byte[] data)
+        throws IOException {
+        ZipEntry entry = new ZipEntry(name);
+        zos.putNextEntry(entry);
+        zos.write(data);
+        zos.closeEntry();
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserLimitsConfigTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserLimitsConfigTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Random;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -265,7 +266,7 @@ class SkillZipParserLimitsConfigTest {
             // Random bytes don't compress, so the produced zip stays roughly the same size as
             // the raw payload. Seeded for determinism so the test is reproducible.
             byte[] payload = new byte[targetMb * 1024 * 1024];
-            new java.util.Random(42).nextBytes(payload);
+            new Random(42).nextBytes(payload);
             addZipEntry(zos, "assets/random.bin", payload);
         }
         return baos.toByteArray();

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserLimitsConfigTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/SkillZipParserLimitsConfigTest.java
@@ -92,6 +92,60 @@ class SkillZipParserLimitsConfigTest {
     }
     
     @Test
+    void resolveMaxUploadBytesReturnsDefaultWhenUnset() {
+        long expectedBytes =
+            (long) SkillZipParser.DEFAULT_MAX_UPLOAD_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, SkillZipParser.resolveMaxUploadBytes());
+    }
+    
+    @Test
+    void resolveMaxUploadBytesHonorsPositiveOverride() {
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(SkillZipParser.CONFIG_MAX_UPLOAD_SIZE_MB, "100");
+        assertEquals(100L * 1024L * 1024L, SkillZipParser.resolveMaxUploadBytes());
+    }
+    
+    @Test
+    void resolveMaxUploadBytesIgnoresNonPositiveOverride() {
+        MockEnvironment env = (MockEnvironment) EnvUtil.getEnvironment();
+        env.setProperty(SkillZipParser.CONFIG_MAX_UPLOAD_SIZE_MB, "0");
+        long expectedBytes =
+            (long) SkillZipParser.DEFAULT_MAX_UPLOAD_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, SkillZipParser.resolveMaxUploadBytes());
+    }
+    
+    @Test
+    void resolveMaxUploadBytesFallsBackToDefaultWhenEnvironmentMissing() {
+        EnvUtil.setEnvironment(null);
+        long expectedBytes =
+            (long) SkillZipParser.DEFAULT_MAX_UPLOAD_SIZE_MB * 1024L * 1024L;
+        assertEquals(expectedBytes, SkillZipParser.resolveMaxUploadBytes());
+    }
+    
+    @Test
+    void parseSkillFromZipUsesConfiguredUploadLimit() throws IOException {
+        // Default upload cap is 10 MB. Lower it to 1 MB so a ~2 MB zip is rejected at the
+        // upload-size guard before reaching the entry-count / decompressed-size guards.
+        // We use incompressible random bytes so the compressed zip really exceeds 1 MB —
+        // the existing zero-fill helper would compress down to a few KB and slip past.
+        ((MockEnvironment) EnvUtil.getEnvironment())
+            .setProperty(SkillZipParser.CONFIG_MAX_UPLOAD_SIZE_MB, "1");
+        byte[] zipBytes = buildZipWithIncompressiblePayloadMb(2);
+        
+        try {
+            SkillZipParser.parseSkillFromZip(zipBytes, NAMESPACE_ID);
+            fail("Expected the configured upload-size limit to reject this zip");
+        } catch (NacosApiException e) {
+            assertTrue(e.getMessage().contains("Skill zip size must not exceed"),
+                "NacosApiException should describe the upload-size violation, got: "
+                    + e.getMessage());
+            assertTrue(e.getMessage().contains("1MB"),
+                "Error message should report the configured maximum (1MB), got: "
+                    + e.getMessage());
+        }
+    }
+    
+    @Test
     void resolveMaxUncompressedBytesReturnsDefaultWhenUnset() {
         long expectedBytes =
             (long) SkillZipParser.DEFAULT_MAX_UNCOMPRESSED_SIZE_MB * 1024L * 1024L;
@@ -200,6 +254,19 @@ class SkillZipParserLimitsConfigTest {
             for (int i = 0; i < entryCount; i++) {
                 addZipEntry(zos, "assets/entry_" + i + ".txt", small);
             }
+        }
+        return baos.toByteArray();
+    }
+    
+    private static byte[] buildZipWithIncompressiblePayloadMb(int targetMb) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
+            addZipEntry(zos, "SKILL.md", VALID_SKILL_MD.getBytes(StandardCharsets.UTF_8));
+            // Random bytes don't compress, so the produced zip stays roughly the same size as
+            // the raw payload. Seeded for determinism so the test is reproducible.
+            byte[] payload = new byte[targetMb * 1024 * 1024];
+            new java.util.Random(42).nextBytes(payload);
+            addZipEntry(zos, "assets/random.bin", payload);
         }
         return baos.toByteArray();
     }

--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -197,6 +197,20 @@ nacos.ai.registry.port=9080
 ### Zip Bomb attacks; raise when legitimate skills exceed it. Values <= 0 fall back to the default.
 #nacos.ai.skill.zip.max-uncompressed-size-mb=50
 
+### Maximum uploaded AgentSpec ZIP size (in MB), default 50. The Spring multipart cap
+### `spring.servlet.multipart.max-file-size` must be raised in lockstep. Values <= 0 fall back to
+### the default.
+#nacos.ai.agentspec.zip.max-upload-size-mb=50
+
+### Maximum number of entries allowed in an uploaded AgentSpec ZIP, default 500. Raise this when
+### legitimately-large specs exceed the default cap; values <= 0 fall back to the default.
+#nacos.ai.agentspec.zip.max-entries=500
+
+### Maximum total decompressed size (in MB) for an uploaded AgentSpec ZIP, default 50. Guards
+### against Zip Bomb attacks; raise when legitimate specs exceed it. Values <= 0 fall back to the
+### default.
+#nacos.ai.agentspec.zip.max-uncompressed-size-mb=50
+
 #--------------- Nacos Web Server Configurations ---------------#
 
 #*************** Nacos Web Server Related Configurations ***************#

--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -184,6 +184,11 @@ nacos.naming.empty-service.clean.period-time-ms=30000
 ### @deprecated: `nacos.ai.mcp.registry.port` is deprecated, use `nacos.ai.registry.port` instead.
 nacos.ai.registry.port=9080
 
+### Maximum uploaded skill ZIP size (in MB), default 10. The Spring multipart cap
+### `spring.servlet.multipart.max-file-size` must be raised in lockstep, since Tomcat rejects
+### oversize uploads before they reach the skill pipeline. Values <= 0 fall back to the default.
+#nacos.ai.skill.zip.max-upload-size-mb=10
+
 ### Maximum number of entries allowed in an uploaded skill ZIP, default 500. Raise this when
 ### legitimately-large skills exceed the default cap; values <= 0 fall back to the default.
 #nacos.ai.skill.zip.max-entries=500

--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -184,6 +184,14 @@ nacos.naming.empty-service.clean.period-time-ms=30000
 ### @deprecated: `nacos.ai.mcp.registry.port` is deprecated, use `nacos.ai.registry.port` instead.
 nacos.ai.registry.port=9080
 
+### Maximum number of entries allowed in an uploaded skill ZIP, default 500. Raise this when
+### legitimately-large skills exceed the default cap; values <= 0 fall back to the default.
+#nacos.ai.skill.zip.max-entries=500
+
+### Maximum total decompressed size (in MB) for an uploaded skill ZIP, default 50. Guards against
+### Zip Bomb attacks; raise when legitimate skills exceed it. Values <= 0 fall back to the default.
+#nacos.ai.skill.zip.max-uncompressed-size-mb=50
+
 #--------------- Nacos Web Server Configurations ---------------#
 
 #*************** Nacos Web Server Related Configurations ***************#


### PR DESCRIPTION
Closes #15164

## What is the purpose of the change

In `SkillZipParser`, the maximum-entries cap (500) and maximum total decompressed size cap (50 MB) are hard-coded as Zip-Bomb hardening introduced in PR #15064 / #15069. The hard-coded caps now block legitimate large skill uploads — the reporter ran into the 500-entry limit on a real skill, and the maintainer agreed the limit should be relaxed for users that need it.

This PR exposes both bounds via existing `EnvUtil` properties so operators can raise them without code changes. Defaults are unchanged, so existing deployments behave identically.

## Brief changelog

- `ai/.../utils/SkillZipParser.java`
  - Replace the two `private static final` caps with named defaults (`DEFAULT_MAX_ZIP_ENTRIES = 500`, `DEFAULT_MAX_UNCOMPRESSED_SIZE_MB = 50`) and add two property keys: `nacos.ai.skill.zip.max-entries`, `nacos.ai.skill.zip.max-uncompressed-size-mb`.
  - Add package-private `resolveMaxZipEntries()` / `resolveMaxUncompressedBytes()` helpers that read overrides from `EnvUtil`. Non-positive values and a missing environment (e.g. unit tests bypassing Spring boot-up) fall back to the default, so the security guard stays intact.
  - `unzipToEntries(...)` reads both bounds into final locals once per invocation and uses them in the existing guards and error messages.
- `bootstrap/src/main/resources/application.properties`
  - Document the two new properties next to the rest of the `nacos.ai.*` section, both commented out at their defaults.
- `ai/.../test/.../SkillZipParserLimitsConfigTest.java`
  - 10 new tests covering: default value, positive override accepted, non-positive (`0`, `-10`) override ignored, environment-missing fallback, and end-to-end `parseSkillFromZip(...)` rejecting / accepting payloads according to the configured limits.

`AgentSpecZipParser` has a duplicate pair of hard-coded constants. The reporter only filed against skill upload and the maintainer's reply scoped to skill, so I left AgentSpec out of this PR. Happy to follow up in a separate PR if maintainers want symmetric configurability there.

## Verifying this change

```bash
mvn -pl ai -am install -DskipTests
mvn -pl ai test -Dtest=SkillZipParserLimitsConfigTest,SkillZipParserRuntimeExceptionTest,AgentSpecZipParserSecurityTest
# Tests run: 18, Failures: 0, Errors: 0, Skipped: 0

mvn -pl ai test
# Tests run: 1240, Failures: 0, Errors: 0, Skipped: 2 (no new failures)

mvn -pl ai -B spotless:check checkstyle:check spotbugs:check -DskipTests
# 0 spotless / checkstyle / spotbugs violations
```

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.