### PR TITLE
Improve plugin module unit test coverage

### DIFF
--- a/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/api/LoginIdentityContextTest.java
+++ b/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/api/LoginIdentityContextTest.java
@@ -40,9 +40,11 @@ class LoginIdentityContextTest {
     @Test
     void testSetParameter() {
         assertNull(loginIdentityContext.getParameter(TEST));
+        assertEquals("default", loginIdentityContext.getParameter(TEST, "default"));
         assertTrue(loginIdentityContext.getAllKey().isEmpty());
         loginIdentityContext.setParameter(TEST, TEST);
         assertEquals(TEST, loginIdentityContext.getParameter(TEST));
+        assertEquals(TEST, loginIdentityContext.getParameter(TEST, "default"));
         assertEquals(1, loginIdentityContext.getAllKey().size());
     }
     

--- a/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/api/RequestResourceTest.java
+++ b/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/api/RequestResourceTest.java
@@ -47,4 +47,21 @@ class RequestResourceTest {
         assertEquals("G", actual.getGroup());
         assertEquals("dataId", actual.getResource());
     }
+    
+    @Test
+    void testBuildLockAndAiRequestResource() {
+        RequestResource lock = RequestResource.lockBuilder().setNamespace("lockNs")
+            .setGroup("lockGroup").setResource("lock").build();
+        RequestResource ai = RequestResource.aiBuilder().setNamespace("aiNs").setGroup("aiGroup")
+            .setResource("skill").build();
+        
+        assertEquals(SignType.LOCK, lock.getType());
+        assertEquals("lockNs", lock.getNamespace());
+        assertEquals("lockGroup", lock.getGroup());
+        assertEquals("lock", lock.getResource());
+        assertEquals(SignType.AI, ai.getType());
+        assertEquals("aiNs", ai.getNamespace());
+        assertEquals("aiGroup", ai.getGroup());
+        assertEquals("skill", ai.getResource());
+    }
 }

--- a/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/spi/client/ClientAuthPluginManagerTest.java
+++ b/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/spi/client/ClientAuthPluginManagerTest.java
@@ -19,6 +19,8 @@ package com.alibaba.nacos.plugin.auth.spi.client;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.spi.NacosServiceLoader;
+import com.alibaba.nacos.plugin.auth.api.LoginIdentityContext;
+import com.alibaba.nacos.plugin.auth.api.RequestResource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,8 +33,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -88,6 +92,47 @@ class ClientAuthPluginManagerTest {
         Set<ClientAuthService> clientAuthServiceSet =
             clientAuthPluginManager.getAuthServiceSpiImplSet();
         assertTrue(clientAuthServiceSet.isEmpty());
+    }
+    
+    @Test
+    void testRefreshServerListAndShutdown() throws Exception {
+        TestClientAuthService service = new TestClientAuthService();
+        clientAuthPluginManager.getAuthServiceSpiImplSet().add(service);
+        List<String> newServerList = Collections.singletonList("127.0.0.1:8848");
+        
+        clientAuthPluginManager.refreshServerList(newServerList);
+        clientAuthPluginManager.shutdown();
+        
+        assertEquals(newServerList, service.serverList);
+        assertTrue(service.shutdown);
+    }
+    
+    private static class TestClientAuthService extends AbstractClientAuthService {
+        
+        private List<String> serverList;
+        
+        private boolean shutdown;
+        
+        @Override
+        public void setServerList(List<String> serverList) {
+            super.setServerList(serverList);
+            this.serverList = serverList;
+        }
+        
+        @Override
+        public Boolean login(Properties properties) {
+            return true;
+        }
+        
+        @Override
+        public LoginIdentityContext getLoginIdentityContext(RequestResource resource) {
+            return null;
+        }
+        
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
     }
     
 }

--- a/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/spi/server/AuthPluginManagerTest.java
+++ b/plugin/auth/src/test/java/com/alibaba/nacos/plugin/auth/spi/server/AuthPluginManagerTest.java
@@ -16,7 +16,11 @@
 
 package com.alibaba.nacos.plugin.auth.spi.server;
 
