### PR TITLE
test: improve plugin module unit test coverage

### DIFF
--- a/plugin/ai/src/test/java/com/alibaba/nacos/plugin/ai/importer/model/AiResourceImportModelTest.java
+++ b/plugin/ai/src/test/java/com/alibaba/nacos/plugin/ai/importer/model/AiResourceImportModelTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.ai.importer.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiResourceImportModelTest {
+    
+    private static final Map<String, String> METADATA = Collections.singletonMap("key", "value");
+    
+    @Test
+    void testImportSourceAccessors() {
+        AiResourceImportSource source = new AiResourceImportSource();
+        
+        source.setSourceId("source");
+        source.setDisplayName("Source");
+        source.setPluginName("plugin");
+        source.setResourceTypes(Arrays.asList("mcp", "skill"));
+        source.setEndpoint("https://example.com");
+        source.setEnabled(true);
+        source.setAuthRef("secret");
+        source.setConnectTimeoutMillis(1000);
+        source.setReadTimeoutMillis(2000);
+        source.setMaxPageCount(3);
+        source.setMaxItemCount(100);
+        source.setMaxArtifactSize(1024L);
+        source.setProperties(METADATA);
+        
+        assertEquals("source", source.getSourceId());
+        assertEquals("Source", source.getDisplayName());
+        assertEquals("plugin", source.getPluginName());
+        assertEquals(Arrays.asList("mcp", "skill"), source.getResourceTypes());
+        assertEquals("https://example.com", source.getEndpoint());
+        assertTrue(source.isEnabled());
+        assertEquals("secret", source.getAuthRef());
+        assertEquals(1000, source.getConnectTimeoutMillis());
+        assertEquals(2000, source.getReadTimeoutMillis());
+        assertEquals(3, source.getMaxPageCount());
+        assertEquals(100, source.getMaxItemCount());
+        assertEquals(1024L, source.getMaxArtifactSize());
+        assertSame(METADATA, source.getProperties());
+    }
+    
+    @Test
+    void testImportContextAccessors() {
+        AiResourceImportSource source = new AiResourceImportSource();
+        AiResourceImportContext context = new AiResourceImportContext();
+        
+        context.setNamespaceId("namespace");
+        context.setResourceType("mcp");
+        context.setSource(source);
+        context.setQuery("nacos");
+        context.setCursor("cursor");
+        context.setLimit(10);
+        context.setOptions(METADATA);
+        context.setRequestId("request");
+        context.setOperator("operator");
+        context.setClientIp("127.0.0.1");
+        
+        assertEquals("namespace", context.getNamespaceId());
+        assertEquals("mcp", context.getResourceType());
+        assertSame(source, context.getSource());
+        assertEquals("nacos", context.getQuery());
+        assertEquals("cursor", context.getCursor());
+        assertEquals(10, context.getLimit());
+        assertSame(METADATA, context.getOptions());
+        assertEquals("request", context.getRequestId());
+        assertEquals("operator", context.getOperator());
+        assertEquals("127.0.0.1", context.getClientIp());
+    }
+    
+    @Test
+    void testImportCandidateAndPageAccessors() {
+        AiResourceImportCandidate candidate = new AiResourceImportCandidate();
+        AiResourceImportCandidatePage page = new AiResourceImportCandidatePage();
+        
+        candidate.setResourceType("skill");
+        candidate.setExternalId("external");
+        candidate.setName("name");
+        candidate.setVersion("v1");
+        candidate.setDescription("description");
+        candidate.setMetadata(METADATA);
+        page.setItems(Collections.singletonList(candidate));
+        page.setNextCursor("next");
+        page.setHasMore(true);
+        page.setSourceMetadata(METADATA);
+        
+        assertEquals("skill", candidate.getResourceType());
+        assertEquals("external", candidate.getExternalId());
+        assertEquals("name", candidate.getName());
+        assertEquals("v1", candidate.getVersion());
+        assertEquals("description", candidate.getDescription());
+        assertSame(METADATA, candidate.getMetadata());
+        assertEquals(Collections.singletonList(candidate), page.getItems());
+        assertEquals("next", page.getNextCursor());
+        assertTrue(page.isHasMore());
+        assertSame(METADATA, page.getSourceMetadata());
+        page.setHasMore(false);
+        assertFalse(page.isHasMore());
+    }
+    
+    @Test
+    void testImportItemAndArtifactAccessors() {
+        byte[] payload = new byte[] {1, 2, 3};
+        AiResourceImportItem item = new AiResourceImportItem();
+        AiResourceImportArtifact artifact = new AiResourceImportArtifact();
+        
+        item.setExternalId("external");
+        item.setName("item");
+        item.setVersion("v1");
+        item.setMetadata(METADATA);
+        artifact.setResourceType("mcp");
+        artifact.setExternalId(item.getExternalId());
+        artifact.setName(item.getName());
+        artifact.setVersion(item.getVersion());
+        artifact.setDescription("description");
+        artifact.setPayloadKind(AiResourceImportPayloadKind.BYTES);
+        artifact.setPayload(payload);
+        artifact.setPayloadJson("{}");
+        artifact.setChecksum("sha256");
+        artifact.setSourceMetadata(METADATA);
+        
+        assertEquals("external", item.getExternalId());
+        assertEquals("item", item.getName());
+        assertEquals("v1", item.getVersion());
+        assertSame(METADATA, item.getMetadata());
+        assertEquals("mcp", artifact.getResourceType());
+        assertEquals("external", artifact.getExternalId());
+        assertEquals("item", artifact.getName());
+        assertEquals("v1", artifact.getVersion());
+        assertEquals("description", artifact.getDescription());
+        assertEquals(AiResourceImportPayloadKind.BYTES, artifact.getPayloadKind());
+        assertArrayEquals(payload, artifact.getPayload());
+        assertEquals("{}", artifact.getPayloadJson());
+        assertEquals("sha256", artifact.getChecksum());
+        assertSame(METADATA, artifact.getSourceMetadata());
+    }
+}

