### PR TITLE
[ISSUE #15183] Add AI resource import manager APIs

### DIFF
--- a/.github/workflows/it-new.yml
+++ b/.github/workflows/it-new.yml
@@ -45,7 +45,32 @@ jobs:
       - name: Wait for Server Startup
         run: |
           echo "Waiting for server to launch on port 8080..."
-          timeout 60s bash -c 'until curl -s localhost:8080 > /dev/null; do sleep 2; done' || (echo "Server failed to start" && exit 1)
+          if ! timeout 60s bash -c 'until curl -s localhost:8080 > /dev/null; do sleep 2; done'; then
+            echo "Server failed to start"
+            LOG_DIR=$(ls -d distribution/target/nacos-server-*/nacos/logs 2>/dev/null | head -n 1 || true)
+            if [ -n "$LOG_DIR" ]; then
+              echo "::group::Nacos startup.log"
+              if [ -f "$LOG_DIR/startup.log" ]; then
+                tail -300 "$LOG_DIR/startup.log"
+              else
+                echo "startup.log not found"
+              fi
+              echo "::endgroup::"
+              echo "::group::Nacos nacos.log"
+              if [ -f "$LOG_DIR/nacos.log" ]; then
+                tail -300 "$LOG_DIR/nacos.log"
+              else
+                echo "nacos.log not found"
+              fi
+              echo "::endgroup::"
+              echo "::group::Nacos log directory"
+              ls -la "$LOG_DIR"
+              echo "::endgroup::"
+            else
+              echo "Nacos log directory not found"
+            fi
+            exit 1
+          fi
           echo "Server is up"
 
       - name: Run IT Tests

--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -29,6 +29,10 @@ public class Constants {
     
     public static final String MCP_CONSOLE_PATH = "/v3/console" + MCP_PATH;
     
+    public static final String AI_RESOURCE_IMPORT_ADMIN_PATH = "/v3/admin/ai/import";
+    
+    public static final String AI_RESOURCE_IMPORT_CONSOLE_PATH = "/v3/console/ai/import";
+    
     public static final String MCP_LIST_SEARCH_ACCURATE = "accurate";
     
     public static final String MCP_LIST_SEARCH_BLUR = "blur";

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AiResourceImportAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AiResourceImportAdminController.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.controller;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.importer.manager.AiResourceImportManager;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.annotation.NacosApi;
+import com.alibaba.nacos.api.common.ApiType;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Admin API controller for AI resource import.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@NacosApi
+@RestController
+@RequestMapping(Constants.AI_RESOURCE_IMPORT_ADMIN_PATH)
+public class AiResourceImportAdminController {
+    
+    private final AiResourceImportManager importManager;
+    
+    public AiResourceImportAdminController(AiResourceImportManager importManager) {
+        this.importManager = importManager;
+    }
+    
+    /**
+     * List configured import sources.
+     *
+     * @param resourceType optional resource type filter
+     * @return source list
+     * @throws NacosException if source configuration is invalid
+     */
+    @GetMapping("/sources")
+    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.ADMIN_API)
+    public Result<List<AiResourceImportSourceInfo>> listSources(
+        @RequestParam(required = false) String resourceType) throws NacosException {
+        return Result.success(importManager.listSources(resourceType));
+    }
+    
+    /**
+     * Search external import candidates.
+     *
+     * @param request search request
+     * @return candidate page
+     * @throws NacosException if the source cannot be searched
+     */
+    @PostMapping("/search")
+    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.ADMIN_API)
+    public Result<AiResourceImportSearchResponse> search(
+        @RequestBody(required = false) AiResourceImportSearchRequest request)
+        throws NacosException {
+        return Result.success(importManager.search(request));
+    }
+    
+    /**
+     * Validate selected import candidates.
+     *
+     * @param request validate request
+     * @return validation result
+     * @throws NacosException if validation cannot start
+     */
+    @PostMapping("/validate")
+    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.ADMIN_API)
+    public Result<AiResourceImportValidateResponse> validate(
+        @RequestBody(required = false) AiResourceImportValidateRequest request)
+        throws NacosException {
+        return Result.success(importManager.validate(request));
+    }
+    
+    /**
+     * Execute import for selected candidates.
+     *
+     * @param request execute request
+     * @return import result
+     * @throws NacosException if import cannot start
+     */
+    @PostMapping("/execute")
+    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.ADMIN_API)
+    public Result<AiResourceImportExecuteResponse> execute(
+        @RequestBody(required = false) AiResourceImportExecuteRequest request)
+        throws NacosException {
+        return Result.success(importManager.execute(request));
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AiResourceImportAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AiResourceImportAdminController.java
@@ -17,13 +17,14 @@
 package com.alibaba.nacos.ai.controller;
 
 import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.form.importer.AiResourceImportExecuteForm;
+import com.alibaba.nacos.ai.form.importer.AiResourceImportSearchForm;
+import com.alibaba.nacos.ai.form.importer.AiResourceImportSourceListForm;
+import com.alibaba.nacos.ai.form.importer.AiResourceImportValidateForm;
 import com.alibaba.nacos.ai.importer.manager.AiResourceImportManager;
-import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
 import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
-import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
 import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
 import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
-import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
 import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
 import com.alibaba.nacos.api.annotation.NacosApi;
 import com.alibaba.nacos.api.common.ApiType;
@@ -34,9 +35,7 @@ import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.constant.SignType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -61,59 +60,60 @@ public class AiResourceImportAdminController {
     /**
      * List configured import sources.
      *
-     * @param resourceType optional resource type filter
+     * @param form source list form
      * @return source list
      * @throws NacosException if source configuration is invalid
      */
     @GetMapping("/sources")
     @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.ADMIN_API)
     public Result<List<AiResourceImportSourceInfo>> listSources(
-        @RequestParam(required = false) String resourceType) throws NacosException {
-        return Result.success(importManager.listSources(resourceType));
+        AiResourceImportSourceListForm form) throws NacosException {
+        form.validate();
+        return Result.success(importManager.listSources(form.getResourceType()));
     }
     
     /**
      * Search external import candidates.
      *
-     * @param request search request
+     * @param form search form
      * @return candidate page
      * @throws NacosException if the source cannot be searched
      */
     @PostMapping("/search")
     @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.ADMIN_API)
