### PR TITLE
[ISSUE #15141] Send namespaceId / namespaceName on namespace update

### DIFF
--- a/console-ui-next/src/api/__tests__/namespace.test.ts
+++ b/console-ui-next/src/api/__tests__/namespace.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Namespace API unit tests.
+ * Verifies wire field names against backend NamespaceForm (namespaceId / namespaceName) and
+ * CreateNamespaceForm (customNamespaceId / namespaceName). Regression coverage for #15141, where
+ * the update path was sending `namespace` / `namespaceShowName` and the backend rejected the
+ * request with "required parameter 'namespaceId' is missing".
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const EXPECTED_BASE = 'v3/console/core/namespace';
+
+const okResponse = () => Promise.resolve({ data: {} });
+
+const mockClient = {
+  get: vi.fn<(...args: unknown[]) => Promise<{ data: object }>>(okResponse),
+  post: vi.fn<(...args: unknown[]) => Promise<{ data: object }>>(okResponse),
+  put: vi.fn<(...args: unknown[]) => Promise<{ data: object }>>(okResponse),
+  delete: vi.fn<(...args: unknown[]) => Promise<{ data: object }>>(okResponse),
+};
+
+vi.mock('../client', () => ({ default: mockClient }));
+
+const { namespaceApi } = await import('../namespace');
+
+describe('Namespace API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('list calls GET /list', async () => {
+    await namespaceApi.list();
+    expect(mockClient.get).toHaveBeenCalledWith(`${EXPECTED_BASE}/list`);
+  });
+
+  it('detail calls GET with namespaceId param', async () => {
+    await namespaceApi.detail('ns-1');
+    expect(mockClient.get).toHaveBeenCalledWith(
+      EXPECTED_BASE,
+      expect.objectContaining({ params: { namespaceId: 'ns-1' } }),
+    );
+  });
+
+  it('create POSTs the customNamespaceId / namespaceName wire field names', async () => {
+    await namespaceApi.create({
+      customNamespaceId: 'custom-id',
+      namespaceName: 'dev',
+      namespaceDesc: '调试',
+    });
+    expect(mockClient.post).toHaveBeenCalledWith(EXPECTED_BASE, {
+      customNamespaceId: 'custom-id',
+      namespaceName: 'dev',
+      namespaceDesc: '调试',
+    });
+  });
+
+  it('update PUTs the namespaceId / namespaceName wire field names', async () => {
+    // Regression for #15141: the previous wire shape used `namespace` and `namespaceShowName`,
+    // which fails the backend NamespaceForm#validate() with "required parameter 'namespaceId'
+    // is missing".
+    await namespaceApi.update({
+      namespaceId: 'ns-1',
+      namespaceName: 'dev',
+      namespaceDesc: '调试',
+    });
+    expect(mockClient.put).toHaveBeenCalledWith(EXPECTED_BASE, {
+      namespaceId: 'ns-1',
+      namespaceName: 'dev',
+      namespaceDesc: '调试',
+    });
+    const sentBody = mockClient.put.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(sentBody?.namespace).toBeUndefined();
+    expect(sentBody?.namespaceShowName).toBeUndefined();
+  });
+
+  it('remove DELETEs with namespaceId query string', async () => {
+    await namespaceApi.remove('ns-1');
+    expect(mockClient.delete).toHaveBeenCalledWith(`${EXPECTED_BASE}?namespaceId=ns-1`);
+  });
+});

--- a/console-ui-next/src/api/namespace.ts
+++ b/console-ui-next/src/api/namespace.ts
@@ -21,8 +21,8 @@ export interface NamespaceCreateData {
 }
 
 export interface NamespaceUpdateData {
-  namespace: string;
-  namespaceShowName: string;
+  namespaceId: string;
+  namespaceName: string;
   namespaceDesc?: string;
 }
 

--- a/console-ui-next/src/pages/namespace/index.tsx
+++ b/console-ui-next/src/pages/namespace/index.tsx
@@ -108,8 +108,8 @@ export default function NamespacePage() {
     setSaving(true);
     try {
       await namespaceApi.update({
-        namespace: selected.namespace,
-        namespaceShowName: formName.trim(),
+        namespaceId: selected.namespace,
+        namespaceName: formName.trim(),
         namespaceDesc: formDesc.trim(),
       });
       toast.success(t('namespace.updateSuccess'));


### PR DESCRIPTION
Closes #15141

## What is the purpose of the change

The new console (`console-ui-next`) sends the wrong wire field names when editing a namespace, so the backend rejects the request with:

```
{"code":10000,"message":"parameter missing","data":"required parameter 'namespaceId' is missing"}
```

Reproduce in 3.2.1 by editing any namespace description from the new console — the PUT payload looks like:

```
namespace=<id>&namespaceShowName=<name>&namespaceDesc=<desc>
```

…but `core/.../form/NamespaceForm` requires `namespaceId` and `namespaceName`. The legacy console-ui translates the form values into those names before sending (see `console-ui/src/components/EditorNameSpace/EditorNameSpace.js`), the new console does not.

## Brief changelog

- `console-ui-next/src/api/namespace.ts`
  - Rename `NamespaceUpdateData` fields to `namespaceId` / `namespaceName` so the PUT body matches `NamespaceForm`.
  - `NamespaceCreateData` is left as-is because `CreateNamespaceForm` (POST) expects `customNamespaceId` / `namespaceName`, both of which the new console already sends correctly.
  - The list/detail response shape (`namespace` / `namespaceShowName`) is unchanged — that mirrors `api.model.response.Namespace`.
- `console-ui-next/src/pages/namespace/index.tsx`
  - The one caller (`handleEdit`) now passes `selected.namespace` as `namespaceId` and `formName.trim()` as `namespaceName`. No other view code references those fields.
- `console-ui-next/src/api/__tests__/namespace.test.ts`
  - New test suite mocking the axios client and asserting wire shapes:
    - `update` PUTs `namespaceId` / `namespaceName` / `namespaceDesc` and **does not** send `namespace` / `namespaceShowName` (the bug shape).
    - `create` keeps the `customNamespaceId` / `namespaceName` shape.
    - `list` / `detail` / `remove` still send the documented URL params.

## Verifying this change

```bash
cd console-ui-next
npm install
npx vitest run src/api/__tests__/namespace.test.ts
# Test Files  1 passed (1)
# Tests       5 passed (5)

npx tsc -b           # type-check passes
npx vite build       # build passes
npx eslint src/api/namespace.ts src/pages/namespace/index.tsx src/api/__tests__/namespace.test.ts
# 0 errors
```

Manual check against the reported scenario:

1. Start Nacos 3.2.1 and the new console.
2. Edit any namespace's description. Previously: ``required parameter 'namespaceId' is missing``. After this change: PUT succeeds and the description is updated.
3. Creating a namespace remains unaffected (`customNamespaceId` was always correct).

## Notes for reviewers

The issue had a casual interest comment from another contributor four days ago but no PR or progress on the tracker, so I went ahead with the fix; happy to defer if there is an existing in-flight branch elsewhere.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass. *(Frontend-only change; backend Maven checks are not exercised by this PR.)*