### PR TITLE
fix(client): guard fuzzy-watch future against lost and spurious wakeups

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchContext.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchContext.java
@@ -527,9 +527,8 @@ public class ConfigFuzzyWatchContext {
             
             @Override
             public Set<String> get() throws InterruptedException, ExecutionException {
-                
-                if (!ConfigFuzzyWatchContext.this.initializationCompleted.get()) {
-                    synchronized (ConfigFuzzyWatchContext.this) {
+                synchronized (ConfigFuzzyWatchContext.this) {
+                    while (!ConfigFuzzyWatchContext.this.initializationCompleted.get()) {
                         ConfigFuzzyWatchContext.this.wait();
                     }
                 }

--- a/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchContextTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchContextTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.config.impl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for {@link ConfigFuzzyWatchContext}, focused on the wait/notify contract of the future
+ * returned by {@link ConfigFuzzyWatchContext#createNewFuture()}.
+ */
+class ConfigFuzzyWatchContextTest {
+    
+    /**
+     * {@code Future#get()} must keep waiting until initialization actually completes: a spurious
+     * wake-up (or any {@code notifyAll} that is not paired with {@code initializationCompleted ==
+     * true}) must not cause it to return the still-incomplete result set.
+     *
+     * <p>With the buggy {@code if (...) { wait(); }} form, the spurious {@code notifyAll} below
+     * makes {@code get()} return early; with the correct {@code while (...) { wait(); }} form it
+     * re-checks the flag and keeps waiting.
+     */
+    @Test
+    void testGetKeepsWaitingOnSpuriousWakeup() throws Exception {
+        ConfigFuzzyWatchContext context = new ConfigFuzzyWatchContext("test", "test:pattern");
+        Future<Set<String>> future = context.createNewFuture();
+        
+        AtomicBoolean returned = new AtomicBoolean(false);
+        AtomicReference<Set<String>> result = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Thread getter = new Thread(() -> {
+            try {
+                result.set(future.get());
+                returned.set(true);
+            } catch (Throwable t) {
+                error.set(t);
+            }
+        });
+        getter.setDaemon(true);
+        getter.start();
+        
+        // Wait until the getter thread is actually parked inside Object#wait().
+        awaitState(getter, Thread.State.WAITING);
+        
+        // Simulate a spurious wake-up: notify without marking initialization complete.
+        synchronized (context) {
+            context.notifyAll();
+        }
+        // Give the getter a chance to (wrongly) wake up and return.
+        Thread.sleep(200L);
+        
+        assertFalse(returned.get(),
+            "get() must not return before initialization completes");
+        assertTrue(getter.isAlive(), "getter thread must still be waiting");
+        assertNotNull(context); // keep the context strongly referenced
+        
+        // A real completion must release the waiter and yield the received keys.
+        context.markInitializationComplete();
+        getter.join(2000L);
+        
+        assertFalse(getter.isAlive(), "getter thread must finish after completion");
+        assertTrue(returned.get(), "get() must return after markInitializationComplete");
+        assertNull(error.get(), "get() must not raise");
+        assertNotNull(result.get(), "completed get() must return a non-null set");
+        assertEquals(context.getReceivedGroupKeys(), result.get());
+    }
+    
+    /**
+     * When initialization has already completed, {@code Future#get()} must return immediately
+     * without blocking.
+     */
+    @Test
+    void testGetReturnsImmediatelyWhenAlreadyCompleted() throws Exception {
+        ConfigFuzzyWatchContext context = new ConfigFuzzyWatchContext("test", "test:pattern");
+        context.markInitializationComplete();
+        Future<Set<String>> future = context.createNewFuture();
+        
+        Set<String> result = future.get();
+        
+        assertNotNull(result);
+        assertEquals(context.getReceivedGroupKeys(), result);
+    }
+    
+    private static void awaitState(Thread thread, Thread.State expected)
+        throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 3000L;
+        while (thread.getState() != expected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10L);
+        }
+        assertEquals(expected, thread.getState(),
+            "thread did not reach state " + expected + " in time");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The `Future` returned by `ConfigFuzzyWatchContext#createNewFuture()` waits for initialization with a plain `if` + `Object#wait()`, and the flag check sits **outside** the `synchronized` block:

```java
public Set<String> get() throws InterruptedException, ExecutionException {
    if (!ConfigFuzzyWatchContext.this.initializationCompleted.get()) {
        synchronized (ConfigFuzzyWatchContext.this) {
            ConfigFuzzyWatchContext.this.wait();
        }
    }
    return new HashSet<>(ConfigFuzzyWatchContext.this.getReceivedGroupKeys());
}
```

`markInitializationComplete()` sets the flag and then calls `notifyAll()` **exactly once**:

```java
public void markInitializationComplete() {
    initializationCompleted.set(true);
    synchronized (this) {
        this.notifyAll();
    }
}
```

This combination has two classic `wait`/`notify` defects:

- **Lost wake-up → permanent hang.** If the caller passes the `!initializationCompleted` check and is descheduled before entering the `synchronized` block, `markInitializationComplete()` can run its `set(true)` + `notifyAll()` in that window. The caller then enters `wait()` *after* the only `notifyAll` has already fired, so `get()` blocks forever — initialization completes only once, so no further notification ever arrives.
- **Spurious wake-up → stale result.** `Object#wait()` may return without any `notifyAll`. With the `if` form the method falls through and returns a result set that reflects an *incomplete* initialization.

## How

The sibling class `NamingFuzzyWatchContext#createNewFuture().get()` already uses the correct canonical form — acquire the monitor first, then re-check the flag inside a `while` loop. Both classes have an identical `markInitializationComplete()` (flag + `notifyAll` on `this`), so this simply aligns the config side with the naming side:

```java
public Set<String> get() throws InterruptedException, ExecutionException {
    synchronized (ConfigFuzzyWatchContext.this) {
        while (!ConfigFuzzyWatchContext.this.initializationCompleted.get()) {
            ConfigFuzzyWatchContext.this.wait();
        }
    }
    return new HashSet<>(ConfigFuzzyWatchContext.this.getReceivedGroupKeys());
}
```

Taking the lock before the check closes the lost-wake-up window (the waiter holds the monitor across check-and-wait, so `markInitializationComplete()` cannot slip its `notifyAll` in between), and the `while` loop re-checks the flag so a spurious wake-up cannot leak an incomplete result.

### Scope

Only the no-timeout `get()` is changed. The timed `get(long, TimeUnit)` overload keeps its `if` form in **both** classes: it re-checks the flag after waking and throws `TimeoutException` when initialization is still incomplete, so a spurious wake-up cannot leak an incomplete result there. Leaving it untouched preserves symmetry between the two context classes; tightening the timed path would be a separate change.

## Brief changelog

- `client/.../ConfigFuzzyWatchContext.java` — acquire the monitor first and wait in a `while` loop guarded by `initializationCompleted`
- `client/.../ConfigFuzzyWatchContextTest.java` — new regression test

## Verifying this change

Red/green verified:

- With the old `if` form, the new test **fails** — a spurious `notifyAll()` (flag still `false`) makes `get()` return early (`expected: <false> but was: <true>`).
- With the `while` form, the test **passes** — `get()` keeps waiting through the spurious wake-up and only returns after a real `markInitializationComplete()`.

```
mvn -pl client -am clean compile spotbugs:check checkstyle:check apache-rat:check spotless:check -DskipTests   # passes
mvn -pl client test -Dtest=ConfigFuzzyWatchContextTest                                                          # 2 passed
```

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a Github issue filed for the change (usually before you start working on it).
- [x] Format the pull request title like `[ISSUE #123] ...`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. A red/green regression test is included in `ConfigFuzzyWatchContextTest`.
- [x] Run `mvn -B clean package apache-rat:check checkstyle:check spotbugs:check -DskipTests` to make sure basic checks pass.