### PR TITLE
[ISSUE #14911] build(plugin): verify LDAP plugin packaging contract

### DIFF
--- a/plugin-default-impl/nacos-default-plugin-all/pom.xml
+++ b/plugin-default-impl/nacos-default-plugin-all/pom.xml
@@ -102,6 +102,12 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${project.basedir}/../../distribution/conf"/>
+                                <mkdir dir="${project.basedir}/../../distribution/plugins"/>
+                                <delete>
+                                    <fileset dir="${project.basedir}/../../distribution/plugins">
+                                        <include name="spring-ldap-core-*.jar"/>
+                                    </fileset>
+                                </delete>
                                 <copy file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/main/resources/META-INF/derby-schema.sql"
                                       tofile="${project.basedir}/../../distribution/conf/derby-schema.sql" overwrite="true"/>
                                 <copy file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/resources/META-INF/mysql-schema.sql"
@@ -154,6 +160,20 @@
                                 <fail unless="schema.output.pg.exists" message="Missing postgresql schema in distribution/conf after packaging."/>
                                 <fail unless="schema.output.pg.grant.exists" message="Missing postgresql grant script in distribution/conf after packaging."/>
                                 <fail unless="schema.output.oracle.exists" message="Missing oracle schema in distribution/conf after packaging."/>
+
+                                <available file="${project.basedir}/../../distribution/plugins/nacos-ldap-auth-plugin-${project.version}.jar"
+                                           property="plugin.output.ldap.exists"/>
+                                <fail unless="plugin.output.ldap.exists" message="Missing nacos-ldap-auth-plugin in distribution/plugins after packaging."/>
+
+                                <condition property="plugin.output.spring.ldap.missing">
+                                    <resourcecount count="0" when="equal">
+                                        <fileset dir="${project.basedir}/../../distribution/plugins">
+                                            <include name="spring-ldap-core-*.jar"/>
+                                        </fileset>
+                                    </resourcecount>
+                                </condition>
+                                <fail unless="plugin.output.spring.ldap.missing"
+                                      message="spring-ldap-core should not exist in distribution/plugins by default."/>
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## What is the purpose of the change

Follow-up to #15118 for ISSUE #14911.

This change adds build-time verification for the LDAP plugin packaging contract introduced by the LDAP plugin split.

The goal is to ensure the default distribution keeps the intended behavior stable:

- `nacos-ldap-auth-plugin` is packaged into `distribution/plugins`
- `org.springframework.ldap:spring-ldap-core` is not packaged by default

## Brief changelog

- add packaging verification in `nacos-default-plugin-all`
- assert `nacos-ldap-auth-plugin-${project.version}.jar` exists in `distribution/plugins` after packaging
- assert `spring-ldap-core-*.jar` does not exist in `distribution/plugins` by default
- remove stale local `spring-ldap-core` jars from `distribution/plugins` before verification so the packaging result reflects the current build output

## Verifying this change

mvn -pl plugin-default-impl/nacos-default-plugin-all -am verify -DskipTests -Dmaven.test.skip=true


Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