+import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
+import com.alibaba.nacos.plugin.auth.spi.mock.MockAuthPluginService;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -26,6 +30,7 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,6 +50,11 @@ class AuthPluginManagerTest {
     
     @Mock
     private AuthPluginService authPluginService;
+    
+    @AfterEach
+    void tearDown() {
+        PluginStateCheckerHolder.setInstance(null);
+    }
     
     @BeforeEach
     void setUp() throws NoSuchFieldException, IllegalAccessException {
@@ -69,6 +79,24 @@ class AuthPluginManagerTest {
         Optional<AuthPluginService> authServiceImpl =
             authPluginManager.findAuthServiceSpiImpl(TYPE);
         assertTrue(authServiceImpl.isPresent());
+    }
+    
+    @Test
+    void testFindAuthServiceSpiImplWhenPluginDisabled() {
+        PluginStateCheckerHolder.setInstance((pluginType, pluginName) -> false);
+        
+        Optional<AuthPluginService> authServiceImpl =
+            authPluginManager.findAuthServiceSpiImpl(TYPE);
+        
+        assertFalse(authServiceImpl.isPresent());
+    }
+    
+    @Test
+    void testDefaultAuthPluginServiceMethods() {
+        AuthPluginService service = new MockAuthPluginService();
+        
+        assertFalse(service.isLoginEnabled());
+        assertTrue(service.isAdminRequest());
     }
     
 }

--- a/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/BlankConfigChangePluginService.java
+++ b/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/BlankConfigChangePluginService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.config;
+
+public class BlankConfigChangePluginService extends SpiConfigChangePluginService {
+    
+    @Override
+    public String getServiceType() {
+        return "";
+    }
+}

--- a/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/ConfigChangePluginManagerTests.java
+++ b/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/ConfigChangePluginManagerTests.java
@@ -260,6 +260,24 @@ class ConfigChangePluginManagerTests {
         assertTrue(isSorted(services));
     }
     
+    @Test
+    void testLoadConfigChangeServicesFromSpi() throws Exception {
+        ConfigChangePluginManager.reset();
+        Method method = ConfigChangePluginManager.class.getDeclaredMethod(
+            "loadConfigChangeServices");
+        method.setAccessible(true);
+        
+        method.invoke(null);
+        
+        Optional<ConfigChangePluginService> service =
+            ConfigChangePluginManager.getInstance().findPluginServiceImpl("spi-config");
+        assertTrue(service.isPresent());
+        assertFalse(ConfigChangePluginManager.getInstance().findPluginServiceImpl("").isPresent());
+        assertTrue(ConfigChangePluginManager.findPluginServicesByPointcut(
+            ConfigChangePointCutTypes.PUBLISH_BY_HTTP).stream()
+            .anyMatch(each -> "spi-config".equals(each.getServiceType())));
+    }
+    
     private boolean isSorted(List<ConfigChangePluginService> list) {
         return IntStream.range(0, list.size() - 1)
             .allMatch(i -> list.get(i).getOrder() <= list.get(i + 1).getOrder());

--- a/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/ConfigChangePluginManagerTests.java
+++ b/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/ConfigChangePluginManagerTests.java
@@ -16,14 +16,17 @@
 
 package com.alibaba.nacos.plugin.config;
 
+import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.plugin.config.constants.ConfigChangeExecuteTypes;
 import com.alibaba.nacos.plugin.config.constants.ConfigChangePointCutTypes;
 import com.alibaba.nacos.plugin.config.model.ConfigChangeRequest;
 import com.alibaba.nacos.plugin.config.model.ConfigChangeResponse;
 import com.alibaba.nacos.plugin.config.spi.ConfigChangePluginService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -31,6 +34,7 @@ import java.util.stream.IntStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -48,6 +52,8 @@ class ConfigChangePluginManagerTests {
     
     @BeforeEach
     void initPluginServices() {
+        PluginStateCheckerHolder.setInstance(null);
+        ConfigChangePluginManager.reset();
         ConfigChangePluginManager.join(new ConfigChangePluginService() {
             
             @Override
@@ -173,6 +179,12 @@ class ConfigChangePluginManagerTests {
         
     }
     
+    @AfterEach
+    void tearDown() {
+        PluginStateCheckerHolder.setInstance(null);
+        ConfigChangePluginManager.reset();
+    }
+    
     @Test
     void testFindPluginServiceQueueByPointcut() {
         List<ConfigChangePluginService> configChangePluginServices =
@@ -220,6 +232,32 @@ class ConfigChangePluginManagerTests {
         configChangePluginServiceOptional =
             ConfigChangePluginManager.getInstance().findPluginServiceImpl("test5");
         assertFalse(configChangePluginServiceOptional.isPresent());
+    }
+    
+    @Test
+    void testFindPluginServiceWhenDisabledAndGetAllPlugins() {
+        PluginStateCheckerHolder.setInstance((pluginType, pluginName) -> false);
+        
+        Optional<ConfigChangePluginService> service =
+            ConfigChangePluginManager.getInstance().findPluginServiceImpl("test1");
+        
+        assertFalse(service.isPresent());
+        assertThrows(UnsupportedOperationException.class,
+            () -> ConfigChangePluginManager.getInstance().getAllPlugins().clear());
+    }
+    
+    @Test
+    void testSortPluginServiceByPointCut() throws Exception {
+        Method method = ConfigChangePluginManager.class.getDeclaredMethod(
+            "sortPluginServiceByPointCut");
+        method.setAccessible(true);
+        
+        method.invoke(null);
+        
+        List<ConfigChangePluginService> services =
+            ConfigChangePluginManager.findPluginServicesByPointcut(
+                ConfigChangePointCutTypes.PUBLISH_BY_RPC);
+        assertTrue(isSorted(services));
     }
     
     private boolean isSorted(List<ConfigChangePluginService> list) {

--- a/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/SpiConfigChangePluginService.java
+++ b/plugin/config/src/test/java/com/alibaba/nacos/plugin/config/SpiConfigChangePluginService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.config;
+
+import com.alibaba.nacos.plugin.config.constants.ConfigChangeExecuteTypes;
+import com.alibaba.nacos.plugin.config.constants.ConfigChangePointCutTypes;
+import com.alibaba.nacos.plugin.config.model.ConfigChangeRequest;
+import com.alibaba.nacos.plugin.config.model.ConfigChangeResponse;
+import com.alibaba.nacos.plugin.config.spi.ConfigChangePluginService;
+
+public class SpiConfigChangePluginService implements ConfigChangePluginService {
+    
+    @Override
+    public void execute(ConfigChangeRequest configChangeRequest,
+        ConfigChangeResponse configChangeResponse) {
+    }
+    
+    @Override
+    public ConfigChangeExecuteTypes executeType() {
+        return ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE;
+    }
+    
+    @Override
+    public String getServiceType() {
+        return "spi-config";
+    }
+    
+    @Override
+    public int getOrder() {
+        return 5;
+    }
+    
+    @Override
+    public ConfigChangePointCutTypes[] pointcutMethodNames() {
+        return new ConfigChangePointCutTypes[] {ConfigChangePointCutTypes.PUBLISH_BY_HTTP};
+    }
+}

--- a/plugin/config/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.config.spi.ConfigChangePluginService
+++ b/plugin/config/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.config.spi.ConfigChangePluginService
@@ -1,0 +1,18 @@
+#
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.nacos.plugin.config.BlankConfigChangePluginService
+com.alibaba.nacos.plugin.config.SpiConfigChangePluginService

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlManagerCenterTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlManagerCenterTest.java
@@ -108,6 +108,16 @@ class ControlManagerCenterTest {
     }
     
     @Test
+    void testGetInstanceFallbackWhenBuilderThrows() {
+        ControlConfigs.getInstance().setControlManagerType("throw");
+        
+        ControlManagerCenter controlManagerCenter = ControlManagerCenter.getInstance();
+        
+        assertEquals("noLimit", controlManagerCenter.getConnectionControlManager().getName());
+        assertEquals("noLimit", controlManagerCenter.getTpsControlManager().getName());
+    }
+    
+    @Test
     void testReloadTpsControlRule() throws Exception {
         String localRuleStorageBaseDir =
             EnvUtils.getNacosHome() + File.separator + "tmpTps" + File.separator + "tps"

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlRequestResponseModelTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlRequestResponseModelTest.java
@@ -19,6 +19,8 @@ package com.alibaba.nacos.plugin.control;
 import com.alibaba.nacos.plugin.control.connection.request.ConnectionCheckRequest;
 import com.alibaba.nacos.plugin.control.connection.response.ConnectionCheckCode;
 import com.alibaba.nacos.plugin.control.connection.response.ConnectionCheckResponse;
+import com.alibaba.nacos.plugin.control.event.ConnectionLimitRuleChangeEvent;
+import com.alibaba.nacos.plugin.control.event.TpsControlRuleChangeEvent;
 import com.alibaba.nacos.plugin.control.spi.ControlPluginProvider;
 import com.alibaba.nacos.plugin.control.tps.request.TpsCheckRequest;
 import com.alibaba.nacos.plugin.control.tps.response.TpsCheckResponse;
@@ -100,6 +102,20 @@ class ControlRequestResponseModelTest {
     void testRuleModelValues() {
         assertEquals(RuleModel.FUZZY, RuleModel.valueOf("FUZZY"));
         assertEquals(RuleModel.PROTO, RuleModel.values()[1]);
+    }
+    
+    @Test
+    void testRuleChangeEvents() {
+        TpsControlRuleChangeEvent tpsEvent = new TpsControlRuleChangeEvent("point", false);
+        ConnectionLimitRuleChangeEvent connectionEvent = new ConnectionLimitRuleChangeEvent(false);
+        
+        tpsEvent.setPointName("newPoint");
+        tpsEvent.setExternal(true);
+        connectionEvent.setExternal(true);
+        
+        assertEquals("newPoint", tpsEvent.getPointName());
+        assertTrue(tpsEvent.isExternal());
+        assertTrue(connectionEvent.isExternal());
     }
     
     @Test

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ThrowControlManagerBuilderTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ThrowControlManagerBuilderTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control;
+
+import com.alibaba.nacos.plugin.control.connection.ConnectionControlManager;
+import com.alibaba.nacos.plugin.control.spi.ControlManagerBuilder;
+import com.alibaba.nacos.plugin.control.tps.TpsControlManager;
+
+public class ThrowControlManagerBuilderTest implements ControlManagerBuilder {
+    
+    @Override
+    public String getName() {
+        return "throw";
+    }
+    
+    @Override
+    public ConnectionControlManager buildConnectionControlManager() {
+        throw new IllegalStateException("connection failed");
+    }
+    
+    @Override
+    public TpsControlManager buildTpsControlManager() {
+        throw new IllegalStateException("tps failed");
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/configs/ControlConfigsTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/configs/ControlConfigsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.configs;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ControlConfigsTest {
+    
+    @AfterEach
+    void tearDown() {
+        ControlConfigs.setInstance(null);
+    }
+    
+    @Test
+    void testLoadInitializerFromSpiAndAccessors() {
+        ControlConfigs.setInstance(null);
+        
+        ControlConfigs configs = ControlConfigs.getInstance();
+        
+        assertEquals("spi-ejector", configs.getConnectionRuntimeEjector());
+        configs.setRuleExternalStorage("external");
+        configs.setLocalRuleStorageBaseDir("local");
+        configs.setControlManagerType("manager");
+        assertEquals("external", configs.getRuleExternalStorage());
+        assertEquals("local", configs.getLocalRuleStorageBaseDir());
+        assertEquals("manager", configs.getControlManagerType());
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/configs/TestControlConfigsInitializer.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/configs/TestControlConfigsInitializer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.configs;
+
+public class TestControlConfigsInitializer implements ControlConfigsInitializer {
+    
+    @Override
+    public void initialize(ControlConfigs controlConfigs) {
+        controlConfigs.setConnectionRuntimeEjector("spi-ejector");
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/rule/ControlRuleChangeActivatorTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/rule/ControlRuleChangeActivatorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.rule;
+
+import com.alibaba.nacos.plugin.control.ControlManagerCenter;
+import com.alibaba.nacos.plugin.control.configs.ControlConfigs;
+import com.alibaba.nacos.plugin.control.event.ConnectionLimitRuleChangeEvent;
+import com.alibaba.nacos.plugin.control.event.TpsControlRuleChangeEvent;
+import com.alibaba.nacos.plugin.control.rule.storage.RuleStorageProxy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ControlRuleChangeActivatorTest {
+    
+    private String localRuleBaseDir;
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        localRuleBaseDir = Files.createTempDirectory("nacos-control-rules").toString();
+        resetControlConfigs();
+        ControlConfigs.getInstance().setLocalRuleStorageBaseDir(localRuleBaseDir);
+        resetRuleStorageProxy();
+        resetControlManagerCenter();
+    }
+    
+    @AfterEach
+    void tearDown() throws Exception {
+        resetControlConfigs();
+        resetControlManagerCenter();
+        resetRuleStorageProxy();
+    }
+    
+    @Test
+    void testTpsRuleSubscriberHandlesNullPointAndNoExternalStorage() {
+        ControlRuleChangeActivator.TpsRuleChangeSubscriber subscriber =
+            new ControlRuleChangeActivator.TpsRuleChangeSubscriber();
+        
+        subscriber.onEvent(new TpsControlRuleChangeEvent(null, false));
+        subscriber.onEvent(new TpsControlRuleChangeEvent("emptyTpsRule", true));
+        
+        assertNotNull(ControlManagerCenter.getInstance().getTpsControlManager());
+    }
+    
+    @Test
+    void testTpsRuleSubscriberIgnoresInvalidLocalRule() throws Exception {
+        RuleStorageProxy.getInstance().getLocalDiskStorage().saveTpsRule("invalidTpsRule", "{");
+        ControlRuleChangeActivator.TpsRuleChangeSubscriber subscriber =
+            new ControlRuleChangeActivator.TpsRuleChangeSubscriber();
+        
+        subscriber.onEvent(new TpsControlRuleChangeEvent("invalidTpsRule", false));
+        
+        assertNotNull(ControlManagerCenter.getInstance().getTpsControlManager());
+    }
+    
+    @Test
+    void testConnectionRuleSubscriberHandlesNoExternalStorageAndInvalidRule() throws Exception {
+        ControlRuleChangeActivator.ConnectionRuleChangeSubscriber subscriber =
+            new ControlRuleChangeActivator.ConnectionRuleChangeSubscriber();
+        
+        subscriber.onEvent(new ConnectionLimitRuleChangeEvent(true));
+        RuleStorageProxy.getInstance().getLocalDiskStorage().saveConnectionRule("{");
+        subscriber.onEvent(new ConnectionLimitRuleChangeEvent(false));
+        
+        assertNotNull(ControlManagerCenter.getInstance().getConnectionControlManager());
+    }
+    
+    private void resetControlConfigs() throws Exception {
+        Field instance = ControlConfigs.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+    }
+    
+    private void resetControlManagerCenter() throws Exception {
+        Field instance = ControlManagerCenter.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+    }
+    
+    private void resetRuleStorageProxy() throws Exception {
+        Field instance = RuleStorageProxy.class.getDeclaredField("INSTANCE");
+        Constructor<RuleStorageProxy> constructor = RuleStorageProxy.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        setStaticFinalField(instance, constructor.newInstance());
+    }
+    
+    private void setStaticFinalField(Field finalField, Object value)
+        throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method getDeclaredFields0 =
+            Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
+        getDeclaredFields0.setAccessible(true);
+        Field[] fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);
+        Field modifiers = null;
+        for (Field each : fields) {
+            if ("modifiers".equals(each.getName())) {
+                modifiers = each;
+            }
+        }
+        modifiers.setAccessible(true);
+        modifiers.setInt(finalField, finalField.getModifiers() & ~Modifier.FINAL);
+        finalField.setAccessible(true);
+        finalField.set(null, value);
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/DefaultNacosTpsBarrierTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/DefaultNacosTpsBarrierTest.java
@@ -69,4 +69,15 @@ class DefaultNacosTpsBarrierTest {
         
     }
     
+    @Test
+    void testApplyRuleClearsRuleForNullOrEmptyRule() {
+        TpsBarrier tpsBarrier = new DefaultNacosTpsBarrier("test_barrier");
+        
+        tpsBarrier.applyRule(null);
+        assertTrue(tpsBarrier.getPointBarrier().isMonitorType());
+        
+        tpsBarrier.applyRule(new TpsControlRule());
+        assertTrue(tpsBarrier.getPointBarrier().isMonitorType());
+    }
+    
 }

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/DefaultTpsControlManagerTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/DefaultTpsControlManagerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.tps;
+
+import com.alibaba.nacos.plugin.control.tps.barrier.TpsBarrier;
+import com.alibaba.nacos.plugin.control.tps.barrier.creator.TpsBarrierCreator;
+import com.alibaba.nacos.plugin.control.tps.request.TpsCheckRequest;
+import com.alibaba.nacos.plugin.control.tps.response.TpsResultCode;
+import com.alibaba.nacos.plugin.control.tps.rule.RuleDetail;
+import com.alibaba.nacos.plugin.control.tps.rule.TpsControlRule;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class DefaultTpsControlManagerTest {
+    
+    @Test
+    void testRegisterApplyCheckAndName() {
+        TestDefaultTpsControlManager manager = new TestDefaultTpsControlManager();
+        TpsControlRule rule = createRule();
+        manager.applyTpsRule("point", rule);
+        
+        manager.registerTpsPoint("point");
+        manager.registerTpsPoint("point");
+        
+        assertEquals(1, manager.getPoints().size());
+        assertSame(rule, manager.getRules().get("point"));
+        assertSame(rule, manager.createdBarrier.appliedRule);
+        assertEquals("noLimit", manager.getName());
+        assertEquals(TpsResultCode.CHECK_SKIP, manager.check(new TpsCheckRequest()).getCode());
+        
+        manager.applyTpsRule("point", null);
+        assertFalse(manager.getRules().containsKey("point"));
+        assertEquals(2, manager.createdBarrier.applyCount);
+        
+        TpsControlRule emptyRule = new TpsControlRule();
+        manager.applyTpsRule("point", emptyRule);
+        assertFalse(manager.getRules().containsKey("point"));
+        assertEquals(3, manager.createdBarrier.applyCount);
+    }
+    
+    private TpsControlRule createRule() {
+        TpsControlRule rule = new TpsControlRule();
+        rule.setPointName("point");
+        RuleDetail detail = new RuleDetail();
+        detail.setMaxCount(1L);
+        rule.setPointRule(detail);
+        return rule;
+    }
+    
+    private static class TestDefaultTpsControlManager extends DefaultTpsControlManager {
+        
+        private TestTpsBarrier createdBarrier;
+        
+        @Override
+        protected TpsBarrierCreator buildTpsBarrierCreator() {
+            return new TpsBarrierCreator() {
+                
+                @Override
+                public String getName() {
+                    return "test";
+                }
+                
+                @Override
+                public TpsBarrier createTpsBarrier(String pointName) {
+                    createdBarrier = new TestTpsBarrier(pointName);
+                    return createdBarrier;
+                }
+            };
+        }
+    }
+    
+    private static class TestTpsBarrier extends TpsBarrier {
+        
+        private TpsControlRule appliedRule;
+        
+        private int applyCount;
+        
+        TestTpsBarrier(String pointName) {
+            super(pointName);
+        }
+        
+        @Override
+        public com.alibaba.nacos.plugin.control.tps.response.TpsCheckResponse applyTps(
+            TpsCheckRequest tpsCheckRequest) {
+            return null;
+        }
+        
+        @Override
+        public void applyRule(TpsControlRule newControlRule) {
+            applyCount++;
+            appliedRule = newControlRule;
+        }
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/TpsControlManagerTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/TpsControlManagerTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.tps;
+
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.plugin.control.rule.parser.NacosTpsControlRuleParser;
+import com.alibaba.nacos.plugin.control.rule.storage.ExternalRuleStorage;
+import com.alibaba.nacos.plugin.control.rule.storage.LocalDiskRuleStorage;
+import com.alibaba.nacos.plugin.control.rule.storage.RuleStorageProxy;
+import com.alibaba.nacos.plugin.control.tps.barrier.DefaultNacosTpsBarrier;
+import com.alibaba.nacos.plugin.control.tps.barrier.TpsBarrier;
+import com.alibaba.nacos.plugin.control.tps.barrier.creator.DefaultNacosTpsBarrierCreator;
+import com.alibaba.nacos.plugin.control.tps.request.TpsCheckRequest;
+import com.alibaba.nacos.plugin.control.tps.response.TpsCheckResponse;
+import com.alibaba.nacos.plugin.control.tps.rule.RuleDetail;
+import com.alibaba.nacos.plugin.control.tps.rule.TpsControlRule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TpsControlManagerTest {
+    
+    @TempDir
+    private Path tempDir;
+    
+    private ExternalRuleStorage originalExternalStorage;
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        originalExternalStorage = getExternalRuleStorage();
+        ((LocalDiskRuleStorage) RuleStorageProxy.getInstance().getLocalDiskStorage())
+            .setLocalRuleBaseDir(tempDir.toString());
+    }
+    
+    @AfterEach
+    void tearDown() throws Exception {
+        setExternalRuleStorage(originalExternalStorage);
+    }
+    
+    @Test
+    void testDefaultParserAndBarrierCreator() {
+        TestTpsControlManager manager = new TestTpsControlManager();
+        
+        assertInstanceOf(NacosTpsControlRuleParser.class, manager.getTpsControlRuleParser());
+        assertEquals("nacos", manager.tpsBarrierCreator.getName());
+        assertInstanceOf(DefaultNacosTpsBarrier.class,
+            manager.tpsBarrierCreator.createTpsBarrier("point"));
+        
+        DefaultNacosTpsBarrierCreator creator = new DefaultNacosTpsBarrierCreator();
+        assertEquals("nacos", creator.getName());
+        assertInstanceOf(DefaultNacosTpsBarrier.class, creator.createTpsBarrier("point"));
+    }
+    
+    @Test
+    void testInitTpsRuleLoadsLocalRule() throws Exception {
+        TpsControlRule rule = createRule("localPoint", 3L);
+        RuleStorageProxy.getInstance().getLocalDiskStorage()
+            .saveTpsRule("localPoint", JacksonUtils.toJson(rule));
+        setExternalRuleStorage(new MemoryExternalRuleStorage(createRule("localPoint", 9L)));
+        
+        TestTpsControlManager manager = new TestTpsControlManager();
+        manager.initRule("localPoint");
+        
+        assertEquals(3L, manager.appliedRules.get("localPoint").getPointRule().getMaxCount());
+    }
+    
+    @Test
+    void testInitTpsRuleLoadsExternalRuleWhenLocalMissing() throws Exception {
+        setExternalRuleStorage(new MemoryExternalRuleStorage(createRule("externalPoint", 7L)));
+        
+        TestTpsControlManager manager = new TestTpsControlManager();
+        manager.initRule("externalPoint");
+        
+        assertEquals(7L, manager.appliedRules.get("externalPoint").getPointRule().getMaxCount());
+    }
+    
+    @Test
+    void testInitTpsRuleSkipsBlankRule() throws Exception {
+        setExternalRuleStorage(new MemoryExternalRuleStorage(null));
+        
+        TestTpsControlManager manager = new TestTpsControlManager();
+        manager.initRule("missingPoint");
+        
+        assertNull(manager.appliedRules.get("missingPoint"));
+    }
+    
+    private TpsControlRule createRule(String pointName, long maxCount) {
+        TpsControlRule result = new TpsControlRule();
+        result.setPointName(pointName);
+        RuleDetail detail = new RuleDetail();
+        detail.setRuleName(pointName + "Rule");
+        detail.setMaxCount(maxCount);
+        detail.setMonitorType(MonitorType.INTERCEPT.getType());
+        result.setPointRule(detail);
+        return result;
+    }
+    
+    private ExternalRuleStorage getExternalRuleStorage() throws Exception {
+        Field field = RuleStorageProxy.class.getDeclaredField("externalRuleStorage");
+        field.setAccessible(true);
+        return (ExternalRuleStorage) field.get(RuleStorageProxy.getInstance());
+    }
+    
+    private void setExternalRuleStorage(ExternalRuleStorage storage) throws Exception {
+        Field field = RuleStorageProxy.class.getDeclaredField("externalRuleStorage");
+        field.setAccessible(true);
+        field.set(RuleStorageProxy.getInstance(), storage);
+    }
+    
+    private static class TestTpsControlManager extends TpsControlManager {
+        
+        private final Map<String, TpsControlRule> appliedRules = new LinkedHashMap<>();
+        
+        void initRule(String pointName) {
+            initTpsRule(pointName);
+        }
+        
+        @Override
+        public void registerTpsPoint(String pointName) {
+        }
+        
+        @Override
+        public Map<String, TpsBarrier> getPoints() {
+            return new LinkedHashMap<>();
+        }
+        
+        @Override
+        public Map<String, TpsControlRule> getRules() {
+            return appliedRules;
+        }
+        
+        @Override
+        public void applyTpsRule(String pointName, TpsControlRule rule) {
+            appliedRules.put(pointName, rule);
+        }
+        
+        @Override
+        public TpsCheckResponse check(TpsCheckRequest tpsRequest) {
+            return null;
+        }
+        
+        @Override
+        public String getName() {
+            return "test";
+        }
+    }
+    
+    private static class MemoryExternalRuleStorage implements ExternalRuleStorage {
+        
+        private final TpsControlRule tpsControlRule;
+        
+        MemoryExternalRuleStorage(TpsControlRule tpsControlRule) {
+            this.tpsControlRule = tpsControlRule;
+        }
+        
+        @Override
+        public String getName() {
+            return "memory";
+        }
+        
+        @Override
+        public void saveConnectionRule(String ruleContent) throws IOException {
+        }
+        
+        @Override
+        public String getConnectionRule() {
+            return null;
+        }
+        
+        @Override
+        public void saveTpsRule(String pointName, String ruleContent) throws IOException {
+        }
+        
+        @Override
+        public String getTpsRule(String pointName) {
+            return tpsControlRule == null ? null : JacksonUtils.toJson(tpsControlRule);
+        }
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/barrier/SimpleCountRuleBarrierTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/barrier/SimpleCountRuleBarrierTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.tps.barrier;
+
+import com.alibaba.nacos.plugin.control.tps.MonitorType;
+import com.alibaba.nacos.plugin.control.tps.TpsMetrics;
+import com.alibaba.nacos.plugin.control.tps.request.BarrierCheckRequest;
+import com.alibaba.nacos.plugin.control.tps.response.TpsCheckResponse;
+import com.alibaba.nacos.plugin.control.tps.rule.RuleDetail;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SimpleCountRuleBarrierTest {
+    
+    @Test
+    void testApplyTpsMonitorAndInterceptBranches() {
+        TestSimpleCountRuleBarrier barrier =
+            new TestSimpleCountRuleBarrier("point", "rule", TimeUnit.SECONDS);
+        BarrierCheckRequest request = new BarrierCheckRequest();
+        request.setTimestamp(1000L);
+        request.setCount(2L);
+        
+        TpsCheckResponse monitorResponse = barrier.applyTps(request);
+        assertTrue(monitorResponse.isSuccess());
+        assertEquals(2L, barrier.counter.total);
+        
+        barrier.setMonitorType(MonitorType.INTERCEPT.getType());
+        barrier.setMaxCount(4L);
+        assertTrue(barrier.applyTps(request).isSuccess());
+        TpsCheckResponse denied = barrier.applyTps(request);
+        assertFalse(denied.isSuccess());
+        assertTrue(denied.getMessage().contains("tps over limit"));
+    }
+    
+    @Test
+    void testMetricsTrimAndRuleDetailBranches() {
+        TestSimpleCountRuleBarrier barrier =
+            new TestSimpleCountRuleBarrier("point", "rule", TimeUnit.SECONDS);
+        assertEquals(1000L, barrier.trimTimeStamp(1234L));
+        barrier.setPeriod(TimeUnit.MINUTES);
+        assertEquals(60000L, barrier.trimTimeStamp(61000L));
+        barrier.setPeriod(TimeUnit.HOURS);
+        assertEquals(3600000L, barrier.trimTimeStamp(3601000L));
+        barrier.setPeriod(TimeUnit.DAYS);
+        assertEquals(1000L, barrier.trimTimeStamp(1234L));
+        
+        assertNull(barrier.getMetrics(1234L));
+        barrier.counter.total = 7L;
+        TpsMetrics metrics = barrier.getMetrics(1234L);
+        assertNotNull(metrics);
+        assertEquals(7L, metrics.getCounter().getPassCount());
+        
+        RuleDetail samePeriod = new RuleDetail();
+        samePeriod.setMaxCount(10L);
+        samePeriod.setMonitorType(MonitorType.INTERCEPT.getType());
+        samePeriod.setPeriod(TimeUnit.DAYS);
+        barrier.applyRuleDetail(samePeriod);
+        assertEquals(TimeUnit.DAYS, barrier.getPeriod());
+        assertEquals(10L, barrier.getMaxCount());
+        
+        RuleDetail newPeriod = new RuleDetail();
+        newPeriod.setRuleName("newRule");
+        newPeriod.setPeriod(TimeUnit.MINUTES);
+        newPeriod.setMaxCount(5L);
+        newPeriod.setMonitorType(MonitorType.MONITOR.getType());
+        barrier.applyRuleDetail(newPeriod);
+        assertEquals(TimeUnit.MINUTES, barrier.getPeriod());
+        assertEquals("newRule", barrier.counter.getName());
+    }
+    
+    @Test
+    void testRuleBarrierAccessorsAndClear() {
+        TestSimpleCountRuleBarrier barrier =
+            new TestSimpleCountRuleBarrier("point", "rule", TimeUnit.SECONDS);
+        barrier.setMaxCount(9L);
+        barrier.setMonitorType(MonitorType.INTERCEPT.getType());
+        
+        assertEquals("test", barrier.getBarrierName());
+        assertEquals("rule", barrier.getRuleName());
+        assertEquals("point", barrier.getPointName());
+        assertFalse(barrier.isMonitorType());
+        assertTrue(barrier.getLimitMsg().contains("\"limitCount\":\"9\""));
+        
+        barrier.clearLimitRule();
+        assertEquals(-1L, barrier.getMaxCount());
+        assertTrue(barrier.isMonitorType());
+    }
+    
+    private static class TestSimpleCountRuleBarrier extends SimpleCountRuleBarrier {
+        
+        private TestRateCounter counter;
+        
+        TestSimpleCountRuleBarrier(String pointName, String ruleName, TimeUnit period) {
+            super(pointName, ruleName, period);
+        }
+        
+        @Override
+        public RateCounter createSimpleCounter(String name, TimeUnit period) {
+            counter = new TestRateCounter(name, period);
+            return counter;
+        }
+        
+        @Override
+        public String getBarrierName() {
+            return "test";
+        }
+    }
+    
+    private static class TestRateCounter extends RateCounter {
+        
+        private long total;
+        
+        TestRateCounter(String name, TimeUnit period) {
+            super(name, period);
+        }
+        
+        @Override
+        public long add(long timestamp, long count) {
+            total += count;
+            return total;
+        }
+        
+        @Override
+        public boolean tryAdd(long timestamp, long countDelta, long upperLimit) {
+            if (total + countDelta > upperLimit) {
+                return false;
+            }
+            total += countDelta;
+            return true;
+        }
+        
+        @Override
+        public long getCount(long timestamp) {
+            return total;
+        }
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/barrier/SimpleCountRuleBarrierTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/tps/barrier/SimpleCountRuleBarrierTest.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.plugin.control.tps.TpsMetrics;
 import com.alibaba.nacos.plugin.control.tps.request.BarrierCheckRequest;
 import com.alibaba.nacos.plugin.control.tps.response.TpsCheckResponse;
 import com.alibaba.nacos.plugin.control.tps.rule.RuleDetail;
+import com.alibaba.nacos.plugin.control.tps.barrier.creator.LocalSimpleCountBarrierCreator;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -105,6 +106,16 @@ class SimpleCountRuleBarrierTest {
         barrier.clearLimitRule();
         assertEquals(-1L, barrier.getMaxCount());
         assertTrue(barrier.isMonitorType());
+    }
+    
+    @Test
+    void testLocalSimpleCountBarrierCreator() {
+        LocalSimpleCountBarrierCreator creator = LocalSimpleCountBarrierCreator.getInstance();
+        
+        RuleBarrier barrier = creator.createRuleBarrier("point", "rule", TimeUnit.SECONDS);
+        
+        assertEquals("localsimplecountor", creator.name());
+        assertEquals("localsimplecount", barrier.getBarrierName());
     }
     
     private static class TestSimpleCountRuleBarrier extends SimpleCountRuleBarrier {

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/utils/DiskUtilsTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/utils/DiskUtilsTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DiskUtilsTest {
@@ -59,6 +60,7 @@ class DiskUtilsTest {
     @Test
     void testReadFile() {
         assertNotNull(DiskUtils.readFile(testFile));
+        assertNull(DiskUtils.readFile(new File("missing-file")));
     }
     
     @Test
@@ -66,6 +68,8 @@ class DiskUtilsTest {
         assertTrue(
             DiskUtils.writeFile(testFile, "unit test".getBytes(StandardCharsets.UTF_8), false));
         assertEquals("unit test", DiskUtils.readFile(testFile));
+        assertFalse(DiskUtils.writeFile(testFile.getParentFile(), "unit test".getBytes(
+            StandardCharsets.UTF_8), false));
     }
     
     @Test

--- a/plugin/control/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.control.configs.ControlConfigsInitializer
+++ b/plugin/control/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.control.configs.ControlConfigsInitializer
@@ -1,0 +1,17 @@
+#
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.nacos.plugin.control.configs.TestControlConfigsInitializer

--- a/plugin/control/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.control.spi.ControlManagerBuilder
+++ b/plugin/control/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.control.spi.ControlManagerBuilder
@@ -15,3 +15,4 @@
 #
 
 com.alibaba.nacos.plugin.control.ControlManagerBuilderTest
+com.alibaba.nacos.plugin.control.ThrowControlManagerBuilderTest

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -82,6 +83,18 @@ class MapperManagerTest {
             () -> MapperManager.instance(false).findMapper("derby", "config_info"));
         assertThrows(NacosRuntimeException.class,
             () -> MapperManager.instance(false).findMapper("mysql", "missing_table"));
+    }
+    
+    @Test
+    void testLoadInitialFromSpi() throws Exception {
+        Method method = MapperManager.class.getDeclaredMethod("loadInitial");
+        method.setAccessible(true);
+        
+        method.invoke(MapperManager.instance(false));
+        
+        Mapper mapper = MapperManager.instance(false).findMapper("spi", "spi_table");
+        assertEquals("spi", mapper.getDataSource());
+        assertEquals("spi_table", mapper.getTableName());
     }
     
     private static class TestMapper implements Mapper {

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/MapperManagerTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource;
+
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.plugin.datasource.mapper.Mapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MapperManagerTest {
+    
+    private Map<String, Map<String, Mapper>> originalMappers;
+    
+    @BeforeEach
+    void setUp() {
+        originalMappers = new HashMap<>();
+        MapperManager.MAPPER_SPI_MAP.forEach((dataSource, tableMappers) -> originalMappers
+            .put(dataSource, new HashMap<>(tableMappers)));
+        MapperManager.MAPPER_SPI_MAP.clear();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        MapperManager.MAPPER_SPI_MAP.clear();
+        originalMappers.forEach((dataSource, tableMappers) -> MapperManager.MAPPER_SPI_MAP
+            .put(dataSource, new HashMap<>(tableMappers)));
+    }
+    
+    @Test
+    void testJoinAndFindMapper() {
+        Mapper mapper = new TestMapper();
+        
+        MapperManager.join(null);
+        MapperManager.join(mapper);
+        MapperManager.join(new DuplicateTestMapper());
+        
+        Mapper found = MapperManager.instance(false).findMapper("mysql", "config_info");
+        assertSame(mapper, found);
+        assertEquals(1, MapperManager.instance(false).getAllMappers().get("mysql").size());
+    }
+    
+    @Test
+    void testFindMapperWithProxyAndFailures() {
+        Mapper mapper = new TestMapper();
+        MapperManager.join(mapper);
+        
+        Mapper proxy = MapperManager.instance(true).findMapper("mysql", "config_info");
+        
+        assertNotSame(mapper, proxy);
+        assertEquals("SELECT data_id FROM config_info WHERE data_id=?",
+            proxy.select(Arrays.asList("data_id"), Arrays.asList("data_id")));
+        assertThrows(UnsupportedOperationException.class,
+            () -> MapperManager.instance(false).getAllMappers().clear());
+        assertThrows(NacosRuntimeException.class,
+            () -> MapperManager.instance(false).findMapper("", "config_info"));
+        assertThrows(NacosRuntimeException.class,
+            () -> MapperManager.instance(false).findMapper("derby", "config_info"));
+        assertThrows(NacosRuntimeException.class,
+            () -> MapperManager.instance(false).findMapper("mysql", "missing_table"));
+    }
+    
+    private static class TestMapper implements Mapper {
+        
+        @Override
+        public String select(List<String> columns, List<String> where) {
+            return "SELECT " + String.join(",", columns) + " FROM config_info WHERE "
+                + where.get(0) + "=?";
+        }
+        
+        @Override
+        public String insert(List<String> columns) {
+            return null;
+        }
+        
+        @Override
+        public String update(List<String> columns, List<String> where) {
+            return null;
+        }
+        
+        @Override
+        public String delete(List<String> params) {
+            return null;
+        }
+        
+        @Override
+        public String count(List<String> where) {
+            return null;
+        }
+        
+        @Override
+        public String getTableName() {
+            return "config_info";
+        }
+        
+        @Override
+        public String getDataSource() {
+            return "mysql";
+        }
+        
+        @Override
+        public String[] getPrimaryKeyGeneratedKeys() {
+            return new String[] {"id"};
+        }
+        
+        @Override
+        public String getFunction(String functionName) {
+            return functionName;
+        }
+    }
+    
+    private static class DuplicateTestMapper extends TestMapper {
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/SpiMapper.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/SpiMapper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource;
+
+import com.alibaba.nacos.plugin.datasource.mapper.Mapper;
+
+import java.util.List;
+
+public class SpiMapper implements Mapper {
+    
+    @Override
+    public String select(List<String> columns, List<String> where) {
+        return null;
+    }
+    
+    @Override
+    public String insert(List<String> columns) {
+        return null;
+    }
+    
+    @Override
+    public String update(List<String> columns, List<String> where) {
+        return null;
+    }
+    
+    @Override
+    public String delete(List<String> params) {
+        return null;
+    }
+    
+    @Override
+    public String count(List<String> where) {
+        return null;
+    }
+    
+    @Override
+    public String getTableName() {
+        return "spi_table";
+    }
+    
+    @Override
+    public String getDataSource() {
+        return "spi";
+    }
+    
+    @Override
+    public String[] getPrimaryKeyGeneratedKeys() {
+        return new String[] {"id"};
+    }
+    
+    @Override
+    public String getFunction(String functionName) {
+        return functionName;
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/manager/DatabaseDialectManagerTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/manager/DatabaseDialectManagerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.manager;
+
+import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
+import com.alibaba.nacos.plugin.datasource.dialect.DatabaseDialect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DatabaseDialectManagerTest {
+    
+    private Map<String, DatabaseDialect> dialectMap;
+    
+    private Map<String, DatabaseDialect> originalDialects;
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        dialectMap = getDialectMap();
+        originalDialects = new HashMap<>(dialectMap);
+        dialectMap.clear();
+        PluginStateCheckerHolder.setInstance(null);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        dialectMap.clear();
+        dialectMap.putAll(originalDialects);
+        PluginStateCheckerHolder.setInstance(null);
+    }
+    
+    @Test
+    void testGetDialectAndAllDialects() {
+        DatabaseDialect mysql = new TestDatabaseDialect("mysql");
+        dialectMap.put("mysql", mysql);
+        
+        DatabaseDialectManager manager = DatabaseDialectManager.getInstance();
+        
+        assertSame(mysql, manager.getDialect("mysql"));
+        assertThrows(UnsupportedOperationException.class, () -> manager.getAllDialects().clear());
+    }
+    
+    @Test
+    void testGetDialectWhenDisabled() {
+        dialectMap.put("mysql", new TestDatabaseDialect("mysql"));
+        PluginStateCheckerHolder.setInstance((pluginType, pluginName) -> false);
+        
+        assertThrows(IllegalStateException.class,
+            () -> DatabaseDialectManager.getInstance().getDialect("mysql"));
+    }
+    
+    @Test
+    void testGetDialectFallbackAndNoEnabledFallback() {
+        DatabaseDialect mysql = new TestDatabaseDialect("mysql");
+        dialectMap.put("mysql", mysql);
+        PluginStateCheckerHolder.setInstance(
+            (pluginType, pluginName) -> "mysql".equals(pluginName) || "unknown".equals(pluginName));
+        
+        assertSame(mysql, DatabaseDialectManager.getInstance().getDialect("unknown"));
+        
+        PluginStateCheckerHolder
+            .setInstance((pluginType, pluginName) -> "unknown".equals(pluginName));
+        assertThrows(IllegalStateException.class,
+            () -> DatabaseDialectManager.getInstance().getDialect("unknown"));
+    }
+    
+    private Map<String, DatabaseDialect> getDialectMap() throws Exception {
+        Field field = DatabaseDialectManager.class.getDeclaredField("SUPPORT_DIALECT_MAP");
+        field.setAccessible(true);
+        return (Map<String, DatabaseDialect>) field.get(null);
+    }
+    
+    private static class TestDatabaseDialect implements DatabaseDialect {
+        
+        private final String type;
+        
+        private TestDatabaseDialect(String type) {
+            this.type = type;
+        }
+        
+        @Override
+        public String getType() {
+            return type;
+        }
+        
+        @Override
+        public int getPagePrevNum(int page, int pageSize) {
+            return 0;
+        }
+        
+        @Override
+        public int getPageLastNum(int page, int pageSize) {
+            return 0;
+        }
+        
+        @Override
+        public String getLimitTopSqlWithMark(String sql) {
+            return sql;
+        }
+        
+        @Override
+        public String getLimitPageSqlWithMark(String sql) {
+            return sql;
+        }
+        
+        @Override
+        public String getLimitPageSql(String sql, int pageNo, int pageSize) {
+            return sql;
+        }
+        
+        @Override
+        public String getLimitPageSqlWithOffset(String sql, int startOffset, int pageSize) {
+            return sql;
+        }
+        
+        @Override
+        public String[] getReturnPrimaryKeys() {
+            return new String[] {"id"};
+        }
+        
+        @Override
+        public String getFunction(String functionName) {
+            return functionName;
+        }
+    }
+}

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/DatasourceMapperDefaultMethodTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/DatasourceMapperDefaultMethodTest.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -198,6 +199,197 @@ class DatasourceMapperDefaultMethodTest {
         assertNull(mapper.castToMap("not-map"));
     }
     
+    @Test
+    void testWhereBuilderFluentBranches() {
+        MapperResult result = new WhereBuilder("SELECT * FROM config_info")
+            .startParentheses()
+            .eq("data_id", "data")
+            .or()
+            .likeWithEscape("content", "%value\\_%")
+            .endParentheses()
+            .and()
+            .exists("SELECT 1 FROM config_tags_relation b WHERE ",
+                sub -> sub.eqColumn("b.id", "a.id").and().in("b.tag_name",
+                    new String[] {"tagA", "tagB"}))
+            .groupBy("data_id")
+            .orderBy("id DESC")
+            .limit(0, 10)
+            .offset(10, 20)
+            .build();
+        
+        assertTrue(result.getSql().contains("content LIKE ? ESCAPE '\\'"));
+        assertTrue(result.getSql().contains("EXISTS ( SELECT 1 FROM config_tags_relation"));
+        assertTrue(result.getSql().contains("b.id = a.id"));
+        assertTrue(result.getSql().contains("GROUP BY data_id"));
+        assertTrue(result.getSql().contains("LIMIT 0,10"));
+        assertTrue(result.getSql().contains("OFFSET 10 ROWS FETCH NEXT 20 ROWS ONLY"));
+        assertEquals(Arrays.asList("data", "%value\\_%", "tagA", "tagB"),
+            result.getParamList());
+    }
+    
+    @Test
+    void testConfigInfoSimpleDefaultSql() {
+        ConfigInfoMapper mapper = new TestConfigInfoMapper();
+        MapperContext context = new MapperContext();
+        context.putWhereParameter(FieldConstant.TENANT_ID, "tenant");
+        context.putWhereParameter(FieldConstant.APP_NAME, "app");
+        context.putWhereParameter(FieldConstant.START_TIME, 100L);
+        context.putWhereParameter(FieldConstant.LAST_MAX_ID, 10L);
+        context.putWhereParameter(FieldConstant.PAGE_SIZE, 50);
+        
+        assertEquals("SELECT MAX(id) FROM config_info", mapper.findConfigMaxId(context).getSql());
+        assertEquals("SELECT DISTINCT data_id, group_id FROM config_info",
+            mapper.findAllDataIdAndGroup(context).getSql());
+        assertEquals(Arrays.asList("tenant", "app"),
+            mapper.findConfigInfoByAppCountRows(context).getParamList());
+        assertEquals(Collections.singletonList("tenant"),
+            mapper.configInfoLikeTenantCount(context).getParamList());
+        
+        MapperResult changeConfig = mapper.findChangeConfig(context);
+        assertTrue(changeConfig.getSql().contains("gmt_modified >= ?"));
+        assertEquals(Arrays.asList(100L, 10L, 50), changeConfig.getParamList());
+        assertEquals("config_info", mapper.getTableName());
+    }
+    
+    @Test
+    void testConfigInfoChangeCountAndExportBranches() {
+        ConfigInfoMapper mapper = new TestConfigInfoMapper();
+        MapperContext context = createQueryContext();
+        Timestamp startTime = Timestamp.valueOf("2026-05-22 00:00:00");
+        Timestamp endTime = Timestamp.valueOf("2026-05-22 01:00:00");
+        context.putWhereParameter(FieldConstant.TENANT, "tenant");
+        context.putWhereParameter(FieldConstant.START_TIME, startTime);
+        context.putWhereParameter(FieldConstant.END_TIME, endTime);
+        
+        MapperResult changeCount = mapper.findChangeConfigCountRows(context);
+        assertTrue(changeCount.getSql().contains("data_id LIKE ?"));
+        assertTrue(changeCount.getSql().contains("gmt_modified <=?"));
+        assertEquals(Arrays.asList("data", "group", "tenant", "app", startTime, endTime),
+            changeCount.getParamList());
+        
+        MapperContext idsContext = new MapperContext();
+        idsContext.putWhereParameter(FieldConstant.IDS, Arrays.asList(1L, 2L));
+        MapperResult idsExport = mapper.findAllConfigInfo4Export(idsContext);
+        assertTrue(idsExport.getSql().contains("id IN (?, ?)"));
+        assertEquals(Arrays.asList(1L, 2L), idsExport.getParamList());
+        
+        MapperResult filteredExport = mapper.findAllConfigInfo4Export(context);
+        assertTrue(filteredExport.getSql().contains("tenant_id = ?"));
+        assertTrue(filteredExport.getSql().contains("app_name= ?"));
+        assertEquals(Arrays.asList("tenantId", "data", "group", "app"),
+            filteredExport.getParamList());
+    }
+    
+    @Test
+    void testConfigInfoCountAndIdListDefaults() {
+        ConfigInfoMapper mapper = new TestConfigInfoMapper();
+        MapperContext context = createQueryContext();
+        context.putWhereParameter(FieldConstant.CONTENT, "content");
+        context.putWhereParameter(FieldConstant.TYPE, new String[] {"yaml", "json"});
+        context.putWhereParameter(FieldConstant.IDS, Arrays.asList(1L, 2L, 3L));
+        
+        MapperResult baseLike = mapper.findConfigInfoBaseLikeCountRows(context);
+        assertTrue(baseLike.getSql().contains("content LIKE ?"));
+        assertEquals(Arrays.asList("data", "group", "content"), baseLike.getParamList());
+        
+        MapperResult pageCount = mapper.findConfigInfo4PageCountRows(context);
+        assertTrue(pageCount.getSql().contains("tenant_id=?"));
+        assertEquals(Arrays.asList("tenantId", "data", "group", "app", "content"),
+            pageCount.getParamList());
+        
+        MapperResult likeCount = mapper.findConfigInfoLike4PageCountRows(context);
+        assertTrue(likeCount.getSql().contains("type IN (?"));
+        assertEquals(Arrays.asList("tenantId", "data", "group", "app", "content", "yaml",
+            "json"), likeCount.getParamList());
+        
+        assertEquals(Arrays.asList(1L, 2L, 3L),
+            mapper.findConfigInfosByIds(context).getParamList());
+        assertTrue(mapper.findConfigInfosByIds(context).getSql().contains("id IN (?, ?, ?)"));
+        assertEquals(Arrays.asList(1L, 2L, 3L),
+            mapper.removeConfigInfoByIdsAtomic(context).getParamList());
+    }
+    
+    @Test
+    void testConfigInfoAtomicCasWithOptionalDescription() {
+        ConfigInfoMapper mapper = new TestConfigInfoMapper();
+        MapperContext context = createUpdateContext();
+        context.putUpdateParameter(FieldConstant.C_DESC, "description");
+        context.putUpdateParameter(FieldConstant.C_USE, "use");
+        context.putUpdateParameter(FieldConstant.EFFECT, "effect");
+        context.putUpdateParameter(FieldConstant.TYPE, "type");
+        context.putUpdateParameter(FieldConstant.C_SCHEMA, "schema");
+        context.putUpdateParameter(FieldConstant.ENCRYPTED_DATA_KEY, "key");
+        
+        MapperResult result = mapper.updateConfigInfoAtomicCas(context);
+        
+        assertTrue(result.getSql().contains("gmt_modified=NOW()"));
+        assertTrue(result.getSql().contains("c_desc=?"));
+        assertEquals(Arrays.asList("content", "md5-new", "127.0.0.1", "nacos", "app",
+            "description", "use", "effect", "type", "schema", "key", "data", "group",
+            "tenant", "md5-old"), result.getParamList());
+        
+        context.putUpdateParameter(FieldConstant.C_DESC, null);
+        assertTrue(!mapper.updateConfigInfoAtomicCas(context).getSql().contains("c_desc=?"));
+    }
+    
+    @Test
+    void testConfigMigrateDefaults() {
+        ConfigMigrateMapper mapper = new TestConfigMigrateMapper();
+        MapperContext context = new MapperContext();
+        context.setPageSize(100);
+        context.putWhereParameter(FieldConstant.ID, 10L);
+        context.putWhereParameter(FieldConstant.IDS, Arrays.asList(1L, 2L));
+        context.putWhereParameter(FieldConstant.SRC_USER, "nacos");
+        context.putWhereParameter(FieldConstant.SRC_TENANT, "");
+        context.putWhereParameter(FieldConstant.TARGET_TENANT, "public");
+        
+        assertEquals(Arrays.asList("nacos", "nacos"),
+            mapper.getConfigConflictCount(context).getParamList());
+        assertEquals(Arrays.asList(10L, 100),
+            mapper.findConfigIdNeedInsertMigrate(context).getParamList());
+        assertEquals(Arrays.asList("", "nacos", "public", "nacos", 10L, 100),
+            mapper.findConfigNeedUpdateMigrate(context).getParamList());
+        assertEquals(Arrays.asList("", "nacos", "public", "nacos", 10L, 100),
+            mapper.findConfigGrayNeedUpdateMigrate(context).getParamList());
+        assertEquals(Arrays.asList("nacos", 1L, 2L),
+            mapper.migrateConfigInsertByIds(context).getParamList());
+        assertEquals(Arrays.asList("nacos", "nacos"),
+            mapper.getConfigGrayConflictCount(context).getParamList());
+        assertEquals(Arrays.asList(10L, 100),
+            mapper.findConfigGrayIdNeedInsertMigrate(context).getParamList());
+        assertEquals(Arrays.asList("nacos", 1L, 2L),
+            mapper.migrateConfigGrayInsertByIds(context).getParamList());
+        assertEquals("migrate_config", mapper.getTableName());
+    }
+    
+    @Test
+    void testHistoryConfigInfoDefaults() {
+        HistoryConfigInfoMapper mapper = new TestHistoryConfigInfoMapper();
+        MapperContext context = createHistoryContext();
+        
+        assertEquals(Collections.singletonList(100L),
+            mapper.findConfigHistoryCountByTime(context).getParamList());
+        assertEquals(Arrays.asList("formal", 100L, 10L, 50),
+            mapper.findDeletedConfig(context).getParamList());
+        assertEquals(Arrays.asList("data", "group", "tenant"),
+            mapper.findConfigHistoryFetchRows(context).getParamList());
+        assertEquals(Collections.singletonList(1L),
+            mapper.detailPreviousConfigHistory(context).getParamList());
+        assertEquals("his_config_info", mapper.getTableName());
+        
+        MapperResult blankGray = mapper.getNextHistoryInfo(context);
+        assertTrue(!blankGray.getSql().contains("gray_name = ?"));
+        assertEquals(Arrays.asList("data", "group", "tenant", "formal", 5L),
+            blankGray.getParamList());
+        
+        context.putWhereParameter(FieldConstant.GRAY_NAME, "gray");
+        context.putContextParameter(FieldConstant.GRAY_NAME, "gray");
+        MapperResult withGray = mapper.getNextHistoryInfo(context);
+        assertTrue(withGray.getSql().contains("gray_name = ?"));
+        assertEquals(Arrays.asList("data", "group", "tenant", "formal", "gray", 5L),
+            withGray.getParamList());
+    }
+    
     private MapperResult buildEmptyOrConditionResult(AiResourceMapper mapper) {
         WhereBuilder where = new WhereBuilder("SELECT * FROM ai_resource");
         Map<String, Object> emptyOr = new LinkedHashMap<>();
@@ -219,6 +411,29 @@ class DatasourceMapperDefaultMethodTest {
         context.putWhereParameter(FieldConstant.GROUP_ID, "group");
         context.putWhereParameter(FieldConstant.TENANT_ID, "tenant");
         context.putWhereParameter(FieldConstant.MD5, "md5-old");
+        return context;
+    }
+    
+    private MapperContext createQueryContext() {
+        MapperContext context = new MapperContext();
+        context.putWhereParameter(FieldConstant.TENANT_ID, "tenantId");
+        context.putWhereParameter(FieldConstant.DATA_ID, "data");
+        context.putWhereParameter(FieldConstant.GROUP_ID, "group");
+        context.putWhereParameter(FieldConstant.APP_NAME, "app");
+        return context;
+    }
+    
+    private MapperContext createHistoryContext() {
+        MapperContext context = new MapperContext();
+        context.putWhereParameter(FieldConstant.START_TIME, 100L);
+        context.putWhereParameter(FieldConstant.LAST_MAX_ID, 10L);
+        context.putWhereParameter(FieldConstant.PAGE_SIZE, 50);
+        context.putWhereParameter(FieldConstant.PUBLISH_TYPE, "formal");
+        context.putWhereParameter(FieldConstant.DATA_ID, "data");
+        context.putWhereParameter(FieldConstant.GROUP_ID, "group");
+        context.putWhereParameter(FieldConstant.TENANT_ID, "tenant");
+        context.putWhereParameter(FieldConstant.ID, 1L);
+        context.putWhereParameter(FieldConstant.NID, 5L);
         return context;
     }
     
@@ -307,6 +522,108 @@ class DatasourceMapperDefaultMethodTest {
         
         @Override
         public MapperResult findAiResourceFetchRows(MapperContext context) {
+            return null;
+        }
+    }
+    
+    private static class TestConfigInfoMapper extends TestAbstractMapper
+        implements ConfigInfoMapper {
+        
+        @Override
+        public String getTableName() {
+            return ConfigInfoMapper.super.getTableName();
+        }
+        
+        @Override
+        public MapperResult findConfigInfoByAppFetchRows(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult getTenantIdList(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult getGroupIdList(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findAllConfigKey(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findAllConfigInfoBaseFetchRows(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findAllConfigInfoFragment(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findChangeConfigFetchRows(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult listGroupKeyMd5ByPageFetchRows(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findConfigInfoBaseLikeFetchRows(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findConfigInfo4PageFetchRows(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findConfigInfoBaseByGroupFetchRows(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findConfigInfoLike4PageFetchRows(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult findAllConfigInfoFetchRows(MapperContext context) {
+            return null;
+        }
+    }
+    
+    private static class TestConfigMigrateMapper extends TestAbstractMapper
+        implements ConfigMigrateMapper {
+        
+        @Override
+        public String getTableName() {
+            return ConfigMigrateMapper.super.getTableName();
+        }
+    }
+    
+    private static class TestHistoryConfigInfoMapper extends TestAbstractMapper
+        implements HistoryConfigInfoMapper {
+        
+        @Override
+        public String getTableName() {
+            return HistoryConfigInfoMapper.super.getTableName();
+        }
+        
+        @Override
+        public MapperResult removeConfigHistory(MapperContext context) {
+            return null;
+        }
+        
+        @Override
+        public MapperResult pageFindConfigHistoryFetchRows(MapperContext context) {
             return null;
         }
     }

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/DatasourceMapperDefaultMethodTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/DatasourceMapperDefaultMethodTest.java
@@ -196,6 +196,15 @@ class DatasourceMapperDefaultMethodTest {
         MapperResult emptyOrResult = buildEmptyOrConditionResult(mapper);
         assertTrue(emptyOrResult.getSql().contains("1 = ?"));
         assertEquals(Collections.singletonList(0), emptyOrResult.getParamList());
+        
+        WhereBuilder emptySingleCondition = new WhereBuilder("SELECT * FROM ai_resource");
+        mapper.appendSingleAndCondition(emptySingleCondition, "type", Collections.emptyList(),
+            false);
+        assertTrue(emptySingleCondition.build().getParamList().isEmpty());
+        
+        Map<Object, Object> rawMap = new LinkedHashMap<>();
+        rawMap.put(null, "empty");
+        assertTrue(mapper.castToMap(rawMap).containsKey(null));
         assertNull(mapper.castToMap("not-map"));
     }
     
@@ -394,6 +403,7 @@ class DatasourceMapperDefaultMethodTest {
         WhereBuilder where = new WhereBuilder("SELECT * FROM ai_resource");
         Map<String, Object> emptyOr = new LinkedHashMap<>();
         emptyOr.put("", "blank");
+        emptyOr.put("owner", Collections.emptyList());
         emptyOr.put("type", null);
         mapper.appendOrConditions(where, emptyOr);
         return where.build();

--- a/plugin/datasource/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.datasource.mapper.Mapper
+++ b/plugin/datasource/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.datasource.mapper.Mapper
@@ -1,0 +1,17 @@
+#
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.nacos.plugin.datasource.SpiMapper

--- a/plugin/encryption/src/test/java/com/alibaba/nacos/plugin/encryption/BlankEncryptionPluginService.java
+++ b/plugin/encryption/src/test/java/com/alibaba/nacos/plugin/encryption/BlankEncryptionPluginService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.encryption;
+
+public class BlankEncryptionPluginService extends SpiEncryptionPluginService {
+    
+    @Override
+    public String algorithmName() {
+        return "";
+    }
+}

--- a/plugin/encryption/src/test/java/com/alibaba/nacos/plugin/encryption/EncryptionPluginManagerTest.java
+++ b/plugin/encryption/src/test/java/com/alibaba/nacos/plugin/encryption/EncryptionPluginManagerTest.java
@@ -16,12 +16,17 @@
 
 package com.alibaba.nacos.plugin.encryption;
 
+import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.plugin.encryption.spi.EncryptionPluginService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -31,6 +36,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class EncryptionPluginManagerTest {
     
+    @AfterEach
+    void tearDown() {
+        PluginStateCheckerHolder.setInstance(null);
+    }
+    
     @Test
     void testInstance() {
         EncryptionPluginManager instance = EncryptionPluginManager.instance();
@@ -39,38 +49,7 @@ class EncryptionPluginManagerTest {
     
     @Test
     void testJoin() {
-        EncryptionPluginManager.join(new EncryptionPluginService() {
-            
-            @Override
-            public String encrypt(String secretKey, String content) {
-                return content;
-            }
-            
-            @Override
-            public String decrypt(String secretKey, String content) {
-                return content;
-            }
-            
-            @Override
-            public String generateSecretKey() {
-                return "12345678";
-            }
-            
-            @Override
-            public String algorithmName() {
-                return "aes";
-            }
-            
-            @Override
-            public String encryptSecretKey(String secretKey) {
-                return secretKey;
-            }
-            
-            @Override
-            public String decryptSecretKey(String secretKey) {
-                return secretKey;
-            }
-        });
+        EncryptionPluginManager.join(new TestEncryptionPluginService("aes"));
         assertNotNull(EncryptionPluginManager.instance().findEncryptionService("aes"));
     }
     
@@ -81,4 +60,67 @@ class EncryptionPluginManagerTest {
         assertTrue(optional.isPresent());
     }
     
+    @Test
+    void testDisabledNullJoinAndGetAllPlugins() {
+        EncryptionPluginManager.join(null);
+        PluginStateCheckerHolder.setInstance((pluginType, pluginName) -> false);
+        
+        Optional<EncryptionPluginService> optional =
+            EncryptionPluginManager.instance().findEncryptionService("aes");
+        
+        assertFalse(optional.isPresent());
+        assertThrows(UnsupportedOperationException.class,
+            () -> EncryptionPluginManager.instance().getAllPlugins().clear());
+    }
+    
+    @Test
+    void testEncryptionPluginServiceMethods() {
+        EncryptionPluginService service = new TestEncryptionPluginService("aes");
+        
+        assertEquals("content", service.encrypt("secretKey", "content"));
+        assertEquals("content", service.decrypt("secretKey", "content"));
+        assertEquals("12345678", service.generateSecretKey());
+        assertEquals("aes", service.algorithmName());
+        assertEquals("secretKey", service.encryptSecretKey("secretKey"));
+        assertEquals("secretKey", service.decryptSecretKey("secretKey"));
+    }
+    
+    private static class TestEncryptionPluginService implements EncryptionPluginService {
+        
+        private final String algorithmName;
+        
+        private TestEncryptionPluginService(String algorithmName) {
+            this.algorithmName = algorithmName;
+        }
+        
+        @Override
+        public String encrypt(String secretKey, String content) {
+            return content;
+        }
+        
+        @Override
+        public String decrypt(String secretKey, String content) {
+            return content;
+        }
+        
+        @Override
+        public String generateSecretKey() {
+            return "12345678";
+        }
+        
+        @Override
+        public String algorithmName() {
+            return algorithmName;
+        }
+        
+        @Override
+        public String encryptSecretKey(String secretKey) {
+            return secretKey;
+        }
+        
+        @Override
+        public String decryptSecretKey(String secretKey) {
+            return secretKey;
+        }
+    }
 }

--- a/plugin/encryption/src/test/java/com/alibaba/nacos/plugin/encryption/EncryptionPluginManagerTest.java
+++ b/plugin/encryption/src/test/java/com/alibaba/nacos/plugin/encryption/EncryptionPluginManagerTest.java
@@ -21,6 +21,10 @@ import com.alibaba.nacos.plugin.encryption.spi.EncryptionPluginService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -83,6 +87,33 @@ class EncryptionPluginManagerTest {
         assertEquals("aes", service.algorithmName());
         assertEquals("secretKey", service.encryptSecretKey("secretKey"));
         assertEquals("secretKey", service.decryptSecretKey("secretKey"));
+    }
+    
+    @Test
+    void testLoadInitialFromSpiSkipsBlankAlgorithmName() throws Exception {
+        Map<String, EncryptionPluginService> plugins = getPlugins();
+        Map<String, EncryptionPluginService> snapshot = new HashMap<>(plugins);
+        plugins.clear();
+        Method method = EncryptionPluginManager.class.getDeclaredMethod("loadInitial");
+        method.setAccessible(true);
+        
+        try {
+            method.invoke(EncryptionPluginManager.instance());
+            
+            assertTrue(EncryptionPluginManager.instance().findEncryptionService("spi-aes")
+                .isPresent());
+            assertFalse(EncryptionPluginManager.instance().findEncryptionService("").isPresent());
+        } finally {
+            plugins.clear();
+            plugins.putAll(snapshot);
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    private Map<String, EncryptionPluginService> getPlugins() throws Exception {
+        Field field = EncryptionPluginManager.class.getDeclaredField("ENCRYPTION_SPI_MAP");
+        field.setAccessible(true);
+        return (Map<String, EncryptionPluginService>) field.get(null);
     }
     
     private static class TestEncryptionPluginService implements EncryptionPluginService {

--- a/plugin/encryption/src/test/java/com/alibaba/nacos/plugin/encryption/SpiEncryptionPluginService.java
+++ b/plugin/encryption/src/test/java/com/alibaba/nacos/plugin/encryption/SpiEncryptionPluginService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.encryption;
+
+import com.alibaba.nacos.plugin.encryption.spi.EncryptionPluginService;
+
+public class SpiEncryptionPluginService implements EncryptionPluginService {
+    
+    @Override
+    public String encrypt(String secretKey, String content) {
+        return content;
+    }
+    
+    @Override
+    public String decrypt(String secretKey, String content) {
+        return content;
+    }
+    
+    @Override
+    public String generateSecretKey() {
+        return "spiSecretKey";
+    }
+    
+    @Override
+    public String algorithmName() {
+        return "spi-aes";
+    }
+    
+    @Override
+    public String encryptSecretKey(String secretKey) {
+        return secretKey;
+    }
+    
+    @Override
+    public String decryptSecretKey(String secretKey) {
+        return secretKey;
+    }
+}

--- a/plugin/encryption/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.encryption.spi.EncryptionPluginService
+++ b/plugin/encryption/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.encryption.spi.EncryptionPluginService
@@ -1,0 +1,18 @@
+#
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.nacos.plugin.encryption.BlankEncryptionPluginService
+com.alibaba.nacos.plugin.encryption.SpiEncryptionPluginService

--- a/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/BlankCustomEnvironmentPluginService.java
+++ b/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/BlankCustomEnvironmentPluginService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.environment;
+
+public class BlankCustomEnvironmentPluginService extends SpiCustomEnvironmentPluginService {
+    
+    @Override
+    public String pluginName() {
+        return "";
+    }
+}

--- a/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManagerTest.java
+++ b/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManagerTest.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
 import com.alibaba.nacos.plugin.environment.spi.EnvironmentPluginProvider;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -54,6 +55,7 @@ class CustomEnvironmentPluginManagerTest {
                 // [issue 13367] check property remove
                 property.put("db.password.1", null);
                 property.put("db.password.2", null);
+                property.put("db.password.extra", "extra");
                 return property;
             }
             
@@ -85,6 +87,42 @@ class CustomEnvironmentPluginManagerTest {
         // [issue 13367] check property remove
         assertFalse(customValues.containsKey("db.password.1"));
         assertFalse(customValues.containsKey("db.password.2"));
+        assertFalse(customValues.containsKey("db.password.extra"));
+        
+        CustomEnvironmentPluginManager.join(null);
+    }
+    
+    @Test
+    void testCustomEnvironmentPluginServiceMethods() {
+        CustomEnvironmentPluginService service = new CustomEnvironmentPluginService() {
+            
+            @Override
+            public Map<String, Object> customValue(Map<String, Object> property) {
+                property.put("key", "value");
+                return property;
+            }
+            
+            @Override
+            public Set<String> propertyKey() {
+                return Collections.singleton("key");
+            }
+            
+            @Override
+            public Integer order() {
+                return 1;
+            }
+            
+            @Override
+            public String pluginName() {
+                return "test";
+            }
+        };
+        
+        Map<String, Object> property = new HashMap<>();
+        assertEquals(property, service.customValue(property));
+        assertEquals(Collections.singleton("key"), service.propertyKey());
+        assertEquals(1, service.order());
+        assertEquals("test", service.pluginName());
     }
     
     @Test

--- a/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManagerTest.java
+++ b/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManagerTest.java
@@ -21,15 +21,20 @@ import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
 import com.alibaba.nacos.plugin.environment.spi.EnvironmentPluginProvider;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * CustomEnvironment Plugin Test.
@@ -126,10 +131,36 @@ class CustomEnvironmentPluginManagerTest {
     }
     
     @Test
+    void testLoadInitialFromSpiSkipsBlankPluginName() throws Exception {
+        List<CustomEnvironmentPluginService> services = getServices();
+        List<CustomEnvironmentPluginService> snapshot = new ArrayList<>(services);
+        services.clear();
+        Method method = CustomEnvironmentPluginManager.class.getDeclaredMethod("loadInitial");
+        method.setAccessible(true);
+        
+        try {
+            method.invoke(CustomEnvironmentPluginManager.getInstance());
+            
+            assertTrue(CustomEnvironmentPluginManager.getInstance().getPropertyKeys()
+                .contains("spi.key"));
+        } finally {
+            services.clear();
+            services.addAll(snapshot);
+        }
+    }
+    
+    @Test
     void testEnvironmentPluginProvider() {
         EnvironmentPluginProvider provider = new EnvironmentPluginProvider();
         
         assertEquals(PluginType.ENVIRONMENT, provider.getPluginType());
         assertNotNull(provider.getAllPlugins());
+    }
+    
+    @SuppressWarnings("unchecked")
+    private List<CustomEnvironmentPluginService> getServices() throws Exception {
+        Field field = CustomEnvironmentPluginManager.class.getDeclaredField("SERVICE_LIST");
+        field.setAccessible(true);
+        return (List<CustomEnvironmentPluginService>) field.get(null);
     }
 }

--- a/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/SpiCustomEnvironmentPluginService.java
+++ b/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/SpiCustomEnvironmentPluginService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.environment;
+
+import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public class SpiCustomEnvironmentPluginService implements CustomEnvironmentPluginService {
+    
+    @Override
+    public Map<String, Object> customValue(Map<String, Object> property) {
+        return property;
+    }
+    
+    @Override
+    public Set<String> propertyKey() {
+        return Collections.singleton("spi.key");
+    }
+    
+    @Override
+    public Integer order() {
+        return 10;
+    }
+    
+    @Override
+    public String pluginName() {
+        return "spi-environment";
+    }
+}

--- a/plugin/environment/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService
+++ b/plugin/environment/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService
@@ -1,0 +1,18 @@
+#
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.nacos.plugin.environment.BlankCustomEnvironmentPluginService
+com.alibaba.nacos.plugin.environment.SpiCustomEnvironmentPluginService

--- a/plugin/trace/src/test/java/com/alibaba/nacos/plugin/trace/NacosTracePluginManagerTest.java
+++ b/plugin/trace/src/test/java/com/alibaba/nacos/plugin/trace/NacosTracePluginManagerTest.java
@@ -16,11 +16,22 @@
 
 package com.alibaba.nacos.plugin.trace;
 
+import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.plugin.trace.spi.NacosTraceSubscriber;
+import com.alibaba.nacos.common.trace.event.TraceEvent;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class NacosTracePluginManagerTest {
@@ -30,10 +41,32 @@ class NacosTracePluginManagerTest {
         NacosTracePluginManager.getInstance();
     }
     
+    @AfterEach
+    void tearDown() {
+        PluginStateCheckerHolder.setInstance(null);
+    }
+    
     @Test
     void testGetAllTraceSubscribers() {
         assertFalse(NacosTracePluginManager.getInstance().getAllTraceSubscribers().isEmpty());
         assertContainsTestPlugin();
+    }
+    
+    @Test
+    void testGetAllTraceSubscribersWhenCheckerPresent() throws Exception {
+        Map<String, NacosTraceSubscriber> subscribers = getSubscribers();
+        subscribers.put("enabled", new TestTraceSubscriber("enabled"));
+        subscribers.put("disabled", new TestTraceSubscriber("disabled"));
+        PluginStateCheckerHolder.setInstance(
+            (pluginType, pluginName) -> !"disabled".equals(pluginName));
+        
+        Collection<NacosTraceSubscriber> result =
+            NacosTracePluginManager.getInstance().getAllTraceSubscribers();
+        
+        assertTrue(result.stream().anyMatch(each -> "enabled".equals(each.getName())));
+        assertFalse(result.stream().anyMatch(each -> "disabled".equals(each.getName())));
+        assertThrows(UnsupportedOperationException.class,
+            () -> NacosTracePluginManager.getInstance().getAllPlugins().clear());
     }
     
     private void assertContainsTestPlugin() {
@@ -44,5 +77,34 @@ class NacosTracePluginManagerTest {
             }
         }
         fail("No found plugin named 'trace-plugin-mock'");
+    }
+    
+    private Map<String, NacosTraceSubscriber> getSubscribers() throws Exception {
+        Field field = NacosTracePluginManager.class.getDeclaredField("traceSubscribers");
+        field.setAccessible(true);
+        return (Map<String, NacosTraceSubscriber>) field.get(NacosTracePluginManager.getInstance());
+    }
+    
+    private static class TestTraceSubscriber implements NacosTraceSubscriber {
+        
+        private final String name;
+        
+        private TestTraceSubscriber(String name) {
+            this.name = name;
+        }
+        
+        @Override
+        public String getName() {
+            return name;
+        }
+        
+        @Override
+        public void onEvent(TraceEvent event) {
+        }
+        
+        @Override
+        public List<Class<? extends TraceEvent>> subscribeTypes() {
+            return Collections.emptyList();
+        }
     }
 }

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/model/VisibilityResourceTest.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/model/VisibilityResourceTest.java
@@ -56,4 +56,16 @@ class VisibilityResourceTest {
     void testDefaultOwnerIsEmpty() {
         assertEquals("", resource.getOwner());
     }
+    
+    @Test
+    void testSetScopeAndOwner() {
+        resource.setScope(VisibilityConstants.SCOPE_PUBLIC);
+        resource.setOwner("nacos");
+        
+        assertEquals(VisibilityConstants.SCOPE_PUBLIC, resource.getScope());
+        assertEquals("nacos", resource.getOwner());
+        assertEquals("test-ns", resource.getNamespaceId());
+        assertEquals("test-resource", resource.getResourceName());
+        assertEquals("skill", resource.getResourceType());
+    }
 }

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/SpiBrokenVisibilityService.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/SpiBrokenVisibilityService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.visibility.spi;
+
+public class SpiBrokenVisibilityService extends SpiLoadedVisibilityService {
+    
+    public SpiBrokenVisibilityService() {
+        throw new IllegalStateException("broken visibility service");
+    }
+}

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/SpiLoadedVisibilityService.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/SpiLoadedVisibilityService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.visibility.spi;
+
+import com.alibaba.nacos.plugin.visibility.model.VisibilityQueryContext;
+import com.alibaba.nacos.plugin.visibility.model.VisibilityResource;
+
+import java.util.Properties;
+
+public class SpiLoadedVisibilityService implements VisibilityService {
+    
+    static Properties initProperties;
+    
+    @Override
+    public void init(Properties properties) {
+        initProperties = properties;
+    }
+    
+    @Override
+    public ValidationResult validateVisibility(String identity, String action, String apiType,
+        VisibilityResource resource) {
+        return ValidationResult.allow();
+    }
+    
+    @Override
+    public QueryAdvisor adviseQuery(String identity, String action, String apiType,
+        VisibilityQueryContext context) {
+        return new QueryAdvisor();
+    }
+    
+    @Override
+    public String getVisibilityServiceName() {
+        return "spi-loaded";
+    }
+}

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManagerTest.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManagerTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.plugin.visibility.spi;
 import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.plugin.visibility.model.VisibilityQueryContext;
 import com.alibaba.nacos.plugin.visibility.model.VisibilityResource;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,7 @@ class VisibilityPluginManagerTest {
     
     @BeforeEach
     void setUp() throws NoSuchFieldException, IllegalAccessException {
+        EnvUtil.reset();
         System.clearProperty(VISIBILITY_ENABLED_KEY);
         PluginStateCheckerHolder.setInstance(null);
         manager = VisibilityPluginManager.getInstance();
@@ -68,6 +70,7 @@ class VisibilityPluginManagerTest {
     
     @AfterEach
     void tearDown() {
+        EnvUtil.reset();
         System.clearProperty(VISIBILITY_ENABLED_KEY);
         PluginStateCheckerHolder.setInstance(null);
         serviceMap.clear();
@@ -143,6 +146,38 @@ class VisibilityPluginManagerTest {
             "custom");
         
         assertTrue(result.isEmpty());
+    }
+    
+    @Test
+    void testResolveInitPropertiesFallsBackWhenEnvUtilThrows() throws Exception {
+        System.setProperty("nacos.plugin.visibility.fallback.timeout", "5000");
+        EnvUtil.setThrowException(true);
+        
+        Method propertiesMethod =
+            VisibilityPluginManager.class.getDeclaredMethod("resolveInitProperties");
+        propertiesMethod.setAccessible(true);
+        
+        Properties result = (Properties) propertiesMethod.invoke(manager);
+        
+        assertEquals("5000", result.getProperty("nacos.plugin.visibility.fallback.timeout"));
+    }
+    
+    @Test
+    void testInitVisibilityServicesLoadsSpiAndSkipsBrokenProvider() throws Exception {
+        System.setProperty("nacos.plugin.visibility.spi-loaded.timeout", "3000");
+        Field initialized = VisibilityPluginManager.class.getDeclaredField("initialized");
+        initialized.setAccessible(true);
+        initialized.set(manager, false);
+        serviceMap.clear();
+        
+        Method initMethod =
+            VisibilityPluginManager.class.getDeclaredMethod("initVisibilityServices");
+        initMethod.setAccessible(true);
+        initMethod.invoke(manager);
+        
+        assertTrue((Boolean) initialized.get(manager));
+        assertTrue(serviceMap.containsKey("spi-loaded"));
+        assertEquals("3000", SpiLoadedVisibilityService.initProperties.getProperty("timeout"));
     }
     
     private void registerVisibilityService(VisibilityService service, Properties properties)

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManagerTest.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManagerTest.java
@@ -16,6 +16,10 @@
 
 package com.alibaba.nacos.plugin.visibility.spi;
 
+import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
+import com.alibaba.nacos.plugin.visibility.model.VisibilityQueryContext;
+import com.alibaba.nacos.plugin.visibility.model.VisibilityResource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,12 +27,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,16 +50,27 @@ class VisibilityPluginManagerTest {
     @Mock
     private VisibilityService mockVisibilityService;
     
+    private Map<String, VisibilityService> serviceMap;
+    
     @BeforeEach
     void setUp() throws NoSuchFieldException, IllegalAccessException {
         System.clearProperty(VISIBILITY_ENABLED_KEY);
+        PluginStateCheckerHolder.setInstance(null);
         manager = VisibilityPluginManager.getInstance();
         Field field = VisibilityPluginManager.class.getDeclaredField("visibilityServiceMap");
         field.setAccessible(true);
         @SuppressWarnings("unchecked")
-        Map<String, VisibilityService> serviceMap = (Map<String, VisibilityService>) field.get(
-            manager);
+        Map<String, VisibilityService> map = (Map<String, VisibilityService>) field.get(manager);
+        serviceMap = map;
+        serviceMap.clear();
         serviceMap.put(TEST_SERVICE_NAME, mockVisibilityService);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(VISIBILITY_ENABLED_KEY);
+        PluginStateCheckerHolder.setInstance(null);
+        serviceMap.clear();
     }
     
     @Test
@@ -72,6 +90,123 @@ class VisibilityPluginManagerTest {
         System.setProperty(VISIBILITY_ENABLED_KEY, "false");
         Optional<VisibilityService> result = manager.findVisibilityService(TEST_SERVICE_NAME);
         assertFalse(result.isPresent());
-        System.clearProperty(VISIBILITY_ENABLED_KEY);
+    }
+    
+    @Test
+    void testFindVisibilityServiceWhenNamedPluginDisabled() {
+        PluginStateCheckerHolder.setInstance((pluginType, pluginName) -> false);
+        
+        Optional<VisibilityService> result = manager.findVisibilityService(TEST_SERVICE_NAME);
+        
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    void testGetAllPluginsIsUnmodifiable() {
+        assertThrows(UnsupportedOperationException.class, () -> manager.getAllPlugins().clear());
+    }
+    
+    @Test
+    void testRegisterVisibilityServiceBranches() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("nacos.plugin.visibility.custom.timeout", "1000");
+        properties.setProperty("nacos.plugin.visibility.other.timeout", "2000");
+        TestVisibilityService service = new TestVisibilityService("custom");
+        
+        registerVisibilityService(service, properties);
+        registerVisibilityService(new TestVisibilityService(""), properties);
+        registerVisibilityService(new ThrowNameVisibilityService(), properties);
+        registerVisibilityService(new ThrowInitVisibilityService("throw-init"), properties);
+        
+        assertEquals(service, serviceMap.get("custom"));
+        assertEquals("1000", service.initProperties.getProperty("timeout"));
+        assertFalse(service.initProperties.containsKey("nacos.plugin.visibility.custom.timeout"));
+        assertFalse(serviceMap.containsKey(""));
+        assertFalse(serviceMap.containsKey("throw-init"));
+    }
+    
+    @Test
+    void testInitAndPropertyResolutionBranches() throws Exception {
+        Field initialized = VisibilityPluginManager.class.getDeclaredField("initialized");
+        initialized.setAccessible(true);
+        initialized.set(manager, true);
+        
+        Method initMethod =
+            VisibilityPluginManager.class.getDeclaredMethod("initVisibilityServices");
+        initMethod.setAccessible(true);
+        initMethod.invoke(manager);
+        
+        Method propertiesMethod = VisibilityPluginManager.class.getDeclaredMethod(
+            "resolveServiceProperties", Properties.class, String.class);
+        propertiesMethod.setAccessible(true);
+        Properties result = (Properties) propertiesMethod.invoke(manager, new Properties(),
+            "custom");
+        
+        assertTrue(result.isEmpty());
+    }
+    
+    private void registerVisibilityService(VisibilityService service, Properties properties)
+        throws Exception {
+        Method method = VisibilityPluginManager.class.getDeclaredMethod("registerVisibilityService",
+            VisibilityService.class, Properties.class);
+        method.setAccessible(true);
+        method.invoke(manager, service, properties);
+    }
+    
+    private static class TestVisibilityService implements VisibilityService {
+        
+        private final String serviceName;
+        
+        private Properties initProperties;
+        
+        private TestVisibilityService(String serviceName) {
+            this.serviceName = serviceName;
+        }
+        
+        @Override
+        public void init(Properties properties) {
+            initProperties = properties;
+        }
+        
+        @Override
+        public ValidationResult validateVisibility(String identity, String action, String apiType,
+            VisibilityResource resource) {
+            return null;
+        }
+        
+        @Override
+        public QueryAdvisor adviseQuery(String identity, String action, String apiType,
+            VisibilityQueryContext context) {
+            return null;
+        }
+        
+        @Override
+        public String getVisibilityServiceName() {
+            return serviceName;
+        }
+    }
+    
+    private static class ThrowNameVisibilityService extends TestVisibilityService {
+        
+        private ThrowNameVisibilityService() {
+            super("throw-name");
+        }
+        
+        @Override
+        public String getVisibilityServiceName() {
+            throw new IllegalStateException("name failed");
+        }
+    }
+    
+    private static class ThrowInitVisibilityService extends TestVisibilityService {
+        
+        private ThrowInitVisibilityService(String serviceName) {
+            super(serviceName);
+        }
+        
+        @Override
+        public void init(Properties properties) {
+            throw new IllegalStateException("init failed");
+        }
     }
 }

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/sys/env/EnvUtil.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/sys/env/EnvUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.sys.env;
+
+/**
+ * Test EnvUtil for visibility plugin, which avoids a production dependency on nacos-sys.
+ *
+ * @author xiweng.yy
+ */
+public final class EnvUtil {
+    
+    private static Object properties;
+    
+    private static boolean throwException;
+    
+    private EnvUtil() {
+    }
+    
+    public static Object getProperties() {
+        if (throwException) {
+            throw new IllegalStateException("failed to load properties");
+        }
+        return properties == null ? System.getProperties() : properties;
+    }
+    
+    public static void setProperties(Object properties) {
+        EnvUtil.properties = properties;
+    }
+    
+    public static void setThrowException(boolean throwException) {
+        EnvUtil.throwException = throwException;
+    }
+    
+    public static void reset() {
+        properties = null;
+        throwException = false;
+    }
+}

--- a/plugin/visibility/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.visibility.spi.VisibilityService
+++ b/plugin/visibility/src/test/resources/META-INF/services/com.alibaba.nacos.plugin.visibility.spi.VisibilityService
@@ -1,0 +1,18 @@
+#
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.nacos.plugin.visibility.spi.SpiBrokenVisibilityService
+com.alibaba.nacos.plugin.visibility.spi.SpiLoadedVisibilityService


### PR DESCRIPTION
## Summary
- Add unit tests for plugin SPI loading paths across visibility, config, encryption, environment, datasource, and control modules.
- Cover key fallback/error branches such as broken SPI providers, blank service names, plugin disabled paths, and control rule reload behavior.
- Improve local plugin module line coverage to about 98.55%.

## Testing
- `./mvnw -B -f plugin/pom.xml clean test`
- `./mvnw -B -f plugin/pom.xml spotless:apply`
- `./mvnw -B -f plugin/pom.xml spotless:check`
- `./mvnw -B -f plugin/pom.xml clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests`