### PR TITLE
[ISSUE #15171] Remove startup bash re-exec logic

### DIFF
--- a/distribution/bin/startup-native.sh
+++ b/distribution/bin/startup-native.sh
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Re-execute under bash when invoked via a non-bash shell (e.g. `sh startup-native.sh`
-# on Debian/Ubuntu, where /bin/sh is dash and does not support the `[[` syntax
-# this script relies on). The `#!/bin/bash` shebang above is honored only when the
-# script is executed directly or via `bash startup-native.sh`; it is ignored when
-# an explicit interpreter such as `sh` is invoked.
-if [ -z "$BASH_VERSION" ]; then
-    if command -v bash >/dev/null 2>&1; then
-        exec bash "$0" "$@"
-    fi
-    echo "ERROR: bash is required to run this script, but it is not installed." >&2
-    exit 1
-fi
-
 #===========================================================================================
 # Setting system properties
 #===========================================================================================
@@ -73,11 +60,11 @@ RUN_CMD="${RUN_CMD} -Dnacos.member.list="
 RUN_CMD="${RUN_CMD} -Dnacos.preferHostnameOverIp=true"
 
 ### If use standalone mode:
-if [[ "${MODE}" == "standalone" ]]; then
+if [ "${MODE}" = "standalone" ]; then
   RUN_CMD="${RUN_CMD} -Dnacos.standalone=true"
 fi
 
-if [[ "${NACOS_TYPE}" == "Java" ]]; then
+if [ "${NACOS_TYPE}" = "Java" ]; then
     ### Define JAVA_HOME, JAVA_PATH and JAVA
     [ ! -e "$JAVA_HOME/bin/java" ] && JAVA_HOME=$HOME/jdk/java
     [ ! -e "$JAVA_HOME/bin/java" ] && JAVA_HOME=/usr/java
@@ -112,7 +99,7 @@ if [[ "${NACOS_TYPE}" == "Java" ]]; then
 
     ### Define gc log rule
     JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-    if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]]; then
+    if [ "$JAVA_MAJOR_VERSION" -ge "9" ]; then
         RUN_CMD="${RUN_CMD} -Xlog:gc*:file=${BASE_DIR}/logs/nacos_gc.log:time,tags:filecount=10,filesize=102400"
         RUN_CMD="${RUN_CMD} --add-opens=java.base/java.lang=ALL-UNNAMED"
         RUN_CMD="${RUN_CMD} --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
@@ -122,7 +109,7 @@ if [[ "${NACOS_TYPE}" == "Java" ]]; then
         RUN_CMD="${RUN_CMD} -Xloggc:${BASE_DIR}/logs/nacos_gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
     fi
 
-    if [[ "${MODE}" == "standalone" ]]; then
+    if [ "${MODE}" = "standalone" ]; then
         RUN_CMD="${RUN_CMD} -Xms512m -Xmx512m -Xmn256m"
     else
         RUN_CMD="${RUN_CMD} -server -Xms2g -Xmx2g -Xmn1g -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=320m"
@@ -134,12 +121,12 @@ if [[ "${NACOS_TYPE}" == "Java" ]]; then
 
     RUN_CMD="${RUN_CMD} --server.max-http-header-size=524288"
 
-    if [[ "$JAVA_OPT_EXT_FIX" == "" ]]; then
+    if [ "$JAVA_OPT_EXT_FIX" = "" ]; then
         RUN_CMD="${JAVA} ${RUN_CMD}"
     else
         RUN_CMD="${JAVA} ${JAVA_OPT_EXT_FIX} ${RUN_CMD}"
     fi
-elif [[ "${NACOS_TYPE}" == "Native" ]]; then
+elif [ "${NACOS_TYPE}" = "Native" ]; then
     RUN_CMD="${NACOS_SERVER} ${RUN_CMD}"
 fi
 

--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -13,19 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Re-execute under bash when invoked via a non-bash shell (e.g. `sh startup.sh`
-# on Debian/Ubuntu, where /bin/sh is dash and does not support the `[[` syntax
-# this script relies on). The `#!/bin/bash` shebang above is honored only when
-# the script is executed directly (./startup.sh) or via `bash startup.sh`; it
-# is ignored when an explicit interpreter such as `sh` is invoked.
-if [ -z "$BASH_VERSION" ]; then
-    if command -v bash >/dev/null 2>&1; then
-        exec bash "$0" "$@"
-    fi
-    echo "ERROR: bash is required to run this script, but it is not installed." >&2
-    exit 1
-fi
-
 cygwin=false
 darwin=false
 os400=false


### PR DESCRIPTION
## What is the purpose of the change

Remove the bash re-exec logic introduced by #15177 now that startup.sh has been made sh-compatible by #15178.

This PR also updates startup-native.sh to use POSIX-compatible conditionals, so it no longer needs the bash re-exec guard.

## Brief changelog

- Remove bash re-exec guard from startup.sh
- Remove bash re-exec guard from startup-native.sh
- Replace remaining bash-only `[[ ... ]]` conditionals in startup-native.sh with POSIX-compatible `[ ... ]`

## Verifying this change

- `Select-String -Path distribution\bin\startup.sh,distribution\bin\startup-native.sh -Pattern "BASH_VERSION|exec bash|Re-execute|re-exec"`
- `rg -n "\[\[|\]\]|&>|read -p" distribution\bin\startup.sh distribution\bin\startup-native.sh`
- `git diff --check`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [√] Make sure there is a Github issue filed for the change.
* [√] Format the pull request title like `[ISSUE #123] ...`.
* [√] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction.
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests`.