### PR TITLE
[ISSUE #15245] Fix race condition in DistroLoadDataTask with non-thread-safe HashMap

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/distributed/distro/task/load/DistroLoadDataTask.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/distro/task/load/DistroLoadDataTask.java
@@ -27,8 +27,8 @@ import com.alibaba.nacos.core.distributed.distro.entity.DistroData;
 import com.alibaba.nacos.core.utils.GlobalExecutor;
 import com.alibaba.nacos.core.utils.Loggers;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -55,7 +55,7 @@ public class DistroLoadDataTask implements Runnable {
         this.distroComponentHolder = distroComponentHolder;
         this.distroConfig = distroConfig;
         this.loadCallback = loadCallback;
-        loadCompletedMap = new HashMap<>(1);
+        loadCompletedMap = new ConcurrentHashMap<>(1);
     }
     
     @Override
@@ -84,7 +84,8 @@ public class DistroLoadDataTask implements Runnable {
             TimeUnit.SECONDS.sleep(1);
         }
         for (String each : distroComponentHolder.getDataStorageTypes()) {
-            if (!loadCompletedMap.containsKey(each) || !loadCompletedMap.get(each)) {
+            Boolean completed = loadCompletedMap.get(each);
+            if (completed == null || !completed) {
                 loadCompletedMap.put(each, loadAllDataSnapshotFromRemote(each));
             }
         }

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/distro/task/load/DistroLoadDataTaskTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/distro/task/load/DistroLoadDataTaskTest.java
@@ -43,6 +43,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -253,5 +258,71 @@ class DistroLoadDataTaskTest {
             new DistroLoadDataTask(memberManager, mockHolder, distroConfig, loadCallback);
         taskWithMockHolder.run();
         verify(loadCallback).onSuccess();
+    }
+    
+    @Test
+    void testConcurrentLoadWithMultipleResourceTypes() throws InterruptedException {
+        String type1 = "com.alibaba.nacos.naming.iplist.1";
+        String type2 = "com.alibaba.nacos.naming.iplist.2";
+        String type3 = "com.alibaba.nacos.naming.iplist.3";
+        
+        DistroComponentHolder holder = new DistroComponentHolder();
+        holder.registerDataStorage(type1, distroDataStorage);
+        holder.registerDataStorage(type2, distroDataStorage);
+        holder.registerDataStorage(type3, distroDataStorage);
+        holder.registerTransportAgent(type1, distroTransportAgent);
+        holder.registerTransportAgent(type2, distroTransportAgent);
+        holder.registerTransportAgent(type3, distroTransportAgent);
+        
+        DistroDataProcessor processor1 = org.mockito.Mockito.mock(DistroDataProcessor.class);
+        DistroDataProcessor processor2 = org.mockito.Mockito.mock(DistroDataProcessor.class);
+        DistroDataProcessor processor3 = org.mockito.Mockito.mock(DistroDataProcessor.class);
+        when(processor1.processType()).thenReturn(type1);
+        when(processor2.processType()).thenReturn(type2);
+        when(processor3.processType()).thenReturn(type3);
+        holder.registerDataProcessor(processor1);
+        holder.registerDataProcessor(processor2);
+        holder.registerDataProcessor(processor3);
+        
+        when(distroTransportAgent.getDatumSnapshot(any(String.class))).thenReturn(distroData);
+        when(processor1.processSnapshot(any(DistroData.class))).thenReturn(false);
+        when(processor2.processSnapshot(any(DistroData.class))).thenReturn(false);
+        when(processor3.processSnapshot(any(DistroData.class))).thenReturn(false);
+        
+        DistroLoadDataTask task =
+            new DistroLoadDataTask(memberManager, holder, distroConfig, loadCallback);
+        
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger exceptionCount = new AtomicInteger(0);
+        
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    task.run();
+                } catch (Exception e) {
+                    exceptionCount.incrementAndGet();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+        
+        startLatch.countDown();
+        assertTrue(doneLatch.await(10, TimeUnit.SECONDS), "Concurrent execution timed out");
+        executor.shutdown();
+        
+        Map<String, Boolean> loadCompletedMap = (Map<String, Boolean>) ReflectionTestUtils
+            .getField(task, "loadCompletedMap");
+        assertNotNull(loadCompletedMap);
+        assertTrue(loadCompletedMap.containsKey(type1));
+        assertTrue(loadCompletedMap.containsKey(type2));
+        assertTrue(loadCompletedMap.containsKey(type3));
+        
+        assertTrue(exceptionCount.get() == 0,
+            "Expected no exceptions from concurrent access, but got " + exceptionCount.get());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
  
  Fix race condition in `DistroLoadDataTask` caused by using non-thread-safe `HashMap` for `loadCompletedMap` while the task runs asynchronously with retries.
  
  ## Brief changelog
  
  - Replace `HashMap` with `ConcurrentHashMap` in constructor
  - Simplify check-then-act pattern to avoid redundant `containsKey()` call
  - Add concurrent test `testConcurrentLoadWithMultipleResourceTypes` to verify thread-safety
  
  ## Verifying this change
  
  This change added tests and can be verified as follows:
  
  - Added `testConcurrentLoadWithMultipleResourceTypes` that spawns 10 threads concurrently calling `run()` on the same task instance
  - All existing tests pass
  - Verified with `mvn test -Dtest=DistroLoadDataTaskTest -pl core`
  
  ## Does this pull request potentially affect one of the following parts
  
  - [ ] Dependencies (add or update license)
  - [x] The public API
  - [ ] The schema 
  - [ ] The default values of configurations
  - [ ] The console 
  - [ ] Prometheus metrics
  - [ ] AI features
  
  ## Checklist
  
  - [x] Make sure there is a [GitHub issue](https://github.com/alibaba/nacos/issues) filed for the change (usually before you start working on it).
  - [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
  - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
  - [x] Write necessary unit tests to verify the code.
  - [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass.                                      
  - [x] Run `mvn clean install` to make sure build and tests pass.
  - [x] Run `mvn clean test-compile failsafe:integration-test` to make sure integration tests pass.