### PR TITLE
[ISSUE #15183] Add secure HTTP client for AI importers

### DIFF
--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProvider.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProvider.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.ai.importer.AiResourceImportConstants;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.DefaultImportHttpClient;
 import com.alibaba.nacos.plugin.ai.importer.defaultimpl.mcp.McpRegistryImportServiceBuilder;
 import com.alibaba.nacos.plugin.ai.importer.defaultimpl.skill.SkillsShImportServiceBuilder;
 import com.alibaba.nacos.plugin.ai.importer.defaultimpl.skill.SkillWellKnownImportServiceBuilder;
@@ -65,14 +66,6 @@ public class DefaultAiResourceImportSourceProvider implements AiResourceImportSo
     private static final int DEFAULT_MAX_ITEM_COUNT = 500;
     
     private static final long DEFAULT_MAX_ARTIFACT_SIZE = 10L * 1024L * 1024L;
-    
-    private static final String PROPERTY_ALLOW_HTTP = "allow-http";
-    
-    private static final String PROPERTY_ALLOW_HTTP_CAMEL = "allowHttp";
-    
-    private static final String PROPERTY_ALLOW_PRIVATE_NETWORK = "allow-private-network";
-    
-    private static final String PROPERTY_ALLOW_PRIVATE_NETWORK_CAMEL = "allowPrivateNetwork";
     
     @Override
     public Collection<AiResourceImportSource> loadSources(Properties properties)
@@ -179,10 +172,11 @@ public class DefaultAiResourceImportSourceProvider implements AiResourceImportSo
     private void applySecurityOptions(Properties properties, String prefix,
         AiResourceImportSource source) {
         Map<String, String> sourceProperties = new LinkedHashMap<>(2);
-        putConfiguredProperty(properties, prefix, PROPERTY_ALLOW_HTTP, PROPERTY_ALLOW_HTTP_CAMEL,
-            sourceProperties);
-        putConfiguredProperty(properties, prefix, PROPERTY_ALLOW_PRIVATE_NETWORK,
-            PROPERTY_ALLOW_PRIVATE_NETWORK_CAMEL, sourceProperties);
+        putConfiguredProperty(properties, prefix, DefaultImportHttpClient.PROPERTY_ALLOW_HTTP,
+            DefaultImportHttpClient.PROPERTY_ALLOW_HTTP_CAMEL, sourceProperties);
+        putConfiguredProperty(properties, prefix,
+            DefaultImportHttpClient.PROPERTY_ALLOW_PRIVATE_NETWORK,
+            DefaultImportHttpClient.PROPERTY_ALLOW_PRIVATE_NETWORK_CAMEL, sourceProperties);
         if (!sourceProperties.isEmpty()) {
             source.setProperties(sourceProperties);
         }

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/DefaultImportHttpClient.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/DefaultImportHttpClient.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.ai.importer.defaultimpl.http;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
+
+/**
+ * Shared HTTP client for built-in AI importers.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class DefaultImportHttpClient {
+    
+    public static final String PROPERTY_ALLOW_HTTP = "allow-http";
+    
+    public static final String PROPERTY_ALLOW_HTTP_CAMEL = "allowHttp";
+    
+    public static final String PROPERTY_ALLOW_PRIVATE_NETWORK = "allow-private-network";
+    
+    public static final String PROPERTY_ALLOW_PRIVATE_NETWORK_CAMEL = "allowPrivateNetwork";
+    
+    private static final String HTTPS_SCHEME = "https";
+    
+    private static final String HTTP_SCHEME = "http";
+    
+    private static final String LOCALHOST = "localhost";
+    
+    private static final String LOCALHOST_SUFFIX = ".localhost";
+    
+    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 10;
+    
+    private static final int DEFAULT_READ_TIMEOUT_SECONDS = 20;
+    
+    private static final long DEFAULT_MAX_RESPONSE_BYTES = 10L * 1024L * 1024L;
+    
+    private final HttpClient httpClient;
+    
+    private final DnsResolver dnsResolver;
+    
+    public DefaultImportHttpClient() {
+        this(HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .connectTimeout(Duration.ofSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS))
+            .build());
+    }
+    
+    public DefaultImportHttpClient(HttpClient httpClient) {
+        this(httpClient, InetAddress::getAllByName);
+    }
+    
+    /**
+     * Create a default importer HTTP client with custom DNS resolver.
+     *
+     * @param httpClient HTTP client
+     * @param dnsResolver DNS resolver
+     */
+    public DefaultImportHttpClient(HttpClient httpClient, DnsResolver dnsResolver) {
+        this.httpClient = httpClient;
+        this.dnsResolver = dnsResolver;
+    }
+    
+    /**
+     * Send a GET request with the default read timeout.
+     *
+     * @param source import source
+     * @param url request URL
+     * @param accept optional Accept header
+     * @return HTTP response
+     * @throws Exception if validation or request fails
+     */
+    public ImportHttpResponse get(AiResourceImportSource source, String url, String accept)
+        throws Exception {
+        return get(source, url, DEFAULT_READ_TIMEOUT_SECONDS, accept);
+    }
+    
+    /**
+     * Send a GET request after applying importer network policy.
+     *
+     * @param source import source
+     * @param url request URL
+     * @param readTimeoutSeconds request read timeout in seconds
+     * @param accept optional Accept header
+     * @return HTTP response
+     * @throws Exception if validation or request fails
+     */
+    public ImportHttpResponse get(AiResourceImportSource source, String url,
+        int readTimeoutSeconds, String accept) throws Exception {
+        URI uri = parseUrl(url);
+        checkRequestTarget(source, uri);
+        long maxResponseBytes = resolveMaxResponseBytes(source);
+        HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
+            .timeout(Duration.ofSeconds(readTimeoutSeconds))
+            .GET();
+        if (StringUtils.isNotBlank(accept)) {
+            builder.header("Accept", accept);
+        }
+        HttpResponse<byte[]> response = httpClient.send(builder.build(),
+            new LimitedByteArrayBodyHandler(maxResponseBytes));
+        byte[] body = response.body() == null ? new byte[0] : response.body();
+        checkResponseSize(body, maxResponseBytes);
+        return new ImportHttpResponse(uri.toString(), response.statusCode(), response.headers(),
+            body);
+    }
+    
+    private URI parseUrl(String url) throws NacosException {
+        if (StringUtils.isBlank(url)) {
+            throw invalid("AI resource import request URL must not be empty.");
+        }
+        try {
+            URI result = URI.create(url.trim());
+            if (!result.isAbsolute()) {
+                throw invalid("AI resource import request URL must be an absolute URL.");
+            }
+            return result;
+        } catch (IllegalArgumentException e) {
+            throw invalid("AI resource import request URL is invalid.");
+        }
+    }
+    
+    private void checkRequestTarget(AiResourceImportSource source, URI uri)
+        throws NacosException {
+        String scheme =
+            uri.getScheme() == null ? null : uri.getScheme().toLowerCase(Locale.ENGLISH);
+        if (!HTTPS_SCHEME.equals(scheme) && !HTTP_SCHEME.equals(scheme)) {
+            throw invalid("AI resource import request URL must use http or https.");
+        }
+        if (HTTP_SCHEME.equals(scheme) && !isSourcePropertyEnabled(source, PROPERTY_ALLOW_HTTP,
+            PROPERTY_ALLOW_HTTP_CAMEL)) {
+            throw invalid(
+                "AI resource import request URL must use https unless allow-http is enabled.");
+        }
+        if (StringUtils.isBlank(uri.getHost())) {
+            throw invalid("AI resource import request URL host must not be empty.");
+        }
+        if (isUnsafeHost(uri.getHost()) && !isSourcePropertyEnabled(source,
+            PROPERTY_ALLOW_PRIVATE_NETWORK, PROPERTY_ALLOW_PRIVATE_NETWORK_CAMEL)) {
+            throw invalid(
+                "AI resource import request URL resolves to a private or local target.");
+        }
+    }
+    
+    private boolean isUnsafeHost(String host) throws NacosException {
+        String normalized = InternetAddressUtil.removeBrackets(host).toLowerCase(Locale.ENGLISH);
+        if (LOCALHOST.equals(normalized) || normalized.endsWith(LOCALHOST_SUFFIX)) {
+            return true;
+        }
+        InetAddress[] addresses = resolveHost(normalized);
+        for (InetAddress each : addresses) {
+            if (isUnsafeAddress(each)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private InetAddress[] resolveHost(String host) throws NacosException {
+        try {
+            InetAddress[] result = dnsResolver.resolve(host);
+            if (result == null || result.length == 0) {
+                throw invalid("AI resource import request URL host cannot be resolved.");
+            }
+            return result;
+        } catch (UnknownHostException e) {
+            throw invalid("AI resource import request URL host cannot be resolved.");
+        }
+    }
+    
+    private boolean isUnsafeAddress(InetAddress address) {
+        return address.isAnyLocalAddress() || address.isLoopbackAddress()
+            || address.isLinkLocalAddress() || address.isSiteLocalAddress()
+            || address.isMulticastAddress() || isUniqueLocalIpv6Address(address);
+    }
+    
+    private boolean isUniqueLocalIpv6Address(InetAddress address) {
+        byte[] bytes = address.getAddress();
+        return bytes.length == 16 && (bytes[0] & 0xfe) == 0xfc;
+    }
+    
+    private boolean isSourcePropertyEnabled(AiResourceImportSource source, String kebabKey,
+        String camelKey) {
+        if (source == null) {
+            return false;
+        }
+        Map<String, String> properties = source.getProperties();
+        if (properties == null || properties.isEmpty()) {
+            return false;
+        }
+        return Boolean.parseBoolean(properties.get(kebabKey))
+            || Boolean.parseBoolean(properties.get(camelKey));
+    }
+    
+    private long resolveMaxResponseBytes(AiResourceImportSource source) {
+        if (source != null && source.getMaxArtifactSize() > 0) {
+            return source.getMaxArtifactSize();
+        }
+        return DEFAULT_MAX_RESPONSE_BYTES;
+    }
+    
+    private void checkResponseSize(byte[] body, long maxResponseBytes) throws NacosException {
+        if (body != null && body.length > maxResponseBytes) {
+            throw invalid("AI resource import response size exceeds source limit.");
+        }
+    }
+    
+    private NacosException invalid(String message) {
+        return new NacosApiException(NacosException.INVALID_PARAM,
+            ErrorCode.PARAMETER_VALIDATE_ERROR, message);
+    }
+    
+    public interface DnsResolver {
+        
+        /**
+         * Resolve host to network addresses.
+         *
+         * @param host request host
+         * @return resolved addresses
+         * @throws UnknownHostException if the host cannot be resolved
+         */
+        InetAddress[] resolve(String host) throws UnknownHostException;
+    }
+    
+    private static class LimitedByteArrayBodyHandler implements HttpResponse.BodyHandler<byte[]> {
+        
+        private final long maxBytes;
+        
+        LimitedByteArrayBodyHandler(long maxBytes) {
+            this.maxBytes = maxBytes;
+        }
+        
+        @Override
+        public HttpResponse.BodySubscriber<byte[]> apply(HttpResponse.ResponseInfo responseInfo) {
+            return new LimitedByteArrayBodySubscriber(maxBytes);
+        }
+    }
+    
+    private static class LimitedByteArrayBodySubscriber
+        implements HttpResponse.BodySubscriber<byte[]> {
+        
+        private final long maxBytes;
+        
+        private final CompletableFuture<byte[]> body = new CompletableFuture<>();
+        
+        private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        
+        private Flow.Subscription subscription;
+        
+        private long totalBytes;
+        
+        LimitedByteArrayBodySubscriber(long maxBytes) {
+            this.maxBytes = maxBytes;
+        }
+        
+        @Override
+        public CompletionStage<byte[]> getBody() {
+            return body;
+        }
+        
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(Long.MAX_VALUE);
+        }
+        
+        @Override
+        public void onNext(List<ByteBuffer> items) {
+            if (body.isDone()) {
+                return;
+            }
+            for (ByteBuffer each : items) {
+                int remaining = each.remaining();
+                if (totalBytes + remaining > maxBytes) {
+                    fail(new IOException("AI resource import response size exceeds source limit."));
+                    return;
+                }
+                byte[] chunk = new byte[remaining];
+                each.get(chunk);
+                output.write(chunk, 0, chunk.length);
+                totalBytes += remaining;
+            }
+        }
+        
+        @Override
+        public void onError(Throwable throwable) {
+            body.completeExceptionally(throwable);
+        }
+        
+        @Override
+        public void onComplete() {
+            body.complete(output.toByteArray());
+        }
+        
+        private void fail(Throwable throwable) {
+            if (subscription != null) {
+                subscription.cancel();
+            }
+            body.completeExceptionally(throwable);
+        }
+    }
+}

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/ImportHttpResponse.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/ImportHttpResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.ai.importer.defaultimpl.http;
+
+import java.net.http.HttpHeaders;
+
+/**
+ * HTTP response fetched by default AI importers.
+ *
+ * @author xiweng.yy
+ * @since 3.2.1
+ */
+public class ImportHttpResponse {
+    
+    private final String url;
+    
+    private final int statusCode;
+    
+    private final HttpHeaders headers;
+    
+    private final byte[] body;
+    
+    public ImportHttpResponse(String url, int statusCode, HttpHeaders headers, byte[] body) {
+        this.url = url;
+        this.statusCode = statusCode;
+        this.headers = headers;
+        this.body = body == null ? new byte[0] : body;
+    }
+    
+    public boolean isSuccess() {
+        return statusCode >= 200 && statusCode < 300;
+    }
+    
+    public String getUrl() {
+        return url;
+    }
+    
+    public int getStatusCode() {
+        return statusCode;
+    }
+    
+    public byte[] getBody() {
+        return body;
+    }
+    
+    public String getContentType() {
+        return headers.firstValue("Content-Type").orElse("");
+    }
+}

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryClient.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryClient.java
@@ -29,14 +29,13 @@ import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.DefaultImportHttpClient;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.ImportHttpResponse;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
 
-import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,8 +56,6 @@ class McpRegistryClient {
     
     private static final String SEARCH_QUERY_NAME = "search";
     
-    private static final String HEADER_ACCEPT = "Accept";
-    
     private static final String HEADER_ACCEPT_JSON = "application/json";
     
     private static final String QUERY_MARK = "?";
@@ -69,35 +66,37 @@ class McpRegistryClient {
     
     private static final int HTTP_STATUS_SUCCESS_MAX = 299;
     
-    private static final int CONNECT_TIMEOUT_SECONDS = 10;
-    
     private static final int READ_TIMEOUT_SECONDS = 20;
     
-    private HttpClient httpClient;
+    private DefaultImportHttpClient httpClient;
     
     McpRegistryClient() {
-        this(null);
+        this(new DefaultImportHttpClient());
     }
     
     McpRegistryClient(HttpClient httpClient) {
+        this(new DefaultImportHttpClient(httpClient));
+    }
+    
+    McpRegistryClient(DefaultImportHttpClient httpClient) {
         this.httpClient = httpClient;
     }
     
-    Page fetchOfficialRegistryPage(String urlData, String cursor, Integer limit, String search)
-        throws Exception {
-        if (StringUtils.isBlank(urlData)) {
+    Page fetchOfficialRegistryPage(AiResourceImportSource source, String cursor, Integer limit,
+        String search) throws Exception {
+        if (source == null || StringUtils.isBlank(source.getEndpoint())) {
             throw new IllegalArgumentException("URL is blank");
         }
-        return fetchUrlPage(urlData.trim(), cursor, limit, search);
+        return fetchUrlPage(source, source.getEndpoint().trim(), cursor, limit, search);
     }
     
-    McpServerDetailInfo fetchOfficialRegistryServer(String urlData, String externalId, int limit)
-        throws Exception {
+    McpServerDetailInfo fetchOfficialRegistryServer(AiResourceImportSource source,
+        String externalId, int limit) throws Exception {
         if (StringUtils.isBlank(externalId)) {
             throw new IllegalArgumentException("MCP server external id is blank");
         }
         int actualLimit = limit > 0 ? limit : 30;
-        Page page = fetchOfficialRegistryPage(urlData, null, actualLimit, externalId);
+        Page page = fetchOfficialRegistryPage(source, null, actualLimit, externalId);
         if (CollectionUtils.isNotEmpty(page.getServers())) {
             for (McpServerDetailInfo each : page.getServers()) {
                 if (StringUtils.equals(externalId, each.getName())
@@ -109,18 +108,18 @@ class McpRegistryClient {
         throw new IllegalStateException("MCP server not found in registry: " + externalId);
     }
     
-    private Page fetchUrlPage(String urlData, String cursor, Integer limit, String search)
-        throws Exception {
+    private Page fetchUrlPage(AiResourceImportSource source, String urlData, String cursor,
+        Integer limit, String search) throws Exception {
         String pageUrl = buildPageUrl(urlData.trim(), cursor, limit, search);
-        HttpResponse<String> response = getHttpClient().send(buildGetRequest(pageUrl),
-            HttpResponse.BodyHandlers.ofString());
-        int code = response.statusCode();
+        ImportHttpResponse response = httpClient.get(source, pageUrl, READ_TIMEOUT_SECONDS,
+            HEADER_ACCEPT_JSON);
+        int code = response.getStatusCode();
         if (!isSuccessStatus(code)) {
             throw new IllegalStateException("HTTP " + code + " when fetching " + pageUrl);
         }
         try {
             McpRegistryServerList listPage =
-                JacksonUtils.toObj(response.body(), McpRegistryServerList.class);
+                JacksonUtils.toObj(response.getBody(), McpRegistryServerList.class);
             List<McpServerDetailInfo> servers = Collections.emptyList();
             String next = null;
             if (listPage != null && listPage.getServers() != null) {
@@ -286,16 +285,6 @@ class McpRegistryClient {
         return new UrlComponents(scheme, host, port, path);
     }
     
-    private HttpClient getHttpClient() {
-        if (httpClient == null) {
-            httpClient = HttpClient.newBuilder()
-                .followRedirects(HttpClient.Redirect.NEVER)
-                .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
-                .build();
-        }
-        return httpClient;
-    }
-    
     private String buildPageUrl(String base, String cursor, Integer limit, String search) {
         StringBuilder url = new StringBuilder(base);
         boolean hasQuery = base.contains(QUERY_MARK);
@@ -314,14 +303,6 @@ class McpRegistryClient {
                 .append(URLEncoder.encode(search, StandardCharsets.UTF_8));
         }
         return url.toString();
-    }
-    
-    private HttpRequest buildGetRequest(String url) {
-        return HttpRequest.newBuilder(URI.create(url))
-            .timeout(Duration.ofSeconds(READ_TIMEOUT_SECONDS))
-            .GET()
-            .header(HEADER_ACCEPT, HEADER_ACCEPT_JSON)
-            .build();
     }
     
     private boolean isSuccessStatus(int code) {

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryImportService.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryImportService.java
@@ -86,9 +86,9 @@ public class McpRegistryImportService implements AiResourceImportService {
     public AiResourceImportCandidatePage search(AiResourceImportContext context)
         throws NacosException {
         try {
+            AiResourceImportSource source = requireSource(context.getSource());
             McpRegistryClient.Page registryPage = client.fetchOfficialRegistryPage(
-                requireEndpoint(context.getSource()), context.getCursor(), context.getLimit(),
-                context.getQuery());
+                source, context.getCursor(), context.getLimit(), context.getQuery());
             AiResourceImportCandidatePage result = new AiResourceImportCandidatePage();
             result.setItems(toCandidates(registryPage.getServers()));
             result.setNextCursor(registryPage.getNextCursor());
@@ -105,9 +105,10 @@ public class McpRegistryImportService implements AiResourceImportService {
     public AiResourceImportArtifact fetch(AiResourceImportContext context,
         AiResourceImportItem item) throws NacosException {
         try {
+            AiResourceImportSource source = requireSource(context.getSource());
             String externalId = resolveExternalId(item);
             McpServerDetailInfo server = client.fetchOfficialRegistryServer(
-                requireEndpoint(context.getSource()), externalId, resolveFetchLimit(context));
+                source, externalId, resolveFetchLimit(context));
             return toArtifact(externalId, server);
         } catch (NacosException e) {
             throw e;
@@ -116,11 +117,12 @@ public class McpRegistryImportService implements AiResourceImportService {
         }
     }
     
-    private String requireEndpoint(AiResourceImportSource source) throws NacosException {
+    private AiResourceImportSource requireSource(AiResourceImportSource source)
+        throws NacosException {
         if (source == null || StringUtils.isBlank(source.getEndpoint())) {
             throw invalid("MCP registry import source endpoint must not be empty.");
         }
-        return source.getEndpoint();
+        return source;
     }
     
     private String resolveExternalId(AiResourceImportItem item) throws NacosException {

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportService.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportService.java
@@ -26,6 +26,8 @@ import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.ai.importer.AiResourceImportConstants;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.DefaultImportHttpClient;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.ImportHttpResponse;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidate;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidatePage;
@@ -40,12 +42,8 @@ import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
-import java.net.http.HttpHeaders;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -114,24 +112,23 @@ public class SkillWellKnownImportService implements AiResourceImportService {
     
     private static final int DEFAULT_LIMIT = 30;
     
-    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 10;
-    
     private static final int DEFAULT_READ_TIMEOUT_SECONDS = 20;
     
     private static final int DEFAULT_MAX_ARCHIVE_ENTRIES = 500;
     
     private static final long DEFAULT_MAX_ARCHIVE_UNCOMPRESSED_BYTES = 50L * 1024L * 1024L;
     
-    private final HttpClient httpClient;
+    private final DefaultImportHttpClient httpClient;
     
     public SkillWellKnownImportService() {
-        this(HttpClient.newBuilder()
-            .followRedirects(HttpClient.Redirect.NEVER)
-            .connectTimeout(Duration.ofSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS))
-            .build());
+        this(new DefaultImportHttpClient());
     }
     
     SkillWellKnownImportService(HttpClient httpClient) {
+        this(new DefaultImportHttpClient(httpClient));
+    }
+    
+    SkillWellKnownImportService(DefaultImportHttpClient httpClient) {
         this.httpClient = httpClient;
     }
     
@@ -198,10 +195,11 @@ public class SkillWellKnownImportService implements AiResourceImportService {
     }
     
     private ResolvedWellKnownIndex fetchIndex(AiResourceImportContext context) throws Exception {
-        List<String> indexUrls = indexUrls(requireSource(context));
+        AiResourceImportSource source = requireSource(context);
+        List<String> indexUrls = indexUrls(source);
         Exception lastFailure = null;
         for (String each : indexUrls) {
-            FetchResult response = fetchUrl(each);
+            ImportHttpResponse response = fetchUrl(source, each);
             if (!response.isSuccess()) {
                 lastFailure = new IllegalStateException(
                     "HTTP " + response.getStatusCode() + " when fetching " + each);
@@ -319,13 +317,14 @@ public class SkillWellKnownImportService implements AiResourceImportService {
     private byte[] fetchVersion010SkillZip(AiResourceImportContext context,
         ResolvedWellKnownIndex resolvedIndex, WellKnownSkillEntry entry) throws Exception {
         String base = resolvedIndex.getWellKnownBase();
+        AiResourceImportSource source = requireSource(context);
         List<String> files = normalizeFiles(entry.getFiles());
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         try (ZipOutputStream zip = new ZipOutputStream(output, StandardCharsets.UTF_8)) {
             for (String each : files) {
                 SkillUtils.validatePathSafety(each);
-                byte[] bytes = fetchBytes(fileUrl(base, entry.getName(), each));
-                checkDownloadedSize(requireSource(context), bytes);
+                byte[] bytes = fetchBytes(source, fileUrl(base, entry.getName(), each));
+                checkDownloadedSize(source, bytes);
                 zip.putNextEntry(new ZipEntry(entry.getName() + "/" + each));
                 zip.write(bytes);
                 zip.closeEntry();
@@ -337,7 +336,7 @@ public class SkillWellKnownImportService implements AiResourceImportService {
     private byte[] fetchVersion020SkillZip(AiResourceImportContext context,
         ResolvedWellKnownIndex resolvedIndex, WellKnownSkillEntry entry) throws Exception {
         String type = normalizeType(entry.getType());
-        FetchResult artifact = fetchVersion020Artifact(context, resolvedIndex, entry);
+        ImportHttpResponse artifact = fetchVersion020Artifact(context, resolvedIndex, entry);
         if (TYPE_SKILL_MD.equals(type)) {
             return toSingleMarkdownSkillZip(entry.getName(), artifact.getBody());
         }
@@ -347,18 +346,19 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         throw invalid("Unsupported Skill well-known distribution type: " + entry.getType());
     }
     
-    private FetchResult fetchVersion020Artifact(AiResourceImportContext context,
+    private ImportHttpResponse fetchVersion020Artifact(AiResourceImportContext context,
         ResolvedWellKnownIndex resolvedIndex, WellKnownSkillEntry entry) throws Exception {
         if (StringUtils.isBlank(entry.getUrl())) {
             throw invalid("Skill well-known 0.2.0 entry url must not be empty.");
         }
-        FetchResult result =
-            fetchUrl(resolveArtifactUrl(resolvedIndex.getIndexUrl(), entry.getUrl()));
+        AiResourceImportSource source = requireSource(context);
+        ImportHttpResponse result = fetchUrl(source,
+            resolveArtifactUrl(resolvedIndex.getIndexUrl(), entry.getUrl()));
         if (!result.isSuccess()) {
             throw new IllegalStateException(
                 "HTTP " + result.getStatusCode() + " when fetching " + result.getUrl());
         }
-        checkDownloadedSize(requireSource(context), result.getBody());
+        checkDownloadedSize(source, result.getBody());
         verifySha256Digest(entry.getDigest(), result.getBody());
         return result;
     }
@@ -373,7 +373,7 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         return output.toByteArray();
     }
     
-    private byte[] toSkillZipFromArchive(FetchResult artifact) throws Exception {
+    private byte[] toSkillZipFromArchive(ImportHttpResponse artifact) throws Exception {
         ArchiveFormat format = resolveArchiveFormat(artifact);
         if (format == ArchiveFormat.ZIP) {
             return artifact.getBody();
@@ -538,8 +538,8 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         return result;
     }
     
-    private byte[] fetchBytes(String url) throws Exception {
-        FetchResult result = fetchUrl(url);
+    private byte[] fetchBytes(AiResourceImportSource source, String url) throws Exception {
+        ImportHttpResponse result = fetchUrl(source, url);
         if (!result.isSuccess()) {
             throw new IllegalStateException(
                 "HTTP " + result.getStatusCode() + " when fetching " + url);
@@ -547,15 +547,9 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         return result.getBody();
     }
     
-    private FetchResult fetchUrl(String url) throws Exception {
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-            .timeout(Duration.ofSeconds(DEFAULT_READ_TIMEOUT_SECONDS))
-            .header("Accept", "*/*")
-            .GET()
-            .build();
-        HttpResponse<byte[]> response = httpClient.send(request,
-            HttpResponse.BodyHandlers.ofByteArray());
-        return new FetchResult(url, response.statusCode(), response.headers(), response.body());
+    private ImportHttpResponse fetchUrl(AiResourceImportSource source, String url)
+        throws Exception {
+        return httpClient.get(source, url, DEFAULT_READ_TIMEOUT_SECONDS, "*/*");
     }
     
     private WellKnownIndexVersion resolveVersion(WellKnownSkillsIndex index)
@@ -612,7 +606,7 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         return result.toString();
     }
     
-    private ArchiveFormat resolveArchiveFormat(FetchResult artifact) throws NacosException {
+    private ArchiveFormat resolveArchiveFormat(ImportHttpResponse artifact) throws NacosException {
         String contentType = artifact.getContentType().toLowerCase(Locale.ENGLISH);
         String url = artifact.getUrl().toLowerCase(Locale.ENGLISH);
         if (contentType.contains("gzip") || url.endsWith(TAR_GZ_SUFFIX)
@@ -708,44 +702,6 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         
         public String getWellKnownBase() {
             return wellKnownBase;
-        }
-    }
-    
-    private static class FetchResult {
-        
-        private final String url;
-        
-        private final int statusCode;
-        
-        private final HttpHeaders headers;
-        
-        private final byte[] body;
-        
-        FetchResult(String url, int statusCode, HttpHeaders headers, byte[] body) {
-            this.url = url;
-            this.statusCode = statusCode;
-            this.headers = headers;
-            this.body = body == null ? new byte[0] : body;
-        }
-        
-        public boolean isSuccess() {
-            return statusCode >= 200 && statusCode < 300;
-        }
-        
-        public String getUrl() {
-            return url;
-        }
-        
-        public int getStatusCode() {
-            return statusCode;
-        }
-        
-        public byte[] getBody() {
-            return body;
-        }
-        
-        public String getContentType() {
-            return headers.firstValue("Content-Type").orElse("");
         }
     }
     

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillsShImportService.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillsShImportService.java
@@ -24,6 +24,8 @@ import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.ai.importer.AiResourceImportConstants;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.DefaultImportHttpClient;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.ImportHttpResponse;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportArtifact;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidate;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportCandidatePage;
@@ -34,13 +36,9 @@ import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
 import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
 
 import java.io.ByteArrayOutputStream;
-import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -88,22 +86,21 @@ public class SkillsShImportService implements AiResourceImportService {
     
     private static final int DEFAULT_LIMIT = 30;
     
-    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 10;
-    
     private static final int DEFAULT_READ_TIMEOUT_SECONDS = 20;
     
     private static final int DEFAULT_MAX_FILE_COUNT = 500;
     
-    private final HttpClient httpClient;
+    private final DefaultImportHttpClient httpClient;
     
     public SkillsShImportService() {
-        this(HttpClient.newBuilder()
-            .followRedirects(HttpClient.Redirect.NEVER)
-            .connectTimeout(Duration.ofSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS))
-            .build());
+        this(new DefaultImportHttpClient());
     }
     
     SkillsShImportService(HttpClient httpClient) {
+        this(new DefaultImportHttpClient(httpClient));
+    }
+    
+    SkillsShImportService(DefaultImportHttpClient httpClient) {
         this.httpClient = httpClient;
     }
     
@@ -121,9 +118,10 @@ public class SkillsShImportService implements AiResourceImportService {
     public AiResourceImportCandidatePage search(AiResourceImportContext context)
         throws NacosException {
         try {
-            String apiRoot = resolveApiRoot(requireSource(context));
-            FetchResult response = fetchUrl(searchUrl(apiRoot, resolveQuery(context.getQuery()),
-                resolveLimit(context.getLimit())));
+            AiResourceImportSource source = requireSource(context);
+            String apiRoot = resolveApiRoot(source);
+            ImportHttpResponse response = fetchUrl(source, searchUrl(apiRoot,
+                resolveQuery(context.getQuery()), resolveLimit(context.getLimit())));
             if (!response.isSuccess()) {
                 throw new IllegalStateException(
                     "HTTP " + response.getStatusCode() + " when fetching " + response.getUrl());
@@ -149,7 +147,7 @@ public class SkillsShImportService implements AiResourceImportService {
             AiResourceImportSource source = requireSource(context);
             String apiRoot = resolveApiRoot(source);
             SkillsShSkillRef skillRef = resolveSkillRef(item);
-            FetchResult response = fetchUrl(downloadUrl(apiRoot, skillRef));
+            ImportHttpResponse response = fetchUrl(source, downloadUrl(apiRoot, skillRef));
             if (!response.isSuccess()) {
                 throw new IllegalStateException(
                     "HTTP " + response.getStatusCode() + " when fetching " + response.getUrl());
@@ -451,15 +449,9 @@ public class SkillsShImportService implements AiResourceImportService {
         return value == null ? "" : value;
     }
     
-    private FetchResult fetchUrl(String url) throws Exception {
-        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-            .timeout(Duration.ofSeconds(DEFAULT_READ_TIMEOUT_SECONDS))
-            .header("Accept", "application/json")
-            .GET()
-            .build();
-        HttpResponse<byte[]> response = httpClient.send(request,
-            HttpResponse.BodyHandlers.ofByteArray());
-        return new FetchResult(url, response.statusCode(), response.body());
+    private ImportHttpResponse fetchUrl(AiResourceImportSource source, String url)
+        throws Exception {
+        return httpClient.get(source, url, DEFAULT_READ_TIMEOUT_SECONDS, "application/json");
     }
     
     private NacosException invalid(String message) {
@@ -470,37 +462,6 @@ public class SkillsShImportService implements AiResourceImportService {
     private NacosException dataAccess(String message, Throwable cause) {
         return new NacosApiException(NacosException.SERVER_ERROR, ErrorCode.DATA_ACCESS_ERROR,
             cause, message);
-    }
-    
-    private static class FetchResult {
-        
-        private final String url;
-        
-        private final int statusCode;
-        
-        private final byte[] body;
-        
-        FetchResult(String url, int statusCode, byte[] body) {
-            this.url = url;
-            this.statusCode = statusCode;
-            this.body = body == null ? new byte[0] : body;
-        }
-        
-        public boolean isSuccess() {
-            return statusCode >= 200 && statusCode < 300;
-        }
-        
-        public String getUrl() {
-            return url;
-        }
-        
-        public int getStatusCode() {
-            return statusCode;
-        }
-        
-        public byte[] getBody() {
-            return body;
-        }
     }
     
     static class SkillsShSearchResponse {

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/DefaultImportHttpClientTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/DefaultImportHttpClientTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.ai.importer.defaultimpl.http;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.net.ssl.SSLSession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Unit tests for {@link DefaultImportHttpClient}.
+ *
+ * @author xiweng.yy
+ */
+@ExtendWith(MockitoExtension.class)
+class DefaultImportHttpClientTest {
+    
+    @Mock
+    private HttpClient httpClient;
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        lenient().when(httpClient.send(any(HttpRequest.class),
+            any(HttpResponse.BodyHandler.class))).thenReturn(response(200, "ok"));
+    }
+    
+    @Test
+    void testRejectsHttpByDefault() {
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        
+        assertThrows(NacosException.class,
+            () -> client.get(source(1024), "http://registry.example.com/index.json", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testRejectsResolvedPrivateAddressByDefault() {
+        DefaultImportHttpClient client = newClient("127.0.0.1");
+        
+        assertThrows(NacosException.class,
+            () -> client.get(source(1024), "https://registry.example.com/index.json", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testAllowsPrivateAddressWhenSourceOptIn() throws Exception {
+        DefaultImportHttpClient client = newClient("127.0.0.1");
+        AiResourceImportSource source = source(1024);
+        source.setProperties(Collections.singletonMap(
+            DefaultImportHttpClient.PROPERTY_ALLOW_PRIVATE_NETWORK, "true"));
+        
+        ImportHttpResponse response =
+            client.get(source, "https://registry.example.com/index.json", "*/*");
+        
+        assertEquals(200, response.getStatusCode());
+        assertEquals("ok", new String(response.getBody(), StandardCharsets.UTF_8));
+    }
+    
+    @Test
+    void testRejectsOversizedResponse() throws Exception {
+        lenient().when(httpClient.send(any(HttpRequest.class),
+            any(HttpResponse.BodyHandler.class))).thenReturn(response(200, "toolong"));
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        
+        assertThrows(NacosException.class,
+            () -> client.get(source(2), "https://registry.example.com/index.json", "*/*"));
+    }
+    
+    private DefaultImportHttpClient newClient(String address) {
+        return new DefaultImportHttpClient(httpClient,
+            host -> new InetAddress[] {InetAddress.getByName(address)});
+    }
+    
+    private AiResourceImportSource source(long maxResponseSize) {
+        AiResourceImportSource source = new AiResourceImportSource();
+        source.setMaxArtifactSize(maxResponseSize);
+        return source;
+    }
+    
+    private HttpResponse<byte[]> response(int status, String body) {
+        Map<String, java.util.List<String>> headers = new HashMap<>(1);
+        headers.put("Content-Type", Collections.singletonList("application/json"));
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        return new HttpResponse<>() {
+            
+            @Override
+            public int statusCode() {
+                return status;
+            }
+            
+            @Override
+            public HttpRequest request() {
+                return null;
+            }
+            
+            @Override
+            public Optional<HttpResponse<byte[]>> previousResponse() {
+                return Optional.empty();
+            }
+            
+            @Override
+            public HttpHeaders headers() {
+                return HttpHeaders.of(headers, (key, value) -> true);
+            }
+            
+            @Override
+            public byte[] body() {
+                return bytes;
+            }
+            
+            @Override
+            public Optional<SSLSession> sslSession() {
+                return Optional.empty();
+            }
+            
+            @Override
+            public URI uri() {
+                return null;
+            }
+            
+            @Override
+            public HttpClient.Version version() {
+                return HttpClient.Version.HTTP_1_1;
+            }
+        };
+    }
+}

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryImportServiceTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryImportServiceTest.java
@@ -38,6 +38,8 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 /**
@@ -63,7 +65,8 @@ class McpRegistryImportServiceTest {
     @Test
     void testSearchReturnsCandidateMetadata() throws Exception {
         McpServerDetailInfo server = newMcpServer();
-        when(client.fetchOfficialRegistryPage(ENDPOINT, "cursor-1", 20, "redis"))
+        when(client.fetchOfficialRegistryPage(any(AiResourceImportSource.class), eq("cursor-1"),
+            eq(20), eq("redis")))
             .thenReturn(new McpRegistryClient.Page(Collections.singletonList(server),
                 "cursor-2"));
         
@@ -80,7 +83,8 @@ class McpRegistryImportServiceTest {
     @Test
     void testFetchReturnsMcpDetailArtifact() throws Exception {
         McpServerDetailInfo server = newMcpServer();
-        when(client.fetchOfficialRegistryServer(ENDPOINT, "io.nacos/test-server", 30))
+        when(client.fetchOfficialRegistryServer(any(AiResourceImportSource.class),
+            eq("io.nacos/test-server"), eq(30)))
             .thenReturn(server);
         AiResourceImportItem item = new AiResourceImportItem();
         item.setExternalId("io.nacos/test-server");

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportServiceTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportServiceTest.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportContext;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.DefaultImportHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.net.InetAddress;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
@@ -84,7 +86,8 @@ class SkillWellKnownImportServiceTest {
         lenient().when(httpClient.send(any(HttpRequest.class),
             any(HttpResponse.BodyHandler.class)))
             .thenAnswer(invocation -> responseFor(invocation.getArgument(0)));
-        importService = new SkillWellKnownImportService(httpClient);
+        importService = new SkillWellKnownImportService(new DefaultImportHttpClient(httpClient,
+            host -> new InetAddress[] {InetAddress.getByName("93.184.216.34")}));
     }
     
     @Test

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillsShImportServiceTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillsShImportServiceTest.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportContext;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.DefaultImportHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -72,7 +74,8 @@ class SkillsShImportServiceTest {
         lenient().when(httpClient.send(any(HttpRequest.class),
             any(HttpResponse.BodyHandler.class)))
             .thenAnswer(invocation -> responseFor(invocation.getArgument(0)));
-        importService = new SkillsShImportService(httpClient);
+        importService = new SkillsShImportService(new DefaultImportHttpClient(httpClient,
+            host -> new InetAddress[] {InetAddress.getByName("93.184.216.34")}));
     }
     
     @Test

--- a/specs/en/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/en/plugin/ai-resource-import-plugin-spec.md
@@ -418,11 +418,19 @@ The import flow must treat external sources as untrusted:
 - localhost, loopback, link-local, multicast, and private-network source
   endpoint targets must be rejected unless an operator-owned source
   configuration explicitly enables `allow-private-network`;
+- built-in importer HTTP requests must re-apply the same scheme and network
+  policy to every derived request URL, including URLs discovered from indexes
+  or search responses;
+- built-in importer HTTP requests must resolve request hosts before sending and
+  reject loopback, link-local, multicast, and private-network DNS results unless
+  the source explicitly enables `allow-private-network`;
 - redirects must be disabled or revalidated against the same safety policy;
 - loopback, link-local, multicast, and private network targets should be blocked
   by default after DNS resolution;
 - source requests must enforce connect timeout, read timeout, response size,
-  page count, and artifact size limits;
+  page count, and artifact size limits. Built-in importers should cap each HTTP
+  response by the source `max-artifact-size` unless a stricter per-protocol
+  limit applies;
 - fetched Skill packages must not execute scripts during import, query, or
   download;
 - importer plugins must not leak secrets in API responses, trace events, or

--- a/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
@@ -361,9 +361,15 @@ source 时，可以按 `sourceId` 解释；否则应失败并提示迁移到
 - 非 HTTPS source endpoint 必须被拒绝，除非运维在 source 配置中显式开启 `allow-http`；
 - localhost、loopback、link-local、multicast 和私网 source endpoint 必须被拒绝，除非运维在
   source 配置中显式开启 `allow-private-network`；
+- 内置 importer 的 HTTP 请求必须对每个派生出来的请求 URL 重新执行同一套 scheme 和网络策略校验，
+  包括从 index 或 search response 中发现的 URL；
+- 内置 importer 的 HTTP 请求必须在发送前解析目标 host，并在 DNS 结果为 loopback、link-local、
+  multicast 或私网地址时默认拒绝，除非 source 显式开启 `allow-private-network`；
 - redirect 必须禁用或按同一安全策略重新校验；
 - DNS 解析后默认阻断 loopback、link-local、multicast 和私网目标；
 - 来源请求必须强制连接超时、读超时、响应大小、页数和 artifact 大小限制；
+  内置 importer 应默认使用 source `max-artifact-size` 限制单次 HTTP 响应大小，除非具体协议定义了
+  更严格的限制；
 - 导入、查询或下载 Skill 包时不得执行包内脚本；
 - importer 插件不得在 API 响应、Trace 事件或日志中泄露 secret。
 


### PR DESCRIPTION
## Summary
- Add a shared secure HTTP client for built-in AI importers.
- Re-apply source network policy to every importer request URL, including derived Skill artifact URLs and MCP registry page URLs.
- Resolve request hosts before sending and reject loopback/link-local/multicast/private DNS results unless the source opts into private-network access.
- Limit HTTP response bodies by source max-artifact-size and keep redirects disabled through the shared client.
- Update AI resource import plugin specs and add negative security tests.

## Validation
- source ~/Documents/switch17.sh && ./mvnw -pl plugin-default-impl/nacos-default-ai-importer-plugin spotless:apply spotless:check
- source ~/Documents/switch17.sh && ./mvnw -pl plugin-default-impl/nacos-default-ai-importer-plugin -am -Dtest=DefaultImportHttpClientTest,DefaultAiResourceImportSourceProviderTest,McpRegistryImportServiceTest,SkillWellKnownImportServiceTest,SkillsShImportServiceTest -Dsurefire.failIfNoSpecifiedTests=false test
- source ~/Documents/switch17.sh && ./mvnw -pl plugin-default-impl/nacos-default-ai-importer-plugin -am -DskipTests apache-rat:check checkstyle:check spotbugs:check spotless:check