### PR TITLE
[ISSUE #15183] Use source based MCP import UI

### DIFF
--- a/console-ui-next/src/api/aiResourceImport.ts
+++ b/console-ui-next/src/api/aiResourceImport.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import client from './client';
+import type { ApiResult } from './types';
+import type {
+  AiResourceImportExecuteResponse,
+  AiResourceImportSearchResponse,
+  AiResourceImportSourceInfo,
+  AiResourceImportValidateResponse,
+} from '@/types/aiResourceImport';
+
+const IMPORT_PATH = 'v3/console/ai/import';
+
+export const aiResourceImportApi = {
+  listSources: (params: { resourceType: string }): ApiResult<AiResourceImportSourceInfo[]> =>
+    client.get(`${IMPORT_PATH}/sources`, { params }) as ApiResult<AiResourceImportSourceInfo[]>,
+
+  search: (data: {
+    namespaceId?: string;
+    resourceType: string;
+    sourceId: string;
+    query?: string;
+    cursor?: string;
+    limit?: number;
+  }): ApiResult<AiResourceImportSearchResponse> =>
+    client.post(`${IMPORT_PATH}/search`, data) as ApiResult<AiResourceImportSearchResponse>,
+
+  validate: (data: {
+    namespaceId?: string;
+    resourceType: string;
+    sourceId: string;
+    selectedItems: string;
+    overwriteExisting?: boolean;
+  }): ApiResult<AiResourceImportValidateResponse> =>
+    client.post(`${IMPORT_PATH}/validate`, data) as ApiResult<AiResourceImportValidateResponse>,
+
+  execute: (data: {
+    namespaceId?: string;
+    resourceType: string;
+    sourceId: string;
+    selectedItems: string;
+    overwriteExisting?: boolean;
+    skipInvalid?: boolean;
+    validationToken?: string;
+  }): ApiResult<AiResourceImportExecuteResponse> =>
+    client.post(`${IMPORT_PATH}/execute`, data) as ApiResult<AiResourceImportExecuteResponse>,
+};

--- a/console-ui-next/src/components/ai/mcp/ImportMcpDialog.tsx
+++ b/console-ui-next/src/components/ai/mcp/ImportMcpDialog.tsx
@@ -1,10 +1,9 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -12,20 +11,68 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { mcpApi } from '@/api/mcp';
-import type { McpImportType, McpImportValidationItem } from '@/types/mcp';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { aiResourceImportApi } from '@/api/aiResourceImport';
+import type {
+  AiResourceImportCandidateItem,
+  AiResourceImportItem,
+  AiResourceImportSourceInfo,
+  AiResourceImportValidationItem,
+} from '@/types/aiResourceImport';
 
 interface ImportMcpDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   namespaceId: string;
   onSuccess: () => void;
+}
+
+const RESOURCE_TYPE = 'mcp';
+const PAGE_SIZE = 12;
+
+function itemKey(item: AiResourceImportCandidateItem | AiResourceImportValidationItem): string {
+  return `${item.externalId || item.name || 'unknown'}__${item.version || ''}`;
+}
+
+function toImportItem(item: AiResourceImportCandidateItem): AiResourceImportItem {
+  return {
+    externalId: item.externalId,
+    name: item.name,
+    version: item.version,
+    metadata: item.metadata,
+  };
+}
+
+function isImportable(item?: AiResourceImportValidationItem, overwriteExisting?: boolean): boolean {
+  const status = item?.status;
+  if (!status) return true;
+  if (status === 'VALID' || status === 'WARNING') return true;
+  if (status === 'CONFLICT') return !!overwriteExisting;
+  return false;
+}
+
+function statusBadge(item?: AiResourceImportValidationItem) {
+  if (!item?.status) return null;
+  if (item.status === 'VALID') {
+    return <Badge className="bg-emerald-100 text-emerald-700 border-0 text-[10px]">valid</Badge>;
+  }
+  if (item.status === 'WARNING') {
+    return <Badge className="bg-amber-100 text-amber-700 border-0 text-[10px]">warning</Badge>;
+  }
+  if (item.status === 'CONFLICT') {
+    return <Badge variant="secondary" className="text-[10px]">conflict</Badge>;
+  }
+  return <Badge variant="destructive" className="text-[10px]">invalid</Badge>;
 }
 
 export function ImportMcpDialog({
@@ -35,49 +82,182 @@ export function ImportMcpDialog({
   onSuccess,
 }: ImportMcpDialogProps) {
   const { t } = useTranslation();
-  const [importType, setImportType] = useState<McpImportType>('url');
-  const [data, setData] = useState('');
-  const [overrideExisting, setOverrideExisting] = useState(false);
-  const [skipInvalid, setSkipInvalid] = useState(false);
+  const [sources, setSources] = useState<AiResourceImportSourceInfo[]>([]);
+  const [sourceId, setSourceId] = useState('');
+  const [query, setQuery] = useState('');
+  const [overwriteExisting, setOverwriteExisting] = useState(false);
+  const [skipInvalid, setSkipInvalid] = useState(true);
   const [loading, setLoading] = useState(false);
-  const [validationResult, setValidationResult] = useState<McpImportValidationItem[] | null>(null);
-  const [selectedServers, setSelectedServers] = useState<Set<string>>(new Set());
+  const [executing, setExecuting] = useState(false);
+  const [candidates, setCandidates] = useState<AiResourceImportCandidateItem[]>([]);
+  const [nextCursor, setNextCursor] = useState('');
+  const [hasMore, setHasMore] = useState(false);
+  const [validationItems, setValidationItems] = useState<AiResourceImportValidationItem[] | null>(null);
+  const [validationToken, setValidationToken] = useState('');
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+
+  const selectedSource = useMemo(
+    () => sources.find(source => source.sourceId === sourceId),
+    [sources, sourceId]
+  );
+
+  const validationMap = useMemo(() => {
+    const result = new Map<string, AiResourceImportValidationItem>();
+    validationItems?.forEach(item => result.set(itemKey(item), item));
+    return result;
+  }, [validationItems]);
 
   const resetForm = useCallback(() => {
-    setImportType('url');
-    setData('');
-    setOverrideExisting(false);
-    setSkipInvalid(false);
-    setValidationResult(null);
-    setSelectedServers(new Set());
+    setSources([]);
+    setSourceId('');
+    setQuery('');
+    setOverwriteExisting(false);
+    setSkipInvalid(true);
+    setCandidates([]);
+    setNextCursor('');
+    setHasMore(false);
+    setValidationItems(null);
+    setValidationToken('');
+    setSelectedKeys(new Set());
   }, []);
 
+  const searchCandidates = useCallback(
+    async (targetSourceId: string, append = false, cursor = '', targetQuery = '') => {
+      if (!targetSourceId) return;
+      setLoading(true);
+      try {
+        const response = await aiResourceImportApi.search({
+          namespaceId,
+          resourceType: RESOURCE_TYPE,
+          sourceId: targetSourceId,
+          query: targetQuery.trim() || undefined,
+          cursor: cursor || undefined,
+          limit: PAGE_SIZE,
+        });
+        const items = response.data?.items || [];
+        setCandidates(prev => {
+          const next = append ? [...prev] : [];
+          const keys = new Set(next.map(itemKey));
+          items.forEach(item => {
+            const key = itemKey(item);
+            if (!keys.has(key)) {
+              keys.add(key);
+              next.push(item);
+            }
+          });
+          setSelectedKeys(new Set(next.map(itemKey)));
+          return next;
+        });
+        setNextCursor(response.data?.nextCursor || '');
+        setHasMore(!!response.data?.hasMore);
+        setValidationItems(null);
+        setValidationToken('');
+      } catch {
+        // Error handled by interceptor
+      } finally {
+        setLoading(false);
+      }
+    },
+    [namespaceId]
+  );
+
+  const loadSources = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await aiResourceImportApi.listSources({ resourceType: RESOURCE_TYPE });
+      const enabledSources = (response.data || []).filter(source => source.enabled !== false);
+      setSources(enabledSources);
+      const firstSourceId = enabledSources[0]?.sourceId || '';
+      setSourceId(firstSourceId);
+      if (firstSourceId) {
+        await searchCandidates(firstSourceId, false, '', '');
+      }
+    } catch {
+      // Error handled by interceptor
+    } finally {
+      setLoading(false);
+    }
+  }, [searchCandidates]);
+
   const handleClose = useCallback(
-    (open: boolean) => {
-      if (!open) resetForm();
-      onOpenChange(open);
+    (nextOpen: boolean) => {
+      if (!nextOpen) resetForm();
+      onOpenChange(nextOpen);
     },
     [onOpenChange, resetForm]
   );
 
-  const handleValidate = async () => {
-    if (!data.trim()) return;
+  useEffect(() => {
+    if (open) {
+      resetForm();
+      loadSources();
+    }
+  }, [open, loadSources, resetForm]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        handleClose(false);
+        return;
+      }
+      onOpenChange(true);
+    },
+    [handleClose, onOpenChange]
+  );
+
+  const handleSourceChange = (value: string) => {
+    setSourceId(value);
+    setCandidates([]);
+    setSelectedKeys(new Set());
+    setValidationItems(null);
+    setValidationToken('');
+    setNextCursor('');
+    setHasMore(false);
+    searchCandidates(value, false, '', query);
+  };
+
+  const handleSearch = () => {
+    setCandidates([]);
+    setSelectedKeys(new Set());
+    setValidationItems(null);
+    setValidationToken('');
+    setNextCursor('');
+    setHasMore(false);
+    searchCandidates(sourceId, false, '', query);
+  };
+
+  const selectedImportItems = (onlyImportable = false) =>
+    candidates
+      .filter(candidate => selectedKeys.has(itemKey(candidate)))
+      .filter(candidate => {
+        if (!onlyImportable) return true;
+        return isImportable(validationMap.get(itemKey(candidate)), overwriteExisting);
+      })
+      .map(toImportItem);
+
+  const validateSelected = async () => {
+    const items = selectedImportItems();
+    if (!items.length) return;
     setLoading(true);
     try {
-      const response = await mcpApi.validateImport({
-        importType,
-        data: data.trim(),
+      const response = await aiResourceImportApi.validate({
         namespaceId,
-        overrideExisting,
-        validateOnly: true,
-        skipInvalid,
+        resourceType: RESOURCE_TYPE,
+        sourceId,
+        selectedItems: JSON.stringify(items),
+        overwriteExisting,
       });
-      const result = response as unknown as { data: { servers?: McpImportValidationItem[] } };
-      const servers = result.data?.servers || [];
-      setValidationResult(servers);
-      // Auto-select all valid servers
-      const validNames = servers.filter((s) => s.valid).map((s) => s.name);
-      setSelectedServers(new Set(validNames));
+      const nextValidationItems = response.data?.items || [];
+      const nextValidationMap = new Map(nextValidationItems.map(item => [itemKey(item), item]));
+      setValidationItems(nextValidationItems);
+      setValidationToken(response.data?.validationToken || '');
+      setSelectedKeys(prev => {
+        const next = new Set<string>();
+        prev.forEach(key => {
+          if (isImportable(nextValidationMap.get(key), overwriteExisting)) next.add(key);
+        });
+        return next;
+      });
     } catch {
       // Error handled by interceptor
     } finally {
@@ -85,103 +265,122 @@ export function ImportMcpDialog({
     }
   };
 
-  const handleExecute = async () => {
-    setLoading(true);
+  const executeImport = async (allImportable = false) => {
+    if (!validationItems) return;
+    const items = allImportable
+      ? candidates
+        .filter(candidate => isImportable(validationMap.get(itemKey(candidate)), overwriteExisting))
+        .map(toImportItem)
+      : selectedImportItems(true);
+    if (!items.length) return;
+    setExecuting(true);
     try {
-      await mcpApi.executeImport({
-        importType,
-        data: data.trim(),
+      const response = await aiResourceImportApi.execute({
         namespaceId,
-        overrideExisting,
+        resourceType: RESOURCE_TYPE,
+        sourceId,
+        selectedItems: JSON.stringify(items),
+        overwriteExisting,
         skipInvalid,
-        selectedServers: Array.from(selectedServers),
+        validationToken,
       });
+      const data = response.data || {};
+      if (data.failedCount) {
+        toast.error(
+          t('mcp.importResult', {
+            defaultValue: 'Import result: {{success}} succeeded, {{failed}} failed, {{skipped}} skipped',
+            success: data.successCount || 0,
+            failed: data.failedCount || 0,
+            skipped: data.skippedCount || 0,
+          })
+        );
+        await searchCandidates(sourceId, false, '', query);
+        return;
+      }
       toast.success(t('mcp.importSuccess'));
       handleClose(false);
       onSuccess();
     } catch {
       // Error handled by interceptor
     } finally {
-      setLoading(false);
+      setExecuting(false);
     }
   };
 
-  const toggleServer = (name: string) => {
-    setSelectedServers((prev) => {
+  const toggleCandidate = (candidate: AiResourceImportCandidateItem) => {
+    const key = itemKey(candidate);
+    const validation = validationMap.get(key);
+    if (validationItems && !isImportable(validation, overwriteExisting)) return;
+    setSelectedKeys(prev => {
       const next = new Set(prev);
-      if (next.has(name)) next.delete(name);
-      else next.add(name);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       return next;
     });
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-w-2xl">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-4xl">
         <DialogHeader>
           <DialogTitle>{t('mcp.importFromRegistry')}</DialogTitle>
-          <DialogDescription>
-            {t('mcp.importUrl')}
-          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
-          {/* Import type */}
-          <div className="space-y-2">
-            <Label>{t('mcp.importType')}</Label>
-            <RadioGroup
-              value={importType}
-              onValueChange={(v) => {
-                setImportType(v as McpImportType);
-                setValidationResult(null);
-              }}
-              className="flex gap-4"
-            >
-              <div className="flex items-center gap-2">
-                <RadioGroupItem value="url" id="import-url" />
-                <Label htmlFor="import-url" className="text-sm font-normal cursor-pointer">
-                  {t('mcp.importTypeUrl')}
-                </Label>
-              </div>
-              <div className="flex items-center gap-2">
-                <RadioGroupItem value="json" id="import-json" />
-                <Label htmlFor="import-json" className="text-sm font-normal cursor-pointer">
-                  {t('mcp.importTypeJson')}
-                </Label>
-              </div>
-            </RadioGroup>
-          </div>
-
-          {/* Data input */}
-          <div className="space-y-2">
-            <Label>{importType === 'url' ? t('mcp.importUrl') : 'JSON'}</Label>
-            {importType === 'url' ? (
+          <div className="grid grid-cols-[minmax(14rem,18rem)_1fr_auto] gap-3 items-end">
+            <div className="space-y-2">
+              <Label>{t('mcp.importSource', { defaultValue: 'Source' })}</Label>
+              <Select value={sourceId} onValueChange={handleSourceChange} disabled={loading || !sources.length}>
+                <SelectTrigger>
+                  <SelectValue placeholder={t('mcp.importSource', { defaultValue: 'Source' })} />
+                </SelectTrigger>
+                <SelectContent>
+                  {sources.map(source => (
+                    <SelectItem key={source.sourceId} value={source.sourceId}>
+                      {source.displayName || source.sourceId}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>{t('common.search')}</Label>
               <Input
-                value={data}
-                onChange={(e) => {
-                  setData(e.target.value);
-                  setValidationResult(null);
+                value={query}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                  setValidationItems(null);
                 }}
-                placeholder="https://registry.example.com/servers"
-              />
-            ) : (
-              <Textarea
-                value={data}
-                onChange={(e) => {
-                  setData(e.target.value);
-                  setValidationResult(null);
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') handleSearch();
                 }}
-                placeholder='[{"name": "...", "protocol": "...", ...}]'
-                rows={6}
-                className="font-mono text-xs"
+                placeholder={t('common.search')}
               />
-            )}
+            </div>
+            <Button onClick={handleSearch} disabled={!sourceId || loading}>
+              {loading ? t('common.loading') : t('common.search')}
+            </Button>
           </div>
 
-          {/* Options */}
+          {selectedSource && (
+            <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+              <span>{selectedSource.description || selectedSource.displayName || selectedSource.sourceId}</span>
+              {selectedSource.pluginName && <Badge variant="secondary">{selectedSource.pluginName}</Badge>}
+              {(selectedSource.capabilities || []).map(capability => (
+                <Badge key={capability} variant="outline">{capability}</Badge>
+              ))}
+            </div>
+          )}
+
           <div className="flex gap-6">
             <div className="flex items-center gap-2">
-              <Switch checked={overrideExisting} onCheckedChange={setOverrideExisting} />
+              <Switch
+                checked={overwriteExisting}
+                onCheckedChange={(checked) => {
+                  setOverwriteExisting(checked);
+                  setValidationItems(null);
+                }}
+              />
               <Label className="text-sm font-normal">{t('mcp.importOverride')}</Label>
             </div>
             <div className="flex items-center gap-2">
@@ -190,56 +389,99 @@ export function ImportMcpDialog({
             </div>
           </div>
 
-          {/* Validation results */}
-          {validationResult && (
-            <div className="space-y-2">
-              <Label>{t('mcp.selectedServers')}</Label>
-              <ScrollArea className="h-48 border rounded-md p-2">
-                <div className="space-y-1">
-                  {validationResult.map((item) => (
-                    <div
-                      key={item.name}
-                      className="flex items-center gap-2 px-2 py-1 rounded hover:bg-muted/50"
+          <ScrollArea className="h-[24rem] border rounded-md p-3">
+            {!sources.length && !loading ? (
+              <div className="h-72 flex items-center justify-center text-sm text-muted-foreground">
+                {t('mcp.noImportSource', { defaultValue: 'No import source available' })}
+              </div>
+            ) : candidates.length ? (
+              <div className="grid grid-cols-2 gap-3">
+                {candidates.map(candidate => {
+                  const key = itemKey(candidate);
+                  const validation = validationMap.get(key);
+                  const disabled = validationItems && !isImportable(validation, overwriteExisting);
+                  const checked = selectedKeys.has(key);
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      disabled={!!disabled}
+                      onClick={() => toggleCandidate(candidate)}
+                      className={`text-left border rounded-md p-3 transition-colors ${
+                        checked ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted/50'
+                      } ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
                     >
-                      <Checkbox
-                        checked={selectedServers.has(item.name)}
-                        onCheckedChange={() => toggleServer(item.name)}
-                        disabled={!item.valid}
-                      />
-                      <span className="text-sm flex-1 truncate">{item.name}</span>
-                      {item.valid ? (
-                        <Badge variant="outline" className="text-[10px] text-emerald-600">
-                          valid
-                        </Badge>
-                      ) : (
-                        <Badge variant="destructive" className="text-[10px]">
-                          {item.message || 'invalid'}
-                        </Badge>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </ScrollArea>
+                      <div className="flex items-start gap-3">
+                        <Checkbox checked={checked} disabled={!!disabled} className="mt-1" />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <span className="text-sm font-medium truncate">
+                              {candidate.name || candidate.externalId || 'Unnamed'}
+                            </span>
+                            {candidate.version && (
+                              <Badge variant="outline" className="text-[10px] shrink-0">
+                                v{candidate.version}
+                              </Badge>
+                            )}
+                            {statusBadge(validation)}
+                          </div>
+                          <p className="text-xs text-muted-foreground line-clamp-2 mt-1">
+                            {candidate.description || '--'}
+                          </p>
+                          <div className="flex items-center gap-2 mt-2 text-[11px] text-muted-foreground">
+                            {candidate.metadata?.protocol && (
+                              <Badge variant="secondary" className="text-[10px]">
+                                {candidate.metadata.protocol}
+                              </Badge>
+                            )}
+                            {validation?.errors?.length ? (
+                              <span className="text-destructive truncate">{validation.errors.join('; ')}</span>
+                            ) : validation?.warnings?.length ? (
+                              <span className="text-amber-600 truncate">{validation.warnings.join('; ')}</span>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="h-72 flex items-center justify-center text-sm text-muted-foreground">
+                {loading ? t('common.loading') : t('common.noData')}
+              </div>
+            )}
+          </ScrollArea>
+
+          {hasMore && (
+            <div className="flex justify-center">
+              <Button variant="outline" onClick={() => searchCandidates(sourceId, true, nextCursor, query)} disabled={loading}>
+                {loading ? t('common.loading') : t('common.loadMore', { defaultValue: 'Load more' })}
+              </Button>
             </div>
           )}
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => handleClose(false)} disabled={loading}>
+          <Button variant="outline" onClick={() => handleClose(false)} disabled={loading || executing}>
             {t('common.cancel')}
           </Button>
-          {!validationResult ? (
-            <Button onClick={handleValidate} disabled={!data.trim() || loading}>
-              {loading ? t('common.loading') : t('mcp.importValidate')}
-            </Button>
-          ) : (
-            <Button
-              onClick={handleExecute}
-              disabled={selectedServers.size === 0 || loading}
-            >
-              {loading ? t('common.loading') : t('mcp.importExecute')}
-            </Button>
-          )}
+          <Button onClick={validateSelected} disabled={!selectedKeys.size || loading || executing}>
+            {loading ? t('common.loading') : t('mcp.importValidate')}
+          </Button>
+          <Button
+            onClick={() => executeImport(false)}
+            disabled={!validationItems || !selectedKeys.size || loading || executing}
+          >
+            {executing ? t('common.loading') : t('mcp.importExecute')}
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => executeImport(true)}
+            disabled={!validationItems || loading || executing}
+          >
+            {t('mcp.importAll', { defaultValue: 'Import all valid' })}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/console-ui-next/src/types/aiResourceImport.ts
+++ b/console-ui-next/src/types/aiResourceImport.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface AiResourceImportSourceInfo {
+  sourceId: string;
+  displayName?: string;
+  description?: string;
+  pluginName?: string;
+  resourceTypes?: string[];
+  enabled?: boolean;
+  capabilities?: string[];
+}
+
+export interface AiResourceImportCandidateItem {
+  externalId?: string;
+  name?: string;
+  version?: string;
+  description?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface AiResourceImportSearchResponse {
+  sourceId: string;
+  resourceType: string;
+  nextCursor?: string;
+  hasMore?: boolean;
+  items?: AiResourceImportCandidateItem[];
+}
+
+export type AiResourceImportValidationStatus = 'VALID' | 'WARNING' | 'INVALID' | 'CONFLICT';
+
+export interface AiResourceImportValidationItem {
+  externalId?: string;
+  name?: string;
+  version?: string;
+  status?: AiResourceImportValidationStatus;
+  exists?: boolean;
+  conflictType?: string;
+  warnings?: string[];
+  errors?: string[];
+}
+
+export interface AiResourceImportValidateResponse {
+  sourceId: string;
+  resourceType: string;
+  validationToken?: string;
+  items?: AiResourceImportValidationItem[];
+}
+
+export type AiResourceImportResultStatus = 'SUCCESS' | 'FAILED' | 'SKIPPED';
+
+export interface AiResourceImportResultItem {
+  externalId?: string;
+  resourceName?: string;
+  version?: string;
+  status?: AiResourceImportResultStatus;
+  errorMessage?: string;
+  warnings?: string[];
+}
+
+export interface AiResourceImportExecuteResponse {
+  success?: boolean;
+  totalCount?: number;
+  successCount?: number;
+  failedCount?: number;
+  skippedCount?: number;
+  results?: AiResourceImportResultItem[];
+}
+
+export interface AiResourceImportItem {
+  externalId?: string;
+  name?: string;
+  version?: string;
+  metadata?: Record<string, string>;
+}

--- a/console-ui/src/pages/AI/McpManagement/ImportMcpDialog.jsx
+++ b/console-ui/src/pages/AI/McpManagement/ImportMcpDialog.jsx
@@ -1,58 +1,100 @@
 /*
- * Import MCP Server Dialog - extracted from McpManagement for modularity
+ * Import MCP Server Dialog - source driven AI resource import.
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Dialog, Form, Input, Icon, Loading, Progress, Card, Balloon, Message, Table } from '@alifd/next';
-import { getParams, request } from '@/globalLib';
+import {
+    Balloon,
+    Button,
+    Card,
+    Checkbox,
+    Dialog,
+    Form,
+    Icon,
+    Input,
+    Loading,
+    Message,
+    Select,
+    Switch,
+    Table,
+} from '@alifd/next';
+import { getParams } from '@/globalLib';
+import AiResourceImportService from '../services/AiResourceImportService';
+
+const RESOURCE_TYPE_MCP = 'mcp';
+const DEFAULT_PAGE_SIZE = 12;
 
 class ImportMcpDialog extends React.Component {
     static propTypes = {
         visible: PropTypes.bool.isRequired,
         onClose: PropTypes.func.isRequired,
-        onImported: PropTypes.func, // callback to refresh list after successful import
+        onImported: PropTypes.func,
         locale: PropTypes.object,
     };
 
     static defaultProps = {
-        onImported: () => { },
+        onImported: () => {},
         locale: {},
     };
-
-    DEFAULT_REGISTRY_URL = 'https://registry.modelcontextprotocol.io/v0.1/servers';
 
     constructor(props) {
         super(props);
         this.state = {
-            importType: 'url',
-            importData: this.DEFAULT_REGISTRY_URL,
-            importOverrideExisting: false,
+            sources: [],
+            selectedSourceId: '',
+            sourceLoading: false,
             importValidating: false,
             importExecuting: false,
-            importValidationResult: null,
-            importSelectedServerIds: [],
-            importUrlCursor: '',
+            importCandidates: [],
+            importNextCursor: '',
+            importHasMore: false,
             importRegistrySearch: '',
-            importAccumulatedServers: [],
-            importNextCursor: null,
+            importSelectedItemKeys: [],
+            importValidationResult: null,
+            importValidationToken: '',
+            importOverrideExisting: false,
+            importSkipInvalid: true,
             importHoverKey: null,
             importCardsReady: false,
-            // front-end pagination
-            importPage: 1,
-            importPageSize: 12,
-            importProgressTotal: 0,
-            importProgressCurrent: 0,
-            importProgressSuccess: 0,
-            importProgressFailed: 0,
-            importFailedItems: [],
-            // local details modal
             detailVisible: false,
             detailContent: '',
             detailTitle: '',
         };
     }
 
-    // 统一关闭处理：关闭弹窗并刷新外部 MCP 列表
+    componentDidUpdate(prevProps) {
+        if (!prevProps.visible && this.props.visible) {
+            this.resetStateForOpen(this.loadSources);
+        }
+    }
+
+    resetStateForOpen = cb => {
+        this.setState(
+            {
+                sources: [],
+                selectedSourceId: '',
+                sourceLoading: false,
+                importValidating: false,
+                importExecuting: false,
+                importCandidates: [],
+                importNextCursor: '',
+                importHasMore: false,
+                importRegistrySearch: '',
+                importSelectedItemKeys: [],
+                importValidationResult: null,
+                importValidationToken: '',
+                importOverrideExisting: false,
+                importSkipInvalid: true,
+                importHoverKey: null,
+                importCardsReady: false,
+                detailVisible: false,
+                detailContent: '',
+                detailTitle: '',
+            },
+            cb
+        );
+    };
+
     handleClose = () => {
         try {
             this.props.onClose && this.props.onClose();
@@ -61,291 +103,255 @@ class ImportMcpDialog extends React.Component {
         }
     };
 
-    componentDidUpdate(prevProps) {
-        // When dialog opens, auto validate and load registry list
-        if (!prevProps.visible && this.props.visible) {
-            this.resetStateForOpen(() => this.validateImport());
+    loadSources = async () => {
+        const { locale = {} } = this.props;
+        this.setState({ sourceLoading: true });
+        try {
+            const result = await AiResourceImportService.listSources({
+                resourceType: RESOURCE_TYPE_MCP,
+            });
+            if (result && result.code === 0) {
+                const sources = (result.data || []).filter(source => source && source.enabled);
+                const selectedSourceId = sources[0] ? sources[0].sourceId : '';
+                this.setState(
+                    {
+                        sources,
+                        selectedSourceId,
+                        sourceLoading: false,
+                    },
+                    () => {
+                        if (selectedSourceId) {
+                            this.searchCandidates();
+                        }
+                    }
+                );
+                return;
+            }
+            Message.error(result?.message || locale.loadFailed || '加载失败');
+        } catch (e) {
+            Message.error(e?.message || locale.loadFailed || '加载失败');
         }
-    }
+        this.setState({ sourceLoading: false });
+    };
 
-    resetStateForOpen = (cb) => {
+    handleSourceChange = selectedSourceId => {
         this.setState(
             {
-                importType: 'url',
-                importData: this.DEFAULT_REGISTRY_URL,
-                importOverrideExisting: false,
-                importValidating: true,
-                importExecuting: false,
+                selectedSourceId,
+                importCandidates: [],
+                importNextCursor: '',
+                importHasMore: false,
+                importSelectedItemKeys: [],
                 importValidationResult: null,
-                importSelectedServerIds: [],
-                importUrlCursor: '',
-                importRegistrySearch: '',
-                importAccumulatedServers: [],
-                importNextCursor: null,
-                importHoverKey: null,
+                importValidationToken: '',
                 importCardsReady: false,
-                importPage: 1,
-                importProgressTotal: 0,
-                importProgressCurrent: 0,
-                importProgressSuccess: 0,
-                importProgressFailed: 0,
-                importFailedItems: [],
             },
-            cb
+            this.searchCandidates
         );
     };
 
-    // 构建 endpointSpecification 字符串
-    buildEndpointSpecByServer(server) {
-        if (!server) return '';
-        try {
-            const proto = (server.protocol || server.frontProtocol || '').toLowerCase();
-            // stdio 类型不需要 endpointSpecification
-            if (proto === 'stdio') return '';
-
-            let remoteCfg = server.remoteServerConfig;
-            // 允许 remoteServerConfig 为字符串/对象/数组
-            if (typeof remoteCfg === 'string') {
-                try { remoteCfg = JSON.parse(remoteCfg); } catch (_) { /* ignore */ }
-            }
-
-            let first = remoteCfg?.frontEndpointConfigList[0];
-
-            if (!first) return '';
-
-            // 根据 McpEndpointSpec 定义转换字段：需要 { address, port } 字符串
-            const raw = first || {};
-            const endpointData = raw.endpointData || raw.address || '';
-            const epProto = (raw.protocol || proto || '').toLowerCase();
-
-            const parseHostPort = (s) => {
-                if (!s || typeof s !== 'string') return { address: '', port: '' };
-                let tmp = s.trim();
-                // 去掉 scheme
-                tmp = tmp.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, '');
-                // 去掉路径
-                const slashIdx = tmp.indexOf('/');
-                if (slashIdx >= 0) tmp = tmp.slice(0, slashIdx);
-                // 处理 IPv6 格式 [host]:port
-                if (tmp.startsWith('[')) {
-                    const end = tmp.indexOf(']');
-                    if (end > 0) {
-                        const host = tmp.slice(1, end);
-                        const rest = tmp.slice(end + 1);
-                        const p = rest.startsWith(':') ? rest.slice(1) : '';
-                        return { address: host, port: p };
-                    }
-                }
-                const lastColon = tmp.lastIndexOf(':');
-                if (lastColon > -1 && tmp.indexOf(':') === lastColon) {
-                    // 单个冒号 host:port
-                    const host = tmp.slice(0, lastColon);
-                    const p = tmp.slice(lastColon + 1);
-                    return { address: host, port: p };
-                }
-                return { address: tmp, port: '' };
-            };
-
-            let { address, port } = parseHostPort(endpointData);
-            if (!port) {
-                if (epProto === 'https' || epProto === 'wss') port = '443';
-                else if (epProto === 'http' || epProto === 'ws') port = '80';
-                else port = '';
-            }
-
-            const data = { address: String(address || ''), port: String(port || '') };
-            return JSON.stringify({ type: 'DIRECT', data });
-        } catch (e) {
-            return '';
-        }
-    }
-
-    validateImport = async () => {
+    searchCandidates = async (append = false) => {
         const { locale = {} } = this.props;
-        const { importType, importData, importOverrideExisting, importAccumulatedServers, importRegistrySearch, importPage, importPageSize } = this.state;
-        if (!importData) {
-            Message.warning(locale.pleaseEnterImportData || '请输入导入数据');
+        const { selectedSourceId, importRegistrySearch, importNextCursor } = this.state;
+        if (!selectedSourceId) {
             return;
         }
         this.setState({ importValidating: true });
-        const namespaceId = getParams('namespace') || '';
-        const limit = importType === 'url' ? Math.max(1, (importPage || 1) * (importPageSize || 12)) : undefined;
         const payload = {
-            namespaceId,
-            importType,
-            data: importData,
-            overrideExisting: !!importOverrideExisting,
-            validateOnly: true,
-            skipInvalid: true,
+            namespaceId: getParams('namespace') || '',
+            resourceType: RESOURCE_TYPE_MCP,
+            sourceId: selectedSourceId,
+            query: importRegistrySearch && String(importRegistrySearch).trim(),
+            limit: DEFAULT_PAGE_SIZE,
         };
-        if (importType === 'url') {
-            // Do not rely on server-side nextCursor. Use larger limit to fetch more.
-            if (!Number.isNaN(limit) && limit > 0) payload.limit = limit;
-            if (importRegistrySearch && String(importRegistrySearch).trim()) {
-                payload.search = String(importRegistrySearch).trim();
-            }
+        if (append && importNextCursor) {
+            payload.cursor = importNextCursor;
         }
-        const result = await request({
-            url: 'v3/console/ai/mcp/import/validate',
-            type: 'post',
-            data: payload,
-            error: () => this.setState({ importValidating: false }),
-        });
-        if (result && result.code === 0) {
-            const validation = result.data || {};
-            // For URL import, we re-fetch from the beginning with a larger limit, so just use returned list
-            const mergedServers = importType === 'url'
-                ? (validation.servers || [])
-                : (validation.servers || []);
-            const mergedKeysSet = new Set((mergedServers || []).map(it => {
-                const name = it.serverName || it.serverId || 'Unnamed';
-                const server = it.server || {};
-                const version = (server.versionDetail && server.versionDetail.version) || '--';
-                return `${name}__${version}`;
-            }).filter(Boolean));
-            const prevSelected = this.state.importSelectedServerIds || [];
-            const nextSelected = (prevSelected && prevSelected.length) ? prevSelected.filter(id => mergedKeysSet.has(id)) : [];
-            this.setState({
-                importValidationResult: { ...validation, servers: mergedServers },
-                importSelectedServerIds: nextSelected,
-                importAccumulatedServers: mergedServers,
-                importNextCursor: validation.nextCursor || null,
-            });
-            if (!this.state.importCardsReady) {
-                setTimeout(() => this.setState({ importCardsReady: true }), 0);
+        try {
+            const result = await AiResourceImportService.search(payload);
+            if (result && result.code === 0) {
+                const data = result.data || {};
+                const incoming = data.items || [];
+                const candidates = append
+                    ? this.mergeCandidates(this.state.importCandidates, incoming)
+                    : incoming;
+                this.setState({
+                    importCandidates: candidates,
+                    importNextCursor: data.nextCursor || '',
+                    importHasMore: !!data.hasMore,
+                    importSelectedItemKeys: candidates.map(this.getImportItemKey),
+                    importValidationResult: null,
+                    importValidationToken: '',
+                    importCardsReady: true,
+                    importValidating: false,
+                });
+                return;
             }
-        } else {
-            Message.error(result?.message || '校验失败');
+            Message.error(result?.message || locale.searchFailed || '搜索失败');
+        } catch (e) {
+            Message.error(e?.message || locale.searchFailed || '搜索失败');
         }
         this.setState({ importValidating: false });
     };
 
-    // 加载更多：前端分页，增大 limit 重新获取
-    handleLoadMore = () => {
-        if (this.state.importValidating) return;
+    mergeCandidates = (current, incoming) => {
+        const result = [...(current || [])];
+        const keys = new Set(result.map(this.getImportItemKey));
+        (incoming || []).forEach(item => {
+            const key = this.getImportItemKey(item);
+            if (!keys.has(key)) {
+                keys.add(key);
+                result.push(item);
+            }
+        });
+        return result;
+    };
+
+    handleSearch = () => {
         this.setState(
-            prev => ({ importPage: (prev.importPage || 1) + 1 }),
-            () => this.validateImport()
+            {
+                importNextCursor: '',
+                importHasMore: false,
+                importCandidates: [],
+                importSelectedItemKeys: [],
+                importValidationResult: null,
+                importValidationToken: '',
+                importCardsReady: false,
+            },
+            () => this.searchCandidates(false)
         );
     };
 
-    // 逐个创建导入
-    executeImportIndividually = async (importAllValid) => {
-        const { importValidationResult, importSelectedServerIds } = this.state;
-        const servers = (importValidationResult && importValidationResult.servers) || [];
-        if (!servers.length) {
-            Message.notice(this.props.locale.noData || '暂无可导入的服务');
+    handleLoadMore = () => {
+        if (!this.state.importValidating && this.state.importHasMore) {
+            this.searchCandidates(true);
+        }
+    };
+
+    validateSelected = async () => {
+        const { locale = {} } = this.props;
+        const selectedItems = this.getSelectedImportItems();
+        if (!selectedItems.length) {
+            Message.warning(locale.pleaseSelect || '请先选择要导入的服务');
             return;
         }
-        let targets = [];
-        if (importAllValid) {
-            targets = servers.filter(it => (it.status || '').toLowerCase() === 'valid');
-        } else {
-            const set = new Set(importSelectedServerIds || []);
-            targets = servers.filter(it => {
-                const name = it.serverName || it.serverId || 'Unnamed';
-                const server = it.server || {};
-                const version = (server.versionDetail && server.versionDetail.version) || '--';
-                const key = `${name}__${version}`;
-                return set.has(key);
+        this.setState({ importValidating: true });
+        try {
+            const result = await AiResourceImportService.validate({
+                namespaceId: getParams('namespace') || '',
+                resourceType: RESOURCE_TYPE_MCP,
+                sourceId: this.state.selectedSourceId,
+                selectedItems: JSON.stringify(selectedItems),
+                overwriteExisting: !!this.state.importOverrideExisting,
             });
+            if (result && result.code === 0) {
+                const data = result.data || {};
+                const validationItems = data.items || [];
+                this.setState(prev => {
+                    const validationMap = this.buildValidationMap(validationItems);
+                    const nextSelected = (prev.importSelectedItemKeys || []).filter(key => {
+                        const validation = validationMap[key];
+                        return !validation || this.isValidationImportable(validation);
+                    });
+                    return {
+                        importValidationResult: validationItems,
+                        importValidationToken: data.validationToken || '',
+                        importSelectedItemKeys: nextSelected,
+                        importValidating: false,
+                    };
+                });
+                return;
+            }
+            Message.error(result?.message || locale.validateFailed || '校验失败');
+        } catch (e) {
+            Message.error(e?.message || locale.validateFailed || '校验失败');
         }
-        if (!targets.length) {
-            Message.warning(this.props.locale.pleaseSelect || '请先选择要导入的服务');
+        this.setState({ importValidating: false });
+    };
+
+    executeImport = async importAllValid => {
+        const { locale = {} } = this.props;
+        if (!this.state.importValidationResult) {
+            Message.warning(locale.importValidate || '请先校验');
             return;
         }
-
-        this.setState({
-            importExecuting: true,
-            importProgressTotal: targets.length,
-            importProgressCurrent: 0,
-            importProgressSuccess: 0,
-            importProgressFailed: 0,
-            importFailedItems: [],
-        });
-
-        let success = 0, failed = 0, current = 0;
-        const failedItems = [];
-        const namespaceId = getParams('namespace') || '';
-        for (const item of targets) {
-            current += 1;
-            const server = item.server || {};
-            const name = server.name || item.serverName || item.serverId;
-            try {
-                let exists = false;
-                let existingId = null;
-                try {
-                    const checkRes = await request({
-                        url: 'v3/console/ai/mcp/list',
-                        method: 'get',
-                        data: { mcpName: name, namespaceId, search: 'accurate', pageNo: 1, pageSize: 10 }
-                    });
-                    if (checkRes && checkRes.code === 0 && checkRes.data && checkRes.data.pageItems) {
-                        const found = checkRes.data.pageItems.find(it => it.name === name);
-                        if (found) {
-                            exists = true;
-                            existingId = found.id;
-                        }
-                    }
-                } catch (e) { /* ignore */ }
-
-                const serverSpecObj = { ...server };
-                if (exists && existingId) {
-                    serverSpecObj.id = existingId;
-                }
-
-                const serverSpec = JSON.stringify(serverSpecObj);
-                const toolSpec = server.toolSpec ? JSON.stringify(server.toolSpec) : '';
-                const endpointSpec = this.buildEndpointSpecByServer(server);
-                const res = await request({
-                    url: 'v3/console/ai/mcp',
-                    type: exists ? 'put' : 'post',
-                    data: { serverSpecification: serverSpec, toolSpecification: toolSpec, endpointSpecification: endpointSpec },
-                });
-                if (res && res.code === 0) {
-                    success += 1;
-                } else {
-                    failed += 1;
-                    failedItems.push({ name, reason: res?.message || 'unknown error' });
-                }
-            } catch (e) {
-                failed += 1;
-                failedItems.push({ name, reason: e?.message || 'exception' });
-            }
-            this.setState({ importProgressCurrent: current, importProgressSuccess: success, importProgressFailed: failed, importFailedItems: failedItems });
+        const selectedItems = importAllValid
+            ? this.getImportableItemsFromValidation()
+            : this.getSelectedImportItems(true);
+        if (!selectedItems.length) {
+            Message.warning(locale.pleaseSelect || '请先选择要导入的服务');
+            return;
         }
+        this.setState({ importExecuting: true });
+        try {
+            const result = await AiResourceImportService.execute({
+                namespaceId: getParams('namespace') || '',
+                resourceType: RESOURCE_TYPE_MCP,
+                sourceId: this.state.selectedSourceId,
+                selectedItems: JSON.stringify(selectedItems),
+                overwriteExisting: !!this.state.importOverrideExisting,
+                skipInvalid: !!this.state.importSkipInvalid,
+                validationToken: this.state.importValidationToken,
+            });
+            if (result && result.code === 0) {
+                this.showExecuteResult(result.data || {});
+                if (!result.data || !result.data.failedCount) {
+                    this.handleClose();
+                } else {
+                    this.searchCandidates(false);
+                }
+                return;
+            }
+            Message.error(result?.message || locale.importFailed || '导入执行失败');
+        } catch (e) {
+            Message.error(e?.message || locale.importFailed || '导入执行异常');
+        }
+        this.setState({ importExecuting: false });
+    };
 
-    this.setState({ importExecuting: false });
+    showExecuteResult = data => {
+        const { locale = {} } = this.props;
+        const results = data.results || [];
+        this.setState({ importExecuting: false });
         Dialog.alert({
-            title: this.props.locale.importResult || '导入结果',
+            title: locale.importResult || '导入结果',
             style: { width: 'clamp(420px, 86vw, 640px)' },
             content: (
                 <div>
-                    <div style={{ marginBottom: 8 }}>{`成功 ${success} 个，失败 ${failed} 个`}</div>
-                    {failedItems && failedItems.length ? (
-                        <div style={{ maxHeight: 260, overflow: 'auto', marginTop: 8 }}>
+                    <div style={{ marginBottom: 8 }}>
+                        {`成功 ${data.successCount || 0} 个，失败 ${data.failedCount || 0} 个，跳过 ${
+                            data.skippedCount || 0
+                        } 个`}
+                    </div>
+                    {results.length ? (
+                        <div style={{ maxHeight: 320, overflow: 'auto', marginTop: 8 }}>
                             <Table
-                                dataSource={(failedItems || []).map((it, idx) => ({ key: idx, name: it.name || '--', status: 'failed', reason: it.reason || '' }))}
+                                dataSource={results.map((item, idx) => ({
+                                    key: idx,
+                                    name: item.resourceName || item.externalId || '--',
+                                    status: item.status || '--',
+                                    reason: item.errorMessage || '',
+                                }))}
                                 size="small"
                                 hasBorder={false}
                                 primaryKey="key"
                                 stickyHeader
                             >
-                                <Table.Column title={this.props.locale.name || '名称'} dataIndex="name" width={220} />
+                                <Table.Column title={locale.name || '名称'} dataIndex="name" width={220} />
                                 <Table.Column
-                                    title={this.props.locale.status || '状态'}
+                                    title={locale.status || '状态'}
                                     dataIndex="status"
                                     width={100}
-                                    cell={val => (
-                                        <span style={{ backgroundColor: '#fee2e2', color: '#991b1b', borderRadius: 12, padding: '2px 8px', fontSize: 12, lineHeight: '18px' }}>
-                                            {this.props.locale.failed || '失败'}
-                                        </span>
-                                    )}
+                                    cell={value => this.renderStatusTag(value)}
                                 />
                                 <Table.Column
-                                    title={this.props.locale.reason || '原因'}
+                                    title={locale.reason || '原因'}
                                     dataIndex="reason"
-                                    cell={val => <span style={{ whiteSpace: 'normal', wordBreak: 'break-all' }}>{val}</span>}
+                                    cell={value => (
+                                        <span style={{ whiteSpace: 'normal', wordBreak: 'break-all' }}>
+                                            {value}
+                                        </span>
+                                    )}
                                 />
                             </Table>
                         </div>
@@ -353,434 +359,598 @@ class ImportMcpDialog extends React.Component {
                 </div>
             ),
         });
-    // 自动刷新弹窗内容，反映已成功导入项（即使部分失败）
-    this.validateImport();
-    if (failed === 0) this.handleClose();
     };
 
-    // 通过后端批量接口执行导入（用于“导入全部”按钮）
-    executeImportByBackend = async () => {
-    const { importType, importData, importOverrideExisting, importUrlCursor, importRegistrySearch } = this.state;
-        const { locale = {} } = this.props;
-        if (!importData) {
-            Message.warning(locale.pleaseEnterImportData || '请输入导入数据');
-            return;
+    toggleCandidateSelection = (item, checked) => {
+        const key = this.getImportItemKey(item);
+        const set = new Set(this.state.importSelectedItemKeys || []);
+        if (checked) {
+            set.add(key);
+        } else {
+            set.delete(key);
         }
-        const namespaceId = getParams('namespace') || '';
-
-        // 设置简易进度，直到服务端返回
-        this.setState({
-            importExecuting: true,
-            importProgressTotal: 1,
-            importProgressCurrent: 0,
-            importProgressSuccess: 0,
-            importProgressFailed: 0,
-            importFailedItems: [],
-        });
-
-        const payload = {
-            namespaceId,
-            importType,
-            data: importData,
-            overrideExisting: !!importOverrideExisting,
-            validateOnly: false,
-            skipInvalid: true,
-        };
-        if (importType === 'url') {
-            // 全量导入：后端按约定 limit = -1 代表抓取所有分页
-            if (importUrlCursor) payload.cursor = importUrlCursor;
-            payload.limit = -1;
-            if (importRegistrySearch && String(importRegistrySearch).trim()) {
-                payload.search = String(importRegistrySearch).trim();
-            }
-        }
-
-        try {
-            const result = await request({
-                url: 'v3/console/ai/mcp/import/execute',
-                type: 'post',
-                data: payload,
-            });
-            this.setState({ importProgressCurrent: 1 });
-            if (result && result.code === 0) {
-                const data = result.data || {};
-                const { successCount = 0, failedCount = 0, skippedCount = 0, results = [] } = data;
-                const failedItems = (results || [])
-                    .filter(r => (r && r.status === 'failed'))
-                    .map(r => ({ name: r && (r.serverName || r.serverId), reason: r && r.errorMessage }));
-                this.setState({
-                    importProgressSuccess: successCount,
-                    importProgressFailed: failedCount,
-                    importFailedItems: failedItems,
-                    importExecuting: false,
-                });
-
-                Dialog.alert({
-                    title: locale.importResult || '导入结果',
-                    style: { width: 'clamp(420px, 86vw, 640px)' },
-                    content: (
-                        <div>
-                            <div style={{ marginBottom: 8 }}>{`成功 ${successCount} 个，失败 ${failedCount} 个，跳过 ${skippedCount} 个`}</div>
-                            {Array.isArray(results) && results.length ? (
-                                <div style={{ maxHeight: 320, overflow: 'auto', marginTop: 8 }}>
-                                    <Table
-                                        dataSource={(results || []).map((r, idx) => ({
-                                            key: idx,
-                                            name: (r && (r.serverName || r.serverId)) || '--',
-                                            status: (r && r.status) || '--',
-                                            reason: (r && (r.errorMessage || r.message)) || '',
-                                        }))}
-                                        size="small"
-                                        hasBorder={false}
-                                        primaryKey="key"
-                                        stickyHeader
-                                    >
-                                        <Table.Column title={locale.name || '名称'} dataIndex="name" width={220} />
-                                        <Table.Column
-                                            title={locale.status || '状态'}
-                                            dataIndex="status"
-                                            width={100}
-                                            cell={val => {
-                                                const lower = String(val || '').toLowerCase();
-                                                if (lower === 'success' || lower === 'succeed' || lower === 'ok') {
-                                                    return (
-                                                        <span style={{ backgroundColor: '#dcfce7', color: '#166534', borderRadius: 12, padding: '2px 8px', fontSize: 12, lineHeight: '18px' }}>
-                                                            {locale.success || '成功'}
-                                                        </span>
-                                                    );
-                                                }
-                                                if (lower === 'skipped' || lower === 'skip') {
-                                                    return (
-                                                        <span style={{ backgroundColor: '#e5e7eb', color: '#374151', borderRadius: 12, padding: '2px 8px', fontSize: 12, lineHeight: '18px' }}>
-                                                            {locale.skipped || '跳过'}
-                                                        </span>
-                                                    );
-                                                }
-                                                return (
-                                                    <span style={{ backgroundColor: '#fee2e2', color: '#991b1b', borderRadius: 12, padding: '2px 8px', fontSize: 12, lineHeight: '18px' }}>
-                                                        {locale.failed || '失败'}
-                                                    </span>
-                                                );
-                                            }}
-                                        />
-                                        <Table.Column
-                                            title={locale.reason || '原因'}
-                                            dataIndex="reason"
-                                            cell={val => <span style={{ whiteSpace: 'normal', wordBreak: 'break-all' }}>{val}</span>}
-                                        />
-                                    </Table>
-                                </div>
-                            ) : null}
-                        </div>
-                    ),
-                });
-                // 自动刷新弹窗内容，反映已成功导入项（即使部分失败）
-                this.validateImport();
-                if (!failedCount) this.handleClose();
-            } else {
-                this.setState({ importExecuting: false });
-                Message.error(result?.message || '导入执行失败');
-            }
-        } catch (e) {
-            this.setState({ importExecuting: false });
-            Message.error(e?.message || '导入执行异常');
-        }
-    };
-
-    // For card selection
-    toggleRegistryCardSelection = (serverKey, checked) => {
-        const set = new Set(this.state.importSelectedServerIds || []);
-        if (checked) set.add(serverKey); else set.delete(serverKey);
-        this.setState({ importSelectedServerIds: Array.from(set) });
+        this.setState({ importSelectedItemKeys: Array.from(set) });
     };
 
     clearAllSelectionForRegistry = () => {
-        this.setState({ importSelectedServerIds: [] });
+        this.setState({ importSelectedItemKeys: [] });
     };
 
-    openDetailModal = (item) => {
-        const name = item.serverName || item.serverId || 'Unnamed';
-        // prefer server object details
-        const detailObj = item.server || item || {};
-        const content = (() => {
-            try { return JSON.stringify(detailObj, null, 2); } catch (e) { return String(detailObj); }
-        })();
-        this.setState({ detailVisible: true, detailContent: content, detailTitle: name });
+    openDetailModal = item => {
+        const title = item.name || item.externalId || 'Unnamed';
+        this.setState({
+            detailVisible: true,
+            detailTitle: title,
+            detailContent: JSON.stringify(item, null, 2),
+        });
     };
 
-    closeDetailModal = () => this.setState({ detailVisible: false, detailContent: '', detailTitle: '' });
+    closeDetailModal = () =>
+        this.setState({ detailVisible: false, detailTitle: '', detailContent: '' });
+
+    getSelectedImportItems = onlyImportable => {
+        const selectedKeys = new Set(this.state.importSelectedItemKeys || []);
+        const validationMap = this.buildValidationMap(this.state.importValidationResult || []);
+        return (this.state.importCandidates || [])
+            .filter(item => selectedKeys.has(this.getImportItemKey(item)))
+            .filter(item => {
+                if (!onlyImportable) {
+                    return true;
+                }
+                const validation = validationMap[this.getImportItemKey(item)];
+                return !validation || this.isValidationImportable(validation);
+            })
+            .map(this.toImportItem);
+    };
+
+    getImportableItemsFromValidation = () => {
+        const validationMap = this.buildValidationMap(this.state.importValidationResult || []);
+        return (this.state.importCandidates || [])
+            .filter(item => {
+                const validation = validationMap[this.getImportItemKey(item)];
+                return validation && this.isValidationImportable(validation);
+            })
+            .map(this.toImportItem);
+    };
+
+    buildValidationMap = validationItems => {
+        const result = {};
+        (validationItems || []).forEach(item => {
+            result[this.getImportItemKey(item)] = item;
+        });
+        return result;
+    };
+
+    getImportItemKey = item => {
+        const id = item && (item.externalId || item.name || item.resourceName);
+        const version = (item && item.version) || '';
+        return `${id || 'unknown'}__${version}`;
+    };
+
+    toImportItem = item => ({
+        externalId: item.externalId,
+        name: item.name,
+        version: item.version,
+        metadata: item.metadata,
+    });
+
+    isValidationImportable = validation => {
+        const status = String(validation && validation.status ? validation.status : '').toLowerCase();
+        if (status === 'valid' || status === 'warning') {
+            return true;
+        }
+        if (status === 'conflict') {
+            return !!this.state.importOverrideExisting;
+        }
+        return false;
+    };
+
+    renderStatusTag = status => {
+        const { locale = {} } = this.props;
+        const lower = String(status || '').toLowerCase();
+        if (lower === 'success') {
+            return (
+                <span style={this.statusStyle('#dcfce7', '#166534')}>
+                    {locale.success || '成功'}
+                </span>
+            );
+        }
+        if (lower === 'skipped') {
+            return (
+                <span style={this.statusStyle('#e5e7eb', '#374151')}>
+                    {locale.skipped || '跳过'}
+                </span>
+            );
+        }
+        if (lower === 'warning') {
+            return (
+                <span style={this.statusStyle('#fef3c7', '#92400e')}>
+                    {locale.warning || '警告'}
+                </span>
+            );
+        }
+        if (lower === 'conflict') {
+            return (
+                <span style={this.statusStyle('#fee2e2', '#991b1b')}>
+                    {locale.conflict || '冲突'}
+                </span>
+            );
+        }
+        if (lower === 'valid') {
+            return (
+                <span style={this.statusStyle('#dcfce7', '#166534')}>
+                    {locale.valid || '有效'}
+                </span>
+            );
+        }
+        return (
+            <span style={this.statusStyle('#fee2e2', '#991b1b')}>
+                {locale.failed || locale.invalid || '失败'}
+            </span>
+        );
+    };
+
+    statusStyle = (backgroundColor, color) => ({
+        backgroundColor,
+        color,
+        borderRadius: 12,
+        padding: '2px 8px',
+        fontSize: 12,
+        lineHeight: '18px',
+        display: 'inline-block',
+    });
+
+    renderSourcePanel() {
+        const { locale = {} } = this.props;
+        const { sources, selectedSourceId } = this.state;
+        const selectedSource = sources.find(source => source.sourceId === selectedSourceId);
+        return (
+            <div style={{ marginBottom: 12 }}>
+                <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+                    <Select
+                        value={selectedSourceId}
+                        onChange={this.handleSourceChange}
+                        disabled={this.state.sourceLoading || this.state.importValidating}
+                        style={{ minWidth: 260 }}
+                        placeholder={locale.selectSource || '选择来源'}
+                    >
+                        {sources.map(source => (
+                            <Select.Option key={source.sourceId} value={source.sourceId}>
+                                {source.displayName || source.sourceId}
+                            </Select.Option>
+                        ))}
+                    </Select>
+                    <Input
+                        placeholder={locale.searchPlaceholder || '按名称关键词搜索'}
+                        value={this.state.importRegistrySearch}
+                        onChange={value =>
+                            this.setState({
+                                importRegistrySearch: value,
+                                importValidationResult: null,
+                                importValidationToken: '',
+                            })
+                        }
+                        onPressEnter={this.handleSearch}
+                        innerAfter={
+                            <Icon
+                                type="search"
+                                size="small"
+                                style={{ margin: '0 6px', color: '#9aa1a7', cursor: 'pointer' }}
+                                onClick={this.handleSearch}
+                            />
+                        }
+                        style={{ flex: 1 }}
+                    />
+                    <Button
+                        type="primary"
+                        loading={this.state.importValidating}
+                        disabled={!selectedSourceId || this.state.importExecuting}
+                        onClick={this.handleSearch}
+                    >
+                        {locale.search || '搜索'}
+                    </Button>
+                </div>
+                {selectedSource ? (
+                    <div
+                        style={{
+                            marginTop: 8,
+                            color: '#6b7280',
+                            display: 'flex',
+                            gap: 12,
+                            flexWrap: 'wrap',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <span>{selectedSource.description || selectedSource.displayName || selectedSource.sourceId}</span>
+                        <span style={this.statusStyle('#eef2ff', '#3730a3')}>
+                            {selectedSource.pluginName || '--'}
+                        </span>
+                        {(selectedSource.capabilities || []).map(capability => (
+                            <span key={capability} style={this.statusStyle('#ecfeff', '#155e75')}>
+                                {capability}
+                            </span>
+                        ))}
+                    </div>
+                ) : null}
+            </div>
+        );
+    }
+
+    renderOptions() {
+        const { locale = {} } = this.props;
+        return (
+            <div style={{ display: 'flex', gap: 24, alignItems: 'center', marginBottom: 12 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <Switch
+                        checked={this.state.importOverrideExisting}
+                        onChange={checked =>
+                            this.setState({
+                                importOverrideExisting: checked,
+                                importValidationResult: null,
+                                importValidationToken: '',
+                            })
+                        }
+                    />
+                    <span>{locale.importOverride || '覆盖已存在资源'}</span>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <Switch
+                        checked={this.state.importSkipInvalid}
+                        onChange={checked => this.setState({ importSkipInvalid: checked })}
+                    />
+                    <span>{locale.importSkipInvalid || '跳过无效项'}</span>
+                </div>
+            </div>
+        );
+    }
+
+    renderCandidateCards() {
+        const { locale = {} } = this.props;
+        const candidates = this.state.importCandidates || [];
+        const validationMap = this.buildValidationMap(this.state.importValidationResult || []);
+        if (!candidates.length) {
+            return (
+                <div
+                    style={{
+                        height: 220,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: '#8a8f8d',
+                    }}
+                >
+                    {this.state.selectedSourceId
+                        ? locale.noSearchResult || '未找到匹配的结果'
+                        : locale.noData || '暂无数据'}
+                </div>
+            );
+        }
+        return (
+            <>
+                <div
+                    style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+                        gap: 20,
+                        width: '100%',
+                        alignItems: 'stretch',
+                        justifyItems: 'stretch',
+                    }}
+                >
+                    {candidates.map((item, idx) => this.renderCandidateCard(item, idx, validationMap))}
+                </div>
+                {this.state.importHasMore ? (
+                    <div style={{ textAlign: 'center', marginTop: 12 }}>
+                        <Button
+                            loading={this.state.importValidating}
+                            disabled={this.state.importValidating}
+                            onClick={this.handleLoadMore}
+                        >
+                            {locale.loadMore || '加载更多'}
+                        </Button>
+                    </div>
+                ) : null}
+            </>
+        );
+    }
+
+    renderCandidateCard(item, idx, validationMap) {
+        const { locale = {} } = this.props;
+        const key = this.getImportItemKey(item);
+        const validation = validationMap[key];
+        const checked = (this.state.importSelectedItemKeys || []).includes(key);
+        const status = validation && validation.status;
+        const importable = !validation || this.isValidationImportable(validation);
+        const disabled = !!validation && !importable;
+        const metadata = item.metadata || {};
+        const protocol = metadata.protocol || '--';
+        const repository = metadata.repository || '';
+        const errors = validation && validation.errors && validation.errors.length
+            ? validation.errors.join('; ')
+            : '';
+        const warnings = validation && validation.warnings && validation.warnings.length
+            ? validation.warnings.join('; ')
+            : '';
+        const borderColor = checked ? '#2563eb' : '#e6e7eb';
+        const isHovered = this.state.importHoverKey === key;
+        const activeHover = !disabled && isHovered;
+        const baseTransform = !this.state.importCardsReady
+            ? 'translateY(6px)'
+            : checked || activeHover
+                ? 'translateY(-2px) scale(1.01)'
+                : 'translateY(0)';
+        const boxShadow = checked
+            ? '0 8px 22px rgba(37,99,235,0.22)'
+            : activeHover
+                ? '0 8px 20px rgba(0,0,0,0.10)'
+                : 'none';
+        return (
+            <div key={key} style={{ minWidth: 0, height: '100%' }}>
+                <div
+                    onClick={() => !disabled && this.toggleCandidateSelection(item, !checked)}
+                    onMouseEnter={() => !disabled && this.setState({ importHoverKey: key })}
+                    onMouseLeave={() => this.setState({ importHoverKey: null })}
+                    style={{
+                        cursor: disabled ? 'not-allowed' : 'pointer',
+                        width: '100%',
+                        height: '100%',
+                        display: 'flex',
+                    }}
+                >
+                    <Card
+                        free
+                        style={{
+                            width: '100%',
+                            height: '100%',
+                            minHeight: 168,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            boxSizing: 'border-box',
+                            border: `1px solid ${disabled ? '#d1d5db' : borderColor}`,
+                            backgroundColor: disabled ? '#f3f4f6' : '#ffffff',
+                            boxShadow,
+                            opacity: disabled ? 0.72 : 1,
+                            transform: baseTransform,
+                            transition:
+                                'transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease, opacity 260ms ease',
+                            transitionDelay: `${Math.min(idx * 30, 240)}ms`,
+                        }}
+                    >
+                        <Card.Header
+                            title={
+                                <span
+                                    title={item.name || item.externalId}
+                                    style={{
+                                        fontWeight: 600,
+                                        display: 'inline-block',
+                                        maxWidth: 'calc(100% - 100px)',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap',
+                                    }}
+                                >
+                                    {item.name || item.externalId || 'Unnamed'}
+                                </span>
+                            }
+                            subTitle={<span style={{ color: '#8a8f8d' }}>v{item.version || '--'}</span>}
+                            extra={
+                                <div
+                                    style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+                                    onClick={e => e.stopPropagation()}
+                                >
+                                    <Checkbox
+                                        checked={checked}
+                                        disabled={disabled}
+                                        onChange={value => this.toggleCandidateSelection(item, value)}
+                                    />
+                                    {errors || warnings ? (
+                                        <Balloon.Tooltip
+                                            trigger={
+                                                <Icon
+                                                    type="prompt"
+                                                    size="small"
+                                                    style={{ color: errors ? '#dc2626' : '#f59e0b' }}
+                                                />
+                                            }
+                                        >
+                                            {errors || warnings}
+                                        </Balloon.Tooltip>
+                                    ) : null}
+                                    <a
+                                        onClick={() => this.openDetailModal(item)}
+                                        style={{ color: '#2563eb' }}
+                                    >
+                                        {locale.details || '详情'}
+                                    </a>
+                                </div>
+                            }
+                        />
+                        <Card.Divider />
+                        <Card.Content style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+                            <div
+                                title={item.description}
+                                style={{
+                                    color: '#666',
+                                    lineHeight: '20px',
+                                    overflow: 'hidden',
+                                    display: '-webkit-box',
+                                    WebkitLineClamp: 3,
+                                    WebkitBoxOrient: 'vertical',
+                                }}
+                            >
+                                {item.description || '--'}
+                            </div>
+                        </Card.Content>
+                        <Card.Divider />
+                        <div
+                            style={{
+                                padding: '8px 12px',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                gap: 12,
+                                flexWrap: 'wrap',
+                            }}
+                        >
+                            <div style={{ color: '#111827' }}>
+                                <span style={{ color: '#6b7280', marginRight: 6 }}>
+                                    {locale.mcpServerType || '服务类型'}:
+                                </span>
+                                <span style={{ color: '#2563eb' }}>{protocol}</span>
+                            </div>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                                {repository ? (
+                                    <a
+                                        href={repository}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        onClick={e => e.stopPropagation()}
+                                        style={{ color: '#2563eb' }}
+                                    >
+                                        {locale.repository || 'Repository'}
+                                    </a>
+                                ) : null}
+                                {status ? this.renderStatusTag(status) : null}
+                            </div>
+                        </div>
+                    </Card>
+                </div>
+            </div>
+        );
+    }
 
     render() {
-        const { visible, onClose, locale = {} } = this.props;
+        const { visible, locale = {} } = this.props;
+        const hasSources = (this.state.sources || []).length > 0;
         return (
             <>
                 <Dialog
                     title={locale.importMcpServer || '导入 MCP Server'}
                     visible={visible}
                     footer={
-                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-                            <div>
-                                <Button disabled={!(this.state.importSelectedServerIds && this.state.importSelectedServerIds.length) || this.state.importExecuting} onClick={this.clearAllSelectionForRegistry}>
-                                    {locale.clearAll || '取消全选'}
+                        <div
+                            style={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                alignItems: 'center',
+                                gap: 8,
+                            }}
+                        >
+                            <Button
+                                disabled={
+                                    !this.state.importSelectedItemKeys.length ||
+                                    this.state.importExecuting
+                                }
+                                onClick={this.clearAllSelectionForRegistry}
+                            >
+                                {locale.clearAll || '取消全选'}
+                            </Button>
+                            <div style={{ display: 'flex', gap: 8 }}>
+                                <Button
+                                    disabled={
+                                        !this.state.importSelectedItemKeys.length ||
+                                        this.state.importValidating ||
+                                        this.state.importExecuting
+                                    }
+                                    loading={this.state.importValidating && !this.state.importExecuting}
+                                    onClick={this.validateSelected}
+                                >
+                                    {locale.importValidate || '校验'}
+                                </Button>
+                                <Button
+                                    type="primary"
+                                    disabled={
+                                        !this.state.importValidationResult ||
+                                        !this.state.importSelectedItemKeys.length ||
+                                        this.state.importExecuting
+                                    }
+                                    loading={this.state.importExecuting}
+                                    onClick={() => this.executeImport(false)}
+                                >
+                                    {locale.importSelected || '导入选中'}
+                                </Button>
+                                <Button
+                                    type="secondary"
+                                    disabled={
+                                        !this.state.importValidationResult ||
+                                        this.state.importExecuting
+                                    }
+                                    onClick={() => this.executeImport(true)}
+                                >
+                                    {locale.importAll || '导入全部'}
                                 </Button>
                             </div>
-                            {this.state.importExecuting ? (
-                                <div style={{ display: 'flex', alignItems: 'center', gap: 16, minWidth: 420, justifyContent: 'flex-end' }}>
-                                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#1d4ed8' }}>
-                                        <Icon type="loading" size="small" />
-                                        <span>{locale.importing || '导入中...'}</span>
-                                    </div>
-                                    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                                        <Progress percent={this.state.importProgressTotal ? Math.round((this.state.importProgressCurrent / this.state.importProgressTotal) * 100) : 0} shape="line" hasBorder={false} style={{ width: 240 }} />
-                                        <span style={{ color: '#6b7280' }}>{`${this.state.importProgressCurrent}/${this.state.importProgressTotal}`}</span>
-                                        {this.state.importProgressSuccess > 0 ? (
-                                            <span style={{ backgroundColor: '#dcfce7', color: '#166534', borderRadius: 12, padding: '2px 8px', fontSize: 12, lineHeight: '18px' }}>
-                                                {(locale.success || '成功')} {this.state.importProgressSuccess}
-                                            </span>
-                                        ) : null}
-                                        {this.state.importProgressFailed > 0 ? (
-                                            <span style={{ backgroundColor: '#fee2e2', color: '#991b1b', borderRadius: 12, padding: '2px 8px', fontSize: 12, lineHeight: '18px' }}>
-                                                {(locale.failed || '失败')} {this.state.importProgressFailed}
-                                            </span>
-                                        ) : null}
-                                    </div>
-                                </div>
-                            ) : (
-                                <div style={{ display: 'flex', gap: 8 }}>
-                                    <Button type="primary" disabled={this.state.importValidating} onClick={() => this.executeImportIndividually(false)}>
-                                        {locale.importSelected || '导入选中'}
-                                    </Button>
-                                    <Button type="secondary" disabled={this.state.importValidating} onClick={this.executeImportByBackend}>
-                                        {locale.importAll || '导入全部'}
-                                    </Button>
-                                </div>
-                            )}
                         </div>
                     }
                     onClose={this.handleClose}
                     v2
-                    style={{ width: 800 }}
+                    style={{ width: 880 }}
                 >
                     <Form labelAlign="left">
                         <Loading
-                            visible={this.state.importValidating || this.state.importExecuting}
-                            tip={(this.state.importExecuting ? (locale.importing || '导入中...') : (locale.loading || '加载中...'))}
+                            visible={
+                                this.state.sourceLoading ||
+                                this.state.importValidating ||
+                                this.state.importExecuting
+                            }
+                            tip={
+                                this.state.importExecuting
+                                    ? locale.importing || '导入中...'
+                                    : locale.loading || '加载中...'
+                            }
                             style={{ width: '100%' }}
                         >
-                            {this.state.importValidationResult ? (
+                            {hasSources ? (
                                 <>
-                                    <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
-                                        <Input
-                                            placeholder={locale.searchPlaceholder || '按名称关键词搜索（模糊）'}
-                                            value={this.state.importRegistrySearch}
-                                            innerAfter={
-                                                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginRight: 6 }}>
-                                                    {this.state.importRegistrySearch ? (
-                                                        <span
-                                                            title={locale.clear || '清除'}
-                                                            onClick={() => !this.state.importValidating && this.setState({ importRegistrySearch: '', importUrlCursor: '', importAccumulatedServers: [], importPage: 1 }, () => this.validateImport())}
-                                                            style={{
-                                                                width: 20,
-                                                                height: 20,
-                                                                lineHeight: '20px',
-                                                                textAlign: 'center',
-                                                                borderRadius: '50%',
-                                                                background: '#c4c6cf',
-                                                                color: '#fff',
-                                                                fontSize: 12,
-                                                                cursor: this.state.importValidating ? 'not-allowed' : 'pointer',
-                                                                userSelect: 'none',
-                                                                display: 'inline-flex',
-                                                                alignItems: 'center',
-                                                                justifyContent: 'center',
-                                                            }}
-                                                        >
-                                                            ×
-                                                        </span>
-                                                    ) : null}
-                                                    <Icon
-                                                        type="search"
-                                                        size="small"
-                                                        style={{ margin: '0 4px', color: '#9aa1a7', cursor: this.state.importValidating ? 'not-allowed' : 'pointer' }}
-                                                        title={locale.search || '搜索'}
-                                                        onClick={() => !this.state.importValidating && this.setState({ importUrlCursor: '', importAccumulatedServers: [], importPage: 1 }, () => this.validateImport())}
-                                                    />
-                                                </div>
-                                            }
-                                            onChange={val => this.setState({ importRegistrySearch: val })}
-                                            onPressEnter={() => this.setState({ importUrlCursor: '', importAccumulatedServers: [], importPage: 1 }, () => this.validateImport())}
-                                            style={{ flex: 1 }}
-                                        />
-                                    </div>
-
-                                    {(() => {
-                                        const serversList = (this.state.importValidationResult.servers || []);
-                                        if (!serversList.length) {
-                                            return (
-                                                <div style={{ height: 220, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', color: '#8a8f8d', textAlign: 'center' }}>
-                                                    <div style={{ marginBottom: 8 }}>
-                                                        {locale.noSearchResult || '未找到匹配的结果'}
-                                                    </div>
-                                                    {this.state.importRegistrySearch ? (
-                                                        <Button text disabled={this.state.importValidating} onClick={() => !this.state.importValidating && this.setState({ importRegistrySearch: '', importUrlCursor: '', importAccumulatedServers: [], importPage: 1 }, () => this.validateImport())}>
-                                                            {locale.clearSearch || '清空搜索并重试'}
-                                                        </Button>
-                                                    ) : null}
-                                                </div>
-                                            );
-                                        }
-                                        return (
-                                            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 20, width: '100%', alignItems: 'stretch', justifyItems: 'stretch' }}>
-                                        {serversList.map((item, idx) => {
-                                            const name = item.serverName || item.serverId || 'Unnamed';
-                                            const server = item.server || {};
-                                            const version = (server.versionDetail && server.versionDetail.version) || '--';
-                                            const key = `${name}__${version}`;
-                                            const validationStatus = (item.status || '').toLowerCase();
-                                            const checked = (this.state.importSelectedServerIds || []).includes(key);
-                                            const proto = server.frontProtocol || server.protocol || '--';
-                                            const serverStatus = (server.status || '').toLowerCase();
-                                            const errorText = (item.errors && item.errors.length) ? item.errors.join('; ') : '';
-                                            const alreadyExists = !!item.exists || /already\s+exists/i.test(errorText);
-                                            const disabled = validationStatus !== 'valid' || alreadyExists;
-                                            const isInvalid = validationStatus === 'invalid';
-                                            const desc = server.description || item.description || '';
-                                            const repoUrl = (server.repository && (server.repository.url || server.repository.link))
-                                                || server.repositoryUrl || server.repositoryURL || server.homepage || server.url || item.repositoryUrl || item.url || '';
-
-                                            const borderColor = checked ? '#2563eb' : '#e6e7eb';
-                                            const isHovered = this.state.importHoverKey === key;
-                                            const isReady = this.state.importCardsReady;
-                                            const activeHover = !disabled && isHovered;
-                                            const baseTransform = !isReady ? 'translateY(6px)' : (checked || activeHover) ? 'translateY(-2px) scale(1.01)' : 'translateY(0)';
-                                            const boxShadow = checked ? '0 8px 22px rgba(37,99,235,0.22)' : activeHover ? '0 8px 20px rgba(0,0,0,0.10)' : 'none';
-                                            const transitionDelay = isReady ? `${Math.min(idx * 30, 240)}ms` : '0ms';
-                                            const wrapperStyle = { cursor: disabled ? 'not-allowed' : 'pointer', width: '100%', height: '100%', display: 'flex' };
-
-                                            return (
-                                                <div key={key} style={{ minWidth: 0, height: '100%' }}>
-                                                    <div
-                                                        onClick={() => !disabled && this.toggleRegistryCardSelection(key, !checked)}
-                                                        onMouseEnter={() => !disabled && this.setState({ importHoverKey: key })}
-                                                        onMouseLeave={() => this.setState({ importHoverKey: null })}
-                                                        style={wrapperStyle}
-                                                    >
-                                                        <Card
-                                                            free
-                                                            style={{
-                                                                width: '100%',
-                                                                height: '100%',
-                                                                minHeight: 160,
-                                                                display: 'flex',
-                                                                flexDirection: 'column',
-                                                                boxSizing: 'border-box',
-                                                                border: `1px solid ${isInvalid ? '#d1d5db' : borderColor}`,
-                                                                backgroundColor: isInvalid ? '#f3f4f6' : '#ffffff',
-                                                                boxShadow,
-                                                                opacity: isInvalid ? 1 : (disabled ? 0.7 : 1),
-                                                                transform: baseTransform,
-                                                                transition: 'transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease, opacity 260ms ease',
-                                                                transitionDelay,
-                                                            }}
-                                                        >
-                                                            <Card.Header
-                                                                style={{ backgroundColor: isInvalid ? '#f3f4f6' : undefined }}
-                                                                title={
-                                                                    <span title={name} style={{ fontWeight: 600, display: 'inline-block', maxWidth: 'calc(100% - 88px)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: isInvalid ? '#4b5563' : undefined }}>
-                                                                        {name}
-                                                                    </span>
-                                                                }
-                                                                subTitle={<span style={{ color: '#8a8f8d' }}>v{version}</span>}
-                                                                extra={
-                                                                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }} onClick={e => e.stopPropagation()}>
-                                                                        {errorText ? (
-                                                                            <Balloon.Tooltip trigger={<Icon type="prompt" size="small" style={{ color: '#f59e0b' }} />}>{errorText}</Balloon.Tooltip>
-                                                                        ) : null}
-                                                                        {repoUrl ? (
-                                                                            <a href={repoUrl} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()} style={{ color: '#2563eb' }}>
-                                                                                {locale.details || '详情'}
-                                                                            </a>
-                                                                        ) : null}
-                                                                    </div>
-                                                                }
-                                                            />
-                                                            <Card.Divider />
-                                                            <Card.Content style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-                                                                <div title={desc} style={{ color: '#666', lineHeight: '20px', overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical' }}>
-                                                                    {desc || '--'}
-                                                                </div>
-                                                            </Card.Content>
-                                                            <Card.Divider />
-                                                            <div style={{ padding: '8px 12px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
-                                                                <div style={{ color: '#111827' }}>
-                                                                    <span style={{ color: '#6b7280', marginRight: 6 }}>{locale.mcpServerType || '服务类型'}:</span>
-                                                                    <span style={{ color: '#2563eb' }}>{proto || '--'}</span>
-                                                                </div>
-                                                                <div style={{ color: '#111827', display: 'flex', alignItems: 'center', gap: 8 }}>
-                                                                    <span style={{ color: '#6b7280' }}>{locale.status || '状态'}:</span>
-                                                                    {serverStatus ? (
-                                                                        <span style={{ backgroundColor: serverStatus === 'active' ? '#dcfce7' : '#fef3c7', color: serverStatus === 'active' ? '#166534' : '#92400e', borderRadius: 12, padding: '2px 8px', fontSize: 12, lineHeight: '18px' }}>
-                                                                            {serverStatus}
-                                                                        </span>
-                                                                    ) : (
-                                                                        <span style={{ color: '#9aa1a7' }}>--</span>
-                                                                    )}
-                                                                    {alreadyExists && (
-                                                                        <span style={{ backgroundColor: '#e5e7eb', color: '#374151', borderRadius: 12, padding: '2px 8px', fontSize: 12, lineHeight: '18px' }}>
-                                                                            {locale.alreadyImported || '已导入'}
-                                                                        </span>
-                                                                    )}
-                                                                </div>
-                                                            </div>
-                                                        </Card>
-                                                    </div>
-                                                </div>
-                                            );
-                                        })}
-                                            </div>
-                                        );
-                                    })()}
-                                    {(() => {
-                                        const servers = this.state.importAccumulatedServers || [];
-                                        const page = this.state.importPage || 1;
-                                        const size = this.state.importPageSize || 12;
-                                        const requested = page * size;
-                                        // 后端未返回 nextCursor 时，若返回数量 >= 请求数量，则认为可能还有更多
-                                        const canLoadMore = (this.state.importType === 'url') && (this.state.importNextCursor || servers.length >= requested);
-                                        return canLoadMore ? (
-                                            <div style={{ textAlign: 'center', marginTop: 12 }}>
-                                                <Button loading={this.state.importValidating} disabled={this.state.importValidating} onClick={this.handleLoadMore}>
-                                                    {locale.loadMore || '加载更多'}
-                                                </Button>
-                                            </div>
-                                        ) : null;
-                                    })()}
+                                    {this.renderSourcePanel()}
+                                    {this.renderOptions()}
+                                    {this.renderCandidateCards()}
                                 </>
                             ) : (
-                                this.state.importValidating ? (
-                                    <div style={{ height: 220 }} />
-                                ) : (
-                                    <div style={{ height: 220, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#8a8f8d' }}>
-                                        {locale.pubNoData || locale.noData || '暂无数据'}
-                                    </div>
-                                )
+                                <div
+                                    style={{
+                                        height: 220,
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        color: '#8a8f8d',
+                                    }}
+                                >
+                                    {locale.noImportSource || '暂无可用导入来源'}
+                                </div>
                             )}
                         </Loading>
                     </Form>
                 </Dialog>
-                {/* local details dialog */}
                 {this.state.detailVisible ? (
                     <Dialog
                         key="mcp-detail"
-                        title={this.state.detailTitle || (locale.details || '详情')}
+                        title={this.state.detailTitle || locale.details || '详情'}
                         visible
                         onClose={this.closeDetailModal}
                         v2
                         style={{ width: 720 }}
                         footer={false}
                     >
-                        <div style={{ maxHeight: 420, overflow: 'auto', background: '#f9fafb', border: '1px solid #e5e7eb', padding: 12, borderRadius: 4 }}>
-                            <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{this.state.detailContent}</pre>
+                        <div
+                            style={{
+                                maxHeight: 420,
+                                overflow: 'auto',
+                                background: '#f9fafb',
+                                border: '1px solid #e5e7eb',
+                                padding: 12,
+                                borderRadius: 4,
+                            }}
+                        >
+                            <pre
+                                style={{
+                                    margin: 0,
+                                    whiteSpace: 'pre-wrap',
+                                    wordBreak: 'break-word',
+                                }}
+                            >
+                                {this.state.detailContent}
+                            </pre>
                         </div>
                     </Dialog>
                 ) : null}

--- a/console-ui/src/pages/AI/McpManagement/McpManagement.js
+++ b/console-ui/src/pages/AI/McpManagement/McpManagement.js
@@ -85,8 +85,6 @@ class McpManagement extends React.Component {
     this.edasAppName = getParams('edasAppName') || '';
     this.inApp = this.edasAppId;
     this.isAdvance = getParams('isAdvanceQuery') || false;
-    this.DEFAULT_REGISTRY_URL = 'https://registry.modelcontextprotocol.io/v0/servers';
-
     this.state = {
       configurations: {
         pageItems: [],

--- a/console-ui/src/pages/AI/services/AiResourceImportService.js
+++ b/console-ui/src/pages/AI/services/AiResourceImportService.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { request } from '@/globalLib';
+
+const IMPORT_PATH = 'v3/console/ai/import';
+
+const AiResourceImportService = {
+    listSources(params) {
+        return request({
+            url: `${IMPORT_PATH}/sources`,
+            type: 'get',
+            data: params,
+        });
+    },
+
+    search(data) {
+        return request({
+            url: `${IMPORT_PATH}/search`,
+            type: 'post',
+            data,
+        });
+    },
+
+    validate(data) {
+        return request({
+            url: `${IMPORT_PATH}/validate`,
+            type: 'post',
+            data,
+        });
+    },
+
+    execute(data) {
+        return request({
+            url: `${IMPORT_PATH}/execute`,
+            type: 'post',
+            data,
+        });
+    },
+};
+
+export default AiResourceImportService;


### PR DESCRIPTION
## What is changed

For #15183 

- Switch the legacy Console MCP import dialog to the unified AI resource import source/search/validate/execute APIs.
- Add a legacy Console AI resource import service wrapper.
- Switch console-ui-next MCP import dialog to source selection and unified import APIs, with typed API models.
- Remove the unused hard-coded official registry URL from MCP management.

## Validation

- PASS: `npx eslint src/components/ai/mcp/ImportMcpDialog.tsx src/api/aiResourceImport.ts src/types/aiResourceImport.ts` in `console-ui-next`.
- PASS: `npx tsc -b` in `console-ui-next`.
- PASS: Babel parser syntax check for legacy `ImportMcpDialog.jsx`, `McpManagement.js`, and `AiResourceImportService.js`.
- PASS: `source ~/Documents/switch17.sh && ./mvnw -pl console -am -DskipTests compile`.
- NOTE: full `npm run lint` in `console-ui-next` still reports existing repo-wide lint issues outside this change; changed files pass targeted eslint.
- NOTE: local `npm run build` reaches Vite but fails on macOS loading Rollup native `@rollup/rollup-darwin-arm64` due code-signature/dlopen failure; TypeScript build passes.