### PR TITLE
test: improve config module unit test coverage

### DIFF
--- a/config/src/test/java/com/alibaba/nacos/config/server/ConfigTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/ConfigTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.boot.SpringApplication;
+
+import static org.mockito.Mockito.mockStatic;
+
+class ConfigTest {
+    
+    @Test
+    void testMain() {
+        String[] args = new String[] {"--server.port=0"};
+        try (MockedStatic<SpringApplication> springApplication =
+            mockStatic(SpringApplication.class)) {
+            Config.main(args);
+            
+            springApplication.verify(() -> SpringApplication.run(Config.class, args));
+        }
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/DefaultConstructorCoverageTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/DefaultConstructorCoverageTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server;
+
+import com.alibaba.nacos.common.task.AbstractDelayTask;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class DefaultConstructorCoverageTest {
+    
+    private static final String BASE = "com.alibaba.nacos.config.server.";
+    
+    @Test
+    void testZeroArgumentConstructors() throws Exception {
+        for (String className : zeroArgumentClassNames()) {
+            Constructor<?> constructor = Class.forName(className).getDeclaredConstructor();
+            constructor.setAccessible(true);
+            
+            assertNotNull(constructor.newInstance());
+        }
+    }
+    
+    @Test
+    void testClientRecordConstructor() throws Exception {
+        Constructor<?> constructor = Class.forName(BASE + "service.ClientRecord")
+            .getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+        
+        Object record = constructor.newInstance("127.0.0.1");
+        
+        assertNotNull(record);
+        assertEquals("127.0.0.1", record.getClass().getMethod("getIp").invoke(record));
+    }
+    
+    @Test
+    void testDumpAllTaskMergeMethods() throws Exception {
+        invokeMerge(BASE + "service.dump.task.DumpAllBetaTask");
+        invokeMerge(BASE + "service.dump.task.DumpAllGrayTask");
+        invokeMerge(BASE + "service.dump.task.DumpAllTagTask");
+        
+        Object dumpAllTask = Class.forName(BASE + "service.dump.task.DumpAllTask")
+            .getDeclaredConstructor(boolean.class).newInstance(true);
+        dumpAllTask.getClass().getMethod("merge", AbstractDelayTask.class)
+            .invoke(dumpAllTask, new Object[] {null});
+    }
+    
+    private void invokeMerge(String className) throws Exception {
+        Object task = Class.forName(className).getDeclaredConstructor().newInstance();
+        task.getClass().getMethod("merge", AbstractDelayTask.class)
+            .invoke(task, new Object[] {null});
+    }
+    
+    private String[] zeroArgumentClassNames() {
+        return new String[] {
+            BASE + "Config",
+            BASE + "constant.Constants",
+            BASE + "model.ConfigAdvanceInfo",
+            BASE + "model.ConfigAllInfo",
+            BASE + "model.ConfigInfoBetaWrapper",
+            BASE + "model.ConfigInfoGrayWrapper",
+            BASE + "model.ConfigInfoTagWrapper",
+            BASE + "model.ConfigInfoWrapper",
+            BASE + "model.gray.GrayRuleManager",
+            BASE + "monitor.MetricsMonitor",
+            BASE + "monitor.ResponseMonitor",
+            BASE + "service.ClientIpWhiteList",
+            BASE + "service.ClientTrackService",
+            BASE + "service.ConfigChangePublisher",
+            BASE + "service.SwitchService",
+            BASE + "service.dump.disk.ConfigDiskServiceFactory",
+            BASE + "service.dump.HistoryConfigCleanerManager",
+            BASE + "service.dump.task.DumpAllBetaTask",
+            BASE + "service.dump.task.DumpAllGrayTask",
+            BASE + "service.dump.task.DumpAllTagTask",
+            BASE + "service.query.handler.ConfigContentTypeHandler",
+            BASE + "service.sql.EmbeddedStorageContextUtils",
+            BASE + "service.sql.ExternalStorageUtils",
+            BASE + "utils.AppNameUtils",
+            BASE + "utils.ConfigExecutor",
+            BASE + "utils.ConfigTagUtil",
+            BASE + "utils.ContentUtils",
+            BASE + "utils.GroupKey",
+            BASE + "utils.GroupKey2",
+            BASE + "utils.LogUtil",
+            BASE + "utils.MD5Util",
+            BASE + "utils.ParamUtils",
+            BASE + "utils.Protocol",
+            BASE + "utils.RegexParser",
+            BASE + "utils.RequestUtil",
+            BASE + "utils.ResponseUtil",
+            BASE + "utils.SystemConfig",
+            BASE + "utils.TimeUtils",
+            BASE + "utils.TraceLogUtil",
+            BASE + "utils.UrlAnalysisUtils"
+        };
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/aspect/CapacityManagementAspectTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/aspect/CapacityManagementAspectTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.config.server.aspect;
 
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.config.server.constant.CounterMode;
+import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
 import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
 import com.alibaba.nacos.config.server.model.capacity.GroupCapacity;
@@ -37,6 +38,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1001,5 +1004,154 @@ class CapacityManagementAspectTest {
             .aroundPublishConfig(proceedingJoinPoint);
         assertEquals(true, result);
         Mockito.verify(capacityService).initTenantCapacity(mockTenant);
+    }
+    
+    @Test
+    void testDo4DeleteCorrectsTenantUsageWhenConfigInfoNull() throws Throwable {
+        when(proceedingJoinPoint.proceed()).thenReturn(true);
+        
+        Object result = invokeDo4Delete(mockGroup, mockTenant, null);
+        
+        assertEquals(true, result);
+        Mockito.verify(capacityService).correctTenantUsage(mockTenant);
+    }
+    
+    @Test
+    void testDo4DeleteCorrectsGroupUsageWhenConfigInfoNull() throws Throwable {
+        when(proceedingJoinPoint.proceed()).thenReturn(true);
+        
+        Object result = invokeDo4Delete(mockGroup, "", null);
+        
+        assertEquals(true, result);
+        Mockito.verify(capacityService).correctGroupUsage(mockGroup);
+    }
+    
+    @Test
+    void testDo4DeleteIgnoresCorrectUsageException() throws Throwable {
+        when(proceedingJoinPoint.proceed()).thenReturn(true);
+        Mockito.doThrow(new RuntimeException("correct failed")).when(capacityService)
+            .correctGroupUsage(mockGroup);
+        
+        Object result = invokeDo4Delete(mockGroup, "", null);
+        
+        assertEquals(true, result);
+    }
+    
+    @Test
+    void testAroundPublishInsertLimitTypeExceptionProceeds() throws Throwable {
+        when(PropertyUtil.isManageCapacity()).thenReturn(true);
+        when(PropertyUtil.isCapacityLimitCheck()).thenReturn(true);
+        when(proceedingJoinPoint.getArgs())
+            .thenReturn(new Object[] {configForm, configRequestInfo});
+        when(configForm.getDataId()).thenReturn("d");
+        when(configForm.getGroup()).thenReturn("g");
+        when(configForm.getContent()).thenReturn("content");
+        when(configInfoPersistService.findConfigInfo(any(), any(), any())).thenReturn(null);
+        when(capacityService.insertAndUpdateClusterUsage(any(), anyBoolean()))
+            .thenThrow(new RuntimeException("quota failed"));
+        when(proceedingJoinPoint.proceed()).thenReturn(true);
+        
+        Object result = capacityManagementAspect.aroundPublishConfig(proceedingJoinPoint);
+        
+        assertEquals(true, result);
+    }
+    
+    @Test
+    void testAroundPublishUpdateNullContentProceeds() throws Throwable {
+        when(PropertyUtil.isManageCapacity()).thenReturn(true);
+        when(PropertyUtil.isCapacityLimitCheck()).thenReturn(true);
+        when(proceedingJoinPoint.getArgs())
+            .thenReturn(new Object[] {configForm, configRequestInfo});
+        when(configForm.getDataId()).thenReturn("d");
+        when(configForm.getGroup()).thenReturn("g");
+        when(configForm.getNamespaceId()).thenReturn("");
+        when(configForm.getContent()).thenReturn(null);
+        when(configInfoPersistService.findConfigInfo(any(), any(), any()))
+            .thenReturn(new ConfigInfoWrapper());
+        when(proceedingJoinPoint.proceed()).thenReturn(true);
+        
+        Object result = capacityManagementAspect.aroundPublishConfig(proceedingJoinPoint);
+        
+        assertEquals(true, result);
+    }
+    
+    @Test
+    void testAroundPublishInsertRollbackUsageExceptionIgnored() throws Throwable {
+        when(PropertyUtil.isManageCapacity()).thenReturn(true);
+        when(PropertyUtil.isCapacityLimitCheck()).thenReturn(false);
+        when(proceedingJoinPoint.getArgs())
+            .thenReturn(new Object[] {configForm, configRequestInfo});
+        when(configForm.getDataId()).thenReturn("d");
+        when(configForm.getGroup()).thenReturn("g");
+        when(configForm.getNamespaceId()).thenReturn("ns");
+        when(configForm.getContent()).thenReturn("content");
+        when(configInfoPersistService.findConfigInfo(any(), any(), any())).thenReturn(null);
+        when(capacityService.insertAndUpdateClusterUsage(any(), anyBoolean())).thenReturn(true);
+        when(capacityService.insertAndUpdateTenantUsage(any(), eq("ns"), anyBoolean()))
+            .thenReturn(true);
+        when(proceedingJoinPoint.proceed()).thenReturn(false);
+        when(capacityService.updateClusterUsage(any()))
+            .thenThrow(new RuntimeException("rollback failed"));
+        
+        Object result = capacityManagementAspect.aroundPublishConfig(proceedingJoinPoint);
+        
+        assertEquals(false, result);
+    }
+    
+    @Test
+    void testAroundPublishInsertRollbackTenantUsageExceptionIgnored() throws Throwable {
+        when(PropertyUtil.isManageCapacity()).thenReturn(true);
+        when(PropertyUtil.isCapacityLimitCheck()).thenReturn(false);
+        when(proceedingJoinPoint.getArgs())
+            .thenReturn(new Object[] {configForm, configRequestInfo});
+        when(configForm.getDataId()).thenReturn("d");
+        when(configForm.getGroup()).thenReturn("g");
+        when(configForm.getNamespaceId()).thenReturn("ns");
+        when(configForm.getContent()).thenReturn("content");
+        when(configInfoPersistService.findConfigInfo(any(), any(), any())).thenReturn(null);
+        when(capacityService.insertAndUpdateClusterUsage(any(), anyBoolean())).thenReturn(true);
+        when(capacityService.insertAndUpdateTenantUsage(any(), eq("ns"), anyBoolean()))
+            .thenReturn(true);
+        when(proceedingJoinPoint.proceed()).thenReturn(false);
+        when(capacityService.updateClusterUsage(any())).thenReturn(true);
+        when(capacityService.updateTenantUsage(any(), eq("ns")))
+            .thenThrow(new RuntimeException("rollback failed"));
+        
+        Object result = capacityManagementAspect.aroundPublishConfig(proceedingJoinPoint);
+        
+        assertEquals(false, result);
+    }
+    
+    @Test
+    void testAroundPublishInsertRollbackClusterExceptionIgnored() throws Throwable {
+        when(PropertyUtil.isManageCapacity()).thenReturn(true);
+        when(PropertyUtil.isCapacityLimitCheck()).thenReturn(true);
+        when(PropertyUtil.getDefaultMaxSize()).thenReturn(5);
+        when(proceedingJoinPoint.getArgs())
+            .thenReturn(new Object[] {configForm, configRequestInfo});
+        when(configForm.getDataId()).thenReturn("d");
+        when(configForm.getGroup()).thenReturn("g");
+        when(configForm.getContent()).thenReturn("oversized content");
+        when(configInfoPersistService.findConfigInfo(any(), any(), any())).thenReturn(null);
+        when(capacityService.insertAndUpdateClusterUsage(any(), anyBoolean())).thenReturn(true);
+        when(capacityService.getGroupCapacity(eq("g"))).thenReturn(null);
+        when(capacityService.updateClusterUsage(any()))
+            .thenThrow(new RuntimeException("rollback failed"));
+        
+        assertThrows(NacosException.class,
+            () -> capacityManagementAspect.aroundPublishConfig(proceedingJoinPoint));
+    }
+    
+    private Object invokeDo4Delete(String group, String namespaceId, ConfigInfo configInfo)
+        throws Throwable {
+        Method method = CapacityManagementAspect.class.getDeclaredMethod("do4Delete",
+            ProceedingJoinPoint.class, String.class, String.class, ConfigInfo.class);
+        method.setAccessible(true);
+        try {
+            return method.invoke(capacityManagementAspect, proceedingJoinPoint, group, namespaceId,
+                configInfo);
+        } catch (ReflectiveOperationException e) {
+            throw e.getCause();
+        }
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspectTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspectTest.java
@@ -252,10 +252,13 @@ class ConfigChangeAspectTest {
     
     @Test
     void testRpcSourceTypeHandling() throws Throwable {
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        
         when(pjp.getArgs()).thenReturn(new Object[] {configForm, configRequestInfo});
         when(configRequestInfo.getSrcType()).thenReturn("rpc");
         when(configForm.getDataId()).thenReturn("dataId");
-        when(pjp.proceed()).thenReturn("Success");
+        when(pjp.proceed(any())).thenReturn("Success");
         
         configChangeAspect.publishOrUpdateConfigAround(pjp);
         ArgumentCaptor<ConfigChangeRequest> requestCaptor =
@@ -342,6 +345,103 @@ class ConfigChangeAspectTest {
         
         verify(configChangePluginService, never()).execute(any(), any());
         assertEquals("Success", result);
+    }
+    
+    @Test
+    void testDisabledPluginSkippedWhenEnabledPluginExists() throws Throwable {
+        ConfigChangePluginService disabledService =
+            Mockito.mock(ConfigChangePluginService.class);
+        Mockito.when(disabledService.getServiceType())
+            .thenReturn("disabledConfigChangeService");
+        Mockito.when(disabledService.pointcutMethodNames())
+            .thenReturn(ConfigChangePointCutTypes.values());
+        Mockito.when(disabledService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        ConfigChangePluginManager.join(disabledService);
+        
+        Properties properties = new Properties();
+        properties.put("mockedConfigChangeService.enabled", "true");
+        properties.put("disabledConfigChangeService.enabled", "false");
+        propertiesStatic.when(() -> PropertiesUtil.getPropertiesWithPrefix(any(), any()))
+            .thenReturn(properties);
+        configChangeConfigs.onEvent(ServerConfigChangeEvent.newEvent());
+        
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        when(pjp.getArgs()).thenReturn(new Object[] {configForm, configRequestInfo});
+        when(configForm.getDataId()).thenReturn("dataId");
+        when(configRequestInfo.getSrcType()).thenReturn("http");
+        when(pjp.proceed(any())).thenReturn("Success");
+        
+        Object result = configChangeAspect.publishOrUpdateConfigAround(pjp);
+        
+        verify(disabledService, never()).execute(any(), any());
+        verify(configChangePluginService).execute(any(), any());
+        assertEquals("Success", result);
+    }
+    
+    @Test
+    void testBeforePluginCanReplaceProceedArgs() throws Throwable {
+        Object[] originalArgs = new Object[] {configForm, configRequestInfo};
+        ConfigForm newConfigForm = Mockito.mock(ConfigForm.class);
+        ConfigRequestInfo newConfigRequestInfo = Mockito.mock(ConfigRequestInfo.class);
+        Object[] replacedArgs = new Object[] {newConfigForm, newConfigRequestInfo};
+        
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
+        Mockito.doAnswer(invocation -> {
+            ConfigChangeResponse response = invocation.getArgument(1);
+            response.setArgs(replacedArgs);
+            return null;
+        }).when(configChangePluginService).execute(any(), any());
+        when(pjp.getArgs()).thenReturn(originalArgs);
+        when(configForm.getDataId()).thenReturn("dataId");
+        when(configRequestInfo.getSrcType()).thenReturn("http");
+        when(pjp.proceed(replacedArgs)).thenReturn("replaced");
+        
+        Object result = configChangeAspect.publishOrUpdateConfigAround(pjp);
+        
+        verify(pjp).proceed(replacedArgs);
+        assertEquals("replaced", result);
+    }
+    
+    @Test
+    void testAfterPluginExceptionHandled() throws Throwable {
+        CountDownLatch latch = new CountDownLatch(1);
+        Mockito.when(configChangePluginService.executeType())
+            .thenReturn(ConfigChangeExecuteTypes.EXECUTE_AFTER_TYPE);
+        Mockito.doAnswer(invocation -> {
+            latch.countDown();
+            throw new RuntimeException("async plugin failed");
+        }).when(configChangePluginService).execute(any(), any());
+        
+        when(pjp.getArgs()).thenReturn(new Object[] {configForm, configRequestInfo});
+        when(configForm.getDataId()).thenReturn("dataId");
+        when(configRequestInfo.getSrcType()).thenReturn("http");
+        when(pjp.proceed(any())).thenReturn("Success");
+        
+        Object result = configChangeAspect.publishOrUpdateConfigAround(pjp);
+        
+        assertEquals("Success", result);
+        assertTrue(latch.await(500, TimeUnit.MILLISECONDS));
+    }
+    
+    @Test
+    void testNullPluginListTreatedAsNoPlugin() throws Throwable {
+        try (MockedStatic<ConfigChangePluginManager> pluginManagerMockedStatic =
+            Mockito.mockStatic(ConfigChangePluginManager.class)) {
+            pluginManagerMockedStatic.when(() -> ConfigChangePluginManager
+                .findPluginServicesByPointcut(ConfigChangePointCutTypes.PUBLISH_BY_HTTP))
+                .thenReturn(null);
+            when(pjp.getArgs()).thenReturn(new Object[] {configForm, configRequestInfo});
+            when(configRequestInfo.getSrcType()).thenReturn("http");
+            when(pjp.proceed()).thenReturn("Success");
+            
+            Object result = configChangeAspect.publishOrUpdateConfigAround(pjp);
+            
+            verify(configChangePluginService, never()).execute(any(), any());
+            assertEquals("Success", result);
+        }
     }
     
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigsTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigsTest.java
@@ -17,10 +17,14 @@
 package com.alibaba.nacos.config.server.configuration;
 
 import com.alibaba.nacos.common.event.ServerConfigChangeEvent;
+import com.alibaba.nacos.plugin.config.constants.ConfigChangeConstants;
 import com.alibaba.nacos.sys.env.EnvUtil;
+import com.alibaba.nacos.sys.utils.PropertiesUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.mock.env.MockEnvironment;
 
 import java.util.Properties;
@@ -77,6 +81,20 @@ class ConfigChangeConfigsTest {
         assertNotNull(properties);
         assertTrue(properties.isEmpty());
         assertNull(properties.getProperty("enabled"));
+    }
+    
+    @Test
+    void testRefreshPluginPropertiesIgnoresPropertyLoadingException() {
+        try (MockedStatic<PropertiesUtil> mocked = Mockito.mockStatic(PropertiesUtil.class)) {
+            mocked.when(() -> PropertiesUtil.getPropertiesWithPrefix(environment,
+                ConfigChangeConstants.NACOS_CORE_CONFIG_PLUGIN_PREFIX))
+                .thenThrow(new RuntimeException("failed"));
+            
+            configChangeConfigs.onEvent(ServerConfigChangeEvent.newEvent());
+        }
+        
+        assertTrue(configChangeConfigs.getPluginProperties("mockPlugin")
+            .containsKey("enabled"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/configuration/NacosConfigConfigurationTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/configuration/NacosConfigConfigurationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.configuration;
+
+import com.alibaba.nacos.config.server.filter.CircuitFilter;
+import com.alibaba.nacos.config.server.filter.NacosWebFilter;
+import com.alibaba.nacos.core.code.ControllerMethodsCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class NacosConfigConfigurationTest {
+    
+    private ControllerMethodsCache methodsCache;
+    
+    private NacosConfigConfiguration configuration;
+    
+    @BeforeEach
+    void setUp() {
+        methodsCache = mock(ControllerMethodsCache.class);
+        configuration = new NacosConfigConfiguration(methodsCache);
+    }
+    
+    @Test
+    void testInit() {
+        configuration.init();
+        
+        verify(methodsCache).initClassMethod("com.alibaba.nacos.config.server.controller");
+    }
+    
+    @Test
+    void testNacosWebFilterRegistration() {
+        FilterRegistrationBean<NacosWebFilter> registration =
+            configuration.nacosWebFilterRegistration();
+        
+        assertInstanceOf(NacosWebFilter.class, registration.getFilter());
+        assertEquals("nacosWebFilter", registration.getFilterName());
+        assertEquals(1, registration.getOrder());
+        assertEquals(1, registration.getUrlPatterns().size());
+        assertEquals("/v1/cs/*", registration.getUrlPatterns().iterator().next());
+    }
+    
+    @Test
+    void testNacosWebFilter() {
+        assertInstanceOf(NacosWebFilter.class, configuration.nacosWebFilter());
+    }
+    
+    @Test
+    void testTransferToLeaderRegistration() {
+        FilterRegistrationBean<CircuitFilter> registration =
+            configuration.transferToLeaderRegistration();
+        
+        assertInstanceOf(CircuitFilter.class, registration.getFilter());
+        assertEquals("curcuitFilter", registration.getFilterName());
+        assertEquals(6, registration.getOrder());
+        assertEquals(1, registration.getUrlPatterns().size());
+        assertEquals("/v1/cs/*", registration.getUrlPatterns().iterator().next());
+    }
+    
+    @Test
+    void testTransferToLeader() {
+        assertInstanceOf(CircuitFilter.class, configuration.transferToLeader());
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/constant/ParametersFieldTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/constant/ParametersFieldTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.constant;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ParametersFieldTest {
+    
+    @Test
+    void testConstructorAndConstants() {
+        assertNotNull(new ParametersField());
+        assertEquals("types", ParametersField.TYPES);
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/constant/PropertiesConstantTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/constant/PropertiesConstantTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.constant;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class PropertiesConstantTest {
+    
+    @Test
+    void testConstructorAndConstants() {
+        assertNotNull(new PropertiesConstant());
+        assertEquals("notifyConnectTimeout", PropertiesConstant.NOTIFY_CONNECT_TIMEOUT);
+        assertEquals("notifySocketTimeout", PropertiesConstant.NOTIFY_SOCKET_TIMEOUT);
+        assertEquals("isHealthCheck", PropertiesConstant.IS_HEALTH_CHECK);
+        assertEquals("maxHealthCheckFailCount", PropertiesConstant.MAX_HEALTH_CHECK_FAIL_COUNT);
+        assertEquals("maxContent", PropertiesConstant.MAX_CONTENT);
+        assertEquals("isManageCapacity", PropertiesConstant.IS_MANAGE_CAPACITY);
+        assertEquals("isCapacityLimitCheck", PropertiesConstant.IS_CAPACITY_LIMIT_CHECK);
+        assertEquals("defaultClusterQuota", PropertiesConstant.DEFAULT_CLUSTER_QUOTA);
+        assertEquals("defaultGroupQuota", PropertiesConstant.DEFAULT_GROUP_QUOTA);
+        assertEquals("defaultTenantQuota", PropertiesConstant.DEFAULT_TENANT_QUOTA);
+        assertEquals("defaultMaxSize", PropertiesConstant.DEFAULT_MAX_SIZE);
+        assertEquals("defaultMaxAggrCount", PropertiesConstant.DEFAULT_MAX_AGGR_COUNT);
+        assertEquals("defaultMaxAggrSize", PropertiesConstant.DEFAULT_MAX_AGGR_SIZE);
+        assertEquals("correctUsageDelay", PropertiesConstant.CORRECT_USAGE_DELAY);
+        assertEquals("initialExpansionPercent", PropertiesConstant.INITIAL_EXPANSION_PERCENT);
+        assertEquals("nacos.config.search.max_capacity", PropertiesConstant.SEARCH_MAX_CAPACITY);
+        assertEquals("nacos.config.search.max_thread", PropertiesConstant.SEARCH_MAX_THREAD);
+        assertEquals("nacos.config.search.wait_timeout", PropertiesConstant.SEARCH_WAIT_TIMEOUT);
+        assertEquals("dumpChangeOn", PropertiesConstant.DUMP_CHANGE_ON);
+        assertEquals("dumpChangeWorkerInterval", PropertiesConstant.DUMP_CHANGE_WORKER_INTERVAL);
+        assertEquals("nacos.config.retention.days", PropertiesConstant.CONFIG_RENTENTION_DAYS);
+        assertEquals("nacos.config.gray.compatible.model", PropertiesConstant.GRAY_CAPATIBEL_MODEL);
+        assertEquals("nacos.config.namespace.compatible.mode",
+            PropertiesConstant.NAMESPACE_COMPATIBLE_MODE);
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/ConfigServletInnerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/ConfigServletInnerTest.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.enums.ApiVersionEnum;
+import com.alibaba.nacos.config.server.exception.NacosConfigException;
 import com.alibaba.nacos.config.server.model.CacheItem;
 import com.alibaba.nacos.config.server.model.ConfigCacheGray;
 import com.alibaba.nacos.config.server.model.ConfigListenState;
@@ -35,6 +36,8 @@ import com.alibaba.nacos.config.server.service.LongPollingService;
 import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskServiceFactory;
 import com.alibaba.nacos.config.server.service.dump.disk.ConfigRocksDbDiskService;
 import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.enums.ResponseCode;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
 import com.alibaba.nacos.config.server.utils.GroupKey;
 import com.alibaba.nacos.config.server.utils.GroupKey2;
 import com.alibaba.nacos.config.server.utils.MD5Util;
@@ -59,11 +62,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.alibaba.nacos.api.common.Constants.CONFIG_TYPE;
 import static com.alibaba.nacos.api.common.Constants.VIPSERVER_TAG;
 import static com.alibaba.nacos.config.server.constant.Constants.CONTENT_MD5;
 import static com.alibaba.nacos.config.server.constant.Constants.ENCODE_UTF8;
 import static com.alibaba.nacos.config.server.utils.RequestUtil.CLIENT_APPNAME_HEADER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -551,5 +556,110 @@ class ConfigServletInnerTest {
         assertEquals(HttpServletResponse.SC_OK + "", actualValue);
         assertTrue(response.getHeader(HttpHeaderConsts.CONTENT_TYPE)
             .contains("text/plain"));
+    }
+    
+    @Test
+    void testDoGetConfigWhenQueryChainFails() {
+        ConfigQueryChainResponse chainResponse = ConfigQueryChainResponse.buildFailResponse(
+            ResponseCode.FAIL.getCode(), "query failed");
+        useMockQueryChain(chainResponse);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        NacosConfigException actual = assertThrows(NacosConfigException.class,
+            () -> configServletInner.doGetConfig(request, response, "data", "group", "tenant",
+                null, "false", "127.0.0.1", ApiVersionEnum.V1));
+        
+        assertEquals("query failed", actual.getMessage());
+    }
+    
+    @Test
+    void testDoGetConfigV1WhenFormalContentIsNull() throws Exception {
+        ConfigQueryChainResponse chainResponse = buildFormalResponse(null);
+        useMockQueryChain(chainResponse);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        String actualValue = configServletInner.doGetConfig(request, response, "data", "group",
+            "tenant", null, "false", "127.0.0.1", ApiVersionEnum.V1);
+        
+        assertEquals(HttpServletResponse.SC_NOT_FOUND + "", actualValue);
+        assertTrue(response.getContentAsString().contains("config data not exist"));
+    }
+    
+    @Test
+    void testDoGetConfigV2WhenFormalContentIsNull() throws Exception {
+        ConfigQueryChainResponse chainResponse = buildFormalResponse(null);
+        useMockQueryChain(chainResponse);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        String actualValue = configServletInner.doGetConfig(request, response, "data", "group",
+            "tenant", null, "false", "127.0.0.1", ApiVersionEnum.V2);
+        
+        assertEquals(HttpServletResponse.SC_NOT_FOUND + "", actualValue);
+        assertTrue(response.getContentAsString().contains("config data not exist"));
+    }
+    
+    @Test
+    void testDoGetConfigV1UsesDefaultHeadersFromChainResponse() throws Exception {
+        ConfigQueryChainResponse chainResponse = buildFormalResponse("content");
+        chainResponse.setContentType("");
+        useMockQueryChain(chainResponse);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        String actualValue = configServletInner.doGetConfig(request, response, "data", "group",
+            "tenant", null, "false", "127.0.0.1", ApiVersionEnum.V1);
+        
+        assertEquals(HttpServletResponse.SC_OK + "", actualValue);
+        assertTrue(response.getHeader(HttpHeaderConsts.CONTENT_TYPE).contains("text/plain"));
+        assertEquals("text", response.getHeader(CONFIG_TYPE));
+        assertEquals("content", response.getContentAsString());
+    }
+    
+    @Test
+    void testDoGetConfigV1UsesConfigTypeFromChainResponse() throws Exception {
+        ConfigQueryChainResponse chainResponse = buildFormalResponse("content");
+        chainResponse.setConfigType("yaml");
+        useMockQueryChain(chainResponse);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        String actualValue = configServletInner.doGetConfig(request, response, "data", "group",
+            "tenant", null, "false", "127.0.0.1", ApiVersionEnum.V1);
+        
+        assertEquals(HttpServletResponse.SC_OK + "", actualValue);
+        assertEquals("yaml", response.getHeader(CONFIG_TYPE));
+    }
+    
+    @Test
+    void testDoGetConfigWhenGrayMatchedInfoIsNull() {
+        ConfigQueryChainResponse chainResponse = buildFormalResponse("content");
+        chainResponse.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_GRAY);
+        useMockQueryChain(chainResponse);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        assertThrows(NullPointerException.class,
+            () -> configServletInner.doGetConfig(request, response, "data", "group", "tenant",
+                null, "false", "127.0.0.1", ApiVersionEnum.V1));
+    }
+    
+    private void useMockQueryChain(ConfigQueryChainResponse chainResponse) {
+        ConfigQueryChainService queryChainService = Mockito.mock(ConfigQueryChainService.class);
+        when(queryChainService.handle(Mockito.any())).thenReturn(chainResponse);
+        ReflectionTestUtils.setField(configServletInner, "configQueryChainService",
+            queryChainService);
+    }
+    
+    private ConfigQueryChainResponse buildFormalResponse(String content) {
+        ConfigQueryChainResponse chainResponse = new ConfigQueryChainResponse();
+        chainResponse.setResultCode(ResponseCode.SUCCESS.getCode());
+        chainResponse.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        chainResponse.setContent(content);
+        chainResponse.setMd5("md5");
+        chainResponse.setLastModified(System.currentTimeMillis());
+        return chainResponse;
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3Test.java
@@ -20,7 +20,9 @@ import com.alibaba.nacos.api.config.model.ConfigBasicInfo;
 import com.alibaba.nacos.api.config.model.ConfigCloneInfo;
 import com.alibaba.nacos.api.config.model.ConfigGrayInfo;
 import com.alibaba.nacos.api.config.model.ConfigListenerInfo;
+import com.alibaba.nacos.api.config.model.SameConfigPolicy;
 import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.http.param.MediaType;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
@@ -51,6 +53,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.core.env.StandardEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -61,7 +64,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -639,6 +644,19 @@ class ConfigControllerV3Test {
     }
     
     @Test
+    void testImportConfigWithFileReadException() throws Exception {
+        MultipartFile file = Mockito.mock(MultipartFile.class);
+        when(file.getBytes()).thenThrow(new IOException("broken"));
+        when(namespacePersistService.tenantInfoCountByTenantId("public")).thenReturn(1);
+        
+        Result<Map<String, Object>> result = configControllerV3.importAndPublishConfig(
+            new MockHttpServletRequest(), "test", "public", SameConfigPolicy.ABORT, file);
+        
+        assertEquals(100004, result.getCode());
+        assertEquals(0, result.getData().get("succCount"));
+    }
+    
+    @Test
     void testCloneConfigEmpty() throws Exception {
         MockHttpServletRequestBuilder builder =
             MockMvcRequestBuilders.post(
@@ -758,6 +776,38 @@ class ConfigControllerV3Test {
     }
     
     @Test
+    void testImportConfigWithMissingConfigFile() throws Exception {
+        ConfigMetadata configMetadata = new ConfigMetadata();
+        configMetadata.setMetadata(new ArrayList<>());
+        ConfigMetadata.ConfigExportItem item = new ConfigMetadata.ConfigExportItem();
+        item.setDataId("missing.json");
+        item.setGroup("group");
+        item.setType("json");
+        configMetadata.getMetadata().add(item);
+        
+        ZipUtils.UnZipResult unziped = new ZipUtils.UnZipResult(new ArrayList<>(),
+            new ZipUtils.ZipItem(Constants.CONFIG_EXPORT_METADATA_NEW,
+                YamlParserUtil.dumpObject(configMetadata)));
+        MockMultipartFile file =
+            new MockMultipartFile("file", "test.zip", "application/zip", "test".getBytes());
+        try (MockedStatic<ZipUtils> zipUtilsMockedStatic = Mockito.mockStatic(ZipUtils.class)) {
+            zipUtilsMockedStatic.when(() -> ZipUtils.unzip(eq(file.getBytes())))
+                .thenReturn(unziped);
+            when(namespacePersistService.tenantInfoCountByTenantId("public"))
+                .thenReturn(1);
+            
+            MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.multipart(
+                Constants.CONFIG_ADMIN_V3_PATH + "/import").file(file).param("src_user", "test")
+                .param("namespaceId", "public").param("policy", "ABORT");
+            
+            String actualValue =
+                mockmvc.perform(builder).andReturn().getResponse().getContentAsString();
+            String code = JacksonUtils.toObj(actualValue).get("code").toString();
+            assertEquals("100005", code);
+        }
+    }
+    
+    @Test
     void testCloneConfigEmptyQueryResult() throws Exception {
         ConfigCloneInfo info = new ConfigCloneInfo();
         info.setConfigId(1L);
@@ -793,6 +843,7 @@ class ConfigControllerV3Test {
         configAllInfo.setDataId("orig");
         configAllInfo.setGroup("origGroup");
         configAllInfo.setAppName("myApp");
+        configAllInfo.setEncryptedDataKey("cipherKey");
         configAllInfo.setId(1L);
         List<ConfigAllInfo> queryedDataList = new ArrayList<>();
         queryedDataList.add(configAllInfo);

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpenApiControllerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpenApiControllerTest.java
@@ -102,6 +102,24 @@ class ConfigOpenApiControllerTest {
     }
     
     @Test
+    void testGetConfigNonExistGrayWithoutMatchedGray()
+        throws NacosApiException, UnsupportedEncodingException {
+        ConfigQueryChainResponse response = new ConfigQueryChainResponse();
+        response.setContent(null);
+        response.setEncryptedDataKey(null);
+        response.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_GRAY);
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response);
+        ConfigFormV3 configForm = new ConfigFormV3();
+        configForm.setDataId("test");
+        configForm.setGroupName("test");
+        
+        Result<ConfigQueryResponse> actual = configOpenApiController.getConfig(configForm);
+        
+        assertEquals(ErrorCode.RESOURCE_NOT_FOUND.getCode(), actual.getCode());
+    }
+    
+    @Test
     void testGetConfigExistBeta() throws NacosApiException, UnsupportedEncodingException {
         ConfigQueryChainResponse response = new ConfigQueryChainResponse();
         response.setContent("test");

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpsControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpsControllerV3Test.java
@@ -16,10 +16,14 @@
 
 package com.alibaba.nacos.config.server.controller.v3;
 
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.common.model.RestResultUtils;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.config.server.configuration.ConfigCommonConfig;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.service.dump.DumpService;
+import com.alibaba.nacos.config.server.utils.LogUtil;
 import com.alibaba.nacos.persistence.configuration.DatasourceConfiguration;
 import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
 import com.alibaba.nacos.persistence.datasource.LocalDataSourceServiceImpl;
@@ -41,6 +45,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -50,6 +55,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -173,6 +179,7 @@ class ConfigOpsControllerV3Test {
         ConfigCommonConfig.getInstance().setDerbyOpsEnabled(true);
         datasourceConfigurationMockedStatic.when(DatasourceConfiguration::isEmbeddedStorage)
             .thenReturn(true);
+        mockLocalDataSource();
         MockHttpServletRequestBuilder builder =
             MockMvcRequestBuilders.get(
                 Constants.OPS_CONTROLLER_V3_ADMIN_PATH + "/derby")
@@ -180,6 +187,17 @@ class ConfigOpsControllerV3Test {
         String actualValue =
             mockMvc.perform(builder).andReturn().getResponse().getContentAsString();
         assertEquals("30000", JacksonUtils.toObj(actualValue).get("code").toString());
+    }
+    
+    @Test
+    void testDerbyOpsNonSelectSqlDirectly() {
+        ConfigCommonConfig.getInstance().setDerbyOpsEnabled(true);
+        datasourceConfigurationMockedStatic.when(DatasourceConfiguration::isEmbeddedStorage)
+            .thenReturn(true);
+        mockLocalDataSource();
+        
+        assertEquals(30000,
+            configOpsControllerV3.derbyOps("DELETE FROM TEST").getCode());
     }
     
     @Test
@@ -291,15 +309,18 @@ class ConfigOpsControllerV3Test {
     
     @Test
     void testSetLogLevelError() throws Exception {
-        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders
-            .put(Constants.OPS_CONTROLLER_V3_ADMIN_PATH + "/log")
-            .param("logName", "nonexistent.invalid.logger.12345")
-            .param("logLevel", "INVALID_LEVEL");
-        String actualValue =
-            mockMvc.perform(builder).andReturn().getResponse().getContentAsString();
-        int status =
-            mockMvc.perform(builder).andReturn().getResponse().getStatus();
-        assertEquals(200, status);
+        try (MockedStatic<LogUtil> logUtilMockedStatic = Mockito.mockStatic(LogUtil.class)) {
+            logUtilMockedStatic.when(() -> LogUtil.setLogLevel("test", "INVALID_LEVEL"))
+                .thenThrow(new IllegalArgumentException("invalid"));
+            MockHttpServletRequestBuilder builder = MockMvcRequestBuilders
+                .put(Constants.OPS_CONTROLLER_V3_ADMIN_PATH + "/log")
+                .param("logName", "test")
+                .param("logLevel", "INVALID_LEVEL");
+            String actualValue =
+                mockMvc.perform(builder).andReturn().getResponse().getContentAsString();
+            
+            assertEquals("30000", JacksonUtils.toObj(actualValue).get("code").toString());
+        }
     }
     
     @Test
@@ -351,5 +372,43 @@ class ConfigOpsControllerV3Test {
             .file(file);
         int status = mockMvc.perform(builder).andReturn().getResponse().getStatus();
         assertEquals(200, status);
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    void testConvertToResultCopiesCompletedRestResult() {
+        DeferredResult<RestResult<String>> restResult = new DeferredResult<>();
+        DeferredResult<Result<String>> wrappedResult =
+            ReflectionTestUtils.invokeMethod(configOpsControllerV3, "convertToResult", restResult);
+        restResult.setResult(RestResultUtils.success("ok"));
+        
+        Runnable completionCallback =
+            (Runnable) ReflectionTestUtils.getField(restResult, "completionCallback");
+        completionCallback.run();
+        
+        Result<String> result = (Result<String>) wrappedResult.getResult();
+        assertEquals(200, result.getCode());
+        assertEquals("ok", result.getData());
+    }
+    
+    @Test
+    void testConvertToResultIgnoresNullRestResult() {
+        DeferredResult<RestResult<String>> restResult = new DeferredResult<>();
+        DeferredResult<Result<String>> wrappedResult =
+            ReflectionTestUtils.invokeMethod(configOpsControllerV3, "convertToResult", restResult);
+        
+        Runnable completionCallback =
+            (Runnable) ReflectionTestUtils.getField(restResult, "completionCallback");
+        completionCallback.run();
+        
+        assertNull(wrappedResult.getResult());
+    }
+    
+    private void mockLocalDataSource() {
+        DynamicDataSource dataSource = Mockito.mock(DynamicDataSource.class);
+        dynamicDataSourceMockedStatic.when(DynamicDataSource::getInstance)
+            .thenReturn(dataSource);
+        when(dataSource.getDataSource())
+            .thenReturn(Mockito.mock(LocalDataSourceServiceImpl.class));
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ListenerControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ListenerControllerV3Test.java
@@ -126,4 +126,45 @@ class ListenerControllerV3Test {
         assertEquals("0", JacksonUtils.toObj(actualValue).get("code").toString());
     }
     
+    @Test
+    void testGetAllSubClientConfigByIpWithAllFlag() throws Exception {
+        ConfigListenerInfo sampleResult = new ConfigListenerInfo();
+        Map<String, String> map = new HashMap<>();
+        map.put("dataId+group+tenant", "md5");
+        sampleResult.setListenersStatus(map);
+        when(configListenerStateDelegate.getListenerStateByIp("localhost", true))
+            .thenReturn(sampleResult);
+        MockHttpServletRequestBuilder builder =
+            MockMvcRequestBuilders.get(Constants.LISTENER_CONTROLLER_V3_ADMIN_PATH)
+                .param("ip", "localhost").param("all", "true");
+        
+        String actualValue =
+            mockmvc.perform(builder).andReturn().getResponse().getContentAsString();
+        
+        String data = JacksonUtils.toObj(actualValue).get("data").toString();
+        ConfigListenerInfo configListenerInfo = JacksonUtils.toObj(data, ConfigListenerInfo.class);
+        assertEquals("md5", configListenerInfo.getListenersStatus().get("dataId+group+tenant"));
+    }
+    
+    @Test
+    void testGetAllSubClientConfigByIpKeepsDefaultNamespaceWhenAllIsFalse()
+        throws Exception {
+        ConfigListenerInfo sampleResult = new ConfigListenerInfo();
+        Map<String, String> map = new HashMap<>();
+        map.put("dataId+group", "md5");
+        sampleResult.setListenersStatus(map);
+        when(configListenerStateDelegate.getListenerStateByIp("localhost", true))
+            .thenReturn(sampleResult);
+        MockHttpServletRequestBuilder builder =
+            MockMvcRequestBuilders.get(Constants.LISTENER_CONTROLLER_V3_ADMIN_PATH)
+                .param("ip", "localhost").param("all", "false");
+        
+        String actualValue =
+            mockmvc.perform(builder).andReturn().getResponse().getContentAsString();
+        
+        String data = JacksonUtils.toObj(actualValue).get("data").toString();
+        ConfigListenerInfo configListenerInfo = JacksonUtils.toObj(data, ConfigListenerInfo.class);
+        assertEquals("md5", configListenerInfo.getListenersStatus().get("dataId+group"));
+    }
+    
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/MetricControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/MetricControllerV3Test.java
@@ -183,6 +183,35 @@ class MetricControllerV3Test {
     }
     
     @Test
+    void testGetClusterMetricTimeoutShouldSetCompleteFalse() throws Exception {
+        List<Member> members = new ArrayList<>();
+        Member member = new Member();
+        member.setIp("127.0.0.1");
+        member.setPort(8848);
+        members.add(member);
+        when(memberManager.allMembers()).thenReturn(members);
+        
+        NacosAsyncRestTemplate nacosAsyncRestTemplate = Mockito.mock(NacosAsyncRestTemplate.class);
+        try (MockedStatic<HttpClientBeanHolder> mockedStatic =
+            Mockito.mockStatic(HttpClientBeanHolder.class)) {
+            mockedStatic
+                .when(() -> HttpClientBeanHolder.getNacosAsyncRestTemplate(any(Logger.class)))
+                .thenReturn(nacosAsyncRestTemplate);
+            MockHttpServletRequestBuilder builder = MockMvcRequestBuilders
+                .get(Constants.METRICS_CONTROLLER_V3_ADMIN_PATH + "/cluster")
+                .param("ip", "127.0.0.1")
+                .param("namespaceId", "test").param("dataId", "test").param("groupName", "test");
+            
+            String actualValue =
+                mockMvc.perform(builder).andReturn().getResponse().getContentAsString();
+            JsonNode data = JacksonUtils.toObj(actualValue).get("data");
+            
+            assertNotNull(data);
+            assertFalse(data.get("complete").asBoolean());
+        }
+    }
+    
+    @Test
     void testClusterMetricsCallBack() {
         
         Member m1 = new Member();

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/MetricsControllerV3Test.java
@@ -16,13 +16,21 @@
 
 package com.alibaba.nacos.config.server.controller.v3;
 
+import com.alibaba.nacos.api.config.remote.response.ClientConfigMetricResponse;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.model.RestResult;
 import com.alibaba.nacos.core.cluster.Member;
+import com.alibaba.nacos.core.cluster.ServerMemberManager;
+import com.alibaba.nacos.core.remote.Connection;
+import com.alibaba.nacos.core.remote.ConnectionManager;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.core.env.StandardEnvironment;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -30,7 +38,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 class MetricsControllerV3Test {
     
@@ -104,5 +116,58 @@ class MetricsControllerV3Test {
         cb.onCancel();
         assertFalse(complete.get());
         assertEquals(0, latch.getCount());
+    }
+    
+    @Test
+    void testMetricInterruptedSetsCompleteFalse() throws Exception {
+        ServerMemberManager serverMemberManager = Mockito.mock(ServerMemberManager.class);
+        ConnectionManager connectionManager = Mockito.mock(ConnectionManager.class);
+        when(serverMemberManager.allMembers()).thenReturn(Collections.emptyList());
+        MetricsControllerV3 controller = new MetricsControllerV3(serverMemberManager,
+            connectionManager);
+        Thread.currentThread().interrupt();
+        try {
+            Result<Map<String, Object>> result =
+                controller.metric("127.0.0.1", "dataId", "group", "");
+            
+            assertEquals(Boolean.FALSE, result.getData().get("complete"));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+    
+    @Test
+    void testGetClientMetrics() throws Exception {
+        ServerMemberManager serverMemberManager = Mockito.mock(ServerMemberManager.class);
+        ConnectionManager connectionManager = Mockito.mock(ConnectionManager.class);
+        Connection connection = Mockito.mock(Connection.class);
+        ClientConfigMetricResponse response = new ClientConfigMetricResponse();
+        response.putMetric("cache", "ok");
+        when(connectionManager.getConnectionByIp("127.0.0.1"))
+            .thenReturn(Collections.singletonList(connection));
+        when(connection.request(any(), eq(1000L))).thenReturn(response);
+        MetricsControllerV3 controller = new MetricsControllerV3(serverMemberManager,
+            connectionManager);
+        
+        Result<Map<String, Object>> result =
+            controller.getClientMetrics("127.0.0.1", "dataId", "group", "");
+        
+        assertEquals("ok", result.getData().get("cache"));
+    }
+    
+    @Test
+    void testGetClientMetricsThrowsNacosExceptionWhenClientRequestFails() throws Exception {
+        ServerMemberManager serverMemberManager = Mockito.mock(ServerMemberManager.class);
+        ConnectionManager connectionManager = Mockito.mock(ConnectionManager.class);
+        Connection connection = Mockito.mock(Connection.class);
+        when(connectionManager.getConnectionByIp("127.0.0.1"))
+            .thenReturn(Collections.singletonList(connection));
+        when(connection.request(any(), eq(1000L)))
+            .thenThrow(new RuntimeException("request failed"));
+        MetricsControllerV3 controller = new MetricsControllerV3(serverMemberManager,
+            connectionManager);
+        
+        assertThrows(NacosException.class,
+            () -> controller.getClientMetrics("127.0.0.1", "dataId", "group", ""));
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/enums/ApiVersionEnumTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/enums/ApiVersionEnumTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ApiVersionEnumTest {
+    
+    @Test
+    void testGetVersion() {
+        assertEquals("v1", ApiVersionEnum.V1.getVersion());
+        assertEquals("v2", ApiVersionEnum.V2.getVersion());
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/enums/OperationTypeTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/enums/OperationTypeTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OperationTypeTest {
+    
+    @Test
+    void testSetValue() {
+        OperationType operationType = OperationType.UPDATE;
+        
+        operationType.setValue("custom");
+        
+        assertEquals("custom", operationType.getValue());
+        operationType.setValue("U");
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/exception/ConfigAlreadyExistsExceptionTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/exception/ConfigAlreadyExistsExceptionTest.java
@@ -25,6 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class ConfigAlreadyExistsExceptionTest {
     
     @Test
+    void testDefaultConstructor() {
+        ConfigAlreadyExistsException ex = new ConfigAlreadyExistsException();
+        assertEquals(0, ex.getErrCode());
+    }
+    
+    @Test
     void testMessageConstructor() {
         ConfigAlreadyExistsException ex =
             new ConfigAlreadyExistsException("already exists");

--- a/config/src/test/java/com/alibaba/nacos/config/server/manager/TaskManagerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/manager/TaskManagerTest.java
@@ -134,6 +134,19 @@ class TaskManagerTest {
     }
     
     @Test
+    void testAwaitWaitsForProcessing() throws InterruptedException {
+        when(taskProcessor.process(abstractTask)).thenAnswer(invocation -> {
+            TimeUnit.MILLISECONDS.sleep(100);
+            return true;
+        });
+        taskManager.addTask("awaitTest", abstractTask);
+        
+        taskManager.await();
+        
+        assertTrue(taskManager.isEmpty());
+    }
+    
+    @Test
     void testAwaitWithTimeoutWhenEmpty() throws InterruptedException {
         assertTrue(taskManager.isEmpty());
         boolean result = taskManager.await(100, TimeUnit.MILLISECONDS);
@@ -162,5 +175,15 @@ class TaskManagerTest {
         ObjectName oName = new ObjectName(
             TaskManagerTest.class.getName() + ":type=" + TaskManager.class.getSimpleName());
         assertTrue(ManagementFactory.getPlatformMBeanServer().isRegistered(oName));
+    }
+    
+    @Test
+    void testInitIgnoresInvalidObjectName() {
+        TaskManager invalidTaskManager = new TaskManager("invalid:name");
+        try {
+            invalidTaskManager.init();
+        } finally {
+            invalidTaskManager.close();
+        }
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/CacheItemTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/CacheItemTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model;
+
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CacheItemTest {
+    
+    @BeforeEach
+    void setUp() {
+        EnvUtil.setEnvironment(new StandardEnvironment());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(null);
+    }
+    
+    @Test
+    void testConstructorAndSimpleAccessors() {
+        CacheItem cacheItem = new CacheItem("groupKey", "encryptedKey");
+        cacheItem.setType("properties");
+        
+        assertEquals("groupKey", cacheItem.getGroupKey());
+        assertEquals("encryptedKey", cacheItem.getConfigCache().getEncryptedDataKey());
+        assertEquals("properties", cacheItem.getType());
+        assertNotNull(cacheItem.getRwLock());
+    }
+    
+    @Test
+    void testSortConfigGrayWhenEmpty() {
+        CacheItem cacheItem = new CacheItem("groupKey");
+        cacheItem.sortConfigGray();
+        
+        assertNull(cacheItem.getSortConfigGrays());
+    }
+    
+    @Test
+    void testSortConfigGrayByPriority() {
+        CacheItem cacheItem = new CacheItem("groupKey");
+        cacheItem.initConfigGrayIfEmpty("low");
+        cacheItem.initConfigGrayIfEmpty("high");
+        cacheItem.getConfigCacheGray().get("low")
+            .resetGrayRule("{\"type\":\"tag\",\"version\":\"1.0.0\","
+                + "\"expr\":\"low\",\"priority\":1}");
+        cacheItem.getConfigCacheGray().get("high")
+            .resetGrayRule("{\"type\":\"tag\",\"version\":\"1.0.0\","
+                + "\"expr\":\"high\",\"priority\":2}");
+        
+        cacheItem.sortConfigGray();
+        
+        assertEquals("high", cacheItem.getSortConfigGrays().get(0).getGrayName());
+        assertEquals("low", cacheItem.getSortConfigGrays().get(1).getGrayName());
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigAdvanceInfoTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigAdvanceInfoTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.config.server.model;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class ConfigAdvanceInfoTest {
@@ -68,12 +69,12 @@ class ConfigAdvanceInfoTest {
     
     @Test
     void testNotEqualsNull() {
-        assertNotEquals(null, new ConfigAdvanceInfo());
+        assertFalse(new ConfigAdvanceInfo().equals(null));
     }
     
     @Test
     void testNotEqualsDifferentClass() {
-        assertNotEquals("str", new ConfigAdvanceInfo());
+        assertFalse(new ConfigAdvanceInfo().equals("str"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigCacheFactoryDelegateTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigCacheFactoryDelegateTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.lang.reflect.Constructor;
 import java.util.Collections;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -92,5 +93,24 @@ class ConfigCacheFactoryDelegateTest {
         configCacheFactoryDelegate.createConfigCacheGray();
         verify(nacosConfigCacheFactory, times(2)).createConfigCache();
         verify(nacosConfigCacheFactory, times(2)).createConfigCacheGray();
+    }
+    
+    @Test
+    public void testConstructorSkipsFactoryWithEmptyName() throws Exception {
+        when(nacosConfigCacheFactory.getName()).thenReturn("");
+        nacosServiceLoaderMockedStatic.when(() -> NacosServiceLoader.load(ConfigCacheFactory.class))
+            .thenReturn(Collections.singletonList(nacosConfigCacheFactory));
+        envUtilMockedStatic.when(() -> EnvUtil.getProperty("nacos.config.cache.type", "nacos"))
+            .thenReturn("nacos");
+        Constructor constructor = ConfigCacheFactoryDelegate.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        
+        ConfigCacheFactoryDelegate configCacheFactoryDelegate =
+            (ConfigCacheFactoryDelegate) constructor.newInstance();
+        configCacheFactoryDelegate.createConfigCache();
+        configCacheFactoryDelegate.createConfigCacheGray();
+        
+        verify(nacosConfigCacheFactory, never()).createConfigCache();
+        verify(nacosConfigCacheFactory, never()).createConfigCacheGray();
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigHistoryInfoTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigHistoryInfoTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ConfigHistoryInfoTest {
+    
+    @Test
+    void testAccessorsEqualsAndHashCode() {
+        ConfigHistoryInfo first = buildConfigHistoryInfo();
+        ConfigHistoryInfo second = buildConfigHistoryInfo();
+        
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+        
+        first.setLastId(2L);
+        
+        assertEquals(2L, first.getLastId());
+        assertNotEquals(first, second);
+        assertNotEquals(first, null);
+        assertNotEquals(first, "history");
+    }
+    
+    private ConfigHistoryInfo buildConfigHistoryInfo() {
+        Timestamp now = new Timestamp(1000L);
+        ConfigHistoryInfo result = new ConfigHistoryInfo();
+        result.setId(1L);
+        result.setLastId(1L);
+        result.setDataId("dataId");
+        result.setGroup("group");
+        result.setTenant("tenant");
+        result.setAppName("app");
+        result.setMd5("md5");
+        result.setContent("content");
+        result.setSrcIp("127.0.0.1");
+        result.setSrcUser("user");
+        result.setOpType("I");
+        result.setPublishType("formal");
+        result.setGrayName("gray");
+        result.setExtInfo("{}");
+        result.setCreatedTime(now);
+        result.setLastModifiedTime(now);
+        result.setEncryptedDataKey("key");
+        return result;
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoBaseTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoBaseTest.java
@@ -22,6 +22,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -193,6 +194,7 @@ class ConfigInfoBaseTest {
     @Test
     void testEqualsNull() {
         ConfigInfoBase base = new ConfigInfoBase("dataId", "group", "content");
+        assertFalse(base.equals(null));
         assertNotEquals(null, base);
     }
     
@@ -218,6 +220,14 @@ class ConfigInfoBaseTest {
     }
     
     @Test
+    void testEqualsDataIdDifferent() {
+        ConfigInfoBase a = new ConfigInfoBase("dataId1", "group", "content");
+        ConfigInfoBase b = new ConfigInfoBase("dataId2", "group", "content");
+        assertFalse(a.equals(b));
+        assertNotEquals(a, b);
+    }
+    
+    @Test
     void testEqualsDataIdNullVsNonNull() {
         ConfigInfoBase a = new ConfigInfoBase();
         a.setContent("content");
@@ -226,6 +236,7 @@ class ConfigInfoBaseTest {
         b.setContent("content");
         b.setGroup("group");
         b.setDataId("dataId");
+        assertFalse(a.equals(b));
         assertNotEquals(a, b);
     }
     
@@ -238,6 +249,15 @@ class ConfigInfoBaseTest {
         b.setDataId("dataId");
         b.setContent("content");
         b.setGroup("group");
+        assertFalse(a.equals(b));
+        assertNotEquals(a, b);
+    }
+    
+    @Test
+    void testEqualsGroupDifferent() {
+        ConfigInfoBase a = new ConfigInfoBase("dataId", "group1", "content");
+        ConfigInfoBase b = new ConfigInfoBase("dataId", "group2", "content");
+        assertFalse(a.equals(b));
         assertNotEquals(a, b);
     }
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoChangedTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoChangedTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.config.server.model;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -61,12 +62,14 @@ class ConfigInfoChangedTest {
     @Test
     void testEqualsNull() {
         ConfigInfoChanged a = new ConfigInfoChanged("d", "g", "t");
+        assertFalse(a.equals(null));
         assertNotEquals(null, a);
     }
     
     @Test
     void testEqualsDifferentClass() {
         ConfigInfoChanged a = new ConfigInfoChanged("d", "g", "t");
+        assertFalse(a.equals("str"));
         assertNotEquals("str", a);
     }
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoStateWrapperTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoStateWrapperTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ConfigInfoStateWrapperTest {
+    
+    @Test
+    void testEqualsAndHashCode() {
+        ConfigInfoStateWrapper wrapper = newWrapper();
+        ConfigInfoStateWrapper sameWrapper = newWrapper();
+        
+        assertEquals(wrapper, wrapper);
+        assertEquals(wrapper, sameWrapper);
+        assertEquals(wrapper.hashCode(), sameWrapper.hashCode());
+        assertNotEquals(wrapper, null);
+        assertNotEquals(wrapper, "wrapper");
+        
+        sameWrapper.setMd5("different");
+        assertNotEquals(wrapper, sameWrapper);
+    }
+    
+    @Test
+    void testAccessors() {
+        ConfigInfoStateWrapper wrapper = newWrapper();
+        
+        assertEquals(1L, wrapper.getId());
+        assertEquals("dataId", wrapper.getDataId());
+        assertEquals("group", wrapper.getGroup());
+        assertEquals("tenant", wrapper.getTenant());
+        assertEquals(123L, wrapper.getLastModified());
+        assertEquals("md5", wrapper.getMd5());
+        assertEquals("gray", wrapper.getGrayName());
+    }
+    
+    private ConfigInfoStateWrapper newWrapper() {
+        ConfigInfoStateWrapper wrapper = new ConfigInfoStateWrapper();
+        wrapper.setId(1L);
+        wrapper.setDataId("dataId");
+        wrapper.setGroup("group");
+        wrapper.setTenant("tenant");
+        wrapper.setLastModified(123L);
+        wrapper.setMd5("md5");
+        wrapper.setGrayName("gray");
+        return wrapper;
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.env.StandardEnvironment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConfigInfoTest {
     
@@ -89,6 +90,63 @@ class ConfigInfoTest {
         assertEquals("DEFAULT_GROUP", configAllInfo.getGroup());
         assertEquals("继承的描述字段", configAllInfo.getDesc());
         assertEquals("inherited,tags", configAllInfo.getConfigTags());
+    }
+    
+    @Test
+    void testConstructorWithAppName() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "appName", "content");
+        
+        assertEquals("dataId", configInfo.getDataId());
+        assertEquals("group", configInfo.getGroup());
+        assertEquals("appName", configInfo.getAppName());
+        assertEquals("content", configInfo.getContent());
+    }
+    
+    @Test
+    void testToString() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "tenant", "app", "content");
+        configInfo.setId(1L);
+        configInfo.setMd5("md5");
+        configInfo.setType("text");
+        configInfo.setDesc("desc");
+        configInfo.setConfigTags("tag");
+        
+        String result = configInfo.toString();
+        
+        assertTrue(result.contains("id=1"));
+        assertTrue(result.contains("dataId='dataId'"));
+        assertTrue(result.contains("tenant='tenant'"));
+        assertTrue(result.contains("configTags='tag'"));
+    }
+    
+    @Test
+    void testConfigInfo4BetaAccessorsAndEqualityDelegate() {
+        ConfigInfo4Beta configInfo = new ConfigInfo4Beta("dataId", "group", "appName",
+            "content", "1.1.1.1");
+        ConfigInfo4Beta sameConfigInfo = new ConfigInfo4Beta("dataId", "group", "appName",
+            "content", "2.2.2.2");
+        
+        assertEquals("1.1.1.1", configInfo.getBetaIps());
+        configInfo.setBetaIps("3.3.3.3");
+        
+        assertEquals("3.3.3.3", configInfo.getBetaIps());
+        assertEquals(configInfo, sameConfigInfo);
+        assertEquals(configInfo.hashCode(), sameConfigInfo.hashCode());
+    }
+    
+    @Test
+    void testConfigInfo4TagAccessorsAndEqualityDelegate() {
+        ConfigInfo4Tag configInfo = new ConfigInfo4Tag("dataId", "group", "tagA",
+            "appName", "content");
+        ConfigInfo4Tag sameConfigInfo = new ConfigInfo4Tag("dataId", "group", "tagB",
+            "appName", "content");
+        
+        assertEquals("tagA", configInfo.getTag());
+        configInfo.setTag("tagC");
+        
+        assertEquals("tagC", configInfo.getTag());
+        assertEquals(configInfo, sameConfigInfo);
+        assertEquals(configInfo.hashCode(), sameConfigInfo.hashCode());
     }
     
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoWrapperCoverageTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigInfoWrapperCoverageTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigInfoWrapperCoverageTest {
+    
+    @Test
+    void testConfigAllInfoDelegatesEqualsAndHashCode() {
+        ConfigAllInfo info = new ConfigAllInfo();
+        
+        assertEquals(info.hashCode(), info.hashCode());
+        assertTrue(info.equals(info));
+    }
+    
+    @Test
+    void testConfigInfoWrapperDelegatesEqualsAndHashCode() {
+        ConfigInfoWrapper wrapper = new ConfigInfoWrapper();
+        wrapper.setLastModified(100L);
+        
+        assertEquals(100L, wrapper.getLastModified());
+        assertEquals(wrapper.hashCode(), wrapper.hashCode());
+        assertTrue(wrapper.equals(wrapper));
+    }
+    
+    @Test
+    void testConfigInfoBetaWrapperDelegatesEqualsAndHashCode() {
+        ConfigInfoBetaWrapper wrapper = new ConfigInfoBetaWrapper();
+        wrapper.setLastModified(100L);
+        
+        assertEquals(100L, wrapper.getLastModified());
+        assertEquals(wrapper.hashCode(), wrapper.hashCode());
+        assertTrue(wrapper.equals(wrapper));
+    }
+    
+    @Test
+    void testConfigInfoGrayWrapperDelegatesEqualsAndHashCode() {
+        ConfigInfoGrayWrapper wrapper = new ConfigInfoGrayWrapper();
+        wrapper.setLastModified(100L);
+        wrapper.setGrayName("gray");
+        wrapper.setGrayRule("rule");
+        wrapper.setSrcUser("user");
+        
+        assertEquals(100L, wrapper.getLastModified());
+        assertEquals("gray", wrapper.getGrayName());
+        assertEquals("rule", wrapper.getGrayRule());
+        assertEquals("user", wrapper.getSrcUser());
+        assertEquals(wrapper.hashCode(), wrapper.hashCode());
+        assertTrue(wrapper.equals(wrapper));
+    }
+    
+    @Test
+    void testConfigInfoTagWrapperDelegatesEqualsAndHashCode() {
+        ConfigInfoTagWrapper wrapper = new ConfigInfoTagWrapper();
+        wrapper.setLastModified(100L);
+        
+        assertEquals(100L, wrapper.getLastModified());
+        assertEquals(wrapper.hashCode(), wrapper.hashCode());
+        assertTrue(wrapper.equals(wrapper));
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigKeyTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigKeyTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.config.server.model;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -64,12 +65,12 @@ class ConfigKeyTest {
     
     @Test
     void testNotEqualsNull() {
-        assertNotEquals(null, new ConfigKey());
+        assertFalse(new ConfigKey().equals(null));
     }
     
     @Test
     void testNotEqualsDifferentClass() {
-        assertNotEquals("str", new ConfigKey());
+        assertFalse(new ConfigKey().equals("str"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigMetadataTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigMetadataTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ConfigMetadataTest {
+    
+    @Test
+    void testMetadataAccessors() {
+        ConfigMetadata.ConfigExportItem item = newItem();
+        ConfigMetadata metadata = new ConfigMetadata();
+        
+        metadata.setMetadata(Collections.singletonList(item));
+        
+        assertEquals(Collections.singletonList(item), metadata.getMetadata());
+    }
+    
+    @Test
+    void testConfigExportItemEqualsAndHashCode() {
+        ConfigMetadata.ConfigExportItem item = newItem();
+        ConfigMetadata.ConfigExportItem sameItem = newItem();
+        ConfigMetadata.ConfigExportItem differentItem = newItem();
+        differentItem.setConfigTags("different");
+        
+        assertEquals(item, item);
+        assertEquals(item, sameItem);
+        assertEquals(item.hashCode(), sameItem.hashCode());
+        assertNotEquals(item, null);
+        assertNotEquals(item, "item");
+        assertNotEquals(item, differentItem);
+    }
+    
+    @Test
+    void testConfigExportItemAccessors() {
+        ConfigMetadata.ConfigExportItem item = newItem();
+        
+        assertEquals("group", item.getGroup());
+        assertEquals("dataId", item.getDataId());
+        assertEquals("desc", item.getDesc());
+        assertEquals("text", item.getType());
+        assertEquals("app", item.getAppName());
+        assertEquals("tagA,tagB", item.getConfigTags());
+    }
+    
+    private ConfigMetadata.ConfigExportItem newItem() {
+        ConfigMetadata.ConfigExportItem item = new ConfigMetadata.ConfigExportItem();
+        item.setGroup("group");
+        item.setDataId("dataId");
+        item.setDesc("desc");
+        item.setType("text");
+        item.setAppName("app");
+        item.setConfigTags("tagA,tagB");
+        return item;
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigOperateResultTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigOperateResultTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigOperateResultTest {
+    
+    @Test
+    void testDefaultConstructorAndSetSuccess() {
+        ConfigOperateResult result = new ConfigOperateResult();
+        
+        result.setSuccess(true);
+        result.setId(7L);
+        
+        assertTrue(result.isSuccess());
+        assertEquals(7L, result.getId());
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigRequestInfoTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/ConfigRequestInfoTest.java
@@ -85,13 +85,13 @@ class ConfigRequestInfoTest {
     @Test
     void testNotEqualsNull() {
         ConfigRequestInfo a = new ConfigRequestInfo("ip", "type", "app", "beta", "md5");
-        assertNotEquals(null, a);
+        assertFalse(a.equals(null));
     }
     
     @Test
     void testNotEqualsDifferentClass() {
         ConfigRequestInfo a = new ConfigRequestInfo("ip", "type", "app", "beta", "md5");
-        assertNotEquals("str", a);
+        assertFalse(a.equals("str"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/capacity/CapacityTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/capacity/CapacityTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model.capacity;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CapacityTest {
+    
+    @Test
+    void testTimestampDefensiveCopyAndNull() {
+        Capacity capacity = new Capacity();
+        Timestamp createTime = new Timestamp(1L);
+        Timestamp modifiedTime = new Timestamp(2L);
+        
+        capacity.setGmtCreate(createTime);
+        capacity.setGmtModified(modifiedTime);
+        
+        assertEquals(createTime, capacity.getGmtCreate());
+        assertEquals(modifiedTime, capacity.getGmtModified());
+        assertNotSame(createTime, capacity.getGmtCreate());
+        assertNotSame(modifiedTime, capacity.getGmtModified());
+        
+        capacity.setGmtCreate(null);
+        capacity.setGmtModified(null);
+        
+        assertNull(capacity.getGmtCreate());
+        assertNull(capacity.getGmtModified());
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/event/ConfigDumpEventTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/event/ConfigDumpEventTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model.event;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigDumpEventTest {
+    
+    @Test
+    void testBuilderWithDelimiterAndBatch() {
+        ConfigDumpEvent event = ConfigDumpEvent.builder()
+            .remove(true)
+            .namespaceId("namespace")
+            .dataId("dataId")
+            .group("group")
+            .delimiter(1)
+            .isBatch(true)
+            .isBeta(true)
+            .tag("tag")
+            .grayName("gray")
+            .grayRule("rule")
+            .content("content")
+            .betaIps("127.0.0.1")
+            .handleIp("127.0.0.2")
+            .encryptedDataKey("key")
+            .type("properties")
+            .lastModifiedTs(123L)
+            .build();
+        
+        assertTrue(event.isRemove());
+        assertEquals("namespace", event.getNamespaceId());
+        assertEquals("dataId", event.getDataId());
+        assertEquals("group", event.getGroup());
+        assertEquals(1, event.getDelimiter());
+        assertTrue(event.isBatch());
+        assertTrue(event.isBeta());
+        assertEquals("tag", event.getTag());
+        assertEquals("gray", event.getGrayName());
+        assertEquals("rule", event.getGrayRule());
+        assertEquals("content", event.getContent());
+        assertEquals("127.0.0.1", event.getBetaIps());
+        assertEquals("127.0.0.2", event.getHandleIp());
+        assertEquals("key", event.getEncryptedDataKey());
+        assertEquals("properties", event.getType());
+        assertEquals(123L, event.getLastModifiedTs());
+    }
+    
+    @Test
+    void testConfigDataChangeEventRejectsNullDataIdOrGroup() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new ConfigDataChangeEvent(null, "group", "tenant", 1L));
+        assertThrows(IllegalArgumentException.class,
+            () -> new ConfigDataChangeEvent("dataId", null, "tenant", 1L));
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/form/ConfigFormTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/form/ConfigFormTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.config.server.model.form;
 
 import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.config.server.service.capacity.CapacityService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * ConfigFormTest
@@ -158,6 +161,73 @@ public class ConfigFormTest {
         form.setGroup("g");
         form.setContent("content");
         assertDoesNotThrow(form::validateWithContent);
+    }
+    
+    @Test
+    void testConfigFormV3ValidateMissingGroupName() {
+        ConfigFormV3 form = new ConfigFormV3();
+        form.setDataId("d");
+        
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testConfigFormV3ValidateUsesGroupName() {
+        ConfigFormV3 form = new ConfigFormV3();
+        form.setDataId("d");
+        form.setGroupName("groupName");
+        
+        assertDoesNotThrow(form::validate);
+        assertEquals("groupName", form.getGroup());
+    }
+    
+    @Test
+    void testConfigFormV3BlurSearchValidateDefaultsNullFields() throws NacosApiException {
+        ConfigFormV3 form = new ConfigFormV3();
+        
+        form.blurSearchValidate();
+        
+        assertEquals("", form.getGroupName());
+        assertEquals("", form.getGroup());
+        assertEquals("", form.getDataId());
+    }
+    
+    @Test
+    void testUpdateCapacityFormValidateRequiresCapacityField() {
+        UpdateCapacityForm form = new UpdateCapacityForm();
+        
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testUpdateCapacityFormValidateWithCapacityField() {
+        UpdateCapacityForm form = new UpdateCapacityForm();
+        form.setQuota(1);
+        form.setMaxSize(2);
+        form.setMaxAggrCount(3);
+        form.setMaxAggrSize(4);
+        
+        assertDoesNotThrow(form::validate);
+        assertEquals(1, form.getQuota());
+        assertEquals(2, form.getMaxSize());
+        assertEquals(3, form.getMaxAggrCount());
+        assertEquals(4, form.getMaxAggrSize());
+    }
+    
+    @Test
+    void testUpdateCapacityFormChecksNamespaceOrGroupName() {
+        UpdateCapacityForm form = new UpdateCapacityForm();
+        CapacityService capacityService = mock(CapacityService.class);
+        
+        assertThrows(NacosApiException.class,
+            () -> form.checkNamespaceIdAndGroupName(capacityService));
+        verify(capacityService).initAllCapacity();
+        
+        form.setGroupName("group");
+        form.setNamespaceId("namespace");
+        assertDoesNotThrow(() -> form.checkNamespaceIdAndGroupName(capacityService));
+        assertEquals("group", form.getGroupName());
+        assertEquals("namespace", form.getNamespaceId());
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/gray/GrayRuleManagerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/gray/GrayRuleManagerTest.java
@@ -16,11 +16,17 @@
 
 package com.alibaba.nacos.config.server.model.gray;
 
+import com.alibaba.nacos.api.exception.NacosException;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GrayRuleManagerTest {
@@ -49,6 +55,15 @@ class GrayRuleManagerTest {
     }
     
     @Test
+    void testTagGrayRuleBlankExpressionAndEqualsSameInstance() {
+        TagGrayRule rule = new TagGrayRule("", TagGrayRule.PRIORITY);
+        
+        assertEquals(TagGrayRule.TYPE_TAG, rule.getType());
+        assertEquals(TagGrayRule.VERSION, rule.getVersion());
+        assertEquals(rule, rule);
+    }
+    
+    @Test
     void testConstructGrayRuleUnknownTypeReturnsNull() {
         ConfigGrayPersistInfo info = new ConfigGrayPersistInfo(
             "unknown_type", "v999", "expr", 1);
@@ -61,6 +76,7 @@ class GrayRuleManagerTest {
         BetaGrayRule betaRule = new BetaGrayRule("1.1.1.1", BetaGrayRule.PRIORITY);
         ConfigGrayPersistInfo info =
             GrayRuleManager.constructConfigGrayPersistInfo(betaRule);
+        assertTrue(betaRule.equals(betaRule));
         assertEquals(BetaGrayRule.TYPE_BETA, info.getType());
         assertEquals(BetaGrayRule.VERSION, info.getVersion());
         assertEquals("1.1.1.1", info.getExpr());
@@ -92,5 +108,133 @@ class GrayRuleManagerTest {
             TagGrayRule.TYPE_TAG, TagGrayRule.VERSION));
         assertNull(GrayRuleManager.getClassByTypeAndVersion(
             "nonexist", "v1"));
+    }
+    
+    @Test
+    void testConstructGrayRuleThrowsWhenRegisteredClassHasNoExpectedConstructor()
+        throws Exception {
+        Map<String, Class<?>> grayRuleMap = getGrayRuleMap();
+        String key = BrokenGrayRule.TYPE + GrayRuleManager.SPLIT + BrokenGrayRule.VERSION;
+        grayRuleMap.put(key, BrokenGrayRule.class);
+        ConfigGrayPersistInfo info = new ConfigGrayPersistInfo(BrokenGrayRule.TYPE,
+            BrokenGrayRule.VERSION, "broken", 1);
+        try {
+            RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> GrayRuleManager.constructGrayRule(info));
+            assertTrue(exception.getMessage().contains(BrokenGrayRule.TYPE));
+            assertTrue(exception.getMessage().contains(BrokenGrayRule.VERSION));
+        } finally {
+            grayRuleMap.remove(key);
+        }
+    }
+    
+    @Test
+    void testAbstractGrayRuleDefaultConstructor() {
+        ValidGrayRule rule = new ValidGrayRule();
+        
+        assertTrue(rule.isValid());
+        assertNull(rule.getRawGrayRuleExp());
+        assertEquals(0, rule.getPriority());
+    }
+    
+    @Test
+    void testAbstractGrayRuleMarksInvalidWhenParseThrows() {
+        InvalidGrayRule rule = new InvalidGrayRule("invalid", 7);
+        
+        assertFalse(rule.isValid());
+        assertEquals("invalid", rule.getRawGrayRuleExp());
+        assertEquals(0, rule.getPriority());
+        rule.setPriority(9);
+        assertEquals(9, rule.getPriority());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private Map<String, Class<?>> getGrayRuleMap() throws Exception {
+        Field field = GrayRuleManager.class.getDeclaredField("GRAY_RULE_MAP");
+        field.setAccessible(true);
+        return (Map<String, Class<?>>) field.get(null);
+    }
+    
+    private static class BrokenGrayRule extends AbstractGrayRule {
+        
+        private static final String TYPE = "broken";
+        
+        private static final String VERSION = "v1";
+        
+        @Override
+        protected void parse(String rawGrayRule) {
+        }
+        
+        @Override
+        public boolean match(Map<String, String> labels) {
+            return false;
+        }
+        
+        @Override
+        public String getType() {
+            return TYPE;
+        }
+        
+        @Override
+        public String getVersion() {
+            return VERSION;
+        }
+    }
+    
+    private static class ValidGrayRule extends AbstractGrayRule {
+        
+        private static final String TYPE = "valid";
+        
+        private static final String VERSION = "v1";
+        
+        @Override
+        protected void parse(String rawGrayRule) {
+        }
+        
+        @Override
+        public boolean match(Map<String, String> labels) {
+            return false;
+        }
+        
+        @Override
+        public String getType() {
+            return TYPE;
+        }
+        
+        @Override
+        public String getVersion() {
+            return VERSION;
+        }
+    }
+    
+    private static class InvalidGrayRule extends AbstractGrayRule {
+        
+        private static final String TYPE = "invalid";
+        
+        private static final String VERSION = "v1";
+        
+        InvalidGrayRule(String rawGrayRuleExp, int priority) {
+            super(rawGrayRuleExp, priority);
+        }
+        
+        @Override
+        protected void parse(String rawGrayRule) throws NacosException {
+            throw new NacosException(NacosException.INVALID_PARAM, "invalid");
+        }
+        
+        @Override
+        public boolean match(Map<String, String> labels) {
+            return false;
+        }
+        
+        @Override
+        public String getType() {
+            return TYPE;
+        }
+        
+        @Override
+        public String getVersion() {
+            return VERSION;
+        }
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/paramcheck/ConfigListenerHttpParamExtractorTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/paramcheck/ConfigListenerHttpParamExtractorTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.config.server.paramcheck;
 
+import com.alibaba.nacos.common.paramcheck.ParamInfo;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,8 @@ import java.util.List;
 
 import static com.alibaba.nacos.api.common.Constants.LINE_SEPARATOR;
 import static com.alibaba.nacos.api.common.Constants.WORD_SEPARATOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 
@@ -51,18 +54,51 @@ class ConfigListenerHttpParamExtractorTest {
     }
     
     @Test
+    void testBlankListeningConfigsReturnEmptyParams() {
+        Mockito.when(httpServletRequest.getParameter(eq("Listening-Configs"))).thenReturn(" ");
+        configListenerHttpParamExtractor = new ConfigListenerHttpParamExtractor();
+        
+        List<ParamInfo> result = configListenerHttpParamExtractor.extractParam(httpServletRequest);
+        
+        assertTrue(result.isEmpty());
+    }
+    
+    @Test
+    void testDecodedBlankListeningConfigsReturnEmptyParams() {
+        Mockito.when(httpServletRequest.getParameter(eq("Listening-Configs")))
+            .thenReturn("%20%20");
+        configListenerHttpParamExtractor = new ConfigListenerHttpParamExtractor();
+        
+        List<ParamInfo> result = configListenerHttpParamExtractor.extractParam(httpServletRequest);
+        
+        assertTrue(result.isEmpty());
+    }
+    
+    @Test
+    void testExtractNamespaceFromFourWords() {
+        String listenerConfigsString = "dataId" + WORD_SEPARATOR + "group"
+            + WORD_SEPARATOR + "md5" + WORD_SEPARATOR + "namespace";
+        Mockito.when(httpServletRequest.getParameter(eq("Listening-Configs")))
+            .thenReturn(listenerConfigsString);
+        configListenerHttpParamExtractor = new ConfigListenerHttpParamExtractor();
+        
+        List<ParamInfo> result = configListenerHttpParamExtractor.extractParam(httpServletRequest);
+        
+        assertEquals(1, result.size());
+        assertEquals("dataId", result.get(0).getDataId());
+        assertEquals("group", result.get(0).getGroup());
+        assertEquals("namespace", result.get(0).getNamespaceId());
+    }
+    
+    @Test
     void testError() {
         String listenerConfigsString = getErrorListenerConfigsString();
         Mockito.when(httpServletRequest.getParameter(eq("Listening-Configs")))
             .thenReturn(listenerConfigsString);
         configListenerHttpParamExtractor = new ConfigListenerHttpParamExtractor();
-        try {
-            configListenerHttpParamExtractor.extractParam(httpServletRequest);
-            assertTrue(false);
-        } catch (Throwable throwable) {
-            throwable.printStackTrace();
-            assertTrue(throwable instanceof IllegalArgumentException);
-        }
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> configListenerHttpParamExtractor.extractParam(httpServletRequest));
     }
     
     private String getListenerConfigsString() {

--- a/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigChangeBatchListenRequestHandlerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigChangeBatchListenRequestHandlerTest.java
@@ -93,4 +93,16 @@ class ConfigChangeBatchListenRequestHandlerTest {
         }
     }
     
+    @Test
+    void testHandleRemoveListen() throws NacosException {
+        ConfigBatchListenRequest configChangeListenRequest = new ConfigBatchListenRequest();
+        configChangeListenRequest.setListen(false);
+        configChangeListenRequest.addConfigListenContext("group", "dataId", "tenant", "md5");
+        
+        ConfigChangeBatchListenResponse response =
+            configQueryRequestHandler.handle(configChangeListenRequest, requestMeta);
+        
+        assertTrue(response.getChangedConfigs().isEmpty());
+    }
+    
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigChangeClusterSyncRequestHandlerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigChangeClusterSyncRequestHandlerTest.java
@@ -121,12 +121,20 @@ class ConfigChangeClusterSyncRequestHandlerTest {
     
     @Test
     void testCheckNamespaceCompatibleDisabled() {
-        ConfigChangeClusterSyncRequest req = new ConfigChangeClusterSyncRequest();
-        req.setTenant("public");
-        RequestMeta meta = new RequestMeta();
-        meta.setClientVersion("Nacos-Server:v3.0.0");
-        assertFalse(
-            configChangeClusterSyncRequestHandler.checkNamespaceCompatible(req, meta));
+        MockedStatic<ConfigCompatibleConfig> mocked =
+            Mockito.mockStatic(ConfigCompatibleConfig.class);
+        ConfigCompatibleConfig config = Mockito.mock(ConfigCompatibleConfig.class);
+        Mockito.when(config.isNamespaceCompatibleMode()).thenReturn(false);
+        mocked.when(ConfigCompatibleConfig::getInstance).thenReturn(config);
+        try {
+            ConfigChangeClusterSyncRequest req = new ConfigChangeClusterSyncRequest();
+            req.setTenant("public");
+            RequestMeta meta = new RequestMeta();
+            meta.setClientVersion("Nacos-Server:v3.0.0");
+            assertFalse(configChangeClusterSyncRequestHandler.checkNamespaceCompatible(req, meta));
+        } finally {
+            mocked.close();
+        }
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigChangeListenContextTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigChangeListenContextTest.java
@@ -21,9 +21,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -72,6 +75,28 @@ class ConfigChangeListenContextTest {
         Map<String, String> connectionIdAfter =
             configChangeListenContext.getListenKeys("connectionId");
         assertNull(connectionIdAfter);
+    }
+    
+    @Test
+    void testClearContextForMissingConnectionId() {
+        configChangeListenContext.clearContextForConnectionId("missingConnectionId");
+        
+        assertEquals(0, configChangeListenContext.getConnectionCount());
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    void testClearContextRemovesMissingGroupKeyContext() {
+        ConcurrentHashMap<String, HashMap<String, ConfigListenState>> connectionIdContext =
+            (ConcurrentHashMap<String, HashMap<String, ConfigListenState>>) ReflectionTestUtils
+                .getField(configChangeListenContext, "connectionIdContext");
+        HashMap<String, ConfigListenState> listenStates = new HashMap<>(1);
+        listenStates.put("groupKey", new ConfigListenState("md5"));
+        connectionIdContext.put("connectionId", listenStates);
+        
+        configChangeListenContext.clearContextForConnectionId("connectionId");
+        
+        assertNull(configChangeListenContext.getListenKeys("connectionId"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigPublishRequestHandlerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigPublishRequestHandlerTest.java
@@ -142,7 +142,7 @@ class ConfigPublishRequestHandlerTest {
             configPublishRequestHandler.handle(configPublishRequest, requestMeta);
         
         assertEquals(ResponseCode.SUCCESS.getCode(), response.getResultCode());
-        Thread.sleep(500L);
+        waitForEvent(reference);
         assertTrue(reference.get() != null);
         assertEquals(dataId, reference.get().dataId);
         assertEquals(group, reference.get().group);
@@ -206,7 +206,7 @@ class ConfigPublishRequestHandlerTest {
             configPublishRequestHandler.handle(configPublishRequest, requestMeta);
         
         assertEquals(ResponseCode.SUCCESS.getCode(), response.getResultCode());
-        Thread.sleep(500L);
+        waitForEvent(reference);
         assertTrue(reference.get() != null);
         assertEquals(dataId, reference.get().dataId);
         assertEquals(group, reference.get().group);
@@ -282,6 +282,36 @@ class ConfigPublishRequestHandlerTest {
     }
     
     @Test
+    void testPublishConfigAlreadyExistsWithEncryptedDataKey() throws Exception {
+        String dataId = "testPublishConfigWithEncryptedDataKey";
+        String group = "group";
+        String tenant = "tenant";
+        
+        ConfigPublishRequest configPublishRequest = new ConfigPublishRequest();
+        configPublishRequest.setDataId(dataId);
+        configPublishRequest.setGroup(group);
+        configPublishRequest.setTenant(tenant);
+        configPublishRequest.setContent("content");
+        Map<String, String> keyMap = new HashMap<>();
+        String srcUser = "src_user111";
+        keyMap.put("src_user", srcUser);
+        keyMap.put("encryptedDataKey", "cipherKey");
+        configPublishRequest.setAdditionMap(keyMap);
+        
+        RequestMeta requestMeta = new RequestMeta();
+        requestMeta.setClientIp("127.0.0.1");
+        
+        when(configInfoPersistService.insertOrUpdate(eq(requestMeta.getClientIp()), eq(srcUser),
+            any(ConfigInfo.class), any(Map.class))).thenReturn(new ConfigOperateResult(false));
+        
+        ConfigPublishResponse response =
+            configPublishRequestHandler.handle(configPublishRequest, requestMeta);
+        
+        assertEquals(ResponseCode.FAIL.getCode(), response.getResultCode());
+        assertTrue(response.getMessage().contains("already exist"));
+    }
+    
+    @Test
     void testBetaPublishNotCas() throws NacosException, InterruptedException {
         String dataId = "testBetaPublish";
         String group = "group";
@@ -334,7 +364,7 @@ class ConfigPublishRequestHandlerTest {
             configPublishRequestHandler.handle(configPublishRequest, requestMeta);
         
         assertEquals(ResponseCode.SUCCESS.getCode(), response.getResultCode());
-        Thread.sleep(500L);
+        waitForEvent(reference);
         assertTrue(reference.get() != null);
         assertEquals(dataId, reference.get().dataId);
         assertEquals(group, reference.get().group);
@@ -399,7 +429,7 @@ class ConfigPublishRequestHandlerTest {
             configPublishRequestHandler.handle(configPublishRequest, requestMeta);
         
         assertEquals(ResponseCode.SUCCESS.getCode(), response.getResultCode());
-        Thread.sleep(500L);
+        waitForEvent(reference);
         assertTrue(reference.get() != null);
         assertEquals(dataId, reference.get().dataId);
         assertEquals(group, reference.get().group);
@@ -465,7 +495,7 @@ class ConfigPublishRequestHandlerTest {
             configPublishRequestHandler.handle(configPublishRequest, requestMeta);
         
         assertEquals(ResponseCode.SUCCESS.getCode(), response.getResultCode());
-        Thread.sleep(500L);
+        waitForEvent(reference);
         assertTrue(reference.get() != null);
         assertEquals(dataId, reference.get().dataId);
         assertEquals(group, reference.get().group);
@@ -525,13 +555,20 @@ class ConfigPublishRequestHandlerTest {
             configPublishRequestHandler.handle(configPublishRequest, requestMeta);
         
         assertEquals(ResponseCode.SUCCESS.getCode(), response.getResultCode());
-        Thread.sleep(500L);
+        waitForEvent(reference);
         assertTrue(reference.get() != null);
         assertEquals(dataId, reference.get().dataId);
         assertEquals(group, reference.get().group);
         assertEquals(tenant, reference.get().tenant);
         assertEquals(timestamp, reference.get().lastModifiedTs);
         assertEquals("tag_" + tag, reference.get().grayName);
+    }
+    
+    private void waitForEvent(AtomicReference<ConfigDataChangeEvent> reference)
+        throws InterruptedException {
+        for (int i = 0; i < 30 && reference.get() == null; i++) {
+            Thread.sleep(100L);
+        }
     }
     
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigQueryRequestHandlerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/remote/ConfigQueryRequestHandlerTest.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.config.remote.request.ConfigQueryRequest;
 import com.alibaba.nacos.api.config.remote.response.ConfigQueryResponse;
 import com.alibaba.nacos.api.remote.request.RequestMeta;
+import com.alibaba.nacos.api.remote.response.ResponseCode;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.model.CacheItem;
 import com.alibaba.nacos.config.server.model.ConfigCacheGray;
@@ -31,6 +32,8 @@ import com.alibaba.nacos.config.server.service.ConfigCacheService;
 import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskServiceFactory;
 import com.alibaba.nacos.config.server.service.dump.disk.ConfigRocksDbDiskService;
 import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.alibaba.nacos.config.server.service.trace.ConfigTraceService;
 import com.alibaba.nacos.config.server.utils.GroupKey2;
 import com.alibaba.nacos.config.server.utils.PropertyUtil;
 import com.alibaba.nacos.sys.env.EnvUtil;
@@ -42,6 +45,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.StandardEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 
@@ -51,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -388,6 +393,76 @@ class ConfigQueryRequestHandlerTest {
         assertFalse(responseConflict.isBeta());
         assertNull(responseConflict.getTag());
         
+    }
+    
+    @Test
+    void testHandleWhenChainResponseFailed() throws Exception {
+        ConfigQueryChainService chainService = Mockito.mock(ConfigQueryChainService.class);
+        ConfigQueryChainResponse chainResponse = new ConfigQueryChainResponse();
+        chainResponse.setResultCode(ResponseCode.FAIL.getCode());
+        chainResponse.setMessage("chain failed");
+        when(chainService.handle(any())).thenReturn(chainResponse);
+        ConfigQueryRequestHandler requestHandler = new ConfigQueryRequestHandler(chainService);
+        
+        ConfigQueryResponse response = requestHandler.handle(newConfigQueryRequest(),
+            newRequestMeta());
+        
+        assertEquals(ResponseCode.FAIL.getCode(), response.getResultCode());
+        assertEquals("chain failed", response.getMessage());
+    }
+    
+    @Test
+    void testHandleGrayResponseWithoutMatchedGray() throws Exception {
+        ConfigQueryChainService chainService = Mockito.mock(ConfigQueryChainService.class);
+        ConfigQueryChainResponse chainResponse = new ConfigQueryChainResponse();
+        chainResponse.setResultCode(ResponseCode.SUCCESS.getCode());
+        chainResponse.setContent("content");
+        chainResponse.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_GRAY);
+        when(chainService.handle(any())).thenReturn(chainResponse);
+        ConfigQueryRequestHandler requestHandler = new ConfigQueryRequestHandler(chainService);
+        
+        ConfigQueryResponse response = requestHandler.handle(newConfigQueryRequest(),
+            newRequestMeta());
+        
+        assertEquals(ResponseCode.FAIL.getCode(), response.getResultCode());
+    }
+    
+    @Test
+    void testResolvePullEventTypeWithGrayStatusButNoMatchedGray() {
+        ConfigQueryChainResponse chainResponse = new ConfigQueryChainResponse();
+        chainResponse.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_GRAY);
+        
+        String pullEvent = ReflectionTestUtils.invokeMethod(configQueryRequestHandler,
+            "resolvePullEventType", chainResponse, "tag");
+        
+        assertEquals(ConfigTraceService.PULL_EVENT, pullEvent);
+    }
+    
+    @Test
+    void testHandleWhenChainServiceThrowsException() throws Exception {
+        ConfigQueryChainService chainService = Mockito.mock(ConfigQueryChainService.class);
+        when(chainService.handle(any())).thenThrow(new RuntimeException("chain boom"));
+        ConfigQueryRequestHandler requestHandler = new ConfigQueryRequestHandler(chainService);
+        
+        ConfigQueryResponse response = requestHandler.handle(newConfigQueryRequest(),
+            newRequestMeta());
+        
+        assertEquals(ResponseCode.FAIL.getCode(), response.getResultCode());
+        assertEquals("chain boom", response.getMessage());
+    }
+    
+    private ConfigQueryRequest newConfigQueryRequest() {
+        ConfigQueryRequest request = new ConfigQueryRequest();
+        request.setDataId(dataId);
+        request.setGroup(group);
+        request.setTenant(tenant);
+        return request;
+    }
+    
+    private RequestMeta newRequestMeta() {
+        RequestMeta requestMeta = new RequestMeta();
+        requestMeta.setClientIp("127.0.0.1");
+        return requestMeta;
     }
     
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/remote/FuzzyWatchSyncNotifyTaskTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/remote/FuzzyWatchSyncNotifyTaskTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.config.server.remote;
 
 import com.alibaba.nacos.api.config.remote.request.ConfigFuzzyWatchSyncRequest;
 import com.alibaba.nacos.common.task.BatchTaskCounter;
+import com.alibaba.nacos.config.server.utils.ConfigExecutor;
 import com.alibaba.nacos.core.remote.Connection;
 import com.alibaba.nacos.core.remote.ConnectionManager;
 import com.alibaba.nacos.core.remote.RpcPushService;
@@ -110,6 +111,25 @@ class FuzzyWatchSyncNotifyTaskTest {
         when(tpsControlManager.check(any())).thenReturn(successResp);
         task.run();
         verify(rpcPushService).pushWithCallback(any(), any(), any(), any());
+    }
+    
+    @Test
+    void testRunSchedulesSelfWhenTpsCheckFails() {
+        ConfigFuzzyWatchSyncRequest request = new ConfigFuzzyWatchSyncRequest();
+        FuzzyWatchSyncNotifyTask task = new FuzzyWatchSyncNotifyTask(
+            connectionManager, rpcPushService, request, batchTaskCounter,
+            3, "conn1");
+        when(connectionManager.getConnection("conn1")).thenReturn(connection);
+        TpsCheckResponse failedResp = new TpsCheckResponse(false, 429, "limited");
+        when(tpsControlManager.check(any())).thenReturn(failedResp);
+        
+        try (MockedStatic<ConfigExecutor> mockedConfigExecutor =
+            Mockito.mockStatic(ConfigExecutor.class)) {
+            task.run();
+            
+            mockedConfigExecutor.verify(
+                () -> ConfigExecutor.scheduleClientConfigNotifier(any(), Mockito.anyLong(), any()));
+        }
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigCacheServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigCacheServiceTest.java
@@ -38,6 +38,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -480,6 +481,29 @@ class ConfigCacheServiceTest {
     }
     
     @Test
+    void testConstructor() {
+        assertNotNull(new ConfigCacheService());
+    }
+    
+    @Test
+    void testDumpWithSameMd5AndTimestampKeepsCache() throws Exception {
+        String dataId = "sameMd5D";
+        String group = "sameMd5G";
+        String tenant = "sameMd5T";
+        String content = "same-content";
+        String md5 = MD5Utils.md5Hex(content, "UTF-8");
+        long timestamp = System.currentTimeMillis();
+        
+        assertTrue(ConfigCacheService.dumpWithMd5(dataId, group, tenant, content, md5,
+            timestamp, "text", ""));
+        assertTrue(ConfigCacheService.dumpWithMd5(dataId, group, tenant, content, md5,
+            timestamp, "text", ""));
+        
+        Mockito.verify(configDiskService, times(1)).saveToDisk(dataId, group, tenant, content);
+        ConfigCacheService.remove(dataId, group, tenant);
+    }
+    
+    @Test
     void testTryReadLock() {
         assertEquals(0, ConfigCacheService.tryReadLock("noExistKey"));
     }
@@ -487,6 +511,16 @@ class ConfigCacheServiceTest {
     @Test
     void testReleaseReadLockNoItem() {
         ConfigCacheService.releaseReadLock("noExistKey");
+    }
+    
+    @Test
+    void testReleaseReadLockExistingItem() {
+        ConfigCacheService.dumpWithMd5("rlD", "rlG", "rlT", "c", "md5",
+            System.currentTimeMillis(), "text", "");
+        String gk = GroupKey2.getKey("rlD", "rlG", "rlT");
+        assertEquals(1, ConfigCacheService.tryReadLock(gk));
+        ConfigCacheService.releaseReadLock(gk);
+        ConfigCacheService.remove("rlD", "rlG", "rlT");
     }
     
     @Test
@@ -515,11 +549,42 @@ class ConfigCacheServiceTest {
         ConfigCacheService.dumpWithMd5("clD", "clG", "clT", "content", "md5val",
             System.currentTimeMillis(), "text", "");
         String gk = GroupKey2.getKey("clD", "clG", "clT");
-        Map<String, String> labels = new java.util.HashMap<>();
+        Map<String, String> labels = new HashMap<>();
         labels.put("clientIp", "1.1.1.1");
         String md5 = ConfigCacheService.getContentMd5(gk, null, null, labels);
         assertEquals("md5val", md5);
         ConfigCacheService.remove("clD", "clG", "clT");
+    }
+    
+    @Test
+    void testGetContentMd5FallsBackWhenGrayRuleDoesNotMatch() {
+        String dataId = "grayMissD";
+        String group = "grayMissG";
+        String tenant = "grayMissT";
+        String grayRule = "{\"type\":\"tag\",\"version\":\"1.0.0\",\"expr\":\"blue\","
+            + "\"priority\":1}";
+        ConfigCacheService.dumpWithMd5(dataId, group, tenant, "formal", "formalMd5",
+            System.currentTimeMillis(), "text", "");
+        ConfigCacheService.dumpGray(dataId, group, tenant, "tag_blue", grayRule,
+            "grayContent", System.currentTimeMillis(), "");
+        
+        String gk = GroupKey2.getKey(dataId, group, tenant);
+        assertEquals("formalMd5", ConfigCacheService.getContentMd5(gk, null, "red", null));
+        ConfigCacheService.remove(dataId, group, tenant);
+    }
+    
+    @Test
+    void testGetContentMd5ReturnsNullConstantWhenMd5IsNull() {
+        String dataId = "nullMd5D";
+        String group = "nullMd5G";
+        String tenant = "nullMd5T";
+        ConfigCacheService.dumpWithMd5(dataId, group, tenant, "content", "md5",
+            System.currentTimeMillis(), "text", "");
+        String gk = GroupKey2.getKey(dataId, group, tenant);
+        ConfigCacheService.getContentCache(gk).getConfigCache().setMd5(null);
+        
+        assertEquals(NULL, ConfigCacheService.getContentMd5(gk));
+        ConfigCacheService.remove(dataId, group, tenant);
     }
     
     @Test
@@ -547,20 +612,13 @@ class ConfigCacheServiceTest {
         String dataId = "lockFailD";
         String group = "lockFailG";
         String tenant = "lockFailT";
-        String groupKey = GroupKey2.getKey(dataId, group, tenant);
-        CacheItem cacheItem = Mockito.mock(CacheItem.class);
         SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
-        Mockito.when(cacheItem.getRwLock()).thenReturn(lock);
         Mockito.when(lock.tryWriteLock()).thenReturn(false);
-        Field cacheField = ConfigCacheService.class.getDeclaredField("CACHE");
-        cacheField.setAccessible(true);
-        ConcurrentHashMap<String, CacheItem> cache =
-            (ConcurrentHashMap<String, CacheItem>) cacheField.get(null);
-        cache.put(groupKey, cacheItem);
+        String groupKey = putMockCacheItem(dataId, group, tenant, lock);
         boolean result = ConfigCacheService.dump(dataId, group, tenant,
             "content", System.currentTimeMillis(), "text", "key");
         assertFalse(result);
-        cache.remove(groupKey);
+        cache().remove(groupKey);
     }
     
     @Test
@@ -568,20 +626,13 @@ class ConfigCacheServiceTest {
         String dataId = "grayLockD";
         String group = "grayLockG";
         String tenant = "grayLockT";
-        String groupKey = GroupKey2.getKey(dataId, group, tenant);
-        CacheItem cacheItem = Mockito.mock(CacheItem.class);
         SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
-        Mockito.when(cacheItem.getRwLock()).thenReturn(lock);
         Mockito.when(lock.tryWriteLock()).thenReturn(false);
-        Field cacheField = ConfigCacheService.class.getDeclaredField("CACHE");
-        cacheField.setAccessible(true);
-        ConcurrentHashMap<String, CacheItem> cache =
-            (ConcurrentHashMap<String, CacheItem>) cacheField.get(null);
-        cache.put(groupKey, cacheItem);
+        String groupKey = putMockCacheItem(dataId, group, tenant, lock);
         boolean result = ConfigCacheService.dumpGray(dataId, group, tenant,
             "gray1", "{}", "content", System.currentTimeMillis(), "key");
         assertFalse(result);
-        cache.remove(groupKey);
+        cache().remove(groupKey);
     }
     
     @Test
@@ -589,19 +640,12 @@ class ConfigCacheServiceTest {
         String dataId = "rmLockD";
         String group = "rmLockG";
         String tenant = "rmLockT";
-        String groupKey = GroupKey2.getKey(dataId, group, tenant);
-        CacheItem cacheItem = Mockito.mock(CacheItem.class);
         SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
-        Mockito.when(cacheItem.getRwLock()).thenReturn(lock);
         Mockito.when(lock.tryWriteLock()).thenReturn(false);
-        Field cacheField = ConfigCacheService.class.getDeclaredField("CACHE");
-        cacheField.setAccessible(true);
-        ConcurrentHashMap<String, CacheItem> cache =
-            (ConcurrentHashMap<String, CacheItem>) cacheField.get(null);
-        cache.put(groupKey, cacheItem);
+        String groupKey = putMockCacheItem(dataId, group, tenant, lock);
         boolean result = ConfigCacheService.remove(dataId, group, tenant);
         assertFalse(result);
-        cache.remove(groupKey);
+        cache().remove(groupKey);
     }
     
     @Test
@@ -609,19 +653,12 @@ class ConfigCacheServiceTest {
         String dataId = "rmGrayLockD";
         String group = "rmGrayLockG";
         String tenant = "rmGrayLockT";
-        String groupKey = GroupKey2.getKey(dataId, group, tenant);
-        CacheItem cacheItem = Mockito.mock(CacheItem.class);
         SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
-        Mockito.when(cacheItem.getRwLock()).thenReturn(lock);
         Mockito.when(lock.tryWriteLock()).thenReturn(false);
-        Field cacheField = ConfigCacheService.class.getDeclaredField("CACHE");
-        cacheField.setAccessible(true);
-        ConcurrentHashMap<String, CacheItem> cache =
-            (ConcurrentHashMap<String, CacheItem>) cacheField.get(null);
-        cache.put(groupKey, cacheItem);
+        String groupKey = putMockCacheItem(dataId, group, tenant, lock);
         boolean result = ConfigCacheService.removeGray(dataId, group, tenant, "gray1");
         assertFalse(result);
-        cache.remove(groupKey);
+        cache().remove(groupKey);
     }
     
     @Test
@@ -633,10 +670,7 @@ class ConfigCacheServiceTest {
         SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
         Mockito.when(cacheItem.getRwLock()).thenReturn(lock);
         String groupKey = GroupKey2.getKey(dataId, group, tenant);
-        Field cache1 = ConfigCacheService.class.getDeclaredField("CACHE");
-        cache1.setAccessible(true);
-        ConcurrentHashMap<String, CacheItem> cache =
-            (ConcurrentHashMap<String, CacheItem>) cache1.get(null);
+        ConcurrentHashMap<String, CacheItem> cache = cache();
         cache.put(groupKey, cacheItem);
         
         // lock ==0,not exist
@@ -667,6 +701,21 @@ class ConfigCacheServiceTest {
     }
     
     @Test
+    void testTryConfigReadLockWhenSleepInterrupted() throws Exception {
+        String dataId = "interruptReadLockD";
+        String group = "interruptReadLockG";
+        String tenant = "interruptReadLockT";
+        SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
+        Mockito.when(lock.tryReadLock()).thenReturn(false);
+        String groupKey = putMockCacheItem(dataId, group, tenant, lock);
+        
+        Thread.currentThread().interrupt();
+        assertEquals(-1, ConfigCacheService.tryConfigReadLock(groupKey));
+        assertFalse(Thread.currentThread().isInterrupted());
+        cache().remove(groupKey);
+    }
+    
+    @Test
     void testGetContentMd5MatchesGrayRule() {
         String dataId = "grayMatchD";
         String group = "grayMatchG";
@@ -685,5 +734,43 @@ class ConfigCacheServiceTest {
         String md5 = ConfigCacheService.getContentMd5(gk, null, "myTag", null);
         assertEquals(grayMd5, md5);
         ConfigCacheService.remove(dataId, group, tenant);
+    }
+    
+    @Test
+    void testRemoveGraySortsRemainingGrayRules() {
+        String dataId = "graySortD";
+        String group = "graySortG";
+        String tenant = "graySortT";
+        String highPriorityRule = "{\"type\":\"tag\",\"version\":\"1.0.0\",\"expr\":\"high\","
+            + "\"priority\":2}";
+        String lowPriorityRule = "{\"type\":\"tag\",\"version\":\"1.0.0\",\"expr\":\"low\","
+            + "\"priority\":1}";
+        ConfigCacheService.dumpWithMd5(dataId, group, tenant, "formal", "formalMd5",
+            System.currentTimeMillis(), "text", "");
+        ConfigCacheService.dumpGray(dataId, group, tenant, "tag_high", highPriorityRule,
+            "highContent", System.currentTimeMillis(), "");
+        ConfigCacheService.dumpGray(dataId, group, tenant, "tag_low", lowPriorityRule,
+            "lowContent", System.currentTimeMillis(), "");
+        
+        assertTrue(ConfigCacheService.removeGray(dataId, group, tenant, "tag_high"));
+        String groupKey = GroupKey2.getKey(dataId, group, tenant);
+        assertEquals("tag_low",
+            ConfigCacheService.getContentCache(groupKey).getSortConfigGrays().get(0).getGrayName());
+        ConfigCacheService.remove(dataId, group, tenant);
+    }
+    
+    private String putMockCacheItem(String dataId, String group, String tenant,
+        SimpleReadWriteLock lock) throws Exception {
+        String groupKey = GroupKey2.getKey(dataId, group, tenant);
+        CacheItem cacheItem = Mockito.mock(CacheItem.class);
+        Mockito.when(cacheItem.getRwLock()).thenReturn(lock);
+        cache().put(groupKey, cacheItem);
+        return groupKey;
+    }
+    
+    private ConcurrentHashMap<String, CacheItem> cache() throws Exception {
+        Field cacheField = ConfigCacheService.class.getDeclaredField("CACHE");
+        cacheField.setAccessible(true);
+        return (ConcurrentHashMap<String, CacheItem>) cacheField.get(null);
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigDetailServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigDetailServiceTest.java
@@ -30,9 +30,11 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -110,6 +112,64 @@ class ConfigDetailServiceTest {
     }
     
     @Test
+    void testFindConfigInfoPageWhenQueueFullThrowsException() {
+        BlockingQueue<ConfigDetailService.SearchEvent> queue = mockSearchEventQueue();
+        when(queue.offer(any())).thenReturn(false);
+        ReflectionTestUtils.setField(configDetailService, "eventLinkedBlockingQueue", queue);
+        
+        assertThrows(NacosRuntimeException.class,
+            () -> configDetailService.findConfigInfoPage(Constants.CONFIG_SEARCH_BLUR, 1, 10,
+                "d", "g", "ns", new HashMap<>()));
+    }
+    
+    @Test
+    void testFindConfigInfoPageWhenInterruptedThrowsException() {
+        BlockingQueue<ConfigDetailService.SearchEvent> queue = mockSearchEventQueue();
+        when(queue.offer(any())).thenReturn(true);
+        ReflectionTestUtils.setField(configDetailService, "eventLinkedBlockingQueue", queue);
+        
+        Thread.currentThread().interrupt();
+        try {
+            assertThrows(NacosRuntimeException.class,
+                () -> configDetailService.findConfigInfoPage(Constants.CONFIG_SEARCH_BLUR, 1, 10,
+                    "d", "g", "ns", new HashMap<>()));
+        } finally {
+            Thread.interrupted();
+        }
+    }
+    
+    @Test
+    void testFindConfigInfoPageWhenNoResponseThrowsException() {
+        BlockingQueue<ConfigDetailService.SearchEvent> queue = mockSearchEventQueue();
+        when(queue.offer(any())).thenReturn(true);
+        ReflectionTestUtils.setField(configDetailService, "eventLinkedBlockingQueue", queue);
+        ConfigDetailService.setWaitTimeout(1L);
+        
+        try {
+            assertThrows(NacosRuntimeException.class,
+                () -> configDetailService.findConfigInfoPage(Constants.CONFIG_SEARCH_BLUR, 1, 10,
+                    "d", "g", "ns", new HashMap<>()));
+        } finally {
+            ConfigDetailService.setWaitTimeout(8000L);
+        }
+    }
+    
+    @Test
+    void testFindConfigInfoPageWhenSearchWorkerCatchesException() throws Exception {
+        when(configInfoPersistService.findConfigInfoLike4Page(anyInt(), anyInt(), anyString(),
+            anyString(), anyString(), any())).thenThrow(new RuntimeException("search failed"));
+        ConfigDetailService.setWaitTimeout(50L);
+        
+        try {
+            assertThrows(NacosRuntimeException.class,
+                () -> configDetailService.findConfigInfoPage(Constants.CONFIG_SEARCH_BLUR, 1, 10,
+                    "d", "g", "ns", new HashMap<>()));
+        } finally {
+            ConfigDetailService.setWaitTimeout(8000L);
+        }
+    }
+    
+    @Test
     void testGettersAndSetters() {
         ConfigDetailService.setMaxCapacity(8);
         assertEquals(8, ConfigDetailService.getMaxCapacity());
@@ -146,5 +206,10 @@ class ConfigDetailServiceTest {
         Page<ConfigInfo> page = new Page<>();
         event.setResponse(page);
         assertEquals(page, event.getResponse());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private BlockingQueue<ConfigDetailService.SearchEvent> mockSearchEventQueue() {
+        return Mockito.mock(BlockingQueue.class);
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigFuzzyWatchContextServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigFuzzyWatchContextServiceTest.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.FuzzyGroupKeyPattern;
 import com.alibaba.nacos.config.server.configuration.ConfigCommonConfig;
 import com.alibaba.nacos.config.server.utils.GroupKey;
+import com.alibaba.nacos.core.utils.GlobalExecutor;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -30,12 +31,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.HashMap;
 import java.util.Set;
 
 import static com.alibaba.nacos.api.common.Constants.ConfigChangedType.ADD_CONFIG;
 import static com.alibaba.nacos.api.common.Constants.ConfigChangedType.DELETE_CONFIG;
 import static com.alibaba.nacos.api.model.v2.ErrorCode.FUZZY_WATCH_PATTERN_OVER_LIMIT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -60,6 +66,8 @@ public class ConfigFuzzyWatchContextServiceTest {
         envUtilMockedStatic
             .when(() -> EnvUtil.getProperty(eq("nacos.config.cache.type"), anyString()))
             .thenReturn("nacos");
+        envUtilMockedStatic.when(() -> EnvUtil.getAvailableProcessors(anyInt()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
         
         configCommonConfigMockedStatic = Mockito.mockStatic(ConfigCommonConfig.class);
         
@@ -121,6 +129,25 @@ public class ConfigFuzzyWatchContextServiceTest {
         Set<String> matchedGroupKeys3 =
             configFuzzyWatchContextService.matchGroupKeys(groupKeyPattern);
         Assertions.assertTrue(matchedGroupKeys3.isEmpty());
+    }
+    
+    @Test
+    public void testInitRunsScheduledTrimTask() {
+        try (MockedStatic<GlobalExecutor> globalExecutorMockedStatic =
+            Mockito.mockStatic(GlobalExecutor.class)) {
+            globalExecutorMockedStatic.when(
+                () -> GlobalExecutor.scheduleWithFixDelayByCommon(any(Runnable.class),
+                    anyLong()))
+                .thenAnswer(invocation -> {
+                    invocation.<Runnable>getArgument(0).run();
+                    return null;
+                });
+            
+            new ConfigFuzzyWatchContextService().init();
+            
+            globalExecutorMockedStatic.verify(
+                () -> GlobalExecutor.scheduleWithFixDelayByCommon(any(Runnable.class), eq(30000L)));
+        }
     }
     
     @Test
@@ -350,6 +377,60 @@ public class ConfigFuzzyWatchContextServiceTest {
         configFuzzyWatchContextService.trimFuzzyWatchContext();
         Assertions.assertTrue(
             configFuzzyWatchContextService.reachToUpLimit(groupKeyPattern));
+    }
+    
+    @Test
+    public void testTrimFuzzyWatchContextWithWarningUsage() throws NacosException {
+        ConfigFuzzyWatchContextService configFuzzyWatchContextService =
+            new ConfigFuzzyWatchContextService();
+        String groupKeyPattern =
+            FuzzyGroupKeyPattern.generatePattern("warn*", "group", "12345");
+        configFuzzyWatchContextService.addFuzzyWatch(groupKeyPattern, "conn1");
+        for (int i = 0; i < 8; i++) {
+            String keyTenant = GroupKey.getKeyTenant("warn" + i, "group", "12345");
+            configFuzzyWatchContextService.syncGroupKeyContext(keyTenant, ADD_CONFIG);
+        }
+        
+        configFuzzyWatchContextService.trimFuzzyWatchContext();
+        
+        Assertions.assertFalse(configFuzzyWatchContextService.reachToUpLimit(groupKeyPattern));
+    }
+    
+    @Test
+    public void testTrimFuzzyWatchContextIgnoresUnexpectedContextFailure() {
+        ConfigFuzzyWatchContextService configFuzzyWatchContextService =
+            new ConfigFuzzyWatchContextService();
+        HashMap<String, Set<String>> brokenContext = new HashMap<String, Set<String>>() {
+            
+            @Override
+            public Set<java.util.Map.Entry<String, Set<String>>> entrySet() {
+                throw new RuntimeException("broken");
+            }
+        };
+        ReflectionTestUtils.setField(configFuzzyWatchContextService, "matchedGroupKeysMap",
+            brokenContext);
+        
+        configFuzzyWatchContextService.trimFuzzyWatchContext();
+    }
+    
+    @Test
+    public void testMakeupMatchedGroupKeysCompletesBelowLimit() throws NacosException {
+        ConfigFuzzyWatchContextService configFuzzyWatchContextService =
+            new ConfigFuzzyWatchContextService();
+        String groupKeyPattern =
+            FuzzyGroupKeyPattern.generatePattern("makeupEnd*", "group", "12345");
+        String firstGroupKey = GroupKey.getKeyTenant("makeupEnd1", "group", "12345");
+        String secondGroupKey = GroupKey.getKeyTenant("makeupEnd2", "group", "12345");
+        configFuzzyWatchContextService.addFuzzyWatch(groupKeyPattern, "conn1");
+        configFuzzyWatchContextService.syncGroupKeyContext(firstGroupKey, ADD_CONFIG);
+        ConfigCacheService.dump("makeupEnd2", "group", "12345", "content",
+            System.currentTimeMillis(), null, null);
+        
+        configFuzzyWatchContextService.makeupMatchedGroupKeys(groupKeyPattern);
+        
+        Assertions.assertTrue(
+            configFuzzyWatchContextService.matchGroupKeys(groupKeyPattern)
+                .contains(secondGroupKey));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigSubServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigSubServiceTest.java
@@ -43,9 +43,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -209,6 +211,43 @@ class ConfigSubServiceTest {
         assertEquals(1, sampleResults2.size());
         assertFalse(sampleResults2.get(0).getLisentersGroupkeyStatus().isEmpty());
         
+    }
+    
+    @Test
+    void testClusterListenerJobWhenSubmitThrowsException() {
+        Map<String, Member> mockedMembers = new HashMap<>();
+        mockedMembers.put("127.0.0.1", createMember("127.0.0.1"));
+        Mockito.when(serverMemberManager.allMembers()).thenReturn(mockedMembers.values());
+        CompletionService mockService = Mockito.mock(CompletionService.class);
+        Mockito.when(mockService.submit(any(Callable.class)))
+            .thenThrow(new RuntimeException("full"));
+        
+        ConfigSubService.ClusterListenerJob clusterListenerJob =
+            new ConfigSubService.ClusterListenerJob(new HashMap<>(), mockService,
+                serverMemberManager);
+        List<SampleResult> sampleResults = clusterListenerJob.runJobs();
+        
+        assertTrue(sampleResults.isEmpty());
+    }
+    
+    @Test
+    void testClusterListenerJobWhenFutureTimeout() throws Exception {
+        Map<String, Member> mockedMembers = new HashMap<>();
+        mockedMembers.put("127.0.0.1", createMember("127.0.0.1"));
+        Mockito.when(serverMemberManager.allMembers()).thenReturn(mockedMembers.values());
+        CompletionService mockService = Mockito.mock(CompletionService.class);
+        Future future = Mockito.mock(Future.class);
+        Mockito.when(mockService.poll(anyLong(), any(TimeUnit.class))).thenReturn(future);
+        Mockito.when(future.get(anyLong(), any(TimeUnit.class)))
+            .thenThrow(new TimeoutException("timeout"));
+        
+        ConfigSubService.ClusterListenerJob clusterListenerJob =
+            new ConfigSubService.ClusterListenerJob(new HashMap<>(), mockService,
+                serverMemberManager);
+        List<SampleResult> sampleResults = clusterListenerJob.runJobs();
+        
+        assertTrue(sampleResults.isEmpty());
+        Mockito.verify(future, Mockito.times(1)).cancel(true);
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/LongPollingServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/LongPollingServiceTest.java
@@ -49,11 +49,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -241,6 +244,30 @@ class LongPollingServiceTest {
     }
     
     @Test
+    void testAddLongPollingClientWithNoHangUp() throws IOException {
+        Map<String, ConfigListenState> clientMd5Map = new HashMap<>();
+        HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(httpServletRequest.getHeader(
+            eq(LongPollingService.LONG_POLLING_NO_HANG_UP_HEADER)))
+            .thenReturn("true");
+        Mockito.when(httpServletRequest.getHeader(eq("X-Forwarded-For")))
+            .thenReturn("192.168.0.1");
+        HttpServletResponse httpServletResponse = Mockito.mock(HttpServletResponse.class);
+        
+        try (MockedStatic<MD5Util> md5UtilMockedStatic = Mockito.mockStatic(MD5Util.class)) {
+            md5UtilMockedStatic.when(() -> MD5Util.compareMd5(httpServletRequest,
+                httpServletResponse, clientMd5Map))
+                .thenReturn(Collections.emptyMap());
+            
+            longPollingService.addLongPollingClient(httpServletRequest, httpServletResponse,
+                clientMd5Map, 1);
+        }
+        
+        Mockito.verify(httpServletRequest, times(0)).startAsync();
+        Mockito.verify(httpServletResponse, times(0)).setStatus(anyInt());
+    }
+    
+    @Test
     void testReceiveDataChangeEventAndNotify() throws Exception {
         configExecutorMocked.close();
         
@@ -386,6 +413,28 @@ class LongPollingServiceTest {
     }
     
     @Test
+    void testCollectSubscribleInfoWhenInterrupted() {
+        Thread.currentThread().interrupt();
+        try {
+            SampleResult result = longPollingService.getCollectSubscribleInfo("d", "g", "t");
+            assertEquals(0, result.getLisentersGroupkeyStatus().size());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+    
+    @Test
+    void testCollectSubscribleInfoByIpWhenInterrupted() {
+        Thread.currentThread().interrupt();
+        try {
+            SampleResult result = longPollingService.getCollectSubscribleInfoByIp("10.0.0.1");
+            assertEquals(0, result.getLisentersGroupkeyStatus().size());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+    
+    @Test
     void testGetRetainIpsAndSubscriberCount() {
         assertFalse(longPollingService.getRetainIps() == null);
         assertEquals(0, longPollingService.getSubscriberCount());
@@ -405,5 +454,123 @@ class LongPollingServiceTest {
         Mockito.when(request.getHeader(eq(LongPollingService.LONG_POLLING_HEADER)))
             .thenReturn(null);
         assertFalse(LongPollingService.isSupportLongPolling(request));
+    }
+    
+    @Test
+    void testDataChangeTaskCatchesException() {
+        String groupKey = GroupKey.getKeyTenant("data", "group", "tenant");
+        AsyncContext asyncContext = Mockito.mock(AsyncContext.class);
+        Mockito.when(asyncContext.getRequest()).thenThrow(new RuntimeException("mock-error"));
+        LongPollingService.ClientLongPolling clientLongPolling = newClientLongPolling(asyncContext,
+            Collections.singletonMap(groupKey, new ConfigListenState("md5")));
+        longPollingService.allSubs.add(clientLongPolling);
+        
+        longPollingService.new DataChangeTask(groupKey).run();
+        
+        assertEquals(0, longPollingService.getSubscriberCount());
+    }
+    
+    @Test
+    void testClientLongPollingTimeoutWhenRemoveFailed() {
+        Runnable[] timeoutRunnable = new Runnable[1];
+        ScheduledFuture<?> future = Mockito.mock(ScheduledFuture.class);
+        configExecutorMocked.when(() -> ConfigExecutor.scheduleLongPolling(any(Runnable.class),
+            anyLong(), any(TimeUnit.class)))
+            .thenAnswer(invocation -> {
+                timeoutRunnable[0] = invocation.getArgument(0);
+                return future;
+            });
+        LongPollingService.ClientLongPolling clientLongPolling = newClientLongPolling(
+            Mockito.mock(AsyncContext.class), Collections.emptyMap());
+        
+        clientLongPolling.run();
+        longPollingService.allSubs.remove(clientLongPolling);
+        timeoutRunnable[0].run();
+        
+        assertEquals(0, longPollingService.getSubscriberCount());
+    }
+    
+    @Test
+    void testClientLongPollingTimeoutCatchesException() {
+        Runnable[] timeoutRunnable = new Runnable[1];
+        ScheduledFuture<?> future = Mockito.mock(ScheduledFuture.class);
+        configExecutorMocked.when(() -> ConfigExecutor.scheduleLongPolling(any(Runnable.class),
+            anyLong(), any(TimeUnit.class)))
+            .thenAnswer(invocation -> {
+                timeoutRunnable[0] = invocation.getArgument(0);
+                return future;
+            });
+        AsyncContext asyncContext = Mockito.mock(AsyncContext.class);
+        Mockito.when(asyncContext.getRequest()).thenThrow(new RuntimeException("mock-error"));
+        LongPollingService.ClientLongPolling clientLongPolling = newClientLongPolling(asyncContext,
+            Collections.emptyMap());
+        
+        clientLongPolling.run();
+        timeoutRunnable[0].run();
+        
+        assertEquals(0, longPollingService.getSubscriberCount());
+    }
+    
+    @Test
+    void testClientLongPollingGenerateResponseWhenWriterThrows() throws Exception {
+        AsyncContext asyncContext = Mockito.mock(AsyncContext.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        Mockito.when(asyncContext.getResponse()).thenReturn(response);
+        Mockito.when(response.getWriter()).thenThrow(new IOException("mock-error"));
+        LongPollingService.ClientLongPolling clientLongPolling = newClientLongPolling(asyncContext,
+            Collections.emptyMap());
+        
+        clientLongPolling.generateResponse(
+            Collections.singletonMap("data+group+tenant", new ConfigListenState("md5")));
+        
+        Mockito.verify(asyncContext, times(1)).complete();
+    }
+    
+    @Test
+    void testClientLongPollingToString() {
+        LongPollingService.ClientLongPolling clientLongPolling = newClientLongPolling(
+            Mockito.mock(AsyncContext.class), Collections.emptyMap());
+        
+        String actual = clientLongPolling.toString();
+        
+        assertFalse(actual.isEmpty());
+    }
+    
+    @Test
+    void testGenerateResponseWithNullChangedGroups() throws Exception {
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        
+        longPollingService.generateResponse(Mockito.mock(HttpServletRequest.class), response, null);
+        
+        Mockito.verify(response, times(0)).getWriter();
+    }
+    
+    @Test
+    void testGenerateResponseWhenWriterThrows() throws Exception {
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        Mockito.when(response.getWriter()).thenThrow(new IOException("mock-error"));
+        
+        longPollingService.generateResponse(Mockito.mock(HttpServletRequest.class), response,
+            Collections.singletonMap("data+group+tenant", new ConfigListenState("md5")));
+        
+        Mockito.verify(response, times(1)).setStatus(HttpServletResponse.SC_OK);
+    }
+    
+    @Test
+    void testGenerate503ResponseWhenWriterThrows() throws Exception {
+        AsyncContext asyncContext = Mockito.mock(AsyncContext.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        Mockito.when(response.getWriter()).thenThrow(new IOException("mock-error"));
+        
+        longPollingService.generate503Response(asyncContext, response, "over limit");
+        
+        Mockito.verify(response, times(1)).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        Mockito.verify(asyncContext, times(0)).complete();
+    }
+    
+    private LongPollingService.ClientLongPolling newClientLongPolling(AsyncContext asyncContext,
+        Map<String, ConfigListenState> clientMd5Map) {
+        return longPollingService.new ClientLongPolling(asyncContext, clientMd5Map, "127.0.0.1",
+            1, 1L, "app", "tag");
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/SwitchServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/SwitchServiceTest.java
@@ -20,14 +20,21 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.alibaba.nacos.common.utils.IoUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringReader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 
 class SwitchServiceTest {
     
@@ -151,6 +158,22 @@ class SwitchServiceTest {
         SwitchService.load("notAnInt=abc");
         
         assertEquals(123, SwitchService.getSwitchInteger("notAnInt", 123));
+    }
+    
+    @Test
+    void testLoadLogsIoExceptionWhenReadLinesFails() {
+        try (MockedStatic<IoUtils> ioUtilsMockedStatic = Mockito.mockStatic(IoUtils.class)) {
+            ioUtilsMockedStatic.when(() -> IoUtils.readLines(any(StringReader.class)))
+                .thenThrow(new IOException("mock error"));
+            
+            SwitchService.load("key=value");
+        }
+        
+        long errorLogs = fatalLogAppender.list.stream()
+            .filter(event -> event.getLevel() == Level.WARN)
+            .filter(event -> event.getFormattedMessage().contains("[reload-switches] error"))
+            .count();
+        assertEquals(1, errorLogs);
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/capacity/CapacityServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/capacity/CapacityServiceTest.java
@@ -21,11 +21,13 @@ import com.alibaba.nacos.config.server.model.capacity.Capacity;
 import com.alibaba.nacos.config.server.model.capacity.GroupCapacity;
 import com.alibaba.nacos.config.server.model.capacity.NamespaceCapacity;
 import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
+import com.alibaba.nacos.config.server.utils.ConfigExecutor;
 import com.alibaba.nacos.config.server.utils.PropertyUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.mock.web.MockServletContext;
@@ -35,10 +37,13 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -76,6 +81,31 @@ class CapacityServiceTest {
     }
     
     @Test
+    void testInitRunsScheduledCorrectUsageTask() {
+        when(groupCapacityPersistService.getCapacityList4CorrectUsage(0L, 100))
+            .thenReturn(new ArrayList<>());
+        when(tenantCapacityPersistService.getCapacityList4CorrectUsage(0L, 100))
+            .thenReturn(new ArrayList<>());
+        try (MockedStatic<ConfigExecutor> configExecutorMockedStatic =
+            Mockito.mockStatic(ConfigExecutor.class)) {
+            configExecutorMockedStatic.when(
+                () -> ConfigExecutor.scheduleCorrectUsageTask(any(Runnable.class), anyLong(),
+                    anyLong(), eq(TimeUnit.SECONDS)))
+                .thenAnswer(invocation -> {
+                    invocation.<Runnable>getArgument(0).run();
+                    return null;
+                });
+            
+            service.init();
+            
+            Mockito.verify(groupCapacityPersistService, times(1))
+                .getCapacityList4CorrectUsage(0L, 100);
+            Mockito.verify(tenantCapacityPersistService, times(1))
+                .getCapacityList4CorrectUsage(0L, 100);
+        }
+    }
+    
+    @Test
     void testCorrectUsage() {
         List<GroupCapacity> groupCapacityList = new ArrayList<>();
         GroupCapacity groupCapacity = new GroupCapacity();
@@ -109,6 +139,40 @@ class CapacityServiceTest {
             100);
         Mockito.verify(tenantCapacityPersistService, times(1)).getCapacityList4CorrectUsage(1L,
             100);
+        Mockito.verify(tenantCapacityPersistService, times(1)).correctUsage(eq("testTenant"),
+            any());
+    }
+    
+    @Test
+    void testCorrectUsageWhenInterrupted() {
+        List<GroupCapacity> groupCapacityList = new ArrayList<>();
+        GroupCapacity groupCapacity = new GroupCapacity();
+        groupCapacity.setId(1L);
+        groupCapacity.setGroupName("testGroup");
+        groupCapacityList.add(groupCapacity);
+        when(groupCapacityPersistService.getCapacityList4CorrectUsage(0L, 100))
+            .thenReturn(groupCapacityList);
+        when(groupCapacityPersistService.getCapacityList4CorrectUsage(1L, 100))
+            .thenReturn(new ArrayList<>());
+        
+        List<NamespaceCapacity> tenantCapacityList = new ArrayList<>();
+        NamespaceCapacity tenantCapacity = new NamespaceCapacity();
+        tenantCapacity.setId(1L);
+        tenantCapacity.setNamespaceId("testTenant");
+        tenantCapacityList.add(tenantCapacity);
+        when(tenantCapacityPersistService.getCapacityList4CorrectUsage(0L, 100))
+            .thenReturn(tenantCapacityList);
+        when(tenantCapacityPersistService.getCapacityList4CorrectUsage(1L, 100))
+            .thenReturn(new ArrayList<>());
+        
+        Thread.currentThread().interrupt();
+        try {
+            service.correctUsage();
+        } finally {
+            Thread.interrupted();
+        }
+        
+        Mockito.verify(groupCapacityPersistService, times(1)).correctUsage(eq("testGroup"), any());
         Mockito.verify(tenantCapacityPersistService, times(1)).correctUsage(eq("testTenant"),
             any());
     }
@@ -163,6 +227,24 @@ class CapacityServiceTest {
         Mockito.verify(tenantCapacityPersistService, times(1)).getTenantCapacity(eq("testTenant"));
         Mockito.verify(tenantCapacityPersistService, times(1)).updateQuota(eq("testTenant"),
             eq(500));
+    }
+    
+    @Test
+    void testInitAllCapacityReadsNextGroupPageWhenPageIsFull() {
+        List<String> fullGroupPage = new ArrayList<>(Collections.nCopies(500, "testGroup"));
+        when(configInfoPersistService.getGroupIdList(eq(1), eq(500))).thenReturn(fullGroupPage);
+        when(configInfoPersistService.getGroupIdList(eq(2), eq(500)))
+            .thenReturn(new ArrayList<>());
+        when(configInfoPersistService.getTenantIdList(eq(1), eq(500)))
+            .thenReturn(new ArrayList<>());
+        when(groupCapacityPersistService.insertGroupCapacity(any())).thenReturn(true);
+        GroupCapacity groupCapacity = new GroupCapacity();
+        groupCapacity.setUsage(0);
+        when(groupCapacityPersistService.getGroupCapacity(anyString())).thenReturn(groupCapacity);
+        
+        service.initAllCapacity();
+        
+        Mockito.verify(configInfoPersistService, times(1)).getGroupIdList(eq(2), eq(500));
     }
     
     @Test
@@ -232,6 +314,18 @@ class CapacityServiceTest {
         
         service.updateGroupUsage(CounterMode.DECREMENT, "testGroup");
         Mockito.verify(groupCapacityPersistService, times(1)).decrementUsage(any());
+    }
+    
+    @Test
+    void testUpdateGroupUsageIncrementWithQuotaLimit() {
+        when(groupCapacityPersistService.incrementUsageWithDefaultQuotaLimit(any()))
+            .thenReturn(false);
+        when(groupCapacityPersistService.incrementUsageWithQuotaLimit(any()))
+            .thenReturn(true);
+        
+        service.updateGroupUsage(CounterMode.INCREMENT, "testGroup");
+        
+        Mockito.verify(groupCapacityPersistService, times(1)).incrementUsageWithQuotaLimit(any());
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/capacity/GroupCapacityPersistServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/capacity/GroupCapacityPersistServiceTest.java
@@ -21,10 +21,13 @@ import com.alibaba.nacos.config.server.model.capacity.Capacity;
 import com.alibaba.nacos.config.server.model.capacity.GroupCapacity;
 import com.alibaba.nacos.config.server.utils.TimeUtils;
 import com.alibaba.nacos.persistence.datasource.DataSourceService;
+import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
 import com.alibaba.nacos.plugin.datasource.MapperManager;
+import com.alibaba.nacos.plugin.datasource.constants.CommonConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
 import com.alibaba.nacos.plugin.datasource.impl.mysql.ConfigInfoMapperByMySql;
 import com.alibaba.nacos.plugin.datasource.impl.mysql.GroupCapacityMapperByMysql;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,6 +55,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -111,6 +116,33 @@ class GroupCapacityPersistServiceTest {
     }
     
     @Test
+    void testInit() {
+        DynamicDataSource dynamicDataSource = Mockito.mock(DynamicDataSource.class);
+        try (MockedStatic<DynamicDataSource> dynamicDataSourceMockedStatic =
+            Mockito.mockStatic(DynamicDataSource.class);
+            MockedStatic<EnvUtil> envUtilMockedStatic = Mockito.mockStatic(EnvUtil.class);
+            MockedStatic<MapperManager> mapperManagerMockedStatic =
+                Mockito.mockStatic(MapperManager.class)) {
+            dynamicDataSourceMockedStatic.when(DynamicDataSource::getInstance)
+                .thenReturn(dynamicDataSource);
+            when(dynamicDataSource.getDataSource()).thenReturn(dataSourceService);
+            when(dataSourceService.getJdbcTemplate()).thenReturn(jdbcTemplate);
+            envUtilMockedStatic.when(() -> EnvUtil.getProperty(
+                CommonConstant.NACOS_PLUGIN_DATASOURCE_LOG, Boolean.class, false))
+                .thenReturn(true);
+            mapperManagerMockedStatic.when(() -> MapperManager.instance(true))
+                .thenReturn(mapperManager);
+            
+            service.init();
+        }
+        
+        assertEquals(jdbcTemplate, ReflectionTestUtils.getField(service, "jdbcTemplate"));
+        assertEquals(dataSourceService,
+            ReflectionTestUtils.getField(service, "dataSourceService"));
+        assertEquals(mapperManager, ReflectionTestUtils.getField(service, "mapperManager"));
+    }
+    
+    @Test
     void testGetClusterCapacity() {
         
         List<GroupCapacity> list = new ArrayList<>();
@@ -143,6 +175,16 @@ class GroupCapacityPersistServiceTest {
                 eq(null), eq("test"));
         
         assertTrue(service.insertGroupCapacity(capacity));
+    }
+    
+    @Test
+    void testInsertGroupCapacityReturnsFalseWhenNoRowUpdated() {
+        GroupCapacity capacity = new GroupCapacity();
+        capacity.setGroupName(GroupCapacityPersistService.CLUSTER);
+        doReturn(0).when(jdbcTemplate).update(anyString(), eq(""), eq(null), eq(null), eq(null),
+            eq(null), eq(null), eq(null));
+        
+        assertFalse(service.insertGroupCapacity(capacity));
     }
     
     @Test
@@ -187,6 +229,23 @@ class GroupCapacityPersistServiceTest {
         } catch (Exception e) {
             assertEquals("conn fail", e.getMessage());
         }
+    }
+    
+    @Test
+    void testIncrementUsageMethodsReturnFalseWhenNoRowUpdated() {
+        GroupCapacity groupCapacity = new GroupCapacity();
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        groupCapacity.setGmtModified(timestamp);
+        groupCapacity.setGroupName("test");
+        groupCapacity.setQuota(1);
+        
+        when(jdbcTemplate.update(anyString(), eq(timestamp), eq("test"), eq(1))).thenReturn(0);
+        assertFalse(service.incrementUsageWithDefaultQuotaLimit(groupCapacity));
+        
+        when(jdbcTemplate.update(anyString(), eq(timestamp), eq("test"))).thenReturn(0);
+        assertFalse(service.incrementUsageWithQuotaLimit(groupCapacity));
+        assertFalse(service.incrementUsage(groupCapacity));
+        assertFalse(service.decrementUsage(groupCapacity));
     }
     
     @Test
@@ -363,6 +422,16 @@ class GroupCapacityPersistServiceTest {
     }
     
     @Test
+    void testUpdateQuotaReturnsFalseWhenNoRowUpdated() {
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        when(TimeUtils.getCurrentTime()).thenReturn(timestamp);
+        when(jdbcTemplate.update(anyString(), eq(1), eq(timestamp), eq("test")))
+            .thenReturn(0);
+        
+        assertFalse(service.updateQuota("test", 1));
+    }
+    
+    @Test
     void testCorrectUsage() {
         
         String group = GroupCapacityPersistService.CLUSTER;
@@ -384,6 +453,33 @@ class GroupCapacityPersistServiceTest {
         } catch (Exception e) {
             assertEquals("conn fail", e.getMessage());
         }
+    }
+    
+    @Test
+    void testCorrectUsageClusterConnectionFailure() {
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        String cluster = GroupCapacityPersistService.CLUSTER;
+        when(jdbcTemplate.update(anyString(), eq(timestamp), eq(cluster)))
+            .thenThrow(new CannotGetJdbcConnectionException("conn fail"));
+        
+        CannotGetJdbcConnectionException actual = assertThrows(
+            CannotGetJdbcConnectionException.class,
+            () -> service.correctUsage(cluster, timestamp));
+        
+        assertEquals("conn fail", actual.getMessage());
+    }
+    
+    @Test
+    void testCorrectUsageReturnsFalseWhenNoRowUpdated() {
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        String cluster = GroupCapacityPersistService.CLUSTER;
+        when(jdbcTemplate.update(anyString(), eq(timestamp), eq(cluster)))
+            .thenReturn(0);
+        assertFalse(service.correctUsage(cluster, timestamp));
+        
+        when(jdbcTemplate.update(anyString(), eq("test"), eq(timestamp), eq("test")))
+            .thenReturn(0);
+        assertFalse(service.correctUsage("test", timestamp));
     }
     
     @Test
@@ -446,6 +542,13 @@ class GroupCapacityPersistServiceTest {
         } catch (Exception e) {
             assertEquals("conn fail", e.getMessage());
         }
+    }
+    
+    @Test
+    void testDeleteGroupCapacityReturnsFalseWhenNoRowUpdated() {
+        when(jdbcTemplate.update(any(PreparedStatementCreator.class))).thenReturn(0);
+        
+        assertFalse(service.deleteGroupCapacity("test"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/capacity/TenantCapacityPersistServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/capacity/TenantCapacityPersistServiceTest.java
@@ -20,9 +20,12 @@ import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.config.server.model.capacity.NamespaceCapacity;
 import com.alibaba.nacos.config.server.utils.TimeUtils;
 import com.alibaba.nacos.persistence.datasource.DataSourceService;
+import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
 import com.alibaba.nacos.plugin.datasource.MapperManager;
+import com.alibaba.nacos.plugin.datasource.constants.CommonConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
 import com.alibaba.nacos.plugin.datasource.impl.mysql.TenantCapacityMapperByMySql;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,7 +52,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -108,6 +113,33 @@ class TenantCapacityPersistServiceTest {
     }
     
     @Test
+    void testInit() {
+        DynamicDataSource dynamicDataSource = Mockito.mock(DynamicDataSource.class);
+        try (MockedStatic<DynamicDataSource> dynamicDataSourceMockedStatic =
+            Mockito.mockStatic(DynamicDataSource.class);
+            MockedStatic<EnvUtil> envUtilMockedStatic = Mockito.mockStatic(EnvUtil.class);
+            MockedStatic<MapperManager> mapperManagerMockedStatic =
+                Mockito.mockStatic(MapperManager.class)) {
+            dynamicDataSourceMockedStatic.when(DynamicDataSource::getInstance)
+                .thenReturn(dynamicDataSource);
+            when(dynamicDataSource.getDataSource()).thenReturn(dataSourceService);
+            when(dataSourceService.getJdbcTemplate()).thenReturn(jdbcTemplate);
+            envUtilMockedStatic.when(() -> EnvUtil.getProperty(
+                CommonConstant.NACOS_PLUGIN_DATASOURCE_LOG, Boolean.class, false))
+                .thenReturn(true);
+            mapperManagerMockedStatic.when(() -> MapperManager.instance(true))
+                .thenReturn(mapperManager);
+            
+            service.init();
+        }
+        
+        assertEquals(jdbcTemplate, ReflectionTestUtils.getField(service, "jdbcTemplate"));
+        assertEquals(dataSourceService,
+            ReflectionTestUtils.getField(service, "dataSourceService"));
+        assertEquals(mapperManager, ReflectionTestUtils.getField(service, "mapperManager"));
+    }
+    
+    @Test
     void testInsertTenantCapacity() {
         
         when(jdbcTemplate.update(anyString(), eq("test"), eq(null), eq(null), eq(null), eq(null),
@@ -131,6 +163,16 @@ class TenantCapacityPersistServiceTest {
     }
     
     @Test
+    void testInsertTenantCapacityReturnsFalseWhenNoRowUpdated() {
+        when(jdbcTemplate.update(anyString(), eq("test"), eq(null), eq(null), eq(null), eq(null),
+            eq(null), eq(null), eq("test"))).thenReturn(0);
+        
+        NamespaceCapacity capacity = new NamespaceCapacity();
+        capacity.setNamespaceId("test");
+        assertFalse(service.insertTenantCapacity(capacity));
+    }
+    
+    @Test
     void testIncrementUsageWithDefaultQuotaLimit() {
         
         NamespaceCapacity tenantCapacity = new NamespaceCapacity();
@@ -151,6 +193,21 @@ class TenantCapacityPersistServiceTest {
         } catch (Exception e) {
             assertEquals("conn fail", e.getMessage());
         }
+    }
+    
+    @Test
+    void testIncrementUsageMethodsReturnFalseWhenNoRowUpdated() {
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        NamespaceCapacity tenantCapacity = newTenantCapacity("test", timestamp);
+        tenantCapacity.setQuota(1);
+        
+        when(jdbcTemplate.update(anyString(), eq(timestamp), eq("test"), eq(1))).thenReturn(0);
+        assertFalse(service.incrementUsageWithDefaultQuotaLimit(tenantCapacity));
+        
+        when(jdbcTemplate.update(anyString(), eq(timestamp), eq("test"))).thenReturn(0);
+        assertFalse(service.incrementUsageWithQuotaLimit(tenantCapacity));
+        assertFalse(service.incrementUsage(tenantCapacity));
+        assertFalse(service.decrementUsage(tenantCapacity));
     }
     
     @Test
@@ -293,6 +350,18 @@ class TenantCapacityPersistServiceTest {
     }
     
     @Test
+    void testUpdateTenantCapacityReturnsFalseWhenNoRowUpdated() {
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        try (MockedStatic<TimeUtils> timeUtilsMockedStatic =
+            Mockito.mockStatic(TimeUtils.class)) {
+            timeUtilsMockedStatic.when(TimeUtils::getCurrentTime).thenReturn(timestamp);
+            when(jdbcTemplate.update(anyString(), any(Object[].class))).thenReturn(0);
+            
+            assertFalse(service.updateTenantCapacity("test", 1, 2, 3, 4));
+        }
+    }
+    
+    @Test
     void testCorrectUsage() {
         
         String tenant = "test";
@@ -310,6 +379,30 @@ class TenantCapacityPersistServiceTest {
         } catch (Exception e) {
             assertEquals("conn fail", e.getMessage());
         }
+    }
+    
+    @Test
+    void testCorrectUsageReturnsFalseWhenNoRowUpdated() {
+        String tenant = "test";
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        when(jdbcTemplate.update(anyString(), eq(tenant), eq(timestamp), eq(tenant)))
+            .thenReturn(0);
+        
+        assertFalse(service.correctUsage(tenant, timestamp));
+    }
+    
+    @Test
+    void testCorrectUsageConnectionFailure() {
+        String tenant = "test";
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        when(jdbcTemplate.update(anyString(), eq(tenant), eq(timestamp), eq(tenant)))
+            .thenThrow(new CannotGetJdbcConnectionException("conn fail"));
+        
+        CannotGetJdbcConnectionException actual = assertThrows(
+            CannotGetJdbcConnectionException.class,
+            () -> service.correctUsage(tenant, timestamp));
+        
+        assertEquals("conn fail", actual.getMessage());
     }
     
     @Test
@@ -356,6 +449,13 @@ class TenantCapacityPersistServiceTest {
         } catch (Exception e) {
             assertEquals("conn fail", e.getMessage());
         }
+    }
+    
+    @Test
+    void testDeleteTenantCapacityReturnsFalseWhenNoRowUpdated() {
+        when(jdbcTemplate.update(any(PreparedStatementCreator.class))).thenReturn(0);
+        
+        assertFalse(service.deleteTenantCapacity("test"));
     }
     
     @Test
@@ -422,5 +522,12 @@ class TenantCapacityPersistServiceTest {
         
         assertTrue(service.deleteTenantCapacity("tenantX"));
         Mockito.verify(ps).setString(1, "tenantX");
+    }
+    
+    private NamespaceCapacity newTenantCapacity(String namespaceId, Timestamp timestamp) {
+        NamespaceCapacity tenantCapacity = new NamespaceCapacity();
+        tenantCapacity.setGmtModified(timestamp);
+        tenantCapacity.setNamespaceId(namespaceId);
+        return tenantCapacity;
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpChangeConfigWorkerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpChangeConfigWorkerTest.java
@@ -45,6 +45,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -316,6 +318,40 @@ class DumpChangeConfigWorkerTest {
                 .getConfigCache()
                 .getMd5());
         
+    }
+    
+    @Test
+    void testDumpChangeWithBlankTenantReadsNextPage() {
+        PropertyUtil.setDumpChangeOn(true);
+        dumpChangeConfigWorker.setPageSize(1);
+        Timestamp startTime = dumpChangeConfigWorker.startTime;
+        ConfigInfoStateWrapper blankTenant =
+            createConfigInfoStateWrapper("blankTenantData", 1, startTime.getTime() + 1);
+        blankTenant.setTenant("");
+        when(configInfoPersistService.findChangeConfig(eq(startTime), eq(0L), eq(1)))
+            .thenReturn(Collections.singletonList(blankTenant));
+        when(configInfoPersistService.findChangeConfig(eq(startTime), eq(1L), eq(1)))
+            .thenReturn(Collections.emptyList());
+        
+        dumpChangeConfigWorker.run();
+        
+        Mockito.verify(configInfoPersistService, times(1))
+            .findChangeConfig(eq(startTime), eq(1L), eq(1));
+        Mockito.verify(configInfoPersistService, times(0))
+            .findConfigInfo(anyString(), anyString(), anyString());
+    }
+    
+    @Test
+    void testDumpChangeHandlesException() {
+        PropertyUtil.setDumpChangeOn(true);
+        Timestamp startTime = dumpChangeConfigWorker.startTime;
+        when(historyConfigInfoPersistService.findDeletedConfig(eq(startTime), eq(0L),
+            anyInt(), eq("formal"))).thenThrow(new RuntimeException("broken"));
+        
+        dumpChangeConfigWorker.run();
+        
+        Mockito.verify(configInfoPersistService, times(0))
+            .findChangeConfig(any(), anyLong(), anyInt());
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpChangeGrayConfigWorkerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpChangeGrayConfigWorkerTest.java
@@ -250,6 +250,68 @@ public class DumpChangeGrayConfigWorkerTest {
             never());
     }
     
+    @Test
+    public void testRunWithDeletedConfigNextPage() {
+        dumpGrayConfigWorker.pageSize = 1;
+        ConfigInfoStateWrapper deleted = new ConfigInfoStateWrapper();
+        deleted.setDataId("d");
+        deleted.setGroup("g");
+        deleted.setTenant("t");
+        deleted.setGrayName("");
+        deleted.setId(10L);
+        
+        when(historyConfigInfoPersistService.findDeletedConfig(
+            any(Timestamp.class), eq(0L), eq(1), anyString()))
+            .thenReturn(Collections.singletonList(deleted));
+        when(historyConfigInfoPersistService.findDeletedConfig(
+            any(Timestamp.class), eq(10L), eq(1), anyString()))
+            .thenReturn(Collections.emptyList());
+        when(configInfoGrayPersistService.findChangeConfig(
+            any(Timestamp.class), anyLong(), eq(1)))
+            .thenReturn(Collections.emptyList());
+        
+        dumpGrayConfigWorker.run();
+        
+        verify(historyConfigInfoPersistService).findDeletedConfig(
+            any(Timestamp.class), eq(10L), eq(1), anyString());
+    }
+    
+    @Test
+    public void testRunWithChangedConfigNextPage() {
+        dumpGrayConfigWorker.pageSize = 1;
+        ConfigInfoGrayWrapper changed = mock(2);
+        changed.setTenant("");
+        changed.setId(20L);
+        
+        when(historyConfigInfoPersistService.findDeletedConfig(
+            any(Timestamp.class), anyLong(), eq(1), anyString()))
+            .thenReturn(Collections.emptyList());
+        when(configInfoGrayPersistService.findChangeConfig(
+            any(Timestamp.class), eq(0L), eq(1)))
+            .thenReturn(Collections.singletonList(changed));
+        when(configInfoGrayPersistService.findChangeConfig(
+            any(Timestamp.class), eq(20L), eq(1)))
+            .thenReturn(Collections.emptyList());
+        
+        dumpGrayConfigWorker.run();
+        
+        verify(configInfoGrayPersistService).findChangeConfig(
+            any(Timestamp.class), eq(20L), eq(1));
+    }
+    
+    @Test
+    public void testRunWithExceptionStillSchedulesNextTask() {
+        when(historyConfigInfoPersistService.findDeletedConfig(
+            any(Timestamp.class), anyLong(), eq(100), anyString()))
+            .thenThrow(new RuntimeException("query failed"));
+        
+        dumpGrayConfigWorker.run();
+        
+        configExecutorMockedStatic.verify(
+            () -> ConfigExecutor.scheduleConfigChangeTask(any(DumpChangeGrayConfigWorker.class),
+                eq(PropertyUtil.getDumpChangeWorkerInterval()), eq(TimeUnit.MILLISECONDS)));
+    }
+    
     ConfigInfoGrayWrapper mock(int id) {
         ConfigInfoGrayWrapper configInfoGrayWrapper = new ConfigInfoGrayWrapper();
         configInfoGrayWrapper.setDataId("mockdataid" + id);
@@ -258,7 +320,8 @@ public class DumpChangeGrayConfigWorkerTest {
         configInfoGrayWrapper.setContent("content" + id);
         configInfoGrayWrapper.setGrayName("graytags1" + id);
         configInfoGrayWrapper.setGrayRule(
-            "{\"type\":\"tagv2\",\"version\":\"1.0.0\",\"expr\":\"middleware.server.key\\u003dgray123\",\"priority\":1}");
+            "{\"type\":\"tagv2\",\"version\":\"1.0.0\","
+                + "\"expr\":\"middleware.server.key\\u003dgray123\",\"priority\":1}");
         return configInfoGrayWrapper;
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpConfigHandlerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpConfigHandlerTest.java
@@ -17,7 +17,9 @@
 package com.alibaba.nacos.config.server.service.dump;
 
 import com.alibaba.nacos.config.server.model.event.ConfigDumpEvent;
+import com.alibaba.nacos.config.server.service.ClientIpWhiteList;
 import com.alibaba.nacos.config.server.service.ConfigCacheService;
+import com.alibaba.nacos.config.server.service.SwitchService;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +51,8 @@ class DumpConfigHandlerTest {
     void tearDown() {
         configCacheServiceMockedStatic.close();
         envUtilMockedStatic.close();
+        ClientIpWhiteList.load("");
+        SwitchService.load("");
     }
     
     @Test
@@ -122,6 +126,39 @@ class DumpConfigHandlerTest {
             .handleIp("1.1.1.1").remove(false).build();
         
         assertFalse(DumpConfigHandler.configDump(event));
+    }
+    
+    @Test
+    void testConfigDumpClientIpWhiteListMetadata() {
+        String content = "{\"isOpen\":true,\"ips\":[\"1.1.1.1\"]}";
+        configCacheServiceMockedStatic.when(() -> ConfigCacheService.dump(
+            ClientIpWhiteList.CLIENT_IP_WHITELIST_METADATA, "g", "ns", content, 100L, "text",
+            "edk")).thenReturn(true);
+        
+        ConfigDumpEvent event = ConfigDumpEvent.builder()
+            .dataId(ClientIpWhiteList.CLIENT_IP_WHITELIST_METADATA).group("g")
+            .namespaceId("ns").content(content).lastModifiedTs(100L).type("text")
+            .encryptedDataKey("edk").handleIp("1.1.1.1").remove(false).build();
+        
+        assertTrue(DumpConfigHandler.configDump(event));
+        assertTrue(ClientIpWhiteList.isEnableWhitelist());
+        assertTrue(ClientIpWhiteList.isLegalClient("1.1.1.1"));
+    }
+    
+    @Test
+    void testConfigDumpSwitchMetadata() {
+        String content = SwitchService.FIXED_DELAY_TIME + "=1000";
+        configCacheServiceMockedStatic.when(() -> ConfigCacheService.dump(
+            SwitchService.SWITCH_META_DATA_ID, "g", "ns", content, 100L, "text", "edk"))
+            .thenReturn(true);
+        
+        ConfigDumpEvent event = ConfigDumpEvent.builder()
+            .dataId(SwitchService.SWITCH_META_DATA_ID).group("g").namespaceId("ns")
+            .content(content).lastModifiedTs(100L).type("text").encryptedDataKey("edk")
+            .handleIp("1.1.1.1").remove(false).build();
+        
+        assertTrue(DumpConfigHandler.configDump(event));
+        assertEquals(1000, SwitchService.getSwitchInteger(SwitchService.FIXED_DELAY_TIME, 0));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpServiceTest.java
@@ -16,9 +16,12 @@
 
 package com.alibaba.nacos.config.server.service.dump;
 
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.config.server.manager.TaskManager;
 import com.alibaba.nacos.config.server.model.event.ConfigDataChangeEvent;
 import com.alibaba.nacos.config.server.service.ConfigMigrateService;
+import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskService;
+import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskServiceFactory;
 import com.alibaba.nacos.config.server.service.dump.task.DumpAllTask;
 import com.alibaba.nacos.config.server.service.dump.task.DumpTask;
 import com.alibaba.nacos.config.server.service.repository.ConfigInfoGrayPersistService;
@@ -44,6 +47,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -126,6 +131,7 @@ class DumpServiceTest {
         configExecutorMocked.close();
         propertyUtilMockedStatic.close();
         historyConfigCleanerManagerMockedStatic.close();
+        ReflectionTestUtils.setField(ConfigDiskServiceFactory.class, "configDiskService", null);
     }
     
     @Test
@@ -166,7 +172,7 @@ class DumpServiceTest {
         Mockito.when(namespacePersistService.isExistTable(TAG_TABLE_NAME)).thenReturn(true);
         
         Mockito.when(configInfoPersistService.findConfigMaxId()).thenReturn(300L);
-        dumpService.dumpOperate();
+        dumpService.init();
         
         // expect dump
         Mockito.verify(configInfoPersistService, times(1)).findAllConfigInfoFragment(0, 100, true);
@@ -196,6 +202,34 @@ class DumpServiceTest {
                 anyLong(), anyLong(),
                 eq(TimeUnit.MINUTES)),
             times(1));
+    }
+    
+    @Test
+    void dumpOperateThrowsNacosExceptionWhenClearAllFails() {
+        ConfigDiskService configDiskService = Mockito.mock(ConfigDiskService.class);
+        Mockito.doThrow(new RuntimeException("clear failed")).when(configDiskService).clearAll();
+        ReflectionTestUtils.setField(ConfigDiskServiceFactory.class, "configDiskService",
+            configDiskService);
+        
+        NacosException exception =
+            assertThrows(NacosException.class, () -> dumpService.dumpOperate());
+        
+        assertTrue(exception.getMessage().contains("bean construction failure"));
+    }
+    
+    @Test
+    void dumpOperateThrowsNacosExceptionWhenClearAllGrayFails() {
+        ConfigDiskService configDiskService = Mockito.mock(ConfigDiskService.class);
+        Mockito.doThrow(new RuntimeException("clear gray failed")).when(configDiskService)
+            .clearAllGray();
+        ReflectionTestUtils.setField(ConfigDiskServiceFactory.class, "configDiskService",
+            configDiskService);
+        Mockito.when(configInfoPersistService.findConfigMaxId()).thenReturn(0L);
+        
+        NacosException exception =
+            assertThrows(NacosException.class, () -> dumpService.dumpOperate());
+        
+        assertTrue(exception.getMessage().contains("bean construction failure"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/EmbeddedDumpServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/EmbeddedDumpServiceTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.service.dump;
+
+import com.alibaba.nacos.common.utils.Observable;
+import com.alibaba.nacos.common.utils.Observer;
+import com.alibaba.nacos.common.utils.ThreadUtils;
+import com.alibaba.nacos.config.server.service.ConfigMigrateService;
+import com.alibaba.nacos.config.server.service.repository.ConfigInfoGrayPersistService;
+import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
+import com.alibaba.nacos.config.server.service.repository.HistoryConfigInfoPersistService;
+import com.alibaba.nacos.config.server.utils.PropertyUtil;
+import com.alibaba.nacos.consistency.ProtocolMetaData;
+import com.alibaba.nacos.consistency.cp.CPProtocol;
+import com.alibaba.nacos.consistency.cp.MetadataKey;
+import com.alibaba.nacos.core.cluster.ServerMemberManager;
+import com.alibaba.nacos.core.distributed.ProtocolManager;
+import com.alibaba.nacos.core.namespace.repository.NamespacePersistService;
+import com.alibaba.nacos.core.utils.GlobalExecutor;
+import com.alibaba.nacos.persistence.constants.PersistenceConstant;
+import com.alibaba.nacos.persistence.datasource.DataSourceService;
+import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmbeddedDumpServiceTest {
+    
+    @Mock
+    private ConfigInfoPersistService configInfoPersistService;
+    
+    @Mock
+    private NamespacePersistService namespacePersistService;
+    
+    @Mock
+    private HistoryConfigInfoPersistService historyConfigInfoPersistService;
+    
+    @Mock
+    private ConfigInfoGrayPersistService configInfoGrayPersistService;
+    
+    @Mock
+    private ServerMemberManager memberManager;
+    
+    @Mock
+    private ProtocolManager protocolManager;
+    
+    @Mock
+    private ConfigMigrateService configMigrateService;
+    
+    @Mock
+    private CPProtocol protocol;
+    
+    @Mock
+    private ProtocolMetaData protocolMetaData;
+    
+    @Mock
+    private DataSourceService dataSourceService;
+    
+    private MockedStatic<EnvUtil> envUtilMockedStatic;
+    
+    private MockedStatic<PropertyUtil> propertyUtilMockedStatic;
+    
+    private TestEmbeddedDumpService dumpService;
+    
+    @BeforeEach
+    void setUp() {
+        envUtilMockedStatic = mockStatic(EnvUtil.class);
+        envUtilMockedStatic.when(() -> EnvUtil.getAvailableProcessors(anyInt()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+        propertyUtilMockedStatic = mockStatic(PropertyUtil.class);
+        propertyUtilMockedStatic.when(PropertyUtil::getAllDumpPageSize).thenReturn(100);
+        ReflectionTestUtils.setField(DynamicDataSource.getInstance(), "localDataSourceService",
+            dataSourceService);
+        ReflectionTestUtils.setField(DynamicDataSource.getInstance(), "basicDataSourceService",
+            dataSourceService);
+        dumpService = new TestEmbeddedDumpService(configInfoPersistService,
+            namespacePersistService, historyConfigInfoPersistService,
+            configInfoGrayPersistService, memberManager, protocolManager,
+            configMigrateService);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        envUtilMockedStatic.close();
+        propertyUtilMockedStatic.close();
+    }
+    
+    @Test
+    void testInitWhenStandalone() throws Throwable {
+        envUtilMockedStatic.when(EnvUtil::getStandaloneMode).thenReturn(true);
+        
+        dumpService.init();
+        
+        assertEquals(1, dumpService.getDumpOperateCount());
+    }
+    
+    @Test
+    void testInitWhenClusterModeSubscribesLeaderMetadata() throws Throwable {
+        prepareClusterMode();
+        try (MockedStatic<ThreadUtils> threadUtilsMockedStatic =
+            mockStatic(ThreadUtils.class)) {
+            dumpService.init();
+        }
+        
+        verify(protocolMetaData).subscribe(eq(PersistenceConstant.CONFIG_MODEL_RAFT_GROUP),
+            eq(MetadataKey.LEADER_META_DATA), any(Observer.class));
+    }
+    
+    @Test
+    void testObserverIgnoresOtherObservable() throws Throwable {
+        Observer observer = initAndCaptureObserver();
+        
+        observer.update(mock(Observable.class));
+        
+        assertEquals(0, dumpService.getDumpOperateCount());
+    }
+    
+    @Test
+    void testObserverIgnoresNullLeaderMetadata() throws Throwable {
+        Observer observer = initAndCaptureObserver();
+        try (MockedStatic<GlobalExecutor> globalExecutor = mockGlobalExecutor()) {
+            observer.update(new ProtocolMetaData.ValueItem("test/path"));
+            runGlobalTask(globalExecutor);
+        }
+        
+        assertEquals(0, dumpService.getDumpOperateCount());
+    }
+    
+    @Test
+    void testObserverDumpsAndUnsubscribes() throws Throwable {
+        Observer observer = initAndCaptureObserver();
+        try (MockedStatic<GlobalExecutor> globalExecutor = mockGlobalExecutor();
+            MockedStatic<ThreadUtils> threadUtilsMockedStatic =
+                mockStatic(ThreadUtils.class)) {
+            observer.update(valueItemWithData("leader"));
+            runGlobalTask(globalExecutor);
+        }
+        
+        assertEquals(1, dumpService.getDumpOperateCount());
+        verify(protocolMetaData).unSubscribe(PersistenceConstant.CONFIG_MODEL_RAFT_GROUP,
+            MetadataKey.LEADER_META_DATA, observer);
+    }
+    
+    @Test
+    void testObserverRetriesTemporaryFailure() throws Throwable {
+        Observer observer = initAndCaptureObserver();
+        dumpService.addFailure(new RuntimeException(
+            "The conformance protocol is temporarily unavailable for reading"));
+        try (MockedStatic<GlobalExecutor> globalExecutor = mockGlobalExecutor();
+            MockedStatic<ThreadUtils> threadUtilsMockedStatic =
+                mockStatic(ThreadUtils.class)) {
+            observer.update(valueItemWithData("leader"));
+            runGlobalTask(globalExecutor);
+        }
+        
+        assertEquals(2, dumpService.getDumpOperateCount());
+        verify(protocolMetaData).unSubscribe(PersistenceConstant.CONFIG_MODEL_RAFT_GROUP,
+            MetadataKey.LEADER_META_DATA, observer);
+    }
+    
+    @Test
+    void testInitThrowsNonRetryFailure() {
+        prepareClusterMode();
+        dumpService.addFailure(new RuntimeException("STATE_ERROR"));
+        doAnswer(invocation -> {
+            Observer observer = invocation.getArgument(2, Observer.class);
+            try (MockedStatic<GlobalExecutor> globalExecutor = mockGlobalExecutor()) {
+                observer.update(valueItemWithData("leader"));
+                runGlobalTask(globalExecutor);
+            }
+            return null;
+        }).when(protocolMetaData)
+            .subscribe(eq(PersistenceConstant.CONFIG_MODEL_RAFT_GROUP),
+                eq(MetadataKey.LEADER_META_DATA), any(Observer.class));
+        
+        try (MockedStatic<ThreadUtils> threadUtilsMockedStatic =
+            mockStatic(ThreadUtils.class)) {
+            assertThrows(RuntimeException.class, () -> dumpService.init());
+        }
+    }
+    
+    @Test
+    void testShouldRetry() throws Exception {
+        assertTrue(invokeShouldRetry(new RuntimeException(
+            "The conformance protocol is temporarily unavailable for reading")));
+        assertFalse(invokeShouldRetry(new RuntimeException("FSMCaller is overload.")));
+        assertFalse(invokeShouldRetry(new RuntimeException("STATE_ERROR")));
+        assertFalse(invokeShouldRetry(new RuntimeException("other error")));
+    }
+    
+    @Test
+    void testCanExecuteWhenStandalone() {
+        envUtilMockedStatic.when(EnvUtil::getStandaloneMode).thenReturn(true);
+        
+        assertTrue(dumpService.canExecute());
+    }
+    
+    @Test
+    void testCanExecuteWhenLeader() {
+        envUtilMockedStatic.when(EnvUtil::getStandaloneMode).thenReturn(false);
+        when(protocolManager.getCpProtocol()).thenReturn(protocol);
+        when(protocol.isLeader(PersistenceConstant.CONFIG_MODEL_RAFT_GROUP)).thenReturn(true);
+        
+        assertTrue(dumpService.canExecute());
+    }
+    
+    @Test
+    void testCanExecuteWhenFollower() {
+        envUtilMockedStatic.when(EnvUtil::getStandaloneMode).thenReturn(false);
+        when(protocolManager.getCpProtocol()).thenReturn(protocol);
+        when(protocol.isLeader(PersistenceConstant.CONFIG_MODEL_RAFT_GROUP)).thenReturn(false);
+        
+        assertFalse(dumpService.canExecute());
+    }
+    
+    private Observer initAndCaptureObserver() throws Throwable {
+        prepareClusterMode();
+        ArgumentCaptor<Observer> captor = ArgumentCaptor.forClass(Observer.class);
+        try (MockedStatic<ThreadUtils> threadUtilsMockedStatic =
+            mockStatic(ThreadUtils.class)) {
+            dumpService.init();
+        }
+        verify(protocolMetaData).subscribe(eq(PersistenceConstant.CONFIG_MODEL_RAFT_GROUP),
+            eq(MetadataKey.LEADER_META_DATA), captor.capture());
+        return captor.getValue();
+    }
+    
+    private void prepareClusterMode() {
+        envUtilMockedStatic.when(EnvUtil::getStandaloneMode).thenReturn(false);
+        when(protocolManager.getCpProtocol()).thenReturn(protocol);
+        when(protocol.protocolMetaData()).thenReturn(protocolMetaData);
+    }
+    
+    private ProtocolMetaData.ValueItem valueItemWithData(Object data) {
+        ProtocolMetaData.ValueItem valueItem = new ProtocolMetaData.ValueItem("test/path");
+        ReflectionTestUtils.setField(valueItem, "data", data);
+        return valueItem;
+    }
+    
+    private MockedStatic<GlobalExecutor> mockGlobalExecutor() {
+        return mockStatic(GlobalExecutor.class);
+    }
+    
+    private void runGlobalTask(MockedStatic<GlobalExecutor> globalExecutor) {
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        globalExecutor.verify(() -> GlobalExecutor.executeByCommon(captor.capture()));
+        captor.getValue().run();
+    }
+    
+    private boolean invokeShouldRetry(Throwable throwable) throws Exception {
+        Method method = EmbeddedDumpService.class.getDeclaredMethod("shouldRetry",
+            Throwable.class);
+        method.setAccessible(true);
+        return (Boolean) method.invoke(dumpService, throwable);
+    }
+    
+    private static class TestEmbeddedDumpService extends EmbeddedDumpService {
+        
+        private final Queue<Throwable> failures = new ArrayDeque<>();
+        
+        private int dumpOperateCount;
+        
+        TestEmbeddedDumpService(ConfigInfoPersistService configInfoPersistService,
+            NamespacePersistService namespacePersistService,
+            HistoryConfigInfoPersistService historyConfigInfoPersistService,
+            ConfigInfoGrayPersistService configInfoGrayPersistService,
+            ServerMemberManager memberManager, ProtocolManager protocolManager,
+            ConfigMigrateService configMigrateService) {
+            super(configInfoPersistService, namespacePersistService,
+                historyConfigInfoPersistService,
+                configInfoGrayPersistService, memberManager, protocolManager,
+                configMigrateService);
+        }
+        
+        @Override
+        protected void dumpOperate() {
+            dumpOperateCount++;
+            Throwable failure = failures.poll();
+            if (failure != null) {
+                throw new RuntimeException(failure);
+            }
+        }
+        
+        void addFailure(Throwable failure) {
+            failures.add(failure);
+        }
+        
+        int getDumpOperateCount() {
+            return dumpOperateCount;
+        }
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/HistoryConfigCleanerConfigTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/HistoryConfigCleanerConfigTest.java
@@ -53,6 +53,16 @@ class HistoryConfigCleanerConfigTest {
         assertEquals("nacos", historyConfigCleanerConfig.getActiveHistoryConfigCleaner());
     }
     
+    @Test
+    public void testSetActiveHistoryConfigCleaner() {
+        HistoryConfigCleanerConfig historyConfigCleanerConfig =
+            HistoryConfigCleanerConfig.getInstance();
+        
+        historyConfigCleanerConfig.setActiveHistoryConfigCleaner("custom");
+        
+        assertEquals("custom", historyConfigCleanerConfig.getActiveHistoryConfigCleaner());
+    }
+    
     @AfterEach
     public void after() {
         envUtilMockedStatic.close();

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/HistoryConfigCleanerManagerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/HistoryConfigCleanerManagerTest.java
@@ -29,4 +29,12 @@ class HistoryConfigCleanerManagerTest {
         assertEquals(cleaner.getName(), "nacos");
     }
     
+    @Test
+    public void testUnknownHistoryConfigCleanerReturnsDefaultCleaner() {
+        HistoryConfigCleaner cleaner =
+            HistoryConfigCleanerManager.getHistoryConfigCleaner("unknown");
+        
+        assertEquals("nacos", cleaner.getName());
+    }
+    
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRawDiskServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRawDiskServiceTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.config.server.service.dump.disk;
 
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.sys.env.EnvUtil;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -34,6 +35,7 @@ import java.nio.file.Paths;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConfigRawDiskServiceTest {
     
@@ -86,6 +88,19 @@ class ConfigRawDiskServiceTest {
     }
     
     @Test
+    void testTargetGrayFileWithInvalidParam() throws Exception {
+        Method method = ConfigRawDiskService.class.getDeclaredMethod("targetGrayFile", String.class,
+            String.class, String.class, String.class);
+        method.setAccessible(true);
+        
+        InvocationTargetException exception =
+            assertThrows(InvocationTargetException.class,
+                () -> method.invoke(null, "dataId", "group", "tenant", "../gray"));
+        
+        assertTrue(exception.getCause() instanceof NacosRuntimeException);
+    }
+    
+    @Test
     void testSaveToDiskAndGetContent() throws IOException {
         try (MockedStatic<EnvUtil> envUtilMock = Mockito.mockStatic(EnvUtil.class)) {
             envUtilMock.when(EnvUtil::getNacosHome).thenReturn(tempDir.getAbsolutePath());
@@ -102,6 +117,19 @@ class ConfigRawDiskServiceTest {
             envUtilMock.when(EnvUtil::getNacosHome).thenReturn(tempDir.getAbsolutePath());
             ConfigRawDiskService service = new ConfigRawDiskService();
             assertNull(service.getContent("noexist", "group", ""));
+        }
+    }
+    
+    @Test
+    void testGetContentReturnsNullWhenTargetIsDirectory() throws IOException {
+        try (MockedStatic<EnvUtil> envUtilMock = Mockito.mockStatic(EnvUtil.class)) {
+            envUtilMock.when(EnvUtil::getNacosHome).thenReturn(tempDir.getAbsolutePath());
+            File target = ConfigRawDiskService.targetFile("dirData", "group", "");
+            FileUtils.forceMkdir(target);
+            
+            ConfigRawDiskService service = new ConfigRawDiskService();
+            
+            assertNull(service.getContent("dirData", "group", ""));
         }
     }
     
@@ -161,6 +189,40 @@ class ConfigRawDiskServiceTest {
             service.clearAllGray();
             assertNull(service.getGrayContent("d1", "g1", "", "gn"));
             assertNull(service.getGrayContent("d2", "g2", "t1", "gn2"));
+        }
+    }
+    
+    @Test
+    void testClearAllWhenDeleteFails() {
+        try (MockedStatic<EnvUtil> envUtilMock = Mockito.mockStatic(EnvUtil.class);
+            MockedStatic<FileUtils> fileUtilsMock = Mockito.mockStatic(FileUtils.class)) {
+            envUtilMock.when(EnvUtil::getNacosHome).thenReturn(tempDir.getAbsolutePath());
+            assertTrue(new File(tempDir, "data/config-data").mkdirs());
+            assertTrue(new File(tempDir, "data/tenant-config-data").mkdirs());
+            fileUtilsMock.when(() -> FileUtils.deleteQuietly(Mockito.any(File.class)))
+                .thenReturn(false);
+            
+            new ConfigRawDiskService().clearAll();
+            
+            fileUtilsMock.verify(() -> FileUtils.deleteQuietly(Mockito.any(File.class)),
+                Mockito.times(2));
+        }
+    }
+    
+    @Test
+    void testClearAllGrayWhenDeleteFails() {
+        try (MockedStatic<EnvUtil> envUtilMock = Mockito.mockStatic(EnvUtil.class);
+            MockedStatic<FileUtils> fileUtilsMock = Mockito.mockStatic(FileUtils.class)) {
+            envUtilMock.when(EnvUtil::getNacosHome).thenReturn(tempDir.getAbsolutePath());
+            assertTrue(new File(tempDir, "data/gray-data").mkdirs());
+            assertTrue(new File(tempDir, "data/tenant-gray-data").mkdirs());
+            fileUtilsMock.when(() -> FileUtils.deleteQuietly(Mockito.any(File.class)))
+                .thenReturn(false);
+            
+            new ConfigRawDiskService().clearAllGray();
+            
+            fileUtilsMock.verify(() -> FileUtils.deleteQuietly(Mockito.any(File.class)),
+                Mockito.times(2));
         }
     }
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRocksDbDiskServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRocksDbDiskServiceTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.service.dump.disk;
+
+import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ConfigRocksDbDiskServiceTest {
+    
+    private static final String BASE_DIR = File.separator + "rocksdata" + File.separator
+        + "config-data";
+    
+    private static final String GRAY_DIR = File.separator + "rocksdata" + File.separator
+        + "gray-data";
+    
+    @TempDir
+    private File tempDir;
+    
+    private MockedStatic<EnvUtil> envUtilMockedStatic;
+    
+    @BeforeEach
+    void setUp() {
+        envUtilMockedStatic = Mockito.mockStatic(EnvUtil.class);
+        envUtilMockedStatic.when(EnvUtil::getNacosHome).thenReturn(tempDir.getAbsolutePath());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        envUtilMockedStatic.close();
+    }
+    
+    @Test
+    void testConstructorCreatesRocksDataDirs() {
+        new ConfigRocksDbDiskService();
+        
+        assertTrue(new File(tempDir, "rocksdata").exists());
+        assertTrue(new File(tempDir.getAbsolutePath() + BASE_DIR).exists());
+        assertTrue(new File(tempDir.getAbsolutePath() + GRAY_DIR).exists());
+    }
+    
+    @Test
+    void testGetKeyByteWhenKeysEmpty() throws Exception {
+        ConfigRocksDbDiskService service = new ConfigRocksDbDiskService();
+        
+        assertArrayEquals(new byte[0], invokeGetKeyByte(service));
+        assertArrayEquals(new byte[0], invokeGetKeyByteWithNullArray(service));
+    }
+    
+    @Test
+    void testGetKeyByteEncodesReservedCharactersAndBlankKeys() throws Exception {
+        ConfigRocksDbDiskService service = new ConfigRocksDbDiskService();
+        
+        byte[] keyBytes = invokeGetKeyByte(service, "a+b%c", " ", null);
+        
+        assertEquals("a%2Bb%25c+++", new String(keyBytes, StandardCharsets.UTF_8));
+    }
+    
+    @Test
+    void testSaveAndRemoveUseRocksDb() throws Exception {
+        RocksDB rocksDB = mock(RocksDB.class);
+        TestConfigRocksDbDiskService service = new TestConfigRocksDbDiskService(rocksDB);
+        
+        service.saveToDisk("dataId", "group", "tenant", "content");
+        service.saveGrayToDisk("dataId", "group", "tenant", "gray", "grayContent");
+        service.removeConfigInfo("dataId", "group", "tenant");
+        service.removeConfigInfo4Gray("dataId", "group", "tenant", "gray");
+        
+        verify(rocksDB, times(2)).put(any(byte[].class), any(byte[].class));
+        verify(rocksDB, times(2)).delete(any(byte[].class));
+    }
+    
+    @Test
+    void testReadContentAndMd5FromRocksDb() throws Exception {
+        RocksDB rocksDB = mock(RocksDB.class);
+        when(rocksDB.get(any(byte[].class))).thenReturn(bytes("content"), bytes("gray"),
+            bytes("md5-content"), null);
+        TestConfigRocksDbDiskService service = new TestConfigRocksDbDiskService(rocksDB);
+        
+        assertEquals("content", service.getContent("dataId", "group", "tenant"));
+        assertEquals("gray", service.getGrayContent("dataId", "group", "tenant", "gray"));
+        assertEquals(MD5Utils.md5Hex("md5-content", "UTF-8"),
+            service.getLocalConfigMd5("dataId", "group", "tenant", "UTF-8"));
+        assertNull(service.getContent("missing", "group", "tenant"));
+    }
+    
+    @Test
+    void testSaveThrowsIoExceptionWhenRocksDbPutFails() throws Exception {
+        RocksDB rocksDB = mock(RocksDB.class);
+        doThrow(new RocksDBException("put failed")).when(rocksDB)
+            .put(any(byte[].class), any(byte[].class));
+        TestConfigRocksDbDiskService service = new TestConfigRocksDbDiskService(rocksDB);
+        
+        assertThrows(IOException.class,
+            () -> service.saveToDisk("dataId", "group", "tenant", "content"));
+        assertThrows(IOException.class,
+            () -> service.saveGrayToDisk("dataId", "group", "tenant", "gray", "content"));
+    }
+    
+    @Test
+    void testReadThrowsIoExceptionWhenRocksDbGetFails() throws Exception {
+        RocksDB rocksDB = mock(RocksDB.class);
+        when(rocksDB.get(any(byte[].class))).thenThrow(new RocksDBException("get failed"));
+        TestConfigRocksDbDiskService service = new TestConfigRocksDbDiskService(rocksDB);
+        
+        assertThrows(IOException.class, () -> service.getContent("dataId", "group", "tenant"));
+        assertThrows(IOException.class,
+            () -> service.getGrayContent("dataId", "group", "tenant", "gray"));
+    }
+    
+    @Test
+    void testRemoveIgnoresRocksDbDeleteFailure() throws Exception {
+        RocksDB rocksDB = mock(RocksDB.class);
+        doThrow(new RocksDBException("delete failed")).when(rocksDB).delete(any(byte[].class));
+        TestConfigRocksDbDiskService service = new TestConfigRocksDbDiskService(rocksDB);
+        
+        service.removeConfigInfo("dataId", "group", "tenant");
+        service.removeConfigInfo4Gray("dataId", "group", "tenant", "gray");
+        
+        verify(rocksDB, times(2)).delete(any(byte[].class));
+    }
+    
+    @Test
+    void testCreateOptionsForGrayDir() {
+        ConfigRocksDbDiskService service = new ConfigRocksDbDiskService();
+        
+        ColumnFamilyOptions columnFamilyOptions = service.createColumnFamilyOptions(GRAY_DIR);
+        Options options = service.createOptions(GRAY_DIR);
+        
+        assertNotNull(columnFamilyOptions);
+        assertNotNull(options);
+        columnFamilyOptions.close();
+        options.close();
+    }
+    
+    @Test
+    void testDeleteDirReturnsWhenRocksDataMissing() throws Exception {
+        ConfigRocksDbDiskService service = new ConfigRocksDbDiskService();
+        deleteRecursively(new File(tempDir, "rocksdata"));
+        
+        Method method = ConfigRocksDbDiskService.class.getDeclaredMethod("deleteDirIfExist",
+            String.class);
+        method.setAccessible(true);
+        method.invoke(service, BASE_DIR);
+        
+        assertTrue(tempDir.exists());
+    }
+    
+    @Test
+    void testInitAndGetDbReturnsSecondCheckedDb() throws Exception {
+        RocksDB rocksDB = mock(RocksDB.class);
+        ConfigRocksDbDiskService service = new ConfigRocksDbDiskService();
+        FlippingContainsMap rocksDbMap = new FlippingContainsMap();
+        rocksDbMap.put(BASE_DIR, rocksDB);
+        service.rocksDbMap = rocksDbMap;
+        
+        assertEquals(rocksDB, service.initAndGetDB(BASE_DIR));
+    }
+    
+    @Test
+    void testCreateDirIfEmptyCreatesMissingDir() throws Exception {
+        ConfigRocksDbDiskService service = new ConfigRocksDbDiskService();
+        File missingDir = new File(tempDir, "missing-rocks-dir");
+        Method method = ConfigRocksDbDiskService.class.getDeclaredMethod("createDirIfEmpty",
+            String.class);
+        method.setAccessible(true);
+        
+        method.invoke(service, missingDir.getAbsolutePath());
+        
+        assertTrue(missingDir.exists());
+    }
+    
+    @Test
+    void testClearAllDestroysDbFailureIsIgnored() throws Exception {
+        RocksDB rocksDB = mock(RocksDB.class);
+        ConfigRocksDbDiskService service = new ConfigRocksDbDiskService();
+        service.rocksDbMap.put(BASE_DIR, rocksDB);
+        
+        try (MockedStatic<RocksDB> rocksDbMockedStatic = Mockito.mockStatic(RocksDB.class)) {
+            rocksDbMockedStatic.when(() -> RocksDB.destroyDB(anyString(), any(Options.class)))
+                .thenThrow(new RocksDBException("destroy failed"));
+            
+            service.clearAll();
+        }
+        
+        verify(rocksDB, times(1)).close();
+    }
+    
+    @Test
+    void testClearAllGrayClosesAndDestroysDb() throws Exception {
+        RocksDB rocksDB = mock(RocksDB.class);
+        ConfigRocksDbDiskService service = new ConfigRocksDbDiskService();
+        service.rocksDbMap.put(GRAY_DIR, rocksDB);
+        
+        try (MockedStatic<RocksDB> rocksDbMockedStatic = Mockito.mockStatic(RocksDB.class)) {
+            service.clearAllGray();
+            
+            rocksDbMockedStatic.verify(
+                () -> RocksDB.destroyDB(anyString(), any(Options.class)), times(1));
+        }
+        verify(rocksDB, times(1)).close();
+    }
+    
+    @Test
+    void testClearAllGrayDestroyDbFailureIsIgnored() throws Exception {
+        RocksDB rocksDB = mock(RocksDB.class);
+        ConfigRocksDbDiskService service = new ConfigRocksDbDiskService();
+        service.rocksDbMap.put(GRAY_DIR, rocksDB);
+        
+        try (MockedStatic<RocksDB> rocksDbMockedStatic = Mockito.mockStatic(RocksDB.class)) {
+            rocksDbMockedStatic.when(() -> RocksDB.destroyDB(anyString(), any(Options.class)))
+                .thenThrow(new RocksDBException("destroy failed"));
+            
+            service.clearAllGray();
+        }
+        
+        verify(rocksDB, times(1)).close();
+    }
+    
+    private byte[] invokeGetKeyByte(ConfigRocksDbDiskService service, String... keys)
+        throws Exception {
+        Method method = ConfigRocksDbDiskService.class.getDeclaredMethod("getKeyByte",
+            String[].class);
+        method.setAccessible(true);
+        return (byte[]) method.invoke(service, (Object) keys);
+    }
+    
+    private byte[] invokeGetKeyByteWithNullArray(ConfigRocksDbDiskService service)
+        throws Exception {
+        Method method = ConfigRocksDbDiskService.class.getDeclaredMethod("getKeyByte",
+            String[].class);
+        method.setAccessible(true);
+        return (byte[]) method.invoke(service, new Object[] {null});
+    }
+    
+    private byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+    
+    private void deleteRecursively(File file) {
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                deleteRecursively(child);
+            }
+        }
+        file.delete();
+    }
+    
+    private static class TestConfigRocksDbDiskService extends ConfigRocksDbDiskService {
+        
+        private final RocksDB rocksDB;
+        
+        TestConfigRocksDbDiskService(RocksDB rocksDB) {
+            this.rocksDB = rocksDB;
+        }
+        
+        @Override
+        RocksDB initAndGetDB(String dir) {
+            return rocksDB;
+        }
+    }
+    
+    private static class FlippingContainsMap extends HashMap<String, RocksDB> {
+        
+        private int containsCount;
+        
+        @Override
+        public boolean containsKey(Object key) {
+            containsCount++;
+            return containsCount > 1 && super.containsKey(key);
+        }
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllGrayProcessorTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllGrayProcessorTest.java
@@ -136,9 +136,12 @@ class DumpAllGrayProcessorTest {
     void testProcessWithValidTaskType() throws Exception {
         final DumpAllGrayTask validTask = mock(DumpAllGrayTask.class);
         List<ConfigInfoGrayWrapper> configList = new ArrayList<>();
-        configList.add(createGrayWrapper("dataId-1", "group-1"));
+        ConfigInfoGrayWrapper wrapper = createGrayWrapper("dataId-1", "group-1");
+        wrapper.setTenant("");
+        configList.add(wrapper);
         
         Page<ConfigInfoGrayWrapper> page = new Page<>();
+        page.setPageItems(configList);
         when(configInfoGrayPersistService.configInfoGrayCount()).thenReturn(1);
         when(configInfoGrayPersistService.findAllConfigInfoGrayForDumpAll(anyInt(), anyInt()))
             .thenReturn(page);

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessorTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/processor/DumpAllProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,283 +16,324 @@
 
 package com.alibaba.nacos.config.server.service.dump.processor;
 
-import com.alibaba.nacos.common.utils.MD5Utils;
-import com.alibaba.nacos.config.server.model.CacheItem;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.common.task.NacosTask;
 import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
+import com.alibaba.nacos.config.server.service.ClientIpWhiteList;
 import com.alibaba.nacos.config.server.service.ConfigCacheService;
-import com.alibaba.nacos.config.server.service.ConfigMigrateService;
-import com.alibaba.nacos.config.server.service.dump.ExternalDumpService;
-import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskServiceFactory;
+import com.alibaba.nacos.config.server.service.SwitchService;
 import com.alibaba.nacos.config.server.service.dump.task.DumpAllTask;
-import com.alibaba.nacos.config.server.service.repository.ConfigInfoGrayPersistService;
 import com.alibaba.nacos.config.server.service.repository.ConfigInfoPersistService;
 import com.alibaba.nacos.config.server.utils.GroupKey2;
 import com.alibaba.nacos.config.server.utils.PropertyUtil;
-import com.alibaba.nacos.persistence.datasource.DataSourceService;
-import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
-import com.alibaba.nacos.api.model.Page;
-import com.alibaba.nacos.plugin.datasource.constants.CommonConstant;
-import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.BeanUtils;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@Disabled(value = "Github CI will crash in this class unit test. "
-    + "It is suspected that the inability to write to the disk is related to the invocation of System.exit.")
 class DumpAllProcessorTest {
     
-    private static int newConfigCount = 1;
+    private static final int PAGE_SIZE = 100;
     
     @Mock
-    DynamicDataSource dynamicDataSource;
+    private ConfigInfoPersistService configInfoPersistService;
     
-    @Mock
-    DataSourceService dataSourceService;
+    private MockedStatic<PropertyUtil> propertyUtilMockedStatic;
     
-    @Mock
-    ConfigInfoGrayPersistService configInfoGrayPersistService;
-    
-    ConfigMigrateService configMigrateService;
-    
-    DumpAllProcessor dumpAllProcessor;
-    
-    ExternalDumpService dumpService;
-    
-    MockedStatic<DynamicDataSource> dynamicDataSourceMockedStatic;
-    
-    MockedStatic<PropertyUtil> propertyUtilMockedStatic;
-    
-    @Mock
-    ConfigInfoPersistService configInfoPersistService;
-    
-    MockedStatic<EnvUtil> envUtilMockedStatic;
-    
-    private String mockMem = "tmpmocklimitfile.txt";
+    private DumpAllProcessor dumpAllProcessor;
     
     @BeforeEach
-    void init() throws Exception {
-        dynamicDataSourceMockedStatic = Mockito.mockStatic(DynamicDataSource.class);
-        envUtilMockedStatic = Mockito.mockStatic(EnvUtil.class);
+    void setUp() {
         propertyUtilMockedStatic = Mockito.mockStatic(PropertyUtil.class);
-        propertyUtilMockedStatic.when(PropertyUtil::getAllDumpPageSize).thenReturn(100);
+        propertyUtilMockedStatic.when(PropertyUtil::getAllDumpPageSize).thenReturn(PAGE_SIZE);
         dumpAllProcessor = new DumpAllProcessor(configInfoPersistService);
-        when(EnvUtil.getNacosHome()).thenReturn(System.getProperty("user.home"));
-        when(EnvUtil.getProperty(eq(CommonConstant.NACOS_PLUGIN_DATASOURCE_LOG), eq(Boolean.class),
-            eq(false))).thenReturn(false);
-        dynamicDataSourceMockedStatic.when(DynamicDataSource::getInstance)
-            .thenReturn(dynamicDataSource);
-        
-        when(dynamicDataSource.getDataSource()).thenReturn(dataSourceService);
-        
-        dumpService = new ExternalDumpService(configInfoPersistService, null,
-            null, configInfoGrayPersistService, null, configMigrateService);
-        
-        dumpAllProcessor = new DumpAllProcessor(configInfoPersistService);
-        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq("memory_limit_file_path"),
-            eq("/sys/fs/cgroup/memory/memory.limit_in_bytes"))).thenReturn(mockMem);
-        
     }
     
     @AfterEach
-    void after() throws Exception {
-        dynamicDataSourceMockedStatic.close();
-        envUtilMockedStatic.close();
+    void tearDown() {
         propertyUtilMockedStatic.close();
     }
     
-    private ConfigInfoWrapper createNewConfig(int id) {
-        ConfigInfoWrapper configInfoWrapper = new ConfigInfoWrapper();
-        String dataId = "dataIdTime" + newConfigCount;
-        configInfoWrapper.setDataId(dataId);
-        String group = "groupTime" + newConfigCount;
-        configInfoWrapper.setGroup(group);
-        String tenant = "tenantTime" + newConfigCount;
-        configInfoWrapper.setTenant(tenant);
-        String content = "content " + newConfigCount;
-        configInfoWrapper.setContent(content);
-        configInfoWrapper.setId(id);
-        newConfigCount++;
-        return configInfoWrapper;
+    @Test
+    void testProcessRejectsInvalidTask() {
+        NacosTask task = () -> true;
+        
+        assertFalse(dumpAllProcessor.process(task));
+        
+        verify(configInfoPersistService, never()).findConfigMaxId();
     }
     
     @Test
-    void testDumpAllOnStartUp() throws Exception {
-        ConfigInfoWrapper configInfoWrapper1 = createNewConfig(1);
-        ConfigInfoWrapper configInfoWrapper2 = createNewConfig(2);
-        long timestamp = System.currentTimeMillis();
-        configInfoWrapper1.setLastModified(timestamp);
-        configInfoWrapper2.setLastModified(timestamp);
-        Page<ConfigInfoWrapper> page = new Page<>();
-        page.setTotalCount(2);
-        page.setPagesAvailable(2);
-        page.setPageNumber(1);
-        List<ConfigInfoWrapper> list = Arrays.asList(configInfoWrapper1, configInfoWrapper2);
-        page.setPageItems(list);
+    void testProcessReturnsTrueWhenNoConfig() {
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(0L);
         
-        Mockito.when(configInfoPersistService.findConfigMaxId()).thenReturn(2L);
-        Mockito
-            .when(configInfoPersistService.findAllConfigInfoFragment(0,
-                PropertyUtil.getAllDumpPageSize(), true))
-            .thenReturn(page);
-        
-        // For config 1, assign a latter time, to make sure that it would be updated.
-        // For config 2, assign an earlier time, to make sure that it is not be updated.
-        String md51 = MD5Utils.md5Hex(configInfoWrapper1.getContent(), "UTF-8");
-        String md52 = MD5Utils.md5Hex(configInfoWrapper2.getContent(), "UTF-8");
-        long latterTimestamp = timestamp + 999;
-        long earlierTimestamp = timestamp - 999;
-        String encryptedDataKey = "testEncryptedDataKey";
-        ConfigCacheService.dumpWithMd5(configInfoWrapper1.getDataId(),
-            configInfoWrapper1.getGroup(),
-            configInfoWrapper1.getTenant(), configInfoWrapper1.getContent(), md51, latterTimestamp,
-            "json",
-            encryptedDataKey);
-        ConfigCacheService.dumpWithMd5(configInfoWrapper2.getDataId(),
-            configInfoWrapper2.getGroup(),
-            configInfoWrapper2.getTenant(), configInfoWrapper2.getContent(), md52, earlierTimestamp,
-            "json",
-            encryptedDataKey);
-        
-        DumpAllTask dumpAllTask = new DumpAllTask(true);
-        
-        boolean process = dumpAllProcessor.process(dumpAllTask);
-        assertTrue(process);
-        
-        //Check cache
-        CacheItem contentCache1 = ConfigCacheService.getContentCache(
-            GroupKey2.getKey(configInfoWrapper1.getDataId(), configInfoWrapper1.getGroup(),
-                configInfoWrapper1.getTenant()));
-        assertEquals(md51, contentCache1.getConfigCache().getMd5());
-        // check if config1 is updated
-        assertTrue(timestamp < contentCache1.getConfigCache().getLastModifiedTs());
-        //check disk
-        String contentFromDisk1 = ConfigDiskServiceFactory.getInstance()
-            .getContent(configInfoWrapper1.getDataId(), configInfoWrapper1.getGroup(),
-                configInfoWrapper1.getTenant());
-        assertEquals(configInfoWrapper1.getContent(), contentFromDisk1);
-        
-        //Check cache
-        CacheItem contentCache2 = ConfigCacheService.getContentCache(
-            GroupKey2.getKey(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
-                configInfoWrapper2.getTenant()));
-        assertEquals(MD5Utils.md5Hex(configInfoWrapper2.getContent(), "UTF-8"),
-            contentCache2.getConfigCache().getMd5());
-        // check if config2 is updated
-        assertEquals(timestamp, contentCache2.getConfigCache().getLastModifiedTs());
-        //check disk
-        String contentFromDisk2 = ConfigDiskServiceFactory.getInstance()
-            .getContent(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
-                configInfoWrapper2.getTenant());
-        assertEquals(configInfoWrapper2.getContent(), contentFromDisk2);
+        try (MockedConstruction<ThreadPoolExecutor> mockedExecutors =
+            mockExecutorConstruction(0)) {
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(true)));
+            
+            assertEquals(1, mockedExecutors.constructed().size());
+            verify(mockedExecutors.constructed().get(0)).shutdown();
+        }
     }
     
-    /**
-     * test dump all for all check task.
-     */
     @Test
-    void testDumpAllOnCheckAll() throws Exception {
-        ConfigInfoWrapper configInfoWrapper1 = createNewConfig(1);
-        ConfigInfoWrapper configInfoWrapper2 = createNewConfig(2);
-        long timestamp = System.currentTimeMillis();
-        configInfoWrapper1.setLastModified(timestamp);
-        configInfoWrapper2.setLastModified(timestamp);
+    void testProcessBreaksWhenPageItemsNull() {
         Page<ConfigInfoWrapper> page = new Page<>();
-        page.setTotalCount(2);
-        page.setPagesAvailable(2);
-        page.setPageNumber(1);
-        List<ConfigInfoWrapper> list = Arrays.asList(configInfoWrapper1, configInfoWrapper2);
-        page.setPageItems(list);
-        
-        Mockito.when(configInfoPersistService.findConfigMaxId()).thenReturn(2L);
-        Mockito
-            .when(configInfoPersistService.findAllConfigInfoFragment(0,
-                PropertyUtil.getAllDumpPageSize(), false))
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(1L);
+        when(configInfoPersistService.findAllConfigInfoFragment(0L, PAGE_SIZE, false))
             .thenReturn(page);
         
-        ConfigInfoWrapper configInfoWrapperSingle1 = new ConfigInfoWrapper();
-        BeanUtils.copyProperties(configInfoWrapper1, configInfoWrapperSingle1);
-        configInfoWrapperSingle1.setContent("content123456");
-        Mockito.when(
-            configInfoPersistService.findConfigInfo(configInfoWrapper1.getDataId(),
-                configInfoWrapper1.getGroup(),
-                configInfoWrapper1.getTenant()))
-            .thenReturn(configInfoWrapperSingle1);
-        
-        ConfigInfoWrapper configInfoWrapperSingle2 = new ConfigInfoWrapper();
-        BeanUtils.copyProperties(configInfoWrapper2, configInfoWrapperSingle2);
-        configInfoWrapperSingle2.setContent("content123456222");
-        Mockito.when(
-            configInfoPersistService.findConfigInfo(configInfoWrapper2.getDataId(),
-                configInfoWrapper2.getGroup(),
-                configInfoWrapper2.getTenant()))
-            .thenReturn(configInfoWrapperSingle2);
-        
-        // For config 1, assign a latter time, to make sure that it would not be updated.
-        // For config 2, assign an earlier time, to make sure that it would be updated.
-        String md51 = MD5Utils.md5Hex(configInfoWrapper1.getContent(), "UTF-8");
-        String md52 = MD5Utils.md5Hex(configInfoWrapper2.getContent(), "UTF-8");
-        long latterTimestamp = timestamp + 999;
-        long earlierTimestamp = timestamp - 999;
-        String encryptedDataKey = "testEncryptedDataKey";
-        ConfigCacheService.dumpWithMd5(configInfoWrapper1.getDataId(),
-            configInfoWrapper1.getGroup(),
-            configInfoWrapper1.getTenant(), configInfoWrapper1.getContent(), md51, latterTimestamp,
-            "json",
-            encryptedDataKey);
-        ConfigCacheService.dumpWithMd5(configInfoWrapper2.getDataId(),
-            configInfoWrapper2.getGroup(),
-            configInfoWrapper2.getTenant(), configInfoWrapper2.getContent(), md52, earlierTimestamp,
-            "json",
-            encryptedDataKey);
-        
-        DumpAllTask dumpAllTask = new DumpAllTask(false);
-        boolean process = dumpAllProcessor.process(dumpAllTask);
-        
-        assertTrue(process);
-        
-        //Check cache
-        CacheItem contentCache1 = ConfigCacheService.getContentCache(
-            GroupKey2.getKey(configInfoWrapper1.getDataId(), configInfoWrapper1.getGroup(),
-                configInfoWrapper1.getTenant()));
-        // check if config1 is not updated
-        assertEquals(md51, contentCache1.getConfigCache().getMd5());
-        assertEquals(latterTimestamp, contentCache1.getConfigCache().getLastModifiedTs());
-        //check disk
-        String contentFromDisk1 = ConfigDiskServiceFactory.getInstance()
-            .getContent(configInfoWrapper1.getDataId(), configInfoWrapper1.getGroup(),
-                configInfoWrapper1.getTenant());
-        assertEquals(configInfoWrapper1.getContent(), contentFromDisk1);
-        
-        //Check cache
-        CacheItem contentCache2 = ConfigCacheService.getContentCache(
-            GroupKey2.getKey(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
-                configInfoWrapper2.getTenant()));
-        // check if config2 is updated
-        assertEquals(MD5Utils.md5Hex(configInfoWrapperSingle2.getContent(), "UTF-8"),
-            contentCache2.getConfigCache().getMd5());
-        assertEquals(configInfoWrapper2.getLastModified(),
-            contentCache2.getConfigCache().getLastModifiedTs());
-        //check disk
-        String contentFromDisk2 = ConfigDiskServiceFactory.getInstance()
-            .getContent(configInfoWrapper2.getDataId(), configInfoWrapper2.getGroup(),
-                configInfoWrapper2.getTenant());
-        assertEquals(configInfoWrapperSingle2.getContent(), contentFromDisk2);
+        try (MockedConstruction<ThreadPoolExecutor> mockedExecutors =
+            mockExecutorConstruction(0)) {
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(false)));
+            
+            assertEquals(1, mockedExecutors.constructed().size());
+            verify(mockedExecutors.constructed().get(0), never()).execute(any(Runnable.class));
+        }
     }
     
+    @Test
+    void testProcessSkipsBlankTenant() {
+        ConfigInfoWrapper configInfo = newConfigInfo(1L, "dataId", "group", " ", "content");
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(1L);
+        when(configInfoPersistService.findAllConfigInfoFragment(0L, PAGE_SIZE, true))
+            .thenReturn(newPage(configInfo));
+        
+        try (MockedConstruction<ThreadPoolExecutor> mockedExecutors =
+            mockExecutorConstruction(0)) {
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(true)));
+            
+            verify(mockedExecutors.constructed().get(0), never()).execute(any(Runnable.class));
+        }
+    }
+    
+    @Test
+    void testProcessStartupDumpsConfigAndLoadsMetadata() {
+        ConfigInfoWrapper whiteList = newConfigInfo(1L,
+            ClientIpWhiteList.CLIENT_IP_WHITELIST_METADATA, "group", "tenant", "127.0.0.1");
+        ConfigInfoWrapper switchConfig = newConfigInfo(2L, SwitchService.SWITCH_META_DATA_ID,
+            "group", "tenant", "switch=true");
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(2L);
+        when(configInfoPersistService.findAllConfigInfoFragment(0L, PAGE_SIZE, true))
+            .thenReturn(newPage(whiteList, switchConfig));
+        
+        try (MockedConstruction<ThreadPoolExecutor> ignored = mockExecutorConstruction(0);
+            MockedStatic<ConfigCacheService> configCacheServiceMockedStatic =
+                mockDumpWithMd5(true);
+            MockedStatic<ClientIpWhiteList> clientIpWhiteListMockedStatic =
+                Mockito.mockStatic(ClientIpWhiteList.class);
+            MockedStatic<SwitchService> switchServiceMockedStatic =
+                Mockito.mockStatic(SwitchService.class)) {
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(true)));
+            
+            clientIpWhiteListMockedStatic.verify(() -> ClientIpWhiteList.load("127.0.0.1"));
+            switchServiceMockedStatic.verify(() -> SwitchService.load("switch=true"));
+            configCacheServiceMockedStatic.verify(() -> ConfigCacheService.dumpWithMd5(
+                eq(whiteList.getDataId()), eq("group"), eq("tenant"), eq("127.0.0.1"),
+                anyString(), eq(10L), eq("text"), eq("key")));
+            configCacheServiceMockedStatic.verify(() -> ConfigCacheService.dumpWithMd5(
+                eq(switchConfig.getDataId()), eq("group"), eq("tenant"), eq("switch=true"),
+                anyString(), eq(20L), eq("text"), eq("key")));
+        }
+    }
+    
+    @Test
+    void testProcessContinuesWhenDumpFails() {
+        ConfigInfoWrapper configInfo = newConfigInfo(1L, "dataId", "group", "tenant", "content");
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(1L);
+        when(configInfoPersistService.findAllConfigInfoFragment(0L, PAGE_SIZE, true))
+            .thenReturn(newPage(configInfo));
+        
+        try (MockedConstruction<ThreadPoolExecutor> ignored = mockExecutorConstruction(0);
+            MockedStatic<ConfigCacheService> configCacheServiceMockedStatic =
+                mockDumpWithMd5(false)) {
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(true)));
+            
+            configCacheServiceMockedStatic.verify(() -> ConfigCacheService.dumpWithMd5(
+                eq("dataId"), eq("group"), eq("tenant"), eq("content"), anyString(),
+                eq(10L), eq("text"), eq("key")));
+        }
+    }
+    
+    @Test
+    void testProcessCheckSkipsWhenCacheUnchanged() {
+        ConfigInfoWrapper configInfo = newConfigInfo(1L, "dataId", "group", "tenant", "content");
+        configInfo.setMd5("sameMd5");
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(1L);
+        when(configInfoPersistService.findAllConfigInfoFragment(0L, PAGE_SIZE, false))
+            .thenReturn(newPage(configInfo));
+        
+        try (MockedConstruction<ThreadPoolExecutor> mockedExecutors =
+            mockExecutorConstruction(0);
+            MockedStatic<ConfigCacheService> configCacheServiceMockedStatic =
+                Mockito.mockStatic(ConfigCacheService.class)) {
+            String groupKey = GroupKey2.getKey("dataId", "group", "tenant");
+            configCacheServiceMockedStatic
+                .when(() -> ConfigCacheService.getLastModifiedTs(groupKey))
+                .thenReturn(configInfo.getLastModified());
+            configCacheServiceMockedStatic.when(() -> ConfigCacheService.getContentMd5(groupKey))
+                .thenReturn("sameMd5");
+            
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(false)));
+            
+            verify(configInfoPersistService, never()).findConfigInfo(anyString(), anyString(),
+                anyString());
+            verify(mockedExecutors.constructed().get(0), never()).execute(any(Runnable.class));
+        }
+    }
+    
+    @Test
+    void testProcessCheckSkipsWhenChangedConfigDeleted() {
+        ConfigInfoWrapper configInfo = newConfigInfo(1L, "dataId", "group", "tenant", "content");
+        configInfo.setMd5("newMd5");
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(1L);
+        when(configInfoPersistService.findAllConfigInfoFragment(0L, PAGE_SIZE, false))
+            .thenReturn(newPage(configInfo));
+        when(configInfoPersistService.findConfigInfo("dataId", "group", "tenant"))
+            .thenReturn(null);
+        
+        try (MockedConstruction<ThreadPoolExecutor> mockedExecutors =
+            mockExecutorConstruction(0);
+            MockedStatic<ConfigCacheService> configCacheServiceMockedStatic =
+                Mockito.mockStatic(ConfigCacheService.class)) {
+            String groupKey = GroupKey2.getKey("dataId", "group", "tenant");
+            configCacheServiceMockedStatic
+                .when(() -> ConfigCacheService.getLastModifiedTs(groupKey))
+                .thenReturn(0L);
+            configCacheServiceMockedStatic.when(() -> ConfigCacheService.getContentMd5(groupKey))
+                .thenReturn("oldMd5");
+            
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(false)));
+            
+            verify(mockedExecutors.constructed().get(0), never()).execute(any(Runnable.class));
+        }
+    }
+    
+    @Test
+    void testProcessCheckDumpsChangedConfig() {
+        ConfigInfoWrapper configInfo = newConfigInfo(1L, "dataId", "group", "tenant", "summary");
+        configInfo.setMd5("newMd5");
+        ConfigInfoWrapper fullConfig = newConfigInfo(1L, "dataId", "group", "tenant", "content");
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(1L);
+        when(configInfoPersistService.findAllConfigInfoFragment(0L, PAGE_SIZE, false))
+            .thenReturn(newPage(configInfo));
+        when(configInfoPersistService.findConfigInfo("dataId", "group", "tenant"))
+            .thenReturn(fullConfig);
+        
+        try (MockedConstruction<ThreadPoolExecutor> ignored = mockExecutorConstruction(0);
+            MockedStatic<ConfigCacheService> configCacheServiceMockedStatic =
+                Mockito.mockStatic(ConfigCacheService.class)) {
+            String groupKey = GroupKey2.getKey("dataId", "group", "tenant");
+            configCacheServiceMockedStatic
+                .when(() -> ConfigCacheService.getLastModifiedTs(groupKey))
+                .thenReturn(0L);
+            configCacheServiceMockedStatic.when(() -> ConfigCacheService.getContentMd5(groupKey))
+                .thenReturn("oldMd5");
+            configCacheServiceMockedStatic.when(() -> ConfigCacheService.dumpWithMd5(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyLong(),
+                anyString(), anyString())).thenReturn(true);
+            
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(false)));
+            
+            configCacheServiceMockedStatic.verify(() -> ConfigCacheService.dumpWithMd5(
+                eq("dataId"), eq("group"), eq("tenant"), eq("content"), anyString(),
+                eq(10L), eq("text"), eq("key")));
+        }
+    }
+    
+    @Test
+    void testProcessWaitsForUnfinishedTasks() {
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(0L);
+        
+        try (MockedConstruction<ThreadPoolExecutor> mockedExecutors =
+            mockExecutorConstruction(1, 0)) {
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(true)));
+            
+            verify(mockedExecutors.constructed().get(0), atLeast(2)).getQueue();
+        }
+    }
+    
+    @Test
+    void testProcessIgnoresWaitException() {
+        when(configInfoPersistService.findConfigMaxId()).thenReturn(0L);
+        
+        try (MockedConstruction<ThreadPoolExecutor> mockedExecutors =
+            mockExecutorConstructionWithWaitException()) {
+            assertTrue(dumpAllProcessor.process(new DumpAllTask(true)));
+            
+            verify(mockedExecutors.constructed().get(0), never()).shutdown();
+        }
+    }
+    
+    private ConfigInfoWrapper newConfigInfo(long id, String dataId, String group, String tenant,
+        String content) {
+        ConfigInfoWrapper configInfo = new ConfigInfoWrapper();
+        configInfo.setId(id);
+        configInfo.setDataId(dataId);
+        configInfo.setGroup(group);
+        configInfo.setTenant(tenant);
+        configInfo.setContent(content);
+        configInfo.setLastModified(id * 10L);
+        configInfo.setType("text");
+        configInfo.setEncryptedDataKey("key");
+        return configInfo;
+    }
+    
+    private Page<ConfigInfoWrapper> newPage(ConfigInfoWrapper... items) {
+        Page<ConfigInfoWrapper> page = new Page<>();
+        page.setPageItems(Arrays.asList(items));
+        return page;
+    }
+    
+    private MockedStatic<ConfigCacheService> mockDumpWithMd5(boolean result) {
+        MockedStatic<ConfigCacheService> configCacheServiceMockedStatic =
+            Mockito.mockStatic(ConfigCacheService.class);
+        configCacheServiceMockedStatic.when(() -> ConfigCacheService.dumpWithMd5(
+            anyString(), anyString(), anyString(), anyString(), anyString(), anyLong(),
+            anyString(), anyString())).thenReturn(result);
+        return configCacheServiceMockedStatic;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private MockedConstruction<ThreadPoolExecutor> mockExecutorConstruction(Integer... queueSizes) {
+        return Mockito.mockConstruction(ThreadPoolExecutor.class, (mock, context) -> {
+            doAnswer(invocation -> {
+                invocation.getArgument(0, Runnable.class).run();
+                return null;
+            }).when(mock).execute(any(Runnable.class));
+            BlockingQueue<Runnable> queue = Mockito.mock(BlockingQueue.class);
+            Integer[] remaining = Arrays.copyOfRange(queueSizes, 1, queueSizes.length);
+            when(queue.size()).thenReturn(queueSizes[0], remaining);
+            when(mock.getQueue()).thenReturn(queue);
+            when(mock.getActiveCount()).thenReturn(0);
+        });
+    }
+    
+    private MockedConstruction<ThreadPoolExecutor> mockExecutorConstructionWithWaitException() {
+        return Mockito.mockConstruction(ThreadPoolExecutor.class,
+            (mock, context) -> when(mock.getQueue()).thenThrow(new RuntimeException("failed")));
+    }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/notify/AsyncNotifyServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/notify/AsyncNotifyServiceTest.java
@@ -46,6 +46,8 @@ import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.nacos.config.server.service.notify.AsyncNotifyService.HEALTHY_CHECK_STATUS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -251,5 +253,23 @@ class AsyncNotifyServiceTest {
                 any(TimeUnit.class)),
             times(2));
         
+    }
+    
+    @Test
+    void testNotifyTaskAccessorsAndCallbackTimeout() {
+        Member member = new Member();
+        member.setIp("testip");
+        AsyncNotifyService.NotifySingleRpcTask task =
+            new AsyncNotifyService.NotifySingleRpcTask("dataId", "group", "tenant", null,
+                System.currentTimeMillis(), member);
+        task.setGrayName("gray");
+        
+        task.merge(task);
+        AsyncRpcNotifyCallBack callback =
+            new AsyncRpcNotifyCallBack(new AsyncNotifyService(serverMemberManager), task);
+        
+        assertEquals("gray", task.getGrayName());
+        assertNull(callback.getExecutor());
+        assertEquals(1000L, callback.getTimeout());
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/notify/HttpClientManagerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/notify/HttpClientManagerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.service.notify;
+
+import com.alibaba.nacos.common.http.HttpClientBeanHolder;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class HttpClientManagerTest {
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new HttpClientManager());
+    }
+    
+    @Test
+    void testGetTemplates() {
+        assertNotNull(HttpClientManager.getNacosRestTemplate());
+        assertNotNull(HttpClientManager.getNacosAsyncRestTemplate());
+    }
+    
+    @Test
+    void testShutdownHandlesException() {
+        HttpClientManager.getNacosRestTemplate();
+        try (MockedStatic<HttpClientBeanHolder> holderMock =
+            Mockito.mockStatic(HttpClientBeanHolder.class, Mockito.CALLS_REAL_METHODS)) {
+            holderMock.when(() -> HttpClientBeanHolder.shutdownNacosSyncRest(
+                "com.alibaba.nacos.config.server.service.notify.HttpClientManager"
+                    + "$ConfigHttpClientFactory"))
+                .thenThrow(new RuntimeException("broken"));
+            
+            ReflectionTestUtils.invokeMethod(HttpClientManager.class, "shutdown");
+        }
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/query/ConfigChainRequestExtractorServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/query/ConfigChainRequestExtractorServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1999-2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.service.query;
+
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ConfigChainRequestExtractorServiceTest {
+    
+    @BeforeEach
+    void setUp() {
+        EnvUtil.setEnvironment(new StandardEnvironment());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(null);
+    }
+    
+    @Test
+    void testGetExtractorReturnsDefaultExtractor() {
+        assertInstanceOf(DefaultChainRequestExtractor.class,
+            ConfigChainRequestExtractorService.getExtractor());
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new ConfigChainRequestExtractorService());
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/query/ConfigQueryChainServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/query/ConfigQueryChainServiceTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.service.query;
+
+import com.alibaba.nacos.common.spi.NacosServiceLoader;
+import com.alibaba.nacos.config.server.exception.NacosConfigException;
+import com.alibaba.nacos.config.server.service.query.enums.ResponseCode;
+import com.alibaba.nacos.config.server.service.query.handler.ConfigQueryHandler;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ConfigQueryChainServiceTest {
+    
+    @Test
+    void testConstructorThrowsWhenBuilderMissing() {
+        try (MockedStatic<EnvUtil> envUtilMock = Mockito.mockStatic(EnvUtil.class);
+            MockedStatic<NacosServiceLoader> serviceLoaderMock =
+                Mockito.mockStatic(NacosServiceLoader.class)) {
+            ConfigQueryHandlerChainBuilder builder = mock(ConfigQueryHandlerChainBuilder.class);
+            when(builder.getName()).thenReturn("other");
+            envUtilMock.when(() -> EnvUtil.getProperty("nacos.config.query.chain.builder", "nacos"))
+                .thenReturn("missing");
+            serviceLoaderMock.when(
+                () -> NacosServiceLoader.load(ConfigQueryHandlerChainBuilder.class))
+                .thenReturn(Collections.singletonList(builder));
+            
+            assertThrows(NacosConfigException.class, ConfigQueryChainService::new);
+        }
+    }
+    
+    @Test
+    void testHandleReturnsChainResponse() throws Exception {
+        ConfigQueryChainResponse expectedResponse = new ConfigQueryChainResponse();
+        ConfigQueryChainService service = createServiceWithHandler(expectedResponse, null);
+        
+        ConfigQueryChainResponse actualResponse = service.handle(new ConfigQueryChainRequest());
+        
+        assertSame(expectedResponse, actualResponse);
+    }
+    
+    @Test
+    void testHandleReturnsFailResponseWhenChainThrowsException() throws Exception {
+        ConfigQueryChainService service = createServiceWithHandler(null, new IOException("disk"));
+        
+        ConfigQueryChainResponse actualResponse = service.handle(new ConfigQueryChainRequest());
+        
+        assertEquals(ResponseCode.FAIL.getCode(), actualResponse.getResultCode());
+        assertEquals("disk", actualResponse.getMessage());
+    }
+    
+    @Test
+    void testAddNullHandlerReturnsSameChain() {
+        ConfigQueryHandlerChain chain = new ConfigQueryHandlerChain();
+        
+        assertSame(chain, chain.addHandler(null));
+    }
+    
+    private ConfigQueryChainService createServiceWithHandler(ConfigQueryChainResponse response,
+        IOException exception) throws Exception {
+        try (MockedStatic<EnvUtil> envUtilMock = Mockito.mockStatic(EnvUtil.class);
+            MockedStatic<NacosServiceLoader> serviceLoaderMock =
+                Mockito.mockStatic(NacosServiceLoader.class)) {
+            ConfigQueryHandler handler = mock(ConfigQueryHandler.class);
+            if (exception == null) {
+                when(handler.handle(any(ConfigQueryChainRequest.class))).thenReturn(response);
+            } else {
+                when(handler.handle(any(ConfigQueryChainRequest.class))).thenThrow(exception);
+            }
+            ConfigQueryHandlerChain chain = new ConfigQueryHandlerChain().addHandler(handler);
+            ConfigQueryHandlerChainBuilder builder = mock(ConfigQueryHandlerChainBuilder.class);
+            when(builder.getName()).thenReturn("nacos");
+            when(builder.build()).thenReturn(chain);
+            envUtilMock.when(() -> EnvUtil.getProperty("nacos.config.query.chain.builder", "nacos"))
+                .thenReturn("nacos");
+            serviceLoaderMock.when(
+                () -> NacosServiceLoader.load(ConfigQueryHandlerChainBuilder.class))
+                .thenReturn(Collections.singletonList(builder));
+            return new ConfigQueryChainService();
+        }
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/query/enums/ResponseCodeTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/query/enums/ResponseCodeTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.service.query.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ResponseCodeTest {
+    
+    @Test
+    void testGetDesc() {
+        assertEquals("Response ok", ResponseCode.SUCCESS.getDesc());
+        assertEquals("Response fail", ResponseCode.FAIL.getDesc());
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/query/handler/ConfigContentTypeHandlerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/query/handler/ConfigContentTypeHandlerTest.java
@@ -44,6 +44,11 @@ class ConfigContentTypeHandlerTest {
     }
     
     @Test
+    public void getNameReturnsHandlerName() {
+        assertEquals("ConfigContentTypeHandler", configContentTypeHandler.getName());
+    }
+    
+    @Test
     public void handleConfigNotFoundReturnsSameResponse() throws IOException {
         ConfigQueryChainRequest request = new ConfigQueryChainRequest();
         ConfigQueryChainResponse response = new ConfigQueryChainResponse();

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/query/model/ConfigQueryChainRequestTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/query/model/ConfigQueryChainRequestTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -76,13 +77,13 @@ class ConfigQueryChainRequestTest {
     @Test
     void testNotEqualsNull() {
         ConfigQueryChainRequest a = new ConfigQueryChainRequest();
-        assertNotEquals(null, a);
+        assertFalse(a.equals(null));
     }
     
     @Test
     void testNotEqualsDifferentClass() {
         ConfigQueryChainRequest a = new ConfigQueryChainRequest();
-        assertNotEquals("str", a);
+        assertFalse(a.equals("str"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/query/model/ConfigQueryChainResponseTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/query/model/ConfigQueryChainResponseTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.config.server.service.query.model;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -88,13 +89,13 @@ class ConfigQueryChainResponseTest {
     @Test
     void testNotEqualsNull() {
         ConfigQueryChainResponse a = new ConfigQueryChainResponse();
-        assertNotEquals(null, a);
+        assertFalse(a.equals(null));
     }
     
     @Test
     void testNotEqualsDifferentClass() {
         ConfigQueryChainResponse a = new ConfigQueryChainResponse();
-        assertNotEquals("str", a);
+        assertFalse(a.equals("str"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/ConfigRowMapperInjectorTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/ConfigRowMapperInjectorTest.java
@@ -47,6 +47,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(SpringExtension.class)
@@ -255,6 +256,42 @@ class ConfigRowMapperInjectorTest {
             new ConfigRowMapperInjector.ConfigInfoRowMapper();
         ConfigInfo configInfoWrapper = configInfoWrapperRowMapper.mapRow(resultSet, 10);
         assertEquals(preConfig, configInfoWrapper);
+    }
+    
+    @Test
+    void testConfigInfoRowMapperIgnoresMissingOptionalFields() throws SQLException {
+        ResultSetImpl resultSet = Mockito.mock(ResultSetImpl.class);
+        Mockito.when(resultSet.getString(eq("data_id"))).thenReturn("dataId");
+        Mockito.when(resultSet.getString(eq("group_id"))).thenReturn("group");
+        Mockito.when(resultSet.getString(eq("tenant_id"))).thenReturn("tenant");
+        Mockito.when(resultSet.getString(eq("app_name"))).thenThrow(new SQLException("missing"));
+        Mockito.when(resultSet.getString(eq("content"))).thenThrow(new SQLException("missing"));
+        Mockito.when(resultSet.getString(eq("md5"))).thenThrow(new SQLException("missing"));
+        Mockito.when(resultSet.getLong(eq("id"))).thenThrow(new SQLException("missing"));
+        Mockito.when(resultSet.getString(eq("type"))).thenThrow(new SQLException("missing"));
+        Mockito.when(resultSet.getString(eq("encrypted_data_key")))
+            .thenThrow(new SQLException("missing"));
+        Mockito.when(resultSet.getString(eq("c_desc"))).thenThrow(new SQLException("missing"));
+        Mockito.when(resultSet.getString(eq("config_tags")))
+            .thenThrow(new SQLException("missing"));
+        Mockito.when(resultSet.getTimestamp(eq("gmt_modified")))
+            .thenThrow(new SQLException("missing"));
+        
+        ConfigInfo configInfo =
+            new ConfigRowMapperInjector.ConfigInfoRowMapper().mapRow(resultSet, 10);
+        
+        assertEquals("dataId", configInfo.getDataId());
+        assertEquals("group", configInfo.getGroup());
+        assertEquals("tenant", configInfo.getTenant());
+        assertNull(configInfo.getAppName());
+        assertNull(configInfo.getContent());
+        assertNull(configInfo.getMd5());
+        assertEquals(0L, configInfo.getId());
+        assertNull(configInfo.getType());
+        assertNull(configInfo.getEncryptedDataKey());
+        assertNull(configInfo.getDesc());
+        assertNull(configInfo.getConfigTags());
+        assertNull(configInfo.getGmtModified());
     }
     
     @Test
@@ -685,6 +722,176 @@ class ConfigRowMapperInjectorTest {
         assertEquals("d", result.getDataId());
         assertEquals("g", result.getGroup());
         assertEquals("app", result.getAppName());
+    }
+    
+    @Test
+    void testConfigInfoStateWrapperRowMapperMissingOptionalColumns() throws SQLException {
+        ResultSetImpl resultSet = mockResultSetWithConfigKey();
+        Mockito.when(resultSet.getTimestamp(eq("gmt_modified"))).thenReturn(new Timestamp(123L));
+        mockMissingString(resultSet, "md5");
+        mockMissingLong(resultSet, "id");
+        
+        ConfigInfoStateWrapper result = new ConfigInfoStateWrapperRowMapper().mapRow(resultSet, 1);
+        
+        assertEquals("d", result.getDataId());
+        assertEquals("g", result.getGroup());
+        assertEquals(123L, result.getLastModified());
+    }
+    
+    @Test
+    void testConfigInfoBetaWrapperRowMapperMissingOptionalColumns() throws SQLException {
+        ResultSetImpl resultSet = mockResultSetWithConfigKey();
+        Mockito.when(resultSet.getString(eq("app_name"))).thenReturn("app");
+        Mockito.when(resultSet.getString(eq("beta_ips"))).thenReturn("127.0.0.1");
+        mockMissingString(resultSet, "content");
+        mockMissingLong(resultSet, "id");
+        mockMissingTimestamp(resultSet, "gmt_modified");
+        mockMissingString(resultSet, "md5");
+        mockMissingString(resultSet, "encrypted_data_key");
+        
+        ConfigInfoBetaWrapper result = new ConfigInfoBetaWrapperRowMapper().mapRow(resultSet, 1);
+        
+        assertEquals("d", result.getDataId());
+        assertEquals("g", result.getGroup());
+        assertEquals("127.0.0.1", result.getBetaIps());
+    }
+    
+    @Test
+    void testConfigInfoTagWrapperRowMapperMissingOptionalColumns() throws SQLException {
+        ResultSetImpl resultSet = mockResultSetWithConfigKey();
+        Mockito.when(resultSet.getString(eq("tag_id"))).thenReturn("tag");
+        Mockito.when(resultSet.getString(eq("app_name"))).thenReturn("app");
+        mockMissingString(resultSet, "content");
+        mockMissingLong(resultSet, "id");
+        mockMissingTimestamp(resultSet, "gmt_modified");
+        mockMissingString(resultSet, "md5");
+        
+        ConfigInfoTagWrapper result = new ConfigInfoTagWrapperRowMapper().mapRow(resultSet, 1);
+        
+        assertEquals("d", result.getDataId());
+        assertEquals("g", result.getGroup());
+        assertEquals("tag", result.getTag());
+    }
+    
+    @Test
+    void testConfigAllInfoRowMapperMissingOptionalColumns() throws SQLException {
+        ResultSetImpl resultSet = mockResultSetWithConfigKey();
+        Mockito.when(resultSet.getString(eq("app_name"))).thenReturn("app");
+        Mockito.when(resultSet.getTimestamp(eq("gmt_create"))).thenReturn(new Timestamp(123L));
+        Mockito.when(resultSet.getTimestamp(eq("gmt_modified"))).thenReturn(new Timestamp(456L));
+        Mockito.when(resultSet.getString(eq("src_user"))).thenReturn("user");
+        Mockito.when(resultSet.getString(eq("src_ip"))).thenReturn("ip");
+        Mockito.when(resultSet.getString(eq("c_desc"))).thenReturn("desc");
+        Mockito.when(resultSet.getString(eq("c_use"))).thenReturn("use");
+        Mockito.when(resultSet.getString(eq("effect"))).thenReturn("effect");
+        Mockito.when(resultSet.getString(eq("type"))).thenReturn("type");
+        Mockito.when(resultSet.getString(eq("c_schema"))).thenReturn("schema");
+        mockMissingString(resultSet, "content");
+        mockMissingString(resultSet, "md5");
+        mockMissingLong(resultSet, "id");
+        mockMissingString(resultSet, "encrypted_data_key");
+        
+        ConfigAllInfo result = new ConfigRowMapperInjector.ConfigAllInfoRowMapper()
+            .mapRow(resultSet, 1);
+        
+        assertEquals("d", result.getDataId());
+        assertEquals("g", result.getGroup());
+        assertEquals("app", result.getAppName());
+    }
+    
+    @Test
+    void testConfigInfo4BetaRowMapperMissingOptionalColumns() throws SQLException {
+        ResultSetImpl resultSet = mockResultSetWithConfigKey();
+        Mockito.when(resultSet.getString(eq("app_name"))).thenReturn("app");
+        Mockito.when(resultSet.getString(eq("beta_ips"))).thenReturn("127.0.0.1");
+        mockMissingString(resultSet, "content");
+        mockMissingLong(resultSet, "id");
+        mockMissingString(resultSet, "md5");
+        
+        ConfigInfo4Beta result = new ConfigInfo4BetaRowMapper().mapRow(resultSet, 1);
+        
+        assertEquals("d", result.getDataId());
+        assertEquals("g", result.getGroup());
+        assertEquals("127.0.0.1", result.getBetaIps());
+    }
+    
+    @Test
+    void testConfigInfo4TagRowMapperMissingOptionalColumns() throws SQLException {
+        ResultSetImpl resultSet = mockResultSetWithConfigKey();
+        Mockito.when(resultSet.getString(eq("tag_id"))).thenReturn("tag");
+        Mockito.when(resultSet.getString(eq("app_name"))).thenReturn("app");
+        mockMissingString(resultSet, "content");
+        mockMissingLong(resultSet, "id");
+        mockMissingString(resultSet, "md5");
+        
+        ConfigInfo4Tag result =
+            new ConfigRowMapperInjector.ConfigInfo4TagRowMapper().mapRow(resultSet, 1);
+        
+        assertEquals("d", result.getDataId());
+        assertEquals("g", result.getGroup());
+        assertEquals("tag", result.getTag());
+    }
+    
+    @Test
+    void testConfigInfoBaseRowMapperMissingOptionalColumns() throws SQLException {
+        ResultSetImpl resultSet = Mockito.mock(ResultSetImpl.class);
+        Mockito.when(resultSet.getString(eq("data_id"))).thenReturn("d");
+        Mockito.when(resultSet.getString(eq("group_id"))).thenReturn("g");
+        mockMissingString(resultSet, "content");
+        mockMissingLong(resultSet, "id");
+        
+        ConfigInfoBase result =
+            new ConfigRowMapperInjector.ConfigInfoBaseRowMapper().mapRow(resultSet, 1);
+        
+        assertEquals("d", result.getDataId());
+        assertEquals("g", result.getGroup());
+    }
+    
+    @Test
+    void testConfigHistoryDetailRowMapperMissingEncryptedDataKey() throws SQLException {
+        ResultSetImpl resultSet = Mockito.mock(ResultSetImpl.class);
+        Mockito.when(resultSet.getLong(eq("nid"))).thenReturn(1L);
+        Mockito.when(resultSet.getString(eq("data_id"))).thenReturn("d");
+        Mockito.when(resultSet.getString(eq("group_id"))).thenReturn("g");
+        Mockito.when(resultSet.getString(eq("tenant_id"))).thenReturn("t");
+        Mockito.when(resultSet.getString(eq("app_name"))).thenReturn("app");
+        Mockito.when(resultSet.getString(eq("md5"))).thenReturn("md5");
+        Mockito.when(resultSet.getString(eq("content"))).thenReturn("content");
+        Mockito.when(resultSet.getString(eq("src_user"))).thenReturn("user");
+        Mockito.when(resultSet.getString(eq("src_ip"))).thenReturn("ip");
+        Mockito.when(resultSet.getString(eq("op_type"))).thenReturn("op");
+        Mockito.when(resultSet.getString(eq("publish_type"))).thenReturn("formal");
+        Mockito.when(resultSet.getString(eq("gray_name"))).thenReturn("gray");
+        Mockito.when(resultSet.getString(eq("ext_info"))).thenReturn("{}");
+        Mockito.when(resultSet.getTimestamp(eq("gmt_create"))).thenReturn(new Timestamp(123L));
+        Mockito.when(resultSet.getTimestamp(eq("gmt_modified"))).thenReturn(new Timestamp(456L));
+        mockMissingString(resultSet, "encrypted_data_key");
+        
+        ConfigHistoryInfo result = new ConfigHistoryDetailRowMapper().mapRow(resultSet, 1);
+        
+        assertEquals("d", result.getDataId());
+        assertEquals("g", result.getGroup());
+        assertEquals("content", result.getContent());
+    }
+    
+    private ResultSetImpl mockResultSetWithConfigKey() throws SQLException {
+        ResultSetImpl resultSet = Mockito.mock(ResultSetImpl.class);
+        Mockito.when(resultSet.getString(eq("data_id"))).thenReturn("d");
+        Mockito.when(resultSet.getString(eq("group_id"))).thenReturn("g");
+        Mockito.when(resultSet.getString(eq("tenant_id"))).thenReturn("t");
+        return resultSet;
+    }
+    
+    private void mockMissingString(ResultSetImpl resultSet, String column) throws SQLException {
+        Mockito.when(resultSet.getString(eq(column))).thenThrow(new SQLException("not found"));
+    }
+    
+    private void mockMissingLong(ResultSetImpl resultSet, String column) throws SQLException {
+        Mockito.when(resultSet.getLong(eq(column))).thenThrow(new SQLException("not found"));
+    }
+    
+    private void mockMissingTimestamp(ResultSetImpl resultSet, String column) throws SQLException {
+        Mockito.when(resultSet.getTimestamp(eq(column))).thenThrow(new SQLException("not found"));
     }
     
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoBetaPersistServiceImplTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.config.server.service.repository.embedded;
 
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.constant.Constants;
+import com.alibaba.nacos.config.server.exception.NacosConfigException;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfoBetaWrapper;
 import com.alibaba.nacos.config.server.model.ConfigInfoStateWrapper;
@@ -43,6 +44,8 @@ import java.util.List;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_BETA_WRAPPER_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -297,6 +300,21 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
     }
     
     @Test
+    void testRemoveConfigInfo4BetaThrowsWhenUpdateFails() {
+        String dataId = "dataId456789";
+        String group = "group4567";
+        String tenant = "tenant56789o0";
+        ConfigInfoStateWrapper mockedConfigInfoStateWrapper = new ConfigInfoStateWrapper();
+        Mockito.when(databaseOperate.queryOne(anyString(), eq(new Object[] {dataId, group, tenant}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(mockedConfigInfoStateWrapper);
+        Mockito.when(databaseOperate.update(any(List.class))).thenReturn(false);
+        
+        assertThrows(NacosConfigException.class,
+            () -> embeddedConfigInfoBetaPersistService.removeConfigInfo4Beta(dataId, group,
+                tenant));
+    }
+    
+    @Test
     void testFindConfigInfo4Beta() {
         String dataId = "dataId456789";
         String group = "group4567";
@@ -323,6 +341,56 @@ class EmbeddedConfigInfoBetaPersistServiceImplTest {
         Mockito.when(databaseOperate.queryOne(anyString(), eq(Integer.class))).thenReturn(101);
         int returnCount = embeddedConfigInfoBetaPersistService.configInfoBetaCount();
         assertEquals(101, returnCount);
+    }
+    
+    @Test
+    void testConfigInfoBetaCountThrowsWhenResultNull() {
+        Mockito.when(databaseOperate.queryOne(anyString(), eq(Integer.class))).thenReturn(null);
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> embeddedConfigInfoBetaPersistService.configInfoBetaCount());
+    }
+    
+    @Test
+    void testAddConfigInfo4BetaReturnsFalseWhenStateMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        
+        ConfigOperateResult result = embeddedConfigInfoBetaPersistService.addConfigInfo4Beta(
+            configInfo, "1.1.1.1", "srcIp", "srcUser");
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4BetaReturnsFalseWhenStateMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        
+        ConfigOperateResult result = embeddedConfigInfoBetaPersistService.updateConfigInfo4Beta(
+            configInfo, "1.1.1.1", "srcIp", "srcUser");
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4BetaCasReturnsFalseWhenBlockUpdateFails() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        Mockito.when(databaseOperate.blockUpdate()).thenReturn(false);
+        
+        ConfigOperateResult result = embeddedConfigInfoBetaPersistService.updateConfigInfo4BetaCas(
+            configInfo, "1.1.1.1", "srcIp", "srcUser");
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4BetaCasReturnsFalseWhenStateMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        Mockito.when(databaseOperate.blockUpdate()).thenReturn(true);
+        
+        ConfigOperateResult result = embeddedConfigInfoBetaPersistService.updateConfigInfo4BetaCas(
+            configInfo, "1.1.1.1", "srcIp", "srcUser");
+        
+        assertFalse(result.isSuccess());
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoGrayPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoGrayPersistServiceImplTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.config.server.service.repository.embedded;
 
 import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfoGrayWrapper;
@@ -48,6 +49,7 @@ import java.util.List;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -330,6 +332,80 @@ public class EmbeddedConfigInfoGrayPersistServiceImplTest {
     }
     
     @Test
+    void testAddConfigInfo4GrayWithBlankOptionalValuesReturnsFalseWhenStateMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
+        
+        ConfigOperateResult result = embeddedConfigInfoGrayPersistService.addConfigInfo4Gray(
+            configInfo, " ", " ", "srcIp", "srcUser");
+        
+        assertTrue(!result.isSuccess());
+        embeddedStorageContextHolderMockedStatic.verify(
+            () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), any(), eq("dataId"),
+                eq("group"), eq(StringUtils.EMPTY), eq(StringUtils.EMPTY), eq(StringUtils.EMPTY),
+                eq(StringUtils.EMPTY), eq("content"), eq(MD5Utils.md5Hex("content",
+                    Constants.ENCODE)),
+                eq("srcIp"), eq("srcUser"), any(Timestamp.class),
+                any(Timestamp.class)),
+            times(1));
+    }
+    
+    @Test
+    void testUpdateConfigInfo4GrayReturnsFalseWhenOldGrayMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER))).thenReturn(null);
+        
+        ConfigOperateResult result = embeddedConfigInfoGrayPersistService.updateConfigInfo4Gray(
+            configInfo, " ", " ", "srcIp", "srcUser");
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4GrayCasReturnsFalseWhenOldGrayMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER))).thenReturn(null);
+        
+        ConfigOperateResult result = embeddedConfigInfoGrayPersistService.updateConfigInfo4GrayCas(
+            configInfo, " ", " ", "srcIp", "srcUser");
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4GrayCasReturnsFalseWhenBlockUpdateFails() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        configInfo.setMd5("oldMd5");
+        ConfigInfoGrayWrapper oldGray = new ConfigInfoGrayWrapper();
+        when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER))).thenReturn(oldGray);
+        when(databaseOperate.blockUpdate()).thenReturn(false);
+        
+        ConfigOperateResult result = embeddedConfigInfoGrayPersistService.updateConfigInfo4GrayCas(
+            configInfo, "", "", "srcIp", "srcUser");
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
+    void testRemoveConfigInfoGrayThrowsWhenOldGrayMissing() {
+        when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER))).thenReturn(null);
+        
+        assertThrows(NullPointerException.class,
+            () -> embeddedConfigInfoGrayPersistService.removeConfigInfoGray(
+                "dataId", "group", null, "", "srcIp", "srcUser"));
+    }
+    
+    @Test
     public void testRemoveConfigInfoGrayName() {
         String dataId = "dataId1112222";
         String group = "group22";
@@ -397,6 +473,14 @@ public class EmbeddedConfigInfoGrayPersistServiceImplTest {
     }
     
     @Test
+    void testConfigInfoGrayCountRejectsNullResult() {
+        Mockito.when(databaseOperate.queryOne(anyString(), eq(Integer.class))).thenReturn(null);
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> embeddedConfigInfoGrayPersistService.configInfoGrayCount());
+    }
+    
+    @Test
     public void testFindAllConfigInfoGrayForDumpAll() {
         
         //mock count
@@ -436,6 +520,19 @@ public class EmbeddedConfigInfoGrayPersistServiceImplTest {
         List<String> configInfoGrays =
             embeddedConfigInfoGrayPersistService.findConfigInfoGrays(dataId, group, tenant);
         assertEquals(mockedGrays, configInfoGrays);
+    }
+    
+    @Test
+    void testFindConfigInfoGraysUsesEmptyTenant() {
+        List<String> mockedGrays = Arrays.asList("gray1", "gray2");
+        Mockito.when(databaseOperate.queryMany(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}), eq(String.class)))
+            .thenReturn(mockedGrays);
+        
+        List<String> result = embeddedConfigInfoGrayPersistService.findConfigInfoGrays(
+            "dataId", "group", null);
+        
+        assertEquals(mockedGrays, result);
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoPersistServiceImplTest.java
@@ -28,6 +28,7 @@ import com.alibaba.nacos.config.server.model.ConfigInfoStateWrapper;
 import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
 import com.alibaba.nacos.config.server.model.ConfigOperateResult;
 import com.alibaba.nacos.api.config.model.SameConfigPolicy;
+import com.alibaba.nacos.config.server.exception.NacosConfigException;
 import com.alibaba.nacos.config.server.service.repository.HistoryConfigInfoPersistService;
 import com.alibaba.nacos.config.server.utils.ConfigExtInfoUtil;
 import com.alibaba.nacos.core.distributed.id.IdGeneratorManager;
@@ -49,9 +50,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_ADVANCE_INFO_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_ALL_INFO_ROW_MAPPER;
@@ -441,6 +444,137 @@ class EmbeddedConfigInfoPersistServiceImplTest {
     }
     
     @Test
+    void testUpdateConfigInfoReturnsFalseWhenOldConfigMissing() {
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(null);
+        
+        ConfigOperateResult result = embeddedConfigInfoPersistService.updateConfigInfo(
+            new ConfigInfo("dataId", "group", "", null, "content"), "srcIp", "srcUser", null);
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfoWithNullTenantAndTagsReturnsLastState() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setId(100L);
+        oldConfig.setDataId("dataId");
+        oldConfig.setGroup("group");
+        oldConfig.setTenant(StringUtils.EMPTY);
+        oldConfig.setAppName("oldApp");
+        ConfigInfoStateWrapper state = new ConfigInfoStateWrapper();
+        state.setId(100L);
+        state.setLastModified(123L);
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(oldConfig);
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(state);
+        Mockito.when(databaseOperate.blockUpdate()).thenReturn(true);
+        Map<String, Object> advanceInfo = new HashMap<>();
+        advanceInfo.put("config_tags", "tag1,tag2");
+        
+        ConfigOperateResult result = embeddedConfigInfoPersistService.updateConfigInfo(
+            configInfo, "srcIp", "srcUser", advanceInfo);
+        
+        assertTrue(result.isSuccess());
+        assertEquals(100L, result.getId());
+        assertEquals(123L, result.getLastModified());
+    }
+    
+    @Test
+    void testUpdateConfigInfoCasReturnsFalseWhenOldConfigMissing() {
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(null);
+        
+        ConfigOperateResult result = embeddedConfigInfoPersistService.updateConfigInfoCas(
+            new ConfigInfo("dataId", "group", "", null, "content"), "srcIp", "srcUser", null);
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfoReturnsFalseWhenUpdatedStateMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setId(100L);
+        oldConfig.setDataId("dataId");
+        oldConfig.setGroup("group");
+        oldConfig.setTenant(StringUtils.EMPTY);
+        oldConfig.setAppName("oldApp");
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(oldConfig);
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
+        Mockito.when(databaseOperate.blockUpdate()).thenReturn(true);
+        
+        ConfigOperateResult result = embeddedConfigInfoPersistService.updateConfigInfo(configInfo,
+            "srcIp", "srcUser", null);
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfoCasReturnsFalseWhenBlockUpdateFails() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setId(100L);
+        oldConfig.setDataId("dataId");
+        oldConfig.setGroup("group");
+        oldConfig.setTenant(StringUtils.EMPTY);
+        oldConfig.setAppName("oldApp");
+        ConfigInfoStateWrapper state = new ConfigInfoStateWrapper();
+        state.setId(100L);
+        state.setLastModified(123L);
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(oldConfig);
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(state);
+        Mockito.when(databaseOperate.blockUpdate()).thenReturn(false);
+        
+        ConfigOperateResult result = embeddedConfigInfoPersistService.updateConfigInfoCas(
+            configInfo, "srcIp", "srcUser", null);
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfoCasReturnsLastState() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setId(100L);
+        oldConfig.setDataId("dataId");
+        oldConfig.setGroup("group");
+        oldConfig.setTenant(StringUtils.EMPTY);
+        oldConfig.setAppName("oldApp");
+        ConfigInfoStateWrapper state = new ConfigInfoStateWrapper();
+        state.setId(101L);
+        state.setLastModified(234L);
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(oldConfig);
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(state);
+        Mockito.when(databaseOperate.blockUpdate()).thenReturn(true);
+        
+        ConfigOperateResult result = embeddedConfigInfoPersistService.updateConfigInfoCas(
+            configInfo, "srcIp", "srcUser", null);
+        
+        assertTrue(result.isSuccess());
+        assertEquals(101L, result.getId());
+        assertEquals(234L, result.getLastModified());
+    }
+    
+    @Test
     void testRemoveConfigInfo() {
         String dataId = "dataId4567";
         String group = "group3456789";
@@ -540,6 +674,52 @@ class EmbeddedConfigInfoPersistServiceImplTest {
                 eq(srcUser), any(), eq("D"), eq("formal"), eq(null),
                 eq(ConfigExtInfoUtil.getExtInfoFromAllInfo(configAllInfos.get(1))));
         
+    }
+    
+    @Test
+    void testRemoveConfigInfoThrowsWhenUpdateFails() {
+        String dataId = "dataIdFailedDelete";
+        String group = "groupFailedDelete";
+        String tenant = "tenantFailedDelete";
+        ConfigAllInfo configAllInfo = new ConfigAllInfo();
+        configAllInfo.setId(123L);
+        configAllInfo.setDataId(dataId);
+        configAllInfo.setGroup(group);
+        configAllInfo.setTenant(tenant);
+        Mockito.when(databaseOperate.queryOne(anyString(), eq(new Object[] {dataId, group, tenant}),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(configAllInfo);
+        Mockito.when(databaseOperate.update(any())).thenReturn(false);
+        
+        assertThrows(NacosConfigException.class,
+            () -> embeddedConfigInfoPersistService.removeConfigInfo(dataId, group, tenant, "srcIp",
+                "srcUser"));
+    }
+    
+    @Test
+    void testRemoveConfigInfoByIdsReturnsNullWhenIdsEmpty() {
+        assertTrue(embeddedConfigInfoPersistService.removeConfigInfoByIds(
+            new ArrayList<>(), "srcIp", "srcUser") == null);
+    }
+    
+    @Test
+    void testRemoveConfigInfoByIdsThrowsWhenUpdateFails() {
+        List<Long> deleteIds = new ArrayList<>(Collections.singletonList(123L));
+        ConfigAllInfo configAllInfo = createMockConfigAllInfo(1);
+        configAllInfo.setId(123L);
+        Mockito.when(databaseOperate.queryMany(anyString(), eq(deleteIds.toArray()),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(Collections.singletonList(configAllInfo));
+        Mockito.when(databaseOperate.update(any())).thenReturn(false);
+        
+        assertThrows(NacosConfigException.class,
+            () -> embeddedConfigInfoPersistService.removeConfigInfoByIds(deleteIds, "srcIp",
+                "srcUser"));
+    }
+    
+    @Test
+    void testRemoveConfigInfoByIdsAtomicSkipsBlankIds() {
+        embeddedConfigInfoPersistService.removeConfigInfoByIdsAtomic("");
+        
+        embeddedStorageContextHolderMockedStatic.verifyNoInteractions();
     }
     
     @Test
@@ -668,6 +848,58 @@ class EmbeddedConfigInfoPersistServiceImplTest {
             ((List<Map<String, String>>) stringObjectMap.get("skipData")).get(0).get("dataId"));
     }
     
+    @Test
+    void testBatchInsertOrUpdateWithNullAdvanceInfoAndDefaultType() throws NacosException {
+        ConfigAllInfo configInfo = createMockConfigAllInfo(0);
+        configInfo.setDataId("plainDataId");
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {configInfo.getDataId(), configInfo.getGroup(),
+                configInfo.getTenant()}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
+        Mockito.doAnswer(invocation -> {
+            BiConsumer<Boolean, Throwable> consumer = invocation.getArgument(0);
+            consumer.accept(true, null);
+            return true;
+        }).when(databaseOperate).blockUpdate(Mockito.<BiConsumer<Boolean, Throwable>>any());
+        
+        Map<String, Object> result = embeddedConfigInfoPersistService.batchInsertOrUpdate(
+            Collections.singletonList(configInfo), "srcUser", "srcIp", null,
+            SameConfigPolicy.SKIP);
+        
+        assertEquals(1, result.get("succCount"));
+        assertEquals(0, result.get("skipCount"));
+    }
+    
+    @Test
+    void testBatchInsertOrUpdateRethrowsInvalidConfig() {
+        ConfigAllInfo configInfo = createMockConfigAllInfo(0);
+        configInfo.setDataId("");
+        
+        assertThrows(NacosException.class,
+            () -> embeddedConfigInfoPersistService.batchInsertOrUpdate(
+                Collections.singletonList(configInfo), "srcUser", "srcIp", new HashMap<>(),
+                SameConfigPolicy.SKIP));
+    }
+    
+    @Test
+    void testBatchInsertOrUpdateRethrowsCallbackException() {
+        ConfigAllInfo configInfo = createMockConfigAllInfo(0);
+        Mockito.when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {configInfo.getDataId(), configInfo.getGroup(),
+                configInfo.getTenant()}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER))).thenReturn(null);
+        Mockito.doAnswer(invocation -> {
+            BiConsumer<Boolean, Throwable> consumer = invocation.getArgument(0);
+            consumer.accept(false, new RuntimeException("block failed"));
+            return false;
+        }).when(databaseOperate).blockUpdate(Mockito.<BiConsumer<Boolean, Throwable>>any());
+        
+        assertThrows(NacosException.class,
+            () -> embeddedConfigInfoPersistService.batchInsertOrUpdate(
+                Collections.singletonList(configInfo), "srcUser", "srcIp", new HashMap<>(),
+                SameConfigPolicy.SKIP));
+    }
+    
     private ConfigAllInfo createMockConfigAllInfo(long mockId) {
         ConfigAllInfo configAllInfo = new ConfigAllInfo();
         configAllInfo.setDataId("test" + mockId + ".yaml");
@@ -702,6 +934,29 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         configInfo.setContent("23456789000content");
         
         return configInfo;
+    }
+    
+    @Test
+    void testGenerateLikeArgumentEscapesUnderscore() {
+        assertEquals("data\\_id%", embeddedConfigInfoPersistService.generateLikeArgument(
+            "data_id*"));
+    }
+    
+    @Test
+    void testAddConfigInfoAtomicWithNullAdvanceInfoAndEncryptedKey() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        
+        long id = embeddedConfigInfoPersistService.addConfigInfoAtomic(7L, "srcIp", "srcUser",
+            configInfo, null);
+        
+        assertEquals(7L, id);
+        embeddedStorageContextHolderMockedStatic.verify(
+            () -> EmbeddedStorageContextHolder.addSqlContext(anyString(), eq(7L), eq("dataId"),
+                eq("group"), eq(StringUtils.EMPTY), eq(StringUtils.EMPTY), eq("content"),
+                eq(MD5Utils.md5Hex("content", Constants.PERSIST_ENCODE)), eq("srcIp"),
+                eq("srcUser"), eq(null), eq(null), eq(null), eq(null), eq(null),
+                eq(StringUtils.EMPTY)),
+            times(1));
     }
     
     @Test
@@ -801,6 +1056,27 @@ class EmbeddedConfigInfoPersistServiceImplTest {
                 tenant, configAdvanceInfo);
         assertEquals(result.size(), configInfo4Page.getPageItems().size());
         assertEquals(9, configInfo4Page.getTotalCount());
+    }
+    
+    @Test
+    void testFindConfigInfo4PageFillsConfigTags() {
+        Map<String, Object> configAdvanceInfo = new HashMap<>();
+        configAdvanceInfo.put("appName", "appName");
+        configAdvanceInfo.put("content", "content");
+        ConfigInfo configInfo = createMockConfigInfo(0);
+        configInfo.setTenant(StringUtils.EMPTY);
+        configInfo.setEncryptedDataKey(StringUtils.EMPTY);
+        when(databaseOperate.queryOne(anyString(), Mockito.<Object[]>any(),
+            eq(Integer.class))).thenReturn(1);
+        when(databaseOperate.queryMany(anyString(), Mockito.<Object[]>any(),
+            eq(CONFIG_INFO_ROW_MAPPER))).thenReturn(Collections.singletonList(configInfo));
+        when(databaseOperate.queryMany(anyString(), Mockito.<Object[]>any(), eq(String.class)))
+            .thenReturn(Arrays.asList("tag1", "tag2"));
+        
+        Page<ConfigInfo> page = embeddedConfigInfoPersistService.findConfigInfo4Page(1, 3,
+            "dataId", "group", "", configAdvanceInfo);
+        
+        assertEquals("tag1,tag2", page.getPageItems().get(0).getConfigTags());
     }
     
     @Test
@@ -916,6 +1192,26 @@ class EmbeddedConfigInfoPersistServiceImplTest {
     }
     
     @Test
+    void testFindConfigInfoLike4PageWithTypesAndReturnedTags() {
+        Map<String, Object> configAdvanceInfo = new HashMap<>();
+        configAdvanceInfo.put("types", "yaml,properties");
+        ConfigInfo configInfo = createMockConfigInfo(0);
+        configInfo.setTenant(StringUtils.EMPTY);
+        configInfo.setEncryptedDataKey(StringUtils.EMPTY);
+        when(databaseOperate.queryOne(anyString(), Mockito.<Object[]>any(),
+            eq(Integer.class))).thenReturn(1);
+        when(databaseOperate.queryMany(anyString(), Mockito.<Object[]>any(),
+            eq(CONFIG_INFO_ROW_MAPPER))).thenReturn(Collections.singletonList(configInfo));
+        when(databaseOperate.queryMany(anyString(), Mockito.<Object[]>any(), eq(String.class)))
+            .thenReturn(Arrays.asList("tag1", "tag2"));
+        
+        Page<ConfigInfo> page = embeddedConfigInfoPersistService.findConfigInfoLike4Page(1, 3,
+            "dataId*", "group*", "", configAdvanceInfo);
+        
+        assertEquals("tag1,tag2", page.getPageItems().get(0).getConfigTags());
+    }
+    
+    @Test
     void testFindChangeConfig() {
         
         //mock page list
@@ -999,6 +1295,22 @@ class EmbeddedConfigInfoPersistServiceImplTest {
         //expect check schema & tags.
         assertEquals(mockedAdvance.getSchema(), configAdvanceInfo.getSchema());
         assertEquals(String.join(",", mockTags), configAdvanceInfo.getConfigTags());
+    }
+    
+    @Test
+    void testFindConfigAdvanceInfoUsesEmptyTenant() {
+        ConfigAdvanceInfo mockedAdvance = new ConfigAdvanceInfo();
+        when(databaseOperate.queryMany(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}), eq(String.class)))
+            .thenReturn(Collections.emptyList());
+        when(databaseOperate.queryOne(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}),
+            eq(CONFIG_ADVANCE_INFO_ROW_MAPPER))).thenReturn(mockedAdvance);
+        
+        ConfigAdvanceInfo result = embeddedConfigInfoPersistService.findConfigAdvanceInfo(
+            "dataId", "group", null);
+        
+        assertEquals(mockedAdvance, result);
     }
     
     @Test
@@ -1088,6 +1400,34 @@ class EmbeddedConfigInfoPersistServiceImplTest {
     }
     
     @Test
+    void testFindAllConfigInfo4ExportReturnsEmptyList() {
+        when(databaseOperate.queryMany(anyString(), Mockito.<Object[]>any(),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(Collections.emptyList());
+        
+        List<ConfigAllInfo> result = embeddedConfigInfoPersistService.findAllConfigInfo4Export(
+            null, null, null, null, null);
+        
+        assertEquals(Collections.emptyList(), result);
+    }
+    
+    @Test
+    void testFindAllConfigInfo4ExportFillsConfigTags() {
+        ConfigAllInfo configAllInfo = createMockConfigAllInfo(1);
+        configAllInfo.setDataId("dataId");
+        configAllInfo.setGroup("group");
+        configAllInfo.setTenant(StringUtils.EMPTY);
+        when(databaseOperate.queryMany(anyString(), Mockito.<Object[]>any(),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(Collections.singletonList(configAllInfo));
+        when(databaseOperate.queryMany(anyString(), Mockito.<Object[]>any(), eq(String.class)))
+            .thenReturn(Arrays.asList("tag1", "tag2"));
+        
+        List<ConfigAllInfo> result = embeddedConfigInfoPersistService.findAllConfigInfo4Export(
+            "dataId", "group", "", null, null);
+        
+        assertEquals("tag1,tag2", result.get(0).getConfigTags());
+    }
+    
+    @Test
     void testQueryConfigInfoByNamespace() {
         
         //mock select config state
@@ -1104,6 +1444,23 @@ class EmbeddedConfigInfoPersistServiceImplTest {
                 tenant);
         //expect check
         assertEquals(mockConfigs, configInfoWrappers);
+    }
+    
+    @Test
+    void testQueryConfigInfoByNamespaceRejectsNullTenant() {
+        assertThrows(IllegalArgumentException.class,
+            () -> embeddedConfigInfoPersistService.queryConfigInfoByNamespace(null));
+    }
+    
+    @Test
+    void testQueryConfigInfoByNamespaceUsesEmptyTenant() {
+        when(databaseOperate.queryMany(anyString(), eq(new Object[] {StringUtils.EMPTY}),
+            eq(CONFIG_INFO_WRAPPER_ROW_MAPPER))).thenReturn(Collections.emptyList());
+        
+        List<ConfigInfoWrapper> result =
+            embeddedConfigInfoPersistService.queryConfigInfoByNamespace("");
+        
+        assertEquals(Collections.emptyList(), result);
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoTagPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigInfoTagPersistServiceImplTest.java
@@ -45,6 +45,8 @@ import java.util.List;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_TAG_WRAPPER_ROW_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -305,6 +307,35 @@ class EmbeddedConfigInfoTagPersistServiceImplTest {
         //execute & verify
         int count = embeddedConfigInfoTagPersistService.configInfoTagCount();
         assertEquals(308, count);
+    }
+    
+    @Test
+    void testConfigInfoTagCountThrowsWhenResultNull() {
+        Mockito.when(databaseOperate.queryOne(anyString(), eq(Integer.class))).thenReturn(null);
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> embeddedConfigInfoTagPersistService.configInfoTagCount());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4TagReturnsFalseWhenStateMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        
+        ConfigOperateResult result = embeddedConfigInfoTagPersistService.updateConfigInfo4Tag(
+            configInfo, "tag", "srcIp", "srcUser");
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4TagCasReturnsFalseWhenBlockUpdateFails() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        Mockito.when(databaseOperate.blockUpdate()).thenReturn(false);
+        
+        ConfigOperateResult result = embeddedConfigInfoTagPersistService.updateConfigInfo4TagCas(
+            configInfo, "tag", "srcIp", "srcUser");
+        
+        assertFalse(result.isSuccess());
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedHistoryConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedHistoryConfigInfoPersistServiceImplTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.HISTORY_DETAIL_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.HISTORY_LIST_ROW_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -259,6 +260,18 @@ class EmbeddedHistoryConfigInfoPersistServiceImplTest {
         int count = embeddedHistoryConfigInfoPersistService.findConfigHistoryCountByTime(timestamp);
         assertEquals(308, count);
         
+    }
+    
+    @Test
+    void testFindConfigHistoryCountByTimeThrowsWhenResultNull() {
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        Mockito
+            .when(databaseOperate.queryOne(anyString(), eq(new Object[] {timestamp}),
+                eq(Integer.class)))
+            .thenReturn(null);
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> embeddedHistoryConfigInfoPersistService.findConfigHistoryCountByTime(timestamp));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoBetaPersistServiceImplTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_BETA_WRAPPER_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -408,6 +409,30 @@ class ExternalConfigInfoBetaPersistServiceImplTest {
             assertEquals("get c fail", exception.getMessage());
         }
         
+    }
+    
+    @Test
+    void testUpdateConfigInfo4BetaReturnsFalseWhenStateMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {"dataId", "group", ""}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenThrow(new EmptyResultDataAccessException(1));
+        
+        ConfigOperateResult result = externalConfigInfoBetaPersistService.updateConfigInfo4Beta(
+            configInfo, "1.1.1.1", "srcIp", "srcUser");
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4BetaCasReturnsFalseWhenUpdateMisses() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        configInfo.setMd5("oldMd5");
+        
+        ConfigOperateResult result = externalConfigInfoBetaPersistService.updateConfigInfo4BetaCas(
+            configInfo, "1.1.1.1", "srcIp", "srcUser");
+        
+        assertFalse(result.isSuccess());
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoGrayPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoGrayPersistServiceImplTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.config.server.service.repository.extrnal;
 
 import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfoGrayWrapper;
 import com.alibaba.nacos.config.server.model.ConfigInfoStateWrapper;
@@ -51,6 +52,7 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -501,6 +503,70 @@ public class ExternalConfigInfoGrayPersistServiceImplTest {
     }
     
     @Test
+    void testAddConfigInfo4GrayWithBlankOptionalValuesReturnsFalseWhenStateMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenThrow(new EmptyResultDataAccessException(1));
+        
+        ConfigOperateResult result = externalConfigInfoGrayPersistService.addConfigInfo4Gray(
+            configInfo, " ", " ", "srcIp", "srcUser");
+        
+        assertTrue(!result.isSuccess());
+        Mockito.verify(jdbcTemplate, times(1)).update(anyString(), eq("dataId"), eq("group"),
+            eq(StringUtils.EMPTY), eq(StringUtils.EMPTY), eq(StringUtils.EMPTY),
+            eq(StringUtils.EMPTY), eq("content"), eq(StringUtils.EMPTY),
+            eq(MD5Utils.md5Hex("content", ENCODE)), eq("srcIp"), eq("srcUser"));
+    }
+    
+    @Test
+    void testUpdateConfigInfo4GrayReturnsFalseWhenOldGrayMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER)))
+            .thenThrow(new EmptyResultDataAccessException(1));
+        
+        ConfigOperateResult result = externalConfigInfoGrayPersistService.updateConfigInfo4Gray(
+            configInfo, " ", " ", "srcIp", "srcUser");
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4GrayCasReturnsFalseWhenOldGrayMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", null, null, "content");
+        when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER)))
+            .thenThrow(new EmptyResultDataAccessException(1));
+        
+        ConfigOperateResult result = externalConfigInfoGrayPersistService.updateConfigInfo4GrayCas(
+            configInfo, " ", " ", "srcIp", "srcUser");
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfo4GrayCasReturnsFalseWhenRowsNotUpdated() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", null, "content");
+        configInfo.setMd5("oldMd5");
+        ConfigInfoGrayWrapper oldGray = new ConfigInfoGrayWrapper();
+        oldGray.setGrayName("");
+        oldGray.setGrayRule("");
+        when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER))).thenReturn(oldGray);
+        when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any())).thenReturn(0);
+        
+        ConfigOperateResult result = externalConfigInfoGrayPersistService.updateConfigInfo4GrayCas(
+            configInfo, "", "", "srcIp", "srcUser");
+        
+        assertTrue(!result.isSuccess());
+    }
+    
+    @Test
     void testRemoveConfigInfo() {
         String dataId = "dataId4567";
         String group = "group3456789";
@@ -536,6 +602,31 @@ public class ExternalConfigInfoGrayPersistServiceImplTest {
             .thenThrow(
                 new CannotGetJdbcConnectionException("mock fail11111"));
         
+    }
+    
+    @Test
+    void testRemoveConfigInfoReturnsWhenGrayMissing() {
+        when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER)))
+            .thenThrow(new EmptyResultDataAccessException(1));
+        
+        externalConfigInfoGrayPersistService.removeConfigInfoGray("dataId", "group", null, "",
+            "srcIp", "srcUser");
+        
+        Mockito.verify(jdbcTemplate, times(0)).update(anyString(), Mockito.<Object[]>any());
+    }
+    
+    @Test
+    void testRemoveConfigInfoRethrowsConnectionException() {
+        when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY, StringUtils.EMPTY}),
+            eq(CONFIG_INFO_GRAY_WRAPPER_ROW_MAPPER)))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoGrayPersistService.removeConfigInfoGray("dataId", "group",
+                null, "", "srcIp", "srcUser"));
     }
     
     @Test
@@ -621,6 +712,28 @@ public class ExternalConfigInfoGrayPersistServiceImplTest {
         when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class))).thenReturn(101);
         int returnCount = externalConfigInfoGrayPersistService.configInfoGrayCount();
         assertEquals(101, returnCount);
+    }
+    
+    @Test
+    void testConfigInfoGrayCountRejectsNullResult() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class))).thenReturn(null);
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> externalConfigInfoGrayPersistService.configInfoGrayCount());
+    }
+    
+    @Test
+    void testFindConfigInfoGraysUsesEmptyTenant() {
+        List<String> grayNames = new ArrayList<>();
+        grayNames.add("gray");
+        when(jdbcTemplate.queryForList(anyString(),
+            eq(new Object[] {"dataId", "group", StringUtils.EMPTY}), eq(String.class)))
+            .thenReturn(grayNames);
+        
+        List<String> result = externalConfigInfoGrayPersistService.findConfigInfoGrays(
+            "dataId", "group", null);
+        
+        assertEquals(grayNames, result);
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
@@ -83,6 +84,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
@@ -441,6 +443,20 @@ class ExternalConfigInfoPersistServiceImplTest {
     }
     
     @Test
+    void testUpdateConfigInfoReturnsFalseWhenOldConfigMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "tenant", "app", "content");
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", "tenant"}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(null);
+        
+        ConfigOperateResult result =
+            externalConfigInfoPersistService.updateConfigInfo(configInfo, "srcIp", "srcUser",
+                null);
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
     void testInsertOrUpdateCasOfUpdateConfigSuccess() {
         Map<String, Object> configAdvanceInfo = new HashMap<>();
         configAdvanceInfo.put("config_tags", "tag1,tag2");
@@ -582,6 +598,75 @@ class ExternalConfigInfoPersistServiceImplTest {
     }
     
     @Test
+    void testCreatePsForInsertConfigInfoWithoutAdvanceInfo() throws SQLException {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "tenant", "app", "content");
+        Connection mockConnection = Mockito.mock(Connection.class);
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        ConfigInfoMapper configInfoMapper =
+            externalConfigInfoPersistService.mapperManager.findMapper(
+                dataSourceService.getDataSourceType(), TableConstant.CONFIG_INFO);
+        Mockito.when(mockConnection.prepareStatement(anyString(), any(String[].class)))
+            .thenReturn(preparedStatement);
+        
+        externalConfigInfoPersistService.createPsForInsertConfigInfo("srcIp", "srcUser",
+            configInfo, null, mockConnection, configInfoMapper);
+        
+        Mockito.verify(preparedStatement, times(14)).setString(anyInt(), nullable(String.class));
+    }
+    
+    @Test
+    void testAddConfigInfoReturnsFalseWhenInsertedStateMissing() {
+        GeneratedKeyHolder generatedKeyHolder = TestCaseUtils.createGeneratedKeyHolder(1L);
+        externalStorageUtilsMockedStatic.when(ExternalStorageUtils::createKeyHolder)
+            .thenReturn(generatedKeyHolder);
+        Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class),
+            eq(generatedKeyHolder))).thenReturn(1);
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "tenant", "app", "content");
+        
+        ConfigOperateResult result =
+            externalConfigInfoPersistService.addConfigInfo("srcIp", "srcUser", configInfo, null);
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testAddConfigInfoAtomicThrowsExceptionWhenGeneratedKeyMissing() {
+        externalStorageUtilsMockedStatic.when(ExternalStorageUtils::createKeyHolder)
+            .thenReturn(new GeneratedKeyHolder());
+        Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class),
+            any(KeyHolder.class))).thenReturn(1);
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "tenant", "app", "content");
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> externalConfigInfoPersistService.addConfigInfoAtomic(-1, "srcIp", "srcUser",
+                configInfo, null));
+    }
+    
+    @Test
+    void testAddConfigInfoAtomicExecutesPreparedStatementCreator() throws SQLException {
+        GeneratedKeyHolder generatedKeyHolder = TestCaseUtils.createGeneratedKeyHolder(7L);
+        externalStorageUtilsMockedStatic.when(ExternalStorageUtils::createKeyHolder)
+            .thenReturn(generatedKeyHolder);
+        Connection connection = Mockito.mock(Connection.class);
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        Mockito.when(connection.prepareStatement(anyString(), any(String[].class)))
+            .thenReturn(preparedStatement);
+        Mockito.doAnswer(invocation -> {
+            PreparedStatementCreator creator = invocation.getArgument(0);
+            creator.createPreparedStatement(connection);
+            return 1;
+        }).when(jdbcTemplate).update(any(PreparedStatementCreator.class), eq(generatedKeyHolder));
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        configInfo.setEncryptedDataKey("secretKey");
+        
+        long id = externalConfigInfoPersistService.addConfigInfoAtomic(1L, "srcIp", "srcUser",
+            configInfo, null);
+        
+        assertEquals(7L, id);
+        Mockito.verify(preparedStatement).setString(eq(14), eq("secretKey"));
+    }
+    
+    @Test
     void testRemoveConfigInfo() {
         String dataId = "dataId4567";
         String group = "group3456789";
@@ -665,6 +750,50 @@ class ExternalConfigInfoPersistServiceImplTest {
                 eq(srcUser), any(), eq("D"), eq("formal"), eq(null),
                 eq(ConfigExtInfoUtil.getExtInfoFromAllInfo(configAllInfos.get(0))));
         
+    }
+    
+    @Test
+    void testRemoveConfigInfoByIdsReturnsNullWhenIdsEmpty() {
+        assertNull(externalConfigInfoPersistService.removeConfigInfoByIds(new ArrayList<>(),
+            "srcIp", "srcUser"));
+    }
+    
+    @Test
+    void testRemoveConfigInfoRethrowsWhenFindOldConfigFails() {
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.removeConfigInfo("dataId", "group", "",
+                "srcIp", "srcUser"));
+    }
+    
+    @Test
+    void testRemoveConfigInfoByIdsRethrowsWhenFindOldConfigsFails() {
+        Mockito.when(jdbcTemplate.query(anyString(), Mockito.<Object[]>any(),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.removeConfigInfoByIds(
+                new ArrayList<>(Arrays.asList(1L, 2L)), "srcIp", "srcUser"));
+    }
+    
+    @Test
+    void testRemoveConfigInfoAtomicWithBlankTenant() {
+        externalConfigInfoPersistService.removeConfigInfoAtomic("dataId", "group", null, "srcIp",
+            "srcUser");
+        
+        Mockito.verify(jdbcTemplate, times(1)).update(anyString(), eq("dataId"), eq("group"),
+            eq(StringUtils.EMPTY));
+    }
+    
+    @Test
+    void testRemoveConfigInfoByIdsAtomicWithBlankIds() {
+        externalConfigInfoPersistService.removeConfigInfoByIdsAtomic("");
+        
+        Mockito.verify(jdbcTemplate, times(0)).update(anyString(), Mockito.<Object[]>any());
     }
     
     @Test
@@ -756,6 +885,65 @@ class ExternalConfigInfoPersistServiceImplTest {
         //skip config 3
         assertEquals(configInfoList.get(2).getDataId(),
             ((List<Map<String, String>>) stringObjectMap.get("skipData")).get(0).get("dataId"));
+    }
+    
+    @Test
+    void testBatchInsertOrUpdateWithNullAdvanceInfoAndDefaultType() throws NacosException {
+        List<ConfigAllInfo> configInfoList = new ArrayList<>();
+        ConfigAllInfo configAllInfo = createMockConfigAllInfo(0);
+        configAllInfo.setDataId("dataIdWithoutExtension");
+        configAllInfo.setEncryptedDataKey("cipherKey");
+        configAllInfo.setType(null);
+        configInfoList.add(configAllInfo);
+        TransactionTemplate transactionTemplateCurrent = Mockito.mock(TransactionTemplate.class);
+        ReflectionTestUtils.setField(externalConfigInfoPersistService, "tjt",
+            transactionTemplateCurrent);
+        Mockito.when(transactionTemplateCurrent.execute(any()))
+            .thenReturn(new ConfigOperateResult(true));
+        
+        Map<String, Object> result = externalConfigInfoPersistService.batchInsertOrUpdate(
+            configInfoList, "srcUser", "srcIp", null, SameConfigPolicy.SKIP);
+        
+        assertEquals(1, result.get("succCount"));
+        assertEquals(0, result.get("skipCount"));
+    }
+    
+    @Test
+    void testBatchInsertOrUpdateSkipsWhenInsertThrowsDataIntegrityViolationException()
+        throws NacosException {
+        List<ConfigAllInfo> configInfoList = Collections.singletonList(createMockConfigAllInfo(0));
+        TransactionTemplate transactionTemplateCurrent = Mockito.mock(TransactionTemplate.class);
+        ReflectionTestUtils.setField(externalConfigInfoPersistService, "tjt",
+            transactionTemplateCurrent);
+        Mockito.when(transactionTemplateCurrent.execute(any()))
+            .thenThrow(new DataIntegrityViolationException("duplicate"));
+        
+        Map<String, Object> result = externalConfigInfoPersistService.batchInsertOrUpdate(
+            configInfoList, "srcUser", "srcIp", new HashMap<>(), SameConfigPolicy.SKIP);
+        
+        assertEquals(0, result.get("succCount"));
+        assertEquals(1, result.get("skipCount"));
+    }
+    
+    @Test
+    void testBatchInsertOrUpdateRethrowsInvalidConfig() {
+        ConfigAllInfo configAllInfo = createMockConfigAllInfo(0);
+        configAllInfo.setDataId("");
+        
+        assertThrows(NacosException.class,
+            () -> externalConfigInfoPersistService.batchInsertOrUpdate(
+                Collections.singletonList(configAllInfo), "srcUser", "srcIp",
+                new HashMap<>(), SameConfigPolicy.SKIP));
+    }
+    
+    @Test
+    void testGetConfigInfoOperateResultReturnsFalseWhenStateMissing() {
+        ConfigOperateResult result = ReflectionTestUtils.invokeMethod(
+            externalConfigInfoPersistService, "getConfigInfoOperateResult", "dataId", "group",
+            "tenant");
+        
+        assertNotNull(result);
+        assertFalse(result.isSuccess());
     }
     
     private ConfigAllInfo createMockConfigAllInfo(long mockId) {
@@ -958,6 +1146,35 @@ class ExternalConfigInfoPersistServiceImplTest {
     }
     
     @Test
+    void testFindConfigInfo4PageWithAdvanceFilters() {
+        Map<String, Object> configAdvanceInfo = new HashMap<>();
+        configAdvanceInfo.put("appName", "appName");
+        configAdvanceInfo.put("content", "content");
+        ConfigInfo configInfo = createMockConfigInfo(0);
+        configInfo.setEncryptedDataKey("");
+        List<ConfigInfo> result = Collections.singletonList(configInfo);
+        when(jdbcTemplate.queryForObject(anyString(), Mockito.<Object[]>any(),
+            eq(Integer.class))).thenReturn(1);
+        when(jdbcTemplate.query(anyString(), Mockito.<Object[]>any(),
+            eq(CONFIG_INFO_ROW_MAPPER))).thenReturn(result);
+        
+        Page<ConfigInfo> page = externalConfigInfoPersistService.findConfigInfo4Page(1, 3,
+            "dataId", "group", "", configAdvanceInfo);
+        
+        assertEquals(1, page.getPageItems().size());
+    }
+    
+    @Test
+    void testFindConfigInfo4PageRethrowsConnectionException() {
+        when(jdbcTemplate.queryForObject(anyString(), Mockito.<Object[]>any(),
+            eq(Integer.class))).thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.findConfigInfo4Page(1, 3, "dataId", "group",
+                "", new HashMap<>()));
+    }
+    
+    @Test
     void testConfigInfoCount() {
         
         //mock total count
@@ -1068,6 +1285,33 @@ class ExternalConfigInfoPersistServiceImplTest {
         assertEquals(result.size(), configInfo4Page.getPageItems().size());
         assertEquals(9, configInfo4Page.getTotalCount());
         
+    }
+    
+    @Test
+    void testFindConfigInfoLike4PageWithTypes() {
+        Map<String, Object> configAdvanceInfo = new HashMap<>();
+        configAdvanceInfo.put("types", "yaml,properties");
+        ConfigInfo configInfo = createMockConfigInfo(0);
+        configInfo.setEncryptedDataKey("");
+        when(jdbcTemplate.queryForObject(anyString(), Mockito.<Object[]>any(),
+            eq(Integer.class))).thenReturn(1);
+        when(jdbcTemplate.query(anyString(), Mockito.<Object[]>any(),
+            eq(CONFIG_INFO_ROW_MAPPER))).thenReturn(Collections.singletonList(configInfo));
+        
+        Page<ConfigInfo> page = externalConfigInfoPersistService.findConfigInfoLike4Page(1, 3,
+            "dataId*", "group*", "", configAdvanceInfo);
+        
+        assertEquals(1, page.getPageItems().size());
+    }
+    
+    @Test
+    void testFindConfigInfoLike4PageRethrowsConnectionException() {
+        when(jdbcTemplate.queryForObject(anyString(), Mockito.<Object[]>any(),
+            eq(Integer.class))).thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.findConfigInfoLike4Page(1, 3, "dataId*",
+                "group*", "", new HashMap<>()));
     }
     
     @Test
@@ -1518,6 +1762,295 @@ class ExternalConfigInfoPersistServiceImplTest {
                 "d", "g", "", null, "newdesc");
         assertNotNull(result);
         assertTrue(result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfoMetadataRethrowsConnectionException() {
+        ConfigInfoWrapper wrapper = new ConfigInfoWrapper();
+        wrapper.setId(100L);
+        Mockito.when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {"d", "g", ""}),
+            eq(CONFIG_INFO_WRAPPER_ROW_MAPPER))).thenReturn(wrapper);
+        Mockito.when(jdbcTemplate.update(anyString(), eq("newdesc"), eq(100L)))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.updateConfigInfoMetadata(
+                "d", "g", "", null, "newdesc"));
+    }
+    
+    @Test
+    void testInsertOrUpdateCasRethrowsLookupException() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.insertOrUpdateCas("srcIp", "srcUser",
+                configInfo, null));
+    }
+    
+    @Test
+    void testUpdateConfigInfoWithTagsReturnsLastState() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setId(100L);
+        oldConfig.setDataId("dataId");
+        oldConfig.setGroup("group");
+        oldConfig.setTenant("");
+        oldConfig.setAppName("oldApp");
+        ConfigInfoStateWrapper state = new ConfigInfoStateWrapper();
+        state.setId(100L);
+        state.setLastModified(123L);
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(oldConfig);
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenReturn(state);
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any())).thenReturn(1);
+        Map<String, Object> advanceInfo = new HashMap<>();
+        advanceInfo.put("config_tags", "tag1,tag2");
+        
+        ConfigOperateResult result = externalConfigInfoPersistService.updateConfigInfo(
+            configInfo, "srcIp", "srcUser", advanceInfo);
+        
+        assertTrue(result.isSuccess());
+        assertEquals(100L, result.getId());
+        assertEquals(123L, result.getLastModified());
+    }
+    
+    @Test
+    void testAddConfigInfoAtomicThrowsWhenGeneratedKeyMissing() {
+        KeyHolder keyHolder = Mockito.mock(KeyHolder.class);
+        externalStorageUtilsMockedStatic.when(ExternalStorageUtils::createKeyHolder)
+            .thenReturn(keyHolder);
+        Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class), eq(keyHolder)))
+            .thenReturn(1);
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> externalConfigInfoPersistService.addConfigInfoAtomic(1L, "srcIp", "srcUser",
+                new ConfigInfo("dataId", "group", "", "app", "content"), null));
+    }
+    
+    @Test
+    void testAddConfigInfoAtomicRethrowsConnectionException() {
+        KeyHolder keyHolder = Mockito.mock(KeyHolder.class);
+        externalStorageUtilsMockedStatic.when(ExternalStorageUtils::createKeyHolder)
+            .thenReturn(keyHolder);
+        Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class), eq(keyHolder)))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.addConfigInfoAtomic(1L, "srcIp", "srcUser",
+                new ConfigInfo("dataId", "group", "", "app", "content"), null));
+    }
+    
+    @Test
+    void testAddConfigTagRelationAtomicRethrowsConnectionException() {
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any()))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.addConfigTagRelationAtomic(1L, "tag",
+                "dataId", "group", ""));
+    }
+    
+    @Test
+    void testRemoveTagByIdAtomicRethrowsConnectionException() {
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any()))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.removeTagByIdAtomic(1L));
+    }
+    
+    @Test
+    void testRemoveConfigInfoAtomicRethrowsConnectionException() {
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any()))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.removeConfigInfoAtomic("dataId", "group",
+                "", "srcIp", "srcUser"));
+    }
+    
+    @Test
+    void testRemoveConfigInfoByIdsAtomicRethrowsConnectionException() {
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any()))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.removeConfigInfoByIdsAtomic("1,2"));
+    }
+    
+    @Test
+    void testUpdateConfigInfoAtomicWithNullAdvanceInfoRethrowsConnectionException() {
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any()))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.updateConfigInfoAtomic(
+                new ConfigInfo("dataId", "group", "", null, "content"), "srcIp", "srcUser",
+                null));
+    }
+    
+    @Test
+    void testUpdateConfigInfoRethrowsConnectionExceptionFromAtomicUpdate() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setAppName("oldApp");
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(oldConfig);
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any()))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.updateConfigInfo(configInfo, "srcIp",
+                "srcUser", null));
+    }
+    
+    @Test
+    void testUpdateConfigInfoCasReturnsFalseWhenRowsZero() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setAppName("oldApp");
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(oldConfig);
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any())).thenReturn(0);
+        
+        ConfigOperateResult result =
+            externalConfigInfoPersistService.updateConfigInfoCas(configInfo, "srcIp", "srcUser",
+                null);
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfoCasReturnsFalseWhenOldConfigMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", null, "content");
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(null);
+        
+        ConfigOperateResult result =
+            externalConfigInfoPersistService.updateConfigInfoCas(configInfo, "srcIp", "srcUser",
+                null);
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfoCasReturnsFalseWhenUpdatedStateMissing() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setAppName("oldApp");
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(oldConfig);
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any())).thenReturn(1);
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenReturn(null);
+        
+        ConfigOperateResult result =
+            externalConfigInfoPersistService.updateConfigInfoCas(configInfo, "srcIp", "srcUser",
+                null);
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testUpdateConfigInfoCasWithTagsReturnsLastState() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setId(100L);
+        oldConfig.setDataId("dataId");
+        oldConfig.setGroup("group");
+        oldConfig.setTenant("");
+        oldConfig.setAppName("oldApp");
+        ConfigInfoStateWrapper state = new ConfigInfoStateWrapper();
+        state.setId(101L);
+        state.setLastModified(234L);
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(oldConfig);
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenReturn(state);
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any())).thenReturn(1);
+        Map<String, Object> advanceInfo = new HashMap<>();
+        advanceInfo.put("config_tags", "tag1,tag2");
+        
+        ConfigOperateResult result = externalConfigInfoPersistService.updateConfigInfoCas(
+            configInfo, "srcIp", "srcUser", advanceInfo);
+        
+        assertTrue(result.isSuccess());
+        assertEquals(101L, result.getId());
+        assertEquals(234L, result.getLastModified());
+    }
+    
+    @Test
+    void testUpdateConfigInfoCasRethrowsConnectionExceptionFromAtomicUpdate() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", null, "content");
+        ConfigAllInfo oldConfig = createMockConfigAllInfo(1);
+        oldConfig.setAppName("oldApp");
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", ""}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(oldConfig);
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any()))
+            .thenThrow(new CannotGetJdbcConnectionException("mock fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoPersistService.updateConfigInfoCas(
+                configInfo, "srcIp", "srcUser", null));
+    }
+    
+    @Test
+    void testFindAllConfigInfo4ExportFillsConfigTags() {
+        ConfigAllInfo configAllInfo = createMockConfigAllInfo(1);
+        configAllInfo.setDataId("dataId");
+        configAllInfo.setGroup("group");
+        configAllInfo.setTenant("");
+        Mockito.when(jdbcTemplate.query(anyString(), Mockito.<Object[]>any(),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(Collections.singletonList(configAllInfo));
+        Mockito.when(jdbcTemplate.queryForList(anyString(), Mockito.<Object[]>any(),
+            eq(String.class))).thenReturn(Arrays.asList("tag1", "tag2"));
+        
+        List<ConfigAllInfo> result = externalConfigInfoPersistService.findAllConfigInfo4Export(
+            "dataId", "group", "", null, null);
+        
+        assertEquals("tag1,tag2", result.get(0).getConfigTags());
+    }
+    
+    @Test
+    void testFindAllConfigInfo4ExportReturnsEmptyResult() {
+        Mockito.when(jdbcTemplate.query(anyString(), Mockito.<Object[]>any(),
+            eq(CONFIG_ALL_INFO_ROW_MAPPER))).thenReturn(Collections.emptyList());
+        
+        List<ConfigAllInfo> result = externalConfigInfoPersistService.findAllConfigInfo4Export(
+            "dataId", "group", "", null, null);
+        
+        assertTrue(result.isEmpty());
+    }
+    
+    @Test
+    void testQueryConfigInfoByNamespaceRejectsNullTenant() {
+        assertThrows(IllegalArgumentException.class,
+            () -> externalConfigInfoPersistService.queryConfigInfoByNamespace(null));
+    }
+    
+    @Test
+    void testQueryConfigInfoByNamespaceUsesEmptyTenant() {
+        Mockito.when(jdbcTemplate.query(anyString(), eq(new Object[] {StringUtils.EMPTY}),
+            eq(CONFIG_INFO_WRAPPER_ROW_MAPPER))).thenReturn(Collections.emptyList());
+        
+        List<ConfigInfoWrapper> result =
+            externalConfigInfoPersistService.queryConfigInfoByNamespace("");
+        
+        assertEquals(Collections.emptyList(), result);
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoTagPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoTagPersistServiceImplTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.config.server.service.repository.extrnal;
 
+import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
@@ -26,7 +27,6 @@ import com.alibaba.nacos.config.server.service.sql.ExternalStorageUtils;
 import com.alibaba.nacos.config.server.utils.TestCaseUtils;
 import com.alibaba.nacos.persistence.datasource.DataSourceService;
 import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
-import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +39,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.sql.Timestamp;
@@ -49,7 +50,9 @@ import java.util.List;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER;
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.CONFIG_INFO_TAG_WRAPPER_ROW_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -258,6 +261,46 @@ class ExternalConfigInfoTagPersistServiceImplTest {
     }
     
     @Test
+    void testInsertOrUpdateTagCasReturnsFalseWhenUpdateAffectsNoRows() {
+        String dataId = "dataId111222";
+        String group = "group";
+        String tenant = "tenant";
+        String appName = "appname1234";
+        String content = "c12345";
+        String tag = "tag123";
+        ConfigInfo configInfo = new ConfigInfo(dataId, group, tenant, appName, content);
+        configInfo.setMd5("casMd5");
+        Mockito
+            .when(jdbcTemplate.queryForObject(anyString(),
+                eq(new Object[] {dataId, group, tenant, tag}),
+                eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenReturn(new ConfigInfoStateWrapper());
+        Mockito.when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()),
+            eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.PERSIST_ENCODE)), anyString(),
+            anyString(), any(Timestamp.class), eq(appName), eq(dataId), eq(group), eq(tenant),
+            eq(tag), eq(configInfo.getMd5()))).thenReturn(0);
+        
+        ConfigOperateResult result = externalConfigInfoTagPersistService.insertOrUpdateTagCas(
+            configInfo, tag, "srcIp", "srcUser");
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
+    void testGetTagOperateResultReturnsFalseWhenStateMissing() {
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {"dataId", "group", "tenant", "tag"}),
+            eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenThrow(new EmptyResultDataAccessException(1));
+        
+        ConfigOperateResult result = ReflectionTestUtils.invokeMethod(
+            externalConfigInfoTagPersistService, "getTagOperateResult", "dataId", "group",
+            "tenant", "tag");
+        
+        assertFalse(result.isSuccess());
+    }
+    
+    @Test
     void testInsertOrUpdateTagCasOfException() {
         String dataId = "dataId111222";
         String group = "group";
@@ -324,6 +367,19 @@ class ExternalConfigInfoTagPersistServiceImplTest {
         } catch (Exception e) {
             assertEquals("throw exception update config tag", e.getMessage());
         }
+    }
+    
+    @Test
+    void testUpdateConfigInfo4TagRethrowsConnectionException() {
+        ConfigInfo configInfo = new ConfigInfo("dataId", "group", "", "app", "content");
+        Mockito.when(jdbcTemplate.update(anyString(), eq(configInfo.getContent()),
+            eq(MD5Utils.md5Hex(configInfo.getContent(), Constants.ENCODE)), eq("srcIp"),
+            eq("srcUser"), any(Timestamp.class), eq("app"), eq("dataId"), eq("group"), eq(""),
+            eq("tag"))).thenThrow(new CannotGetJdbcConnectionException("update fail"));
+        
+        assertThrows(CannotGetJdbcConnectionException.class,
+            () -> externalConfigInfoTagPersistService.updateConfigInfo4Tag(configInfo, "tag",
+                "srcIp", "srcUser"));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalHistoryConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalHistoryConfigInfoPersistServiceImplTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -46,6 +47,7 @@ import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapper
 import static com.alibaba.nacos.config.server.service.repository.ConfigRowMapperInjector.HISTORY_LIST_ROW_MAPPER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -374,6 +376,17 @@ class ExternalHistoryConfigInfoPersistServiceImplTest {
             externalHistoryConfigInfoPersistService.getNextHistoryInfo("d", "g", "t",
                 "formal", null, 1L);
         assertNull(result);
+    }
+    
+    @Test
+    void testGetNextHistoryInfoRethrowsDataAccessException() {
+        Mockito.when(jdbcTemplate.queryForObject(anyString(), Mockito.any(Object[].class),
+            eq(HISTORY_DETAIL_ROW_MAPPER)))
+            .thenThrow(new DataAccessResourceFailureException("db failed"));
+        
+        assertThrows(DataAccessResourceFailureException.class,
+            () -> externalHistoryConfigInfoPersistService.getNextHistoryInfo("d", "g", "t",
+                "formal", null, 1L));
     }
     
     private ConfigHistoryInfo createMockConfigHistoryInfo(long mockId) {

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/sql/ExternalStorageUtilsTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/sql/ExternalStorageUtilsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.service.sql;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class ExternalStorageUtilsTest {
+    
+    @Test
+    void testCreateKeyHolder() {
+        KeyHolder keyHolder = ExternalStorageUtils.createKeyHolder();
+        
+        assertInstanceOf(GeneratedKeyHolder.class, keyHolder);
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/trace/ConfigTraceServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/trace/ConfigTraceServiceTest.java
@@ -16,11 +16,57 @@
 
 package com.alibaba.nacos.config.server.service.trace;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import com.alibaba.nacos.config.server.utils.LogUtil;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ConfigTraceServiceTest {
+    
+    @BeforeAll
+    static void setUpEnvironment() {
+        EnvUtil.setEnvironment(new MockEnvironment());
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new ConfigTraceService());
+    }
+    
+    @Test
+    void testLogEventsReturnWhenTraceLogDisabled() {
+        Logger traceLogger = (Logger) LogUtil.TRACE_LOG;
+        Level originalLevel = traceLogger.getLevel();
+        traceLogger.setLevel(Level.OFF);
+        try {
+            assertDoesNotThrow(() -> ConfigTraceService.logPersistenceEvent(
+                "dataId", "group", "tenant", "app", System.currentTimeMillis(),
+                "127.0.0.1", ConfigTraceService.PERSISTENCE_EVENT,
+                ConfigTraceService.PERSISTENCE_TYPE_PUB, "content"));
+            assertDoesNotThrow(() -> ConfigTraceService.logNotifyEvent(
+                "dataId", "group", "tenant", "app", System.currentTimeMillis(),
+                "127.0.0.1", ConfigTraceService.NOTIFY_EVENT,
+                ConfigTraceService.NOTIFY_TYPE_OK, 100L, "10.0.0.1"));
+            assertDoesNotThrow(() -> ConfigTraceService.logDumpEvent(
+                "dataId", "group", "tenant", "app", System.currentTimeMillis(),
+                "127.0.0.1", ConfigTraceService.DUMP_TYPE_OK, 50L, 1024L));
+            assertDoesNotThrow(() -> ConfigTraceService.logDumpAllEvent(
+                "dataId", "group", "tenant", "app", System.currentTimeMillis(),
+                "127.0.0.1", ConfigTraceService.DUMP_TYPE_OK));
+            assertDoesNotThrow(() -> ConfigTraceService.logPullEvent(
+                "dataId", "group", "tenant", "app", System.currentTimeMillis(),
+                ConfigTraceService.PULL_EVENT, ConfigTraceService.PULL_TYPE_OK,
+                200L, "10.0.0.1", false, "http"));
+        } finally {
+            traceLogger.setLevel(originalLevel);
+        }
+    }
     
     @Test
     void testLogPersistenceEvent() {

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/ConfigExtInfoUtilTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/ConfigExtInfoUtilTest.java
@@ -148,6 +148,24 @@ class ConfigExtInfoUtilTest {
     }
     
     @Test
+    void testGetExtraInfoFromAdvanceInfoMapReturnsNullWhenMapThrowsException() {
+        Map<String, Object> map = new HashMap<>() {
+            
+            @Override
+            public boolean isEmpty() {
+                return false;
+            }
+            
+            @Override
+            public Object get(Object key) {
+                throw new IllegalStateException("broken map");
+            }
+        };
+        
+        assertNull(ConfigExtInfoUtil.getExtraInfoFromAdvanceInfoMap(map, "user"));
+    }
+    
+    @Test
     void testExt4GrayWithPartialGrayRule() {
         String partialGrayRule = "{\"type\":\"tag\"}";
         String result =

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/ContentUtilsTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/ContentUtilsTest.java
@@ -73,6 +73,11 @@ class ContentUtilsTest {
     }
     
     @Test
+    void testVerifyIncrementPubContentAllowsPlainContent() {
+        ContentUtils.verifyIncrementPubContent("plain-content");
+    }
+    
+    @Test
     void testGetContentIdentity() {
         String content = "abc" + Constants.WORD_SEPARATOR + "edf";
         String result = ContentUtils.getContentIdentity(content);

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/GroupKey2Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/GroupKey2Test.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
@@ -33,41 +32,18 @@ class GroupKey2Test {
     
     @Test
     void testParseInvalidGroupKey2() {
-        String key = "11111+222+333333+444";
-        try {
-            GroupKey2.parseKey(key);
-            fail();
-        } catch (IllegalArgumentException e) {
-            System.out.println(e.toString());
-        }
+        assertThrows(IllegalArgumentException.class,
+            () -> GroupKey2.parseKey("11111+222+333333+444"));
+        assertThrows(IllegalArgumentException.class, () -> GroupKey2.parseKey("11111+"));
+        assertThrows(IllegalArgumentException.class, () -> GroupKey2.parseKey("11111%29+222"));
+        assertThrows(IllegalArgumentException.class, () -> GroupKey2.parseKey("11111%2b+222"));
         
-        key = "11111+";
-        try {
-            GroupKey2.parseKey(key);
-            fail();
-        } catch (IllegalArgumentException e) {
-            System.out.println(e.toString());
-        }
-        
-        key = "11111%29+222";
-        try {
-            GroupKey2.parseKey(key);
-            fail();
-        } catch (IllegalArgumentException e) {
-            System.out.println(e.toString());
-        }
-        
-        key = "11111%2b+222";
-        try {
-            GroupKey2.parseKey(key);
-            fail();
-        } catch (IllegalArgumentException e) {
-            System.out.println(e.toString());
-        }
-        
-        key = "11111%25+222";
-        String[] pair = GroupKey2.parseKey(key);
+        String[] pair = GroupKey2.parseKey("11111%25+222");
         assertEquals("11111%", pair[0]);
+        assertEquals("222", pair[1]);
+        
+        pair = GroupKey2.parseKey("11111%2B+222");
+        assertEquals("11111+", pair[0]);
         assertEquals("222", pair[1]);
     }
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/GroupKeyTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/GroupKeyTest.java
@@ -69,6 +69,10 @@ class GroupKeyTest {
         String[] pair = GroupKey.parseKey(key);
         assertEquals("11111%", pair[0]);
         assertEquals("222", pair[1]);
+        
+        pair = GroupKey.parseKey("11111%2B+222");
+        assertEquals("11111+", pair[0]);
+        assertEquals("222", pair[1]);
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/MD5UtilTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/MD5UtilTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -172,6 +173,15 @@ class MD5UtilTest {
     }
     
     @Test
+    void testToStringUsesDefaultEncodingWhenEncodingIsNull() throws IOException {
+        InputStream input = IOUtils.toInputStream("test", StandardCharsets.UTF_8);
+        
+        String actualValue = MD5Util.toString(input, null);
+        
+        assertEquals("test", actualValue);
+    }
+    
+    @Test
     void testToStringV2() {
         
         try {
@@ -198,6 +208,17 @@ class MD5UtilTest {
         } catch (IOException e) {
             System.out.println(e.toString());
         }
+    }
+    
+    @Test
+    void testCopyEmptyReader() throws IOException {
+        Reader input = new CharArrayReader(new char[0]);
+        Writer output = new CharArrayWriter();
+        
+        long actualValue = MD5Util.copy(input, output);
+        
+        assertEquals(0, actualValue);
+        assertEquals("", output.toString());
     }
     
     @Test
@@ -243,5 +264,19 @@ class MD5UtilTest {
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("too much key"));
         }
+    }
+    
+    @Test
+    void testGetClientMd5MapTooManyListeners() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i <= 10000; i++) {
+            sb.append("d").append(i).append(MD5Util.WORD_SEPARATOR_CHAR);
+            sb.append("g").append(i).append(MD5Util.WORD_SEPARATOR_CHAR);
+            sb.append("md5").append(i).append(MD5Util.LINE_SEPARATOR_CHAR);
+        }
+        
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> MD5Util.getClientMd5Map(sb.toString()));
+        assertTrue(exception.getMessage().contains("too much listener"));
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/PropertyUtilTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/PropertyUtilTest.java
@@ -32,7 +32,9 @@ import java.lang.reflect.Field;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(SpringExtension.class)
@@ -51,8 +53,10 @@ class PropertyUtilTest {
     }
     
     @AfterEach
-    void after() {
+    void after() throws Exception {
         envUtilMockedStatic.close();
+        resetPropertyValues();
+        clearAllDumpFiled();
         File file = new File(mockMem);
         if (file.exists()) {
             file.delete();
@@ -83,6 +87,31 @@ class PropertyUtilTest {
         Field limitMemoryFileFiled = FieldUtils.getField(PropertyUtil.class, "limitMemoryFile");
         limitMemoryFileFiled.setAccessible(true);
         limitMemoryFileFiled.set(null, null);
+    }
+    
+    private void resetPropertyValues() throws Exception {
+        PropertyUtil.setDumpChangeOn(true);
+        PropertyUtil.setDumpChangeWorkerInterval(30 * 1000L);
+        PropertyUtil.setNotifyConnectTimeout(100);
+        PropertyUtil.setNotifySocketTimeout(200);
+        PropertyUtil.setMaxHealthCheckFailCount(12);
+        PropertyUtil.setHealthCheck(true);
+        PropertyUtil.setMaxContent(10 * 1024 * 1024);
+        PropertyUtil.setManageCapacity(true);
+        PropertyUtil.setDefaultClusterQuota(100000);
+        PropertyUtil.setCapacityLimitCheck(false);
+        PropertyUtil.setDefaultGroupQuota(200);
+        PropertyUtil.setDefaultTenantQuota(200);
+        PropertyUtil.setInitialExpansionPercent(100);
+        PropertyUtil.setDefaultMaxSize(100 * 1024);
+        PropertyUtil.setDefaultMaxAggrCount(10000);
+        PropertyUtil.setGrayCompatibleModel(true);
+        PropertyUtil.setDefaultMaxAggrSize(1024);
+        PropertyUtil.setCorrectUsageDelay(10 * 60);
+        Field configRententionDaysField =
+            FieldUtils.getField(PropertyUtil.class, "configRententionDays");
+        configRententionDaysField.setAccessible(true);
+        configRententionDaysField.set(null, 30);
     }
     
     @Test
@@ -187,5 +216,119 @@ class PropertyUtilTest {
         String result = (String) m.invoke(new PropertyUtil(), "test.key.existing",
             "default");
         assertEquals("actual_value", result);
+    }
+    
+    @Test
+    void testGetStringDefaultValue() throws Exception {
+        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq("test.key.missing")))
+            .thenReturn(null);
+        
+        java.lang.reflect.Method method = PropertyUtil.class.getDeclaredMethod("getString",
+            String.class, String.class);
+        method.setAccessible(true);
+        
+        String result = (String) method.invoke(new PropertyUtil(), "test.key.missing",
+            "default");
+        
+        assertEquals("default", result);
+    }
+    
+    @Test
+    void testAccessors() {
+        PropertyUtil.setDumpChangeWorkerInterval(1L);
+        PropertyUtil.setNotifyConnectTimeout(2);
+        PropertyUtil.setNotifySocketTimeout(3);
+        PropertyUtil.setMaxHealthCheckFailCount(4);
+        PropertyUtil.setHealthCheck(false);
+        PropertyUtil.setMaxContent(5);
+        PropertyUtil.setManageCapacity(false);
+        PropertyUtil.setDefaultClusterQuota(6);
+        PropertyUtil.setCapacityLimitCheck(true);
+        PropertyUtil.setDefaultGroupQuota(7);
+        PropertyUtil.setDefaultTenantQuota(8);
+        PropertyUtil.setInitialExpansionPercent(9);
+        PropertyUtil.setDefaultMaxSize(10);
+        PropertyUtil.setDefaultMaxAggrCount(11);
+        PropertyUtil.setGrayCompatibleModel(false);
+        PropertyUtil.setDefaultMaxAggrSize(12);
+        PropertyUtil.setCorrectUsageDelay(13);
+        
+        assertEquals(1L, PropertyUtil.getDumpChangeWorkerInterval());
+        assertEquals(2, PropertyUtil.getNotifyConnectTimeout());
+        assertEquals(3, PropertyUtil.getNotifySocketTimeout());
+        assertEquals(4, PropertyUtil.getMaxHealthCheckFailCount());
+        assertFalse(PropertyUtil.isHealthCheck());
+        assertEquals(5, PropertyUtil.getMaxContent());
+        assertFalse(PropertyUtil.isManageCapacity());
+        assertEquals(6, PropertyUtil.getDefaultClusterQuota());
+        assertTrue(PropertyUtil.isCapacityLimitCheck());
+        assertEquals(7, PropertyUtil.getDefaultGroupQuota());
+        assertEquals(8, PropertyUtil.getDefaultTenantQuota());
+        assertEquals(9, PropertyUtil.getInitialExpansionPercent());
+        assertEquals(10, PropertyUtil.getDefaultMaxSize());
+        assertEquals(11, PropertyUtil.getDefaultMaxAggrCount());
+        assertFalse(PropertyUtil.isGrayCompatibleModel());
+        assertEquals(12, PropertyUtil.getDefaultMaxAggrSize());
+        assertEquals(13, PropertyUtil.getCorrectUsageDelay());
+    }
+    
+    @Test
+    void testInitialize() {
+        mockPropertyWithDefault("notifyConnectTimeout", "101");
+        mockPropertyWithDefault("notifySocketTimeout", "202");
+        mockPropertyWithDefault("isHealthCheck", "false");
+        mockPropertyWithDefault("maxHealthCheckFailCount", "3");
+        mockPropertyWithDefault("maxContent", "123");
+        mockPropertyWithDefault("isManageCapacity", "false");
+        mockPropertyWithDefault("isCapacityLimitCheck", "true");
+        mockPropertyWithDefault("defaultClusterQuota", "10");
+        mockPropertyWithDefault("defaultGroupQuota", "11");
+        mockPropertyWithDefault("defaultTenantQuota", "12");
+        mockPropertyWithDefault("defaultMaxSize", "13");
+        mockPropertyWithDefault("defaultMaxAggrCount", "14");
+        mockPropertyWithDefault("defaultMaxAggrSize", "15");
+        mockPropertyWithDefault("correctUsageDelay", "16");
+        mockPropertyWithDefault("initialExpansionPercent", "17");
+        mockPropertyWithDefault("dumpChangeOn", "false");
+        mockPropertyWithDefault("dumpChangeWorkerInterval", "18000");
+        mockPropertyWithDefault("nacos.config.gray.compatible.model", "false");
+        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq("nacos.config.retention.days")))
+            .thenReturn("19");
+        
+        new PropertyUtil().initialize(null);
+        
+        assertEquals(101, PropertyUtil.getNotifyConnectTimeout());
+        assertEquals(202, PropertyUtil.getNotifySocketTimeout());
+        assertFalse(PropertyUtil.isHealthCheck());
+        assertEquals(3, PropertyUtil.getMaxHealthCheckFailCount());
+        assertEquals(123, PropertyUtil.getMaxContent());
+        assertFalse(PropertyUtil.isManageCapacity());
+        assertTrue(PropertyUtil.isCapacityLimitCheck());
+        assertEquals(10, PropertyUtil.getDefaultClusterQuota());
+        assertEquals(11, PropertyUtil.getDefaultGroupQuota());
+        assertEquals(12, PropertyUtil.getDefaultTenantQuota());
+        assertEquals(13, PropertyUtil.getDefaultMaxSize());
+        assertEquals(14, PropertyUtil.getDefaultMaxAggrCount());
+        assertEquals(15, PropertyUtil.getDefaultMaxAggrSize());
+        assertEquals(16, PropertyUtil.getCorrectUsageDelay());
+        assertEquals(17, PropertyUtil.getInitialExpansionPercent());
+        assertEquals(19, PropertyUtil.getConfigRententionDays());
+        assertFalse(PropertyUtil.isDumpChangeOn());
+        assertEquals(18000L, PropertyUtil.getDumpChangeWorkerInterval());
+        assertFalse(PropertyUtil.isGrayCompatibleModel());
+    }
+    
+    @Test
+    void testInitializeWhenPropertyInvalidThrowsException() {
+        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq("notifyConnectTimeout"),
+            anyString())).thenReturn("invalid");
+        
+        assertThrows(NumberFormatException.class, () -> new PropertyUtil().initialize(null));
+    }
+    
+    private void mockPropertyWithDefault(String key, String value) {
+        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq(key), anyString()))
+            .thenReturn(value);
+        envUtilMockedStatic.when(() -> EnvUtil.getProperty(eq(key))).thenReturn(value);
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/ResponseUtilTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/ResponseUtilTest.java
@@ -27,13 +27,18 @@ import com.alibaba.nacos.config.server.model.ConfigHistoryInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfoGrayWrapper;
 import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.sql.Timestamp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ResponseUtilTest {
     
@@ -49,6 +54,16 @@ class ResponseUtilTest {
         } catch (UnsupportedEncodingException e) {
             System.out.println(e.toString());
         }
+    }
+    
+    @Test
+    void testWriteErrMsgIgnoresWriterIoException() throws IOException {
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getWriter()).thenThrow(new IOException("mock error"));
+        
+        ResponseUtil.writeErrMsg(response, 500, "error");
+        
+        verify(response).setStatus(500);
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/SimpleCacheTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/SimpleCacheTest.java
@@ -37,4 +37,13 @@ class SimpleCacheTest {
         assertNull(value);
     }
     
+    @Test
+    void testPutIgnoresNullKeyOrValue() {
+        SimpleCache<String> simpleCache = new SimpleCache<>();
+        simpleCache.put(null, "value", 1000);
+        simpleCache.put("key", null, 1000);
+        
+        assertNull(simpleCache.get("key"));
+    }
+    
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/SimpleIpFlowDataTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/SimpleIpFlowDataTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.config.server.utils;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SimpleIpFlowDataTest {
@@ -51,6 +52,18 @@ class SimpleIpFlowDataTest {
         SimpleIpFlowData data = new SimpleIpFlowData(3, 10000);
         assertEquals(1, data.incrementAndGet(null));
         assertEquals(1, data.getCurrentCount(null));
+    }
+    
+    @Test
+    void testNegativeHashIp() {
+        SimpleIpFlowData data = new SimpleIpFlowData(5, 10000);
+        assertEquals(1, data.incrementAndGet("client-ip"));
+        assertEquals(1, data.getCurrentCount("client-ip"));
+    }
+    
+    @Test
+    void testNonPositiveSlotCountUsesMinimumSlotCount() {
+        assertDoesNotThrow(() -> new SimpleIpFlowData(0, 10000));
     }
     
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/SimpleReadWriteLockTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/SimpleReadWriteLockTest.java
@@ -79,4 +79,12 @@ class SimpleReadWriteLockTest {
         
         assertFalse(lock.tryWriteLock());
     }
+    
+    @Test
+    void testReleaseReadLockWithoutReadLockDoesNothing() {
+        SimpleReadWriteLock lock = new SimpleReadWriteLock();
+        lock.releaseReadLock();
+        
+        assertTrue(lock.tryWriteLock());
+    }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/SystemConfigTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/SystemConfigTest.java
@@ -16,16 +16,59 @@
 
 package com.alibaba.nacos.config.server.utils;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
+import java.lang.reflect.Method;
+import java.net.NetworkInterface;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mockStatic;
 
 class SystemConfigTest {
     
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("nacos.server.ip");
+    }
+    
     @Test
     void testGetHostAddress() {
-        System.setProperty("nacos.server.ip", "127.0.0.1");
-        assertEquals("127.0.0.1", SystemConfig.LOCAL_IP);
+        assertNotNull(SystemConfig.LOCAL_IP);
+    }
+    
+    @Test
+    void testGetHostAddressFromSystemProperty() throws Exception {
+        System.setProperty("nacos.server.ip", "1.1.1.1");
+        
+        assertEquals("1.1.1.1", invokeGetHostAddress());
+    }
+    
+    @Test
+    void testGetHostAddressFromLocalNetwork() throws Exception {
+        System.clearProperty("nacos.server.ip");
+        
+        assertNotNull(invokeGetHostAddress());
+    }
+    
+    @Test
+    void testGetHostAddressWhenNetworkInterfaceThrowsException() {
+        System.clearProperty("nacos.server.ip");
+        try (MockedStatic<NetworkInterface> networkInterface = mockStatic(NetworkInterface.class)) {
+            networkInterface.when(NetworkInterface::getNetworkInterfaces)
+                .thenThrow(new RuntimeException("test"));
+            
+            assertDoesNotThrow(() -> assertNotNull(invokeGetHostAddress()));
+        }
+    }
+    
+    private String invokeGetHostAddress() throws Exception {
+        Method method = SystemConfig.class.getDeclaredMethod("getHostAddress");
+        method.setAccessible(true);
+        return (String) method.invoke(null);
     }
     
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/TimeoutUtilsTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/TimeoutUtilsTest.java
@@ -51,4 +51,13 @@ class TimeoutUtilsTest {
         timeoutUtils.resetTotalTime();
         assertEquals(0L, timeoutUtils.getTotalTime().get());
     }
+    
+    @Test
+    void testInitLastResetTimeOnlyOnce() {
+        TimeoutUtils timeoutUtils = new TimeoutUtils(10, 1000);
+        timeoutUtils.initLastResetTime();
+        timeoutUtils.initLastResetTime();
+        
+        assertEquals(0L, timeoutUtils.getTotalTime().get());
+    }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/UrlAnalysisUtilsTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/UrlAnalysisUtilsTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.config.server.utils;
 
+import com.alibaba.nacos.config.server.constant.Constants;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,5 +35,13 @@ class UrlAnalysisUtilsTest {
         
         String url3 = "";
         assertNull(UrlAnalysisUtils.getContentIdentity(url3));
+    }
+    
+    @Test
+    void testGetContentIdentityRejectsInvalidContent() {
+        assertNull(UrlAnalysisUtils.getContentIdentity(null));
+        assertNull(UrlAnalysisUtils.getContentIdentity("127.0.0.1:8080\npath"));
+        assertNull(UrlAnalysisUtils.getContentIdentity("127.0.0.1:8080"
+            + Constants.WORD_SEPARATOR + "path"));
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/YamlParserUtilTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/YamlParserUtilTest.java
@@ -16,16 +16,23 @@
 
 package com.alibaba.nacos.config.server.utils;
 
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.config.server.model.ConfigMetadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.constructor.ConstructorException;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.Tag;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class YamlParserUtilTest {
@@ -53,6 +60,11 @@ class YamlParserUtilTest {
         item2.setType("yaml");
         item2.setAppName("testAppName");
         item2.setDesc("test desc");
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new YamlParserUtil());
     }
     
     @Test
@@ -87,6 +99,26 @@ class YamlParserUtilTest {
         assertThrows(ConstructorException.class, () -> {
             YamlParserUtil.loadObject("name: test", YamlTest.class);
         });
+    }
+    
+    @Test
+    void testConstructYamlConfigMetadataRejectsWrongTag() {
+        Node node = new MappingNode(new Tag("!wrong"), Collections.emptyList(),
+            DumperOptions.FlowStyle.BLOCK);
+        YamlParserUtil.ConstructYamlConfigMetadata construct =
+            new YamlParserUtil.ConstructYamlConfigMetadata();
+        
+        assertThrows(NacosRuntimeException.class, () -> construct.construct(node));
+    }
+    
+    @Test
+    void testConstructYamlConfigMetadataReturnsNullWhenNodeEmpty() {
+        Node node = new MappingNode(YamlParserUtil.YamlParserConstructor.CONFIG_METADATA_TAG,
+            Collections.emptyList(), DumperOptions.FlowStyle.BLOCK);
+        YamlParserUtil.ConstructYamlConfigMetadata construct =
+            new YamlParserUtil.ConstructYamlConfigMetadata();
+        
+        assertNull(construct.construct(node));
     }
     
     private static class YamlTest {

--- a/config/src/test/java/com/alibaba/nacos/config/server/utils/ZipUtilsTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/utils/ZipUtilsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -34,11 +35,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ZipUtilsTest {
     
     @Test
+    void testConstructor() {
+        assertNotNull(new ZipUtils());
+    }
+    
+    @Test
     void testZip() {
         List<ZipUtils.ZipItem> zipItemList = new ArrayList<>();
         zipItemList.add(new ZipUtils.ZipItem("test", "content"));
         byte[] zip = ZipUtils.zip(zipItemList);
         assertTrue(zip != null && zip.length > 0);
+    }
+    
+    @Test
+    void testZipReturnsNullWhenDuplicateEntryFails() {
+        List<ZipUtils.ZipItem> zipItemList = new ArrayList<>();
+        zipItemList.add(new ZipUtils.ZipItem("test", "content"));
+        zipItemList.add(new ZipUtils.ZipItem("test", "duplicate"));
+        
+        assertNull(ZipUtils.zip(zipItemList));
     }
     
     @Test
@@ -97,6 +112,35 @@ class ZipUtilsTest {
         }
         ZipUtils.UnZipResult result = ZipUtils.unzip(baos.toByteArray());
         assertEquals(1, result.getZipItemList().size());
+    }
+    
+    @Test
+    void testUnzipIgnoresCorruptedEntry() {
+        List<ZipUtils.ZipItem> zipItemList = new ArrayList<>();
+        zipItemList.add(new ZipUtils.ZipItem("test", "content"));
+        byte[] zip = ZipUtils.zip(zipItemList);
+        
+        ZipUtils.UnZipResult result = ZipUtils.unzip(Arrays.copyOf(zip, zip.length / 2));
+        
+        assertNotNull(result);
+    }
+    
+    @Test
+    void testUnzipIgnoresMalformedLocalHeaders() {
+        byte[] malformedEntryData = new byte[] {
+            0x50, 0x4b, 0x03, 0x04, 20, 0, 0, 0, 8, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 5, 0,
+            0, 0, 5, 0, 0, 0, 4, 0, 0, 0,
+            't', 'e', 's', 't', 1, 2, 3, 4, 5
+        };
+        byte[] truncatedHeader = new byte[] {
+            0x50, 0x4b, 0x03, 0x04, 20, 0, 0, 0, 8, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 5, 0,
+            0, 0, 5, 0, 0, 0, 4, 0, 0, 0
+        };
+        
+        assertNotNull(ZipUtils.unzip(malformedEntryData));
+        assertNotNull(ZipUtils.unzip(truncatedHeader));
     }
     
     @Test


### PR DESCRIPTION
## Summary
- Add and extend config module unit tests across controllers, services, repositories, dump logic, query chain, and utility classes.
- Improve line coverage for reachable code paths while excluding legacy config migration paths that are planned for removal.
- Record remaining missed lines as unreachable or unsuitable for forced unit coverage, such as fixed UTF-8 exception fallbacks and JVM/static environment branches.

## Test
- source ~/Documents/switch17.sh && ./mvnw test -pl config -am
- source ~/Documents/switch17.sh && ./mvnw -pl config spotless:apply
- git diff --cached --check