-    public Result<AiResourceImportSearchResponse> search(
-        @RequestBody(required = false) AiResourceImportSearchRequest request)
+    public Result<AiResourceImportSearchResponse> search(AiResourceImportSearchForm form)
         throws NacosException {
-        return Result.success(importManager.search(request));
+        form.validate();
+        return Result.success(importManager.search(form.toRequest()));
     }
     
     /**
      * Validate selected import candidates.
      *
-     * @param request validate request
+     * @param form validate form
      * @return validation result
      * @throws NacosException if validation cannot start
      */
     @PostMapping("/validate")
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.ADMIN_API)
-    public Result<AiResourceImportValidateResponse> validate(
-        @RequestBody(required = false) AiResourceImportValidateRequest request)
+    public Result<AiResourceImportValidateResponse> validate(AiResourceImportValidateForm form)
         throws NacosException {
-        return Result.success(importManager.validate(request));
+        form.validate();
+        return Result.success(importManager.validate(form.toRequest()));
     }
     
     /**
      * Execute import for selected candidates.
      *
-     * @param request execute request
+     * @param form execute form
      * @return import result
      * @throws NacosException if import cannot start
      */
     @PostMapping("/execute")
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.ADMIN_API)
-    public Result<AiResourceImportExecuteResponse> execute(
-        @RequestBody(required = false) AiResourceImportExecuteRequest request)
+    public Result<AiResourceImportExecuteResponse> execute(AiResourceImportExecuteForm form)
         throws NacosException {
-        return Result.success(importManager.execute(request));
+        form.validate();
+        return Result.success(importManager.execute(form.toRequest()));
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AbstractAiResourceImportForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AbstractAiResourceImportForm.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.form.importer;
+
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportItem;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.NacosForm;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base form for AI resource import APIs.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public abstract class AbstractAiResourceImportForm implements NacosForm, Serializable {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private String namespaceId;
+    
+    private String resourceType;
+    
+    private String sourceId;
+    
+    private String options;
+    
+    protected void validateSource() throws NacosApiException {
+        if (StringUtils.isBlank(resourceType)) {
+            throw missingParameter("resourceType");
+        }
+        if (StringUtils.isBlank(sourceId)) {
+            throw missingParameter("sourceId");
+        }
+    }
+    
+    protected Map<String, String> parseOptions() throws NacosApiException {
+        if (StringUtils.isBlank(options)) {
+            return null;
+        }
+        try {
+            return JacksonUtils.toObj(options, new TypeReference<Map<String, String>>() {
+            });
+        } catch (RuntimeException e) {
+            throw parseFailed("options", e);
+        }
+    }
+    
+    protected List<AiResourceImportItem> parseSelectedItems(String selectedItems)
+        throws NacosApiException {
+        if (StringUtils.isBlank(selectedItems)) {
+            return null;
+        }
+        try {
+            return JacksonUtils.toObj(selectedItems,
+                new TypeReference<List<AiResourceImportItem>>() {
+                });
+        } catch (RuntimeException e) {
+            throw parseFailed("selectedItems", e);
+        }
+    }
+    
+    protected NacosApiException missingParameter(String name) {
+        return new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
+            "Required parameter `" + name + "` is not present.");
+    }
+    
+    private NacosApiException parseFailed(String name, RuntimeException cause) {
+        return new NacosApiException(NacosException.INVALID_PARAM,
+            ErrorCode.PARAMETER_VALIDATE_ERROR, cause,
+            "Request parameter `" + name + "` can't be parsed.");
+    }
+    
+    public String getNamespaceId() {
+        return namespaceId;
+    }
+    
+    public void setNamespaceId(String namespaceId) {
+        this.namespaceId = namespaceId;
+    }
+    
+    public String getResourceType() {
+        return resourceType;
+    }
+    
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+    
+    public String getSourceId() {
+        return sourceId;
+    }
+    
+    public void setSourceId(String sourceId) {
+        this.sourceId = sourceId;
+    }
+    
+    public String getOptions() {
+        return options;
+    }
+    
+    public void setOptions(String options) {
+        this.options = options;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AiResourceImportExecuteForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AiResourceImportExecuteForm.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.form.importer;
+
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.common.utils.StringUtils;
+
+/**
+ * Form for executing AI resource import.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class AiResourceImportExecuteForm extends AbstractAiResourceImportForm {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private String selectedItems;
+    
+    private boolean overwriteExisting;
+    
+    private boolean skipInvalid;
+    
+    private String validationToken;
+    
+    @Override
+    public void validate() throws NacosApiException {
+        validateSource();
+        if (StringUtils.isBlank(selectedItems)) {
+            throw missingParameter("selectedItems");
+        }
+    }
+    
+    /**
+     * Convert form data to import execute request.
+     *
+     * @return import execute request
+     * @throws NacosApiException if form JSON fields can't be parsed
+     */
+    public AiResourceImportExecuteRequest toRequest() throws NacosApiException {
+        AiResourceImportExecuteRequest request = new AiResourceImportExecuteRequest();
+        request.setNamespaceId(getNamespaceId());
+        request.setResourceType(getResourceType());
+        request.setSourceId(getSourceId());
+        request.setSelectedItems(parseSelectedItems(selectedItems));
+        request.setOverwriteExisting(overwriteExisting);
+        request.setSkipInvalid(skipInvalid);
+        request.setValidationToken(validationToken);
+        request.setOptions(parseOptions());
+        return request;
+    }
+    
+    public String getSelectedItems() {
+        return selectedItems;
+    }
+    
+    public void setSelectedItems(String selectedItems) {
+        this.selectedItems = selectedItems;
+    }
+    
+    public boolean isOverwriteExisting() {
+        return overwriteExisting;
+    }
+    
+    public void setOverwriteExisting(boolean overwriteExisting) {
+        this.overwriteExisting = overwriteExisting;
+    }
+    
+    public boolean isSkipInvalid() {
+        return skipInvalid;
+    }
+    
+    public void setSkipInvalid(boolean skipInvalid) {
+        this.skipInvalid = skipInvalid;
+    }
+    
+    public String getValidationToken() {
+        return validationToken;
+    }
+    
+    public void setValidationToken(String validationToken) {
+        this.validationToken = validationToken;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AiResourceImportSearchForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AiResourceImportSearchForm.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.form.importer;
+
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+
+/**
+ * Form for searching external AI resource import candidates.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class AiResourceImportSearchForm extends AbstractAiResourceImportForm {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private String query;
+    
+    private String cursor;
+    
+    private Integer limit;
+    
+    @Override
+    public void validate() throws NacosApiException {
+        validateSource();
+    }
+    
+    /**
+     * Convert form data to import search request.
+     *
+     * @return import search request
+     * @throws NacosApiException if options can't be parsed
+     */
+    public AiResourceImportSearchRequest toRequest() throws NacosApiException {
+        AiResourceImportSearchRequest request = new AiResourceImportSearchRequest();
+        request.setNamespaceId(getNamespaceId());
+        request.setResourceType(getResourceType());
+        request.setSourceId(getSourceId());
+        request.setQuery(query);
+        request.setCursor(cursor);
+        request.setLimit(limit);
+        request.setOptions(parseOptions());
+        return request;
+    }
+    
+    public String getQuery() {
+        return query;
+    }
+    
+    public void setQuery(String query) {
+        this.query = query;
+    }
+    
+    public String getCursor() {
+        return cursor;
+    }
+    
+    public void setCursor(String cursor) {
+        this.cursor = cursor;
+    }
+    
+    public Integer getLimit() {
+        return limit;
+    }
+    
+    public void setLimit(Integer limit) {
+        this.limit = limit;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AiResourceImportSourceListForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AiResourceImportSourceListForm.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.form.importer;
+
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.NacosForm;
+
+import java.io.Serializable;
+
+/**
+ * Form for listing AI resource import sources.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class AiResourceImportSourceListForm implements NacosForm, Serializable {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private String resourceType;
+    
+    @Override
+    public void validate() throws NacosApiException {
+    }
+    
+    public String getResourceType() {
+        return resourceType;
+    }
+    
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AiResourceImportValidateForm.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/form/importer/AiResourceImportValidateForm.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.form.importer;
+
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.common.utils.StringUtils;
+
+/**
+ * Form for validating external AI resource import candidates.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class AiResourceImportValidateForm extends AbstractAiResourceImportForm {
+    
+    private static final long serialVersionUID = 1L;
+    
+    private String selectedItems;
+    
+    private boolean overwriteExisting;
+    
+    @Override
+    public void validate() throws NacosApiException {
+        validateSource();
+        if (StringUtils.isBlank(selectedItems)) {
+            throw missingParameter("selectedItems");
+        }
+    }
+    
+    /**
+     * Convert form data to import validate request.
+     *
+     * @return import validate request
+     * @throws NacosApiException if form JSON fields can't be parsed
+     */
+    public AiResourceImportValidateRequest toRequest() throws NacosApiException {
+        AiResourceImportValidateRequest request = new AiResourceImportValidateRequest();
+        request.setNamespaceId(getNamespaceId());
+        request.setResourceType(getResourceType());
+        request.setSourceId(getSourceId());
+        request.setSelectedItems(parseSelectedItems(selectedItems));
+        request.setOverwriteExisting(overwriteExisting);
+        request.setOptions(parseOptions());
+        return request;
+    }
+    
+    public String getSelectedItems() {
+        return selectedItems;
+    }
+    
+    public void setSelectedItems(String selectedItems) {
+        this.selectedItems = selectedItems;
+    }
+    
+    public boolean isOverwriteExisting() {
+        return overwriteExisting;
+    }
+    
+    public void setOverwriteExisting(boolean overwriteExisting) {
+        this.overwriteExisting = overwriteExisting;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/config/AiResourceImportProperties.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/config/AiResourceImportProperties.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.config;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.sys.env.EnvUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * AI resource import runtime properties.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class AiResourceImportProperties {
+    
+    public static final String PREFIX = "nacos.ai.resource.import.";
+    
+    public static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 3000;
+    
+    public static final int DEFAULT_READ_TIMEOUT_MILLIS = 10000;
+    
+    public static final int DEFAULT_MAX_PAGE_COUNT = 20;
+    
+    public static final int DEFAULT_MAX_ITEM_COUNT = 500;
+    
+    public static final long DEFAULT_MAX_ARTIFACT_SIZE = 10L * 1024 * 1024;
+    
+    private static final String SOURCES_PREFIX = PREFIX + "sources[";
+    
+    private boolean enabled;
+    
+    private boolean allowUserUrl;
+    
+    private int defaultConnectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT_MILLIS;
+    
+    private int defaultReadTimeoutMillis = DEFAULT_READ_TIMEOUT_MILLIS;
+    
+    private int defaultMaxPageCount = DEFAULT_MAX_PAGE_COUNT;
+    
+    private int defaultMaxItemCount = DEFAULT_MAX_ITEM_COUNT;
+    
+    private long defaultMaxArtifactSize = DEFAULT_MAX_ARTIFACT_SIZE;
+    
+    private boolean blockPrivateNetwork = true;
+    
+    private List<AiResourceImportSourceConfig> sources = Collections.emptyList();
+    
+    /**
+     * Load import properties from the current Nacos environment.
+     *
+     * @return loaded properties
+     */
+    public static AiResourceImportProperties loadFromEnvironment() {
+        return load(EnvUtil.getProperties());
+    }
+    
+    /**
+     * Load import properties from raw properties.
+     *
+     * @param properties raw properties
+     * @return loaded properties
+     */
+    public static AiResourceImportProperties load(Properties properties) {
+        AiResourceImportProperties result = new AiResourceImportProperties();
+        result.setEnabled(getBoolean(properties, PREFIX + "enabled", false));
+        result.setAllowUserUrl(getBoolean(properties, PREFIX + "allow-user-url", false));
+        result.setDefaultConnectTimeoutMillis(getInt(properties,
+            PREFIX + "default-connect-timeout-ms", DEFAULT_CONNECT_TIMEOUT_MILLIS));
+        result.setDefaultReadTimeoutMillis(getInt(properties,
+            PREFIX + "default-read-timeout-ms", DEFAULT_READ_TIMEOUT_MILLIS));
+        result.setDefaultMaxPageCount(getInt(properties, PREFIX + "default-max-page-count",
+            DEFAULT_MAX_PAGE_COUNT));
+        result.setDefaultMaxItemCount(getInt(properties, PREFIX + "default-max-item-count",
+            DEFAULT_MAX_ITEM_COUNT));
+        result.setDefaultMaxArtifactSize(getLong(properties, PREFIX + "default-max-artifact-size",
+            DEFAULT_MAX_ARTIFACT_SIZE));
+        result.setBlockPrivateNetwork(getBoolean(properties, PREFIX + "block-private-network",
+            true));
+        result.setSources(loadSources(properties, result));
+        return result;
+    }
+    
+    private static List<AiResourceImportSourceConfig> loadSources(Properties properties,
+        AiResourceImportProperties defaults) {
+        List<AiResourceImportSourceConfig> result = new ArrayList<>();
+        for (int i = 0; hasSourceIndex(properties, i); i++) {
+            String base = SOURCES_PREFIX + i + "].";
+            AiResourceImportSourceConfig source = new AiResourceImportSourceConfig();
+            source.setSourceId(getString(properties, base, "source-id", "sourceId"));
+            source.setDisplayName(getString(properties, base, "display-name", "displayName"));
+            source.setDescription(getString(properties, base, "description", "description"));
+            source.setPluginName(getString(properties, base, "plugin-name", "pluginName"));
+            source.setResourceTypes(getStringList(properties, base, "resource-types",
+                "resourceTypes"));
+            source.setEndpoint(getString(properties, base, "endpoint", "endpoint"));
+            source.setEnabled(getBoolean(properties, base + "enabled", true));
+            source.setAuthRef(getString(properties, base, "auth-ref", "authRef"));
+            source.setConnectTimeoutMillis(getInt(properties, base + "connect-timeout-ms",
+                defaults.getDefaultConnectTimeoutMillis()));
+            source.setReadTimeoutMillis(getInt(properties, base + "read-timeout-ms",
+                defaults.getDefaultReadTimeoutMillis()));
+            source.setMaxPageCount(getInt(properties, base + "max-page-count",
+                defaults.getDefaultMaxPageCount()));
+            source.setMaxItemCount(getInt(properties, base + "max-item-count",
+                defaults.getDefaultMaxItemCount()));
+            source.setMaxArtifactSize(getLong(properties, base + "max-artifact-size",
+                defaults.getDefaultMaxArtifactSize()));
+            source.setProperties(getSourceProperties(properties, base));
+            result.add(source);
+        }
+        return result;
+    }
+    
+    private static boolean hasSourceIndex(Properties properties, int index) {
+        String base = SOURCES_PREFIX + index + "].";
+        for (String each : properties.stringPropertyNames()) {
+            if (each.startsWith(base)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private static String getString(Properties properties, String base, String kebabKey,
+        String camelKey) {
+        String value = properties.getProperty(base + kebabKey);
+        if (StringUtils.isBlank(value)) {
+            value = properties.getProperty(base + camelKey);
+        }
+        return StringUtils.isBlank(value) ? null : StringUtils.trim(value);
+    }
+    
+    private static List<String> getStringList(Properties properties, String base, String kebabKey,
+        String camelKey) {
+        String value = getString(properties, base, kebabKey, camelKey);
+        if (StringUtils.isBlank(value)) {
+            return Collections.emptyList();
+        }
+        String[] values = value.split(",");
+        List<String> result = new ArrayList<>(values.length);
+        for (String each : values) {
+            if (StringUtils.isNotBlank(each)) {
+                result.add(StringUtils.trim(each));
+            }
+        }
+        return result;
+    }
+    
+    private static Map<String, String> getSourceProperties(Properties properties, String base) {
+        String prefix = base + "properties.";
+        Map<String, String> result = new LinkedHashMap<>();
+        for (String each : properties.stringPropertyNames()) {
+            if (each.startsWith(prefix)) {
+                result.put(each.substring(prefix.length()), properties.getProperty(each));
+            }
+        }
+        return result;
+    }
+    
+    private static boolean getBoolean(Properties properties, String key, boolean defaultValue) {
+        String value = properties.getProperty(key);
+        return StringUtils.isBlank(value) ? defaultValue : Boolean.parseBoolean(value);
+    }
+    
+    private static int getInt(Properties properties, String key, int defaultValue) {
+        String value = properties.getProperty(key);
+        return StringUtils.isBlank(value) ? defaultValue : Integer.parseInt(value);
+    }
+    
+    private static long getLong(Properties properties, String key, long defaultValue) {
+        String value = properties.getProperty(key);
+        return StringUtils.isBlank(value) ? defaultValue : Long.parseLong(value);
+    }
+    
+    public boolean isEnabled() {
+        return enabled;
+    }
+    
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+    
+    public boolean isAllowUserUrl() {
+        return allowUserUrl;
+    }
+    
+    public void setAllowUserUrl(boolean allowUserUrl) {
+        this.allowUserUrl = allowUserUrl;
+    }
+    
+    public int getDefaultConnectTimeoutMillis() {
+        return defaultConnectTimeoutMillis;
+    }
+    
+    public void setDefaultConnectTimeoutMillis(int defaultConnectTimeoutMillis) {
+        this.defaultConnectTimeoutMillis = defaultConnectTimeoutMillis;
+    }
+    
+    public int getDefaultReadTimeoutMillis() {
+        return defaultReadTimeoutMillis;
+    }
+    
+    public void setDefaultReadTimeoutMillis(int defaultReadTimeoutMillis) {
+        this.defaultReadTimeoutMillis = defaultReadTimeoutMillis;
+    }
+    
+    public int getDefaultMaxPageCount() {
+        return defaultMaxPageCount;
+    }
+    
+    public void setDefaultMaxPageCount(int defaultMaxPageCount) {
+        this.defaultMaxPageCount = defaultMaxPageCount;
+    }
+    
+    public int getDefaultMaxItemCount() {
+        return defaultMaxItemCount;
+    }
+    
+    public void setDefaultMaxItemCount(int defaultMaxItemCount) {
+        this.defaultMaxItemCount = defaultMaxItemCount;
+    }
+    
+    public long getDefaultMaxArtifactSize() {
+        return defaultMaxArtifactSize;
+    }
+    
+    public void setDefaultMaxArtifactSize(long defaultMaxArtifactSize) {
+        this.defaultMaxArtifactSize = defaultMaxArtifactSize;
+    }
+    
+    public boolean isBlockPrivateNetwork() {
+        return blockPrivateNetwork;
+    }
+    
+    public void setBlockPrivateNetwork(boolean blockPrivateNetwork) {
+        this.blockPrivateNetwork = blockPrivateNetwork;
+    }
+    
+    public List<AiResourceImportSourceConfig> getSources() {
+        return sources;
+    }
+    
+    public void setSources(List<AiResourceImportSourceConfig> sources) {
+        this.sources = sources;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/config/AiResourceImportSourceConfig.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/config/AiResourceImportSourceConfig.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.config;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Operator-owned AI resource import source configuration.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class AiResourceImportSourceConfig {
+    
+    private String sourceId;
+    
+    private String displayName;
+    
+    private String description;
+    
+    private String pluginName;
+    
+    private List<String> resourceTypes;
+    
+    private String endpoint;
+    
+    private boolean enabled;
+    
+    private String authRef;
+    
+    private int connectTimeoutMillis;
+    
+    private int readTimeoutMillis;
+    
+    private int maxPageCount;
+    
+    private int maxItemCount;
+    
+    private long maxArtifactSize;
+    
+    private Map<String, String> properties;
+    
+    public String getSourceId() {
+        return sourceId;
+    }
+    
+    public void setSourceId(String sourceId) {
+        this.sourceId = sourceId;
+    }
+    
+    public String getDisplayName() {
+        return displayName;
+    }
+    
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public String getPluginName() {
+        return pluginName;
+    }
+    
+    public void setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+    }
+    
+    public List<String> getResourceTypes() {
+        return resourceTypes;
+    }
+    
+    public void setResourceTypes(List<String> resourceTypes) {
+        this.resourceTypes = resourceTypes;
+    }
+    
+    public String getEndpoint() {
+        return endpoint;
+    }
+    
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+    
+    public boolean isEnabled() {
+        return enabled;
+    }
+    
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+    
+    public String getAuthRef() {
+        return authRef;
+    }
+    
+    public void setAuthRef(String authRef) {
+        this.authRef = authRef;
+    }
+    
+    public int getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+    
+    public void setConnectTimeoutMillis(int connectTimeoutMillis) {
+        this.connectTimeoutMillis = connectTimeoutMillis;
+    }
+    
+    public int getReadTimeoutMillis() {
+        return readTimeoutMillis;
+    }
+    
+    public void setReadTimeoutMillis(int readTimeoutMillis) {
+        this.readTimeoutMillis = readTimeoutMillis;
+    }
+    
+    public int getMaxPageCount() {
+        return maxPageCount;
+    }
+    
+    public void setMaxPageCount(int maxPageCount) {
+        this.maxPageCount = maxPageCount;
+    }
+    
+    public int getMaxItemCount() {
+        return maxItemCount;
+    }
+    
+    public void setMaxItemCount(int maxItemCount) {
+        this.maxItemCount = maxItemCount;
+    }
+    
+    public long getMaxArtifactSize() {
+        return maxArtifactSize;
+    }
+    
+    public void setMaxArtifactSize(long maxArtifactSize) {
+        this.maxArtifactSize = maxArtifactSize;
+    }
+    
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+    
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManager.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.manager;
+
+import com.alibaba.nacos.ai.importer.operator.AiResourceOperator;
+import com.alibaba.nacos.ai.importer.operator.AiResourceOperatorRegistry;
+import com.alibaba.nacos.ai.importer.security.AiResourceImportSecurityGuard;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportCandidateItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultStatus;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationStatus;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidate;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidatePage;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportContext;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Orchestrates AI resource import search, validation, and execution.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+public class AiResourceImportManager {
+    
+    private final AiResourceImportSourceManager sourceManager;
+    
+    private final AiResourceImportPluginManager pluginManager;
+    
+    private final AiResourceOperatorRegistry operatorRegistry;
+    
+    private final AiResourceImportSecurityGuard securityGuard;
+    
+    public AiResourceImportManager(AiResourceImportSourceManager sourceManager,
+        AiResourceImportPluginManager pluginManager, AiResourceOperatorRegistry operatorRegistry,
+        AiResourceImportSecurityGuard securityGuard) {
+        this.sourceManager = sourceManager;
+        this.pluginManager = pluginManager;
+        this.operatorRegistry = operatorRegistry;
+        this.securityGuard = securityGuard;
+    }
+    
+    /**
+     * List enabled import sources.
+     *
+     * @param resourceType optional resource type
+     * @return source info list
+     * @throws NacosException if source configuration is invalid
+     */
+    public List<AiResourceImportSourceInfo> listSources(String resourceType)
+        throws NacosException {
+        return sourceManager.listSourceInfos(resourceType);
+    }
+    
+    /**
+     * Search external candidates from an operator-configured source.
+     *
+     * @param request search request
+     * @return search response
+     * @throws NacosException if source or plugin cannot handle the request
+     */
+    public AiResourceImportSearchResponse search(AiResourceImportSearchRequest request)
+        throws NacosException {
+        requireRequest(request);
+        AiResourceImportSource source =
+            sourceManager.resolveSource(request.getSourceId(), request.getResourceType());
+        AiResourceImportService importer =
+            pluginManager.resolveImporter(source, request.getResourceType());
+        AiResourceImportCandidatePage page = importer.search(buildSearchContext(source, request));
+        AiResourceImportSearchResponse response = new AiResourceImportSearchResponse();
+        response.setSourceId(source.getSourceId());
+        response.setResourceType(request.getResourceType());
+        response.setItems(toCandidateItems(page == null ? null : page.getItems()));
+        if (page != null) {
+            response.setNextCursor(page.getNextCursor());
+            response.setHasMore(page.isHasMore());
+        }
+        return response;
+    }
+    
+    /**
+     * Validate selected external candidates.
+     *
+     * @param request validate request
+     * @return validate response
+     * @throws NacosException if source or plugin cannot be resolved
+     */
+    public AiResourceImportValidateResponse validate(AiResourceImportValidateRequest request)
+        throws NacosException {
+        requireRequest(request);
+        requireSelectedItems(request.getSelectedItems());
+        AiResourceImportSource source =
+            sourceManager.resolveSource(request.getSourceId(), request.getResourceType());
+        AiResourceImportService importer =
+            pluginManager.resolveImporter(source, request.getResourceType());
+        AiResourceImportContext context = buildItemContext(source, request.getNamespaceId(),
+            request.getResourceType(), request.getOptions());
+        List<AiResourceImportValidationItem> items = new ArrayList<>();
+        for (AiResourceImportItem each : request.getSelectedItems()) {
+            items.add(validateItem(source, importer, context, each, request.isOverwriteExisting()));
+        }
+        AiResourceImportValidateResponse response = new AiResourceImportValidateResponse();
+        response.setSourceId(source.getSourceId());
+        response.setResourceType(request.getResourceType());
+        response.setItems(items);
+        return response;
+    }
+    
+    /**
+     * Execute import for selected external candidates.
+     *
+     * @param request execute request
+     * @return execute response
+     * @throws NacosException if source or plugin cannot be resolved
+     */
+    public AiResourceImportExecuteResponse execute(AiResourceImportExecuteRequest request)
+        throws NacosException {
+        requireRequest(request);
+        requireSelectedItems(request.getSelectedItems());
+        AiResourceImportSource source =
+            sourceManager.resolveSource(request.getSourceId(), request.getResourceType());
+        AiResourceImportService importer =
+            pluginManager.resolveImporter(source, request.getResourceType());
+        AiResourceImportContext context = buildItemContext(source, request.getNamespaceId(),
+            request.getResourceType(), request.getOptions());
+        List<AiResourceImportResultItem> results = new ArrayList<>();
+        for (AiResourceImportItem each : request.getSelectedItems()) {
+            results.add(executeItem(source, importer, context, each, request.isOverwriteExisting(),
+                request.isSkipInvalid()));
+        }
+        return buildExecuteResponse(results);
+    }
+    
+    private void requireRequest(AiResourceImportSearchRequest request) throws NacosException {
+        if (request == null) {
+            throw invalid("AI resource import request must not be null.");
+        }
+        if (StringUtils.isBlank(request.getResourceType())) {
+            throw invalid("AI resource import resource type must not be empty.");
+        }
+        if (StringUtils.isBlank(request.getSourceId())) {
+            throw invalid("AI resource import source id must not be empty.");
+        }
+    }
+    
+    private void requireRequest(AiResourceImportValidateRequest request) throws NacosException {
+        if (request == null) {
+            throw invalid("AI resource import request must not be null.");
+        }
+        if (StringUtils.isBlank(request.getResourceType())) {
+            throw invalid("AI resource import resource type must not be empty.");
+        }
+        if (StringUtils.isBlank(request.getSourceId())) {
+            throw invalid("AI resource import source id must not be empty.");
+        }
+    }
+    
+    private void requireRequest(AiResourceImportExecuteRequest request) throws NacosException {
+        if (request == null) {
+            throw invalid("AI resource import request must not be null.");
+        }
+        if (StringUtils.isBlank(request.getResourceType())) {
+            throw invalid("AI resource import resource type must not be empty.");
+        }
+        if (StringUtils.isBlank(request.getSourceId())) {
+            throw invalid("AI resource import source id must not be empty.");
+        }
+    }
+    
+    private void requireSelectedItems(List<AiResourceImportItem> selectedItems)
+        throws NacosException {
+        if (CollectionUtils.isEmpty(selectedItems)) {
+            throw invalid("AI resource import selected items must not be empty.");
+        }
+    }
+    
+    private AiResourceImportContext buildSearchContext(AiResourceImportSource source,
+        AiResourceImportSearchRequest request) {
+        AiResourceImportContext context = buildItemContext(source, request.getNamespaceId(),
+            request.getResourceType(), request.getOptions());
+        context.setQuery(request.getQuery());
+        context.setCursor(request.getCursor());
+        context.setLimit(resolveLimit(source, request.getLimit()));
+        return context;
+    }
+    
+    private AiResourceImportContext buildItemContext(AiResourceImportSource source,
+        String namespaceId, String resourceType, java.util.Map<String, String> options) {
+        AiResourceImportContext context = new AiResourceImportContext();
+        context.setNamespaceId(StringUtils.isBlank(namespaceId)
+            ? com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID : namespaceId);
+        context.setResourceType(resourceType);
+        context.setSource(source);
+        context.setOptions(options);
+        return context;
+    }
+    
+    private int resolveLimit(AiResourceImportSource source, Integer requestedLimit) {
+        int defaultLimit = source.getMaxItemCount() > 0 ? source.getMaxItemCount() : 100;
+        if (requestedLimit == null || requestedLimit <= 0) {
+            return defaultLimit;
+        }
+        return Math.min(requestedLimit, defaultLimit);
+    }
+    
+    private List<AiResourceImportCandidateItem> toCandidateItems(
+        List<AiResourceImportCandidate> candidates) {
+        if (CollectionUtils.isEmpty(candidates)) {
+            return Collections.emptyList();
+        }
+        List<AiResourceImportCandidateItem> result = new ArrayList<>(candidates.size());
+        for (AiResourceImportCandidate each : candidates) {
+            AiResourceImportCandidateItem item = new AiResourceImportCandidateItem();
+            item.setExternalId(each.getExternalId());
+            item.setName(each.getName());
+            item.setVersion(each.getVersion());
+            item.setDescription(each.getDescription());
+            item.setMetadata(each.getMetadata());
+            result.add(item);
+        }
+        return result;
+    }
+    
+    private AiResourceImportValidationItem validateItem(AiResourceImportSource source,
+        AiResourceImportService importer, AiResourceImportContext context,
+        AiResourceImportItem item,
+        boolean overwriteExisting) {
+        try {
+            AiResourceImportArtifact artifact = importer.fetch(context, toPluginItem(item));
+            securityGuard.checkArtifact(source, context.getResourceType(), artifact);
+            AiResourceOperator operator = operatorRegistry.getOperator(artifact.getResourceType());
+            AiResourceImportValidationItem result =
+                operator.validate(context.getNamespaceId(), artifact, overwriteExisting);
+            return result == null ? defaultValidationItem(artifact) : result;
+        } catch (NacosException e) {
+            return invalidValidationItem(item, e.getErrMsg());
+        }
+    }
+    
+    private AiResourceImportResultItem executeItem(AiResourceImportSource source,
+        AiResourceImportService importer, AiResourceImportContext context,
+        AiResourceImportItem item,
+        boolean overwriteExisting, boolean skipInvalid) {
+        try {
+            AiResourceImportArtifact artifact = importer.fetch(context, toPluginItem(item));
+            securityGuard.checkArtifact(source, context.getResourceType(), artifact);
+            AiResourceOperator operator = operatorRegistry.getOperator(artifact.getResourceType());
+            AiResourceImportResultItem result =
+                operator.importResource(context.getNamespaceId(), artifact, overwriteExisting);
+            return result == null ? defaultResultItem(artifact) : result;
+        } catch (NacosException e) {
+            return failedResultItem(item, e.getErrMsg(), skipInvalid);
+        }
+    }
+    
+    private com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem toPluginItem(
+        AiResourceImportItem item) {
+        com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem result =
+            new com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem();
+        result.setExternalId(item.getExternalId());
+        result.setName(item.getName());
+        result.setVersion(item.getVersion());
+        result.setMetadata(item.getMetadata());
+        return result;
+    }
+    
+    private AiResourceImportValidationItem defaultValidationItem(
+        AiResourceImportArtifact artifact) {
+        AiResourceImportValidationItem result = new AiResourceImportValidationItem();
+        result.setExternalId(artifact.getExternalId());
+        result.setName(artifact.getName());
+        result.setVersion(artifact.getVersion());
+        result.setStatus(AiResourceImportValidationStatus.VALID);
+        return result;
+    }
+    
+    private AiResourceImportValidationItem invalidValidationItem(AiResourceImportItem item,
+        String errorMessage) {
+        AiResourceImportValidationItem result = new AiResourceImportValidationItem();
+        result.setExternalId(item.getExternalId());
+        result.setName(item.getName());
+        result.setVersion(item.getVersion());
+        result.setStatus(AiResourceImportValidationStatus.INVALID);
+        result.setErrors(Collections.singletonList(errorMessage));
+        return result;
+    }
+    
+    private AiResourceImportResultItem defaultResultItem(AiResourceImportArtifact artifact) {
+        AiResourceImportResultItem result = new AiResourceImportResultItem();
+        result.setExternalId(artifact.getExternalId());
+        result.setResourceName(artifact.getName());
+        result.setVersion(artifact.getVersion());
+        result.setStatus(AiResourceImportResultStatus.SUCCESS);
+        return result;
+    }
+    
+    private AiResourceImportResultItem failedResultItem(AiResourceImportItem item,
+        String errorMessage, boolean skipInvalid) {
+        AiResourceImportResultItem result = new AiResourceImportResultItem();
+        result.setExternalId(item.getExternalId());
+        result.setResourceName(item.getName());
+        result.setVersion(item.getVersion());
+        result.setStatus(skipInvalid ? AiResourceImportResultStatus.SKIPPED
+            : AiResourceImportResultStatus.FAILED);
+        result.setErrorMessage(errorMessage);
+        return result;
+    }
+    
+    private AiResourceImportExecuteResponse buildExecuteResponse(
+        List<AiResourceImportResultItem> results) {
+        AiResourceImportExecuteResponse response = new AiResourceImportExecuteResponse();
+        response.setResults(results);
+        response.setTotalCount(results.size());
+        int successCount = 0;
+        int failedCount = 0;
+        int skippedCount = 0;
+        for (AiResourceImportResultItem each : results) {
+            if (AiResourceImportResultStatus.SUCCESS == each.getStatus()) {
+                successCount++;
+            } else if (AiResourceImportResultStatus.SKIPPED == each.getStatus()) {
+                skippedCount++;
+            } else {
+                failedCount++;
+            }
+        }
+        response.setSuccessCount(successCount);
+        response.setFailedCount(failedCount);
+        response.setSkippedCount(skippedCount);
+        response.setSuccess(failedCount == 0);
+        return response;
+    }
+    
+    private NacosException invalid(String message) {
+        return new NacosApiException(NacosException.INVALID_PARAM,
+            ErrorCode.PARAMETER_VALIDATE_ERROR, message);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportPluginManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportPluginManager.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.manager;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.spi.NacosServiceLoader;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Loads and routes AI resource import plugins.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+public class AiResourceImportPluginManager {
+    
+    private final Map<String, AiResourceImportServiceBuilder> builders;
+    
+    public AiResourceImportPluginManager() {
+        this(NacosServiceLoader.load(AiResourceImportServiceBuilder.class));
+    }
+    
+    AiResourceImportPluginManager(Collection<AiResourceImportServiceBuilder> builders) {
+        Map<String, AiResourceImportServiceBuilder> loadedBuilders = new LinkedHashMap<>();
+        for (AiResourceImportServiceBuilder each : builders) {
+            if (StringUtils.isBlank(each.importerType())) {
+                throw new IllegalStateException("AI resource importer type must not be empty.");
+            }
+            if (loadedBuilders.containsKey(each.importerType())) {
+                throw new IllegalStateException(
+                    "Duplicate AI resource importer type: " + each.importerType());
+            }
+            loadedBuilders.put(each.importerType(), each);
+        }
+        this.builders = Collections.unmodifiableMap(loadedBuilders);
+    }
+    
+    /**
+     * Whether the importer builder exists.
+     *
+     * @param importerType importer type
+     * @return true if the importer exists
+     */
+    public boolean hasImporter(String importerType) {
+        return builders.containsKey(importerType);
+    }
+    
+    /**
+     * Resolve an importer for a source and resource type.
+     *
+     * @param source resolved source
+     * @param resourceType expected resource type
+     * @return importer service
+     * @throws NacosException if importer is missing or cannot support the resource type
+     */
+    public AiResourceImportService resolveImporter(AiResourceImportSource source,
+        String resourceType) throws NacosException {
+        AiResourceImportServiceBuilder builder = builders.get(source.getPluginName());
+        if (builder == null) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                "AI resource import plugin not found: " + source.getPluginName());
+        }
+        AiResourceImportService service = builder.build(toProperties(source));
+        if (service == null) {
+            throw new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.DATA_ACCESS_ERROR,
+                "AI resource import plugin returned null service: " + source.getPluginName());
+        }
+        if (!StringUtils.equals(source.getPluginName(), service.importerType())) {
+            throw new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.DATA_ACCESS_ERROR,
+                "AI resource import plugin type mismatch: " + source.getPluginName());
+        }
+        if (CollectionUtils.isEmpty(service.supportedResourceTypes())
+            || !service.supportedResourceTypes().contains(resourceType)) {
+            throw new NacosApiException(NacosException.INVALID_PARAM,
+                ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "AI resource import plugin does not support resource type: " + resourceType);
+        }
+        return service;
+    }
+    
+    private Properties toProperties(AiResourceImportSource source) {
+        Properties properties = new Properties();
+        if (source.getProperties() != null) {
+            properties.putAll(source.getProperties());
+        }
+        return properties;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportSourceManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportSourceManager.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.manager;
+
+import com.alibaba.nacos.ai.importer.config.AiResourceImportProperties;
+import com.alibaba.nacos.ai.importer.config.AiResourceImportSourceConfig;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Resolves operator-configured AI resource import sources.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+public class AiResourceImportSourceManager {
+    
+    private static final List<String> DEFAULT_CAPABILITIES =
+        Arrays.asList("search", "validate", "execute");
+    
+    private final AiResourceImportPluginManager pluginManager;
+    
+    private final Supplier<AiResourceImportProperties> propertiesSupplier;
+    
+    public AiResourceImportSourceManager(AiResourceImportPluginManager pluginManager) {
+        this(pluginManager, AiResourceImportProperties::loadFromEnvironment);
+    }
+    
+    AiResourceImportSourceManager(AiResourceImportPluginManager pluginManager,
+        Supplier<AiResourceImportProperties> propertiesSupplier) {
+        this.pluginManager = pluginManager;
+        this.propertiesSupplier = propertiesSupplier;
+    }
+    
+    /**
+     * List enabled sources and hide runtime-only fields such as endpoint and secrets.
+     *
+     * @param resourceType optional resource type filter
+     * @return import source infos
+     * @throws NacosException if source configuration is invalid
+     */
+    public List<AiResourceImportSourceInfo> listSourceInfos(String resourceType)
+        throws NacosException {
+        AiResourceImportProperties properties = propertiesSupplier.get();
+        if (!properties.isEnabled()) {
+            return new ArrayList<>();
+        }
+        List<AiResourceImportSourceInfo> result = new ArrayList<>();
+        for (AiResourceImportSourceConfig each : validateAndGetSources(properties)) {
+            if (!each.isEnabled() || !supportsResourceType(each, resourceType)) {
+                continue;
+            }
+            result.add(toSourceInfo(each));
+        }
+        return result;
+    }
+    
+    /**
+     * Resolve an enabled source for request execution.
+     *
+     * @param sourceId source id
+     * @param resourceType expected resource type
+     * @return runtime source
+     * @throws NacosException if source is missing, disabled, or incompatible
+     */
+    public AiResourceImportSource resolveSource(String sourceId, String resourceType)
+        throws NacosException {
+        AiResourceImportProperties properties = propertiesSupplier.get();
+        if (!properties.isEnabled()) {
+            throw new NacosApiException(NacosException.SERVER_NOT_IMPLEMENTED,
+                ErrorCode.API_FUNCTION_DISABLED, "AI resource import is disabled.");
+        }
+        for (AiResourceImportSourceConfig each : validateAndGetSources(properties)) {
+            if (!StringUtils.equals(each.getSourceId(), sourceId)) {
+                continue;
+            }
+            if (!each.isEnabled()) {
+                throw new NacosApiException(NacosException.INVALID_PARAM,
+                    ErrorCode.PARAMETER_VALIDATE_ERROR,
+                    "AI resource import source is disabled: " + sourceId);
+            }
+            if (!supportsResourceType(each, resourceType)) {
+                throw new NacosApiException(NacosException.INVALID_PARAM,
+                    ErrorCode.PARAMETER_VALIDATE_ERROR,
+                    "AI resource import source does not support resource type: " + resourceType);
+            }
+            return toRuntimeSource(each);
+        }
+        throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+            "AI resource import source not found: " + sourceId);
+    }
+    
+    private List<AiResourceImportSourceConfig> validateAndGetSources(
+        AiResourceImportProperties properties) throws NacosException {
+        Set<String> sourceIds = new HashSet<>();
+        for (AiResourceImportSourceConfig each : properties.getSources()) {
+            validateSource(each, sourceIds);
+        }
+        return properties.getSources();
+    }
+    
+    private void validateSource(AiResourceImportSourceConfig source, Set<String> sourceIds)
+        throws NacosException {
+        if (StringUtils.isBlank(source.getSourceId())) {
+            throw invalidConfig("AI resource import source id must not be empty.");
+        }
+        if (!sourceIds.add(source.getSourceId())) {
+            throw invalidConfig("Duplicate AI resource import source id: " + source.getSourceId());
+        }
+        if (StringUtils.isBlank(source.getPluginName())) {
+            throw invalidConfig("AI resource import plugin name must not be empty.");
+        }
+        if (CollectionUtils.isEmpty(source.getResourceTypes())) {
+            throw invalidConfig("AI resource import source must declare resource types: "
+                + source.getSourceId());
+        }
+        if (!pluginManager.hasImporter(source.getPluginName())) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                "AI resource import plugin not found: " + source.getPluginName());
+        }
+    }
+    
+    private NacosException invalidConfig(String message) {
+        return new NacosApiException(NacosException.INVALID_PARAM,
+            ErrorCode.PARAMETER_VALIDATE_ERROR, message);
+    }
+    
+    private boolean supportsResourceType(AiResourceImportSourceConfig source, String resourceType) {
+        return StringUtils.isBlank(resourceType)
+            || source.getResourceTypes().contains(resourceType);
+    }
+    
+    private AiResourceImportSourceInfo toSourceInfo(AiResourceImportSourceConfig source) {
+        AiResourceImportSourceInfo result = new AiResourceImportSourceInfo();
+        result.setSourceId(source.getSourceId());
+        result.setDisplayName(source.getDisplayName());
+        result.setDescription(source.getDescription());
+        result.setPluginName(source.getPluginName());
+        result.setResourceTypes(source.getResourceTypes());
+        result.setEnabled(source.isEnabled());
+        result.setCapabilities(DEFAULT_CAPABILITIES);
+        return result;
+    }
+    
+    private AiResourceImportSource toRuntimeSource(AiResourceImportSourceConfig source) {
+        AiResourceImportSource result = new AiResourceImportSource();
+        result.setSourceId(source.getSourceId());
+        result.setDisplayName(source.getDisplayName());
+        result.setPluginName(source.getPluginName());
+        result.setResourceTypes(source.getResourceTypes());
+        result.setEndpoint(source.getEndpoint());
+        result.setEnabled(source.isEnabled());
+        result.setAuthRef(source.getAuthRef());
+        result.setConnectTimeoutMillis(source.getConnectTimeoutMillis());
+        result.setReadTimeoutMillis(source.getReadTimeoutMillis());
+        result.setMaxPageCount(source.getMaxPageCount());
+        result.setMaxItemCount(source.getMaxItemCount());
+        result.setMaxArtifactSize(source.getMaxArtifactSize());
+        result.setProperties(source.getProperties());
+        return result;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportSourceManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportSourceManager.java
@@ -25,7 +25,6 @@ import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -51,15 +50,9 @@ public class AiResourceImportSourceManager {
     
     private final Supplier<AiResourceImportProperties> propertiesSupplier;
     
-    @Autowired
     public AiResourceImportSourceManager(AiResourceImportPluginManager pluginManager) {
-        this(pluginManager, AiResourceImportProperties::loadFromEnvironment);
-    }
-    
-    AiResourceImportSourceManager(AiResourceImportPluginManager pluginManager,
-        Supplier<AiResourceImportProperties> propertiesSupplier) {
         this.pluginManager = pluginManager;
-        this.propertiesSupplier = propertiesSupplier;
+        this.propertiesSupplier = AiResourceImportProperties::loadFromEnvironment;
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportSourceManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportSourceManager.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -50,6 +51,7 @@ public class AiResourceImportSourceManager {
     
     private final Supplier<AiResourceImportProperties> propertiesSupplier;
     
+    @Autowired
     public AiResourceImportSourceManager(AiResourceImportPluginManager pluginManager) {
         this(pluginManager, AiResourceImportProperties::loadFromEnvironment);
     }

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/operator/AiResourceOperator.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/operator/AiResourceOperator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.operator;
+
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationItem;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+
+/**
+ * Applies import artifacts to a Nacos AI resource type.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public interface AiResourceOperator {
+    
+    /**
+     * Resource type supported by this operator.
+     *
+     * @return resource type, for example {@code mcp} or {@code skill}
+     */
+    String resourceType();
+    
+    /**
+     * Validate one import artifact against current Nacos state.
+     *
+     * @param namespaceId namespace id
+     * @param artifact import artifact
+     * @param overwriteExisting whether overwriting existing resources is allowed
+     * @return validation item
+     * @throws NacosException if validation cannot be completed
+     */
+    AiResourceImportValidationItem validate(String namespaceId, AiResourceImportArtifact artifact,
+        boolean overwriteExisting) throws NacosException;
+    
+    /**
+     * Import one artifact into the current resource implementation.
+     *
+     * @param namespaceId namespace id
+     * @param artifact import artifact
+     * @param overwriteExisting whether overwriting existing resources is allowed
+     * @return import result item
+     * @throws NacosException if import cannot be completed
+     */
+    AiResourceImportResultItem importResource(String namespaceId,
+        AiResourceImportArtifact artifact,
+        boolean overwriteExisting) throws NacosException;
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/operator/AiResourceOperatorRegistry.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/operator/AiResourceOperatorRegistry.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.operator;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Registry for AI resource import operators.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+public class AiResourceOperatorRegistry {
+    
+    private final Map<String, AiResourceOperator> operators;
+    
+    public AiResourceOperatorRegistry(Collection<AiResourceOperator> operators) {
+        Map<String, AiResourceOperator> loadedOperators = new LinkedHashMap<>();
+        for (AiResourceOperator each : operators) {
+            if (StringUtils.isBlank(each.resourceType())) {
+                throw new IllegalStateException("AI resource import operator type is empty.");
+            }
+            if (loadedOperators.containsKey(each.resourceType())) {
+                throw new IllegalStateException(
+                    "Duplicate AI resource import operator type: " + each.resourceType());
+            }
+            loadedOperators.put(each.resourceType(), each);
+        }
+        this.operators = Collections.unmodifiableMap(loadedOperators);
+    }
+    
+    /**
+     * Resolve the operator for a resource type.
+     *
+     * @param resourceType resource type
+     * @return resource operator
+     * @throws NacosException if no operator is registered
+     */
+    public AiResourceOperator getOperator(String resourceType) throws NacosException {
+        AiResourceOperator operator = operators.get(resourceType);
+        if (operator == null) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                "AI resource import operator not found: " + resourceType);
+        }
+        return operator;
+    }
+    
+    /**
+     * Whether an operator exists for the resource type.
+     *
+     * @param resourceType resource type
+     * @return true if an operator exists
+     */
+    public boolean hasOperator(String resourceType) {
+        return operators.containsKey(resourceType);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/security/AiResourceImportSecurityGuard.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/security/AiResourceImportSecurityGuard.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.security;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import org.springframework.stereotype.Service;
+
+/**
+ * Central guard for import artifacts crossing the plugin boundary.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+public class AiResourceImportSecurityGuard {
+    
+    /**
+     * Check artifact type and size before validation or import.
+     *
+     * @param source resolved source
+     * @param expectedResourceType expected resource type
+     * @param artifact fetched artifact
+     * @throws NacosException if the artifact violates the import boundary
+     */
+    public void checkArtifact(AiResourceImportSource source, String expectedResourceType,
+        AiResourceImportArtifact artifact) throws NacosException {
+        if (artifact == null) {
+            throw invalid("AI resource import artifact must not be null.");
+        }
+        if (!StringUtils.equals(expectedResourceType, artifact.getResourceType())) {
+            throw invalid("AI resource import artifact resource type mismatch.");
+        }
+        long payloadSize = 0;
+        if (artifact.getPayload() != null) {
+            payloadSize += artifact.getPayload().length;
+        }
+        if (artifact.getPayloadJson() != null) {
+            payloadSize += artifact.getPayloadJson().length();
+        }
+        if (source.getMaxArtifactSize() > 0 && payloadSize > source.getMaxArtifactSize()) {
+            throw invalid("AI resource import artifact size exceeds source limit.");
+        }
+    }
+    
+    private NacosException invalid(String message) {
+        return new NacosApiException(NacosException.INVALID_PARAM,
+            ErrorCode.PARAMETER_VALIDATE_ERROR, message);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/AiResourceImportAdminControllerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/AiResourceImportAdminControllerTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -44,6 +43,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,14 +87,14 @@ class AiResourceImportAdminControllerTest {
         searchResponse.setItems(Collections.singletonList(candidate));
         when(importManager.search(any(AiResourceImportSearchRequest.class))).thenReturn(
             searchResponse);
-        AiResourceImportSearchRequest request = new AiResourceImportSearchRequest();
-        request.setResourceType("mcp");
-        request.setSourceId("source-1");
         
         MockHttpServletResponse response = mockMvc.perform(
             MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_ADMIN_PATH + "/search")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(JacksonUtils.toJson(request)))
+                .param("resourceType", "mcp")
+                .param("sourceId", "source-1")
+                .param("query", "database")
+                .param("limit", "10")
+                .param("options", "{\"stage\":\"dev\"}"))
             .andReturn().getResponse();
         
         Result<AiResourceImportSearchResponse> result = JacksonUtils.toObj(
@@ -102,7 +102,10 @@ class AiResourceImportAdminControllerTest {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("server-1", result.getData().getItems().get(0).getExternalId());
-        verify(importManager).search(any(AiResourceImportSearchRequest.class));
+        verify(importManager).search(argThat(request -> "mcp".equals(request.getResourceType())
+            && "source-1".equals(request.getSourceId())
+            && "database".equals(request.getQuery()) && request.getLimit() == 10
+            && "dev".equals(request.getOptions().get("stage"))));
     }
     
     @Test
@@ -111,15 +114,19 @@ class AiResourceImportAdminControllerTest {
         
         MockHttpServletResponse response = mockMvc.perform(
             MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_ADMIN_PATH + "/validate")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
+                .param("resourceType", "mcp")
+                .param("sourceId", "source-1")
+                .param("selectedItems", selectedItemsJson())
+                .param("overwriteExisting", "true"))
             .andReturn().getResponse();
         
         Result<AiResourceImportValidateResponse> result = JacksonUtils.toObj(
             response.getContentAsString(), new TypeReference<>() {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
-        verify(importManager).validate(any());
+        verify(importManager).validate(argThat(request -> "mcp".equals(request.getResourceType())
+            && "source-1".equals(request.getSourceId()) && request.isOverwriteExisting()
+            && "server-1".equals(request.getSelectedItems().get(0).getExternalId())));
     }
     
     @Test
@@ -128,14 +135,22 @@ class AiResourceImportAdminControllerTest {
         
         MockHttpServletResponse response = mockMvc.perform(
             MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_ADMIN_PATH + "/execute")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
+                .param("resourceType", "mcp")
+                .param("sourceId", "source-1")
+                .param("selectedItems", selectedItemsJson())
+                .param("skipInvalid", "true"))
             .andReturn().getResponse();
         
         Result<AiResourceImportExecuteResponse> result = JacksonUtils.toObj(
             response.getContentAsString(), new TypeReference<>() {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
-        verify(importManager).execute(any());
+        verify(importManager).execute(argThat(request -> "mcp".equals(request.getResourceType())
+            && "source-1".equals(request.getSourceId()) && request.isSkipInvalid()
+            && "server-1".equals(request.getSelectedItems().get(0).getExternalId())));
+    }
+    
+    private String selectedItemsJson() {
+        return "[{\"externalId\":\"server-1\",\"name\":\"server\",\"version\":\"1.0.0\"}]";
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/AiResourceImportAdminControllerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/AiResourceImportAdminControllerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.controller;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.importer.manager.AiResourceImportManager;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportCandidateItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AiResourceImportAdminControllerTest {
+    
+    @Mock
+    private AiResourceImportManager importManager;
+    
+    private MockMvc mockMvc;
+    
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(
+            new AiResourceImportAdminController(importManager)).build();
+    }
+    
+    @Test
+    void testListSources() throws Exception {
+        AiResourceImportSourceInfo source = new AiResourceImportSourceInfo();
+        source.setSourceId("source-1");
+        when(importManager.listSources("mcp")).thenReturn(Collections.singletonList(source));
+        
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.get(Constants.AI_RESOURCE_IMPORT_ADMIN_PATH + "/sources")
+                .param("resourceType", "mcp"))
+            .andReturn().getResponse();
+        
+        Result<List<AiResourceImportSourceInfo>> result = JacksonUtils.toObj(
+            response.getContentAsString(), new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        assertEquals("source-1", result.getData().get(0).getSourceId());
+    }
+    
+    @Test
+    void testSearch() throws Exception {
+        AiResourceImportSearchResponse searchResponse = new AiResourceImportSearchResponse();
+        AiResourceImportCandidateItem candidate = new AiResourceImportCandidateItem();
+        candidate.setExternalId("server-1");
+        searchResponse.setItems(Collections.singletonList(candidate));
+        when(importManager.search(any(AiResourceImportSearchRequest.class))).thenReturn(
+            searchResponse);
+        AiResourceImportSearchRequest request = new AiResourceImportSearchRequest();
+        request.setResourceType("mcp");
+        request.setSourceId("source-1");
+        
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_ADMIN_PATH + "/search")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JacksonUtils.toJson(request)))
+            .andReturn().getResponse();
+        
+        Result<AiResourceImportSearchResponse> result = JacksonUtils.toObj(
+            response.getContentAsString(), new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        assertEquals("server-1", result.getData().getItems().get(0).getExternalId());
+        verify(importManager).search(any(AiResourceImportSearchRequest.class));
+    }
+    
+    @Test
+    void testValidate() throws Exception {
+        when(importManager.validate(any())).thenReturn(new AiResourceImportValidateResponse());
+        
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_ADMIN_PATH + "/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andReturn().getResponse();
+        
+        Result<AiResourceImportValidateResponse> result = JacksonUtils.toObj(
+            response.getContentAsString(), new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        verify(importManager).validate(any());
+    }
+    
+    @Test
+    void testExecute() throws Exception {
+        when(importManager.execute(any())).thenReturn(new AiResourceImportExecuteResponse());
+        
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_ADMIN_PATH + "/execute")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andReturn().getResponse();
+        
+        Result<AiResourceImportExecuteResponse> result = JacksonUtils.toObj(
+            response.getContentAsString(), new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        verify(importManager).execute(any());
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/config/AiResourceImportPropertiesTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/config/AiResourceImportPropertiesTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiResourceImportPropertiesTest {
+    
+    @Test
+    void testLoadSourcesFromProperties() {
+        Properties raw = new Properties();
+        raw.setProperty("nacos.ai.resource.import.enabled", "true");
+        raw.setProperty("nacos.ai.resource.import.default-connect-timeout-ms", "2000");
+        raw.setProperty("nacos.ai.resource.import.default-max-artifact-size", "2048");
+        raw.setProperty("nacos.ai.resource.import.sources[0].source-id", "mcp-official");
+        raw.setProperty("nacos.ai.resource.import.sources[0].display-name", "MCP Official");
+        raw.setProperty("nacos.ai.resource.import.sources[0].description", "official source");
+        raw.setProperty("nacos.ai.resource.import.sources[0].plugin-name", "mcp-registry");
+        raw.setProperty("nacos.ai.resource.import.sources[0].resource-types", "mcp, skill");
+        raw.setProperty("nacos.ai.resource.import.sources[0].endpoint", "https://example.com");
+        raw.setProperty("nacos.ai.resource.import.sources[0].auth-ref", "token-ref");
+        raw.setProperty("nacos.ai.resource.import.sources[0].properties.protocol-version", "v0");
+        
+        AiResourceImportProperties properties = AiResourceImportProperties.load(raw);
+        
+        assertTrue(properties.isEnabled());
+        assertFalse(properties.isAllowUserUrl());
+        assertEquals(2000, properties.getDefaultConnectTimeoutMillis());
+        assertEquals(2048, properties.getDefaultMaxArtifactSize());
+        assertEquals(1, properties.getSources().size());
+        AiResourceImportSourceConfig source = properties.getSources().get(0);
+        assertEquals("mcp-official", source.getSourceId());
+        assertEquals("MCP Official", source.getDisplayName());
+        assertEquals("official source", source.getDescription());
+        assertEquals("mcp-registry", source.getPluginName());
+        assertEquals(Arrays.asList("mcp", "skill"), source.getResourceTypes());
+        assertEquals("https://example.com", source.getEndpoint());
+        assertEquals("token-ref", source.getAuthRef());
+        assertEquals(2000, source.getConnectTimeoutMillis());
+        assertEquals(2048, source.getMaxArtifactSize());
+        assertEquals("v0", source.getProperties().get("protocol-version"));
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManagerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManagerTest.java
@@ -44,12 +44,14 @@ import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
 import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -225,7 +227,9 @@ class AiResourceImportManagerTest {
         AiResourceImportPluginManager pluginManager =
             new AiResourceImportPluginManager(Collections.singletonList(builder));
         AiResourceImportSourceManager sourceManager =
-            new AiResourceImportSourceManager(pluginManager, () -> properties);
+            new AiResourceImportSourceManager(pluginManager);
+        ReflectionTestUtils.setField(sourceManager, "propertiesSupplier",
+            (Supplier<AiResourceImportProperties>) () -> properties);
         return new AiResourceImportManager(sourceManager, pluginManager,
             new AiResourceOperatorRegistry(operators), new AiResourceImportSecurityGuard());
     }
@@ -234,7 +238,11 @@ class AiResourceImportManagerTest {
         AiResourceImportPluginManager pluginManager =
             new AiResourceImportPluginManager(Collections.singletonList(
                 new FakeImportServiceBuilder()));
-        return new AiResourceImportSourceManager(pluginManager, () -> properties);
+        AiResourceImportSourceManager result =
+            new AiResourceImportSourceManager(pluginManager);
+        ReflectionTestUtils.setField(result, "propertiesSupplier",
+            (Supplier<AiResourceImportProperties>) () -> properties);
+        return result;
     }
     
     private AiResourceImportProperties enabledProperties() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManagerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManagerTest.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.manager;
+
+import com.alibaba.nacos.ai.importer.config.AiResourceImportProperties;
+import com.alibaba.nacos.ai.importer.config.AiResourceImportSourceConfig;
+import com.alibaba.nacos.ai.importer.operator.AiResourceOperator;
+import com.alibaba.nacos.ai.importer.operator.AiResourceOperatorRegistry;
+import com.alibaba.nacos.ai.importer.security.AiResourceImportSecurityGuard;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultStatus;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationStatus;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidate;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidatePage;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportContext;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiResourceImportManagerTest {
+    
+    @Test
+    void testListSourcesFiltersResourceTypeAndMasksEndpoint() throws NacosException {
+        AiResourceImportSourceManager sourceManager = newSourceManager(enabledProperties());
+        
+        List<AiResourceImportSourceInfo> result = sourceManager.listSourceInfos("mcp");
+        
+        assertEquals(1, result.size());
+        assertEquals("source-1", result.get(0).getSourceId());
+        assertEquals("Fake Source", result.get(0).getDisplayName());
+        assertEquals("fake-importer", result.get(0).getPluginName());
+        assertEquals(Collections.singletonList("mcp"), result.get(0).getResourceTypes());
+        assertEquals(Arrays.asList("search", "validate", "execute"),
+            result.get(0).getCapabilities());
+    }
+    
+    @Test
+    void testSearchRoutesToResolvedImporter() throws NacosException {
+        FakeImportServiceBuilder builder = new FakeImportServiceBuilder();
+        AiResourceImportManager manager = newManager(enabledProperties(), builder,
+            Collections.singletonList(new FakeOperator()));
+        AiResourceImportSearchRequest request = new AiResourceImportSearchRequest();
+        request.setResourceType("mcp");
+        request.setSourceId("source-1");
+        request.setQuery("database");
+        request.setLimit(50);
+        
+        AiResourceImportSearchResponse response = manager.search(request);
+        
+        assertEquals("source-1", response.getSourceId());
+        assertEquals("mcp", response.getResourceType());
+        assertEquals(1, response.getItems().size());
+        assertEquals("server-1", response.getItems().get(0).getExternalId());
+        assertEquals(10, builder.service.lastContext.getLimit());
+        assertEquals("database", builder.service.lastContext.getQuery());
+    }
+    
+    @Test
+    void testValidateFetchesArtifactAndUsesOperator() throws NacosException {
+        AiResourceImportManager manager = newManager(enabledProperties(),
+            new FakeImportServiceBuilder(), Collections.singletonList(new FakeOperator()));
+        AiResourceImportValidateRequest request = new AiResourceImportValidateRequest();
+        request.setResourceType("mcp");
+        request.setSourceId("source-1");
+        request.setSelectedItems(Collections.singletonList(selectedItem("server-1")));
+        
+        AiResourceImportValidateResponse response = manager.validate(request);
+        
+        assertEquals("source-1", response.getSourceId());
+        assertEquals(1, response.getItems().size());
+        assertEquals(AiResourceImportValidationStatus.VALID,
+            response.getItems().get(0).getStatus());
+        assertEquals("server-1", response.getItems().get(0).getExternalId());
+    }
+    
+    @Test
+    void testValidateReturnsInvalidItemWhenOperatorMissing() throws NacosException {
+        AiResourceImportManager manager = newManager(enabledProperties(),
+            new FakeImportServiceBuilder(), Collections.emptyList());
+        AiResourceImportValidateRequest request = new AiResourceImportValidateRequest();
+        request.setResourceType("mcp");
+        request.setSourceId("source-1");
+        request.setSelectedItems(Collections.singletonList(selectedItem("server-1")));
+        
+        AiResourceImportValidateResponse response = manager.validate(request);
+        
+        assertEquals(AiResourceImportValidationStatus.INVALID,
+            response.getItems().get(0).getStatus());
+        assertTrue(response.getItems().get(0).getErrors().get(0)
+            .contains("AI resource import operator not found"));
+    }
+    
+    @Test
+    void testExecuteCountsSkippedWhenSkipInvalid() throws NacosException {
+        AiResourceImportManager manager = newManager(enabledProperties(),
+            new FakeImportServiceBuilder(), Collections.singletonList(new FakeOperator()));
+        AiResourceImportExecuteRequest request = new AiResourceImportExecuteRequest();
+        request.setResourceType("mcp");
+        request.setSourceId("source-1");
+        request.setSelectedItems(Collections.singletonList(selectedItem("bad")));
+        request.setSkipInvalid(true);
+        
+        AiResourceImportExecuteResponse response = manager.execute(request);
+        
+        assertTrue(response.isSuccess());
+        assertEquals(1, response.getTotalCount());
+        assertEquals(0, response.getSuccessCount());
+        assertEquals(1, response.getSkippedCount());
+        assertEquals(AiResourceImportResultStatus.SKIPPED,
+            response.getResults().get(0).getStatus());
+    }
+    
+    @Test
+    void testDisabledSourceManagerRejectsResolve() {
+        AiResourceImportProperties properties = enabledProperties();
+        properties.setEnabled(false);
+        AiResourceImportSourceManager sourceManager = newSourceManager(properties);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> sourceManager.resolveSource("source-1", "mcp"));
+        
+        assertEquals(NacosException.SERVER_NOT_IMPLEMENTED, exception.getErrCode());
+    }
+    
+    @Test
+    void testDuplicateSourceIdRejected() {
+        AiResourceImportProperties properties = enabledProperties();
+        properties.setSources(Arrays.asList(sourceConfig(), sourceConfig()));
+        AiResourceImportSourceManager sourceManager = newSourceManager(properties);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> sourceManager.listSourceInfos(null));
+        
+        assertTrue(exception.getErrMsg().contains("Duplicate AI resource import source id"));
+    }
+    
+    @Test
+    void testDuplicateImporterRejected() {
+        FakeImportServiceBuilder builder = new FakeImportServiceBuilder();
+        
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> new AiResourceImportPluginManager(Arrays.asList(builder, builder)));
+        
+        assertTrue(exception.getMessage().contains("Duplicate AI resource importer type"));
+    }
+    
+    @Test
+    void testDuplicateOperatorRejected() {
+        FakeOperator operator = new FakeOperator();
+        
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> new AiResourceOperatorRegistry(Arrays.asList(operator, operator)));
+        
+        assertTrue(exception.getMessage().contains("Duplicate AI resource import operator type"));
+    }
+    
+    @Test
+    void testArtifactSizeLimitReturnsInvalidValidation() throws NacosException {
+        AiResourceImportProperties properties = enabledProperties();
+        properties.getSources().get(0).setMaxArtifactSize(1);
+        AiResourceImportManager manager = newManager(properties, new FakeImportServiceBuilder(),
+            Collections.singletonList(new FakeOperator()));
+        AiResourceImportValidateRequest request = new AiResourceImportValidateRequest();
+        request.setResourceType("mcp");
+        request.setSourceId("source-1");
+        request.setSelectedItems(Collections.singletonList(selectedItem("server-1")));
+        
+        AiResourceImportValidateResponse response = manager.validate(request);
+        
+        assertEquals(AiResourceImportValidationStatus.INVALID,
+            response.getItems().get(0).getStatus());
+        assertTrue(response.getItems().get(0).getErrors().get(0).contains("size exceeds"));
+    }
+    
+    private AiResourceImportManager newManager(AiResourceImportProperties properties,
+        FakeImportServiceBuilder builder, List<AiResourceOperator> operators) {
+        AiResourceImportPluginManager pluginManager =
+            new AiResourceImportPluginManager(Collections.singletonList(builder));
+        AiResourceImportSourceManager sourceManager =
+            new AiResourceImportSourceManager(pluginManager, () -> properties);
+        return new AiResourceImportManager(sourceManager, pluginManager,
+            new AiResourceOperatorRegistry(operators), new AiResourceImportSecurityGuard());
+    }
+    
+    private AiResourceImportSourceManager newSourceManager(AiResourceImportProperties properties) {
+        AiResourceImportPluginManager pluginManager =
+            new AiResourceImportPluginManager(Collections.singletonList(
+                new FakeImportServiceBuilder()));
+        return new AiResourceImportSourceManager(pluginManager, () -> properties);
+    }
+    
+    private AiResourceImportProperties enabledProperties() {
+        AiResourceImportProperties properties = new AiResourceImportProperties();
+        properties.setEnabled(true);
+        properties.setSources(Collections.singletonList(sourceConfig()));
+        return properties;
+    }
+    
+    private AiResourceImportSourceConfig sourceConfig() {
+        AiResourceImportSourceConfig source = new AiResourceImportSourceConfig();
+        source.setSourceId("source-1");
+        source.setDisplayName("Fake Source");
+        source.setPluginName("fake-importer");
+        source.setResourceTypes(Collections.singletonList("mcp"));
+        source.setEndpoint("https://example.com/registry");
+        source.setEnabled(true);
+        source.setMaxItemCount(10);
+        source.setMaxArtifactSize(1024);
+        return source;
+    }
+    
+    private AiResourceImportItem selectedItem(String externalId) {
+        AiResourceImportItem item = new AiResourceImportItem();
+        item.setExternalId(externalId);
+        item.setName("server");
+        item.setVersion("1.0.0");
+        return item;
+    }
+    
+    private static class FakeImportServiceBuilder implements AiResourceImportServiceBuilder {
+        
+        private final FakeImportService service = new FakeImportService();
+        
+        @Override
+        public String importerType() {
+            return "fake-importer";
+        }
+        
+        @Override
+        public AiResourceImportService build(Properties properties) {
+            return service;
+        }
+    }
+    
+    private static class FakeImportService implements AiResourceImportService {
+        
+        private AiResourceImportContext lastContext;
+        
+        @Override
+        public String importerType() {
+            return "fake-importer";
+        }
+        
+        @Override
+        public Set<String> supportedResourceTypes() {
+            return Collections.singleton("mcp");
+        }
+        
+        @Override
+        public AiResourceImportCandidatePage search(AiResourceImportContext context) {
+            lastContext = context;
+            AiResourceImportCandidate candidate = new AiResourceImportCandidate();
+            candidate.setResourceType("mcp");
+            candidate.setExternalId("server-1");
+            candidate.setName("server");
+            candidate.setVersion("1.0.0");
+            candidate.setDescription("fake server");
+            AiResourceImportCandidatePage page = new AiResourceImportCandidatePage();
+            page.setItems(Collections.singletonList(candidate));
+            page.setHasMore(false);
+            return page;
+        }
+        
+        @Override
+        public AiResourceImportArtifact fetch(AiResourceImportContext context,
+            com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem item)
+            throws NacosException {
+            if ("bad".equals(item.getExternalId())) {
+                throw new NacosException(NacosException.SERVER_ERROR, "fetch failed");
+            }
+            AiResourceImportArtifact artifact = new AiResourceImportArtifact();
+            artifact.setResourceType(context.getResourceType());
+            artifact.setExternalId(item.getExternalId());
+            artifact.setName(item.getName());
+            artifact.setVersion(item.getVersion());
+            artifact.setPayloadKind(AiResourceImportPayloadKind.JSON);
+            artifact.setPayloadJson("{}");
+            return artifact;
+        }
+    }
+    
+    private static class FakeOperator implements AiResourceOperator {
+        
+        @Override
+        public String resourceType() {
+            return "mcp";
+        }
+        
+        @Override
+        public AiResourceImportValidationItem validate(String namespaceId,
+            AiResourceImportArtifact artifact, boolean overwriteExisting) {
+            AiResourceImportValidationItem result = new AiResourceImportValidationItem();
+            result.setExternalId(artifact.getExternalId());
+            result.setName(artifact.getName());
+            result.setVersion(artifact.getVersion());
+            result.setStatus(AiResourceImportValidationStatus.VALID);
+            return result;
+        }
+        
+        @Override
+        public AiResourceImportResultItem importResource(String namespaceId,
+            AiResourceImportArtifact artifact, boolean overwriteExisting) {
+            AiResourceImportResultItem result = new AiResourceImportResultItem();
+            result.setExternalId(artifact.getExternalId());
+            result.setResourceName(artifact.getName());
+            result.setVersion(artifact.getVersion());
+            result.setStatus(AiResourceImportResultStatus.SUCCESS);
+            return result;
+        }
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManagerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManagerTest.java
@@ -43,6 +43,7 @@ import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
 import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
 import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,6 +52,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,6 +71,15 @@ class AiResourceImportManagerTest {
         assertEquals(Collections.singletonList("mcp"), result.get(0).getResourceTypes());
         assertEquals(Arrays.asList("search", "validate", "execute"),
             result.get(0).getCapabilities());
+        try (
+            AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.register(AiResourceImportPluginManager.class,
+                AiResourceImportSourceManager.class,
+                AiResourceOperatorRegistry.class, AiResourceImportSecurityGuard.class,
+                AiResourceImportManager.class);
+            context.refresh();
+            assertNotNull(context.getBean(AiResourceImportManager.class));
+        }
     }
     
     @Test

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAiResourceImportController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAiResourceImportController.java
@@ -17,12 +17,13 @@
 package com.alibaba.nacos.console.controller.v3.ai;
 
 import com.alibaba.nacos.ai.constant.Constants;
-import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.ai.form.importer.AiResourceImportExecuteForm;
+import com.alibaba.nacos.ai.form.importer.AiResourceImportSearchForm;
+import com.alibaba.nacos.ai.form.importer.AiResourceImportSourceListForm;
+import com.alibaba.nacos.ai.form.importer.AiResourceImportValidateForm;
 import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
-import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
 import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
 import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
-import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
 import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
 import com.alibaba.nacos.api.annotation.NacosApi;
 import com.alibaba.nacos.api.common.ApiType;
@@ -34,9 +35,7 @@ import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.constant.SignType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -61,59 +60,60 @@ public class ConsoleAiResourceImportController {
     /**
      * List configured import sources for Console.
      *
-     * @param resourceType optional resource type filter
+     * @param form source list form
      * @return source list
      * @throws NacosException if source configuration is invalid
      */
     @GetMapping("/sources")
     @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
     public Result<List<AiResourceImportSourceInfo>> listSources(
-        @RequestParam(required = false) String resourceType) throws NacosException {
-        return Result.success(importProxy.listSources(resourceType));
+        AiResourceImportSourceListForm form) throws NacosException {
+        form.validate();
+        return Result.success(importProxy.listSources(form.getResourceType()));
     }
     
     /**
      * Search external import candidates for Console.
      *
-     * @param request search request
+     * @param form search form
      * @return candidate page
      * @throws NacosException if the source cannot be searched
      */
     @PostMapping("/search")
     @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
-    public Result<AiResourceImportSearchResponse> search(
-        @RequestBody(required = false) AiResourceImportSearchRequest request)
+    public Result<AiResourceImportSearchResponse> search(AiResourceImportSearchForm form)
         throws NacosException {
-        return Result.success(importProxy.search(request));
+        form.validate();
+        return Result.success(importProxy.search(form.toRequest()));
     }
     
     /**
      * Validate selected import candidates for Console.
      *
-     * @param request validate request
+     * @param form validate form
      * @return validation result
      * @throws NacosException if validation cannot start
      */
     @PostMapping("/validate")
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
-    public Result<AiResourceImportValidateResponse> validate(
-        @RequestBody(required = false) AiResourceImportValidateRequest request)
+    public Result<AiResourceImportValidateResponse> validate(AiResourceImportValidateForm form)
         throws NacosException {
-        return Result.success(importProxy.validate(request));
+        form.validate();
+        return Result.success(importProxy.validate(form.toRequest()));
     }
     
     /**
      * Execute import for selected candidates from Console.
      *
-     * @param request execute request
+     * @param form execute form
      * @return import result
      * @throws NacosException if import cannot start
      */
     @PostMapping("/execute")
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
-    public Result<AiResourceImportExecuteResponse> execute(
-        @RequestBody(required = false) AiResourceImportExecuteRequest request)
+    public Result<AiResourceImportExecuteResponse> execute(AiResourceImportExecuteForm form)
         throws NacosException {
-        return Result.success(importProxy.execute(request));
+        form.validate();
+        return Result.success(importProxy.execute(form.toRequest()));
     }
 }

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAiResourceImportController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAiResourceImportController.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.controller.v3.ai;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.annotation.NacosApi;
+import com.alibaba.nacos.api.common.ApiType;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.console.proxy.ai.AiResourceImportProxy;
+import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Console API controller for AI resource import.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@NacosApi
+@RestController
+@RequestMapping(Constants.AI_RESOURCE_IMPORT_CONSOLE_PATH)
+public class ConsoleAiResourceImportController {
+    
+    private final AiResourceImportProxy importProxy;
+    
+    public ConsoleAiResourceImportController(AiResourceImportProxy importProxy) {
+        this.importProxy = importProxy;
+    }
+    
+    /**
+     * List configured import sources for Console.
+     *
+     * @param resourceType optional resource type filter
+     * @return source list
+     * @throws NacosException if source configuration is invalid
+     */
+    @GetMapping("/sources")
+    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
+    public Result<List<AiResourceImportSourceInfo>> listSources(
+        @RequestParam(required = false) String resourceType) throws NacosException {
+        return Result.success(importProxy.listSources(resourceType));
+    }
+    
+    /**
+     * Search external import candidates for Console.
+     *
+     * @param request search request
+     * @return candidate page
+     * @throws NacosException if the source cannot be searched
+     */
+    @PostMapping("/search")
+    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
+    public Result<AiResourceImportSearchResponse> search(
+        @RequestBody(required = false) AiResourceImportSearchRequest request)
+        throws NacosException {
+        return Result.success(importProxy.search(request));
+    }
+    
+    /**
+     * Validate selected import candidates for Console.
+     *
+     * @param request validate request
+     * @return validation result
+     * @throws NacosException if validation cannot start
+     */
+    @PostMapping("/validate")
+    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
+    public Result<AiResourceImportValidateResponse> validate(
+        @RequestBody(required = false) AiResourceImportValidateRequest request)
+        throws NacosException {
+        return Result.success(importProxy.validate(request));
+    }
+    
+    /**
+     * Execute import for selected candidates from Console.
+     *
+     * @param request execute request
+     * @return import result
+     * @throws NacosException if import cannot start
+     */
+    @PostMapping("/execute")
+    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
+    public Result<AiResourceImportExecuteResponse> execute(
+        @RequestBody(required = false) AiResourceImportExecuteRequest request)
+        throws NacosException {
+        return Result.success(importProxy.execute(request));
+    }
+}

--- a/console/src/main/java/com/alibaba/nacos/console/handler/ai/AiResourceImportHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/ai/AiResourceImportHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.ai;
+
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.exception.NacosException;
+
+import java.util.List;
+
+/**
+ * Handler for Console AI resource import operations.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public interface AiResourceImportHandler {
+    
+    /**
+     * List import sources.
+     *
+     * @param resourceType optional resource type filter
+     * @return source list
+     * @throws NacosException if source configuration is invalid
+     */
+    List<AiResourceImportSourceInfo> listSources(String resourceType) throws NacosException;
+    
+    /**
+     * Search external candidates.
+     *
+     * @param request search request
+     * @return search response
+     * @throws NacosException if the source cannot be searched
+     */
+    AiResourceImportSearchResponse search(AiResourceImportSearchRequest request)
+        throws NacosException;
+    
+    /**
+     * Validate selected candidates.
+     *
+     * @param request validate request
+     * @return validation response
+     * @throws NacosException if validation cannot start
+     */
+    AiResourceImportValidateResponse validate(AiResourceImportValidateRequest request)
+        throws NacosException;
+    
+    /**
+     * Execute import for selected candidates.
+     *
+     * @param request execute request
+     * @return execute response
+     * @throws NacosException if import cannot start
+     */
+    AiResourceImportExecuteResponse execute(AiResourceImportExecuteRequest request)
+        throws NacosException;
+}

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/AiResourceImportInnerHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/AiResourceImportInnerHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.impl.inner.ai;
+
+import com.alibaba.nacos.ai.importer.manager.AiResourceImportManager;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.console.handler.ai.AiResourceImportHandler;
+import com.alibaba.nacos.console.handler.ai.EnabledAiHandler;
+import com.alibaba.nacos.console.handler.impl.inner.EnabledInnerHandler;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Inner implementation of Console AI resource import handler.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+@EnabledInnerHandler
+@EnabledAiHandler
+public class AiResourceImportInnerHandler implements AiResourceImportHandler {
+    
+    private final AiResourceImportManager importManager;
+    
+    public AiResourceImportInnerHandler(AiResourceImportManager importManager) {
+        this.importManager = importManager;
+    }
+    
+    @Override
+    public List<AiResourceImportSourceInfo> listSources(String resourceType)
+        throws NacosException {
+        return importManager.listSources(resourceType);
+    }
+    
+    @Override
+    public AiResourceImportSearchResponse search(AiResourceImportSearchRequest request)
+        throws NacosException {
+        return importManager.search(request);
+    }
+    
+    @Override
+    public AiResourceImportValidateResponse validate(AiResourceImportValidateRequest request)
+        throws NacosException {
+        return importManager.validate(request);
+    }
+    
+    @Override
+    public AiResourceImportExecuteResponse execute(AiResourceImportExecuteRequest request)
+        throws NacosException {
+        return importManager.execute(request);
+    }
+}

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/AiResourceImportNoopHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/noop/ai/AiResourceImportNoopHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.impl.noop.ai;
+
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.console.handler.ai.AiResourceImportHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Noop implementation of AI resource import handler.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+@ConditionalOnMissingBean(value = AiResourceImportHandler.class,
+    ignored = AiResourceImportNoopHandler.class)
+public class AiResourceImportNoopHandler implements AiResourceImportHandler {
+    
+    private static final String AI_IMPORT_NOT_ENABLED_MESSAGE =
+        "Nacos AI resource import module is not enabled.";
+    
+    @Override
+    public List<AiResourceImportSourceInfo> listSources(String resourceType)
+        throws NacosException {
+        throw disabled();
+    }
+    
+    @Override
+    public AiResourceImportSearchResponse search(AiResourceImportSearchRequest request)
+        throws NacosException {
+        throw disabled();
+    }
+    
+    @Override
+    public AiResourceImportValidateResponse validate(AiResourceImportValidateRequest request)
+        throws NacosException {
+        throw disabled();
+    }
+    
+    @Override
+    public AiResourceImportExecuteResponse execute(AiResourceImportExecuteRequest request)
+        throws NacosException {
+        throw disabled();
+    }
+    
+    private NacosException disabled() {
+        return new NacosApiException(NacosException.SERVER_NOT_IMPLEMENTED,
+            ErrorCode.API_FUNCTION_DISABLED, AI_IMPORT_NOT_ENABLED_MESSAGE);
+    }
+}

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/AiResourceImportRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/AiResourceImportRemoteHandler.java
@@ -31,6 +31,7 @@ import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.http.HttpUtils;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.console.handler.ai.AiResourceImportHandler;
 import com.alibaba.nacos.console.handler.ai.EnabledAiHandler;
 import com.alibaba.nacos.console.handler.impl.remote.EnabledRemoteHandler;
@@ -42,14 +43,14 @@ import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Remote implementation of Console AI resource import handler.
@@ -86,7 +87,8 @@ public class AiResourceImportRemoteHandler implements AiResourceImportHandler {
     @Override
     public AiResourceImportSearchResponse search(AiResourceImportSearchRequest request)
         throws NacosException {
-        Result<AiResourceImportSearchResponse> result = executePost("/search", request,
+        Result<AiResourceImportSearchResponse> result = executePost("/search",
+            buildSearchForm(request),
             new TypeReference<>() {
             });
         return unwrap(result);
@@ -95,7 +97,8 @@ public class AiResourceImportRemoteHandler implements AiResourceImportHandler {
     @Override
     public AiResourceImportValidateResponse validate(AiResourceImportValidateRequest request)
         throws NacosException {
-        Result<AiResourceImportValidateResponse> result = executePost("/validate", request,
+        Result<AiResourceImportValidateResponse> result = executePost("/validate",
+            buildValidateForm(request),
             new TypeReference<>() {
             });
         return unwrap(result);
@@ -104,7 +107,8 @@ public class AiResourceImportRemoteHandler implements AiResourceImportHandler {
     @Override
     public AiResourceImportExecuteResponse execute(AiResourceImportExecuteRequest request)
         throws NacosException {
-        Result<AiResourceImportExecuteResponse> result = executePost("/execute", request,
+        Result<AiResourceImportExecuteResponse> result = executePost("/execute",
+            buildExecuteForm(request),
             new TypeReference<>() {
             });
         return unwrap(result);
@@ -125,19 +129,73 @@ public class AiResourceImportRemoteHandler implements AiResourceImportHandler {
         }
     }
     
-    private <T> Result<T> executePost(String subPath, Object request,
+    private <T> Result<T> executePost(String subPath, Map<String, String> form,
         TypeReference<Result<T>> typeReference) throws NacosException {
         Member serverMember = remoteServerConnector.randomOneHealthyMember();
         String url = buildUrl(serverMember, subPath);
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpPost httpPost = new HttpPost(url);
-            httpPost.setEntity(new StringEntity(JacksonUtils.toJson(request),
-                ContentType.APPLICATION_JSON));
+            HttpUtils.initRequestFromEntity(httpPost, form, "UTF-8");
             remoteServerConnector.addAuthIdentity(httpPost);
             String response = httpClient.execute(httpPost, new BasicHttpClientResponseHandler());
             return JacksonUtils.toObj(response, typeReference);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw remoteFailed(serverMember, e);
+        }
+    }
+    
+    private Map<String, String> buildSearchForm(AiResourceImportSearchRequest request) {
+        Map<String, String> result = buildSourceForm(request.getNamespaceId(),
+            request.getResourceType(), request.getSourceId(), request.getOptions());
+        addIfNotBlank(result, "query", request.getQuery());
+        addIfNotBlank(result, "cursor", request.getCursor());
+        addIfNotNull(result, "limit", request.getLimit());
+        return result;
+    }
+    
+    private Map<String, String> buildValidateForm(AiResourceImportValidateRequest request) {
+        Map<String, String> result = buildSourceForm(request.getNamespaceId(),
+            request.getResourceType(), request.getSourceId(), request.getOptions());
+        addIfNotNull(result, "selectedItems", request.getSelectedItems());
+        if (request.isOverwriteExisting()) {
+            result.put("overwriteExisting", Boolean.TRUE.toString());
+        }
+        return result;
+    }
+    
+    private Map<String, String> buildExecuteForm(AiResourceImportExecuteRequest request) {
+        Map<String, String> result = buildSourceForm(request.getNamespaceId(),
+            request.getResourceType(), request.getSourceId(), request.getOptions());
+        addIfNotNull(result, "selectedItems", request.getSelectedItems());
+        if (request.isOverwriteExisting()) {
+            result.put("overwriteExisting", Boolean.TRUE.toString());
+        }
+        if (request.isSkipInvalid()) {
+            result.put("skipInvalid", Boolean.TRUE.toString());
+        }
+        addIfNotBlank(result, "validationToken", request.getValidationToken());
+        return result;
+    }
+    
+    private Map<String, String> buildSourceForm(String namespaceId, String resourceType,
+        String sourceId, Map<String, String> options) {
+        Map<String, String> result = new LinkedHashMap<>();
+        addIfNotBlank(result, "namespaceId", namespaceId);
+        addIfNotBlank(result, "resourceType", resourceType);
+        addIfNotBlank(result, "sourceId", sourceId);
+        addIfNotNull(result, "options", options);
+        return result;
+    }
+    
+    private void addIfNotBlank(Map<String, String> form, String key, String value) {
+        if (StringUtils.isNotBlank(value)) {
+            form.put(key, value);
+        }
+    }
+    
+    private void addIfNotNull(Map<String, String> form, String key, Object value) {
+        if (value != null) {
+            form.put(key, JacksonUtils.toJson(value));
         }
     }
     

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/AiResourceImportRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/AiResourceImportRemoteHandler.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.impl.remote.ai;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.http.HttpUtils;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.console.handler.ai.AiResourceImportHandler;
+import com.alibaba.nacos.console.handler.ai.EnabledAiHandler;
+import com.alibaba.nacos.console.handler.impl.remote.EnabledRemoteHandler;
+import com.alibaba.nacos.console.handler.impl.remote.RemoteServerConnector;
+import com.alibaba.nacos.core.cluster.Member;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.BasicHttpClientResponseHandler;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+/**
+ * Remote implementation of Console AI resource import handler.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+@EnabledRemoteHandler
+@EnabledAiHandler
+public class AiResourceImportRemoteHandler implements AiResourceImportHandler {
+    
+    private static final String REMOTE_IMPORT_URL = "http://%s%s%s%s";
+    
+    private final RemoteServerConnector remoteServerConnector;
+    
+    public AiResourceImportRemoteHandler(RemoteServerConnector remoteServerConnector) {
+        this.remoteServerConnector = remoteServerConnector;
+    }
+    
+    @Override
+    public List<AiResourceImportSourceInfo> listSources(String resourceType)
+        throws NacosException {
+        Query query = Query.newInstance();
+        if (resourceType != null) {
+            query.addParam("resourceType", resourceType);
+        }
+        Result<List<AiResourceImportSourceInfo>> result = executeGet("/sources", query,
+            new TypeReference<>() {
+            });
+        return unwrap(result);
+    }
+    
+    @Override
+    public AiResourceImportSearchResponse search(AiResourceImportSearchRequest request)
+        throws NacosException {
+        Result<AiResourceImportSearchResponse> result = executePost("/search", request,
+            new TypeReference<>() {
+            });
+        return unwrap(result);
+    }
+    
+    @Override
+    public AiResourceImportValidateResponse validate(AiResourceImportValidateRequest request)
+        throws NacosException {
+        Result<AiResourceImportValidateResponse> result = executePost("/validate", request,
+            new TypeReference<>() {
+            });
+        return unwrap(result);
+    }
+    
+    @Override
+    public AiResourceImportExecuteResponse execute(AiResourceImportExecuteRequest request)
+        throws NacosException {
+        Result<AiResourceImportExecuteResponse> result = executePost("/execute", request,
+            new TypeReference<>() {
+            });
+        return unwrap(result);
+    }
+    
+    private <T> Result<T> executeGet(String subPath, Query query,
+        TypeReference<Result<T>> typeReference) throws NacosException {
+        Member serverMember = remoteServerConnector.randomOneHealthyMember();
+        String url = buildUrl(serverMember, subPath);
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            URI uri = HttpUtils.buildUri(url, query);
+            HttpGet httpGet = new HttpGet(uri);
+            remoteServerConnector.addAuthIdentity(httpGet);
+            String response = httpClient.execute(httpGet, new BasicHttpClientResponseHandler());
+            return JacksonUtils.toObj(response, typeReference);
+        } catch (IOException | URISyntaxException e) {
+            throw remoteFailed(serverMember, e);
+        }
+    }
+    
+    private <T> Result<T> executePost(String subPath, Object request,
+        TypeReference<Result<T>> typeReference) throws NacosException {
+        Member serverMember = remoteServerConnector.randomOneHealthyMember();
+        String url = buildUrl(serverMember, subPath);
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpPost httpPost = new HttpPost(url);
+            httpPost.setEntity(new StringEntity(JacksonUtils.toJson(request),
+                ContentType.APPLICATION_JSON));
+            remoteServerConnector.addAuthIdentity(httpPost);
+            String response = httpClient.execute(httpPost, new BasicHttpClientResponseHandler());
+            return JacksonUtils.toObj(response, typeReference);
+        } catch (IOException e) {
+            throw remoteFailed(serverMember, e);
+        }
+    }
+    
+    private String buildUrl(Member serverMember, String subPath) {
+        return String.format(REMOTE_IMPORT_URL, serverMember.getAddress(),
+            remoteServerConnector.getServerContextPath(), Constants.AI_RESOURCE_IMPORT_ADMIN_PATH,
+            subPath);
+    }
+    
+    private <T> T unwrap(Result<T> result) throws NacosException {
+        if (result == null) {
+            throw new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.DATA_ACCESS_ERROR,
+                "Remote AI resource import response is empty.");
+        }
+        if (!ErrorCode.SUCCESS.getCode().equals(result.getCode())) {
+            throw new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.DATA_ACCESS_ERROR,
+                result.getMessage());
+        }
+        return result.getData();
+    }
+    
+    private NacosException remoteFailed(Member serverMember, Exception cause) {
+        return new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.DATA_ACCESS_ERROR,
+            cause, "Remote AI resource import request failed: " + serverMember.getAddress());
+    }
+}

--- a/console/src/main/java/com/alibaba/nacos/console/proxy/ai/AiResourceImportProxy.java
+++ b/console/src/main/java/com/alibaba/nacos/console/proxy/ai/AiResourceImportProxy.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.proxy.ai;
+
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.console.handler.ai.AiResourceImportHandler;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Proxy for Console AI resource import operations.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+public class AiResourceImportProxy {
+    
+    private final AiResourceImportHandler importHandler;
+    
+    public AiResourceImportProxy(AiResourceImportHandler importHandler) {
+        this.importHandler = importHandler;
+    }
+    
+    /**
+     * List import sources.
+     *
+     * @param resourceType optional resource type filter
+     * @return source list
+     * @throws NacosException if source configuration is invalid
+     */
+    public List<AiResourceImportSourceInfo> listSources(String resourceType)
+        throws NacosException {
+        return importHandler.listSources(resourceType);
+    }
+    
+    /**
+     * Search external candidates.
+     *
+     * @param request search request
+     * @return search response
+     * @throws NacosException if the source cannot be searched
+     */
+    public AiResourceImportSearchResponse search(AiResourceImportSearchRequest request)
+        throws NacosException {
+        return importHandler.search(request);
+    }
+    
+    /**
+     * Validate selected candidates.
+     *
+     * @param request validate request
+     * @return validation response
+     * @throws NacosException if validation cannot start
+     */
+    public AiResourceImportValidateResponse validate(AiResourceImportValidateRequest request)
+        throws NacosException {
+        return importHandler.validate(request);
+    }
+    
+    /**
+     * Execute import for selected candidates.
+     *
+     * @param request execute request
+     * @return execute response
+     * @throws NacosException if import cannot start
+     */
+    public AiResourceImportExecuteResponse execute(AiResourceImportExecuteRequest request)
+        throws NacosException {
+        return importHandler.execute(request);
+    }
+}

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAiResourceImportControllerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAiResourceImportControllerTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -43,6 +42,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -83,21 +83,23 @@ class ConsoleAiResourceImportControllerTest {
     void testSearch() throws Exception {
         when(importProxy.search(any(AiResourceImportSearchRequest.class))).thenReturn(
             new AiResourceImportSearchResponse());
-        AiResourceImportSearchRequest request = new AiResourceImportSearchRequest();
-        request.setResourceType("mcp");
-        request.setSourceId("source-1");
         
         MockHttpServletResponse response = mockMvc.perform(
             MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_CONSOLE_PATH + "/search")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(JacksonUtils.toJson(request)))
+                .param("resourceType", "mcp")
+                .param("sourceId", "source-1")
+                .param("query", "database")
+                .param("options", "{\"stage\":\"dev\"}"))
             .andReturn().getResponse();
         
         Result<AiResourceImportSearchResponse> result = JacksonUtils.toObj(
             response.getContentAsString(), new TypeReference<>() {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
-        verify(importProxy).search(any(AiResourceImportSearchRequest.class));
+        verify(importProxy).search(argThat(request -> "mcp".equals(request.getResourceType())
+            && "source-1".equals(request.getSourceId())
+            && "database".equals(request.getQuery())
+            && "dev".equals(request.getOptions().get("stage"))));
     }
     
     @Test
@@ -106,15 +108,18 @@ class ConsoleAiResourceImportControllerTest {
         
         MockHttpServletResponse response = mockMvc.perform(
             MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_CONSOLE_PATH + "/validate")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
+                .param("resourceType", "mcp")
+                .param("sourceId", "source-1")
+                .param("selectedItems", selectedItemsJson()))
             .andReturn().getResponse();
         
         Result<AiResourceImportValidateResponse> result = JacksonUtils.toObj(
             response.getContentAsString(), new TypeReference<>() {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
-        verify(importProxy).validate(any());
+        verify(importProxy).validate(argThat(request -> "mcp".equals(request.getResourceType())
+            && "source-1".equals(request.getSourceId())
+            && "server-1".equals(request.getSelectedItems().get(0).getExternalId())));
     }
     
     @Test
@@ -123,14 +128,22 @@ class ConsoleAiResourceImportControllerTest {
         
         MockHttpServletResponse response = mockMvc.perform(
             MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_CONSOLE_PATH + "/execute")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
+                .param("resourceType", "mcp")
+                .param("sourceId", "source-1")
+                .param("selectedItems", selectedItemsJson())
+                .param("overwriteExisting", "true"))
             .andReturn().getResponse();
         
         Result<AiResourceImportExecuteResponse> result = JacksonUtils.toObj(
             response.getContentAsString(), new TypeReference<>() {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
-        verify(importProxy).execute(any());
+        verify(importProxy).execute(argThat(request -> "mcp".equals(request.getResourceType())
+            && "source-1".equals(request.getSourceId()) && request.isOverwriteExisting()
+            && "server-1".equals(request.getSelectedItems().get(0).getExternalId())));
+    }
+    
+    private String selectedItemsJson() {
+        return "[{\"externalId\":\"server-1\",\"name\":\"server\",\"version\":\"1.0.0\"}]";
     }
 }

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAiResourceImportControllerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAiResourceImportControllerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.controller.v3.ai;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.console.proxy.ai.AiResourceImportProxy;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConsoleAiResourceImportControllerTest {
+    
+    @Mock
+    private AiResourceImportProxy importProxy;
+    
+    private MockMvc mockMvc;
+    
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(
+            new ConsoleAiResourceImportController(importProxy)).build();
+    }
+    
+    @Test
+    void testListSources() throws Exception {
+        AiResourceImportSourceInfo source = new AiResourceImportSourceInfo();
+        source.setSourceId("source-1");
+        when(importProxy.listSources("skill")).thenReturn(Collections.singletonList(source));
+        
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.get(Constants.AI_RESOURCE_IMPORT_CONSOLE_PATH + "/sources")
+                .param("resourceType", "skill"))
+            .andReturn().getResponse();
+        
+        Result<List<AiResourceImportSourceInfo>> result = JacksonUtils.toObj(
+            response.getContentAsString(), new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        assertEquals("source-1", result.getData().get(0).getSourceId());
+        verify(importProxy).listSources("skill");
+    }
+    
+    @Test
+    void testSearch() throws Exception {
+        when(importProxy.search(any(AiResourceImportSearchRequest.class))).thenReturn(
+            new AiResourceImportSearchResponse());
+        AiResourceImportSearchRequest request = new AiResourceImportSearchRequest();
+        request.setResourceType("mcp");
+        request.setSourceId("source-1");
+        
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_CONSOLE_PATH + "/search")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JacksonUtils.toJson(request)))
+            .andReturn().getResponse();
+        
+        Result<AiResourceImportSearchResponse> result = JacksonUtils.toObj(
+            response.getContentAsString(), new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        verify(importProxy).search(any(AiResourceImportSearchRequest.class));
+    }
+    
+    @Test
+    void testValidate() throws Exception {
+        when(importProxy.validate(any())).thenReturn(new AiResourceImportValidateResponse());
+        
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_CONSOLE_PATH + "/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andReturn().getResponse();
+        
+        Result<AiResourceImportValidateResponse> result = JacksonUtils.toObj(
+            response.getContentAsString(), new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        verify(importProxy).validate(any());
+    }
+    
+    @Test
+    void testExecute() throws Exception {
+        when(importProxy.execute(any())).thenReturn(new AiResourceImportExecuteResponse());
+        
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.post(Constants.AI_RESOURCE_IMPORT_CONSOLE_PATH + "/execute")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andReturn().getResponse();
+        
+        Result<AiResourceImportExecuteResponse> result = JacksonUtils.toObj(
+            response.getContentAsString(), new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        verify(importProxy).execute(any());
+    }
+}

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/ai/AiResourceImportInnerHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/ai/AiResourceImportInnerHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.impl.inner.ai;
+
+import com.alibaba.nacos.ai.importer.manager.AiResourceImportManager;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.exception.NacosException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AiResourceImportInnerHandlerTest {
+    
+    @Mock
+    private AiResourceImportManager importManager;
+    
+    private AiResourceImportInnerHandler handler;
+    
+    @BeforeEach
+    void setUp() {
+        handler = new AiResourceImportInnerHandler(importManager);
+    }
+    
+    @Test
+    void testListSources() throws NacosException {
+        List<AiResourceImportSourceInfo> sources =
+            Collections.singletonList(new AiResourceImportSourceInfo());
+        when(importManager.listSources("mcp")).thenReturn(sources);
+        
+        assertSame(sources, handler.listSources("mcp"));
+        
+        verify(importManager).listSources("mcp");
+    }
+    
+    @Test
+    void testSearch() throws NacosException {
+        AiResourceImportSearchRequest request = new AiResourceImportSearchRequest();
+        AiResourceImportSearchResponse response = new AiResourceImportSearchResponse();
+        when(importManager.search(request)).thenReturn(response);
+        
+        assertSame(response, handler.search(request));
+        
+        verify(importManager).search(request);
+    }
+    
+    @Test
+    void testValidate() throws NacosException {
+        AiResourceImportValidateRequest request = new AiResourceImportValidateRequest();
+        AiResourceImportValidateResponse response = new AiResourceImportValidateResponse();
+        when(importManager.validate(request)).thenReturn(response);
+        
+        assertSame(response, handler.validate(request));
+        
+        verify(importManager).validate(request);
+    }
+    
+    @Test
+    void testExecute() throws NacosException {
+        AiResourceImportExecuteRequest request = new AiResourceImportExecuteRequest();
+        AiResourceImportExecuteResponse response = new AiResourceImportExecuteResponse();
+        when(importManager.execute(request)).thenReturn(response);
+        
+        assertSame(response, handler.execute(request));
+        
+        verify(importManager).execute(request);
+    }
+}

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/noop/ai/AiResourceImportNoopHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/noop/ai/AiResourceImportNoopHandlerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.handler.impl.noop.ai;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AiResourceImportNoopHandlerTest {
+    
+    private final AiResourceImportNoopHandler handler = new AiResourceImportNoopHandler();
+    
+    @Test
+    void testListSourcesDisabled() {
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> handler.listSources("mcp"));
+        
+        assertEquals(NacosException.SERVER_NOT_IMPLEMENTED, exception.getErrCode());
+    }
+}

--- a/console/src/test/java/com/alibaba/nacos/console/proxy/ai/AiResourceImportProxyTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/proxy/ai/AiResourceImportProxyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.proxy.ai;
+
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSourceInfo;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.console.handler.ai.AiResourceImportHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AiResourceImportProxyTest {
+    
+    @Mock
+    private AiResourceImportHandler importHandler;
+    
+    private AiResourceImportProxy importProxy;
+    
+    @BeforeEach
+    void setUp() {
+        importProxy = new AiResourceImportProxy(importHandler);
+    }
+    
+    @Test
+    void testListSources() throws NacosException {
+        List<AiResourceImportSourceInfo> sources =
+            Collections.singletonList(new AiResourceImportSourceInfo());
+        when(importHandler.listSources("mcp")).thenReturn(sources);
+        
+        assertSame(sources, importProxy.listSources("mcp"));
+        
+        verify(importHandler).listSources("mcp");
+    }
+    
+    @Test
+    void testSearch() throws NacosException {
+        AiResourceImportSearchRequest request = new AiResourceImportSearchRequest();
+        AiResourceImportSearchResponse response = new AiResourceImportSearchResponse();
+        when(importHandler.search(request)).thenReturn(response);
+        
+        assertSame(response, importProxy.search(request));
+        
+        verify(importHandler).search(request);
+    }
+    
+    @Test
+    void testValidate() throws NacosException {
+        AiResourceImportValidateRequest request = new AiResourceImportValidateRequest();
+        AiResourceImportValidateResponse response = new AiResourceImportValidateResponse();
+        when(importHandler.validate(request)).thenReturn(response);
+        
+        assertSame(response, importProxy.validate(request));
+        
+        verify(importHandler).validate(request);
+    }
+    
+    @Test
+    void testExecute() throws NacosException {
+        AiResourceImportExecuteRequest request = new AiResourceImportExecuteRequest();
+        AiResourceImportExecuteResponse response = new AiResourceImportExecuteResponse();
+        when(importHandler.execute(request)).thenReturn(response);
+        
+        assertSame(response, importProxy.execute(request));
+        
+        verify(importHandler).execute(request);
+    }
+}

--- a/specs/en/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/en/plugin/ai-resource-import-plugin-spec.md
@@ -174,6 +174,13 @@ Nacos should expose unified Admin and Console import APIs:
 All unified APIs must use standard v3 `Result<T>` response, error, and
 authorization conventions.
 
+Unified import APIs must follow the Nacos v3 form binding convention. Controller
+methods should expose `*Form` parameters instead of direct request-model
+`@RequestBody` contracts. Scalar fields may be submitted as query parameters or
+`application/x-www-form-urlencoded` form fields. Complex import fields, such as
+`selectedItems` and `options`, should be submitted as JSON string form fields
+and converted by the form object into the internal request model.
+
 The recommended browser flow is:
 
 ```text

--- a/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
@@ -156,6 +156,11 @@ Nacos 应暴露统一的 Admin 和 Console 导入 API：
 
 所有统一 API 必须使用标准 v3 `Result<T>` 响应、错误和鉴权约定。
 
+统一导入 API 必须遵循 Nacos v3 表单绑定约定。Controller 方法应暴露 `*Form` 参数，而不是直接以
+request model 作为 `@RequestBody` 契约。标量字段可以通过 query 参数或
+`application/x-www-form-urlencoded` 表单字段提交。`selectedItems`、`options` 等复杂导入字段应
+作为 JSON 字符串表单字段提交，并由 Form 对象转换为内部 request model。
+
 推荐的浏览器流程为：
 
 ```text


### PR DESCRIPTION
## Summary
- Add configurable AI resource import source/plugin managers, artifact guard, and operator registry.
- Add unified admin and console import APIs for list sources, search, validate, and execute flows.
- Cover source loading, manager routing, controllers, console proxy, and handlers with unit tests.

## Tests
- `./mvnw -pl ai,console -am -Dtest=AiResourceImportManagerTest,AiResourceImportPropertiesTest,AiResourceImportAdminControllerTest,ConsoleAiResourceImportControllerTest,AiResourceImportProxyTest,AiResourceImportInnerHandlerTest,AiResourceImportNoopHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl ai,console -am -DskipTests spotless:check checkstyle:check apache-rat:check`
- `./mvnw -pl console -DskipTests spotbugs:check`