--- a/plugin/ai/src/test/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineModelTest.java
+++ b/plugin/ai/src/test/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineModelTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.ai.pipeline.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PublishPipelineModelTest {
+    
+    @Test
+    void testPublishPipelineContextAccessors() {
+        PublishPipelineContext context = new PublishPipelineContext();
+        
+        context.setResourceType(PublishPipelineResourceType.PROMPT);
+        context.setResourceName("prompt");
+        context.setNamespaceId("namespace");
+        context.setVersion("v1");
+        
+        assertEquals(PublishPipelineResourceType.PROMPT, context.getResourceType());
+        assertEquals("prompt", context.getResourceName());
+        assertEquals("namespace", context.getNamespaceId());
+        assertEquals("v1", context.getVersion());
+    }
+    
+    @Test
+    void testResourceFilesPipelineContextLoadsFilesLazilyOnce() {
+        ResourceFileContent file = new ResourceFileContent("SKILL.md", "content");
+        AtomicInteger loadCount = new AtomicInteger();
+        ResourceFilesPipelineContext context = new ResourceFilesPipelineContext();
+        context.setFilesLoader(() -> {
+            loadCount.incrementAndGet();
+            return Collections.singletonList(file);
+        });
+        
+        assertSame(context.getFiles(), context.getFiles());
+        assertEquals(1, loadCount.get());
+        assertEquals("SKILL.md", context.getFiles().get(0).getFilePath());
+        assertEquals("content", context.getFiles().get(0).getContent());
+        assertEquals("ResourceFileContent{filePath='SKILL.md'}", file.toString());
+    }
+    
+    @Test
+    void testResourceFilesPipelineContextUsesExplicitFiles() {
+        List<ResourceFileContent> files = Collections.singletonList(new ResourceFileContent());
+        ResourceFilesPipelineContext context = new ResourceFilesPipelineContext();
+        
+        context.setFiles(files);
+        
+        assertSame(files, context.getFiles());
+        assertNull(context.getFilesLoader());
+    }
+    
+    @Test
+    void testTypedPipelineContextsSetResourceType() {
+        assertEquals(PublishPipelineResourceType.SKILL,
+            new SkillPipelineContext().getResourceType());
+        assertEquals(PublishPipelineResourceType.AGENTSPEC,
+            new AgentSpecPipelineContext().getResourceType());
+    }
+    
+    @Test
+    void testPublishPipelineResultFactoriesAndAccessors() {
+        List<Checkpoint> checkpoints = Arrays.asList(new Checkpoint("format", true),
+            new Checkpoint("security", false));
+        
+        PublishPipelineResult passed =
+            PublishPipelineResult.pass("ok", PublishPipelineMessageType.MARKDOWN, checkpoints);
+        PublishPipelineResult rejected = PublishPipelineResult.reject("bad", null, checkpoints);
+        PublishPipelineResult constructed = new PublishPipelineResult(true, "created");
+        PublishPipelineResult simplePassed = PublishPipelineResult.pass("simple-ok");
+        PublishPipelineResult simpleRejected = PublishPipelineResult.reject("simple-bad");
+        
+        assertTrue(passed.isPassed());
+        assertEquals("ok", passed.getMessage());
+        assertEquals(PublishPipelineMessageType.MARKDOWN, passed.getType());
+        assertSame(checkpoints, passed.getCheckpoints());
+        assertTrue(passed.toString().contains("passed=true"));
+        assertFalse(rejected.isPassed());
+        assertEquals(PublishPipelineMessageType.TEXT, rejected.getType());
+        assertEquals(PublishPipelineMessageType.TEXT, constructed.getType());
+        assertTrue(simplePassed.isPassed());
+        assertFalse(simpleRejected.isPassed());
+        
+        constructed.setPassed(false);
+        constructed.setMessage("updated");
+        constructed.setType(PublishPipelineMessageType.JSON);
+        constructed.setCheckpoints(checkpoints);
+        assertFalse(constructed.isPassed());
+        assertEquals("updated", constructed.getMessage());
+        assertEquals(PublishPipelineMessageType.JSON, constructed.getType());
+        assertSame(checkpoints, constructed.getCheckpoints());
+    }
+    
+    @Test
+    void testPublishPipelineMessageTypeFromCode() {
+        assertEquals(PublishPipelineMessageType.TEXT, PublishPipelineMessageType.fromCode("TEXT"));
+        assertEquals(PublishPipelineMessageType.JSON, PublishPipelineMessageType.fromCode("json"));
+        assertEquals(PublishPipelineMessageType.MARKDOWN,
+            PublishPipelineMessageType.fromCode("markdown"));
+        assertEquals(PublishPipelineMessageType.HTML, PublishPipelineMessageType.fromCode("html"));
+        assertNull(PublishPipelineMessageType.fromCode(null));
+        assertNull(PublishPipelineMessageType.fromCode(""));
+        assertNull(PublishPipelineMessageType.fromCode("unknown"));
+        assertEquals("markdown", PublishPipelineMessageType.MARKDOWN.getCode());
+    }
+    
+    @Test
+    void testResourceFileContentAccessors() {
+        ResourceFileContent file = new ResourceFileContent();
+        
+        file.setFilePath("README.md");
+        file.setContent("content");
+        
+        assertEquals("README.md", file.getFilePath());
+        assertEquals("content", file.getContent());
+    }
+    
+    @Test
+    void testCheckpointEqualsAndHashCode() {
+        Checkpoint checkpoint = new Checkpoint("format", true);
+        Checkpoint same = new Checkpoint();
+        same.setTitle("format");
+        same.setPassed(true);
+        
+        assertEquals(checkpoint, checkpoint);
+        assertEquals(checkpoint, same);
+        assertEquals(checkpoint.hashCode(), same.hashCode());
+        assertNotEquals(checkpoint, new Checkpoint("format", false));
+        assertNotEquals(checkpoint, null);
+        assertNotEquals(checkpoint, "format");
+        assertEquals("format", same.getTitle());
+        assertTrue(same.getPassed());
+    }
+}

--- a/plugin/ai/src/test/java/com/alibaba/nacos/plugin/ai/storage/AiResourceStorageRouterTest.java
+++ b/plugin/ai/src/test/java/com/alibaba/nacos/plugin/ai/storage/AiResourceStorageRouterTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.ai.storage;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiResourceStorageRouterTest {
+    
+    @AfterEach
+    void tearDown() {
+        AiResourceStorageRouter.reset();
+    }
+    
+    @Test
+    void testJoinAndRouteStorage() throws NacosException {
+        FakeStorage storage = new FakeStorage("fake");
+        StorageKey emptyStorageKey = new StorageKey();
+        emptyStorageKey.setProvider("fake");
+        emptyStorageKey.setKey("resource");
+        
+        assertTrue(AiResourceStorageRouter.join(storage));
+        
+        AiResourceStorage routed = AiResourceStorageRouter.getInstance().route(emptyStorageKey);
+        routed.save(emptyStorageKey, "content".getBytes(StandardCharsets.UTF_8));
+        
+        assertSame(storage, routed);
+        assertArrayEquals("resource".getBytes(StandardCharsets.UTF_8), routed.get(emptyStorageKey));
+        assertEquals(1, AiResourceStorageRouter.getInstance().allStorages().size());
+        assertEquals("StorageKey{provider='fake', key='resource'}", emptyStorageKey.toString());
+    }
+    
+    @Test
+    void testJoinRejectsInvalidStorageAndRouteRejectsInvalidKey() {
+        assertFalse(AiResourceStorageRouter.join(null));
+        assertFalse(AiResourceStorageRouter.join(new FakeStorage(" ")));
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AiResourceStorageRouter.getInstance().route(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AiResourceStorageRouter.getInstance().route(new StorageKey("", "key")));
+        assertThrows(IllegalStateException.class,
+            () -> AiResourceStorageRouter.getInstance().route(new StorageKey("missing", "key")));
+    }
+    
+    private static class FakeStorage implements AiResourceStorage {
+        
+        private final String type;
+        
+        private FakeStorage(String type) {
+            this.type = type;
+        }
+        
+        @Override
+        public String type() {
+            return type;
+        }
+        
+        @Override
+        public void save(StorageKey storageKey, byte[] content) {
+        }
+        
+        @Override
+        public byte[] get(StorageKey storageKey) {
+            return storageKey.getKey().getBytes(StandardCharsets.UTF_8);
+        }
+        
+        @Override
+        public void delete(StorageKey storageKey) {
+        }
+    }
+}

--- a/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/api/AuthResultTest.java
+++ b/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/api/AuthResultTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.auth.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AuthResultTest {
+    
+    @Test
+    void testSuccessAndFailureFactories() {
+        AuthResult<Object> emptySuccess = AuthResult.successResult();
+        AuthResult<String> success = AuthResult.successResult("data");
+        AuthResult<Object> failure = AuthResult.failureResult(403, "denied");
+        
+        assertTrue(emptySuccess.isSuccess());
+        assertNull(emptySuccess.getData());
+        assertTrue(success.isSuccess());
+        assertEquals("data", success.getData());
+        assertFalse(failure.isSuccess());
+        assertEquals(403, failure.getErrorCode());
+        assertEquals("denied", failure.getErrorMessage());
+        assertEquals("Code: 403, Message: denied.", failure.format());
+    }
+    
+    @Test
+    void testAccessors() {
+        AuthResult<String> result = new AuthResult<>();
+        
+        result.setSuccess(true);
+        result.setErrorCode(401);
+        result.setErrorMessage("unauthorized");
+        result.setData("token");
+        
+        assertTrue(result.isSuccess());
+        assertEquals(401, result.getErrorCode());
+        assertEquals("unauthorized", result.getErrorMessage());
+        assertEquals("token", result.getData());
+    }
+}

--- a/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/constant/ConstantsTest.java
+++ b/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/constant/ConstantsTest.java
@@ -18,7 +18,10 @@ package com.alibaba.nacos.plugin.auth.constant;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ConstantsTest {
     
@@ -55,5 +58,19 @@ class ConstantsTest {
         assertEquals("config", SignType.CONFIG);
         assertEquals("console", SignType.CONSOLE);
         assertEquals("specified", SignType.SPECIFIED);
+    }
+    
+    @Test
+    void testConstantClassesConstructors() throws Exception {
+        assertNotNull(new Constants());
+        assertNotNull(new Constants.Auth());
+        assertNotNull(new Constants.Resource());
+        assertNotNull(new Constants.Identity());
+        assertNotNull(new Constants.Tag());
+        assertNotNull(new SignType());
+        Constructor<OidcProtocolConstants> constructor =
+            OidcProtocolConstants.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        assertNotNull(constructor.newInstance());
     }
 }

