### PR TITLE
[ISSUE #15183] Support Skill well-known discovery versions

### DIFF
--- a/ai/pom.xml
+++ b/ai/pom.xml
@@ -58,6 +58,11 @@
             <version>1.26.0</version>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.16.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test-autoconfigure</artifactId>
             <scope>test</scope>

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/operator/SkillResourceOperator.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/operator/SkillResourceOperator.java
@@ -36,6 +36,7 @@ import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * Applies imported Skill ZIP artifacts through the current Skill upload flow.
@@ -49,6 +50,10 @@ public class SkillResourceOperator implements AiResourceOperator {
     private static final String CONFLICT_TYPE_WORKING_VERSION = "working_version";
     
     private static final String CONFLICT_TYPE_EXISTING = "existing";
+    
+    private static final String METADATA_ARTIFACT_URL = "artifactUrl";
+    
+    private static final String METADATA_SOURCE = "source";
     
     private final SkillOperationService skillOperationService;
     
@@ -97,12 +102,35 @@ public class SkillResourceOperator implements AiResourceOperator {
         String version = resolveVersion(artifact);
         String skillName = skillOperationService.uploadSkillFromZip(namespaceId,
             artifact.getPayload(), overwriteExisting, version);
+        syncSource(namespaceId, skillName, artifact);
         AiResourceImportResultItem result = new AiResourceImportResultItem();
         result.setExternalId(artifact.getExternalId());
         result.setResourceName(skillName);
         result.setVersion(version);
         result.setStatus(AiResourceImportResultStatus.SUCCESS);
         return result;
+    }
+    
+    private void syncSource(String namespaceId, String skillName,
+        AiResourceImportArtifact artifact) {
+        String source = resolveSource(artifact);
+        if (StringUtils.isBlank(source)) {
+            return;
+        }
+        AiResource meta = resourceManager.findMeta(namespaceId, skillName, resourceType());
+        resourceManager.syncImportedSource(namespaceId, meta, source);
+    }
+    
+    private String resolveSource(AiResourceImportArtifact artifact) {
+        Map<String, String> metadata = artifact.getSourceMetadata();
+        if (metadata == null || metadata.isEmpty()) {
+            return null;
+        }
+        String artifactUrl = metadata.get(METADATA_ARTIFACT_URL);
+        if (StringUtils.isNotBlank(artifactUrl)) {
+            return artifactUrl;
+        }
+        return metadata.get(METADATA_SOURCE);
     }
     
     private boolean hasWorkingVersion(ResourceVersionInfo info) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/skill/SkillWellKnownImportService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/skill/SkillWellKnownImportService.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.ai.importer.skill;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.alibaba.nacos.ai.utils.SkillZipParser;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
@@ -35,15 +37,19 @@ import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
 import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
 
 import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -51,6 +57,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 
 /**
  * Importer for Skill well-known registry endpoints.
@@ -68,17 +77,51 @@ public class SkillWellKnownImportService implements AiResourceImportService {
     
     private static final String INDEX_JSON = "/index.json";
     
+    private static final String INDEX_JSON_FILE = "index.json";
+    
+    private static final String SCHEMA_0_1 =
+        "https://schemas.agentskills.io/discovery/0.1.0/schema.json";
+    
+    private static final String SCHEMA_0_2 =
+        "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+    
     private static final String MARKDOWN_FILE = "SKILL.md";
     
     private static final String METADATA_FILE_COUNT = "fileCount";
     
     private static final String METADATA_SOURCE = "source";
     
+    private static final String METADATA_SCHEMA_VERSION = "schemaVersion";
+    
+    private static final String METADATA_DISTRIBUTION_TYPE = "distributionType";
+    
+    private static final String METADATA_ARTIFACT_URL = "artifactUrl";
+    
+    private static final String METADATA_DIGEST = "digest";
+    
+    private static final String TYPE_SKILL_MD = "skill-md";
+    
+    private static final String TYPE_ARCHIVE = "archive";
+    
+    private static final String DIGEST_SHA256_PREFIX = "sha256:";
+    
+    private static final String ZIP_SUFFIX = ".zip";
+    
+    private static final String TAR_SUFFIX = ".tar";
+    
+    private static final String TAR_GZ_SUFFIX = ".tar.gz";
+    
+    private static final String TGZ_SUFFIX = ".tgz";
+    
     private static final int DEFAULT_LIMIT = 30;
     
     private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 10;
     
     private static final int DEFAULT_READ_TIMEOUT_SECONDS = 20;
+    
+    private static final int DEFAULT_MAX_ARCHIVE_ENTRIES = 500;
+    
+    private static final long DEFAULT_MAX_ARCHIVE_UNCOMPRESSED_BYTES = 50L * 1024L * 1024L;
     
     private final HttpClient httpClient;
     
@@ -107,14 +150,15 @@ public class SkillWellKnownImportService implements AiResourceImportService {
     public AiResourceImportCandidatePage search(AiResourceImportContext context)
         throws NacosException {
         try {
-            List<WellKnownSkillEntry> matched = filterSkills(fetchIndex(context).getSkills(),
-                context.getQuery());
+            ResolvedWellKnownIndex resolvedIndex = fetchIndex(context);
+            List<WellKnownSkillEntry> matched = filterSkills(resolvedIndex.getIndex().getSkills(),
+                resolvedIndex.getVersion(), context.getQuery());
             int offset = parseCursor(context.getCursor());
             int limit = resolveLimit(context.getLimit());
             int toIndex = Math.min(offset + limit, matched.size());
             List<AiResourceImportCandidate> items = new ArrayList<>();
             for (int i = offset; i < toIndex; i++) {
-                items.add(toCandidate(matched.get(i)));
+                items.add(toCandidate(matched.get(i), resolvedIndex));
             }
             AiResourceImportCandidatePage result = new AiResourceImportCandidatePage();
             result.setItems(items);
@@ -133,8 +177,10 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         AiResourceImportItem item) throws NacosException {
         try {
             String skillName = resolveExternalId(item);
-            WellKnownSkillEntry entry = findSkillEntry(fetchIndex(context).getSkills(), skillName);
-            byte[] zipBytes = fetchSkillZip(context, entry);
+            ResolvedWellKnownIndex resolvedIndex = fetchIndex(context);
+            WellKnownSkillEntry entry = findSkillEntry(resolvedIndex.getIndex().getSkills(),
+                skillName);
+            byte[] zipBytes = fetchSkillZip(context, resolvedIndex, entry);
             Skill skill = SkillZipParser.parseSkillFromZip(zipBytes, context.getNamespaceId());
             AiResourceImportArtifact result = new AiResourceImportArtifact();
             result.setResourceType(RESOURCE_TYPE_SKILL);
@@ -144,7 +190,7 @@ public class SkillWellKnownImportService implements AiResourceImportService {
             result.setDescription(skill.getDescription());
             result.setPayloadKind(AiResourceImportPayloadKind.SKILL_ZIP);
             result.setPayload(zipBytes);
-            result.setSourceMetadata(buildMetadata(entry));
+            result.setSourceMetadata(buildMetadata(entry, resolvedIndex));
             return result;
         } catch (NacosException e) {
             throw e;
@@ -153,13 +199,31 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         }
     }
     
-    private WellKnownSkillsIndex fetchIndex(AiResourceImportContext context) throws Exception {
-        String body = fetchString(indexUrl(requireSource(context)));
-        WellKnownSkillsIndex result = JacksonUtils.toObj(body, WellKnownSkillsIndex.class);
+    private ResolvedWellKnownIndex fetchIndex(AiResourceImportContext context) throws Exception {
+        List<String> indexUrls = indexUrls(requireSource(context));
+        Exception lastFailure = null;
+        for (String each : indexUrls) {
+            FetchResult response = fetchUrl(each);
+            if (!response.isSuccess()) {
+                lastFailure = new IllegalStateException(
+                    "HTTP " + response.getStatusCode() + " when fetching " + each);
+                continue;
+            }
+            return parseIndex(each, response.getBody());
+        }
+        throw dataAccess("Fetch Skill well-known index failed: "
+            + (lastFailure == null ? "No index URL available." : lastFailure.getMessage()),
+            lastFailure);
+    }
+    
+    private ResolvedWellKnownIndex parseIndex(String indexUrl, byte[] body) throws NacosException {
+        String content = new String(body, StandardCharsets.UTF_8);
+        WellKnownSkillsIndex result = JacksonUtils.toObj(content, WellKnownSkillsIndex.class);
         if (result == null) {
             throw invalid("Skill well-known index cannot be parsed.");
         }
-        return result;
+        WellKnownIndexVersion version = resolveVersion(result);
+        return new ResolvedWellKnownIndex(result, version, indexUrl, wellKnownBase(indexUrl));
     }
     
     private AiResourceImportSource requireSource(AiResourceImportContext context)
@@ -172,7 +236,7 @@ public class SkillWellKnownImportService implements AiResourceImportService {
     }
     
     private List<WellKnownSkillEntry> filterSkills(List<WellKnownSkillEntry> skills,
-        String query) {
+        WellKnownIndexVersion version, String query) {
         if (CollectionUtils.isEmpty(skills)) {
             return Collections.emptyList();
         }
@@ -180,7 +244,7 @@ public class SkillWellKnownImportService implements AiResourceImportService {
             StringUtils.isBlank(query) ? null : query.toLowerCase(Locale.ENGLISH);
         List<WellKnownSkillEntry> result = new ArrayList<>(skills.size());
         for (WellKnownSkillEntry each : skills) {
-            if (each == null || StringUtils.isBlank(each.getName())) {
+            if (!isSupportedEntry(each, version)) {
                 continue;
             }
             if (normalizedQuery == null || contains(each.getName(), normalizedQuery)
@@ -189,6 +253,17 @@ public class SkillWellKnownImportService implements AiResourceImportService {
             }
         }
         return result;
+    }
+    
+    private boolean isSupportedEntry(WellKnownSkillEntry entry, WellKnownIndexVersion version) {
+        if (entry == null || StringUtils.isBlank(entry.getName())) {
+            return false;
+        }
+        if (version == WellKnownIndexVersion.V0_1_0) {
+            return true;
+        }
+        String type = normalizeType(entry.getType());
+        return TYPE_SKILL_MD.equals(type) || TYPE_ARCHIVE.equals(type);
     }
     
     private boolean contains(String value, String normalizedQuery) {
@@ -211,13 +286,14 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         return limit == null || limit <= 0 ? DEFAULT_LIMIT : limit;
     }
     
-    private AiResourceImportCandidate toCandidate(WellKnownSkillEntry entry) {
+    private AiResourceImportCandidate toCandidate(WellKnownSkillEntry entry,
+        ResolvedWellKnownIndex resolvedIndex) {
         AiResourceImportCandidate result = new AiResourceImportCandidate();
         result.setResourceType(RESOURCE_TYPE_SKILL);
         result.setExternalId(entry.getName());
         result.setName(entry.getName());
         result.setDescription(entry.getDescription());
-        result.setMetadata(buildMetadata(entry));
+        result.setMetadata(buildMetadata(entry, resolvedIndex));
         return result;
     }
     
@@ -234,17 +310,117 @@ public class SkillWellKnownImportService implements AiResourceImportService {
             "Skill not found in well-known index: " + skillName);
     }
     
-    private byte[] fetchSkillZip(AiResourceImportContext context, WellKnownSkillEntry entry)
-        throws Exception {
-        String base = wellKnownBase(requireSource(context));
+    private byte[] fetchSkillZip(AiResourceImportContext context,
+        ResolvedWellKnownIndex resolvedIndex, WellKnownSkillEntry entry) throws Exception {
+        if (resolvedIndex.getVersion() == WellKnownIndexVersion.V0_2_0) {
+            return fetchVersion020SkillZip(context, resolvedIndex, entry);
+        }
+        return fetchVersion010SkillZip(context, resolvedIndex, entry);
+    }
+    
+    private byte[] fetchVersion010SkillZip(AiResourceImportContext context,
+        ResolvedWellKnownIndex resolvedIndex, WellKnownSkillEntry entry) throws Exception {
+        String base = resolvedIndex.getWellKnownBase();
         List<String> files = normalizeFiles(entry.getFiles());
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         try (ZipOutputStream zip = new ZipOutputStream(output, StandardCharsets.UTF_8)) {
             for (String each : files) {
                 SkillUtils.validatePathSafety(each);
                 byte[] bytes = fetchBytes(fileUrl(base, entry.getName(), each));
+                checkDownloadedSize(requireSource(context), bytes);
                 zip.putNextEntry(new ZipEntry(entry.getName() + "/" + each));
                 zip.write(bytes);
+                zip.closeEntry();
+            }
+        }
+        return output.toByteArray();
+    }
+    
+    private byte[] fetchVersion020SkillZip(AiResourceImportContext context,
+        ResolvedWellKnownIndex resolvedIndex, WellKnownSkillEntry entry) throws Exception {
+        String type = normalizeType(entry.getType());
+        FetchResult artifact = fetchVersion020Artifact(context, resolvedIndex, entry);
+        if (TYPE_SKILL_MD.equals(type)) {
+            return toSingleMarkdownSkillZip(entry.getName(), artifact.getBody());
+        }
+        if (TYPE_ARCHIVE.equals(type)) {
+            return toSkillZipFromArchive(artifact);
+        }
+        throw invalid("Unsupported Skill well-known distribution type: " + entry.getType());
+    }
+    
+    private FetchResult fetchVersion020Artifact(AiResourceImportContext context,
+        ResolvedWellKnownIndex resolvedIndex, WellKnownSkillEntry entry) throws Exception {
+        if (StringUtils.isBlank(entry.getUrl())) {
+            throw invalid("Skill well-known 0.2.0 entry url must not be empty.");
+        }
+        FetchResult result =
+            fetchUrl(resolveArtifactUrl(resolvedIndex.getIndexUrl(), entry.getUrl()));
+        if (!result.isSuccess()) {
+            throw new IllegalStateException(
+                "HTTP " + result.getStatusCode() + " when fetching " + result.getUrl());
+        }
+        checkDownloadedSize(requireSource(context), result.getBody());
+        verifySha256Digest(entry.getDigest(), result.getBody());
+        return result;
+    }
+    
+    private byte[] toSingleMarkdownSkillZip(String skillName, byte[] markdown) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(output, StandardCharsets.UTF_8)) {
+            zip.putNextEntry(new ZipEntry(skillName + "/" + MARKDOWN_FILE));
+            zip.write(markdown);
+            zip.closeEntry();
+        }
+        return output.toByteArray();
+    }
+    
+    private byte[] toSkillZipFromArchive(FetchResult artifact) throws Exception {
+        ArchiveFormat format = resolveArchiveFormat(artifact);
+        if (format == ArchiveFormat.ZIP) {
+            return artifact.getBody();
+        }
+        if (format == ArchiveFormat.TAR || format == ArchiveFormat.TAR_GZ) {
+            return convertTarToZip(artifact.getBody(), format == ArchiveFormat.TAR_GZ);
+        }
+        throw invalid("Unsupported Skill well-known archive format: " + artifact.getUrl());
+    }
+    
+    private byte[] convertTarToZip(byte[] bytes, boolean gzip) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Set<String> entryNames = new HashSet<>();
+        try (TarArchiveInputStream tar = new TarArchiveInputStream(
+            gzip ? new GzipCompressorInputStream(new ByteArrayInputStream(bytes))
+                : new ByteArrayInputStream(bytes));
+            ZipOutputStream zip = new ZipOutputStream(output, StandardCharsets.UTF_8)) {
+            TarArchiveEntry entry;
+            byte[] buffer = new byte[8192];
+            int entryCount = 0;
+            long totalSize = 0;
+            while ((entry = tar.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                String name = normalizeArchiveEntryName(entry.getName());
+                if (StringUtils.isBlank(name)) {
+                    continue;
+                }
+                SkillUtils.validatePathSafety(name);
+                if (!entryNames.add(name)) {
+                    continue;
+                }
+                if (++entryCount > DEFAULT_MAX_ARCHIVE_ENTRIES) {
+                    throw invalid("Skill well-known archive contains too many entries.");
+                }
+                zip.putNextEntry(new ZipEntry(name));
+                int n;
+                while ((n = tar.read(buffer)) != -1) {
+                    totalSize += n;
+                    if (totalSize > DEFAULT_MAX_ARCHIVE_UNCOMPRESSED_BYTES) {
+                        throw invalid("Skill well-known archive decompressed size exceeds limit.");
+                    }
+                    zip.write(buffer, 0, n);
+                }
                 zip.closeEntry();
             }
         }
@@ -278,23 +454,55 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         return externalId;
     }
     
-    private Map<String, String> buildMetadata(WellKnownSkillEntry entry) {
+    private Map<String, String> buildMetadata(WellKnownSkillEntry entry,
+        ResolvedWellKnownIndex resolvedIndex) {
         Map<String, String> metadata = new LinkedHashMap<>();
-        metadata.put(METADATA_FILE_COUNT, String.valueOf(normalizeFiles(entry.getFiles()).size()));
-        metadata.put(METADATA_SOURCE, WELL_KNOWN_AGENT_SKILLS);
+        metadata.put(METADATA_SCHEMA_VERSION, resolvedIndex.getVersion().getVersion());
+        metadata.put(METADATA_SOURCE, resolvedIndex.getWellKnownBase());
+        if (resolvedIndex.getVersion() == WellKnownIndexVersion.V0_1_0) {
+            metadata.put(METADATA_FILE_COUNT,
+                String.valueOf(normalizeFiles(entry.getFiles()).size()));
+            return metadata;
+        }
+        metadata.put(METADATA_DISTRIBUTION_TYPE, normalizeType(entry.getType()));
+        if (StringUtils.isNotBlank(entry.getUrl())) {
+            metadata.put(METADATA_ARTIFACT_URL,
+                resolveArtifactUrl(resolvedIndex.getIndexUrl(), entry.getUrl()));
+        }
+        if (StringUtils.isNotBlank(entry.getDigest())) {
+            metadata.put(METADATA_DIGEST, entry.getDigest());
+        }
         return metadata;
     }
     
-    private String indexUrl(AiResourceImportSource source) throws NacosException {
-        return wellKnownBase(source) + INDEX_JSON;
+    private List<String> indexUrls(AiResourceImportSource source) throws NacosException {
+        String endpoint = trimTrailingSlash(source.getEndpoint());
+        if (endpoint.endsWith(INDEX_JSON)) {
+            return Collections.singletonList(endpoint);
+        }
+        if (isWellKnownBase(endpoint)) {
+            return Collections.singletonList(endpoint + INDEX_JSON);
+        }
+        List<String> result = new ArrayList<>(2);
+        result.add(endpoint + WELL_KNOWN_AGENT_SKILLS + INDEX_JSON);
+        result.add(endpoint + WELL_KNOWN_SKILLS + INDEX_JSON);
+        return result;
     }
     
-    private String wellKnownBase(AiResourceImportSource source) throws NacosException {
-        String endpoint = trimTrailingSlash(source.getEndpoint());
-        if (endpoint.endsWith(WELL_KNOWN_AGENT_SKILLS) || endpoint.endsWith(WELL_KNOWN_SKILLS)) {
-            return endpoint;
+    private boolean isWellKnownBase(String endpoint) {
+        return endpoint.endsWith(WELL_KNOWN_AGENT_SKILLS)
+            || endpoint.endsWith(WELL_KNOWN_SKILLS);
+    }
+    
+    private String wellKnownBase(String indexUrl) {
+        String normalized = trimTrailingSlashUnchecked(indexUrl);
+        if (normalized.endsWith(INDEX_JSON)) {
+            return normalized.substring(0, normalized.length() - INDEX_JSON.length());
         }
-        return endpoint + WELL_KNOWN_AGENT_SKILLS;
+        if (normalized.endsWith(INDEX_JSON_FILE)) {
+            return normalized.substring(0, normalized.length() - INDEX_JSON_FILE.length() - 1);
+        }
+        return normalized;
     }
     
     private String fileUrl(String base, String skillName, String file) {
@@ -321,6 +529,10 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         if (StringUtils.isBlank(value)) {
             throw invalid("Skill well-known import source endpoint must not be empty.");
         }
+        return trimTrailingSlashUnchecked(value);
+    }
+    
+    private String trimTrailingSlashUnchecked(String value) {
         String result = value.trim();
         while (result.endsWith("/")) {
             result = result.substring(0, result.length() - 1);
@@ -328,12 +540,16 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         return result;
     }
     
-    private String fetchString(String url) throws Exception {
-        byte[] bytes = fetchBytes(url);
-        return new String(bytes, StandardCharsets.UTF_8);
+    private byte[] fetchBytes(String url) throws Exception {
+        FetchResult result = fetchUrl(url);
+        if (!result.isSuccess()) {
+            throw new IllegalStateException(
+                "HTTP " + result.getStatusCode() + " when fetching " + url);
+        }
+        return result.getBody();
     }
     
-    private byte[] fetchBytes(String url) throws Exception {
+    private FetchResult fetchUrl(String url) throws Exception {
         HttpRequest request = HttpRequest.newBuilder(URI.create(url))
             .timeout(Duration.ofSeconds(DEFAULT_READ_TIMEOUT_SECONDS))
             .header("Accept", "*/*")
@@ -341,11 +557,89 @@ public class SkillWellKnownImportService implements AiResourceImportService {
             .build();
         HttpResponse<byte[]> response = httpClient.send(request,
             HttpResponse.BodyHandlers.ofByteArray());
-        int code = response.statusCode();
-        if (code < 200 || code >= 300) {
-            throw new IllegalStateException("HTTP " + code + " when fetching " + url);
+        return new FetchResult(url, response.statusCode(), response.headers(), response.body());
+    }
+    
+    private WellKnownIndexVersion resolveVersion(WellKnownSkillsIndex index)
+        throws NacosException {
+        String schema = index.getSchema();
+        if (StringUtils.isBlank(schema) || StringUtils.equals(schema, SCHEMA_0_1)
+            || schema.contains("/0.1.0/")) {
+            return WellKnownIndexVersion.V0_1_0;
         }
-        return response.body();
+        if (StringUtils.equals(schema, SCHEMA_0_2) || schema.contains("/0.2.0/")) {
+            return WellKnownIndexVersion.V0_2_0;
+        }
+        throw invalid("Unsupported Skill well-known schema: " + schema);
+    }
+    
+    private String normalizeType(String type) {
+        return StringUtils.isBlank(type) ? "" : type.trim().toLowerCase(Locale.ENGLISH);
+    }
+    
+    private String resolveArtifactUrl(String indexUrl, String artifactUrl) {
+        return URI.create(indexUrl).resolve(artifactUrl).toString();
+    }
+    
+    private void checkDownloadedSize(AiResourceImportSource source, byte[] bytes)
+        throws NacosException {
+        if (source.getMaxArtifactSize() > 0 && bytes != null
+            && bytes.length > source.getMaxArtifactSize()) {
+            throw invalid("Skill well-known artifact size exceeds source limit.");
+        }
+    }
+    
+    private void verifySha256Digest(String digest, byte[] bytes) throws Exception {
+        if (StringUtils.isBlank(digest)) {
+            throw invalid("Skill well-known 0.2.0 entry digest must not be empty.");
+        }
+        String normalizedDigest = digest.trim().toLowerCase(Locale.ENGLISH);
+        if (!normalizedDigest.startsWith(DIGEST_SHA256_PREFIX)) {
+            throw invalid("Skill well-known digest must use sha256.");
+        }
+        String expected = normalizedDigest.substring(DIGEST_SHA256_PREFIX.length());
+        String actual = sha256Hex(bytes);
+        if (!StringUtils.equals(expected, actual)) {
+            throw invalid("Skill well-known artifact digest mismatch.");
+        }
+    }
+    
+    private String sha256Hex(byte[] bytes) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(bytes);
+        StringBuilder result = new StringBuilder(hash.length * 2);
+        for (byte each : hash) {
+            result.append(String.format("%02x", each & 0xff));
+        }
+        return result.toString();
+    }
+    
+    private ArchiveFormat resolveArchiveFormat(FetchResult artifact) throws NacosException {
+        String contentType = artifact.getContentType().toLowerCase(Locale.ENGLISH);
+        String url = artifact.getUrl().toLowerCase(Locale.ENGLISH);
+        if (contentType.contains("gzip") || url.endsWith(TAR_GZ_SUFFIX)
+            || url.endsWith(TGZ_SUFFIX)) {
+            return ArchiveFormat.TAR_GZ;
+        }
+        if (contentType.contains("zip") || url.endsWith(ZIP_SUFFIX)) {
+            return ArchiveFormat.ZIP;
+        }
+        if (contentType.contains("tar") || url.endsWith(TAR_SUFFIX)) {
+            return ArchiveFormat.TAR;
+        }
+        throw invalid("Unsupported Skill well-known archive content type: "
+            + artifact.getContentType());
+    }
+    
+    private String normalizeArchiveEntryName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return null;
+        }
+        String result = name.trim().replace('\\', '/');
+        while (result.startsWith("./")) {
+            result = result.substring(2);
+        }
+        return result;
     }
     
     private NacosException invalid(String message) {
@@ -358,9 +652,119 @@ public class SkillWellKnownImportService implements AiResourceImportService {
             cause, message);
     }
     
