### PR TITLE
[ISSUE #15183] Add AI resource import plugin spec

### DIFF
--- a/specs/en/ai/README.md
+++ b/specs/en/ai/README.md
@@ -45,5 +45,6 @@ plugin specs:
 
 - [AI Publish Pipeline Plugin Spec](../plugin/ai-pipeline-plugin-spec.md)
 - [AI Storage Plugin Spec](../plugin/ai-storage-plugin-spec.md)
+- [AI Resource Import Plugin Spec](../plugin/ai-resource-import-plugin-spec.md)
 - [Visibility Plugin Spec](../auth/visibility-plugin-spec.md)
 - [Trace Plugin Spec](../plugin/trace-plugin-spec.md)

--- a/specs/en/ai/ai-registry-spec.md
+++ b/specs/en/ai/ai-registry-spec.md
@@ -32,7 +32,7 @@ AI Registry owns:
   AgentSpec;
 - runtime query and subscription behavior for supported AI resources;
 - management workflows such as draft creation, review, publish, force publish,
-  online/offline, delete, upload, and download;
+  online/offline, delete, upload, import, and download;
 - domain usage of publish pipelines, storage plugins, visibility, auth, and
   trace hooks.
 
@@ -44,8 +44,8 @@ AI Registry does not own:
   Naming services and instances;
 - community registry protocol definitions exposed by the
   [AI Registry Adaptor Spec](ai-registry-adaptor-spec.md);
-- plugin extension contracts. Pipeline, storage, visibility, and trace
-  extension rules are defined by their plugin specs.
+- plugin extension contracts. Pipeline, storage, resource import, visibility,
+  and trace extension rules are defined by their plugin specs.
 
 ## 2. Design Principles
 
@@ -60,8 +60,10 @@ AI Registry does not own:
   AI resources should not introduce Config-style `groupName` identity unless a
   compatibility path requires it.
 - **Plugin composition**: visibility, storage, trace, and publish pipeline
-  behavior should be composed through plugins and linked from this domain spec,
-  not redefined as hidden AI-only extension mechanisms.
+  behavior should be composed through plugins and linked from this domain spec.
+  External resource import should use the same plugin model and route imported
+  artifacts back through resource operators, not be redefined as a hidden
+  AI-only extension mechanism.
 - **Fast evolution tolerance**: AI protocols and resource formats change
   quickly. Specs may need incompatible or major revisions when MCP, A2A, agent
   packaging, or model-tool ecosystems change. Such revisions must state
@@ -109,7 +111,7 @@ AI Registry is exposed through multiple surfaces:
 | Surface | Audience | Rules |
 | --- | --- | --- |
 | `/v3/client/ai/...` | Runtime clients and agent frameworks. | Query known resources, download runtime artifacts, subscribe, and register client-owned endpoints. |
-| `/v3/admin/ai/...` | Management tools and Maintainer SDK. | Create, update, list, publish, delete, upload, and operate versions. |
+| `/v3/admin/ai/...` | Management tools and Maintainer SDK. | Create, update, list, publish, delete, upload, import, and operate versions. |
 | `/v3/console/ai/...` | Nacos console UI. | UI orchestration over the same domain semantics. |
 | gRPC AI requests | Java Client SDK runtime traffic. | Query and release MCP/A2A/Prompt resources and register endpoints where supported. |
 | Java SDK | Runtime application integration. | See the [Java SDK Implementation Spec](../sdk/sdk-java-impl-spec.md). |
@@ -128,6 +130,11 @@ AI Registry is exposed through multiple surfaces:
   [AI Publish Pipeline Plugin Spec](../plugin/ai-pipeline-plugin-spec.md).
 - Resource storage extension behavior must use the
   [AI Storage Plugin Spec](../plugin/ai-storage-plugin-spec.md).
+- External AI resource import behavior must use the
+  [AI Resource Import Plugin Spec](../plugin/ai-resource-import-plugin-spec.md).
+  Import plugins convert operator-configured external sources into import
+  artifacts; resource operators apply those artifacts to the current storage and
+  lifecycle model.
 - Trace and audit events should use the [Trace Plugin Spec](../plugin/trace-plugin-spec.md)
   and the shared observability rules.
 

--- a/specs/en/ai/mcp-server-spec.md
+++ b/specs/en/ai/mcp-server-spec.md
@@ -90,7 +90,25 @@ This is compatibility storage, not the target canonical model. New MCP
 semantics should be specified as AI Registry semantics, then mapped to current
 storage until migration is complete.
 
-## 6. Pending Migration Issues
+## 6. External Import
+
+MCP import from external registries or marketplaces should use the
+[AI Resource Import Plugin Spec](../plugin/ai-resource-import-plugin-spec.md).
+Import plugins convert operator-configured external MCP registry data into MCP
+import artifacts. They must not write MCP storage directly.
+
+The MCP resource operator applies imported artifacts through the MCP domain
+operation service. In the current implementation this may use the Config-backed
+`McpServerOperationService`. After MCP metadata and versions migrate to
+`ai_resource`, the MCP resource operator should change to the new storage model
+while import plugins and unified import APIs remain compatible.
+
+Legacy MCP import APIs may remain as compatibility routes, but they should
+delegate to the unified AI resource import flow. User-provided registry URLs or
+MCP endpoint addresses must not be used as direct server-side network targets by
+default.
+
+## 7. Pending Migration Issues
 
 - Migrate MCP metadata and version rows to `ai_resource` and
   `ai_resource_version`.
@@ -101,7 +119,7 @@ storage until migration is complete.
 - Define endpoint ownership and cleanup rules for direct endpoints registered
   by runtime clients.
 
-## 7. Evolution Note
+## 8. Evolution Note
 
 MCP is evolving quickly. Tool schema, resources, transport modes, auth
 metadata, and registry interoperability may change. MCP Server spec changes may

--- a/specs/en/ai/skill-spec.md
+++ b/specs/en/ai/skill-spec.md
@@ -79,6 +79,13 @@ endpoints, is defined by the
 optional compatibility surface and does not replace the canonical Skill resource
 lifecycle.
 
+External Skill import from marketplaces or registries is defined by the
+[AI Resource Import Plugin Spec](../plugin/ai-resource-import-plugin-spec.md).
+Import plugins must produce standard Skill package artifacts, and the Skill
+resource operator must apply those artifacts through the normal Skill upload or
+draft lifecycle. Import plugins must not bypass package validation, visibility,
+storage, or publish governance.
+
 Nacos registry paths must not execute package scripts during upload, query, or
 download. Script execution, static analysis, or security scanning belongs to
 publish pipeline plugins or to clients that explicitly activate a Skill. The AI
@@ -108,6 +115,11 @@ Skill follows the shared [AI Resource Lifecycle Spec](ai-resource-lifecycle-spec
 - submit may run publish pipeline and then publish or return to draft;
 - labels, online/offline, scope, business tags, and delete operations update
   metadata through CAS where required.
+
+Imported Skills follow the upload and draft rules unless the operation is an
+explicit bootstrap flow owned by the server. Dependency handling, such as a
+Skill referencing MCP tools, is previewed through the unified import flow and
+must not recursively import dependencies by default.
 
 ## 6. Runtime Behavior
 

--- a/specs/en/plugin/README.md
+++ b/specs/en/plugin/README.md
@@ -45,6 +45,7 @@ follow [HTTP API](../http-api/api-spec.md) rules when exposing HTTP endpoints.
 
 - [AI Publish Pipeline Plugin Spec](ai-pipeline-plugin-spec.md)
 - [AI Storage Plugin Spec](ai-storage-plugin-spec.md)
+- [AI Resource Import Plugin Spec](ai-resource-import-plugin-spec.md)
 
 ## Security Extensions
 

--- a/specs/en/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/en/plugin/ai-resource-import-plugin-spec.md
@@ -1,0 +1,271 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# AI Resource Import Plugin Spec
+
+## Scope
+
+The AI resource import plugin type lets Nacos import AI resources from
+operator-configured external registries or marketplaces. It is intended for MCP
+Server, Skill, and future AI resource types that need external discovery and
+conversion before they enter the Nacos AI Registry governance flow.
+
+An import plugin owns only the external source protocol and conversion from that
+source into a Nacos import artifact. It does not own Nacos resource identity,
+authorization, visibility, storage, version lifecycle, publish pipeline, or
+trace behavior. Those rules remain owned by the
+[AI Registry Spec](../ai/ai-registry-spec.md), resource-type specs, and the
+resource operator selected by the AI Registry domain.
+
+The plugin type is exposed to the core plugin manager as `ai-resource-import`.
+Common plugin lifecycle and state rules are defined by the
+[Nacos Plugin Spec](plugin-spec.md).
+
+The SPI contract should live in the plugin system, for example in the
+`plugin/ai` module, consistent with AI storage, visibility, and other plugin
+types. Nacos should allow users to extend importer sources through the plugin
+mechanism, such as enterprise Skill marketplaces, private MCP registries, or
+Git indexes. Resource operators are not user extension plugins; in the first
+stage they should be built into the `ai` module and write resources through the
+current Nacos domain services.
+
+## Concepts
+
+| Concept | Meaning |
+|---------|---------|
+| Import source | Operator-defined source configuration identified by `sourceId`. |
+| Importer | Plugin implementation selected by an import source. |
+| Candidate | External resource summary returned during search, without full importable content. |
+| Artifact | Fetched payload and metadata that can be applied by a resource operator. |
+| Resource operator | Nacos domain service that validates and writes one resource type. |
+| Dependency | Resource referenced by an imported artifact, such as a Skill requiring MCP tools. |
+
+Import sources are part of Nacos server configuration or plugin configuration.
+End users select a `sourceId`; they must not submit arbitrary endpoint URLs,
+IP addresses, credentials, or registry base paths in import requests.
+
+## Execution Mode
+
+`ai-resource-import` is a configured single-service plugin type.
+
+Multiple importer implementations may be loaded at the same time, for example
+`mcp-registry`, `skills-well-known`, or an internal enterprise marketplace
+importer. For each request, the AI import source manager resolves `sourceId` to
+one enabled source, then selects the importer named by that source.
+
+The importer returns candidates during search and fetches artifacts for selected
+items during validate and execute. The AI Registry import manager then routes
+each artifact to the resource operator for its `resourceType`.
+
+```text
+sourceId -> ImportSource(pluginName, resourceTypes, endpoint, limits, authRef)
+         -> AiResourceImportService
+         -> AiResourceOperator(resourceType)
+```
+
+## Source Configuration
+
+An import source should include:
+
+| Field | Requirement |
+|-------|-------------|
+| `sourceId` | Stable user-visible source id. |
+| `pluginName` | Importer implementation name under `ai-resource-import`. |
+| `resourceTypes` | Resource types supported by this source, such as `mcp` or `skill`. |
+| `endpoint` | Operator-configured source endpoint or registry root. |
+| `enabled` | Whether the source may serve import requests. |
+| `authRef` | Optional reference to server-side credentials; secrets are not returned to users. |
+| `connectTimeout` / `readTimeout` | Per-source network timeouts. |
+| `maxPageCount` / `maxItemCount` | Pagination guards. |
+| `maxArtifactSize` | Maximum fetched artifact size. |
+| `properties` | Importer-specific non-secret options. |
+
+The source manager must reject duplicate `sourceId` values and sources whose
+importer plugin is not loaded or disabled.
+
+## SPI
+
+Import implementations are created by a builder.
+
+| Builder method | Requirement |
+|----------------|-------------|
+| `importerType()` | Stable importer implementation name. |
+| `build(properties)` | Build an import service with importer-owned properties. |
+
+The import service implements:
+
+| Service method | Requirement |
+|----------------|-------------|
+| `importerType()` | Runtime importer type. |
+| `supportedResourceTypes()` | Resource types the importer can produce. |
+| `search(context)` | Return a candidate page from the configured source with necessary metadata only. |
+| `fetch(context, item)` | Fetch one selected artifact from the configured source. |
+
+`context` contains namespace, resource type, source configuration, query,
+cursor, limit, and importer options. It must not contain a user-provided
+network endpoint.
+
+`search` should be side-effect free and must not return MCP tools, Skill package
+content, secrets, or any other full importable payload. `fetch` may call the
+external source and return bytes or structured payload, but it must not write
+Nacos resources.
+
+## Import Artifact
+
+An artifact should include:
+
+| Field | Meaning |
+|-------|---------|
+| `resourceType` | Target Nacos AI resource type. |
+| `externalId` | Source-specific stable id. |
+| `name` | Candidate Nacos resource name, if known. |
+| `version` | Candidate version, if known. |
+| `description` | Resource description. |
+| `payloadKind` | Payload shape, such as `MCP_DETAIL`, `SKILL_ZIP`, or `JSON`. |
+| `payload` | Fetched payload bytes or structured data. |
+| `dependencies` | Optional referenced resources. |
+| `sourceMetadata` | Non-secret source metadata for trace and diagnostics. |
+
+The artifact is an import boundary object, not a persisted resource model. The
+resource operator converts it into the current storage and lifecycle model.
+
+## Resource Operators
+
+Resource operators live in the AI Registry domain, not in the import plugin.
+They validate and write artifacts through the resource type's current service
+layer.
+
+For MCP, the initial operator may call the current `McpServerOperationService`
+and related validation services, even though MCP is still backed by Config
+records. When MCP later migrates to `ai_resource`, only the MCP operator should
+change. Import plugins and unified import APIs must remain compatible.
+
+For Skill, the operator should preserve the Skill package boundary and write
+through the Skill upload or draft lifecycle APIs.
+
+## API Flow
+
+Nacos should expose unified Admin and Console import APIs:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/v3/admin/ai/import/sources` | List enabled import sources. |
+| `POST` | `/v3/admin/ai/import/search` | Search candidate summaries from a source. |
+| `POST` | `/v3/admin/ai/import/validate` | Validate selected candidates and return conflicts, dependencies, and warnings. |
+| `POST` | `/v3/admin/ai/import/execute` | Import selected candidates. |
+| `GET` | `/v3/console/ai/import/sources` | Console source list. |
+| `POST` | `/v3/console/ai/import/search` | Console search flow. |
+| `POST` | `/v3/console/ai/import/validate` | Console validate flow. |
+| `POST` | `/v3/console/ai/import/execute` | Console execute flow. |
+
+All unified APIs must use standard v3 `Result<T>` response, error, and
+authorization conventions.
+
+The recommended browser flow is:
+
+```text
+list sources(resourceType)
+  -> select sourceId
+  -> search candidates by sourceId and query
+  -> user selects candidates
+  -> validate selected candidates
+  -> show conflicts, dependency warnings, and overwrite options
+  -> execute selected candidates
+```
+
+The browser must not receive full artifacts. MCP tools/specification, Skill zip
+content, and other importable payloads may flow only among the server-side
+Importer, Import Manager, and Resource Operator.
+
+## Legacy MCP Import Compatibility
+
+Existing MCP import APIs may remain during a compatibility window:
+
+```text
+POST /v3/console/ai/mcp/import/validate
+POST /v3/console/ai/mcp/import/execute
+GET  /v3/console/ai/mcp/importToolsFromMcp
+```
+
+The validate and execute endpoints should be routed through a compatibility
+adapter into the unified import manager. They must not continue to grow as an
+independent implementation.
+
+For legacy `importType=url`, the request must not use a user-provided URL as a
+network target by default. It may be interpreted as a `sourceId` when it matches
+an enabled source. Otherwise the request should fail with a migration message.
+Legacy direct URL import may only be enabled by explicit operator configuration
+for controlled deployments.
+
+Legacy `importType=json` and `importType=file` may be mapped to built-in local
+importers because they do not require server-side network access.
+
+## Dependency Handling
+
+Imported artifacts may reference other AI resources. A Skill may require MCP
+tools or servers, for example. The unified import flow should support these
+dependency policies:
+
+| Policy | Meaning |
+|--------|---------|
+| `IGNORE` | Keep dependency metadata but do not validate or link it. |
+| `VALIDATE_ONLY` | Report whether matching resources exist in Nacos. |
+| `LINK_EXISTING` | Link to existing matching resources when possible. |
+| `IMPORT_SELECTED` | Import only dependencies explicitly selected by the user. |
+
+The default should be `VALIDATE_ONLY`. Automatic recursive import must not be
+the default because it expands the supply-chain and authorization boundary.
+
+## Security Requirements
+
+The import flow must treat external sources as untrusted:
+
+- users cannot submit arbitrary URLs, IPs, registry roots, or credentials;
+- operator-configured HTTP sources should use HTTPS by default;
+- redirects must be disabled or revalidated against the same safety policy;
+- loopback, link-local, multicast, and private network targets should be blocked
+  by default after DNS resolution;
+- source requests must enforce connect timeout, read timeout, response size,
+  page count, and artifact size limits;
+- fetched Skill packages must not execute scripts during import, query, or
+  download;
+- importer plugins must not leak secrets in API responses, trace events, or
+  logs.
+
+Deployments that intentionally import from private networks must opt in through
+operator-owned configuration.
+
+## Trace And Audit
+
+Search, validate, and execute operations should emit trace or audit events that include:
+
+- source id;
+- importer type;
+- resource type;
+- candidate count and selected count;
+- per-item success, skipped, or failed status;
+- non-secret source metadata;
+- operator identity and client address when available.
+
+Trace behavior must follow the [Trace Plugin Spec](trace-plugin-spec.md).
+
+## Evolution Notes
+
+This plugin type is a conversion boundary. It should remain stable while the
+storage implementation of individual resources evolves. In particular, MCP
+import must continue to work across the migration from Config-backed records to
+the standard AI resource model by changing the MCP resource operator rather
+than each external importer.

--- a/specs/en/plugin/plugin-spec.md
+++ b/specs/en/plugin/plugin-spec.md
@@ -22,7 +22,7 @@ Nacos uses plugins and SPI extensions to keep cross-cutting infrastructure and
 replaceable domain capabilities outside the fixed core. A plugin may provide
 authentication, resource visibility, data source dialects, encryption, tracing,
 flow control, environment adaptation, AI pipeline behavior, AI storage behavior,
-or Java client-side request adaptation.
+AI resource import behavior, or Java client-side request adaptation.
 
 The plugin mechanism must let Nacos keep a stable core model while allowing
 deployments to choose an implementation that matches their identity system,
@@ -55,6 +55,7 @@ The current plugin type registry is defined by `PluginType`.
 | `control` | Traffic and control extension. | [Control Plugin Spec](control-plugin-spec.md) |
 | `ai-pipeline` | AI registry pipeline extension. | [AI Publish Pipeline Plugin Spec](ai-pipeline-plugin-spec.md) |
 | `ai-storage` | AI registry storage extension. | [AI Storage Plugin Spec](ai-storage-plugin-spec.md) |
+| `ai-resource-import` | AI registry external import extension. | [AI Resource Import Plugin Spec](ai-resource-import-plugin-spec.md) |
 
 Domain-specific plugin contracts are defined by their own specs. This document
 defines the common runtime contract shared by all plugin categories.
@@ -86,7 +87,7 @@ define its execution mode explicitly.
 | Mode | Meaning | Examples |
 |------|---------|----------|
 | Exclusive selection | One implementation is selected for the process or request scope. Other loaded implementations remain inactive for that decision. | `auth`, `datasource-dialect` |
-| Configured single service | Multiple implementations may be loaded, while a domain chooses one service by configuration or request context. | `visibility` |
+| Configured single service | Multiple implementations may be loaded, while a domain chooses one service by configuration or request context. | `visibility`, `ai-resource-import` |
 | Ordered chain | Multiple matching plugins are invoked in a stable order. Each node may contribute a result, and the domain defines whether failure stops the chain. | `ai-pipeline`, `config-change` |
 | Subscriber or broadcast | Multiple subscribers observe the same event or trace point without owning the primary decision. | `trace`, event-style extensions |
 

--- a/specs/tmp/plan/issue-15183/ai-resource-import-plan.md
+++ b/specs/tmp/plan/issue-15183/ai-resource-import-plan.md
@@ -1,0 +1,693 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Issue 15183 AI Resource Import Development Plan
+
+Issue: https://github.com/alibaba/nacos/issues/15183
+
+Note: this was the initial English planning draft. The latest landing plan is
+`implementation-plan-zh-cn.md`; when the two documents differ, follow the
+newer landing plan.
+
+## 1. Goal
+
+Support importing AI resources, initially MCP Server and Skill, from
+operator-configured external registries or marketplaces. The import flow should
+be pluggable, storage-independent, and safe by default.
+
+The feature must solve three concrete problems:
+
+- Skill marketplaces do not share one registry protocol, so external protocol
+  support must be implemented as plugins.
+- Existing MCP registry import is coupled to an implementation that can accept
+  user-provided URLs. That needs a safer source model controlled by operators.
+- Skill import may reference MCP resources, so the design needs dependency
+  validation and explicit dependency policy.
+
+## 2. Non-Goals
+
+- Do not complete the MCP `ai_resource` migration in this feature.
+- Do not change the canonical Skill package model.
+- Do not make `ai-registry-adaptor` a write/import surface.
+- Do not allow arbitrary user-provided registry URLs, IP addresses, MCP
+  endpoints, or credentials in the unified import APIs.
+- Do not recursively import dependencies by default.
+
+## 3. Design Principles
+
+### 3.1 Import Plugins Are Conversion Boundaries
+
+An `ai-resource-import` plugin owns only:
+
+- external registry or marketplace protocol;
+- source-specific pagination and query parameters;
+- conversion from external records to Nacos import candidates;
+- fetching selected external artifacts.
+
+It does not own:
+
+- Nacos resource identity;
+- conflict handling;
+- authorization or visibility;
+- storage backend choice;
+- draft/review/publish lifecycle;
+- dependency application;
+- trace and audit persistence.
+
+### 3.2 Resource Operators Own Application
+
+The AI Registry domain owns resource operators. A resource operator applies an
+import artifact to the current resource implementation.
+
+For MCP, the first implementation should call the current
+`McpServerOperationService`, `McpServerValidationService`, and related endpoint,
+tool, and resource services. This is intentionally allowed even though MCP is
+still Config-backed.
+
+When MCP later migrates to `ai_resource`, the MCP operator should be replaced or
+rewired. Import plugins and unified APIs should not change.
+
+For Skill, the operator should use existing Skill upload and draft lifecycle
+services so that parsing, validation, storage, manifest, and pipeline behavior
+remain consistent.
+
+### 3.3 Unified APIs Own Routing
+
+New Admin and Console APIs should be the primary surface. Existing MCP import
+APIs remain as compatibility routes and call the same import manager.
+
+### 3.4 Operator-Configured Sources
+
+Users select `sourceId`. Operators configure the source endpoint, credentials,
+timeouts, limits, and importer plugin. This avoids server-side requests to
+untrusted user-supplied targets.
+
+## 4. Proposed Modules
+
+### 4.1 `plugin/ai`
+
+Add the SPI and shared model for import plugins:
+
+```text
+com.alibaba.nacos.plugin.ai.importer.spi
+  AiResourceImportServiceBuilder
+  AiResourceImportService
+
+com.alibaba.nacos.plugin.ai.importer.model
+  AiResourceImportContext
+  AiResourceImportCandidate
+  AiResourceImportCandidatePage
+  AiResourceImportArtifact
+  AiResourceImportDependency
+  AiResourceImportSource
+  AiResourceImportPayloadKind
+```
+
+Expected SPI shape:
+
+```java
+public interface AiResourceImportServiceBuilder {
+
+    String importerType();
+
+    AiResourceImportService build(Map<String, String> properties);
+}
+
+public interface AiResourceImportService {
+
+    String importerType();
+
+    Set<String> supportedResourceTypes();
+
+    AiResourceImportCandidatePage list(AiResourceImportContext context)
+            throws NacosException;
+
+    AiResourceImportArtifact fetch(AiResourceImportContext context,
+            AiResourceImportCandidate candidate) throws NacosException;
+}
+```
+
+The SPI model should avoid depending on MCP or Skill concrete classes. Concrete
+payloads can be represented by `payloadKind` plus bytes or JSON.
+
+### 4.2 `ai/import/source`
+
+Owns source configuration:
+
+```text
+AiResourceImportSourceProperties
+AiResourceImportSourceConfig
+AiResourceImportSourceManager
+AiResourceImportSourceValidator
+```
+
+Example properties:
+
+```properties
+nacos.ai.resource.import.sources[0].source-id=mcp-official
+nacos.ai.resource.import.sources[0].plugin-name=mcp-registry
+nacos.ai.resource.import.sources[0].resource-types=mcp
+nacos.ai.resource.import.sources[0].endpoint=https://registry.modelcontextprotocol.io
+nacos.ai.resource.import.sources[0].enabled=true
+nacos.ai.resource.import.sources[0].max-page-count=20
+nacos.ai.resource.import.sources[0].max-artifact-size=10485760
+```
+
+Source manager responsibilities:
+
+- load and normalize sources;
+- reject duplicate source ids;
+- ensure plugin exists and supports configured resource types;
+- hide secrets from API responses;
+- provide an immutable source view for requests.
+
+### 4.3 `ai/import/core`
+
+Owns orchestration:
+
+```text
+AiResourceImportManager
+AiResourceImportSearchService
+AiResourceImportValidationService
+AiResourceImportExecutionService
+AiResourceImportSecurityGuard
+AiResourceImportTraceService
+```
+
+Search flow:
+
+```text
+request
+  -> validate namespace/resourceType/sourceId
+  -> resolve source
+  -> resolve importer
+  -> importer.search(context)
+  -> return candidate summaries
+```
+
+Validate flow:
+
+```text
+request
+  -> validate namespace/resourceType/sourceId/selected items
+  -> resolve source and importer
+  -> for each selected item:
+       importer.fetch(context, item)
+       security guard validates artifact size and type
+       resourceOperator.validate(artifact)
+       dependency validation
+  -> return validation response without artifact payload
+```
+
+Execute flow:
+
+```text
+request
+  -> validate namespace/resourceType/sourceId/selected items
+  -> resolve source and importer
+  -> for each selected item:
+       importer.fetch(context, item)
+       security guard validates artifact size and type
+       resourceOperator.validate(artifact)
+       resourceOperator.importResource(artifact, policy)
+       trace per-item result
+  -> return aggregate result
+```
+
+### 4.4 `ai/import/operator`
+
+Owns resource-specific application:
+
+```text
+AiResourceOperator
+AiResourceOperatorRegistry
+McpResourceOperator
+SkillResourceOperator
+```
+
+Suggested operator interface:
+
+```java
+public interface AiResourceOperator {
+
+    String resourceType();
+
+    AiResourceImportValidationItem validate(String namespaceId,
+            AiResourceImportArtifact artifact, ImportPolicy policy)
+            throws NacosException;
+
+    AiResourceImportItemResult importResource(String namespaceId,
+            AiResourceImportArtifact artifact, ImportPolicy policy)
+            throws NacosException;
+}
+```
+
+`McpResourceOperator` initial behavior:
+
+- convert `MCP_DETAIL` artifact to `McpServerDetailInfo`;
+- call `McpServerValidationService` for validation;
+- detect existing MCP by namespace and name through current MCP index/service;
+- call `McpServerOperationService.createMcpServer` or `updateMcpServer`;
+- keep endpoint, tool, and resource handling inside MCP operation services.
+
+`SkillResourceOperator` initial behavior:
+
+- require `SKILL_ZIP` artifact or artifact convertible to a standard Skill zip;
+- call `SkillOperationService.uploadSkillFromZip`;
+- default to draft creation or overwrite behavior based on request policy;
+- validate MCP dependencies and return warnings by default.
+
+### 4.5 `ai/import/compat`
+
+Owns legacy routes:
+
+```text
+McpLegacyImportAdapter
+McpLegacyImportTypeMapper
+```
+
+Mapping:
+
+| Legacy input | New behavior |
+|--------------|--------------|
+| `importType=url`, `data=<sourceId>` | Route to source `<sourceId>`. |
+| `importType=url`, `data=<url>` | Reject by default; optionally allow only with explicit operator opt-in. |
+| `importType=json` | Route to built-in local MCP JSON importer. |
+| `importType=file` | Route to built-in local MCP seed importer. |
+
+`/importToolsFromMcp` should be deprecated. If still needed, it should use a
+configured source and a selected candidate rather than user-provided `baseUrl`
+and `endpoint`.
+
+### 4.6 Controllers
+
+Add:
+
+```text
+AiResourceImportAdminController
+AiResourceImportConsoleController
+```
+
+Admin paths:
+
+```text
+GET  /v3/admin/ai/import/sources
+POST /v3/admin/ai/import/search
+POST /v3/admin/ai/import/validate
+POST /v3/admin/ai/import/execute
+```
+
+Console paths:
+
+```text
+GET  /v3/console/ai/import/sources
+POST /v3/console/ai/import/search
+POST /v3/console/ai/import/validate
+POST /v3/console/ai/import/execute
+```
+
+All endpoints must use `Result<T>` and `@Secured` with `SignType.AI`.
+
+## 5. Request And Response Model
+
+### 5.1 Source List
+
+Request:
+
+```text
+resourceType optional
+```
+
+Response:
+
+```text
+sourceId
+pluginName
+resourceTypes
+enabled
+displayName
+description
+capabilities
+```
+
+Do not return endpoint credentials, secret headers, or raw token values.
+
+### 5.2 Search
+
+Request:
+
+```text
+namespaceId
+resourceType
+sourceId
+query
+cursor
+limit
+options
+```
+
+Response:
+
+```text
+sourceId
+resourceType
+nextCursor
+items[]
+  externalId
+  name
+  version
+  description
+  metadata
+```
+
+### 5.3 Validate
+
+Request:
+
+```text
+namespaceId
+resourceType
+sourceId
+selectedItems[]
+dependencyPolicy
+overwriteExisting
+options
+```
+
+Response:
+
+```text
+sourceId
+resourceType
+items[]
+  externalId
+  name
+  version
+  status: valid | warning | invalid | conflict
+  exists
+  conflictType
+  warnings[]
+  errors[]
+  dependencies[]
+```
+
+### 5.4 Execute
+
+Request:
+
+```text
+namespaceId
+resourceType
+sourceId
+selectedItems[]
+dependencyPolicy
+overwriteExisting
+skipInvalid
+options
+```
+
+Response:
+
+```text
+success
+totalCount
+successCount
+failedCount
+skippedCount
+results[]
+  externalId
+  resourceName
+  version
+  status: success | failed | skipped
+  errorMessage
+  warnings[]
+```
+
+## 6. Dependency Policy
+
+Initial policies:
+
+| Policy | Behavior |
+|--------|----------|
+| `IGNORE` | Preserve dependency metadata only. |
+| `VALIDATE_ONLY` | Check whether matching resource exists; return warning if missing. |
+| `LINK_EXISTING` | Link existing matching resources when supported by the target type. |
+| `IMPORT_SELECTED` | Import only dependency items explicitly selected in the request. |
+
+Default: `VALIDATE_ONLY`.
+
+Skill-to-MCP dependencies should be validated before import. The system should avoid
+automatic recursive imports because dependency expansion may cross trust,
+license, and authorization boundaries.
+
+## 7. Security Plan
+
+### 7.1 Source Control
+
+- Unified import APIs accept `sourceId`, not URL or IP.
+- Source endpoint and credentials are configured by operators.
+- Source definitions should be available to Console only as sanitized views.
+
+### 7.2 Network Guard
+
+For HTTP-based importers:
+
+- require HTTPS by default;
+- set connect and read timeouts;
+- cap response size and page count;
+- disable redirects or revalidate redirected target;
+- resolve DNS and block loopback, link-local, multicast, and private ranges by
+  default;
+- allow private network import only through explicit operator opt-in.
+
+### 7.3 Artifact Guard
+
+- enforce maximum artifact size;
+- validate Skill zip limits before storage;
+- do not execute Skill scripts during import;
+- validate MCP remote endpoints as data, not as targets to probe, unless the
+  source configuration explicitly enables controlled probing.
+
+### 7.4 Audit
+
+Trace or audit events should include:
+
+- source id;
+- importer type;
+- resource type;
+- selected item count;
+- per-item result;
+- operator identity;
+- client address;
+- sanitized source metadata.
+
+## 8. Compatibility Plan
+
+### 8.1 Existing MCP Import APIs
+
+Keep routes for one compatibility window:
+
+```text
+POST /v3/console/ai/mcp/import/validate
+POST /v3/console/ai/mcp/import/execute
+```
+
+Internally:
+
+- convert legacy forms to unified validate or execute requests;
+- map legacy response fields from unified results;
+- log deprecation warnings for `importType=url` with direct URL input.
+
+### 8.2 Remote Console Handler
+
+Current remote Console MCP handler does not support MCP import. The unified API
+should be exposed through maintainer client or Admin API so remote mode can use
+the same server-side import manager.
+
+### 8.3 `importToolsFromMcp`
+
+This route should be marked deprecated. Replacement options:
+
+1. Search MCP candidates from configured source and show tool summaries from
+   registry metadata.
+2. Add controlled endpoint probing as a source capability, enabled only by
+   operator configuration.
+
+## 9. Implementation Phases
+
+### Phase 0: Spec And API Contract
+
+- Add `ai-resource-import` plugin spec.
+- Update plugin, AI Registry, MCP, and Skill specs.
+- Add development plan under `specs/tmp/plan/issue-15183`.
+- Confirm naming: plugin type `ai-resource-import`, enum
+  `AI_RESOURCE_IMPORT`.
+
+### Phase 1: Core SPI And Source Manager
+
+- Add `PluginType.AI_RESOURCE_IMPORT`.
+- Add import SPI and model classes in `plugin/ai`.
+- Add source property model in `ai`.
+- Add importer loading and source validation.
+- Add unit tests for duplicate source id, unsupported resource type, missing
+  plugin, and secret sanitization.
+
+### Phase 2: Unified Import Manager And API
+
+- Add `AiResourceImportManager`.
+- Add source, search, validate, and execute controllers for Admin and Console.
+- Add forms and request param extractors.
+- Add operator registry and common result model.
+- Add trace hooks for search, validate, and execute.
+- Add controller tests and manager tests.
+
+### Phase 3: MCP Import Migration
+
+- Split current `McpExternalDataAdaptor` into a default `mcp-registry`
+  importer.
+- Add built-in local MCP JSON and seed importers for legacy `json` and `file`
+  modes.
+- Add `McpResourceOperator` around current MCP services.
+- Route legacy MCP validate and execute APIs to the unified manager.
+- Deprecate direct URL import by default.
+- Add compatibility tests for legacy response mapping.
+
+### Phase 4: Skill Import
+
+- Add `skills-well-known` or compatible Skill registry importer.
+- Add `SkillResourceOperator`.
+- Convert external Skill records to standard Skill zip artifacts.
+- Add dependency validation for Skill references to MCP resources.
+- Add tests for Skill package validation, overwrite policy, and dependency
+  policies.
+
+### Phase 5: Security Hardening
+
+- Implement source network guard.
+- Add DNS and redirected target validation.
+- Add artifact size and page count guards.
+- Add tests for loopback, private address, redirect, oversized response,
+  timeout, and oversized Skill zip cases.
+
+### Phase 6: Maintainer SDK And Console
+
+- Add maintainer-client methods for unified import APIs.
+- Wire remote Console handler to server-side import APIs.
+- Add Console UI source selection, candidate table, conflict display, dependency
+  warnings, and execute result display.
+
+## 10. Detailed TODO
+
+### Specs
+
+- [x] Add English `ai-resource-import` plugin spec.
+- [x] Add Chinese `ai-resource-import` plugin spec.
+- [x] Link the new plugin spec from plugin READMEs.
+- [x] Update AI Registry spec with import responsibilities.
+- [x] Update MCP spec with storage-independent import boundary.
+- [x] Update Skill spec with external import and dependency behavior.
+
+### API And Models
+
+- [ ] Add common import request and response models under API module if exposed
+      to maintainer-client.
+- [ ] Add server-side form classes for Admin and Console endpoints.
+- [ ] Define `sourceId`, `resourceType`, `dependencyPolicy`,
+      `overwriteExisting`, and `skipInvalid` validation rules.
+- [ ] Define API errors for missing source, disabled source, unsupported
+      resource type, and unsafe source target.
+
+### Plugin SPI
+
+- [ ] Add `AiResourceImportServiceBuilder`.
+- [ ] Add `AiResourceImportService`.
+- [ ] Add import context, candidate, page, artifact, dependency, and payload
+      kind models.
+- [ ] Add Nacos SPI service file support in default import plugin modules.
+
+### Source Manager
+
+- [ ] Add import source properties.
+- [ ] Add source manager.
+- [ ] Add source sanitizer for API responses.
+- [ ] Add source validation at startup or first use.
+- [ ] Add tests for invalid configuration.
+
+### Import Core
+
+- [ ] Add search service.
+- [ ] Add validate service.
+- [ ] Add execute service.
+- [ ] Add operator registry.
+- [ ] Add trace service.
+- [ ] Add aggregate result builder.
+- [ ] Add best-effort behavior for `skipInvalid`.
+
+### MCP
+
+- [ ] Convert `McpExternalDataAdaptor` into an importer.
+- [ ] Add `McpResourceOperator`.
+- [ ] Add legacy form adapter.
+- [ ] Route legacy Console MCP import APIs.
+- [ ] Add Admin unified import support for MCP.
+- [ ] Update tests for URL source migration.
+
+### Skill
+
+- [ ] Add Skill registry importer.
+- [ ] Add Skill artifact conversion to standard zip.
+- [ ] Add `SkillResourceOperator`.
+- [ ] Add dependency validation for MCP references.
+- [ ] Add dependency policy tests.
+
+### Security
+
+- [ ] Add HTTP client factory for importers.
+- [ ] Add endpoint safety validation.
+- [ ] Add DNS resolution guard.
+- [ ] Add redirect validation.
+- [ ] Add response and artifact size limit checks.
+- [ ] Add negative SSRF tests.
+
+### Documentation
+
+- [ ] Add user-facing operator configuration documentation after API stabilizes.
+- [ ] Add deprecation note for legacy MCP direct URL import.
+- [ ] Add migration notes for existing Console behavior.
+
+## 11. Open Questions
+
+- Should local `json` and `file` MCP imports be plugin implementations or
+  built-in compatibility handlers?
+- Should source configuration be purely environment/application properties in
+  the first release, or should it support runtime plugin config updates?
+- What metadata schema should Skill importers use to express MCP dependencies?
+- Should controlled endpoint probing be part of MCP import, or should it remain
+  a separate diagnostic feature?
+- What is the deprecation window for legacy direct URL MCP import?
+
+## 12. Acceptance Criteria
+
+- Users can list operator-configured import sources.
+- Users can search MCP registry candidates without providing a URL.
+- Users can import selected MCP resources through the unified API.
+- Existing MCP import APIs still work for compatible `sourceId`, `json`, and
+  `file` cases.
+- Direct user-provided URL import is rejected by default.
+- Users can search and validate Skill candidates from a configured source.
+- Skill dependency warnings identify missing MCP resources.
+- Import plugins do not depend on MCP Config storage or Skill storage internals.
+- Unit tests cover routing, compatibility, and security guards.

--- a/specs/tmp/plan/issue-15183/implementation-plan-zh-cn.md
+++ b/specs/tmp/plan/issue-15183/implementation-plan-zh-cn.md
@@ -1,0 +1,1062 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Issue 15183 AI 资源导入落地开发计划
+
+Issue: https://github.com/alibaba/nacos/issues/15183
+
+## 1. 目标与交付边界
+
+本计划用于把 `ai-resource-import` 从 spec 概念落到可开发、可评审、可分阶段合入的工程任务。
+
+第一阶段交付目标：
+
+- 提供统一的 AI 资源导入框架，支持按 `sourceId` 从运维配置的来源导入资源。
+- 支持 MCP registry 导入迁移到统一框架。
+- 支持 Skill 外部来源导入的框架和最小可用 importer。
+- 保留旧 MCP 导入 API 的兼容路径，但禁止默认使用用户传入 URL 作为服务端访问目标。
+- 使导入插件不依赖 MCP 当前 Config 存储，也不依赖 Skill 存储实现细节。
+
+非目标：
+
+- 不在本任务内完成 MCP `ai_resource` 化迁移。
+- 不把 `ai-registry-adaptor` 改造成写入或导入面。
+- 不实现任意第三方 Skill 市场的全部高级能力。
+- 不默认递归导入 Skill 依赖的 MCP 资源。
+- 不在第一阶段实现所有第三方市场的定制 UI，但 MCP 导入迁移必须包含 Console 可用入口；
+  Skill UI 可先复用统一导入弹窗的最小能力。
+
+## 2. 总体落地策略
+
+实现按四层推进：
+
+```text
+Import API
+  -> Import Manager
+     -> Import Plugin
+     -> Resource Operator
+        -> Current Resource Service
+```
+
+各层职责：
+
+| 层级 | 职责 | 不负责 |
+|------|------|--------|
+| API | 参数校验、鉴权、响应包装、兼容路由 | 外部协议转换、资源写入细节 |
+| Import Manager | source 路由、search/validate/execute 编排、依赖策略、审计 | 具体外部协议、具体资源存储 |
+| Import Plugin | 外部来源查询、分页、拉取 artifact、外部模型转换 | Nacos 写入、权限、生命周期 |
+| Resource Operator | 资源类型校验、冲突处理、调用领域服务写入 | 外部来源协议 |
+| Resource Service | 当前资源的真实创建、更新、存储、索引、事件 | 外部导入来源 |
+
+MCP 当前没有完成 `ai_resource` 化，因此 `McpResourceOperator` 只面向
+`McpServerOperationService` 等领域服务。未来 MCP 存储迁移时，只替换 Operator 内部实现。
+
+## 3. 建议 PR 拆分
+
+### PR 1: Spec 与开发计划
+
+内容：
+
+- 新增 `ai-resource-import` 插件 spec。
+- 更新 AI Registry、MCP、Skill、Plugin spec 的导入边界。
+- 新增本落地开发计划。
+
+验收：
+
+- `apache-rat:check` 通过。
+- 文档能解释旧 MCP 导入 API 如何迁移到统一导入框架。
+
+### PR 2: SPI 与基础模型
+
+内容：
+
+- 在 `api` 或 `plugin/ai` 中增加插件类型和导入 SPI。
+- 增加 importer 共享模型。
+- 增加 source 配置模型的基础类。
+- 增加基础单元测试。
+
+建议先只提供模型和加载框架，不接具体 MCP/Skill 业务。Importer SPI 放在 `plugin/ai`，
+允许用户自定义导入来源；Operator 第一阶段放在 `ai` 模块内置，避免插件绕过 Nacos 资源生命周期。
+
+### PR 3: Source Manager 与 Import Manager
+
+内容：
+
+- 实现 source 配置读取、校验、脱敏输出。
+- 实现统一 search/validate/execute 编排。
+- 增加 operator registry。
+- 暴露 Admin/Console 的统一导入 API。
+- 增加 Console proxy/handler 抽象，保证本地 Console 与 remote Console 的调用路径一致。
+
+建议先接一个测试用 fake importer 和 fake operator，保证框架行为独立可测。
+
+### PR 4: MCP registry 导入迁移
+
+内容：
+
+- 把当前 `McpExternalDataAdaptor` 的 registry URL/seed/json 解析能力迁移为 importer。
+- 增加 `McpResourceOperator`，内部复用当前 MCP service。
+- 旧 MCP `/import/validate` 和 `/import/execute` 路由到统一 manager。
+- 默认禁止旧 `importType=url` 的任意 URL 访问。
+- 改造现有 `ImportMcpDialog`，URL 输入改为 source 选择 + 搜索 + 选择 + 校验 + 导入。
+
+### PR 5: Skill 导入最小能力
+
+内容：
+
+- 增加一个 Skill well-known/registry importer。
+- 增加 `SkillResourceOperator`，内部复用 `SkillOperationService.uploadSkillFromZip`。
+- search 阶段展示 Skill 元数据，validate 阶段展示冲突状态和 MCP 依赖 warning。
+- Skill 管理页面增加导入入口，复用统一导入弹窗，第一阶段只开启 source 导入。
+
+### PR 6: 安全加固与远程 Console
+
+内容：
+
+- 统一 HTTP source 安全 guard。
+- DNS、redirect、私网地址、响应大小、页数、超时限制。
+- maintainer-client 或 remote handler 接入统一 import API。
+- 完善负向安全测试。
+
+### PR 7: Console UI 增强与文档
+
+内容：
+
+- Console 批量选择、详情抽屉、结果过滤、失败重试、空状态和错误态优化。
+- 用户文档和迁移说明。
+
+如果 UI 工作量较大，可以继续拆成 MCP UI 与 Skill UI 两个 PR。
+
+## 4. 代码模块与建议包名
+
+### 4.1 `api` 模块
+
+如需要暴露给 maintainer-client，公共请求响应模型建议放在：
+
+```text
+api/src/main/java/com/alibaba/nacos/api/ai/model/importer/
+```
+
+建议类：
+
+| 类名 | 用途 |
+|------|------|
+| `AiResourceImportSourceInfo` | API 返回的脱敏 source 信息。 |
+| `AiResourceImportSearchRequest` | search 请求。 |
+| `AiResourceImportValidateRequest` | validate 请求。 |
+| `AiResourceImportExecuteRequest` | execute 请求。 |
+| `AiResourceImportSearchResponse` | search 聚合响应。 |
+| `AiResourceImportValidateResponse` | validate 聚合响应。 |
+| `AiResourceImportExecuteResponse` | execute 聚合响应。 |
+| `AiResourceImportItem` | 选中的外部资源项。 |
+| `AiResourceImportCandidateItem` | search 单项候选摘要。 |
+| `AiResourceImportValidationItem` | validate 单项结果。 |
+| `AiResourceImportResultItem` | execute 单项结果。 |
+| `AiResourceImportDependency` | 资源依赖描述。 |
+| `AiResourceImportDependencyPolicy` | 依赖策略枚举。 |
+
+如果第一阶段只做服务端内部 API，模型可先放在 `ai` 模块，等 maintainer-client 接入时再下沉到
+`api`。但为了 remote Console，建议一开始就把稳定请求响应模型放入 `api`。
+
+### 4.2 `plugin/ai` 模块
+
+插件 SPI 建议放在：
+
+```text
+plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/importer/
+```
+
+建议类：
+
+```text
+model/AiResourceImportContext
+model/AiResourceImportCandidate
+model/AiResourceImportCandidatePage
+model/AiResourceImportValidation
+model/AiResourceImportArtifact
+model/AiResourceImportPayloadKind
+model/AiResourceImportSource
+model/AiResourceImportSourceSecretRef
+spi/AiResourceImportService
+spi/AiResourceImportServiceBuilder
+```
+
+注意：
+
+- SPI 模型不要 import MCP/Skill 的具体 API 类。
+- `payload` 可以先设计为 `byte[] payload` + `String payloadJson` 二选一。
+- `source` 里不要放明文 secret，只放引用和已解析但不可输出的运行时配置。
+
+### 4.3 `ai` 模块
+
+建议包结构：
+
+```text
+ai/src/main/java/com/alibaba/nacos/ai/importer/
+  config/
+  controller/
+  form/
+  manager/
+  operator/
+  security/
+  trace/
+  compat/
+  builtin/
+```
+
+建议类：
+
+| 包 | 类名 | 职责 |
+|----|------|------|
+| `config` | `AiResourceImportProperties` | 读取 `nacos.ai.resource.import.*` 配置。 |
+| `config` | `AiResourceImportSourceConfig` | 单个 source 内部配置。 |
+| `manager` | `AiResourceImportSourceManager` | source 查询、校验、脱敏。 |
+| `manager` | `AiResourceImportManager` | search/validate/execute 统一入口。 |
+| `manager` | `AiResourceImportPluginManager` | SPI 加载和 importer 路由。 |
+| `operator` | `AiResourceOperator` | 资源写入抽象。 |
+| `operator` | `AiResourceOperatorRegistry` | 按 resourceType 找 Operator。 |
+| `operator` | `McpResourceOperator` | MCP artifact 到当前 MCP service。 |
+| `operator` | `SkillResourceOperator` | Skill artifact 到 Skill service。 |
+| `security` | `AiResourceImportSecurityGuard` | source 和 artifact 安全检查。 |
+| `trace` | `AiResourceImportTraceService` | search/validate/execute 审计和 trace。 |
+| `compat` | `McpLegacyImportAdapter` | 旧 MCP import form 到统一请求的转换。 |
+| `builtin` | `McpRegistryImportService` | MCP registry importer。 |
+| `builtin` | `McpJsonImportService` | MCP JSON 本地 importer。 |
+| `builtin` | `McpSeedImportService` | MCP seed file 本地 importer。 |
+
+### 4.4 完整模块划分
+
+导入功能应拆成 Console 表达层、Console 转发层、AI 导入编排层、插件层、资源写入层和领域服务层。
+模块间只传稳定模型，不把外部平台模型或存储模型泄漏到其他层。
+
+```mermaid
+flowchart LR
+    UI["console-ui Import Dialog"]
+    ConsoleController["ConsoleAiResourceImportController"]
+    ConsoleProxy["AiResourceImportProxy"]
+    Handler["AiResourceImportHandler<br/>Local / Remote"]
+    AdminController["AdminAiResourceImportController"]
+    Manager["AiResourceImportManager"]
+    SourceManager["AiResourceImportSourceManager"]
+    PluginManager["AiResourceImportPluginManager"]
+    Importer["AiResourceImportService<br/>MCP / Skill plugins"]
+    OperatorRegistry["AiResourceOperatorRegistry"]
+    Operator["McpResourceOperator / SkillResourceOperator"]
+    DomainService["Current MCP / Skill Service"]
+
+    UI -->|search / validate / execute request| ConsoleController
+    ConsoleController -->|validated form + user context| ConsoleProxy
+    ConsoleProxy -->|stable api model| Handler
+    Handler -->|local call or remote admin call| AdminController
+    AdminController -->|api request model| Manager
+    Manager -->|sourceId + resourceType| SourceManager
+    Manager -->|pluginName + resourceType| PluginManager
+    PluginManager --> Importer
+    Manager -->|artifact + write policy| OperatorRegistry
+    OperatorRegistry --> Operator
+    Operator --> DomainService
+```
+
+| 模块 | 建议位置 | 输入 | 输出 | 关键职责 |
+|------|----------|------|------|----------|
+| Console UI | `console-ui/src/pages/AI/...` | 用户选择、搜索词、导入选项 | Console API request | source 选择、候选展示、校验提示、结果展示。 |
+| Console Controller | `console/.../controller/v3/ai` | Form + auth context | API model | 参数校验、`Result<T>` 包装、Console 鉴权。 |
+| Console Proxy | `console/.../proxy/ai` | API model | API model | 屏蔽 local/remote handler 差异。 |
+| Console Handler | `console/.../handler/ai` | API model | API model | 本地直调或远程转发到 server import API。 |
+| Admin Controller | `ai/.../controller` | API model | API model | 统一 Admin 导入入口，供 Console remote handler 复用。 |
+| Import Manager | `ai/.../importer/manager` | search/validate/execute request | search/validate/execute response | source 路由、插件调用、operator 调用、审计。 |
+| Source Manager | `ai/.../importer/manager` | sourceId、resourceType | runtime source | 读取运维配置、校验、脱敏、secret 引用解析。 |
+| Plugin Manager | `ai/.../importer/manager` | pluginName、resourceType | importer 实例 | SPI 加载、能力匹配、插件状态检查。 |
+| Import Plugin | `plugin/ai/.../importer` 或内置实现 | source、query、cursor、selected item | candidate 或 artifact | 外部平台访问、协议转换、artifact 生成。 |
+| Operator Registry | `ai/.../importer/operator` | resourceType | operator 实例 | 资源类型到写入适配器的路由。 |
+| Resource Operator | `ai/.../importer/operator` | artifact、write policy | result item | 校验冲突、转换为领域模型、调用当前服务。 |
+| Domain Service | 现有 MCP/Skill service | 领域模型 | 资源 ID/版本/错误 | 当前真实存储和生命周期。 |
+
+### 4.5 生命周期与数据契约
+
+一次导入分成四个显式生命周期：`sources` 只返回脱敏来源，`search` 只做外部候选发现和摘要标准化，
+`validate` 按选中项在服务端拉取 artifact 并进行冲突、依赖和可导入性校验，`execute` 重新拉取
+artifact 或使用服务端短期 validation plan 完成写入。`search` 的结果不能作为可信写入内容，
+也不能包含 MCP tools、Skill zip 或其他完整可导入 payload。
+
+状态流转：
+
+```text
+SOURCE_LOADED
+  -> SEARCH_REQUESTED
+  -> SOURCE_RESOLVED
+  -> IMPORTER_SELECTED
+  -> CANDIDATES_LISTED
+  -> CANDIDATES_NORMALIZED
+  -> SEARCH_RETURNED
+  -> VALIDATE_REQUESTED
+  -> SELECTED_ARTIFACT_FETCHED
+  -> ARTIFACT_VALIDATED
+  -> EXISTING_RESOURCE_CHECKED
+  -> VALIDATE_RETURNED
+  -> EXECUTE_REQUESTED
+  -> ITEM_ARTIFACT_FETCHED
+  -> ARTIFACT_VALIDATED
+  -> RESOURCE_CONFLICT_CHECKED
+  -> RESOURCE_WRITTEN | ITEM_SKIPPED | ITEM_FAILED
+  -> EXECUTE_RETURNED
+```
+
+关键传输对象：
+
+| 传输边界 | 对象 | 必须包含 | 不能包含 |
+|----------|------|----------|----------|
+| UI -> Console API | `AiResourceImportSearchRequest` | `namespaceId`、`resourceType`、`sourceId`、`query`、`cursor`、`limit` | endpoint、token、任意 URL、完整 artifact。 |
+| UI -> Console API | `AiResourceImportValidateRequest` | `namespaceId`、`resourceType`、`sourceId`、`selectedItems`、dependency policy | 完整 artifact、source secret。 |
+| UI -> Console API | `AiResourceImportExecuteRequest` | `namespaceId`、`resourceType`、`sourceId`、`selectedItems`、write policy | search 返回的完整 artifact。 |
+| Controller -> Manager | API request + runtime context | 用户、namespace、api type、request id | Console 组件状态。 |
+| Manager -> SourceManager | `sourceId`、`resourceType` | source 标识和资源类型 | 用户传入 endpoint。 |
+| SourceManager -> Manager | `AiResourceImportSource` | endpoint、pluginName、resourceTypes、limits、secret refs | 可输出明文 secret。 |
+| Manager -> Importer | `AiResourceImportContext` | namespace、source、query/cursor、limits、request id | Nacos 写入服务。 |
+| Importer -> Manager | `AiResourceImportCandidatePage` | candidate、nextCursor、capabilities | Nacos resource id。 |
+| Importer -> Manager | `AiResourceImportArtifact` | `externalId`、`payloadKind`、`payloadJson` 或 `payloadBytes`、checksum | 已信任的领域对象。 |
+| Operator -> Manager | `AiResourceImportValidation` | exists、conflictType、warnings、errors、dependencies | artifact payload。 |
+| Manager -> Operator | artifact + `AiResourceImportWritePolicy` | overwrite、skipInvalid、dependencyPolicy、operator options | 外部访问 client。 |
+| Operator -> Domain Service | MCP/Skill 当前领域模型 | 当前 service 所需参数 | import source secret。 |
+
+MCP 使用新 API 导入时的端到端流程：
+
+```mermaid
+sequenceDiagram
+    participant User as Console User
+    participant UI as ImportMcpDialog
+    participant CC as ConsoleAiResourceImportController
+    participant Proxy as AiResourceImportProxy
+    participant Handler as AiResourceImportHandler
+    participant AC as AdminAiResourceImportController
+    participant Manager as AiResourceImportManager
+    participant Source as SourceManager
+    participant Plugin as McpRegistryImportService
+    participant Operator as McpResourceOperator
+    participant Mcp as McpServerOperationService
+
+    User->>UI: list sources and select source
+    UI->>CC: GET /v3/console/ai/import/sources?resourceType=mcp
+    CC-->>UI: sanitized source list
+    User->>UI: input search keyword
+    UI->>CC: POST /v3/console/ai/import/search
+    CC->>Proxy: AiResourceImportSearchRequest
+    Proxy->>Handler: search(request)
+    Handler->>AC: local call or remote admin request
+    AC->>Manager: search(request, runtimeContext)
+    Manager->>Source: getSource(sourceId, mcp)
+    Source-->>Manager: runtime source with endpoint and limits
+    Manager->>Plugin: search(context, query, cursor)
+    Plugin-->>Manager: candidate page
+    Manager-->>AC: AiResourceImportSearchResponse
+    AC-->>UI: Result<search response>
+    User->>UI: select candidates
+    UI->>CC: POST /v3/console/ai/import/validate
+    CC->>Manager: validate request through proxy/handler/admin path
+    Manager->>Plugin: fetchArtifact(selected item)
+    Plugin-->>Manager: MCP_DETAIL artifact
+    Manager->>Operator: validate(artifact)
+    Operator-->>Manager: exists/conflict/warnings
+    Manager-->>UI: Result<validate response>
+    User->>UI: confirm import
+    UI->>CC: POST /v3/console/ai/import/execute
+    CC->>Manager: execute request through proxy/handler/admin path
+    Manager->>Plugin: fetchArtifact(selected item)
+    Plugin-->>Manager: MCP_DETAIL artifact
+    Manager->>Operator: importResource(artifact, writePolicy)
+    Operator->>Mcp: createMcpServer or updateMcpServer
+    Mcp-->>Operator: resource id / error
+    Operator-->>Manager: result item
+    Manager-->>UI: Result<execute response>
+```
+
+## 5. 配置设计
+
+建议配置前缀：
+
+```text
+nacos.ai.resource.import
+```
+
+全局配置：
+
+| 配置 | 默认值 | 含义 |
+|------|--------|------|
+| `nacos.ai.resource.import.enabled` | `false` | 是否启用统一导入能力。 |
+| `nacos.ai.resource.import.allow-user-url` | `false` | 是否允许旧 MCP API 直接 URL。默认关闭。 |
+| `nacos.ai.resource.import.default-connect-timeout-ms` | `3000` | 默认连接超时。 |
+| `nacos.ai.resource.import.default-read-timeout-ms` | `10000` | 默认读超时。 |
+| `nacos.ai.resource.import.default-max-page-count` | `20` | 默认最大分页数。 |
+| `nacos.ai.resource.import.default-max-item-count` | `500` | 默认最大候选数。 |
+| `nacos.ai.resource.import.default-max-artifact-size` | `10485760` | 默认 artifact 大小。 |
+| `nacos.ai.resource.import.block-private-network` | `true` | 是否默认阻断私网目标。 |
+
+Source 配置：
+
+```properties
+nacos.ai.resource.import.sources[0].source-id=mcp-official
+nacos.ai.resource.import.sources[0].display-name=MCP Official Registry
+nacos.ai.resource.import.sources[0].plugin-name=mcp-registry
+nacos.ai.resource.import.sources[0].resource-types=mcp
+nacos.ai.resource.import.sources[0].endpoint=https://registry.modelcontextprotocol.io
+nacos.ai.resource.import.sources[0].enabled=true
+nacos.ai.resource.import.sources[0].max-page-count=20
+nacos.ai.resource.import.sources[0].max-artifact-size=10485760
+nacos.ai.resource.import.sources[0].properties.protocol-version=v0
+```
+
+Secret 配置第一阶段建议只支持引用，不在 API 响应中返回：
+
+```properties
+nacos.ai.resource.import.sources[0].auth-ref=mcpOfficialToken
+```
+
+后续再决定是否接入统一 secret manager 或插件配置。
+
+## 6. API 详细设计
+
+### 6.1 查询来源
+
+路径：
+
+```text
+GET /v3/admin/ai/import/sources
+GET /v3/console/ai/import/sources
+```
+
+参数：
+
+| 参数 | 必填 | 含义 |
+|------|------|------|
+| `resourceType` | 否 | 按 `mcp`、`skill` 等资源类型过滤。 |
+
+返回：
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": [
+    {
+      "sourceId": "mcp-official",
+      "displayName": "MCP Official Registry",
+      "pluginName": "mcp-registry",
+      "resourceTypes": ["mcp"],
+      "enabled": true,
+      "capabilities": ["search", "pagination"]
+    }
+  ]
+}
+```
+
+### 6.2 Search
+
+路径：
+
+```text
+POST /v3/admin/ai/import/search
+POST /v3/console/ai/import/search
+```
+
+请求字段：
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `namespaceId` | 否 | 缺省按当前 AI 资源默认 namespace 规则处理。 |
+| `resourceType` | 是 | `mcp` 或 `skill`。 |
+| `sourceId` | 是 | 运维配置的来源 ID。 |
+| `query` | 否 | 搜索关键字。 |
+| `cursor` | 否 | 分页游标。 |
+| `limit` | 否 | 分页大小。 |
+| `options` | 否 | importer 专属非敏感选项。 |
+
+返回字段：
+
+| 字段 | 说明 |
+|------|------|
+| `sourceId` | 来源 ID。 |
+| `resourceType` | 资源类型。 |
+| `nextCursor` | 下一页游标。 |
+| `items` | 候选摘要。 |
+
+`items` 单项：
+
+| 字段 | 说明 |
+|------|------|
+| `externalId` | 外部来源 ID。 |
+| `name` | 预计导入后的资源名。 |
+| `version` | 预计版本。 |
+| `description` | 描述。 |
+| `metadata` | tags、protocol、homepage 等非敏感摘要。 |
+
+Search 阶段不得返回完整 MCP tools/specification、Skill zip、secret 或其他可导入 payload。
+
+### 6.3 Validate
+
+路径：
+
+```text
+POST /v3/admin/ai/import/validate
+POST /v3/console/ai/import/validate
+```
+
+请求字段：
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `namespaceId` | 否 | 缺省按当前 AI 资源默认 namespace 规则处理。 |
+| `resourceType` | 是 | `mcp` 或 `skill`。 |
+| `sourceId` | 是 | 来源 ID。 |
+| `selectedItems` | 是 | 用户选中的候选项，只包含 `externalId`、`name`、`version` 等摘要标识。 |
+| `overwriteExisting` | 否 | 是否按覆盖策略校验。默认 false。 |
+| `dependencyPolicy` | 否 | 缺省 `VALIDATE_ONLY`。 |
+| `options` | 否 | importer/operator 专属非敏感选项。 |
+
+返回字段：
+
+| 字段 | 说明 |
+|------|------|
+| `sourceId` | 来源 ID。 |
+| `resourceType` | 资源类型。 |
+| `items` | 单项校验结果。 |
+
+`items` 单项：
+
+| 字段 | 说明 |
+|------|------|
+| `externalId` | 外部来源 ID。 |
+| `name` | 预计导入后的资源名。 |
+| `version` | 预计版本。 |
+| `status` | `valid`、`warning`、`invalid`、`conflict`。 |
+| `exists` | Nacos 中是否已有同名资源。 |
+| `conflictType` | `same-name`、`same-version`、`draft-exists` 等。 |
+| `warnings` | 可继续导入的风险提示。 |
+| `errors` | 阻断导入的问题。 |
+| `dependencies` | 依赖资源校验结果。 |
+
+Validate 阶段可以在服务端拉取 artifact 做校验，但响应中不得回传完整 artifact。若需要减少 execute
+阶段重复拉取，可以返回短期 `validationToken` 或服务端缓存引用；该 token 不能包含 artifact 内容，
+并必须有短 TTL。
+
+### 6.4 Execute
+
+路径：
+
+```text
+POST /v3/admin/ai/import/execute
+POST /v3/console/ai/import/execute
+```
+
+请求字段：
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `namespaceId` | 否 | 缺省按当前 AI 资源默认 namespace 规则处理。 |
+| `resourceType` | 是 | `mcp` 或 `skill`。 |
+| `sourceId` | 是 | 来源 ID。 |
+| `selectedItems` | 是 | 用户选中的候选项。 |
+| `overwriteExisting` | 否 | 是否覆盖已有资源或 draft。默认 false。 |
+| `skipInvalid` | 否 | 是否跳过无效项。默认 false。 |
+| `dependencyPolicy` | 否 | 缺省 `VALIDATE_ONLY`。 |
+| `validationToken` | 否 | validate 阶段返回的短期服务端校验引用。 |
+| `options` | 否 | importer/operator 专属非敏感选项。 |
+
+返回字段：
+
+| 字段 | 说明 |
+|------|------|
+| `success` | 是否全部成功。 |
+| `totalCount` | 总数。 |
+| `successCount` | 成功数。 |
+| `failedCount` | 失败数。 |
+| `skippedCount` | 跳过数。 |
+| `results` | 单项结果。 |
+
+单项结果：
+
+| 字段 | 说明 |
+|------|------|
+| `externalId` | 外部来源 ID。 |
+| `resourceName` | Nacos 资源名。 |
+| `version` | 导入版本。 |
+| `status` | `success`、`failed`、`skipped`。 |
+| `errorMessage` | 失败原因。 |
+| `warnings` | 非阻断告警。 |
+
+### 6.5 Console UI 设计
+
+导入能力第一使用面应放在 Console。Admin API 主要用于 remote Console、运维脚本和自动化测试，
+不直接暴露给普通用户操作。
+
+#### 6.5.1 入口与复用关系
+
+| 页面 | 当前文件 | 新入口 | 资源类型 |
+|------|----------|--------|----------|
+| MCP 管理 | `console-ui/src/pages/AI/McpManagement/McpManagement.js` | 保留“导入 MCP Server”按钮 | `mcp` |
+| MCP 导入弹窗 | `console-ui/src/pages/AI/McpManagement/ImportMcpDialog.jsx` | 从旧 URL 输入改成 source 驱动 | `mcp` |
+| Skill 管理 | `console-ui/src/pages/AI/SkillManagement/*` | 新增“导入 Skill”按钮 | `skill` |
+| 通用导入服务 | 新增 `console-ui/src/pages/AI/services/AiResourceImportService.js` | 封装统一 API | `mcp`、`skill` |
+| 通用导入组件 | 可新增 `console-ui/src/pages/AI/components/AiResourceImportDialog.jsx` | MCP/Skill 共享流程 | 多资源类型 |
+
+建议实现顺序：
+
+1. 先在 `ImportMcpDialog.jsx` 内完成新 API 改造，降低首个 PR 的组件迁移成本。
+2. 把稳定的 source selector、candidate table、validate result、result summary 抽成
+   `AiResourceImportDialog`。
+3. Skill 管理页面复用通用组件，只提供 `resourceType=skill` 和列配置。
+
+#### 6.5.2 MCP 导入弹窗交互
+
+MCP 导入弹窗从“用户输入 registry URL”改为“用户选择运维配置 source”。默认不再展示
+`https://registry.modelcontextprotocol.io/...` 这类可编辑 URL。
+
+```text
+Dialog: 导入 MCP Server
+  Source selector:
+    - 下拉选择 source
+    - 展示 source displayName、pluginName、capabilities
+    - 无可用 source 时展示运维配置提示
+  Search toolbar:
+    - keyword input
+    - refresh button
+    - overwriteExisting switch
+    - skipInvalid switch
+  Candidate area:
+    - card/table view
+    - only metadata: name / version / description / tags / protocol
+    - detail drawer
+  Validate area:
+    - status: valid / warning / invalid / conflict
+    - conflict and dependency warning
+  Footer:
+    - clear selection
+    - validate selected
+    - import selected after validate
+    - import all valid
+  Result dialog:
+    - success / failed / skipped summary
+    - failed reason table
+    - retry failed
+```
+
+候选与校验列建议：
+
+| 列 | MCP 显示 | Skill 显示 |
+|----|----------|------------|
+| 名称 | server name | skill name |
+| 版本 | MCP version | skill version |
+| 来源 | source displayName | source displayName |
+| 类型 | protocol/frontProtocol | skill package type |
+| 冲突 | validate 后展示 exists/conflictType | validate 后展示 exists/draft conflict |
+| 依赖 | validate 后展示 tools/endpoint warning | validate 后展示 MCP dependency warning |
+| 状态 | validate 后展示 valid/warning/invalid/conflict | validate 后展示 valid/warning/invalid/conflict |
+| 操作 | detail | detail |
+
+状态展示规则：
+
+| 状态 | UI 行为 |
+|------|---------|
+| `valid` | 默认可选择。 |
+| `warning` | 可选择，展示黄色提示，导入前二次确认。 |
+| `conflict` | 默认不可选择，开启 `overwriteExisting` 后可选择。 |
+| `invalid` | 不可选择，展示错误原因。 |
+
+#### 6.5.3 前端 API 绑定
+
+新增前端服务：
+
+```javascript
+const AiResourceImportService = {
+  listSources: params => request.get('v3/console/ai/import/sources', { params }),
+  search: data => request.post('v3/console/ai/import/search', data),
+  validate: data => request.post('v3/console/ai/import/validate', data),
+  execute: data => request.post('v3/console/ai/import/execute', data),
+};
+```
+
+MCP 旧服务保留兼容：
+
+```javascript
+validateImport: data => request.post('v3/console/ai/mcp/import/validate', data)
+executeImport: data => request.post('v3/console/ai/mcp/import/execute', data)
+```
+
+但新 UI 不再直接调用旧 MCP import API。旧 API 只供历史脚本、旧页面或回滚时使用。
+
+#### 6.5.4 Console 后端流转
+
+Console 后端建议新增独立 import proxy，而不是把统一导入逻辑挂在 `McpProxy`：
+
+```text
+ConsoleAiResourceImportController
+  -> AiResourceImportProxy
+     -> AiResourceImportHandler
+        -> LocalAiResourceImportHandler
+        -> RemoteAiResourceImportHandler
+```
+
+| Handler | 调用方式 | 使用场景 |
+|---------|----------|----------|
+| `LocalAiResourceImportHandler` | 直接调用 `AiResourceImportManager` 或 server bean | Console 与 server 同进程。 |
+| `RemoteAiResourceImportHandler` | 转发到 server 侧 Admin import API | 独立 Console 或 remote 模式。 |
+
+旧 MCP 导入 controller 继续保留：
+
+```text
+ConsoleMcpController#import/validate
+  -> McpProxy
+     -> McpHandler
+        -> McpLegacyImportAdapter
+           -> AiResourceImportManager#validate
+```
+
+这样旧路径和新路径最终都进入同一个 Import Manager，但旧路径只负责模型映射和兼容响应。
+
+#### 6.5.5 UI 边界与降级
+
+- Source endpoint、authRef、secret 不进入浏览器。
+- UI 只展示 source 的脱敏 view：`sourceId`、`displayName`、`pluginName`、`resourceTypes`、
+  `capabilities`、`enabled`。
+- 如果没有可用 source，MCP 导入弹窗不再给 URL 输入框，而是展示“请联系运维配置导入来源”。
+- 如果服务端关闭 `nacos.ai.resource.import.enabled`，按钮可以置灰或点击后展示 feature disabled。
+- 如果旧 URL 兼容开关打开，可以把“旧 URL 导入”放在高级区域，并清晰标注仅兼容用途。
+
+## 7. 旧 MCP API 兼容方案
+
+旧 API：
+
+```text
+POST /v3/console/ai/mcp/import/validate
+POST /v3/console/ai/mcp/import/execute
+GET  /v3/console/ai/mcp/importToolsFromMcp
+```
+
+兼容策略：
+
+| 旧输入 | 新行为 |
+|--------|--------|
+| `importType=url` 且 `data` 命中 `sourceId` | validate 转为统一 validate，execute 转为统一 execute。 |
+| `importType=url` 且 `data` 是 URL | 默认拒绝，提示使用 source 配置。 |
+| `importType=url` 且开启 `allow-user-url` | 使用临时兼容 source，并经过完整安全 guard。 |
+| `importType=json` | 转到内置 `mcp-json` importer。 |
+| `importType=file` | 转到内置 `mcp-seed` importer。 |
+
+响应兼容：
+
+- 旧 validate 返回 `McpServerImportValidationResult`，由统一 validation item 映射。
+- 旧 execute 返回 `McpServerImportResponse`，由统一 execute result 映射。
+- 新字段丢失时允许降级，但不能丢失错误信息。
+
+`importToolsFromMcp`：
+
+- 第一阶段标记 deprecated。
+- 默认仍可保留，但应增加开关，默认关闭用户传入地址探测。
+- 替代方案是从配置 source 的 candidate detail 中展示 tools。
+
+## 8. MCP 导入实现细节
+
+### 8.1 Importer
+
+`McpRegistryImportService` 从 MCP registry API 拉取数据，输出：
+
+```text
+payloadKind = MCP_DETAIL
+payloadJson = McpServerDetailInfo-compatible JSON
+```
+
+它可以复用当前 `McpExternalDataAdaptor` 的转换逻辑，但需要拆掉用户 URL 输入：
+
+- `endpoint` 来自 source config；
+- `cursor`、`limit`、`search` 来自 request；
+- HTTP client 走 `AiResourceImportSecurityGuard` 或安全 client factory；
+- list 只返回 candidate；
+- fetch 返回完整 artifact。
+
+### 8.2 Operator
+
+`McpResourceOperator` 执行：
+
+```text
+artifact
+  -> parse McpServerDetailInfo
+  -> validationService.validateServers(namespaceId, singletonList(server))
+  -> check selected/overwrite/skipInvalid
+  -> generate McpServerBasicInfo, McpToolSpecification, McpResourceSpecification, McpEndpointSpec
+  -> operationService.createMcpServer or updateMcpServer
+```
+
+注意：
+
+- 不直接 publish Config。
+- 不直接操作 Naming endpoint。
+- 不直接依赖 `McpConfigUtils` 以外的存储细节。
+- 当前生成 endpoint spec 的逻辑可以先从 `McpServerImportService` 搬到 Operator。
+
+### 8.3 当前类迁移建议
+
+| 当前类 | 迁移方向 |
+|--------|----------|
+| `McpExternalDataAdaptor` | 拆为 MCP registry importer + 本地 JSON/seed importer。 |
+| `McpServerImportService` | 改为旧兼容 facade 或删除核心逻辑。 |
+| `McpServerValidationService` | 保留，由 `McpResourceOperator` 调用。 |
+| `ConsoleMcpController#import/validate` | 调 `McpLegacyImportAdapter`。 |
+| `ConsoleMcpController#import/execute` | 调 `McpLegacyImportAdapter`。 |
+
+## 9. Skill 导入实现细节
+
+### 9.1 Importer
+
+第一阶段建议实现一个最小 importer：
+
+```text
+skills-well-known
+```
+
+支持：
+
+- list skill index；
+- fetch `SKILL.md` 和必要文本资源；
+- 组装标准 Skill zip；
+- 产出 `payloadKind = SKILL_ZIP`。
+
+暂不支持：
+
+- 二进制资源下载；
+- 复杂认证；
+- 任意脚本执行；
+- 自动递归下载依赖。
+
+### 9.2 Operator
+
+`SkillResourceOperator` 执行：
+
+```text
+artifact
+  -> validate payloadKind is SKILL_ZIP
+  -> SkillZipParser parse metadata
+  -> check existing resource and working draft
+  -> validate dependencies
+  -> SkillOperationService.uploadSkillFromZip(namespaceId, zipBytes, overwrite, targetVersion)
+```
+
+依赖处理：
+
+- `VALIDATE_ONLY`：检查 MCP 是否存在，缺失则 warning。
+- `LINK_EXISTING`：如果 Skill metadata 支持引用信息，则写入 metadata 或 ext；否则先退化为 warning。
+- `IMPORT_SELECTED`：先导入用户选择的 MCP 依赖，再导入 Skill。第一阶段可只设计接口，不实现自动导入。
+
+## 10. 安全实现细节
+
+### 10.1 Source 校验
+
+Source 初始化和请求时都应校验：
+
+- `sourceId` 非空且唯一；
+- `pluginName` 存在；
+- `resourceTypes` 非空；
+- `endpoint` 协议合法；
+- source 启用后 importer 支持对应 resourceType；
+- secret 不出现在 API view。
+
+### 10.2 HTTP 安全 client
+
+建议实现：
+
+```text
+AiResourceImportHttpClientFactory
+AiResourceImportEndpointValidator
+AiResourceImportNetworkPolicy
+```
+
+校验顺序：
+
+```text
+URI parse
+  -> scheme check
+  -> host check
+  -> DNS resolve
+  -> address policy check
+  -> build request with timeout
+  -> response size guard
+```
+
+默认阻断：
+
+- `127.0.0.0/8`
+- `::1`
+- link-local
+- multicast
+- private IPv4 ranges
+- unique local IPv6
+
+如果运维明确允许私网 source，只对该 source 放开，不提供用户级绕过参数。
+
+### 10.3 Artifact 安全
+
+- `maxArtifactSize` 先于 parse 生效。
+- Skill zip 使用现有 `SkillZipParser` 限制。
+- MCP remote endpoint 作为资源数据保存，不作为导入时探测目标。
+- 日志中只打印 `sourceId`、`externalId`、resource name，不打印 secret 或 auth header。
+
+## 11. 测试计划
+
+### 11.1 单元测试
+
+| 模块 | 测试重点 |
+|------|----------|
+| SourceManager | 重复 source、禁用 source、未知 plugin、不支持 resourceType、脱敏。 |
+| ImportPluginManager | SPI 加载、重复 importer、disabled plugin。 |
+| ImportManager | search/validate/execute 路由、skipInvalid、overwriteExisting。 |
+| McpLegacyImportAdapter | url sourceId 映射、直接 URL 拒绝、json/file 兼容。 |
+| McpResourceOperator | create/update/skipped/failed 结果。 |
+| SkillResourceOperator | zip parse、draft 冲突、依赖 warning。 |
+| SecurityGuard | 私网阻断、redirect 阻断、超时、响应过大。 |
+| Console Proxy/Handler | local/remote 路由、异常透传、Admin API 转发。 |
+
+### 11.2 Controller 测试
+
+- Admin source list。
+- Console source list。
+- Admin search/validate/execute。
+- Console search/validate/execute。
+- 旧 MCP validate/execute 兼容。
+- 鉴权注解和参数校验。
+- Console import disabled/source empty/error response。
+
+### 11.3 集成测试
+
+如测试成本允许，增加：
+
+- fake HTTP registry + MCP importer 流程。
+- fake Skill well-known registry + Skill upload 流程。
+- remote Console handler 调 server Admin API。
+- 旧 MCP import API 与新统一 API 结果一致性。
+
+### 11.4 回归测试
+
+- 现有 MCP create/update/delete 不变。
+- 现有 Skill upload/batch upload 不变。
+- AI registry adaptor 只读行为不变。
+- 现有 MCP 管理页面列表、搜索、详情、新建、编辑不受导入 UI 改造影响。
+
+### 11.5 Console UI 测试
+
+如果当前 Console UI 测试体系支持，增加：
+
+- source list 成功时渲染 source selector。
+- 没有 source 时展示空状态，不展示 URL 输入框。
+- validate 返回 `valid/warning/conflict/invalid` 时，选择态和按钮状态正确。
+- `overwriteExisting` 开启后 conflict 项可选择。
+- execute 返回部分失败时展示失败列表和 retry failed。
+- Skill 导入入口使用 `resourceType=skill` 调用统一 API。
+
+## 12. 验收标准
+
+第一阶段验收：
+
+- 新统一 API 可以列出 source。
+- 新统一 API 可以 search MCP registry candidate。
+- 新统一 API 可以 validate 选中的 MCP candidate。
+- 新统一 API 可以 execute 导入选中的 MCP。
+- MCP Console 导入入口使用 source selector，不再默认展示可编辑 registry URL。
+- MCP Console 导入选中项时走 `/v3/console/ai/import/execute`。
+- 旧 MCP import validate/execute 对 `json`、`file` 仍兼容。
+- 旧 MCP `url` 只有传 `sourceId` 或显式配置允许时才工作。
+- Skill importer 可以 search、validate 并导入一个标准 Skill zip。
+- Skill Console 至少有导入入口和通用 candidate/validation/result 展示。
+- Skill validate 能返回 MCP 依赖 warning。
+- 默认安全策略阻断用户任意 URL 与私网目标。
+- RAT、checkstyle 相关检查通过。
+
+## 13. 风险与回滚
+
+| 风险 | 缓解 |
+|------|------|
+| 旧 MCP URL 导入行为变化影响用户 | 增加兼容开关，默认安全，文档说明迁移。 |
+| Source 配置复杂度高 | 第一阶段只支持静态配置，动态配置后续再做。 |
+| Skill 外部协议不统一 | 先实现 well-known/zip artifact，其他市场用插件扩展。 |
+| MCP Operator 绑定旧实现 | Operator 层明确隔离，MCP `ai_resource` 化时替换 Operator。 |
+| SSRF 绕过 | DNS 后校验、redirect 重校验、source 级 opt-in、负向测试。 |
+
+回滚策略：
+
+- 统一导入能力由 `nacos.ai.resource.import.enabled` 控制。
+- 旧 MCP 兼容 adapter 可保留，但直接 URL 导入开关独立控制。
+- MCP/Skill 原有 create/upload API 不受新功能影响。
+
+## 14. 未决问题
+
+- `json` 和 `file` MCP 本地导入是否也作为正式 importer 暴露，还是只作为 legacy adapter 内部实现。
+- Skill dependency metadata 的标准字段需要进一步定义。
+- `LINK_EXISTING` 是否应在第一阶段写入 Skill ext，还是只返回计划。
+- source secret 应接入现有插件配置体系，还是先走环境变量引用。
+- maintainer-client 是否需要在第一阶段同步支持统一导入 API。
+- Console UI 是先在 `ImportMcpDialog` 内渐进改造，还是直接抽通用 `AiResourceImportDialog`。
+
+## 15. 细化 TODO List
+
+### 15.1 PR 2 SPI 与模型
+
+- [ ] 定义 `AiResourceImportService`、`AiResourceImportContext`、candidate、artifact、source SPI 模型。
+- [ ] 定义 API 层 search/validate/execute request/response。
+- [ ] 定义 `payloadKind`、`dependencyPolicy`、`writePolicy` 枚举。
+- [ ] 增加 SPI 加载和模型序列化单元测试。
+
+### 15.2 PR 3 Manager、Source 与 Console API
+
+- [ ] 实现 `AiResourceImportProperties` 和 source 配置校验。
+- [ ] 实现 `AiResourceImportSourceManager`，返回脱敏 source view。
+- [ ] 实现 `AiResourceImportPluginManager` 和 fake importer。
+- [ ] 实现 `AiResourceImportManager#search/#validate/#execute` 编排。
+- [ ] 实现 `AiResourceOperatorRegistry` 和 fake operator。
+- [ ] 新增 Admin import controller。
+- [ ] 新增 Console import controller、proxy、handler。
+- [ ] 补 local/remote Console handler 测试。
+
+### 15.3 PR 4 MCP 导入迁移
+
+- [ ] 把 `McpExternalDataAdaptor` 的 registry 访问拆到 `McpRegistryImportService`。
+- [ ] 增加 `McpJsonImportService` 和 `McpSeedImportService`，承接 legacy json/file。
+- [ ] 增加 `McpResourceOperator`，复用 `McpServerValidationService` 和当前 MCP operation service。
+- [ ] 增加 `McpLegacyImportAdapter`，映射旧 request/response。
+- [ ] 改造 `ConsoleMcpController#import/validate` 和 `#import/execute` 路由到 legacy adapter。
+- [ ] 改造 `ImportMcpDialog.jsx`，使用 source selector 和统一 search/validate/execute API。
+- [ ] 保留旧 API 前端 service 但新 UI 不主动调用。
+
+### 15.4 PR 5 Skill 导入
+
+- [ ] 实现 Skill well-known importer。
+- [ ] 实现 `SkillResourceOperator`，复用 `SkillOperationService.uploadSkillFromZip`。
+- [ ] search 中返回 Skill metadata，validate 中返回 draft/版本冲突和 MCP 依赖 warning。
+- [ ] Skill 管理页新增导入按钮。
+- [ ] 抽取或复用 `AiResourceImportDialog`。
+
+### 15.5 PR 6 安全与观测
+
+- [ ] 实现 endpoint validator、network policy 和安全 HTTP client factory。
+- [ ] 增加 DNS 后校验、redirect 后重校验、私网阻断和响应大小限制。
+- [ ] 增加 source 级网络策略 opt-in。
+- [ ] 增加 import trace/audit 日志，确保 secret 不落日志。
+- [ ] 补 SSRF 负向测试。
+
+### 15.6 PR 7 UI 增强与文档
+
+- [ ] 增加导入结果失败过滤和 retry failed。
+- [ ] 增加 candidate detail drawer。
+- [ ] 增加 dependency warning 聚合展示。
+- [ ] 增加 source 为空、source disabled、feature disabled 的空状态。
+- [ ] 补中文和英文用户文档。
+- [ ] 补旧 MCP URL 导入迁移说明。

--- a/specs/zh-cn/ai/README.md
+++ b/specs/zh-cn/ai/README.md
@@ -44,5 +44,6 @@ AI Registry 可以使用扩展点，但扩展契约由插件规范定义：
 
 - [AI 发布流水线插件规范](../plugin/ai-pipeline-plugin-spec.md)
 - [AI 存储插件规范](../plugin/ai-storage-plugin-spec.md)
+- [AI 资源导入插件规范](../plugin/ai-resource-import-plugin-spec.md)
 - [可见性插件规范](../auth/visibility-plugin-spec.md)
 - [Trace 插件规范](../plugin/trace-plugin-spec.md)

--- a/specs/zh-cn/ai/ai-registry-spec.md
+++ b/specs/zh-cn/ai/ai-registry-spec.md
@@ -28,7 +28,7 @@ AI Registry 负责：
 - AI 资源元数据、版本、标签、状态、scope、owner 和业务标签；
 - MCP Server、A2A Agent、Prompt、Skill、AgentSpec 等资源类型契约；
 - 已支持 AI 资源的运行时查询和订阅行为；
-- draft 创建、审核、发布、强制发布、上线/下线、删除、上传和下载等管理流程；
+- draft 创建、审核、发布、强制发布、上线/下线、删除、上传、导入和下载等管理流程；
 - AI 发布流水线、存储插件、可见性、鉴权和 Trace 钩子的领域使用方式。
 
 AI Registry 不负责：
@@ -36,7 +36,7 @@ AI Registry 不负责：
 - Config 资源语义，即使默认 AI 存储实现通过 Config 保存资源内容；
 - Naming service 语义，即使 MCP 或 A2A endpoint 通过 Naming service 和 instance 表达；
 - [AI Registry 适配器规范](ai-registry-adaptor-spec.md)暴露的社区 registry 协议定义；
-- 插件扩展契约。流水线、存储、可见性和 Trace 的扩展规则由对应插件规范定义。
+- 插件扩展契约。流水线、存储、资源导入、可见性和 Trace 的扩展规则由对应插件规范定义。
 
 ## 2. 设计原则
 
@@ -48,7 +48,8 @@ AI Registry 不负责：
 - **资源身份稳定**：`resourceType` 是第二层身份。AI 资源不应引入 Config 风格的
   `groupName` 身份，除非兼容路径必须保留。
 - **插件组合**：可见性、存储、Trace 和发布流水线应通过插件组合，并在本领域规范中
-  建立链接，不应定义隐藏的 AI 专用扩展机制。
+  建立链接。外部资源导入也应使用相同插件模型，并把导入 artifact 路由回资源
+  Operator。不应定义隐藏的 AI 专用扩展机制。
 - **允许快速演进**：AI 协议和资源格式变化很快。当 MCP、A2A、Agent 包格式或
   模型工具生态变化时，规范可能需要不兼容或大幅调整。调整必须按照
   [兼容与废弃策略规范](../design/compatibility-deprecation-spec.md)说明迁移、兼容和废弃行为。
@@ -109,6 +110,10 @@ AI Registry 通过多个接口面暴露：
 - 发布流水线扩展行为必须使用
   [AI 发布流水线插件规范](../plugin/ai-pipeline-plugin-spec.md)。
 - 资源存储扩展行为必须使用 [AI 存储插件规范](../plugin/ai-storage-plugin-spec.md)。
+- 外部 AI 资源导入行为必须使用
+  [AI 资源导入插件规范](../plugin/ai-resource-import-plugin-spec.md)。导入插件负责把
+  运维配置的外部来源转换为导入 artifact；资源 Operator 负责把 artifact 应用到当前存储和
+  生命周期模型。
 - Trace 和审计事件应使用 [Trace 插件规范](../plugin/trace-plugin-spec.md)和共享
   可观测规则。
 

--- a/specs/zh-cn/ai/mcp-server-spec.md
+++ b/specs/zh-cn/ai/mcp-server-spec.md
@@ -83,14 +83,27 @@ endpoint：
 这是兼容存储，不是目标标准模型。新的 MCP 语义应按 AI Registry 语义定义，然后在迁移
 完成前映射到当前存储。
 
-## 6. 待迁移问题
+## 6. 外部导入
+
+从外部 registry 或市场导入 MCP 应使用
+[AI 资源导入插件规范](../plugin/ai-resource-import-plugin-spec.md)。导入插件负责把运维配置的
+外部 MCP registry 数据转换为 MCP 导入 artifact，不得直接写入 MCP 存储。
+
+MCP Resource Operator 负责通过 MCP 领域操作服务应用导入 artifact。当前实现可以使用
+Config-backed 的 `McpServerOperationService`。未来 MCP 元数据和版本迁移到 `ai_resource`
+后，应替换 MCP Resource Operator 到新的存储模型，同时保持导入插件和统一导入 API 兼容。
+
+旧 MCP 导入 API 可以作为兼容路由保留，但应委托给统一 AI 资源导入流程。默认情况下，不得把用户传入的
+registry URL 或 MCP endpoint 地址作为服务端直接访问的网络目标。
+
+## 7. 待迁移问题
 
 - 将 MCP 元数据和版本行迁移到 `ai_resource` 和 `ai_resource_version`。
 - 定义现有 Config-backed MCP 记录在混合版本集群中的发现、迁移和服务方式。
 - 让 MCP label 和 latest-version 行为与共享 AI 资源 label 模型对齐。
 - 定义运行时客户端注册 direct endpoint 的所有权和清理规则。
 
-## 7. 演进说明
+## 8. 演进说明
 
 MCP 仍在快速演进。Tool schema、resources、transport mode、auth metadata 和 registry
 互操作都可能变化。因此 MCP Server 规范的调整可能大于普通 Nacos 领域变更，但必须

--- a/specs/zh-cn/ai/skill-spec.md
+++ b/specs/zh-cn/ai/skill-spec.md
@@ -67,6 +67,11 @@ Skill 定义为“一个目录，至少包含一个 `SKILL.md` 文件”。Nacos
 [AI Registry 适配器规范](ai-registry-adaptor-spec.md)定义。适配器是可选兼容面，
 不会替代标准 Skill resource 生命周期。
 
+从外部市场或 registry 导入 Skill 由
+[AI 资源导入插件规范](../plugin/ai-resource-import-plugin-spec.md)定义。导入插件必须产出标准
+Skill 包 artifact，Skill Resource Operator 必须通过普通 Skill upload 或 draft 生命周期应用这些
+artifact。导入插件不得绕过包校验、可见性、存储或发布治理。
+
 Nacos 注册中心路径不得在 upload、query 或 download 过程中执行包内脚本。脚本执行、静态
 分析或安全扫描属于发布流水线插件，或属于显式激活 Skill 的客户端行为。AI 流水线插件契约
 由 [AI 流水线插件规范](../plugin/ai-pipeline-plugin-spec.md)定义。
@@ -89,6 +94,9 @@ Skill 遵循共享的 [AI 资源生命周期规范](ai-resource-lifecycle-spec.m
 - bootstrap 内置 Skill 可以直接创建 online 元数据和版本行；
 - submit 可以运行发布流水线，并发布或退回 draft；
 - labels、online/offline、scope、bizTags 和 delete 操作按需通过 CAS 更新元数据。
+
+导入的 Skill 遵循 upload 和 draft 规则，除非该操作是服务端拥有的显式 bootstrap 流程。
+依赖处理，例如 Skill 引用 MCP tools，应通过统一导入流程 preview，默认不得递归导入依赖。
 
 ## 6. 运行时行为
 

--- a/specs/zh-cn/plugin/README.md
+++ b/specs/zh-cn/plugin/README.md
@@ -44,6 +44,7 @@
 
 - [AI 发布 Pipeline 插件规范](ai-pipeline-plugin-spec.md)
 - [AI 存储插件规范](ai-storage-plugin-spec.md)
+- [AI 资源导入插件规范](ai-resource-import-plugin-spec.md)
 
 ## 安全扩展
 

--- a/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
@@ -1,0 +1,238 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# AI 资源导入插件规范
+
+## 范围
+
+AI 资源导入插件用于让 Nacos 从运维人员配置的外部 registry 或市场导入 AI 资源。它面向
+MCP Server、Skill 以及未来需要先做外部发现和转换再进入 Nacos AI Registry 治理流程的
+AI 资源类型。
+
+导入插件只拥有外部来源协议，以及从外部模型转换为 Nacos 导入 artifact 的逻辑。它不拥有
+Nacos 资源身份、鉴权、可见性、存储、版本生命周期、发布流水线或 Trace 行为。这些规则仍由
+[AI Registry 规范](../ai/ai-registry-spec.md)、资源类型规范以及 AI Registry 领域选择的
+资源 Operator 负责。
+
+该插件类型以 `ai-resource-import` 暴露给核心插件管理器。通用插件生命周期和状态规则由
+[Nacos 插件化规范](plugin-spec.md)定义。
+
+SPI 契约应定义在插件体系中，例如 `plugin/ai` 模块，和 AI storage、visibility 等插件类型保持
+一致。Nacos 应允许用户通过插件机制扩展新的 importer 来源，例如企业内部 Skill 市场、私有 MCP
+registry 或 Git 索引。资源 Operator 不属于用户扩展插件，第一阶段应由 `ai` 模块内置并通过
+Nacos 当前领域服务写入资源。
+
+## 概念
+
+| 概念 | 含义 |
+|------|------|
+| Import source | 由运维定义、通过 `sourceId` 标识的导入来源配置。 |
+| Importer | 导入来源选择的插件实现。 |
+| Candidate | search 阶段返回的外部资源摘要，不包含可导入完整内容。 |
+| Artifact | 可被资源 Operator 应用的 payload 和元数据。 |
+| Resource operator | 校验并写入某一资源类型的 Nacos 领域服务。 |
+| Dependency | 被导入 artifact 引用的其他资源，例如 Skill 依赖 MCP tools。 |
+
+Import source 属于 Nacos 服务端配置或插件配置。终端用户选择 `sourceId`；导入请求不得提交任意
+endpoint URL、IP 地址、凭证或 registry base path。
+
+## 执行形态
+
+`ai-resource-import` 是配置选择的单服务插件类型。
+
+同一进程可以加载多个 importer 实现，例如 `mcp-registry`、`skills-well-known` 或企业内部
+市场 importer。每次请求中，AI 导入来源管理器先把 `sourceId` 解析为一个已启用 source，再选择
+该 source 指定的 importer。
+
+Importer 在 search 阶段返回 candidate，在 validate 和 execute 阶段按选中项拉取 artifact。
+随后 AI Registry 导入管理器根据 artifact 的 `resourceType` 路由到对应资源 Operator。
+
+```text
+sourceId -> ImportSource(pluginName, resourceTypes, endpoint, limits, authRef)
+         -> AiResourceImportService
+         -> AiResourceOperator(resourceType)
+```
+
+## Source 配置
+
+一个导入来源应包含：
+
+| 字段 | 要求 |
+|------|------|
+| `sourceId` | 稳定、面向用户展示的来源标识。 |
+| `pluginName` | `ai-resource-import` 类型下的 importer 实现名。 |
+| `resourceTypes` | 该来源支持的资源类型，例如 `mcp` 或 `skill`。 |
+| `endpoint` | 运维配置的来源 endpoint 或 registry root。 |
+| `enabled` | 该来源是否可以服务导入请求。 |
+| `authRef` | 可选的服务端凭证引用；secret 不返回给用户。 |
+| `connectTimeout` / `readTimeout` | 来源级网络超时。 |
+| `maxPageCount` / `maxItemCount` | 分页保护限制。 |
+| `maxArtifactSize` | 单个 artifact 最大大小。 |
+| `properties` | importer 专属非 secret 配置。 |
+
+来源管理器必须拒绝重复 `sourceId`，并拒绝 importer 插件未加载或已禁用的 source。
+
+## SPI
+
+导入实现由 builder 创建。
+
+| Builder 方法 | 要求 |
+|--------------|------|
+| `importerType()` | 稳定 importer 实现名。 |
+| `build(properties)` | 使用 importer 自有配置构造导入服务。 |
+
+导入服务实现：
+
+| Service 方法 | 要求 |
+|--------------|------|
+| `importerType()` | 运行时 importer 类型。 |
+| `supportedResourceTypes()` | importer 可以产出的资源类型。 |
+| `search(context)` | 从配置来源返回 candidate 分页，结果只包含必要元数据。 |
+| `fetch(context, item)` | 从配置来源拉取一个被选择的 artifact。 |
+
+`context` 包含 namespace、resource type、source 配置、query、cursor、limit 和 importer
+选项。它不得包含用户传入的网络 endpoint。
+
+`search` 应无副作用，并且不得返回 MCP tools、Skill 包内容、secret 或其他完整可导入 payload。
+`fetch` 可以访问外部来源并返回字节或结构化 payload，但不得写入 Nacos
+资源。
+
+## 导入 Artifact
+
+Artifact 应包含：
+
+| 字段 | 含义 |
+|------|------|
+| `resourceType` | 目标 Nacos AI 资源类型。 |
+| `externalId` | 来源内部的稳定 ID。 |
+| `name` | 候选 Nacos 资源名，如已知。 |
+| `version` | 候选版本，如已知。 |
+| `description` | 资源描述。 |
+| `payloadKind` | Payload 形态，例如 `MCP_DETAIL`、`SKILL_ZIP` 或 `JSON`。 |
+| `payload` | 拉取到的字节或结构化数据。 |
+| `dependencies` | 可选的被引用资源。 |
+| `sourceMetadata` | 用于 Trace 和诊断的非 secret 来源元数据。 |
+
+Artifact 是导入边界对象，不是持久化资源模型。资源 Operator 负责把它转换为当前存储和生命周期模型。
+
+## Resource Operator
+
+Resource Operator 位于 AI Registry 领域内，不属于导入插件。它们通过资源类型当前的服务层校验并
+写入 artifact。
+
+对 MCP 而言，初始 Operator 可以调用当前 `McpServerOperationService` 和相关校验服务，即使 MCP
+当前仍由 Config 记录承载。未来 MCP 迁移到 `ai_resource` 后，只应修改 MCP Operator。导入插件和
+统一导入 API 应保持兼容。
+
+对 Skill 而言，Operator 应保持 Skill 包边界，并通过 Skill upload 或 draft 生命周期 API 写入。
+
+## API 流程
+
+Nacos 应暴露统一的 Admin 和 Console 导入 API：
+
+| 方法 | 路径 | 目的 |
+|------|------|------|
+| `GET` | `/v3/admin/ai/import/sources` | 查询可用导入来源。 |
+| `POST` | `/v3/admin/ai/import/search` | 根据 source 查询候选摘要。 |
+| `POST` | `/v3/admin/ai/import/validate` | 校验被选择的候选并返回冲突、依赖和 warning。 |
+| `POST` | `/v3/admin/ai/import/execute` | 导入被选择的候选。 |
+| `GET` | `/v3/console/ai/import/sources` | Console 来源列表。 |
+| `POST` | `/v3/console/ai/import/search` | Console search 流程。 |
+| `POST` | `/v3/console/ai/import/validate` | Console validate 流程。 |
+| `POST` | `/v3/console/ai/import/execute` | Console execute 流程。 |
+
+所有统一 API 必须使用标准 v3 `Result<T>` 响应、错误和鉴权约定。
+
+推荐的浏览器流程为：
+
+```text
+list sources(resourceType)
+  -> select sourceId
+  -> search candidates by sourceId and query
+  -> user selects candidates
+  -> validate selected candidates
+  -> show conflicts, dependency warnings, and overwrite options
+  -> execute selected candidates
+```
+
+浏览器不得接收完整 artifact。MCP 的 tools/specification、Skill zip 或其他可导入内容只允许在
+服务端 Importer、Import Manager 和 Resource Operator 之间流转。
+
+## 旧 MCP 导入兼容
+
+现有 MCP 导入 API 可以在兼容窗口期内保留：
+
+```text
+POST /v3/console/ai/mcp/import/validate
+POST /v3/console/ai/mcp/import/execute
+GET  /v3/console/ai/mcp/importToolsFromMcp
+```
+
+validate 和 execute 端点应通过兼容 adapter 路由到统一导入管理器，不应继续作为独立导入实现扩展。
+
+对于旧的 `importType=url`，请求默认不得把用户传入 URL 作为网络目标。当 `data` 匹配已启用
+source 时，可以按 `sourceId` 解释；否则应失败并提示迁移到
+`nacos.ai.resource.import.sources` 配置。旧的直接 URL 导入只能由运维显式配置后用于受控部署。
+
+旧的 `importType=json` 和 `importType=file` 可以映射为内置本地 importer，因为它们不需要服务端
+发起网络访问。
+
+## 依赖处理
+
+导入 artifact 可以引用其他 AI 资源。例如 Skill 可能需要 MCP tools 或 servers。统一导入流程应支持：
+
+| 策略 | 含义 |
+|------|------|
+| `IGNORE` | 保留依赖元数据，但不校验、不关联。 |
+| `VALIDATE_ONLY` | 报告 Nacos 内是否已有匹配资源。 |
+| `LINK_EXISTING` | 尽量关联已有匹配资源。 |
+| `IMPORT_SELECTED` | 只导入用户显式选择的依赖。 |
+
+默认应为 `VALIDATE_ONLY`。自动递归导入不应作为默认行为，因为它会扩大供应链和鉴权边界。
+
+## 安全要求
+
+导入流程必须把外部来源视为不可信：
+
+- 用户不能提交任意 URL、IP、registry root 或凭证；
+- 运维配置的 HTTP source 默认应使用 HTTPS；
+- redirect 必须禁用或按同一安全策略重新校验；
+- DNS 解析后默认阻断 loopback、link-local、multicast 和私网目标；
+- 来源请求必须强制连接超时、读超时、响应大小、页数和 artifact 大小限制；
+- 导入、查询或下载 Skill 包时不得执行包内脚本；
+- importer 插件不得在 API 响应、Trace 事件或日志中泄露 secret。
+
+需要从私网导入的部署必须通过运维配置显式开启。
+
+## Trace 与审计
+
+Search、validate 和 execute 操作应发出 Trace 或审计事件，包含：
+
+- source id；
+- importer 类型；
+- 资源类型；
+- candidate 数量和选中数量；
+- 单项成功、跳过或失败状态；
+- 非 secret 来源元数据；
+- 可用时的操作者身份和客户端地址。
+
+Trace 行为必须遵循 [Trace 插件规范](trace-plugin-spec.md)。
+
+## 演进说明
+
+该插件类型是转换边界。单个资源的存储实现演进时，它应保持稳定。特别是 MCP 从 Config-backed
+记录迁移到标准 AI 资源模型时，应通过替换 MCP Resource Operator 保持导入兼容，而不是修改每个
+外部 importer。

--- a/specs/zh-cn/plugin/plugin-spec.md
+++ b/specs/zh-cn/plugin/plugin-spec.md
@@ -20,7 +20,7 @@
 
 Nacos 使用插件机制和 SPI 扩展，将横切基础能力和可替换的领域能力从固定核心中拆出。
 插件可以提供鉴权、资源可见性、数据源方言、加解密、链路追踪、流量控制、环境适配、
-AI pipeline、AI 存储或 Java 客户端侧请求适配等能力。
+AI pipeline、AI 存储、AI 资源导入或 Java 客户端侧请求适配等能力。
 
 插件机制的目标，是在保持 Nacos 核心模型稳定的同时，让不同部署环境可以选择符合自身
 身份系统、数据库、观测体系或扩展场景的实现。
@@ -51,6 +51,7 @@ AI pipeline、AI 存储或 Java 客户端侧请求适配等能力。
 | `control` | 流量与控制扩展。 | [Control 插件规范](control-plugin-spec.md) |
 | `ai-pipeline` | AI 注册中心 pipeline 扩展。 | [AI 发布 Pipeline 插件规范](ai-pipeline-plugin-spec.md) |
 | `ai-storage` | AI 注册中心存储扩展。 | [AI 存储插件规范](ai-storage-plugin-spec.md) |
+| `ai-resource-import` | AI 注册中心外部资源导入扩展。 | [AI 资源导入插件规范](ai-resource-import-plugin-spec.md) |
 
 各插件类别的领域契约由对应规范定义。本文档定义所有插件类别共享的运行时契约。
 
@@ -78,7 +79,7 @@ Nacos 资源身份、鉴权和 payload 语义，因为它们会影响 SDK 发出
 | 形态 | 含义 | 示例 |
 |------|------|------|
 | 互斥选择 | 在进程或请求范围内选择一个实现，其他已加载实现不参与该次判断。 | `auth`、`datasource-dialect` |
-| 配置选择的单服务 | 可以加载多个实现，但领域根据配置或请求上下文选择一个服务。 | `visibility` |
+| 配置选择的单服务 | 可以加载多个实现，但领域根据配置或请求上下文选择一个服务。 | `visibility`、`ai-resource-import` |
 | 有序链式执行 | 多个匹配插件按稳定顺序执行。每个节点可以贡献结果，失败是否中断由领域定义。 | `ai-pipeline`、`config-change` |
 | 订阅或广播 | 多个订阅者观察同一个事件或 trace 点，不拥有主决策权。 | `trace`、事件型扩展 |
 


### PR DESCRIPTION
## What is changed

- Add the AI resource import plugin spec in English and Chinese.
- Clarify source-based search/validate/execute import flow for MCP and Skill resources.
- Document that importer SPI lives in the plugin system while resource operators stay in the AI domain.
- Update related AI Registry, MCP, Skill, and plugin specs.
- Add phased implementation plans under specs/tmp/plan/issue-15183.

## Related issue

- #15183

## Check

- ./mvnw -B apache-rat:check -DskipTests\n