### PR TITLE
fix(naming): close addPublisherIndexes race that re-emits ADD_SERVICE

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManager.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManager.java
@@ -134,14 +134,21 @@ public class ClientServiceIndexesManager extends SmartSubscriber {
     }
     
     private void addPublisherIndexes(Service service, String clientId) {
-        String serviceChangedType = Constants.ServiceChangedType.INSTANCE_CHANGED;
-        if (!publisherIndexes.containsKey(service)) {
-            // The only time the index needs to be updated is when the service is first created
-            serviceChangedType = Constants.ServiceChangedType.ADD_SERVICE;
-        }
-        NotifyCenter
-            .publishEvent(new ServiceEvent.ServiceChangedEvent(service, serviceChangedType, true));
-        publisherIndexes.computeIfAbsent(service, key -> new ConcurrentHashSet<>()).add(clientId);
+        // Detect the first registration atomically: only the thread whose mapping function actually
+        // ran on ConcurrentHashMap#computeIfAbsent sets firstInsert[0] = true, so concurrent
+        // first-time registrations of the same service no longer each see containsKey == false and
+        // each emit an ADD_SERVICE event. The event is also published only after the index entry
+        // exists, so subscribers that re-query the map on ADD_SERVICE no longer race the writer.
+        boolean[] firstInsert = {false};
+        publisherIndexes.computeIfAbsent(service, key -> {
+            firstInsert[0] = true;
+            return new ConcurrentHashSet<>();
+        }).add(clientId);
+        String serviceChangedType = firstInsert[0]
+            ? Constants.ServiceChangedType.ADD_SERVICE
+            : Constants.ServiceChangedType.INSTANCE_CHANGED;
+        NotifyCenter.publishEvent(
+            new ServiceEvent.ServiceChangedEvent(service, serviceChangedType, true));
     }
     
     private void removePublisherIndexes(Service service, String clientId) {

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManagerTest.java
@@ -16,13 +16,17 @@
 
 package com.alibaba.nacos.naming.core.v2.index;
 
+import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.common.notify.Event;
+import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.event.client.ClientOperationEvent;
+import com.alibaba.nacos.naming.core.v2.event.service.ServiceEvent;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -36,9 +40,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
 class ClientServiceIndexesManagerTest {
@@ -163,6 +169,58 @@ class ClientServiceIndexesManagerTest {
         
         assertNotNull(allClientsSubscribeService);
         assertEquals(2, allClientsSubscribeService.size());
+    }
+    
+    @Test
+    void testAddPublisherIndexesEmitsAddServiceOnFirstAndInstanceChangedOnRepeat()
+        throws Exception {
+        // The shared setUp() pre-seeds publisherIndexes for `service`, so use a fresh
+        // manager + fresh service to exercise the "first-time registration" path.
+        ClientServiceIndexesManager freshManager = new ClientServiceIndexesManager();
+        Service freshService = Mockito.mock(Service.class);
+        Method addPublisherIndexes = ClientServiceIndexesManager.class.getDeclaredMethod(
+            "addPublisherIndexes", Service.class, String.class);
+        addPublisherIndexes.setAccessible(true);
+        
+        AtomicInteger addServiceEventCount = new AtomicInteger();
+        AtomicInteger instanceChangedEventCount = new AtomicInteger();
+        
+        try (MockedStatic<NotifyCenter> mocked = Mockito.mockStatic(NotifyCenter.class)) {
+            mocked.when(() -> NotifyCenter.publishEvent(any())).thenAnswer(invocation -> {
+                Object event = invocation.getArgument(0);
+                if (event instanceof ServiceEvent.ServiceChangedEvent) {
+                    String type = ((ServiceEvent.ServiceChangedEvent) event).getChangedType();
+                    if (Constants.ServiceChangedType.ADD_SERVICE.equals(type)) {
+                        addServiceEventCount.incrementAndGet();
+                    } else if (Constants.ServiceChangedType.INSTANCE_CHANGED.equals(type)) {
+                        instanceChangedEventCount.incrementAndGet();
+                    }
+                }
+                return true;
+            });
+            
+            // First registration of the service: must emit ADD_SERVICE exactly once and the
+            // index entry must already exist by the time the event is published (the new
+            // implementation orders the computeIfAbsent before the publishEvent for that reason).
+            addPublisherIndexes.invoke(freshManager, freshService, "client-1");
+            assertEquals(1, addServiceEventCount.get(),
+                "First-time registration must emit ADD_SERVICE once");
+            assertEquals(0, instanceChangedEventCount.get(),
+                "First-time registration must not emit INSTANCE_CHANGED");
+            assertEquals(1, freshManager.getAllClientsRegisteredService(freshService).size(),
+                "Index entry must be present by the time the event is published");
+            
+            // Subsequent registrations of the same service must emit INSTANCE_CHANGED, not
+            // another ADD_SERVICE.
+            addPublisherIndexes.invoke(freshManager, freshService, "client-2");
+            addPublisherIndexes.invoke(freshManager, freshService, "client-3");
+            assertEquals(1, addServiceEventCount.get(),
+                "Re-registration must not re-emit ADD_SERVICE");
+            assertEquals(2, instanceChangedEventCount.get(),
+                "Each re-registration must emit one INSTANCE_CHANGED");
+            assertEquals(3, freshManager.getAllClientsRegisteredService(freshService).size(),
+                "All three clients must be present in the index");
+        }
     }
     
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Follow-up to #15182 (which I called out in that PR's description). The publisher-index registration path in `ClientServiceIndexesManager#addPublisherIndexes` decides the event type from a non-atomic `containsKey` check and publishes the event *before* the index entry is written:

```java
String serviceChangedType = INSTANCE_CHANGED;
if (!publisherIndexes.containsKey(service)) {
    serviceChangedType = ADD_SERVICE;
}
NotifyCenter.publishEvent(new ServiceChangedEvent(service, serviceChangedType, true));
publisherIndexes.computeIfAbsent(service, key -> new ConcurrentHashSet<>()).add(clientId);
```

Two concurrent first-time registrations of the same service can each see `containsKey` return `false` and each publish a redundant `ADD_SERVICE` event before the eventual `computeIfAbsent`. Downstream subscribers (fuzzy-watch notify, push planner, metrics) then react twice to what should be a single first-creation event. The ordering is also wrong on its own — a subscriber that queries the map on `ADD_SERVICE` is racing the writer.

## Brief changelog

`ClientServiceIndexesManager#addPublisherIndexes` now uses `computeIfAbsent`'s mapping function as the atomic first-insert signal, and publishes the event only after the entry is in the index:

```java
boolean[] firstInsert = {false};
publisherIndexes.computeIfAbsent(service, key -> {
    firstInsert[0] = true;
    return new ConcurrentHashSet<>();
}).add(clientId);
String serviceChangedType = firstInsert[0] ? ADD_SERVICE : INSTANCE_CHANGED;
NotifyCenter.publishEvent(new ServiceChangedEvent(service, serviceChangedType, true));
```

`ConcurrentHashMap`'s contract guarantees the mapping function runs at most once per absent key, so exactly one caller observes `firstInsert[0] == true`. The exact same `computeIfAbsent` atomicity is already relied on directly below in `removePublisherIndexes` (via `computeIfPresent`), so the idiom is consistent with the surrounding code.

A code comment above the call site spells out the two invariants the change restores (atomic first-insert detection + index-then-event ordering) so future readers don't accidentally re-order the two calls.

## Verifying this change

```bash
mvn -pl naming -am install -DskipTests
mvn -pl naming test -Dtest=ClientServiceIndexesManagerTest
# Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
mvn -pl naming -B spotless:check checkstyle:check spotbugs:check -DskipTests
# 0 spotless / 0 checkstyle / 0 spotbugs violations
```

New test `testAddPublisherIndexesEmitsAddServiceOnFirstAndInstanceChangedOnRepeat` asserts the contract on a fresh `ClientServiceIndexesManager` (the shared `setUp()` pre-seeds the index, which would mask first-time behavior). It uses `MockedStatic<NotifyCenter>` to count events and verifies:

- first call → exactly one `ADD_SERVICE` event,
- the index entry exists before the event is published (the new ordering),
- subsequent calls → only `INSTANCE_CHANGED`, never another `ADD_SERVICE`,
- all clients end up in the index.

## Notes for reviewers

I deliberately did **not** add a multi-threaded test that reproduces the race itself. `MockedStatic` is thread-confined to the thread that created it, so a real concurrent test would have to stand up `NotifyCenter`'s actual publisher pipeline plus a synchronous bridge to count events — disproportionate test infrastructure for asserting an atomicity property the JDK already guarantees. The race argument relies entirely on `ConcurrentHashMap#computeIfAbsent` running its mapping function at most once for an absent key, which is the same guarantee the file already uses for the symmetric `removePublisherIndexes` flow.

This is the follow-up I called out in #15182:

> `ClientServiceIndexesManager#addPublisherIndexes` (line 136-145) carries a different race — concurrent first-time registrations of the same service can each see `containsKey` return `false` and each emit a redundant `ADD_SERVICE` event before the eventual `computeIfAbsent`. Fixing that requires reordering the `publishEvent` to follow the `computeIfAbsent`, which is a behavioral change worth its own PR and its own concurrent test.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. *(Direct follow-up to #14751 / #15182; same module, same anti-pattern family, same contributor.)*
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.