### PR TITLE
[ISSUE #15225] Fix regression of #9461: NPE in ConfigRpcTransportClient.checkListenCache

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -1048,11 +1048,17 @@ public class ClientWorker implements Closeable {
                     }));
         }
         
-        private void refreshContentAndCheck(RpcClient rpcClient, String groupKey, boolean notify) {
-            if (cacheMap.get() != null && cacheMap.get().containsKey(groupKey)) {
-                CacheData cache = cacheMap.get().get(groupKey);
-                refreshContentAndCheck(rpcClient, cache, notify);
+        private void refreshContentAndCheck(RpcClient rpcClient, String groupKey) {
+            Map<String, CacheData> cacheMapSnapshot = cacheMap.get();
+            if (cacheMapSnapshot == null) {
+                return;
             }
+            CacheData cache = cacheMapSnapshot.get(groupKey);
+            if (cache == null) {
+                return;
+            }
+            boolean notify = !cache.isInitializing();
+            refreshContentAndCheck(rpcClient, cache, notify);
         }
         
         private void refreshContentAndCheck(RpcClient rpcClient, CacheData cacheData,
@@ -1174,10 +1180,7 @@ public class ClientWorker implements Closeable {
                                             changeConfig.getDataId(),
                                             changeConfig.getGroup(), changeConfig.getTenant());
                                         changeKeys.add(changeKey);
-                                        boolean isInitializing =
-                                            cacheMap.get().get(changeKey).isInitializing();
-                                        refreshContentAndCheck(rpcClient, changeKey,
-                                            !isInitializing);
+                                        refreshContentAndCheck(rpcClient, changeKey);
                                     }
                                     
                                 }
@@ -1188,10 +1191,7 @@ public class ClientWorker implements Closeable {
                                             cacheData.group,
                                             cacheData.getTenant());
                                         if (!changeKeys.contains(changeKey)) {
-                                            boolean isInitializing =
-                                                cacheMap.get().get(changeKey).isInitializing();
-                                            refreshContentAndCheck(rpcClient, changeKey,
-                                                !isInitializing);
+                                            refreshContentAndCheck(rpcClient, changeKey);
                                         }
                                     }
                                 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ClientWorkerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ClientWorkerTest.java
@@ -643,6 +643,101 @@ class ClientWorkerTest {
         
     }
     
