### PR TITLE
[ISSUE #15183] Add MCP registry resource import

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/mcp/McpRegistryImportService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/mcp/McpRegistryImportService.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.mcp;
+
+import com.alibaba.nacos.ai.model.mcp.UrlPageResult;
+import com.alibaba.nacos.ai.service.McpExternalDataAdaptor;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.registry.Repository;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidate;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidatePage;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportContext;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Built-in importer for the official MCP registry API.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class McpRegistryImportService implements AiResourceImportService {
+    
+    public static final String RESOURCE_TYPE_MCP = "mcp";
+    
+    private static final int DEFAULT_FETCH_LIMIT = 30;
+    
+    private static final String METADATA_ID = "id";
+    
+    private static final String METADATA_PROTOCOL = "protocol";
+    
+    private static final String METADATA_STATUS = "status";
+    
+    private static final String METADATA_REPOSITORY = "repository";
+    
+    private final McpExternalDataAdaptor adaptor;
+    
+    public McpRegistryImportService(McpExternalDataAdaptor adaptor) {
+        this.adaptor = adaptor;
+    }
+    
+    @Override
+    public String importerType() {
+        return McpRegistryImportServiceBuilder.IMPORTER_TYPE;
+    }
+    
+    @Override
+    public Set<String> supportedResourceTypes() {
+        return Collections.singleton(RESOURCE_TYPE_MCP);
+    }
+    
+    @Override
+    public AiResourceImportCandidatePage search(AiResourceImportContext context)
+        throws NacosException {
+        try {
+            UrlPageResult registryPage = adaptor.fetchOfficialRegistryPage(
+                requireEndpoint(context.getSource()), context.getCursor(), context.getLimit(),
+                context.getQuery());
+            AiResourceImportCandidatePage result = new AiResourceImportCandidatePage();
+            result.setItems(toCandidates(registryPage.getServers()));
+            result.setNextCursor(registryPage.getNextCursor());
+            result.setHasMore(StringUtils.isNotBlank(registryPage.getNextCursor()));
+            return result;
+        } catch (NacosException e) {
+            throw e;
+        } catch (Exception e) {
+            throw dataAccess("Search MCP registry source failed: " + e.getMessage(), e);
+        }
+    }
+    
+    @Override
+    public AiResourceImportArtifact fetch(AiResourceImportContext context,
+        AiResourceImportItem item) throws NacosException {
+        try {
+            String externalId = resolveExternalId(item);
+            McpServerDetailInfo server = adaptor.fetchOfficialRegistryServer(
+                requireEndpoint(context.getSource()), externalId, resolveFetchLimit(context));
+            return toArtifact(externalId, server);
+        } catch (NacosException e) {
+            throw e;
+        } catch (Exception e) {
+            throw dataAccess("Fetch MCP registry artifact failed: " + e.getMessage(), e);
+        }
+    }
+    
+    private String requireEndpoint(AiResourceImportSource source) throws NacosException {
+        if (source == null || StringUtils.isBlank(source.getEndpoint())) {
+            throw invalid("MCP registry import source endpoint must not be empty.");
+        }
+        return source.getEndpoint();
+    }
+    
+    private String resolveExternalId(AiResourceImportItem item) throws NacosException {
+        if (item == null) {
+            throw invalid("MCP registry import item must not be null.");
+        }
+        String externalId = StringUtils.isNotBlank(item.getExternalId()) ? item.getExternalId()
+            : item.getName();
+        if (StringUtils.isBlank(externalId)) {
+            throw invalid("MCP registry import item external id must not be empty.");
+        }
+        return externalId;
+    }
+    
+    private int resolveFetchLimit(AiResourceImportContext context) {
+        return context.getLimit() > 0 ? context.getLimit() : DEFAULT_FETCH_LIMIT;
+    }
+    
+    private List<AiResourceImportCandidate> toCandidates(List<McpServerDetailInfo> servers) {
+        if (CollectionUtils.isEmpty(servers)) {
+            return Collections.emptyList();
+        }
+        List<AiResourceImportCandidate> result = new ArrayList<>(servers.size());
+        for (McpServerDetailInfo each : servers) {
+            result.add(toCandidate(each));
+        }
+        return result;
+    }
+    
+    private AiResourceImportCandidate toCandidate(McpServerDetailInfo server) {
+        AiResourceImportCandidate result = new AiResourceImportCandidate();
+        result.setResourceType(RESOURCE_TYPE_MCP);
+        result.setExternalId(server.getName());
+        result.setName(server.getName());
+        result.setVersion(resolveVersion(server));
+        result.setDescription(server.getDescription());
+        result.setMetadata(buildMetadata(server));
+        return result;
+    }
+    
+    private AiResourceImportArtifact toArtifact(String externalId, McpServerDetailInfo server) {
+        AiResourceImportArtifact result = new AiResourceImportArtifact();
+        result.setResourceType(RESOURCE_TYPE_MCP);
+        result.setExternalId(externalId);
+        result.setName(server.getName());
+        result.setVersion(resolveVersion(server));
+        result.setDescription(server.getDescription());
+        result.setPayloadKind(AiResourceImportPayloadKind.MCP_DETAIL);
+        result.setPayloadJson(JacksonUtils.toJson(server));
+        result.setSourceMetadata(buildMetadata(server));
+        return result;
+    }
+    
+    private String resolveVersion(McpServerDetailInfo server) {
+        ServerVersionDetail versionDetail = server.getVersionDetail();
+        return versionDetail == null ? server.getVersion() : versionDetail.getVersion();
+    }
+    
+    private Map<String, String> buildMetadata(McpServerDetailInfo server) {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        putIfNotBlank(metadata, METADATA_ID, server.getId());
+        putIfNotBlank(metadata, METADATA_PROTOCOL, server.getProtocol());
+        putIfNotBlank(metadata, METADATA_STATUS, server.getStatus());
+        Repository repository = server.getRepository();
+        if (repository != null) {
+            putIfNotBlank(metadata, METADATA_REPOSITORY, repository.getUrl());
+        }
+        return metadata;
+    }
+    
+    private void putIfNotBlank(Map<String, String> metadata, String key, String value) {
+        if (StringUtils.isNotBlank(value)) {
+            metadata.put(key, value);
+        }
+    }
+    
+    private NacosException invalid(String message) {
+        return new NacosApiException(NacosException.INVALID_PARAM,
+            ErrorCode.PARAMETER_VALIDATE_ERROR, message);
+    }
+    
+    private NacosException dataAccess(String message, Throwable cause) {
+        return new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.DATA_ACCESS_ERROR,
+            cause, message);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/mcp/McpRegistryImportServiceBuilder.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/mcp/McpRegistryImportServiceBuilder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.mcp;
+
+import com.alibaba.nacos.ai.service.McpExternalDataAdaptor;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder;
+
+import java.util.Properties;
+
+/**
+ * Builder for the built-in official MCP registry import service.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class McpRegistryImportServiceBuilder implements AiResourceImportServiceBuilder {
+    
+    static final String IMPORTER_TYPE = "mcp-registry";
+    
+    @Override
+    public String importerType() {
+        return IMPORTER_TYPE;
+    }
+    
+    @Override
+    public AiResourceImportService build(Properties properties) {
+        return new McpRegistryImportService(new McpExternalDataAdaptor());
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/operator/McpResourceOperator.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/operator/McpResourceOperator.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.operator;
+
+import com.alibaba.nacos.ai.constant.McpServerValidationConstants;
+import com.alibaba.nacos.ai.enums.McpImportResultStatusEnum;
+import com.alibaba.nacos.ai.importer.mcp.McpRegistryImportService;
+import com.alibaba.nacos.ai.service.McpServerImportService;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultStatus;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationStatus;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportResult;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportValidationResult;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerValidationItem;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+/**
+ * Applies imported MCP artifacts to the current MCP server domain service.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+public class McpResourceOperator implements AiResourceOperator {
+    
+    private static final String CONFLICT_TYPE_EXISTING = "existing";
+    
+    private static final String CONFLICT_TYPE_DUPLICATE = "duplicate";
+    
+    private final McpServerImportService mcpServerImportService;
+    
+    public McpResourceOperator(McpServerImportService mcpServerImportService) {
+        this.mcpServerImportService = mcpServerImportService;
+    }
+    
+    @Override
+    public String resourceType() {
+        return McpRegistryImportService.RESOURCE_TYPE_MCP;
+    }
+    
+    @Override
+    public AiResourceImportValidationItem validate(String namespaceId,
+        AiResourceImportArtifact artifact, boolean overwriteExisting) throws NacosException {
+        McpServerValidationItem validationItem = validateArtifact(namespaceId, artifact);
+        return toValidationItem(artifact, validationItem);
+    }
+    
+    @Override
+    public AiResourceImportResultItem importResource(String namespaceId,
+        AiResourceImportArtifact artifact, boolean overwriteExisting) throws NacosException {
+        McpServerValidationItem validationItem = validateArtifact(namespaceId, artifact);
+        if (McpServerValidationConstants.STATUS_INVALID.equals(validationItem.getStatus())) {
+            return failedItem(artifact, String.join(", ", validationItem.getErrors()));
+        }
+        McpServerImportResult importResult = mcpServerImportService.importValidatedServer(
+            namespaceId, validationItem, overwriteExisting);
+        return toResultItem(artifact, importResult);
+    }
+    
+    private McpServerValidationItem validateArtifact(String namespaceId,
+        AiResourceImportArtifact artifact) throws NacosException {
+        McpServerDetailInfo server = parseServer(artifact);
+        McpServerImportValidationResult validationResult = mcpServerImportService
+            .validateMcpServers(namespaceId, Collections.singletonList(server));
+        if (validationResult == null || CollectionUtils.isEmpty(validationResult.getServers())) {
+            throw invalid("MCP import validation returned empty result.");
+        }
+        return validationResult.getServers().get(0);
+    }
+    
+    private McpServerDetailInfo parseServer(AiResourceImportArtifact artifact)
+        throws NacosException {
+        if (artifact == null) {
+            throw invalid("MCP import artifact must not be null.");
+        }
+        if (artifact.getPayloadKind() != AiResourceImportPayloadKind.MCP_DETAIL
+            && artifact.getPayloadKind() != AiResourceImportPayloadKind.JSON) {
+            throw invalid("MCP import artifact payload kind is unsupported.");
+        }
+        if (StringUtils.isBlank(artifact.getPayloadJson())) {
+            throw invalid("MCP import artifact payload json must not be empty.");
+        }
+        try {
+            McpServerDetailInfo result =
+                JacksonUtils.toObj(artifact.getPayloadJson(), McpServerDetailInfo.class);
+            if (result == null) {
+                throw invalid("MCP import artifact cannot be parsed.");
+            }
+            return result;
+        } catch (NacosException e) {
+            throw e;
+        } catch (Exception e) {
+            throw invalid("MCP import artifact cannot be parsed: " + e.getMessage());
+        }
+    }
+    
+    private AiResourceImportValidationItem toValidationItem(AiResourceImportArtifact artifact,
+        McpServerValidationItem item) {
+        AiResourceImportValidationItem result = new AiResourceImportValidationItem();
+        result.setExternalId(artifact.getExternalId());
+        result.setName(StringUtils.isNotBlank(item.getServerName()) ? item.getServerName()
+            : artifact.getName());
+        result.setVersion(resolveVersion(artifact, item.getServer()));
+        result.setExists(item.isExists());
+        result.setErrors(item.getErrors());
+        if (McpServerValidationConstants.STATUS_VALID.equals(item.getStatus())) {
+            result.setStatus(AiResourceImportValidationStatus.VALID);
+        } else if (McpServerValidationConstants.STATUS_DUPLICATE.equals(item.getStatus())) {
+            result.setStatus(AiResourceImportValidationStatus.CONFLICT);
+            result.setConflictType(item.isExists() ? CONFLICT_TYPE_EXISTING
+                : CONFLICT_TYPE_DUPLICATE);
+        } else {
+            result.setStatus(AiResourceImportValidationStatus.INVALID);
+        }
+        return result;
+    }
+    
+    private AiResourceImportResultItem toResultItem(AiResourceImportArtifact artifact,
+        McpServerImportResult importResult) {
+        AiResourceImportResultItem result = new AiResourceImportResultItem();
+        result.setExternalId(artifact.getExternalId());
+        result.setResourceName(importResult.getServerName());
+        result.setVersion(artifact.getVersion());
+        result.setErrorMessage(importResult.getErrorMessage());
+        if (McpImportResultStatusEnum.SUCCESS.getName().equals(importResult.getStatus())) {
+            result.setStatus(AiResourceImportResultStatus.SUCCESS);
+        } else if (McpImportResultStatusEnum.SKIPPED.getName().equals(importResult.getStatus())) {
+            result.setStatus(AiResourceImportResultStatus.SKIPPED);
+        } else {
+            result.setStatus(AiResourceImportResultStatus.FAILED);
+        }
+        return result;
+    }
+    
+    private AiResourceImportResultItem failedItem(AiResourceImportArtifact artifact,
+        String errorMessage) {
+        AiResourceImportResultItem result = new AiResourceImportResultItem();
+        result.setExternalId(artifact.getExternalId());
+        result.setResourceName(artifact.getName());
+        result.setVersion(artifact.getVersion());
+        result.setStatus(AiResourceImportResultStatus.FAILED);
+        result.setErrorMessage(errorMessage);
+        return result;
+    }
+    
+    private String resolveVersion(AiResourceImportArtifact artifact, McpServerDetailInfo server) {
+        if (server != null && server.getVersionDetail() != null) {
+            return server.getVersionDetail().getVersion();
+        }
+        return artifact.getVersion();
+    }
+    
+    private NacosException invalid(String message) {
+        return new NacosApiException(NacosException.INVALID_PARAM,
+            ErrorCode.PARAMETER_VALIDATE_ERROR, message);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpExternalDataAdaptor.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpExternalDataAdaptor.java
@@ -53,11 +53,11 @@ import java.util.stream.Collectors;
  * <p>Adapt the External data(mcp server json file, mcp registry api data) to Nacos MCP server format
  * {@link McpServerDetailInfo}. MCP official formats docs.</p>
  *
- * <p>1. MCP Server format is defined in 
+ * <p>1. MCP Server format is defined in
  * <a href="https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/server.schema.json">
  * server.schema.json</a>.</p>
  *
- * <p>2. MCP Registry Api is defined in 
+ * <p>2. MCP Registry Api is defined in
  * <a href="https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/api/openapi.yaml">
  * openapi.yaml</a>.</p>
  *
@@ -119,6 +119,52 @@ public class McpExternalDataAdaptor {
         } else {
             throw new IllegalArgumentException("Unsupported import type: " + externalDataTypeEnum);
         }
+    }
+    
+    /**
+     * Fetch one official MCP registry page and adapt it to Nacos MCP server detail info.
+     *
+     * @param urlData registry endpoint
+     * @param cursor page cursor
+     * @param limit page size
+     * @param search search keyword
+     * @return adapted page result
+     * @throws Exception if registry fetch or adaptation failed
+     */
+    public UrlPageResult fetchOfficialRegistryPage(String urlData, String cursor, Integer limit,
+        String search)
+        throws Exception {
+        if (StringUtils.isBlank(urlData)) {
+            throw new IllegalArgumentException("URL is blank");
+        }
+        return fetchUrlPage(urlData.trim(), cursor, limit, search);
+    }
+    
+    /**
+     * Fetch one official MCP registry server by name or generated id.
+     *
+     * @param urlData registry endpoint
+     * @param externalId selected server name or generated id
+     * @param limit search page size
+     * @return adapted MCP server detail
+     * @throws Exception if registry fetch or adaptation failed
+     */
+    public McpServerDetailInfo fetchOfficialRegistryServer(String urlData, String externalId,
+        int limit) throws Exception {
+        if (StringUtils.isBlank(externalId)) {
+            throw new IllegalArgumentException("MCP server external id is blank");
+        }
+        int actualLimit = limit > 0 ? limit : 30;
+        UrlPageResult page = fetchOfficialRegistryPage(urlData, null, actualLimit, externalId);
+        if (CollectionUtils.isNotEmpty(page.getServers())) {
+            for (McpServerDetailInfo each : page.getServers()) {
+                if (StringUtils.equals(externalId, each.getName())
+                    || StringUtils.equals(externalId, each.getId())) {
+                    return each;
+                }
+            }
+        }
+        throw new IllegalStateException("MCP server not found in registry: " + externalId);
     }
     
     private UrlPageResult fetchUrlPage(String urlData, String cursor, Integer limit, String search)
@@ -192,9 +238,10 @@ public class McpExternalDataAdaptor {
      */
     private McpServerDetailInfo adaptOfficialMcpServerFromResponse(ServerResponse response) {
         McpServerDetailInfo adaptOfficialMcpServer = adaptOfficialMcpServer(response.getServer());
-        OfficialMeta official = response.getMeta().getOfficial();
         ServerVersionDetail versionDetail = adaptOfficialMcpServer.getVersionDetail();
-        if (versionDetail != null) {
+        OfficialMeta official =
+            response.getMeta() == null ? null : response.getMeta().getOfficial();
+        if (versionDetail != null && official != null) {
             versionDetail.setRelease_date(official.getPublishedAt());
             versionDetail.setIs_latest(true);
             String status = official.getStatus();

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpLegacyImportAdapter.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpLegacyImportAdapter.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service;
+
+import com.alibaba.nacos.ai.enums.ExternalDataTypeEnum;
+import com.alibaba.nacos.ai.importer.config.AiResourceImportProperties;
+import com.alibaba.nacos.ai.importer.mcp.McpRegistryImportService;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportCandidateItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultStatus;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationStatus;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportRequest;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportResponse;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportResult;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportValidationResult;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerValidationItem;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Compatibility adapter from legacy MCP import APIs to unified AI resource import APIs.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+@Service
+public class McpLegacyImportAdapter {
+    
+    private static final String STATUS_VALID = "valid";
+    
+    private static final String STATUS_INVALID = "invalid";
+    
+    private static final String STATUS_DUPLICATE = "duplicate";
+    
+    private final McpServerImportService mcpServerImportService;
+    
+    private final com.alibaba.nacos.ai.importer.manager.AiResourceImportManager importManager;
+    
+    private Supplier<AiResourceImportProperties> propertiesSupplier =
+        AiResourceImportProperties::loadFromEnvironment;
+    
+    public McpLegacyImportAdapter(McpServerImportService mcpServerImportService,
+        com.alibaba.nacos.ai.importer.manager.AiResourceImportManager importManager) {
+        this.mcpServerImportService = mcpServerImportService;
+        this.importManager = importManager;
+    }
+    
+    /**
+     * Validate a legacy MCP import request.
+     *
+     * @param namespaceId namespace ID
+     * @param request legacy import request
+     * @return legacy validation response
+     * @throws NacosException if validation cannot start
+     */
+    public McpServerImportValidationResult validateImport(String namespaceId,
+        McpServerImportRequest request) throws NacosException {
+        if (!shouldRouteToUnifiedImport(request)) {
+            return shouldRejectUserUrl(request) ? rejectedValidation()
+                : mcpServerImportService.validateImport(namespaceId, request);
+        }
+        try {
+            AiResourceImportValidateResponse response = importManager
+                .validate(buildValidateRequest(namespaceId, request));
+            return toLegacyValidationResult(response);
+        } catch (NacosException e) {
+            return failedValidation(e.getErrMsg());
+        }
+    }
+    
+    /**
+     * Execute a legacy MCP import request.
+     *
+     * @param namespaceId namespace ID
+     * @param request legacy import request
+     * @return legacy execute response
+     * @throws NacosException if import cannot start
+     */
+    public McpServerImportResponse executeImport(String namespaceId, McpServerImportRequest request)
+        throws NacosException {
+        if (!shouldRouteToUnifiedImport(request)) {
+            return shouldRejectUserUrl(request) ? rejectedResponse()
+                : mcpServerImportService.executeImport(namespaceId, request);
+        }
+        try {
+            AiResourceImportExecuteResponse response = importManager
+                .execute(buildExecuteRequest(namespaceId, request));
+            return toLegacyExecuteResponse(response);
+        } catch (NacosException e) {
+            return failedResponse(e.getErrMsg());
+        }
+    }
+    
+    private boolean shouldRouteToUnifiedImport(McpServerImportRequest request) {
+        return request != null && ExternalDataTypeEnum.URL.getName().equals(request.getImportType())
+            && !isUrl(request.getData());
+    }
+    
+    private boolean shouldRejectUserUrl(McpServerImportRequest request) {
+        return request != null && ExternalDataTypeEnum.URL.getName().equals(request.getImportType())
+            && isUrl(request.getData()) && !propertiesSupplier.get().isAllowUserUrl();
+    }
+    
+    private boolean isUrl(String value) {
+        if (StringUtils.isBlank(value)) {
+            return false;
+        }
+        try {
+            URI uri = URI.create(value);
+            return "http".equalsIgnoreCase(uri.getScheme())
+                || "https".equalsIgnoreCase(uri.getScheme());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    private AiResourceImportValidateRequest buildValidateRequest(String namespaceId,
+        McpServerImportRequest request) throws NacosException {
+        AiResourceImportValidateRequest result = new AiResourceImportValidateRequest();
+        result.setNamespaceId(namespaceId);
+        result.setResourceType(McpRegistryImportService.RESOURCE_TYPE_MCP);
+        result.setSourceId(request.getData());
+        result.setOverwriteExisting(request.isOverrideExisting());
+        result.setSelectedItems(resolveSelectedItems(namespaceId, request));
+        return result;
+    }
+    
+    private AiResourceImportExecuteRequest buildExecuteRequest(String namespaceId,
+        McpServerImportRequest request) throws NacosException {
+        AiResourceImportExecuteRequest result = new AiResourceImportExecuteRequest();
+        result.setNamespaceId(namespaceId);
+        result.setResourceType(McpRegistryImportService.RESOURCE_TYPE_MCP);
+        result.setSourceId(request.getData());
+        result.setOverwriteExisting(request.isOverrideExisting());
+        result.setSkipInvalid(request.isSkipInvalid());
+        result.setSelectedItems(resolveSelectedItems(namespaceId, request));
+        return result;
+    }
+    
+    private List<AiResourceImportItem> resolveSelectedItems(String namespaceId,
+        McpServerImportRequest request) throws NacosException {
+        if (request.getSelectedServers() != null && request.getSelectedServers().length > 0) {
+            List<AiResourceImportItem> result =
+                new ArrayList<>(request.getSelectedServers().length);
+            for (String each : request.getSelectedServers()) {
+                if (StringUtils.isNotBlank(each)) {
+                    result.add(selectedItem(each, each, null));
+                }
+            }
+            return result;
+        }
+        AiResourceImportSearchRequest searchRequest = new AiResourceImportSearchRequest();
+        searchRequest.setNamespaceId(namespaceId);
+        searchRequest.setResourceType(McpRegistryImportService.RESOURCE_TYPE_MCP);
+        searchRequest.setSourceId(request.getData());
+        searchRequest.setCursor(request.getCursor());
+        searchRequest.setLimit(request.getLimit());
+        searchRequest.setQuery(request.getSearch());
+        AiResourceImportSearchResponse searchResponse = importManager.search(searchRequest);
+        if (searchResponse == null || CollectionUtils.isEmpty(searchResponse.getItems())) {
+            return Collections.emptyList();
+        }
+        List<AiResourceImportItem> result = new ArrayList<>(searchResponse.getItems().size());
+        for (AiResourceImportCandidateItem each : searchResponse.getItems()) {
+            result.add(selectedItem(each.getExternalId(), each.getName(), each.getVersion()));
+        }
+        return result;
+    }
+    
+    private AiResourceImportItem selectedItem(String externalId, String name, String version) {
+        AiResourceImportItem result = new AiResourceImportItem();
+        result.setExternalId(externalId);
+        result.setName(name);
+        result.setVersion(version);
+        return result;
+    }
+    
+    private McpServerImportValidationResult toLegacyValidationResult(
+        AiResourceImportValidateResponse response) {
+        McpServerImportValidationResult result = new McpServerImportValidationResult();
+        List<McpServerValidationItem> servers = new ArrayList<>();
+        int validCount = 0;
+        int invalidCount = 0;
+        int duplicateCount = 0;
+        for (AiResourceImportValidationItem each : response.getItems()) {
+            McpServerValidationItem item = toLegacyValidationItem(each);
+            servers.add(item);
+            if (STATUS_VALID.equals(item.getStatus())) {
+                validCount++;
+            } else if (STATUS_DUPLICATE.equals(item.getStatus())) {
+                duplicateCount++;
+            } else {
+                invalidCount++;
+            }
+        }
+        result.setServers(servers);
+        result.setTotalCount(servers.size());
+        result.setValidCount(validCount);
+        result.setInvalidCount(invalidCount);
+        result.setDuplicateCount(duplicateCount);
+        result.setValid(invalidCount == 0);
+        result.setErrors(Collections.emptyList());
+        return result;
+    }
+    
+    private McpServerValidationItem toLegacyValidationItem(AiResourceImportValidationItem item) {
+        McpServerValidationItem result = new McpServerValidationItem();
+        result.setServerId(item.getExternalId());
+        result.setServerName(item.getName());
+        result.setExists(item.isExists());
+        result.setErrors(item.getErrors());
+        result.setSelected(true);
+        if (AiResourceImportValidationStatus.VALID == item.getStatus()
+            || AiResourceImportValidationStatus.WARNING == item.getStatus()) {
+            result.setStatus(STATUS_VALID);
+        } else if (AiResourceImportValidationStatus.CONFLICT == item.getStatus()) {
+            result.setStatus(STATUS_DUPLICATE);
+        } else {
+            result.setStatus(STATUS_INVALID);
+        }
+        return result;
+    }
+    
+    private McpServerImportResponse toLegacyExecuteResponse(
+        AiResourceImportExecuteResponse response) {
+        McpServerImportResponse result = new McpServerImportResponse();
+        result.setSuccess(response.isSuccess());
+        result.setTotalCount(response.getTotalCount());
+        result.setSuccessCount(response.getSuccessCount());
+        result.setFailedCount(response.getFailedCount());
+        result.setSkippedCount(response.getSkippedCount());
+        List<McpServerImportResult> results = new ArrayList<>();
+        for (AiResourceImportResultItem each : response.getResults()) {
+            results.add(toLegacyImportResult(each));
+        }
+        result.setResults(results);
+        return result;
+    }
+    
+    private McpServerImportResult toLegacyImportResult(AiResourceImportResultItem item) {
+        McpServerImportResult result = new McpServerImportResult();
+        result.setServerId(item.getExternalId());
+        result.setServerName(item.getResourceName());
+        result.setErrorMessage(item.getErrorMessage());
+        if (AiResourceImportResultStatus.SUCCESS == item.getStatus()) {
+            result.setStatus("success");
+        } else if (AiResourceImportResultStatus.SKIPPED == item.getStatus()) {
+            result.setStatus("skipped");
+        } else {
+            result.setStatus("failed");
+        }
+        return result;
+    }
+    
+    private McpServerImportValidationResult rejectedValidation() {
+        return failedValidation(
+            "Legacy URL import is disabled. Please use a configured source id.");
+    }
+    
+    private McpServerImportResponse rejectedResponse() {
+        return failedResponse("Legacy URL import is disabled. Please use a configured source id.");
+    }
+    
+    private McpServerImportValidationResult failedValidation(String errorMessage) {
+        McpServerImportValidationResult result = new McpServerImportValidationResult();
+        result.setValid(false);
+        result.setErrors(Collections.singletonList(errorMessage));
+        return result;
+    }
+    
+    private McpServerImportResponse failedResponse(String errorMessage) {
+        McpServerImportResponse result = new McpServerImportResponse();
+        result.setSuccess(false);
+        result.setErrorMessage(errorMessage);
+        return result;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerImportService.java
@@ -139,6 +139,34 @@ public class McpServerImportService {
         }
     }
     
+    /**
+     * Validate transformed MCP server details.
+     *
+     * @param namespaceId namespace ID
+     * @param servers transformed MCP servers
+     * @return validation result
+     * @throws NacosException if validation fails
+     */
+    public McpServerImportValidationResult validateMcpServers(String namespaceId,
+        List<McpServerDetailInfo> servers)
+        throws NacosException {
+        return validationService.validateServers(namespaceId, servers);
+    }
+    
+    /**
+     * Import one validated MCP server item.
+     *
+     * @param namespaceId namespace ID
+     * @param item validated MCP server item
+     * @param overrideExisting whether existing MCP server should be overwritten
+     * @return import result
+     */
+    public McpServerImportResult importValidatedServer(String namespaceId,
+        McpServerValidationItem item,
+        boolean overrideExisting) {
+        return importSingleServer(namespaceId, item, overrideExisting);
+    }
+    
     private static McpServerImportResponse responseError(String msg) {
         McpServerImportResponse response = new McpServerImportResponse();
         response.setSuccess(false);

--- a/ai/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder
+++ b/ai/src/main/resources/META-INF/services/com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportServiceBuilder
@@ -1,0 +1,15 @@
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+com.alibaba.nacos.ai.importer.mcp.McpRegistryImportServiceBuilder

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/mcp/McpRegistryImportServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/mcp/McpRegistryImportServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.mcp;
+
+import com.alibaba.nacos.ai.model.mcp.UrlPageResult;
+import com.alibaba.nacos.ai.service.McpExternalDataAdaptor;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidatePage;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportContext;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link McpRegistryImportService}.
+ *
+ * @author xiweng.yy
+ */
+@ExtendWith(MockitoExtension.class)
+class McpRegistryImportServiceTest {
+    
+    private static final String ENDPOINT = "https://registry.example.com/v0/servers";
+    
+    @Mock
+    private McpExternalDataAdaptor adaptor;
+    
+    private McpRegistryImportService importService;
+    
+    @BeforeEach
+    void setUp() {
+        importService = new McpRegistryImportService(adaptor);
+    }
+    
+    @Test
+    void testSearchReturnsCandidateMetadata() throws Exception {
+        McpServerDetailInfo server = newMcpServer();
+        when(adaptor.fetchOfficialRegistryPage(ENDPOINT, "cursor-1", 20, "redis"))
+            .thenReturn(new UrlPageResult(Collections.singletonList(server), "cursor-2"));
+        
+        AiResourceImportCandidatePage result = importService.search(newContext());
+        
+        assertEquals(1, result.getItems().size());
+        assertEquals("io.nacos/test-server", result.getItems().get(0).getExternalId());
+        assertEquals("1.0.0", result.getItems().get(0).getVersion());
+        assertEquals(AiConstants.Mcp.MCP_PROTOCOL_STDIO,
+            result.getItems().get(0).getMetadata().get("protocol"));
+        assertEquals("cursor-2", result.getNextCursor());
+    }
+    
+    @Test
+    void testFetchReturnsMcpDetailArtifact() throws Exception {
+        McpServerDetailInfo server = newMcpServer();
+        when(adaptor.fetchOfficialRegistryServer(ENDPOINT, "io.nacos/test-server", 30))
+            .thenReturn(server);
+        AiResourceImportItem item = new AiResourceImportItem();
+        item.setExternalId("io.nacos/test-server");
+        
+        AiResourceImportArtifact result = importService.fetch(newFetchContext(), item);
+        
+        assertEquals(McpRegistryImportService.RESOURCE_TYPE_MCP, result.getResourceType());
+        assertEquals(AiResourceImportPayloadKind.MCP_DETAIL, result.getPayloadKind());
+        assertEquals("io.nacos/test-server", result.getName());
+        McpServerDetailInfo parsed =
+            JacksonUtils.toObj(result.getPayloadJson(), McpServerDetailInfo.class);
+        assertEquals("io.nacos/test-server", parsed.getName());
+    }
+    
+    @Test
+    void testSearchRejectsMissingEndpoint() {
+        AiResourceImportContext context = newContext();
+        context.getSource().setEndpoint(null);
+        
+        assertThrows(NacosException.class, () -> importService.search(context));
+    }
+    
+    @Test
+    void testSupportedResourceTypeAndImporterType() {
+        assertEquals(McpRegistryImportServiceBuilder.IMPORTER_TYPE, importService.importerType());
+        assertFalse(importService.supportedResourceTypes().isEmpty());
+    }
+    
+    private AiResourceImportContext newContext() {
+        AiResourceImportContext context = newFetchContext();
+        context.setCursor("cursor-1");
+        context.setLimit(20);
+        context.setQuery("redis");
+        return context;
+    }
+    
+    private AiResourceImportContext newFetchContext() {
+        AiResourceImportContext context = new AiResourceImportContext();
+        AiResourceImportSource source = new AiResourceImportSource();
+        source.setEndpoint(ENDPOINT);
+        context.setSource(source);
+        return context;
+    }
+    
+    private McpServerDetailInfo newMcpServer() {
+        McpServerDetailInfo server = new McpServerDetailInfo();
+        server.setId("server-id");
+        server.setName("io.nacos/test-server");
+        server.setDescription("test server");
+        server.setProtocol(AiConstants.Mcp.MCP_PROTOCOL_STDIO);
+        ServerVersionDetail versionDetail = new ServerVersionDetail();
+        versionDetail.setVersion("1.0.0");
+        server.setVersionDetail(versionDetail);
+        return server;
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/operator/McpResourceOperatorTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/operator/McpResourceOperatorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.importer.operator;
+
+import com.alibaba.nacos.ai.constant.McpServerValidationConstants;
+import com.alibaba.nacos.ai.enums.McpImportResultStatusEnum;
+import com.alibaba.nacos.ai.importer.mcp.McpRegistryImportService;
+import com.alibaba.nacos.ai.service.McpServerImportService;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultStatus;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationStatus;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportResult;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportValidationResult;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerValidationItem;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link McpResourceOperator}.
+ *
+ * @author xiweng.yy
+ */
+@ExtendWith(MockitoExtension.class)
+class McpResourceOperatorTest {
+    
+    @Mock
+    private McpServerImportService mcpServerImportService;
+    
+    private McpResourceOperator operator;
+    
+    @BeforeEach
+    void setUp() {
+        operator = new McpResourceOperator(mcpServerImportService);
+    }
+    
+    @Test
+    void testValidateMapsDuplicateToConflict() throws Exception {
+        when(mcpServerImportService.validateMcpServers(eq("public"), any()))
+            .thenReturn(validationResult(McpServerValidationConstants.STATUS_DUPLICATE, true));
+        
+        AiResourceImportValidationItem result =
+            operator.validate("public", artifact(), false);
+        
+        assertEquals(AiResourceImportValidationStatus.CONFLICT, result.getStatus());
+        assertEquals("existing", result.getConflictType());
+        assertEquals("io.nacos/test-server", result.getName());
+        assertEquals("1.0.0", result.getVersion());
+    }
+    
+    @Test
+    void testImportUsesMcpImportService() throws Exception {
+        when(mcpServerImportService.validateMcpServers(eq("public"), any()))
+            .thenReturn(validationResult(McpServerValidationConstants.STATUS_VALID, false));
+        McpServerImportResult importResult = new McpServerImportResult();
+        importResult.setServerId("server-id");
+        importResult.setServerName("io.nacos/test-server");
+        importResult.setStatus(McpImportResultStatusEnum.SUCCESS.getName());
+        when(mcpServerImportService.importValidatedServer(eq("public"), any(), eq(true)))
+            .thenReturn(importResult);
+        
+        AiResourceImportResultItem result = operator.importResource("public", artifact(), true);
+        
+        assertEquals(AiResourceImportResultStatus.SUCCESS, result.getStatus());
+        assertEquals("io.nacos/test-server", result.getResourceName());
+        verify(mcpServerImportService).importValidatedServer(eq("public"), any(), eq(true));
+    }
+    
+    @Test
+    void testImportInvalidArtifactReturnsFailedItem() throws Exception {
+        when(mcpServerImportService.validateMcpServers(eq("public"), any()))
+            .thenReturn(validationResult(McpServerValidationConstants.STATUS_INVALID, false));
+        
+        AiResourceImportResultItem result = operator.importResource("public", artifact(), false);
+        
+        assertEquals(AiResourceImportResultStatus.FAILED, result.getStatus());
+        verify(mcpServerImportService, never()).importValidatedServer(any(), any(), eq(false));
+    }
+    
+    @Test
+    void testValidateRejectsUnsupportedPayloadKind() {
+        AiResourceImportArtifact artifact = artifact();
+        artifact.setPayloadKind(AiResourceImportPayloadKind.SKILL_ZIP);
+        
+        assertThrows(Exception.class, () -> operator.validate("public", artifact, false));
+    }
+    
+    @Test
+    void testResourceType() {
+        assertEquals(McpRegistryImportService.RESOURCE_TYPE_MCP, operator.resourceType());
+    }
+    
+    private McpServerImportValidationResult validationResult(String status, boolean exists) {
+        McpServerValidationItem item = new McpServerValidationItem();
+        item.setServerId("server-id");
+        item.setServerName("io.nacos/test-server");
+        item.setStatus(status);
+        item.setExists(exists);
+        item.setErrors(Collections.singletonList("validation error"));
+        item.setServer(server());
+        McpServerImportValidationResult result = new McpServerImportValidationResult();
+        result.setServers(Collections.singletonList(item));
+        return result;
+    }
+    
+    private AiResourceImportArtifact artifact() {
+        AiResourceImportArtifact artifact = new AiResourceImportArtifact();
+        artifact.setResourceType(McpRegistryImportService.RESOURCE_TYPE_MCP);
+        artifact.setExternalId("io.nacos/test-server");
+        artifact.setName("io.nacos/test-server");
+        artifact.setVersion("1.0.0");
+        artifact.setPayloadKind(AiResourceImportPayloadKind.MCP_DETAIL);
+        artifact.setPayloadJson(JacksonUtils.toJson(server()));
+        return artifact;
+    }
+    
+    private McpServerDetailInfo server() {
+        McpServerDetailInfo server = new McpServerDetailInfo();
+        server.setId("server-id");
+        server.setName("io.nacos/test-server");
+        server.setDescription("test server");
+        server.setProtocol(AiConstants.Mcp.MCP_PROTOCOL_STDIO);
+        ServerVersionDetail versionDetail = new ServerVersionDetail();
+        versionDetail.setVersion("1.0.0");
+        server.setVersionDetail(versionDetail);
+        return server;
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpLegacyImportAdapterTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpLegacyImportAdapterTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service;
+
+import com.alibaba.nacos.ai.enums.ExternalDataTypeEnum;
+import com.alibaba.nacos.ai.importer.config.AiResourceImportProperties;
+import com.alibaba.nacos.ai.importer.manager.AiResourceImportManager;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportCandidateItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportExecuteResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportResultStatus;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportSearchResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateRequest;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidateResponse;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationItem;
+import com.alibaba.nacos.api.ai.model.importer.AiResourceImportValidationStatus;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportRequest;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportResponse;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerImportValidationResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link McpLegacyImportAdapter}.
+ *
+ * @author xiweng.yy
+ */
+@ExtendWith(MockitoExtension.class)
+class McpLegacyImportAdapterTest {
+    
+    @Mock
+    private McpServerImportService mcpServerImportService;
+    
+    @Mock
+    private AiResourceImportManager importManager;
+    
+    private McpLegacyImportAdapter adapter;
+    
+    @BeforeEach
+    void setUp() {
+        adapter = new McpLegacyImportAdapter(mcpServerImportService, importManager);
+        AiResourceImportProperties properties = new AiResourceImportProperties();
+        ReflectionTestUtils.setField(adapter, "propertiesSupplier",
+            (Supplier<AiResourceImportProperties>) () -> properties);
+    }
+    
+    @Test
+    void testRejectsLegacyUrlWhenUserUrlDisabled() throws Exception {
+        McpServerImportRequest request = request("https://registry.example.com/v0/servers");
+        
+        McpServerImportValidationResult result = adapter.validateImport("public", request);
+        
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().get(0).contains("Legacy URL import is disabled"));
+        verifyNoInteractions(mcpServerImportService, importManager);
+    }
+    
+    @Test
+    void testValidateRoutesSourceIdToUnifiedManager() throws Exception {
+        when(importManager.search(any())).thenReturn(searchResponse());
+        when(importManager.validate(any())).thenReturn(validateResponse());
+        McpServerImportRequest request = request("source-1");
+        request.setSearch("redis");
+        request.setLimit(10);
+        
+        McpServerImportValidationResult result = adapter.validateImport("public", request);
+        
+        assertTrue(result.isValid());
+        assertEquals(1, result.getValidCount());
+        ArgumentCaptor<AiResourceImportValidateRequest> captor =
+            ArgumentCaptor.forClass(AiResourceImportValidateRequest.class);
+        verify(importManager).validate(captor.capture());
+        assertEquals("source-1", captor.getValue().getSourceId());
+        assertEquals("server-1", captor.getValue().getSelectedItems().get(0).getExternalId());
+    }
+    
+    @Test
+    void testExecuteRoutesSourceIdToUnifiedManager() throws Exception {
+        when(importManager.search(any())).thenReturn(searchResponse());
+        when(importManager.execute(any())).thenReturn(executeResponse());
+        McpServerImportRequest request = request("source-1");
+        
+        McpServerImportResponse result = adapter.executeImport("public", request);
+        
+        assertTrue(result.isSuccess());
+        assertEquals(1, result.getSuccessCount());
+        assertEquals("success", result.getResults().get(0).getStatus());
+        assertEquals("server-1", result.getResults().get(0).getServerId());
+    }
+    
+    @Test
+    void testUserUrlFallbackWhenExplicitlyAllowed() throws Exception {
+        AiResourceImportProperties properties = new AiResourceImportProperties();
+        properties.setAllowUserUrl(true);
+        ReflectionTestUtils.setField(adapter, "propertiesSupplier",
+            (Supplier<AiResourceImportProperties>) () -> properties);
+        McpServerImportRequest request = request("https://registry.example.com/v0/servers");
+        McpServerImportResponse expected = new McpServerImportResponse();
+        expected.setSuccess(true);
+        when(mcpServerImportService.executeImport(eq("public"), eq(request))).thenReturn(expected);
+        
+        McpServerImportResponse result = adapter.executeImport("public", request);
+        
+        assertTrue(result.isSuccess());
+        verify(mcpServerImportService).executeImport("public", request);
+    }
+    
+    private McpServerImportRequest request(String data) {
+        McpServerImportRequest request = new McpServerImportRequest();
+        request.setImportType(ExternalDataTypeEnum.URL.getName());
+        request.setData(data);
+        return request;
+    }
+    
+    private AiResourceImportSearchResponse searchResponse() {
+        AiResourceImportCandidateItem item = new AiResourceImportCandidateItem();
+        item.setExternalId("server-1");
+        item.setName("test-server");
+        item.setVersion("1.0.0");
+        AiResourceImportSearchResponse response = new AiResourceImportSearchResponse();
+        response.setItems(Collections.singletonList(item));
+        return response;
+    }
+    
+    private AiResourceImportValidateResponse validateResponse() {
+        AiResourceImportValidationItem item = new AiResourceImportValidationItem();
+        item.setExternalId("server-1");
+        item.setName("test-server");
+        item.setVersion("1.0.0");
+        item.setStatus(AiResourceImportValidationStatus.VALID);
+        AiResourceImportValidateResponse response = new AiResourceImportValidateResponse();
+        response.setItems(Collections.singletonList(item));
+        return response;
+    }
+    
+    private AiResourceImportExecuteResponse executeResponse() {
+        AiResourceImportResultItem item = new AiResourceImportResultItem();
+        item.setExternalId("server-1");
+        item.setResourceName("test-server");
+        item.setVersion("1.0.0");
+        item.setStatus(AiResourceImportResultStatus.SUCCESS);
+        AiResourceImportExecuteResponse response = new AiResourceImportExecuteResponse();
+        response.setSuccess(true);
+        response.setTotalCount(1);
+        response.setSuccessCount(1);
+        response.setResults(Collections.singletonList(item));
+        return response;
+    }
+}

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/McpInnerHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/inner/ai/McpInnerHandler.java
@@ -16,7 +16,7 @@
 
 package com.alibaba.nacos.console.handler.impl.inner.ai;
 
-import com.alibaba.nacos.ai.service.McpServerImportService;
+import com.alibaba.nacos.ai.service.McpLegacyImportAdapter;
 import com.alibaba.nacos.ai.service.McpServerOperationService;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
@@ -44,12 +44,12 @@ public class McpInnerHandler implements McpHandler {
     
     private final McpServerOperationService mcpServerOperationService;
     
-    private final McpServerImportService mcpServerImportService;
+    private final McpLegacyImportAdapter mcpLegacyImportAdapter;
     
     public McpInnerHandler(McpServerOperationService mcpServerOperationService,
-        McpServerImportService mcpServerImportService) {
+        McpLegacyImportAdapter mcpLegacyImportAdapter) {
         this.mcpServerOperationService = mcpServerOperationService;
-        this.mcpServerImportService = mcpServerImportService;
+        this.mcpLegacyImportAdapter = mcpLegacyImportAdapter;
     }
     
     @Override
@@ -95,12 +95,12 @@ public class McpInnerHandler implements McpHandler {
     @Override
     public McpServerImportValidationResult validateImport(String namespaceId,
         McpServerImportRequest request) throws NacosException {
-        return mcpServerImportService.validateImport(namespaceId, request);
+        return mcpLegacyImportAdapter.validateImport(namespaceId, request);
     }
     
     @Override
     public McpServerImportResponse executeImport(String namespaceId, McpServerImportRequest request)
         throws NacosException {
-        return mcpServerImportService.executeImport(namespaceId, request);
+        return mcpLegacyImportAdapter.executeImport(namespaceId, request);
     }
 }

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/ai/McpInnerHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/ai/McpInnerHandlerTest.java
@@ -17,7 +17,7 @@
 package com.alibaba.nacos.console.handler.impl.inner.ai;
 
 import com.alibaba.nacos.ai.constant.Constants;
-import com.alibaba.nacos.ai.service.McpServerImportService;
+import com.alibaba.nacos.ai.service.McpLegacyImportAdapter;
 import com.alibaba.nacos.ai.service.McpServerOperationService;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.McpEndpointSpec;
@@ -49,13 +49,13 @@ class McpInnerHandlerTest {
     McpServerOperationService mcpServerOperationService;
     
     @Mock
-    McpServerImportService mcpServerImportService;
+    McpLegacyImportAdapter mcpLegacyImportAdapter;
     
     McpInnerHandler mcpInnerHandler;
     
     @BeforeEach
     void setUp() {
-        mcpInnerHandler = new McpInnerHandler(mcpServerOperationService, mcpServerImportService);
+        mcpInnerHandler = new McpInnerHandler(mcpServerOperationService, mcpLegacyImportAdapter);
     }
     
     @Test
@@ -127,7 +127,7 @@ class McpInnerHandlerTest {
     void validateImport() throws NacosException {
         McpServerImportRequest request = new McpServerImportRequest();
         McpServerImportValidationResult expected = new McpServerImportValidationResult();
-        when(mcpServerImportService.validateImport(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, request))
+        when(mcpLegacyImportAdapter.validateImport(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, request))
             .thenReturn(expected);
         
         McpServerImportValidationResult result =
@@ -141,7 +141,7 @@ class McpInnerHandlerTest {
     void executeImport() throws NacosException {
         McpServerImportRequest request = new McpServerImportRequest();
         McpServerImportResponse expected = new McpServerImportResponse();
-        when(mcpServerImportService.executeImport(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, request))
+        when(mcpLegacyImportAdapter.executeImport(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, request))
             .thenReturn(expected);
         
         McpServerImportResponse result =


### PR DESCRIPTION
## Summary
- add built-in mcp-registry import service and SPI registration
- add MCP resource operator that validates and imports unified artifacts through existing MCP import logic
- route legacy MCP URL import through configured source ids and reject arbitrary user URLs by default

## Tests
- source ~/Documents/switch17.sh; ./mvnw -pl ai -Dtest=McpRegistryImportServiceTest,McpResourceOperatorTest,McpLegacyImportAdapterTest,McpExternalDataAdaptorTest,McpServerImportServiceTest test
- source ~/Documents/switch17.sh; ./mvnw -pl ai,console -am -DskipTests compile
- source ~/Documents/switch17.sh; ./mvnw -pl ai,console -am apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests

Refs #15183