+    private enum WellKnownIndexVersion {
+        
+        V0_1_0("0.1.0"),
+        
+        V0_2_0("0.2.0");
+        
+        private final String version;
+        
+        WellKnownIndexVersion(String version) {
+            this.version = version;
+        }
+        
+        public String getVersion() {
+            return version;
+        }
+    }
+    
+    private enum ArchiveFormat {
+        
+        ZIP,
+        
+        TAR,
+        
+        TAR_GZ
+    }
+    
+    private static class ResolvedWellKnownIndex {
+        
+        private final WellKnownSkillsIndex index;
+        
+        private final WellKnownIndexVersion version;
+        
+        private final String indexUrl;
+        
+        private final String wellKnownBase;
+        
+        ResolvedWellKnownIndex(WellKnownSkillsIndex index, WellKnownIndexVersion version,
+            String indexUrl, String wellKnownBase) {
+            this.index = index;
+            this.version = version;
+            this.indexUrl = indexUrl;
+            this.wellKnownBase = wellKnownBase;
+        }
+        
+        public WellKnownSkillsIndex getIndex() {
+            return index;
+        }
+        
+        public WellKnownIndexVersion getVersion() {
+            return version;
+        }
+        
+        public String getIndexUrl() {
+            return indexUrl;
+        }
+        
+        public String getWellKnownBase() {
+            return wellKnownBase;
+        }
+    }
+    
+    private static class FetchResult {
+        
+        private final String url;
+        
+        private final int statusCode;
+        
+        private final HttpHeaders headers;
+        
+        private final byte[] body;
+        
+        FetchResult(String url, int statusCode, HttpHeaders headers, byte[] body) {
+            this.url = url;
+            this.statusCode = statusCode;
+            this.headers = headers;
+            this.body = body == null ? new byte[0] : body;
+        }
+        
+        public boolean isSuccess() {
+            return statusCode >= 200 && statusCode < 300;
+        }
+        
+        public String getUrl() {
+            return url;
+        }
+        
+        public int getStatusCode() {
+            return statusCode;
+        }
+        
+        public byte[] getBody() {
+            return body;
+        }
+        
+        public String getContentType() {
+            return headers.firstValue("Content-Type").orElse("");
+        }
+    }
+    
     static class WellKnownSkillsIndex {
         
+        @JsonProperty("$schema")
+        private String schema;
+        
         private List<WellKnownSkillEntry> skills;
+        
+        public String getSchema() {
+            return schema;
+        }
+        
+        public void setSchema(String schema) {
+            this.schema = schema;
+        }
         
         public List<WellKnownSkillEntry> getSkills() {
             return skills;
@@ -378,6 +782,12 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         private String description;
         
         private List<String> files;
+        
+        private String type;
+        
+        private String url;
+        
+        private String digest;
         
         public String getName() {
             return name;
@@ -401,6 +811,30 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         
         public void setFiles(List<String> files) {
             this.files = files;
+        }
+        
+        public String getType() {
+            return type;
+        }
+        
+        public void setType(String type) {
+            this.type = type;
+        }
+        
+        public String getUrl() {
+            return url;
+        }
+        
+        public void setUrl(String url) {
+            this.url = url;
+        }
+        
+        public String getDigest() {
+            return digest;
+        }
+        
+        public void setDigest(String digest) {
+            this.digest = digest;
         }
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourcePersistService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourcePersistService.java
@@ -105,6 +105,14 @@ public interface AiResourcePersistService {
     boolean updateMetaCas(String namespaceId, String name, String type, long expectedMetaVersion,
         AiResource newValue);
     
+    /**
+     * Update resource source with optimistic lock on meta_version.
+     *
+     * @return true if updated successfully (affectedRows == 1)
+     */
+    boolean updateSourceCas(String namespaceId, String name, String type, long expectedMetaVersion,
+        String source);
+    
     int delete(String namespaceId, String name, String type);
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourcePersistServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourcePersistServiceImpl.java
@@ -164,6 +164,22 @@ public class AiResourcePersistServiceImpl implements AiResourcePersistService {
     }
     
     @Override
+    public boolean updateSourceCas(String namespaceId, String name, String type,
+        long expectedMetaVersion,
+        String source) {
+        AiResourceMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+            TableConstant.AI_RESOURCE);
+        
+        String sql = "UPDATE ai_resource SET c_from=?, meta_version=meta_version+1, "
+            + "gmt_modified=" + mapper.getFunction("NOW()")
+            + " WHERE namespace_id=? AND name=? AND type=? AND meta_version=?";
+        
+        int rows = jt.update(sql, source, normalizeNamespaceId(namespaceId), name, type,
+            expectedMetaVersion);
+        return rows == 1;
+    }
+    
+    @Override
     public int delete(String namespaceId, String name, String type) {
         AiResourceMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
             TableConstant.AI_RESOURCE);

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/EmbeddedAiResourcePersistServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/EmbeddedAiResourcePersistServiceImpl.java
@@ -160,6 +160,29 @@ public class EmbeddedAiResourcePersistServiceImpl implements AiResourcePersistSe
     }
     
     @Override
+    public boolean updateSourceCas(String namespaceId, String name, String type,
+        long expectedMetaVersion,
+        String source) {
+        AiResourceMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
+            TableConstant.AI_RESOURCE);
+        
+        String sql = "UPDATE ai_resource SET c_from=?, meta_version=meta_version+1, "
+            + "gmt_modified=" + mapper.getFunction("NOW()")
+            + " WHERE namespace_id=? AND name=? AND type=? AND meta_version=?";
+        
+        Object[] args = new Object[] {source, normalizeNamespaceId(namespaceId), name, type,
+            expectedMetaVersion};
+        
+        EmbeddedStorageContextHolder.addSqlContext(sql, args);
+        Boolean success = databaseOperate.blockUpdate();
+        if (success == null || !success) {
+            return false;
+        }
+        AiResource updated = find(namespaceId, name, type);
+        return updated != null && updated.getMetaVersion() == expectedMetaVersion + 1;
+    }
+    
+    @Override
     public int delete(String namespaceId, String name, String type) {
         AiResourceMapper mapper = mapperManager.findMapper(dataSourceService.getDataSourceType(),
             TableConstant.AI_RESOURCE);

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/resource/AiResourceManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/resource/AiResourceManager.java
@@ -276,6 +276,28 @@ public class AiResourceManager {
             });
     }
     