+    /**
+     * Regression test for NPE in ConfigRpcTransportClient.checkListenCache.
+     *
+     * <p>Reproduces the same bug class fixed by PR #9461 (issue: NullPointer judgement order):
+     * if server returns a {@code changeKey} in {@link ConfigChangeBatchListenResponse} that no
+     * longer exists in the local {@code cacheMap} (e.g. user has just called {@code removeListener}
+     * concurrently), the call site previously did
+     * {@code cacheMap.get().get(changeKey).isInitializing()} without null-check.
+     *
+     * <p>The NPE is swallowed by the surrounding {@code catch (Throwable)} so we cannot
+     * detect it via {@code assertDoesNotThrow}. Instead we observe an indirect post-condition:
+     * the buggy code aborts the {@code listenCaches} loop (which clears
+     * {@code cacheData.isInitializing()}), whereas the fixed code skips the ghost key and
+     * still executes that loop. So an unchanged {@code isInitializing()=true} after
+     * {@code executeConfigListen} reveals the swallowed NPE.
+     *
+     * <p>Both former call sites at the buggy lines 1125 and 1136 share the same helper
+     * {@code refreshContentAndCheck(RpcClient, String, boolean)}, so making either one safe
+     * makes the other safe by construction; this test exercises the line-1125 path
+     * (changedConfigs branch) and asserts the helper-level safety.
+     */
+    @Test
+    void testCheckListenCacheSkipsRemovedKey() throws Exception {
+        Properties prop = new Properties();
+        ConfigFilterChainManager filter = new ConfigFilterChainManager(new Properties());
+        ConfigServerListManager agent = Mockito.mock(ConfigServerListManager.class);
+        Mockito.when(agent.getName()).thenReturn("mocktest");
+        final NacosClientProperties nacosClientProperties =
+            NacosClientProperties.PROTOTYPE.derive(prop);
+        ClientWorker clientWorker = new ClientWorker(filter, agent, nacosClientProperties);
+        clientWorker.shutdown();
+        
+        String group = "group-regression";
+        String tenant = "tenant-regression";
+        
+        // local cache contains key K_LOCAL
+        String dataIdLocal = "dataIdLocal" + System.currentTimeMillis();
+        CacheData localCache =
+            normalNotConsistentCache(filter, agent.getName(), dataIdLocal, group, tenant);
+        List<CacheData> cacheDatas = new ArrayList<>();
+        cacheDatas.add(localCache);
+        
+        // cacheMap.values() must return the local cache so executeConfigListen builds a non-empty
+        // listenCachesMap. Production code under test only ever queries cacheMap.get(ghostKey),
+        // which returns null by default (Mockito mock) — exactly modeling the concurrent
+        // removeListener race we want to exercise.
+        Map<String, CacheData> cacheDataMapMocked = Mockito.mock(Map.class);
+        Mockito.when(cacheDataMapMocked.values()).thenReturn(cacheDatas);
+        AtomicReference<Map<String, CacheData>> cacheMapMocked =
+            Mockito.mock(AtomicReference.class);
+        Mockito.when(cacheMapMocked.get()).thenReturn(cacheDataMapMocked);
+        Field cacheMap = ClientWorker.class.getDeclaredField("cacheMap");
+        cacheMap.setAccessible(true);
+        cacheMap.set(clientWorker, cacheMapMocked);
+        
+        // server response carries a "ghost" changeKey that is NOT in cacheMap (concurrent remove)
+        String dataIdGhost = "dataIdGhost" + System.currentTimeMillis();
+        ConfigChangeBatchListenResponse.ConfigContext ghostContext =
+            new ConfigChangeBatchListenResponse.ConfigContext();
+        ghostContext.setDataId(dataIdGhost);
+        ghostContext.setGroup(group);
+        ghostContext.setTenant(tenant);
+        ConfigChangeBatchListenResponse response = new ConfigChangeBatchListenResponse();
+        response.setChangedConfigs(Collections.singletonList(ghostContext));
+        
+        RpcClient rpcClientInner = Mockito.mock(RpcClient.class);
+        Mockito.when(rpcClientInner.isWaitInitiated()).thenReturn(true, false);
+        rpcClientFactoryMockedStatic
+            .when(() -> RpcClientFactory.createClient(anyString(), any(ConnectionType.class),
+                any(GrpcClientConfig.class)))
+            .thenReturn(rpcClientInner);
+        Mockito.when(rpcClientInner.request(any(ConfigBatchListenRequest.class)))
+            .thenReturn(response, response);
+        
+        // sanity check: localCache starts as initializing.
+        assertTrue(localCache.isInitializing(),
+            "precondition: CacheData should start with isInitializing=true");
+        
+        (clientWorker.getAgent()).executeConfigListen();
+        
+        // After executeConfigListen finishes:
+        //   buggy 3.1.1 code: NPE is thrown at lines 1125 / 1136 because cacheMap.get().get(ghostKey)
+        //               returns null; the surrounding catch (Throwable) swallows it but aborts the
+        //               listenCaches loop, so cacheData.setInitializing(false) is never called and
+        //               localCache.isInitializing() is still true.
+        //   fixed code: ghost key is skipped (null-check inside refreshContentAndCheck shared by
+        //               both former call sites), the listenCaches loop runs to completion, and
+        //               localCache.isInitializing() is now false.
+        assertFalse(localCache.isInitializing(),
+            "ConfigRpcTransportClient.checkListenCache must clear isInitializing for the local "
+                + "cache even when server returns a ghost changeKey; "
+                + "if this assertion fails, the listen loop was likely aborted by an "
+                + "NPE in cacheMap.get().get(changeKey).isInitializing() (regression of #9461)");
+    }
+    
     private CacheData discardCache(ConfigFilterChainManager filter, String envName, String dataId,
         String group,
         String tenant) {

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ClientWorkerTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ClientWorkerTest.java
@@ -595,9 +595,6 @@ class ClientWorkerTest {
         Map<String, CacheData> cacheDataMapMocked = Mockito.mock(Map.class);
         Mockito.when(cacheDataMapMocked.get(GroupKey.getKeyTenant(dataIdNormal, group, tenant)))
             .thenReturn(cacheNormal);
-        Mockito.when(
-            cacheDataMapMocked.containsKey(GroupKey.getKeyTenant(dataIdNormal, group, tenant)))
-            .thenReturn(true);
         
         Mockito.when(cacheDataMapMocked.values()).thenReturn(cacheDatas);
         AtomicReference<Map<String, CacheData>> cacheMapMocked =


### PR DESCRIPTION
 ## What is the purpose of the change

  Fix a regression of PR #9461. `ConfigRpcTransportClient.checkListenCache` may
  throw NullPointerException when the server returns a `changeKey` in
  `ConfigChangeBatchListenResponse` that has been concurrently removed from
  the local `cacheMap` (e.g. user has just called `removeListener`).

  The unsafe pattern `cacheMap.get().get(changeKey).isInitializing()` was
  originally fixed in PR #9461 (milestone 2.2.0, commit c8c64a1c5) by moving
  the `notify` computation into `refreshContentAndCheck` to share its existing
  null-check. When the gRPC long-connection variant `ConfigRpcTransportClient`
  was introduced in 3.x, a fresh copy of `refreshContentAndCheck(RpcClient,
  String, boolean)` was added — its body has a defensive null-check, but the
  two callers (lines 1125 and 1136 in 3.1.1) re-introduced the unsafe
  pre-dereference, defeating the protection.

  The NPE is currently swallowed by the surrounding `catch (Throwable)` and
  only surfaces as `Execute listen config change error` log noise, but the
  batch processing of remaining `changeKey`s is aborted whenever it triggers.
  
  ## Brief changelog

  - Refactor `ConfigRpcTransportClient.refreshContentAndCheck(RpcClient,
    String, boolean)` to `refreshContentAndCheck(RpcClient, String)` —
    `notify = !cache.isInitializing()` is now computed inside the method,
    under the existing `cache != null` guard.
  - Take a single `cacheMap.get()` snapshot to avoid duplicate volatile reads
    and replace `containsKey + get` double-lookup with a single `get + null
    check`.
  - Simplify the two unsafe call sites in `checkListenCache` accordingly.
  - Add regression test `ClientWorkerTest#testCheckListenCacheSkipsRemovedKey`
    that asserts no NPE-induced batch abort when the server returns an unknown
    `changeKey`.

  ## Verifying this change

  - New unit test `ClientWorkerTest#testCheckListenCacheSkipsRemovedKey`
    FAILS on `3.1.1` (NPE aborts the listenCaches loop) and PASSES with this
    change.
  - Existing `ClientWorkerTest#testExecuteConfigListen` still passes —
    confirming the simpler call signature is behavior-preserving on the happy
    path.
  - Full `ClientWorkerTest` (28 tests): all pass.
  - Full `client` module (683 tests): all pass.
  - `mvn -B clean package apache-rat:check -Dmaven.test.skip=true -pl client -am` ✅
  - `mvn clean install -DskipITs -pl client -am` ✅
  - `mvn checkstyle:check -pl client` ✅
  - `mvn pmd:check -pl client` ✅

  Follow this checklist to help us incorporate your contribution quickly and easily:

  * [x] Make sure there is a Github issue filed for the change: #15225
  * [x] Format the pull request title like `[ISSUE #15225] Fix regression of #9461`
  * [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
  * [x] Write necessary unit-test to verify logic correction.
  * [x] Run `mvn -B clean package apache-rat:check -Dmaven.test.skip=true` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass.

  Closes #15225

  ---