### PR TITLE
[ISSUE #15171] Re-exec startup scripts under bash when invoked via sh

### DIFF
--- a/distribution/bin/startup-native.sh
+++ b/distribution/bin/startup-native.sh
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Re-execute under bash when invoked via a non-bash shell (e.g. `sh startup-native.sh`
+# on Debian/Ubuntu, where /bin/sh is dash and does not support the `[[` syntax
+# this script relies on). The `#!/bin/bash` shebang above is honored only when the
+# script is executed directly or via `bash startup-native.sh`; it is ignored when
+# an explicit interpreter such as `sh` is invoked.
+if [ -z "$BASH_VERSION" ]; then
+    if command -v bash >/dev/null 2>&1; then
+        exec bash "$0" "$@"
+    fi
+    echo "ERROR: bash is required to run this script, but it is not installed." >&2
+    exit 1
+fi
+
 #===========================================================================================
 # Setting system properties
 #===========================================================================================

--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -13,6 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Re-execute under bash when invoked via a non-bash shell (e.g. `sh startup.sh`
+# on Debian/Ubuntu, where /bin/sh is dash and does not support the `[[` syntax
+# this script relies on). The `#!/bin/bash` shebang above is honored only when
+# the script is executed directly (./startup.sh) or via `bash startup.sh`; it
+# is ignored when an explicit interpreter such as `sh` is invoked.
+if [ -z "$BASH_VERSION" ]; then
+    if command -v bash >/dev/null 2>&1; then
+        exec bash "$0" "$@"
+    fi
+    echo "ERROR: bash is required to run this script, but it is not installed." >&2
+    exit 1
+fi
+
 cygwin=false
 darwin=false
 os400=false


### PR DESCRIPTION
Closes #15171

## What is the purpose of the change

On Debian / Ubuntu systems `/bin/sh` is `dash`, which does not support the `[[` syntax used by `distribution/bin/startup.sh` and `startup-native.sh`. The shebang `#!/bin/bash` is honored only when the script is executed directly (`./startup.sh`) or via `bash startup.sh`; when a user runs `sh bin/startup.sh -m standalone` (a common invocation pattern in docs and muscle-memory), dash interprets the script itself and the result is:

```
bin/startup.sh: 172: [[: not found
bin/startup.sh: 176: [[: not found
...
nacos is starting with cluster    # -m standalone was silently dropped
```

This PR adds a small re-exec fence at the top of each script that detects the absence of `BASH_VERSION` and re-executes the script under `bash` with the original argv. The existing bash body is left untouched, so the fix is non-invasive and macOS / RHEL / Alpine (where `/bin/sh` is already bash-compatible) are unaffected.

## Brief changelog

- `distribution/bin/startup.sh`
  - Add a 10-line bash-detection fence directly after the license header: if `BASH_VERSION` is unset, look for `bash` on `PATH`, and either `exec bash "$0" "$@"` to re-run the script under bash with the original argv, or emit a clear error message and exit 1 when bash is genuinely unavailable.
- `distribution/bin/startup-native.sh`
  - Same fence with the script name in the comment adjusted; this file also uses `[[` and has the same shebang, so it has the same dash failure mode.

No bash-only constructs are removed; the fence is purely additive and only fires on the misinvocation path.

## Verifying this change

A 3-way invocation smoke test (script source attached at the end):

```text
=== bash invocation (control) ===
[reached-real-body] BASH_VERSION=5.2.32(1)-release
PASS: bash reaches the body and BASH_VERSION is set

=== dash invocation (the bug case) ===
[reached-real-body] BASH_VERSION=5.2.32(1)-release
PASS: dash invocation rexecs into bash and reaches the body without [[ errors

=== sh invocation (user's reported case) ===
PASS: sh invocation also works

=== All checks passed ===
```

The harness rewrites a temp copy of `startup.sh` with `echo "[reached-real-body]"; exit 0` inserted right before `cygwin=false` so the verification does not actually start Nacos.

```bash
#!/bin/bash
set -e
cd /path/to/nacos
TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
awk '/^cygwin=false$/ && !i { print "echo \"[reached-real-body] BASH_VERSION=$BASH_VERSION\""; print "exit 0"; i=1 } { print }' \
  distribution/bin/startup.sh > "$TMP/startup.sh"
chmod +x "$TMP/startup.sh"
for sh in bash dash sh; do "$sh" "$TMP/startup.sh"; done
```

`bash -n` / `sh -n` (POSIX syntax check) both pass against the new fence — it uses only single-bracket `[ ... ]`, `command -v`, and `exec`, all POSIX.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test). *(Shell distribution artifact; verified by the 3-way invocation harness above. The repo does not currently host shell-unit tests for `distribution/bin/`.)*
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass. *(This PR only touches `distribution/bin/*.sh`; no Java sources are changed.)*