### PR TITLE
[ISSUE #15183] Harden AI importer source endpoints

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManager.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManager.java
@@ -99,6 +99,7 @@ public class AiResourceImportManager {
         requireRequest(request);
         AiResourceImportSource source =
             sourceManager.resolveSource(request.getSourceId(), request.getResourceType());
+        securityGuard.checkSourceEndpoint(source);
         AiResourceImportService importer =
             pluginManager.resolveImporter(source, request.getResourceType());
         AiResourceImportCandidatePage page = importer.search(buildSearchContext(source, request));
@@ -126,6 +127,7 @@ public class AiResourceImportManager {
         requireSelectedItems(request.getSelectedItems());
         AiResourceImportSource source =
             sourceManager.resolveSource(request.getSourceId(), request.getResourceType());
+        securityGuard.checkSourceEndpoint(source);
         AiResourceImportService importer =
             pluginManager.resolveImporter(source, request.getResourceType());
         AiResourceImportContext context = buildItemContext(source, request.getNamespaceId(),
@@ -154,6 +156,7 @@ public class AiResourceImportManager {
         requireSelectedItems(request.getSelectedItems());
         AiResourceImportSource source =
             sourceManager.resolveSource(request.getSourceId(), request.getResourceType());
+        securityGuard.checkSourceEndpoint(source);
         AiResourceImportService importer =
             pluginManager.resolveImporter(source, request.getResourceType());
         AiResourceImportContext context = buildItemContext(source, request.getNamespaceId(),

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/security/AiResourceImportSecurityGuard.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/security/AiResourceImportSecurityGuard.java
@@ -19,10 +19,16 @@ package com.alibaba.nacos.ai.importer.security;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
 import org.springframework.stereotype.Service;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Central guard for import artifacts crossing the plugin boundary.
@@ -32,6 +38,22 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class AiResourceImportSecurityGuard {
+    
+    public static final String PROPERTY_ALLOW_HTTP = "allow-http";
+    
+    public static final String PROPERTY_ALLOW_HTTP_CAMEL = "allowHttp";
+    
+    public static final String PROPERTY_ALLOW_PRIVATE_NETWORK = "allow-private-network";
+    
+    public static final String PROPERTY_ALLOW_PRIVATE_NETWORK_CAMEL = "allowPrivateNetwork";
+    
+    private static final String HTTPS_SCHEME = "https";
+    
+    private static final String HTTP_SCHEME = "http";
+    
+    private static final String LOCALHOST = "localhost";
+    
+    private static final String LOCALHOST_SUFFIX = ".localhost";
     
     /**
      * Check artifact type and size before validation or import.
@@ -59,6 +81,85 @@ public class AiResourceImportSecurityGuard {
         if (source.getMaxArtifactSize() > 0 && payloadSize > source.getMaxArtifactSize()) {
             throw invalid("AI resource import artifact size exceeds source limit.");
         }
+    }
+    
+    /**
+     * Check source endpoint before an importer makes network requests.
+     *
+     * @param source resolved source
+     * @throws NacosException if the source endpoint violates the import boundary
+     */
+    public void checkSourceEndpoint(AiResourceImportSource source) throws NacosException {
+        if (source == null || StringUtils.isBlank(source.getEndpoint())) {
+            return;
+        }
+        URI endpoint = parseEndpoint(source.getEndpoint());
+        String scheme = endpoint.getScheme() == null ? null
+            : endpoint.getScheme().toLowerCase(Locale.ENGLISH);
+        if (!HTTPS_SCHEME.equals(scheme) && !HTTP_SCHEME.equals(scheme)) {
+            throw invalid("AI resource import source endpoint must use http or https.");
+        }
+        if (HTTP_SCHEME.equals(scheme) && !isSourcePropertyEnabled(source, PROPERTY_ALLOW_HTTP,
+            PROPERTY_ALLOW_HTTP_CAMEL)) {
+            throw invalid(
+                "AI resource import source endpoint must use https unless allow-http is enabled.");
+        }
+        if (StringUtils.isBlank(endpoint.getHost())) {
+            throw invalid("AI resource import source endpoint host must not be empty.");
+        }
+        if (isUnsafeHost(endpoint.getHost()) && !isSourcePropertyEnabled(source,
+            PROPERTY_ALLOW_PRIVATE_NETWORK, PROPERTY_ALLOW_PRIVATE_NETWORK_CAMEL)) {
+            throw invalid(
+                "AI resource import source endpoint resolves to a private or local target.");
+        }
+    }
+    
+    private URI parseEndpoint(String endpoint) throws NacosException {
+        try {
+            URI result = URI.create(endpoint.trim());
+            if (!result.isAbsolute()) {
+                throw invalid("AI resource import source endpoint must be an absolute URL.");
+            }
+            return result;
+        } catch (IllegalArgumentException e) {
+            throw invalid("AI resource import source endpoint is invalid.");
+        }
+    }
+    
+    private boolean isUnsafeHost(String host) throws NacosException {
+        String normalized = InternetAddressUtil.removeBrackets(host).toLowerCase(Locale.ENGLISH);
+        if (LOCALHOST.equals(normalized) || normalized.endsWith(LOCALHOST_SUFFIX)) {
+            return true;
+        }
+        if (!InternetAddressUtil.isIp(normalized)) {
+            return false;
+        }
+        try {
+            return isUnsafeAddress(InetAddress.getByName(normalized));
+        } catch (Exception e) {
+            throw invalid("AI resource import source endpoint host is invalid.");
+        }
+    }
+    
+    private boolean isUnsafeAddress(InetAddress address) {
+        return address.isAnyLocalAddress() || address.isLoopbackAddress()
+            || address.isLinkLocalAddress() || address.isSiteLocalAddress()
+            || address.isMulticastAddress() || isUniqueLocalIpv6Address(address);
+    }
+    
+    private boolean isUniqueLocalIpv6Address(InetAddress address) {
+        byte[] bytes = address.getAddress();
+        return bytes.length == 16 && (bytes[0] & 0xfe) == 0xfc;
+    }
+    
+    private boolean isSourcePropertyEnabled(AiResourceImportSource source, String kebabKey,
+        String camelKey) {
+        Map<String, String> properties = source.getProperties();
+        if (properties == null || properties.isEmpty()) {
+            return false;
+        }
+        return Boolean.parseBoolean(properties.get(kebabKey))
+            || Boolean.parseBoolean(properties.get(camelKey));
     }
     
     private NacosException invalid(String message) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManagerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/manager/AiResourceImportManagerTest.java
@@ -50,7 +50,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -105,6 +107,63 @@ class AiResourceImportManagerTest {
         assertEquals("server-1", response.getItems().get(0).getExternalId());
         assertEquals(10, builder.service.lastContext.getLimit());
         assertEquals("database", builder.service.lastContext.getQuery());
+    }
+    
+    @Test
+    void testSearchRejectsHttpEndpointByDefault() {
+        AiResourceImportProperties properties = enabledProperties();
+        properties.getSources().get(0).setEndpoint("http://example.com/registry");
+        AiResourceImportManager manager = newManager(properties, new FakeImportServiceBuilder(),
+            Collections.singletonList(new FakeOperator()));
+        AiResourceImportSearchRequest request = searchRequest();
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> manager.search(request));
+        
+        assertTrue(exception.getErrMsg().contains("must use https"));
+    }
+    
+    @Test
+    void testSearchAllowsHttpEndpointWhenConfigured() throws NacosException {
+        AiResourceImportProperties properties = enabledProperties();
+        properties.getSources().get(0).setEndpoint("http://example.com/registry");
+        properties.getSources().get(0).setProperties(
+            Collections.singletonMap("allow-http", "true"));
+        AiResourceImportManager manager = newManager(properties, new FakeImportServiceBuilder(),
+            Collections.singletonList(new FakeOperator()));
+        
+        AiResourceImportSearchResponse response = manager.search(searchRequest());
+        
+        assertEquals(1, response.getItems().size());
+    }
+    
+    @Test
+    void testSearchRejectsPrivateEndpointByDefault() {
+        AiResourceImportProperties properties = enabledProperties();
+        properties.getSources().get(0).setEndpoint("https://127.0.0.1/registry");
+        AiResourceImportManager manager = newManager(properties, new FakeImportServiceBuilder(),
+            Collections.singletonList(new FakeOperator()));
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> manager.search(searchRequest()));
+        
+        assertTrue(exception.getErrMsg().contains("private or local target"));
+    }
+    
+    @Test
+    void testSearchAllowsPrivateEndpointWhenConfigured() throws NacosException {
+        AiResourceImportProperties properties = enabledProperties();
+        properties.getSources().get(0).setEndpoint("http://127.0.0.1/registry");
+        Map<String, String> sourceProperties = new HashMap<>(2);
+        sourceProperties.put("allow-http", "true");
+        sourceProperties.put("allow-private-network", "true");
+        properties.getSources().get(0).setProperties(sourceProperties);
+        AiResourceImportManager manager = newManager(properties, new FakeImportServiceBuilder(),
+            Collections.singletonList(new FakeOperator()));
+        
+        AiResourceImportSearchResponse response = manager.search(searchRequest());
+        
+        assertEquals(1, response.getItems().size());
     }
     
     @Test
@@ -292,6 +351,15 @@ class AiResourceImportManagerTest {
         source.setMaxItemCount(10);
         source.setMaxArtifactSize(1024);
         return source;
+    }
+    
+    private AiResourceImportSearchRequest searchRequest() {
+        AiResourceImportSearchRequest request = new AiResourceImportSearchRequest();
+        request.setResourceType("mcp");
+        request.setSourceId("source-1");
+        request.setQuery("database");
+        request.setLimit(50);
+        return request;
     }
     
     private AiResourceImportSource providerSource() {

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -393,6 +393,9 @@ nacos.istio.mcp.server.enabled=false
 #nacos.plugin.ai.importer.skills.well-known.url=https://developers.cloudflare.com
 # Optional: enable the built-in skills.sh import source. Source id: skills-sh.
 #nacos.plugin.ai.importer.skills.skills-sh.enabled=true
+# Optional: allow non-HTTPS or private-network endpoints only for controlled deployments.
+#nacos.plugin.ai.importer.<preset>.allow-http=false
+#nacos.plugin.ai.importer.<preset>.allow-private-network=false
 
 #--------------- Nacos Experimental Features Configurations ---------------#
 

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProvider.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProvider.java
@@ -30,7 +30,9 @@ import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportSourceProvider;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -63,6 +65,14 @@ public class DefaultAiResourceImportSourceProvider implements AiResourceImportSo
     private static final int DEFAULT_MAX_ITEM_COUNT = 500;
     
     private static final long DEFAULT_MAX_ARTIFACT_SIZE = 10L * 1024L * 1024L;
+    
+    private static final String PROPERTY_ALLOW_HTTP = "allow-http";
+    
+    private static final String PROPERTY_ALLOW_HTTP_CAMEL = "allowHttp";
+    
+    private static final String PROPERTY_ALLOW_PRIVATE_NETWORK = "allow-private-network";
+    
+    private static final String PROPERTY_ALLOW_PRIVATE_NETWORK_CAMEL = "allowPrivateNetwork";
     
     @Override
     public Collection<AiResourceImportSource> loadSources(Properties properties)
@@ -108,7 +118,8 @@ public class DefaultAiResourceImportSourceProvider implements AiResourceImportSo
         if (!getBoolean(properties, SKILL_WELL_KNOWN_PREFIX + "enabled", false)) {
             return null;
         }
-        String endpoint = getString(properties, SKILL_WELL_KNOWN_PREFIX, "url", "endpoint", null);
+        String endpoint = getString(properties, SKILL_WELL_KNOWN_PREFIX, "url", "endpoint",
+            null);
         if (StringUtils.isBlank(endpoint)) {
             throw invalidConfig(
                 "Skill well-known import source url must not be empty when enabled.");
@@ -162,6 +173,27 @@ public class DefaultAiResourceImportSourceProvider implements AiResourceImportSo
             DEFAULT_MAX_ITEM_COUNT));
         source.setMaxArtifactSize(getLong(properties, prefix + "max-artifact-size",
             DEFAULT_MAX_ARTIFACT_SIZE));
+        applySecurityOptions(properties, prefix, source);
+    }
+    
+    private void applySecurityOptions(Properties properties, String prefix,
+        AiResourceImportSource source) {
+        Map<String, String> sourceProperties = new LinkedHashMap<>(2);
+        putConfiguredProperty(properties, prefix, PROPERTY_ALLOW_HTTP, PROPERTY_ALLOW_HTTP_CAMEL,
+            sourceProperties);
+        putConfiguredProperty(properties, prefix, PROPERTY_ALLOW_PRIVATE_NETWORK,
+            PROPERTY_ALLOW_PRIVATE_NETWORK_CAMEL, sourceProperties);
+        if (!sourceProperties.isEmpty()) {
+            source.setProperties(sourceProperties);
+        }
+    }
+    
+    private void putConfiguredProperty(Properties properties, String prefix, String kebabKey,
+        String camelKey, Map<String, String> sourceProperties) {
+        String value = getString(properties, prefix, kebabKey, camelKey, null);
+        if (StringUtils.isNotBlank(value)) {
+            sourceProperties.put(kebabKey, value);
+        }
     }
     
     private String getString(Properties properties, String prefix, String kebabKey,

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryClient.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryClient.java
@@ -289,7 +289,7 @@ class McpRegistryClient {
     private HttpClient getHttpClient() {
         if (httpClient == null) {
             httpClient = HttpClient.newBuilder()
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
                 .build();
         }

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportService.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportService.java
@@ -126,7 +126,7 @@ public class SkillWellKnownImportService implements AiResourceImportService {
     
     public SkillWellKnownImportService() {
         this(HttpClient.newBuilder()
-            .followRedirects(HttpClient.Redirect.NORMAL)
+            .followRedirects(HttpClient.Redirect.NEVER)
             .connectTimeout(Duration.ofSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS))
             .build());
     }

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillsShImportService.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillsShImportService.java
@@ -98,7 +98,7 @@ public class SkillsShImportService implements AiResourceImportService {
     
     public SkillsShImportService() {
         this(HttpClient.newBuilder()
-            .followRedirects(HttpClient.Redirect.NORMAL)
+            .followRedirects(HttpClient.Redirect.NEVER)
             .connectTimeout(Duration.ofSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS))
             .build());
     }

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProviderTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProviderTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -99,6 +100,23 @@ class DefaultAiResourceImportSourceProviderTest {
             source.getEndpoint());
         assertEquals(AiResourceImportConstants.RESOURCE_TYPE_SKILL,
             source.getResourceTypes().get(0));
+    }
+    
+    @Test
+    void testLoadSourceSecurityOptions() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "true");
+        properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.allow-http", "true");
+        properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.allow-private-network",
+            "true");
+        
+        List<AiResourceImportSource> sources = toList(provider.loadSources(properties));
+        
+        assertEquals(1, sources.size());
+        AiResourceImportSource source = sources.get(0);
+        assertNotNull(source.getProperties());
+        assertEquals("true", source.getProperties().get("allow-http"));
+        assertEquals("true", source.getProperties().get("allow-private-network"));
     }
     
     private List<AiResourceImportSource> toList(Collection<AiResourceImportSource> sources) {

--- a/specs/en/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/en/plugin/ai-resource-import-plugin-spec.md
@@ -198,6 +198,15 @@ the preset source id, display name, endpoint, auth reference, timeouts, item
 limits, and artifact size by using the same
 `nacos.plugin.ai.importer.mcp.official.*` prefix.
 
+All built-in source presets accept the following security opt-ins under their
+own prefix. They default to `false` and should be enabled only by operators for
+controlled private deployments:
+
+| Property suffix | Meaning |
+|-----------------|---------|
+| `allow-http` / `allowHttp` | Allows a non-HTTPS source endpoint. |
+| `allow-private-network` / `allowPrivateNetwork` | Allows localhost, loopback, link-local, multicast, or private-network source endpoints. |
+
 The `skills-well-known` importer connects to an operator-configured Skill
 marketplace or registry root. If the source endpoint is not already a
 well-known path, the importer should first try `/.well-known/agent-skills` and
@@ -404,6 +413,11 @@ The import flow must treat external sources as untrusted:
 
 - users cannot submit arbitrary URLs, IPs, registry roots, or credentials;
 - operator-configured HTTP sources should use HTTPS by default;
+- non-HTTPS source endpoints must be rejected unless an operator-owned source
+  configuration explicitly enables `allow-http`;
+- localhost, loopback, link-local, multicast, and private-network source
+  endpoint targets must be rejected unless an operator-owned source
+  configuration explicitly enables `allow-private-network`;
 - redirects must be disabled or revalidated against the same safety policy;
 - loopback, link-local, multicast, and private network targets should be blocked
   by default after DNS resolution;

--- a/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
@@ -173,6 +173,14 @@ nacos.plugin.ai.importer.mcp.official.enabled=true
 `nacos.plugin.ai.importer.mcp.official.*` 前缀覆盖 source id、展示名、endpoint、auth 引用、
 超时、条目限制和 artifact 大小。
 
+所有内置 source 预置都支持在自身前缀下配置如下安全 opt-in。默认值均为 `false`，只应由运维在受控私网
+部署中显式开启：
+
+| 配置后缀 | 含义 |
+|----------|------|
+| `allow-http` / `allowHttp` | 允许非 HTTPS source endpoint。 |
+| `allow-private-network` / `allowPrivateNetwork` | 允许 localhost、loopback、link-local、multicast 或私网 source endpoint。 |
+
 `skills-well-known` importer 对接运维配置的 Skill 市场或 registry root。若 source endpoint
 不是 well-known 路径，importer 应先尝试 `/.well-known/agent-skills`，再 fallback 到
 `/.well-known/skills` 以兼容 v0.1 来源；若 endpoint 已以 `/.well-known/agent-skills` 或
@@ -350,6 +358,9 @@ source 时，可以按 `sourceId` 解释；否则应失败并提示迁移到
 
 - 用户不能提交任意 URL、IP、registry root 或凭证；
 - 运维配置的 HTTP source 默认应使用 HTTPS；
+- 非 HTTPS source endpoint 必须被拒绝，除非运维在 source 配置中显式开启 `allow-http`；
+- localhost、loopback、link-local、multicast 和私网 source endpoint 必须被拒绝，除非运维在
+  source 配置中显式开启 `allow-private-network`；
 - redirect 必须禁用或按同一安全策略重新校验；
 - DNS 解析后默认阻断 loopback、link-local、multicast 和私网目标；
 - 来源请求必须强制连接超时、读超时、响应大小、页数和 artifact 大小限制；


### PR DESCRIPTION
## Summary
- Add source endpoint guard before importer search, validate, and execute calls.
- Reject non-HTTP(S), non-HTTPS, and local/private literal endpoints unless operator-owned source config opts in.
- Propagate allow-http and allow-private-network options from default importer presets, document the options, and disable automatic redirects in built-in registry clients.

## Validation
- source ~/Documents/switch17.sh && ./mvnw -pl ai,plugin-default-impl/nacos-default-ai-importer-plugin spotless:apply spotless:check
- source ~/Documents/switch17.sh && ./mvnw -pl ai -am -Dtest=AiResourceImportManagerTest -Dsurefire.failIfNoSpecifiedTests=false test
- source ~/Documents/switch17.sh && ./mvnw -pl plugin-default-impl/nacos-default-ai-importer-plugin -am -Dtest=DefaultAiResourceImportSourceProviderTest,McpRegistryImportServiceTest,SkillWellKnownImportServiceTest,SkillsShImportServiceTest -Dsurefire.failIfNoSpecifiedTests=false test
- source ~/Documents/switch17.sh && ./mvnw -pl ai,plugin-default-impl/nacos-default-ai-importer-plugin -am -DskipTests apache-rat:check checkstyle:check spotbugs:check spotless:check