+    /**
+     * Best-effort CAS-update source field for an imported resource meta.
+     */
+    public void syncImportedSource(String namespaceId, AiResource meta, String source) {
+        if (meta == null || meta.getMetaVersion() == null || StringUtils.isBlank(source)) {
+            return;
+        }
+        long expected = meta.getMetaVersion();
+        for (int i = 0; i < AiResourceConstants.MAX_WORKING_VERSION_RETRY; i++) {
+            if (aiResourcePersistService.updateSourceCas(namespaceId, meta.getName(),
+                meta.getType(), expected, source)) {
+                return;
+            }
+            AiResource latest = aiResourcePersistService.find(namespaceId, meta.getName(),
+                meta.getType());
+            if (latest == null || latest.getMetaVersion() == null) {
+                return;
+            }
+            expected = latest.getMetaVersion();
+        }
+    }
+    
     // ---- 2.2 Query / validation helpers ----
     
     /**

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/operator/SkillResourceOperatorTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/operator/SkillResourceOperatorTest.java
@@ -36,6 +36,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -114,6 +116,25 @@ class SkillResourceOperatorTest {
         assertEquals("demo-skill", result.getResourceName());
         verify(skillOperationService).uploadSkillFromZip(eq("public"), any(), eq(true),
             eq("1.2.3"));
+    }
+    
+    @Test
+    void testImportSyncsSourceMetadata() throws Exception {
+        AiResource meta = metaWithEditingVersion();
+        when(skillOperationService.uploadSkillFromZip(eq("public"), any(), eq(true),
+            eq("1.2.3"))).thenReturn("demo-skill");
+        when(resourceManager.findMeta("public", "demo-skill", "skill")).thenReturn(meta);
+        AiResourceImportArtifact artifact = artifact();
+        Map<String, String> metadata = new HashMap<>(2);
+        metadata.put("source", "https://developers.cloudflare.com/.well-known/agent-skills");
+        metadata.put("artifactUrl",
+            "https://developers.cloudflare.com/.well-known/agent-skills/cloudflare.tar.gz");
+        artifact.setSourceMetadata(metadata);
+        
+        operator.importResource("public", artifact, true);
+        
+        verify(resourceManager).syncImportedSource("public", meta,
+            "https://developers.cloudflare.com/.well-known/agent-skills/cloudflare.tar.gz");
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/skill/SkillWellKnownImportServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/skill/SkillWellKnownImportServiceTest.java
@@ -31,14 +31,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import javax.net.ssl.SSLSession;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -55,6 +63,15 @@ import static org.mockito.Mockito.lenient;
 class SkillWellKnownImportServiceTest {
     
     private static final String ENDPOINT = "https://registry.example.com/registry/public";
+    
+    private static final String LEGACY_ENDPOINT = "https://registry.example.com/legacy";
+    
+    private static final String VERSION_020_ENDPOINT = "https://registry.example.com/v2";
+    
+    private static final String BAD_VERSION_020_ENDPOINT = "https://registry.example.com/bad-v2";
+    
+    private static final String SCHEMA_0_2 =
+        "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
     
     @Mock
     private HttpClient httpClient;
@@ -81,6 +98,7 @@ class SkillWellKnownImportServiceTest {
         assertEquals("demo-skill", result.getItems().get(0).getExternalId());
         assertEquals(SkillWellKnownImportService.RESOURCE_TYPE_SKILL,
             result.getItems().get(0).getResourceType());
+        assertEquals("0.1.0", result.getItems().get(0).getMetadata().get("schemaVersion"));
         assertEquals("2", result.getItems().get(0).getMetadata().get("fileCount"));
         assertFalse(result.isHasMore());
     }
@@ -97,6 +115,51 @@ class SkillWellKnownImportServiceTest {
         assertEquals("demo-skill", skill.getName());
         assertEquals("Demo skill", skill.getDescription());
         assertEquals(1, skill.getResource().size());
+    }
+    
+    @Test
+    void testSearchFallsBackToLegacyWellKnownSkillsPath() throws Exception {
+        AiResourceImportContext context = newContext(LEGACY_ENDPOINT);
+        
+        AiResourceImportCandidatePage result = importService.search(context);
+        
+        assertEquals(1, result.getItems().size());
+        assertEquals("legacy-skill", result.getItems().get(0).getExternalId());
+        assertEquals("https://registry.example.com/legacy/.well-known/skills",
+            result.getItems().get(0).getMetadata().get("source"));
+    }
+    
+    @Test
+    void testFetchVersion020SkillMdReturnsSkillZipArtifact() throws Exception {
+        AiResourceImportArtifact result = importService.fetch(newContext(VERSION_020_ENDPOINT),
+            item("md-skill"));
+        
+        assertEquals(SkillWellKnownImportService.RESOURCE_TYPE_SKILL, result.getResourceType());
+        assertEquals(AiResourceImportPayloadKind.SKILL_ZIP, result.getPayloadKind());
+        assertEquals("md-skill", result.getName());
+        assertEquals("skill-md", result.getSourceMetadata().get("distributionType"));
+        Skill skill = SkillZipParser.parseSkillFromZip(result.getPayload(), "public");
+        assertEquals("md-skill", skill.getName());
+        assertEquals("Markdown skill", skill.getDescription());
+    }
+    
+    @Test
+    void testFetchVersion020TarGzArchiveReturnsSkillZipArtifact() throws Exception {
+        AiResourceImportArtifact result = importService.fetch(newContext(VERSION_020_ENDPOINT),
+            item("archive-skill"));
+        
+        assertEquals("archive-skill", result.getName());
+        assertEquals("archive", result.getSourceMetadata().get("distributionType"));
+        Skill skill = SkillZipParser.parseSkillFromZip(result.getPayload(), "public");
+        assertEquals("archive-skill", skill.getName());
+        assertEquals("Archive skill", skill.getDescription());
+        assertEquals(1, skill.getResource().size());
+    }
+    
+    @Test
+    void testFetchVersion020RejectsDigestMismatch() {
+        assertThrows(NacosException.class,
+            () -> importService.fetch(newContext(BAD_VERSION_020_ENDPOINT), item("md-skill")));
     }
     
     @Test
@@ -121,10 +184,15 @@ class SkillWellKnownImportServiceTest {
     }
     
     private AiResourceImportContext newContext() {
+        return newContext(ENDPOINT);
+    }
+    
+    private AiResourceImportContext newContext(String endpoint) {
         AiResourceImportContext context = new AiResourceImportContext();
         context.setNamespaceId("public");
         AiResourceImportSource source = new AiResourceImportSource();
-        source.setEndpoint(ENDPOINT);
+        source.setEndpoint(endpoint);
+        source.setMaxArtifactSize(10L * 1024L * 1024L);
         context.setSource(source);
         return context;
     }
@@ -145,13 +213,53 @@ class SkillWellKnownImportServiceTest {
             + "]}";
     }
     
+    private String legacyIndexJson() {
+        return "{\"skills\":["
+            + "{\"name\":\"legacy-skill\",\"description\":\"Legacy skill\","
+            + "\"files\":[\"SKILL.md\"]}"
+            + "]}";
+    }
+    
+    private String version020IndexJson() throws Exception {
+        byte[] markdown = skillMarkdown("md-skill").getBytes(StandardCharsets.UTF_8);
+        byte[] archive = tarGzSkillArchive();
+        return "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
+            + "{\"name\":\"md-skill\",\"type\":\"skill-md\","
+            + "\"description\":\"Markdown skill\","
+            + "\"url\":\"md-skill/SKILL.md\","
+            + "\"digest\":\"sha256:" + sha256Hex(markdown) + "\"},"
+            + "{\"name\":\"archive-skill\",\"type\":\"archive\","
+            + "\"description\":\"Archive skill\","
+            + "\"url\":\"archive-skill.tar.gz\","
+            + "\"digest\":\"sha256:" + sha256Hex(archive) + "\"}"
+            + "]}";
+    }
+    
+    private String badVersion020IndexJson() {
+        return "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
+            + "{\"name\":\"md-skill\",\"type\":\"skill-md\","
+            + "\"description\":\"Markdown skill\","
+            + "\"url\":\"md-skill/SKILL.md\","
+            + "\"digest\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\"}"
+            + "]}";
+    }
+    
     private String skillMarkdown(String name) {
-        String description = "demo-skill".equals(name) ? "Demo skill" : "Other skill";
+        String description = "Demo skill";
+        if ("other-skill".equals(name)) {
+            description = "Other skill";
+        } else if ("legacy-skill".equals(name)) {
+            description = "Legacy skill";
+        } else if ("md-skill".equals(name)) {
+            description = "Markdown skill";
+        } else if ("archive-skill".equals(name)) {
+            description = "Archive skill";
+        }
         return "---\nname: " + name + "\ndescription: " + description
             + "\nversion: 1.2.3\n---\n\nUse this skill.";
     }
     
-    private HttpResponse<byte[]> responseFor(HttpRequest request) {
+    private HttpResponse<byte[]> responseFor(HttpRequest request) throws Exception {
         String path = request.uri().getPath();
         if ("/registry/public/.well-known/agent-skills/index.json".equals(path)) {
             return response(200, indexJson());
@@ -166,11 +274,40 @@ class SkillWellKnownImportServiceTest {
         if ("/registry/public/.well-known/agent-skills/other-skill/SKILL.md".equals(path)) {
             return response(200, skillMarkdown("other-skill"));
         }
+        if ("/legacy/.well-known/agent-skills/index.json".equals(path)) {
+            return response(404, "");
+        }
+        if ("/legacy/.well-known/skills/index.json".equals(path)) {
+            return response(200, legacyIndexJson());
+        }
+        if ("/legacy/.well-known/skills/legacy-skill/SKILL.md".equals(path)) {
+            return response(200, skillMarkdown("legacy-skill"));
+        }
+        if ("/v2/.well-known/agent-skills/index.json".equals(path)) {
+            return response(200, version020IndexJson());
+        }
+        if ("/v2/.well-known/agent-skills/md-skill/SKILL.md".equals(path)) {
+            return response(200, skillMarkdown("md-skill"));
+        }
+        if ("/v2/.well-known/agent-skills/archive-skill.tar.gz".equals(path)) {
+            return response(200, tarGzSkillArchive(), "application/gzip");
+        }
+        if ("/bad-v2/.well-known/agent-skills/index.json".equals(path)) {
+            return response(200, badVersion020IndexJson());
+        }
+        if ("/bad-v2/.well-known/agent-skills/md-skill/SKILL.md".equals(path)) {
+            return response(200, skillMarkdown("md-skill"));
+        }
         return response(404, "");
     }
     
     private HttpResponse<byte[]> response(int status, String body) {
-        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        return response(status, body.getBytes(StandardCharsets.UTF_8), "application/json");
+    }
+    
+    private HttpResponse<byte[]> response(int status, byte[] bytes, String contentType) {
+        Map<String, java.util.List<String>> headers = new HashMap<>(1);
+        headers.put("Content-Type", Collections.singletonList(contentType));
         return new HttpResponse<>() {
             
             @Override
@@ -190,7 +327,7 @@ class SkillWellKnownImportServiceTest {
             
             @Override
             public HttpHeaders headers() {
-                return HttpHeaders.of(Collections.emptyMap(), (key, value) -> true);
+                return HttpHeaders.of(headers, (key, value) -> true);
             }
             
             @Override
@@ -213,5 +350,38 @@ class SkillWellKnownImportServiceTest {
                 return HttpClient.Version.HTTP_1_1;
             }
         };
+    }
+    
+    private byte[] tarGzSkillArchive() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (GzipCompressorOutputStream gzip = new GzipCompressorOutputStream(output);
+            TarArchiveOutputStream tar = new TarArchiveOutputStream(gzip)) {
+            addTarEntry(tar, "archive-skill/SKILL.md",
+                skillMarkdown("archive-skill").getBytes(StandardCharsets.UTF_8));
+            addTarEntry(tar, "archive-skill/docs/guide.md",
+                "# Guide".getBytes(StandardCharsets.UTF_8));
+        }
+        return output.toByteArray();
+    }
+    
+    private void addTarEntry(TarArchiveOutputStream tar, String name, byte[] bytes)
+        throws Exception {
+        TarArchiveEntry entry = new TarArchiveEntry(name);
+        entry.setSize(bytes.length);
+        tar.putArchiveEntry(entry);
+        try (ByteArrayInputStream input = new ByteArrayInputStream(bytes)) {
+            input.transferTo(tar);
+        }
+        tar.closeArchiveEntry();
+    }
+    
+    private String sha256Hex(byte[] bytes) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(bytes);
+        StringBuilder result = new StringBuilder(hash.length * 2);
+        for (byte each : hash) {
+            result.append(String.format("%02x", each & 0xff));
+        }
+        return result.toString();
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecClientVisibilityTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecClientVisibilityTest.java
@@ -331,6 +331,13 @@ class AgentSpecClientVisibilityTest {
         }
         
         @Override
+        public boolean updateSourceCas(String namespaceId, String name, String type,
+            long expectedMetaVersion,
+            String source) {
+            return false;
+        }
+        
+        @Override
         public int delete(String namespaceId, String name, String type) {
             store.removeIf(r -> namespaceId.equals(r.getNamespaceId()) && name.equals(r.getName())
                 && type.equals(

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecDeletionTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecDeletionTest.java
@@ -359,6 +359,13 @@ class AgentSpecDeletionTest {
         }
         
         @Override
+        public boolean updateSourceCas(String namespaceId, String name, String type,
+            long expectedMetaVersion,
+            String source) {
+            return false;
+        }
+        
+        @Override
         public int delete(String namespaceId, String name, String type) {
             store.removeIf(r -> namespaceId.equals(r.getNamespaceId()) && name.equals(r.getName())
                 && type.equals(

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecTypeIsolationTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecTypeIsolationTest.java
@@ -333,6 +333,13 @@ class AgentSpecTypeIsolationTest {
         }
         
         @Override
+        public boolean updateSourceCas(String namespaceId, String name, String type,
+            long expectedMetaVersion,
+            String source) {
+            return false;
+        }
+        
+        @Override
         public int delete(String namespaceId, String name, String type) {
             store.removeIf(r -> namespaceId.equals(r.getNamespaceId()) && name.equals(r.getName())
                 && type.equals(

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/resource/AiResourceManagerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/resource/AiResourceManagerTest.java
@@ -903,6 +903,49 @@ class AiResourceManagerTest {
             .updateMetaCas(anyString(), anyString(), anyString(), anyLong(), any());
     }
     
+    // ---- syncImportedSource ----
+    
+    @Test
+    void syncImportedSourceShouldDoNothingForBlankSource() {
+        manager.syncImportedSource(NAMESPACE_ID, buildMeta("res"), "");
+        
+        verify(aiResourcePersistService, never()).updateSourceCas(anyString(), anyString(),
+            anyString(), anyLong(), anyString());
+    }
+    
+    @Test
+    void syncImportedSourceShouldUpdateSource() {
+        AiResource meta = buildMeta("res");
+        String source =
+            "https://developers.cloudflare.com/.well-known/agent-skills/cloudflare.tar.gz";
+        when(aiResourcePersistService.updateSourceCas(NAMESPACE_ID, "res", RESOURCE_TYPE, 1L,
+            source)).thenReturn(true);
+        
+        manager.syncImportedSource(NAMESPACE_ID, meta, source);
+        
+        verify(aiResourcePersistService).updateSourceCas(NAMESPACE_ID, "res", RESOURCE_TYPE, 1L,
+            source);
+    }
+    
+    @Test
+    void syncImportedSourceShouldRetryOnCasConflict() {
+        AiResource meta = buildMeta("res");
+        AiResource latestMeta = buildMeta("res");
+        latestMeta.setMetaVersion(2L);
+        String source = "https://example.com/skill.tar.gz";
+        when(aiResourcePersistService.updateSourceCas(NAMESPACE_ID, "res", RESOURCE_TYPE, 1L,
+            source)).thenReturn(false);
+        when(aiResourcePersistService.find(NAMESPACE_ID, "res", RESOURCE_TYPE))
+            .thenReturn(latestMeta);
+        when(aiResourcePersistService.updateSourceCas(NAMESPACE_ID, "res", RESOURCE_TYPE, 2L,
+            source)).thenReturn(true);
+        
+        manager.syncImportedSource(NAMESPACE_ID, meta, source);
+        
+        verify(aiResourcePersistService).updateSourceCas(NAMESPACE_ID, "res", RESOURCE_TYPE, 2L,
+            source);
+    }
+    
     // ---- ensureReadableOrNotFound ----
     
     @Test

--- a/specs/en/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/en/plugin/ai-resource-import-plugin-spec.md
@@ -164,11 +164,19 @@ endpoint. Search returns MCP Server summaries only, and fetch returns an
 
 The `skills-well-known` importer connects to an operator-configured Skill
 marketplace or registry root. If the source endpoint is not already a
-well-known path, the importer should append `/.well-known/agent-skills`. If the
+well-known path, the importer should first try `/.well-known/agent-skills` and
+then fall back to `/.well-known/skills` for v0.1-compatible sources. If the
 endpoint already ends with `/.well-known/agent-skills` or `/.well-known/skills`,
 the importer should use that path directly.
 
-A Skill well-known source should expose `index.json` with this minimum shape:
+The importer must support both Skill well-known discovery versions:
+
+- v0.1.0 or legacy sources, identified by an absent `$schema` field or the
+  `https://schemas.agentskills.io/discovery/0.1.0/schema.json` schema URI;
+- v0.2.0 sources, identified by the
+  `https://schemas.agentskills.io/discovery/0.2.0/schema.json` schema URI.
+
+For v0.1.0 or legacy sources, `index.json` uses a file list for each Skill:
 
 ```json
 {
@@ -190,6 +198,40 @@ downloads the selected Skill files from `{wellKnownBase}/{skillName}/{file}`,
 validates path safety, assembles a standard Skill ZIP artifact, and passes it to
 the Skill resource operator so it is applied through the normal Skill upload or
 draft lifecycle.
+
+For v0.2.0 sources, `index.json` uses artifact references:
+
+```json
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "demo-skill",
+      "type": "skill-md",
+      "description": "Demo skill",
+      "url": "/.well-known/agent-skills/demo-skill/SKILL.md",
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    },
+    {
+      "name": "archive-skill",
+      "type": "archive",
+      "description": "Demo archive skill",
+      "url": "/.well-known/agent-skills/archive-skill.tar.gz",
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  ]
+}
+```
+
+Search must not download artifact content. It may expose only `name`,
+`description`, `type`, `url`, `digest`, schema version, and other non-secret
+metadata needed by the console. Fetch must resolve `url` against the index URL,
+download the selected artifact server-side, verify the `sha256` digest, and
+convert the artifact into the standard Nacos Skill ZIP boundary. The built-in
+importer must support `skill-md` single-file artifacts and `archive` artifacts
+packaged as ZIP, TAR, TAR.GZ, or TGZ. Archive extraction must validate path
+safety, limit file count and decompressed size, and reject unsupported archive
+formats before the artifact is handed to the Skill resource operator.
 
 ## API Flow
 

--- a/specs/en/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/en/plugin/ai-resource-import-plugin-spec.md
@@ -154,7 +154,10 @@ records. When MCP later migrates to `ai_resource`, only the MCP operator should
 change. Import plugins and unified import APIs must remain compatible.
 
 For Skill, the operator should preserve the Skill package boundary and write
-through the Skill upload or draft lifecycle APIs.
+through the Skill upload or draft lifecycle APIs. After a successful import, if
+the artifact contains `sourceMetadata.artifactUrl`, the Skill operator should
+record that URL as the imported resource source (`ai_resource.c_from`). If
+`artifactUrl` is absent, it should fall back to `sourceMetadata.source`.
 
 ## Built-in Importers
 

--- a/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
@@ -137,7 +137,9 @@ Resource Operator 位于 AI Registry 领域内，不属于导入插件。它们�
 当前仍由 Config 记录承载。未来 MCP 迁移到 `ai_resource` 后，只应修改 MCP Operator。导入插件和
 统一导入 API 应保持兼容。
 
-对 Skill 而言，Operator 应保持 Skill 包边界，并通过 Skill upload 或 draft 生命周期 API 写入。
+对 Skill 而言，Operator 应保持 Skill 包边界，并通过 Skill upload 或 draft 生命周期 API 写入。导入成功后，
+如果 artifact 包含 `sourceMetadata.artifactUrl`，Skill Operator 应将该 URL 记录为导入后资源的来源
+字段（`ai_resource.c_from`）；如果没有 `artifactUrl`，则回退使用 `sourceMetadata.source`。
 
 ## 内置 Importer
 

--- a/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
@@ -145,10 +145,18 @@ Resource Operator 位于 AI Registry 领域内，不属于导入插件。它们�
 摘要，fetch 阶段返回可由 MCP Resource Operator 写入的 `MCP_DETAIL` artifact。
 
 `skills-well-known` importer 对接运维配置的 Skill 市场或 registry root。若 source endpoint
-不是 well-known 路径，importer 应在 endpoint 后追加 `/.well-known/agent-skills`；若 endpoint
-已以 `/.well-known/agent-skills` 或 `/.well-known/skills` 结尾，则直接使用该路径。
+不是 well-known 路径，importer 应先尝试 `/.well-known/agent-skills`，再 fallback 到
+`/.well-known/skills` 以兼容 v0.1 来源；若 endpoint 已以 `/.well-known/agent-skills` 或
+`/.well-known/skills` 结尾，则直接使用该路径。
 
-Skill well-known 来源应提供 `index.json`，其最小结构为：
+Importer 必须同时支持两类 Skill well-known discovery 版本：
+
+- v0.1.0 或 legacy 来源，通过缺失 `$schema` 字段，或
+  `https://schemas.agentskills.io/discovery/0.1.0/schema.json` schema URI 识别；
+- v0.2.0 来源，通过
+  `https://schemas.agentskills.io/discovery/0.2.0/schema.json` schema URI 识别。
+
+v0.1.0 或 legacy 来源的 `index.json` 使用每个 Skill 的文件列表：
 
 ```json
 {
@@ -168,6 +176,37 @@ Skill well-known 来源应提供 `index.json`，其最小结构为：
 Search 阶段只能返回 `name`、`description` 和非 secret metadata。Fetch 阶段按
 `{wellKnownBase}/{skillName}/{file}` 拉取被选择 Skill 的文件，校验文件路径安全性，组装为标准
 Skill ZIP artifact，并交给 Skill Resource Operator 通过普通 Skill upload 或 draft 生命周期写入。
+
+v0.2.0 来源的 `index.json` 使用 artifact 引用：
+
+```json
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "demo-skill",
+      "type": "skill-md",
+      "description": "Demo skill",
+      "url": "/.well-known/agent-skills/demo-skill/SKILL.md",
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    },
+    {
+      "name": "archive-skill",
+      "type": "archive",
+      "description": "Demo archive skill",
+      "url": "/.well-known/agent-skills/archive-skill.tar.gz",
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  ]
+}
+```
+
+Search 阶段不得下载 artifact 内容，只能暴露 `name`、`description`、`type`、`url`、`digest`、
+schema version 和其他 Console 所需的非 secret metadata。Fetch 阶段必须以 index URL 为基准解析
+`url`，在服务端下载被选择的 artifact，校验 `sha256` digest，并将 artifact 转换为标准 Nacos
+Skill ZIP 边界。内置 importer 必须支持 `skill-md` 单文件 artifact，以及 ZIP、TAR、TAR.GZ、
+TGZ 形式的 `archive` artifact。Archive 解包必须校验路径安全性，限制文件数量和解压后总大小，
+并在交给 Skill Resource Operator 前拒绝不支持的 archive 格式。
 
 ## API 流程
 


### PR DESCRIPTION
## Summary
- support skills-well-known import from v0.1/legacy and v0.2 discovery indexes
- add v0.2 skill-md/archive fetch with URL resolution, sha256 verification, and ZIP/TAR/TAR.GZ/TGZ conversion into Skill ZIP artifacts
- update import plugin specs and add tests for fallback, skill-md, archive, and digest mismatch

## Tests
- mvn -pl ai -Dtest=SkillWellKnownImportServiceTest test
- mvn -pl ai -DskipTests compile apache-rat:check checkstyle:check spotbugs:check spotless:check