### PR TITLE
[ISSUE #15240] Fix skill download filename overflow

### DIFF
--- a/console-ui-next/src/components/ai/CliCommandCard.tsx
+++ b/console-ui-next/src/components/ai/CliCommandCard.tsx
@@ -25,6 +25,7 @@ interface CliCommandCardProps {
 
 export function CliCommandCard({ commands, className, onDownload, downloadFileName, downloadDisabled }: CliCommandCardProps) {
   const { t } = useTranslation();
+  const downloadLabel = downloadFileName || t('common.cliUsage.downloadZip');
 
   if (commands.length === 0 && !onDownload) return null;
 
@@ -44,12 +45,14 @@ export function CliCommandCard({ commands, className, onDownload, downloadFileNa
             <Button
               variant="outline"
               size="sm"
-              className="w-full h-8 text-xs gap-1.5"
+              className="w-full h-8 min-w-0 overflow-hidden text-xs gap-1.5"
               disabled={downloadDisabled}
               onClick={onDownload}
             >
               <Download className="h-3.5 w-3.5" />
-              {downloadFileName || t('common.cliUsage.downloadZip')}
+              <span className="min-w-0 truncate" title={downloadLabel}>
+                {downloadLabel}
+              </span>
             </Button>
           </>
         )}

--- a/console-ui-next/src/components/ai/__tests__/cli-command-card-layout.test.ts
+++ b/console-ui-next/src/components/ai/__tests__/cli-command-card-layout.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const SOURCE = fs.readFileSync(path.resolve(__dirname, '../CliCommandCard.tsx'), 'utf-8');
+
+function getDownloadButtonBlock(): string {
+  const match = SOURCE.match(/<Button[\s\S]*?onClick=\{onDownload\}[\s\S]*?<\/Button>/);
+  return match?.[0] ?? '';
+}
+
+describe('CliCommandCard layout', () => {
+  it('constrains the manual download filename inside the download button', () => {
+    const downloadButtonBlock = getDownloadButtonBlock();
+
+    expect(downloadButtonBlock).toContain('overflow-hidden');
+    expect(downloadButtonBlock).toContain('min-w-0');
+    expect(downloadButtonBlock).toContain('truncate');
+    expect(downloadButtonBlock).toContain('title={downloadLabel}');
+  });
+});


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fixes #15240.

Fix the Nacos Console next Skill detail install card so very long manual download filenames stay inside the fixed-width right sidebar.

Root cause: the shared `CliCommandCard` download button inherited nowrap button styling and rendered the full filename as a raw text node. The button width was constrained, but the filename had no shrinkable/truncated flex child, so long names overflowed the manual download area.

## Brief changelog

- Add an overflow constraint to the manual download button.
- Render the download filename in a `min-w-0 truncate` span with the full filename in `title`.
- Add a regression test for the download button layout classes.

## Verifying this change

- `npm test -- src/components/ai/__tests__/cli-command-card-layout.test.ts`
- `npx eslint src/components/ai/CliCommandCard.tsx src/components/ai/__tests__/cli-command-card-layout.test.ts`
- `npx tsc -b`
- `npx vite build`

Note: `npm run lint` currently fails on existing unrelated files such as `VersionLabelEditor.tsx`, `sidebar.tsx`, `historyDetail/index.tsx`, `mcpServerDetail/index.tsx`, and others.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.