--- a/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/model/ConfigChangeModelTest.java
+++ b/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/model/ConfigChangeModelTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.config.model;
+
+import com.alibaba.nacos.plugin.config.constants.ConfigChangeExecuteTypes;
+import com.alibaba.nacos.plugin.config.constants.ConfigChangeConstants;
+import com.alibaba.nacos.plugin.config.constants.ConfigChangePointCutTypes;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigChangeModelTest {
+    
+    @Test
+    void testConfigChangeRequestStoresArguments() {
+        ConfigChangeRequest request =
+            new ConfigChangeRequest(ConfigChangePointCutTypes.PUBLISH_BY_HTTP);
+        
+        request.setArg("dataId", "test");
+        
+        assertEquals(ConfigChangePointCutTypes.PUBLISH_BY_HTTP, request.getRequestType());
+        assertEquals("test", request.getArg("dataId"));
+        assertNull(request.getArg("missing"));
+        assertSame(request.getRequestArgs(), request.getRequestArgs());
+    }
+    
+    @Test
+    void testConfigChangeResponseAccessors() {
+        Object[] args = new Object[] {"dataId", "group"};
+        ConfigChangeResponse response =
+            new ConfigChangeResponse(ConfigChangePointCutTypes.PUBLISH_BY_HTTP);
+        
+        response.setResponseType(ConfigChangePointCutTypes.REMOVE_BY_HTTP);
+        response.setSuccess(true);
+        response.setRetVal("ok");
+        response.setMsg("success");
+        response.setArgs(args);
+        
+        assertEquals(ConfigChangePointCutTypes.REMOVE_BY_HTTP, response.getResponseType());
+        assertTrue(response.isSuccess());
+        assertEquals("ok", response.getRetVal());
+        assertEquals("success", response.getMsg());
+        assertArrayEquals(args, response.getArgs());
+        response.setSuccess(false);
+        assertFalse(response.isSuccess());
+    }
+    
+    @Test
+    void testEnumValues() {
+        assertEquals(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE,
+            ConfigChangeExecuteTypes.valueOf("EXECUTE_BEFORE_TYPE"));
+        assertEquals(ConfigChangeExecuteTypes.EXECUTE_AFTER_TYPE,
+            ConfigChangeExecuteTypes.values()[1]);
+        assertEquals("publishOrUpdateByHttp", ConfigChangePointCutTypes.PUBLISH_BY_HTTP.value());
+        assertEquals("nacos.core.config.plugin.",
+            ConfigChangeConstants.NACOS_CORE_CONFIG_PLUGIN_PREFIX);
+        assertEquals("pluginProperties", ConfigChangeConstants.PLUGIN_PROPERTIES);
+        assertEquals("originalArgs", ConfigChangeConstants.ORIGINAL_ARGS);
+        assertEquals(ConfigChangeConstants.class, new ConfigChangeConstants().getClass());
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlRequestResponseModelTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlRequestResponseModelTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control;
+
+import com.alibaba.nacos.plugin.control.connection.request.ConnectionCheckRequest;
+import com.alibaba.nacos.plugin.control.connection.response.ConnectionCheckCode;
+import com.alibaba.nacos.plugin.control.connection.response.ConnectionCheckResponse;
+import com.alibaba.nacos.plugin.control.spi.ControlPluginProvider;
+import com.alibaba.nacos.plugin.control.tps.request.TpsCheckRequest;
+import com.alibaba.nacos.plugin.control.tps.response.TpsCheckResponse;
+import com.alibaba.nacos.plugin.control.tps.response.TpsResultCode;
+import com.alibaba.nacos.plugin.control.tps.rule.RuleModel;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ControlRequestResponseModelTest {
+    
+    @Test
+    void testConnectionCheckRequestAccessors() {
+        ConnectionCheckRequest request =
+            new ConnectionCheckRequest("127.0.0.1", "app", "sdk");
+        
+        request.setClientIp("127.0.0.2");
+        request.setAppName("console");
+        request.setSource("grpc");
+        request.setLabels(Collections.singletonMap("region", "cn"));
+        
+        assertEquals("127.0.0.2", request.getClientIp());
+        assertEquals("console", request.getAppName());
+        assertEquals("grpc", request.getSource());
+        assertEquals(Collections.singletonMap("region", "cn"), request.getLabels());
+    }
+    
+    @Test
+    void testTpsCheckRequestAccessors() {
+        TpsCheckRequest request = new TpsCheckRequest("point", "conn", "127.0.0.1");
+        
+        request.setPointName("newPoint");
+        request.setConnectionId("newConn");
+        request.setClientIp("127.0.0.2");
+        request.setTimestamp(100L);
+        request.setCount(3L);
+        
+        assertEquals("newPoint", request.getPointName());
+        assertEquals("newConn", request.getConnectionId());
+        assertEquals("127.0.0.2", request.getClientIp());
+        assertEquals(100L, request.getTimestamp());
+        assertEquals(3L, request.getCount());
+    }
+    
+    @Test
+    void testResponsesAndCodes() {
+        TpsCheckResponse tps = new TpsCheckResponse(true, TpsResultCode.PASS_BY_POINT, "pass");
+        ConnectionCheckResponse connection = new ConnectionCheckResponse();
+        
+        tps.setSuccess(false);
+        tps.setCode(TpsResultCode.DENY_BY_POINT);
+        tps.setMessage("deny");
+        connection.setSuccess(true);
+        connection.setCode(ConnectionCheckCode.PASS_BY_TOTAL);
+        connection.setMessage("ok");
+        connection.setLimitMessage("limit");
+        
+        assertFalse(tps.isSuccess());
+        assertEquals(TpsResultCode.DENY_BY_POINT, tps.getCode());
+        assertEquals("deny", tps.getMessage());
+        assertTrue(connection.isSuccess());
+        assertEquals(ConnectionCheckCode.PASS_BY_TOTAL, connection.getCode());
+        assertEquals("ok", connection.getMessage());
+        assertEquals("limit", connection.getLimitMessage());
+        assertEquals(201, TpsResultCode.PASS_BY_MONITOR);
+        assertEquals(100, TpsResultCode.CHECK_SKIP);
+        assertEquals(205, ConnectionCheckCode.PASS_BY_MONITOR);
+        assertEquals(100, ConnectionCheckCode.CHECK_SKIP);
+        assertEquals(TpsResultCode.class, new TpsResultCode().getClass());
+        assertEquals(ConnectionCheckCode.class, new ConnectionCheckCode().getClass());
+    }
+    
+    @Test
+    void testRuleModelValues() {
+        assertEquals(RuleModel.FUZZY, RuleModel.valueOf("FUZZY"));
+        assertEquals(RuleModel.PROTO, RuleModel.values()[1]);
+    }
+    
+    @Test
+    void testControlPluginProvider() {
+        ControlPluginProvider provider = new ControlPluginProvider();
+        
+        assertEquals("control", provider.getPluginType().getType());
+        assertNotNull(provider.getAllPlugins());
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/TpsMetricsTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/TpsMetricsTest.java
@@ -18,6 +18,8 @@ package com.alibaba.nacos.plugin.control.tps;
 
 import org.junit.jupiter.api.Test;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,8 +33,9 @@ class TpsMetricsTest {
         TpsMetrics.Counter counter = new TpsMetrics.Counter(3, 1);
         metrics.setCounter(counter);
         
-        assertEquals("1970-01-01 08:00:00", metrics.getTimeFormatOfSecond(0L));
-        assertEquals("point|monitor|SECONDS|1970-01-01 08:00:00|3|1", metrics.getMsg());
+        String expectedTime = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(0L));
+        assertEquals(expectedTime, metrics.getTimeFormatOfSecond(0L));
+        assertEquals("point|monitor|SECONDS|" + expectedTime + "|3|1", metrics.getMsg());
         assertTrue(metrics.toString().contains("pointName='point'"));
         assertEquals("3|1", counter.getSimpleLog());
         assertEquals("{passCount=3, deniedCount=1}", counter.toString());

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/TpsMetricsTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/TpsMetricsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.tps;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TpsMetricsTest {
+    
+    @Test
+    void testMetricsAccessorsAndMessage() {
+        TpsMetrics metrics = new TpsMetrics("point", "monitor", 0L, TimeUnit.SECONDS);
+        TpsMetrics.Counter counter = new TpsMetrics.Counter(3, 1);
+        metrics.setCounter(counter);
+        
+        assertEquals("1970-01-01 08:00:00", metrics.getTimeFormatOfSecond(0L));
+        assertEquals("point|monitor|SECONDS|1970-01-01 08:00:00|3|1", metrics.getMsg());
+        assertTrue(metrics.toString().contains("pointName='point'"));
+        assertEquals("3|1", counter.getSimpleLog());
+        assertEquals("{passCount=3, deniedCount=1}", counter.toString());
+        
+        metrics.setPointName("newPoint");
+        metrics.setType("newType");
+        metrics.setTimeStamp(1000L);
+        metrics.setPeriod(TimeUnit.MINUTES);
+        counter.setPassCount(5);
+        counter.setDeniedCount(2);
+        
+        assertEquals("newPoint", metrics.getPointName());
+        assertEquals("newType", metrics.getType());
+        assertEquals(1000L, metrics.getTimeStamp());
+        assertEquals(TimeUnit.MINUTES, metrics.getPeriod());
+        assertEquals(counter, metrics.getCounter());
+        assertEquals(5, counter.getPassCount());
+        assertEquals(2, counter.getDeniedCount());
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/barrier/LocalSimpleCountRateCounterTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/barrier/LocalSimpleCountRateCounterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.tps.barrier;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LocalSimpleCountRateCounterTest {
+    
+    @Test
+    void testAddTryAddMinusAndWindowLookup() {
+        LocalSimpleCountRateCounter counter =
+            new LocalSimpleCountRateCounter("point", TimeUnit.SECONDS);
+        long timestamp = counter.startTime;
+        
+        assertEquals(2L, counter.add(timestamp, 2L));
+        assertTrue(counter.tryAdd(timestamp, 1L, 3L));
+        assertFalse(counter.tryAdd(timestamp, 1L, 3L));
+        assertEquals(4L, counter.getCount(timestamp));
+        
+        counter.minus(timestamp, 2L);
+        assertEquals(2L, counter.getCount(timestamp));
+        assertEquals(0L, counter.getCount(timestamp + TimeUnit.SECONDS.toMillis(20)));
+        assertTrue(counter.createSlotIfAbsent(timestamp).toString().contains("TpsSlot{time="));
+    }
+    
+    @Test
+    void testConstructorTrimsDifferentPeriods() {
+        assertEquals(0L, new LocalSimpleCountRateCounter("second", TimeUnit.SECONDS).startTime
+            % TimeUnit.SECONDS.toMillis(1));
+        assertEquals(0L, new LocalSimpleCountRateCounter("minute", TimeUnit.MINUTES).startTime
+            % TimeUnit.MINUTES.toMillis(1));
+        assertEquals(0L, new LocalSimpleCountRateCounter("hour", TimeUnit.HOURS).startTime
+            % TimeUnit.HOURS.toMillis(1));
+        assertEquals(0L, new LocalSimpleCountRateCounter("default", TimeUnit.DAYS).startTime
+            % TimeUnit.SECONDS.toMillis(1));
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/constants/DatasourceConstantsTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/constants/DatasourceConstantsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.constants;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class DatasourceConstantsTest {
+    
+    @Test
+    void testConstantClassesCanBeLoaded() {
+        assertNotNull(new CommonConstant());
+        assertNotNull(new ContextConstant());
+        assertNotNull(new DataSourceConstant());
+        assertNotNull(new DatabaseTypeConstant());
+        assertNotNull(new FieldConstant());
+        assertNotNull(new PrimaryKeyConstant());
+        assertNotNull(new TableConstant());
+    }
+    
+    @Test
+    void testRepresentativeConstants() {
+        assertEquals("nacos.plugin.datasource.log.enabled",
+            CommonConstant.NACOS_PLUGIN_DATASOURCE_LOG);
+        assertEquals("needContent", ContextConstant.NEED_CONTENT);
+        assertEquals("mysql", DataSourceConstant.MYSQL);
+        assertEquals("postgresql", DatabaseTypeConstant.POSTGRESQL);
+        assertEquals("tenantId", FieldConstant.TENANT_ID);
+        assertEquals("config_info", TableConstant.CONFIG_INFO);
+        assertArrayEquals(new String[] {"id"}, PrimaryKeyConstant.LOWER_RETURN_PRIMARY_KEYS);
+        assertArrayEquals(new String[] {"ID"}, PrimaryKeyConstant.UPPER_RETURN_PRIMARY_KEYS);
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/DatasourceMapperDefaultMethodTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/DatasourceMapperDefaultMethodTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.mapper;
+
+import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
+import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
+import com.alibaba.nacos.plugin.datasource.mapper.ext.WhereBuilder;
+import com.alibaba.nacos.plugin.datasource.model.MapperContext;
+import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatasourceMapperDefaultMethodTest {
+    
+    @Test
+    void testConfigTagsRelationCountRows() {
+        ConfigTagsRelationMapper mapper = new TestConfigTagsRelationMapper();
+        MapperContext context = new MapperContext();
+        context.putWhereParameter(FieldConstant.TENANT_ID, "tenant");
+        context.putWhereParameter(FieldConstant.DATA_ID, "data");
+        context.putWhereParameter(FieldConstant.GROUP_ID, "group");
+        context.putWhereParameter(FieldConstant.APP_NAME, "app");
+        context.putWhereParameter(FieldConstant.CONTENT, "%content%");
+        context.putWhereParameter(FieldConstant.TAG_ARR, new String[] {"tagA", "tagB"});
+        
+        MapperResult result = mapper.findConfigInfo4PageCountRows(context);
+        
+        assertTrue(result.getSql().contains("LEFT JOIN config_tags_relation"));
+        assertTrue(result.getSql().contains("b.tag_name IN (?, ?)"));
+        assertEquals(Arrays.asList("tenant", "data", "group", "app", "%content%", "tagA",
+            "tagB"), result.getParamList());
+        assertEquals("config_tags_relation", mapper.getTableName());
+    }
+    
+    @Test
+    void testConfigTagsRelationLikeCountRowsWithOptionalFilters() {
+        ConfigTagsRelationMapper mapper = new TestConfigTagsRelationMapper();
+        MapperContext context = new MapperContext();
+        context.putWhereParameter(FieldConstant.TENANT_ID, "tenant");
+        context.putWhereParameter(FieldConstant.DATA_ID, "data");
+        context.putWhereParameter(FieldConstant.GROUP_ID, "group");
+        context.putWhereParameter(FieldConstant.APP_NAME, "app");
+        context.putWhereParameter(FieldConstant.CONTENT, "content");
+        context.putWhereParameter(FieldConstant.TAG_ARR, new String[] {"tagA", "tagB"});
+        context.putWhereParameter(FieldConstant.TYPE, new String[] {"yaml", "json"});
+        
+        MapperResult result = mapper.findConfigInfoLike4PageCountRows(context);
+        
+        assertTrue(result.getSql().contains("a.tenant_id LIKE ?"));
+        assertTrue(result.getSql().contains("b.tag_name LIKE ?"));
+        assertTrue(result.getSql().contains("a.type IN (?"));
+        assertEquals(Arrays.asList("tenant", "data", "group", "app", "content", "tagA", "tagB",
+            "yaml", "json"), result.getParamList());
+    }
+    
+    @Test
+    void testConfigInfoBetaAndTagCasUpdates() {
+        ConfigInfoBetaMapper betaMapper = new TestConfigInfoBetaMapper();
+        ConfigInfoTagMapper tagMapper = new TestConfigInfoTagMapper();
+        MapperContext context = createUpdateContext();
+        context.putUpdateParameter(FieldConstant.BETA_IPS, "1.1.1.1");
+        context.putWhereParameter(FieldConstant.TAG_ID, "tag");
+        
+        MapperResult beta = betaMapper.updateConfigInfo4BetaCas(context);
+        MapperResult tag = tagMapper.updateConfigInfo4TagCas(context);
+        
+        assertTrue(beta.getSql().contains("UPDATE config_info_beta SET content"));
+        assertTrue(beta.getSql().contains("gmt_modified = NOW()"));
+        assertEquals("config_info_beta", betaMapper.getTableName());
+        assertEquals(Arrays.asList("content", "md5-new", "1.1.1.1", "127.0.0.1", "nacos",
+            "app", "data", "group", "tenant", "md5-old"), beta.getParamList());
+        assertTrue(tag.getSql().contains("UPDATE config_info_tag SET content"));
+        assertEquals("config_info_tag", tagMapper.getTableName());
+        assertEquals(Arrays.asList("content", "md5-new", "127.0.0.1", "nacos", "now", "app",
+            "data", "group", "tenant", "tag", "md5-old"), tag.getParamList());
+    }
+    
+    @Test
+    void testConfigInfoGrayDefaults() {
+        ConfigInfoGrayMapper mapper = new TestConfigInfoGrayMapper();
+        MapperContext context = createUpdateContext();
+        context.putWhereParameter(FieldConstant.GRAY_NAME, "gray");
+        context.putWhereParameter(FieldConstant.GRAY_RULE, "rule");
+        context.putWhereParameter(FieldConstant.START_TIME, 100L);
+        context.putWhereParameter(FieldConstant.LAST_MAX_ID, 10L);
+        context.putWhereParameter(FieldConstant.PAGE_SIZE, 200);
+        
+        MapperResult updateResult = mapper.updateConfigInfo4GrayCas(context);
+        MapperResult changeResult = mapper.findChangeConfig(context);
+        
+        assertTrue(updateResult.getSql().contains("UPDATE config_info_gray SET content"));
+        assertEquals("config_info_gray", mapper.getTableName());
+        assertEquals(Arrays.asList("content", "md5-new", "127.0.0.1", "nacos", "app", "rule",
+            "data", "group", "tenant", "gray", "md5-old"), updateResult.getParamList());
+        assertTrue(changeResult.getSql().contains("FROM config_info_gray WHERE"));
+        assertEquals(Arrays.asList(100L, 10L, 200), changeResult.getParamList());
+    }
+    
+    @Test
+    void testAiResourceVersionCountRows() {
+        AiResourceVersionMapper mapper = new TestAiResourceVersionMapper();
+        MapperContext context = new MapperContext();
+        context.putWhereParameter(FieldConstant.NAMESPACE_ID, "namespace");
+        context.putWhereParameter(FieldConstant.NAME, "resource");
+        context.putWhereParameter(FieldConstant.TYPE, "skill");
+        context.putWhereParameter(FieldConstant.STATUS, "released");
+        context.putWhereParameter(FieldConstant.VERSION, "v1");
+        
+        MapperResult result = mapper.findAiResourceVersionCountRows(context);
+        
+        assertEquals("ai_resource_version", mapper.getTableName());
+        assertTrue(result.getSql().contains("namespace_id = ?"));
+        assertTrue(result.getSql().contains("name = ?"));
+        assertTrue(result.getSql().contains("type = ?"));
+        assertEquals(Arrays.asList("namespace", "resource", "skill", "released", "v1"),
+            result.getParamList());
+    }
+    
+    @Test
+    void testAiResourceConditions() {
+        AiResourceMapper mapper = new TestAiResourceMapper();
+        MapperContext context = new MapperContext();
+        context.putWhereParameter(FieldConstant.NAMESPACE_ID, "namespace");
+        context.putWhereParameter(FieldConstant.NAME, "resource");
+        context.putWhereParameter(FieldConstant.BIZ_TAGS, "tag");
+        context.putWhereParameter(FieldConstant.TYPE, Arrays.asList("skill", "prompt"));
+        context.putWhereParameter(FieldConstant.ORDER_BY, FieldConstant.ORDER_BY_DOWNLOAD_COUNT);
+        
+        MapperResult result = mapper.findAiResourceCountRows(context);
+        
+        assertEquals("ai_resource", mapper.getTableName());
+        assertTrue(result.getSql().contains("name LIKE ?"));
+        assertTrue(result.getSql().contains("type IN (?"));
+        assertEquals(Arrays.asList("namespace", "resource", "tag", "skill", "prompt"),
+            result.getParamList());
+        assertEquals(" ORDER BY download_count DESC", mapper.resolveOrderByClause(context));
+        context.putWhereParameter(FieldConstant.ORDER_BY, "unknown");
+        assertEquals(" ORDER BY gmt_modified DESC", mapper.resolveOrderByClause(context));
+    }
+    
+    @Test
+    void testAiResourceExtraConditionsBranches() {
+        AiResourceMapper mapper = new TestAiResourceMapper();
+        MapperContext context = new MapperContext();
+        context.putWhereParameter(FieldConstant.NAMESPACE_ID, "namespace");
+        context.putWhereParameter(AiResourceMapper.QUERY_CONDITION_ALWAYS_EMPTY, true);
+        
+        MapperResult alwaysEmpty = mapper.findAiResourceCountRows(context);
+        assertTrue(alwaysEmpty.getSql().contains("1 = ?"));
+        assertEquals(Arrays.asList("namespace", 0), alwaysEmpty.getParamList());
+        
+        MapperContext singleOrContext = new MapperContext();
+        singleOrContext.putWhereParameter(FieldConstant.NAMESPACE_ID, "namespace");
+        Map<Object, Object> singleOr = new LinkedHashMap<>();
+        singleOr.put("owner", "nacos");
+        singleOrContext.putWhereParameter(AiResourceMapper.QUERY_CONDITION_OR_GROUP, singleOr);
+        MapperResult singleOrResult = mapper.findAiResourceCountRows(singleOrContext);
+        assertTrue(singleOrResult.getSql().contains("owner = ?"));
+        assertEquals(Arrays.asList("namespace", "nacos"), singleOrResult.getParamList());
+        
+        MapperContext multiOrContext = new MapperContext();
+        multiOrContext.putWhereParameter(FieldConstant.NAMESPACE_ID, "namespace");
+        Map<Object, Object> multiOr = new LinkedHashMap<>();
+        multiOr.put("type", Arrays.asList("skill", "prompt"));
+        multiOr.put("owner", "nacos");
+        multiOrContext.putWhereParameter(AiResourceMapper.QUERY_CONDITION_OR_GROUP, multiOr);
+        MapperResult multiOrResult = mapper.findAiResourceCountRows(multiOrContext);
+        assertTrue(multiOrResult.getSql().contains("type IN (?"));
+        assertTrue(multiOrResult.getSql().contains("owner = ?"));
+        assertEquals(Arrays.asList("namespace", "skill", "prompt", "nacos"),
+            multiOrResult.getParamList());
+        
+        MapperResult emptyOrResult = buildEmptyOrConditionResult(mapper);
+        assertTrue(emptyOrResult.getSql().contains("1 = ?"));
+        assertEquals(Collections.singletonList(0), emptyOrResult.getParamList());
+        assertNull(mapper.castToMap("not-map"));
+    }
+    
+    private MapperResult buildEmptyOrConditionResult(AiResourceMapper mapper) {
+        WhereBuilder where = new WhereBuilder("SELECT * FROM ai_resource");
+        Map<String, Object> emptyOr = new LinkedHashMap<>();
+        emptyOr.put("", "blank");
+        emptyOr.put("type", null);
+        mapper.appendOrConditions(where, emptyOr);
+        return where.build();
+    }
+    
+    private MapperContext createUpdateContext() {
+        MapperContext context = new MapperContext();
+        context.putUpdateParameter(FieldConstant.CONTENT, "content");
+        context.putUpdateParameter(FieldConstant.MD5, "md5-new");
+        context.putUpdateParameter(FieldConstant.SRC_IP, "127.0.0.1");
+        context.putUpdateParameter(FieldConstant.SRC_USER, "nacos");
+        context.putUpdateParameter(FieldConstant.GMT_MODIFIED, "now");
+        context.putUpdateParameter(FieldConstant.APP_NAME, "app");
+        context.putWhereParameter(FieldConstant.DATA_ID, "data");
+        context.putWhereParameter(FieldConstant.GROUP_ID, "group");
+        context.putWhereParameter(FieldConstant.TENANT_ID, "tenant");
+        context.putWhereParameter(FieldConstant.MD5, "md5-old");
+        return context;
+    }
+    
+    private static class TestConfigTagsRelationMapper extends TestAbstractMapper
+        implements ConfigTagsRelationMapper {
+        
+        @Override
+        public String getTableName() {
+            return ConfigTagsRelationMapper.super.getTableName();
+        }
+        
+        @Override
+        public MapperResult findConfigInfo4PageFetchRows(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findConfigInfoLike4PageFetchRows(MapperContext context) {
+            return null;
+        }
+    }
+    
+    private static class TestConfigInfoBetaMapper extends TestAbstractMapper
+        implements ConfigInfoBetaMapper {
+        
+        @Override
+        public String getTableName() {
+            return ConfigInfoBetaMapper.super.getTableName();
+        }
+        
+        @Override
+        public MapperResult findAllConfigInfoBetaForDumpAllFetchRows(MapperContext context) {
+            return null;
+        }
+    }
+    
+    private static class TestConfigInfoTagMapper extends TestAbstractMapper
+        implements ConfigInfoTagMapper {
+        
+        @Override
+        public String getTableName() {
+            return ConfigInfoTagMapper.super.getTableName();
+        }
+        
+        @Override
+        public MapperResult findAllConfigInfoTagForDumpAllFetchRows(MapperContext context) {
+            return null;
+        }
+    }
+    
+    private static class TestConfigInfoGrayMapper extends TestAbstractMapper
+        implements ConfigInfoGrayMapper {
+        
+        @Override
+        public String getTableName() {
+            return ConfigInfoGrayMapper.super.getTableName();
+        }
+        
+        @Override
+        public MapperResult findAllConfigInfoGrayForDumpAllFetchRows(MapperContext context) {
+            return null;
+        }
+    }
+    
+    private static class TestAiResourceVersionMapper extends TestAbstractMapper
+        implements AiResourceVersionMapper {
+        
+        @Override
+        public String getTableName() {
+            return AiResourceVersionMapper.super.getTableName();
+        }
+        
+        @Override
+        public MapperResult findAiResourceVersionFetchRows(MapperContext context) {
+            return null;
+        }
+    }
+    
+    private static class TestAiResourceMapper extends TestAbstractMapper
+        implements AiResourceMapper {
+        
+        @Override
+        public String getTableName() {
+            return AiResourceMapper.super.getTableName();
+        }
+        
+        @Override
+        public MapperResult findAiResourceFetchRows(MapperContext context) {
+            return null;
+        }
+    }
+    
+    private abstract static class TestAbstractMapper extends AbstractMapper {
+        
+        @Override
+        public String getDataSource() {
+            return DataSourceConstant.MYSQL;
+        }
+        
+        @Override
+        public String getFunction(String functionName) {
+            return functionName;
+        }
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/model/MapperModelTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/model/MapperModelTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MapperModelTest {
+    
+    @Test
+    void testMapperContextParametersAndPaging() {
+        MapperContext context = new MapperContext(10, 20);
+        
+        context.putWhereParameter("id", 1L);
+        context.putUpdateParameter("name", "nacos");
+        context.putContextParameter("needContent", "true");
+        context.setStartRow(30);
+        context.setPageSize(40);
+        
+        assertEquals(1L, context.getWhereParameter("id"));
+        assertEquals("nacos", context.getUpdateParameter("name"));
+        assertEquals("true", context.getContextParameter("needContent"));
+        assertEquals(30, context.getStartRow());
+        assertEquals(40, context.getPageSize());
+        assertTrue(context.toString().contains("whereParamMap"));
+        assertEquals(context, context);
+        assertNotEquals(context, new MapperContext());
+    }
+    
+    @Test
+    void testMapperResultAccessors() {
+        MapperResult result = new MapperResult("SELECT 1", Collections.singletonList(1));
+        
+        assertEquals("SELECT 1", result.getSql());
+        assertEquals(Collections.singletonList(1), result.getParamList());
+        assertTrue(result.toString().contains("SELECT 1"));
+        assertEquals(result, result);
+        assertNotEquals(result, new MapperResult());
+        
+        result.setSql("SELECT ?");
+        result.setParamList(Arrays.asList("a", "b"));
+        assertEquals("SELECT ?", result.getSql());
+        assertEquals(Arrays.asList("a", "b"), result.getParamList());
+        assertSame(result.getParamList(), result.getParamList());
+    }
+}

--- a/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManagerTest.java
+++ b/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManagerTest.java
@@ -16,7 +16,9 @@
 
 package com.alibaba.nacos.plugin.environment;
 
+import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
+import com.alibaba.nacos.plugin.environment.spi.EnvironmentPluginProvider;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -25,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -82,5 +85,13 @@ class CustomEnvironmentPluginManagerTest {
         // [issue 13367] check property remove
         assertFalse(customValues.containsKey("db.password.1"));
         assertFalse(customValues.containsKey("db.password.2"));
+    }
+    
+    @Test
+    void testEnvironmentPluginProvider() {
+        EnvironmentPluginProvider provider = new EnvironmentPluginProvider();
+        
+        assertEquals(PluginType.ENVIRONMENT, provider.getPluginType());
+        assertNotNull(provider.getAllPlugins());
     }
 }

--- a/plugin/trace/src/test/java/com/alibaba/nacos/plugin/trace/TracePluginProviderTest.java
+++ b/plugin/trace/src/test/java/com/alibaba/nacos/plugin/trace/TracePluginProviderTest.java
@@ -18,9 +18,11 @@ package com.alibaba.nacos.plugin.trace;
 
 import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.plugin.trace.spi.NacosTraceSubscriber;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,5 +63,27 @@ class TracePluginProviderTest {
         int order = provider.getOrder();
         
         assertEquals(0, order);
+    }
+    
+    @Test
+    void testSubscriberDefaultExecutor() {
+        NacosTraceSubscriber subscriber = new NacosTraceSubscriber() {
+            
+            @Override
+            public String getName() {
+                return "test";
+            }
+            
+            @Override
+            public void onEvent(com.alibaba.nacos.common.trace.event.TraceEvent event) {
+            }
+            
+            @Override
+            public java.util.List<Class<? extends com.alibaba.nacos.common.trace.event.TraceEvent>> subscribeTypes() {
+                return Collections.emptyList();
+            }
+        };
+        
+        Assertions.assertNull(subscriber.executor());
     }
 }

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/model/AuthorizedResourcesTest.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/model/AuthorizedResourcesTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.visibility.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AuthorizedResourcesTest {
+    
+    @Test
+    void testAccessorsAndDefaultResources() {
+        AuthorizedResources resources = new AuthorizedResources();
+        
+        assertTrue(resources.getResources().isEmpty());
+        resources.setResourceType("skill");
+        resources.setResources(Arrays.asList("a", "b"));
+        
+        assertEquals("skill", resources.getResourceType());
+        assertEquals(Arrays.asList("a", "b"), resources.getResources());
+    }
+    
+    @Test
+    void testVisibilityQueryContextAccessorsAndBasePredicateValues() {
+        VisibilityQueryContext context = new VisibilityQueryContext();
+        
+        context.setNamespaceId("namespace");
+        context.setResourceType("skill");
+        
+        assertEquals("namespace", context.getNamespaceId());
+        assertEquals("skill", context.getResourceType());
+        assertEquals(BaseVisibilityPredicate.ALL, BaseVisibilityPredicate.valueOf("ALL"));
+        assertEquals(BaseVisibilityPredicate.PUBLIC_AND_OWNER, BaseVisibilityPredicate.values()[3]);
+    }
+}

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/ValidationResultTest.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/ValidationResultTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.visibility.spi;
+
+import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
+import com.alibaba.nacos.plugin.visibility.model.AuthorizedResources;
+import com.alibaba.nacos.plugin.visibility.model.BaseVisibilityPredicate;
+import com.alibaba.nacos.plugin.visibility.model.VisibilityQueryContext;
+import com.alibaba.nacos.plugin.visibility.model.VisibilityResource;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ValidationResultTest {
+    
+    @Test
+    void testAllowAndDenyFactories() {
+        ValidationResult allow = ValidationResult.allow();
+        ValidationResult deny = ValidationResult.deny("private");
+        
+        assertTrue(allow.isAllowed());
+        assertNull(allow.getReason());
+        assertFalse(deny.isAllowed());
+        assertEquals("private", deny.getReason());
+    }
+    
+    @Test
+    void testQueryAdvisorAccessors() {
+        QueryAdvisor advisor = new QueryAdvisor();
+        AuthorizedResources resources = new AuthorizedResources();
+        
+        advisor.setBasePredicate(BaseVisibilityPredicate.ALL);
+        advisor.setAuthorizedPredicate(resources);
+        
+        assertEquals(BaseVisibilityPredicate.ALL, advisor.getBasePredicate());
+        assertSame(resources, advisor.getAuthorizedPredicate());
+    }
+    
+    @Test
+    void testVisibilityServiceDefaultMethods() {
+        VisibilityService service = new FakeVisibilityService();
+        
+        service.init(new Properties());
+        
+        assertEquals(VisibilityConstants.SCOPE_PRIVATE,
+            service.resolveDefaultScopeForCreate("user", "console", "skill"));
+        assertTrue(service.validateVisibility("user", "r", "console", null).isAllowed());
+        assertEquals("fake", service.getVisibilityServiceName());
+        assertEquals(BaseVisibilityPredicate.PUBLIC_AND_OWNER,
+            service.adviseQuery("user", "r", "console", new VisibilityQueryContext())
+                .getBasePredicate());
+    }
+    
+    private static class FakeVisibilityService implements VisibilityService {
+        
+        @Override
+        public ValidationResult validateVisibility(String identity, String action, String apiType,
+            VisibilityResource resource) {
+            return ValidationResult.allow();
+        }
+        
+        @Override
+        public QueryAdvisor adviseQuery(String identity, String action, String apiType,
+            VisibilityQueryContext context) {
+            return new QueryAdvisor();
+        }
+        
+        @Override
+        public String getVisibilityServiceName() {
+            return "fake";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for plugin AI importer/pipeline/storage models and router behavior
- cover datasource mapper/model/constants default paths
- add focused coverage for control, visibility, auth, config, trace, and environment plugin small classes/default methods

## Testing
- source ~/Documents/switch17.sh && ./mvnw -B -f plugin/pom.xml spotless:apply
- source ~/Documents/switch17.sh && ./mvnw -B -f plugin/pom.xml spotless:check
- source ~/Documents/switch17.sh && ./mvnw -B -f plugin/pom.xml clean test
- source ~/Documents/switch17.sh && ./mvnw -B -f plugin/pom.xml clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests