### PR TITLE
[ISSUE #15247] Support Skill well-known v0.2 adapter

### DIFF
--- a/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/controller/SkillsRegistryController.java
+++ b/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/controller/SkillsRegistryController.java
@@ -26,6 +26,7 @@ import com.alibaba.nacos.airegistry.model.skills.WellKnownSkillsIndex;
 import com.alibaba.nacos.airegistry.service.NacosSkillsRegistryService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.AntPathMatcher;
@@ -52,6 +53,8 @@ public class SkillsRegistryController {
     
     private static final String WELL_KNOWN_SKILLS = BASE_PATH + "/{namespaceId}/.well-known/skills";
     
+    private static final String APPLICATION_ZIP_VALUE = "application/zip";
+    
     private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
     
     private final NacosSkillsRegistryService nacosSkillsRegistryService;
@@ -67,12 +70,25 @@ public class SkillsRegistryController {
      * @return well-known index payload
      * @throws NacosException if query fails
      */
-    @GetMapping(value = {
-        WELL_KNOWN_AGENT_SKILLS + "/index.json",
-        WELL_KNOWN_SKILLS + "/index.json"
-    }, produces = MediaType.APPLICATION_JSON_VALUE)
-    public WellKnownSkillsIndex getIndex(@PathVariable String namespaceId) throws NacosException {
-        return nacosSkillsRegistryService.buildIndex(namespaceId);
+    @GetMapping(value = WELL_KNOWN_AGENT_SKILLS + "/index.json",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    public WellKnownSkillsIndex getAgentSkillsIndex(@PathVariable String namespaceId)
+        throws NacosException {
+        return nacosSkillsRegistryService.buildAgentSkillsIndex(namespaceId);
+    }
+    
+    /**
+     * Expose legacy well-known index.json for v0.1-compatible clients.
+     *
+     * @param namespaceId namespace to query
+     * @return legacy well-known index payload
+     * @throws NacosException if query fails
+     */
+    @GetMapping(value = WELL_KNOWN_SKILLS + "/index.json",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    public WellKnownSkillsIndex getLegacySkillsIndex(@PathVariable String namespaceId)
+        throws NacosException {
+        return nacosSkillsRegistryService.buildLegacySkillsIndex(namespaceId);
     }
     
     /**
@@ -120,6 +136,31 @@ public class SkillsRegistryController {
             form.getFilePath());
         return content == null ? ResponseEntity.notFound().build()
             : ResponseEntity.ok().contentType(MediaType.TEXT_PLAIN).body(content);
+    }
+    
+    /**
+     * Return an exported skill archive for v0.2 well-known discovery.
+     *
+     * @param namespaceId namespace to query
+     * @param skillName skill name
+     * @return skill ZIP archive when exportable, otherwise 404
+     * @throws NacosException if query fails
+     */
+    @GetMapping(value = {
+        WELL_KNOWN_AGENT_SKILLS + "/{skillName}.zip",
+        WELL_KNOWN_SKILLS + "/{skillName}.zip"
+    }, produces = APPLICATION_ZIP_VALUE)
+    public ResponseEntity<byte[]> getSkillArchive(@PathVariable String namespaceId,
+        @PathVariable String skillName)
+        throws NacosException {
+        byte[] content = nacosSkillsRegistryService.getSkillArchiveContent(namespaceId,
+            skillName);
+        return content == null ? ResponseEntity.notFound().build()
+            : ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                    "attachment;filename=" + skillName + ".zip")
+                .contentType(MediaType.parseMediaType(APPLICATION_ZIP_VALUE))
+                .body(content);
     }
     
     /**

--- a/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/model/skills/WellKnownSkillEntry.java
+++ b/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/model/skills/WellKnownSkillEntry.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.airegistry.model.skills;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.List;
 
 /**
@@ -23,11 +25,20 @@ import java.util.List;
  *
  * @author nacos
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WellKnownSkillEntry {
     
     private String name;
     
+    private String type;
+    
     private String description;
+    
+    private String url;
+    
+    private String digest;
+    
+    private String version;
     
     private List<String> files;
     
@@ -39,12 +50,44 @@ public class WellKnownSkillEntry {
         this.name = name;
     }
     
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
     public String getDescription() {
         return description;
     }
     
     public void setDescription(String description) {
         this.description = description;
+    }
+    
+    public String getUrl() {
+        return url;
+    }
+    
+    public void setUrl(String url) {
+        this.url = url;
+    }
+    
+    public String getDigest() {
+        return digest;
+    }
+    
+    public void setDigest(String digest) {
+        this.digest = digest;
+    }
+    
+    public String getVersion() {
+        return version;
+    }
+    
+    public void setVersion(String version) {
+        this.version = version;
     }
     
     public List<String> getFiles() {

--- a/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/model/skills/WellKnownSkillsIndex.java
+++ b/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/model/skills/WellKnownSkillsIndex.java
@@ -16,6 +16,9 @@
 
 package com.alibaba.nacos.airegistry.model.skills;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 /**
@@ -23,9 +26,21 @@ import java.util.List;
  *
  * @author nacos
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class WellKnownSkillsIndex {
     
+    @JsonProperty("$schema")
+    private String schema;
+    
     private List<WellKnownSkillEntry> skills;
+    
+    public String getSchema() {
+        return schema;
+    }
+    
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
     
     public List<WellKnownSkillEntry> getSkills() {
         return skills;

--- a/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/service/NacosSkillsRegistryService.java
+++ b/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/service/NacosSkillsRegistryService.java
@@ -36,6 +36,10 @@ import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
+import java.io.ByteArrayOutputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -44,6 +48,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Service for exposing Nacos skills through the well-known protocol expected by the skills CLI.
@@ -54,11 +60,24 @@ import java.util.Set;
 @ConditionalOnProperty(name = "nacos.ai.skill.registry.enabled", havingValue = "true")
 public class NacosSkillsRegistryService {
     
+    private static final String SCHEMA_0_2 =
+        "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+    
     private static final int LIST_PAGE_SIZE = 100;
     
     private static final Set<String> BINARY_EXTENSIONS = new HashSet<>();
     
     private static final String MARKDOWN_FILE = "SKILL.md";
+    
+    private static final String ARCHIVE_TYPE = "archive";
+    
+    private static final String SKILL_MD_TYPE = "skill-md";
+    
+    private static final String ZIP_SUFFIX = ".zip";
+    
+    private static final String DIGEST_SHA256_PREFIX = "sha256:";
+    
+    private static final long STABLE_ZIP_ENTRY_TIME = 0L;
     
     private static final String METADATA_ENCODING = "encoding";
     
@@ -86,15 +105,34 @@ public class NacosSkillsRegistryService {
      * @return well-known index response
      * @throws NacosException if query fails
      */
-    public WellKnownSkillsIndex buildIndex(String namespaceId) throws NacosException {
+    public WellKnownSkillsIndex buildAgentSkillsIndex(String namespaceId) throws NacosException {
+        return buildIndex(namespaceId, WellKnownIndexVersion.V0_2_0);
+    }
+    
+    /**
+     * Build the legacy well-known skill index for a namespace.
+     *
+     * @param namespaceId namespace to query
+     * @return legacy well-known index response
+     * @throws NacosException if query fails
+     */
+    public WellKnownSkillsIndex buildLegacySkillsIndex(String namespaceId) throws NacosException {
+        return buildIndex(namespaceId, WellKnownIndexVersion.V0_1_0);
+    }
+    
+    private WellKnownSkillsIndex buildIndex(String namespaceId, WellKnownIndexVersion version)
+        throws NacosException {
         List<ExportableSkill> skills =
             collectExportableSkills(namespaceId, null, Integer.MAX_VALUE);
         skills.sort(Comparator.comparing(each -> each.summary().getName()));
         List<WellKnownSkillEntry> entries = new ArrayList<>(skills.size());
         for (ExportableSkill each : skills) {
-            entries.add(toWellKnownEntry(each));
+            entries.add(toWellKnownEntry(each, version));
         }
         WellKnownSkillsIndex result = new WellKnownSkillsIndex();
+        if (version == WellKnownIndexVersion.V0_2_0) {
+            result.setSchema(SCHEMA_0_2);
+        }
         result.setSkills(entries);
         return result;
     }
@@ -133,7 +171,7 @@ public class NacosSkillsRegistryService {
     
     public String getSkillFileContent(String namespaceId, String skillName, String relativePath)
         throws NacosException {
-        ExportableSkill skill = loadExportableSkill(namespaceId, skillName);
+        ExportableSkill skill = loadExportableSkill(namespaceId, skillName, false);
         if (skill == null) {
             return null;
         }
@@ -154,6 +192,12 @@ public class NacosSkillsRegistryService {
         return null;
     }
     
+    public byte[] getSkillArchiveContent(String namespaceId, String skillName)
+        throws NacosException {
+        ExportableSkill skill = loadExportableSkill(namespaceId, skillName, true);
+        return skill == null ? null : toArchiveBytes(skill.skill());
+    }
+    
     private List<ExportableSkill> collectExportableSkills(String namespaceId, String query,
         int limit)
         throws NacosException {
@@ -172,7 +216,8 @@ public class NacosSkillsRegistryService {
                 if (!isEligibleSummary(each)) {
                     continue;
                 }
-                ExportableSkill exportable = loadExportableSkill(namespaceId, each.getName(), each);
+                ExportableSkill exportable =
+                    loadExportableSkill(namespaceId, each.getName(), each, false);
                 if (exportable == null) {
                     continue;
                 }
@@ -186,7 +231,8 @@ public class NacosSkillsRegistryService {
         return result;
     }
     
-    private ExportableSkill loadExportableSkill(String namespaceId, String skillName)
+    private ExportableSkill loadExportableSkill(String namespaceId, String skillName,
+        boolean download)
         throws NacosException {
         Page<SkillSummary> page = skillOperationService.listSkills(namespaceId, skillName,
             Constants.Skills.SEARCH_ACCURATE,
@@ -198,11 +244,11 @@ public class NacosSkillsRegistryService {
         if (!isEligibleSummary(summary)) {
             return null;
         }
-        return loadExportableSkill(namespaceId, skillName, summary);
+        return loadExportableSkill(namespaceId, skillName, summary, download);
     }
     
     private ExportableSkill loadExportableSkill(String namespaceId, String skillName,
-        SkillSummary summary)
+        SkillSummary summary, boolean download)
         throws NacosException {
         SkillIndexManifest manifest = skillIndexManifestService.query(namespaceId, skillName);
         String resolvedVersion = SkillIndexManifestService.resolveVersion(manifest, null,
@@ -212,8 +258,10 @@ public class NacosSkillsRegistryService {
         }
         Skill skill;
         try {
-            skill = skillOperationService.getSkillVersionDetail(namespaceId, skillName,
-                resolvedVersion);
+            skill = download ? skillOperationService.downloadSkillVersion(namespaceId, skillName,
+                resolvedVersion)
+                : skillOperationService.getSkillVersionDetail(namespaceId, skillName,
+                    resolvedVersion);
         } catch (NacosException e) {
             if (e.getErrCode() == NacosException.NOT_FOUND
                 || e.getErrCode() == NacosException.NO_RIGHT) {
@@ -229,7 +277,7 @@ public class NacosSkillsRegistryService {
         if (files == null) {
             return null;
         }
-        return new ExportableSkill(summary, skill, files);
+        return new ExportableSkill(summary, skill, resolvedVersion, files);
     }
     
     private boolean isEligibleSummary(SkillSummary summary) {
@@ -287,18 +335,122 @@ public class NacosSkillsRegistryService {
         return resource.getType() + "/" + resource.getName();
     }
     
-    private WellKnownSkillEntry toWellKnownEntry(ExportableSkill each) {
+    private WellKnownSkillEntry toWellKnownEntry(ExportableSkill each,
+        WellKnownIndexVersion version)
+        throws NacosException {
         WellKnownSkillEntry entry = new WellKnownSkillEntry();
         entry.setName(each.skill().getName());
         entry.setDescription(each.skill().getDescription());
-        entry.setFiles(each.files());
+        if (version == WellKnownIndexVersion.V0_1_0) {
+            entry.setFiles(each.files());
+            return entry;
+        }
+        entry.setVersion(each.version());
+        if (isSingleMarkdownSkill(each)) {
+            entry.setType(SKILL_MD_TYPE);
+            entry.setUrl(fileUrl(each.skill().getName(), MARKDOWN_FILE));
+            entry.setDigest(
+                sha256Digest(SkillUtils.toMarkdown(each.skill()).getBytes(StandardCharsets.UTF_8)));
+            return entry;
+        }
+        entry.setType(ARCHIVE_TYPE);
+        entry.setUrl(archiveUrl(each.skill().getName()));
+        entry.setDigest(sha256Digest(toArchiveBytes(each.skill())));
         return entry;
+    }
+    
+    private boolean isSingleMarkdownSkill(ExportableSkill skill) {
+        return skill.files().size() == 1 && MARKDOWN_FILE.equals(skill.files().get(0));
+    }
+    
+    private byte[] toArchiveBytes(Skill skill) throws NacosException {
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            try (ZipOutputStream zip = new ZipOutputStream(output, StandardCharsets.UTF_8)) {
+                addZipEntry(zip, MARKDOWN_FILE,
+                    SkillUtils.toMarkdown(skill).getBytes(StandardCharsets.UTF_8));
+                if (skill.getResource() != null && !skill.getResource().isEmpty()) {
+                    List<SkillResource> resources = new ArrayList<>();
+                    for (SkillResource each : skill.getResource().values()) {
+                        if (each != null && StringUtils.isNotBlank(each.getName())) {
+                            resources.add(each);
+                        }
+                    }
+                    resources.sort(Comparator.comparing(this::buildRelativePath));
+                    for (SkillResource each : resources) {
+                        addZipEntry(zip, buildRelativePath(each),
+                            each.getContent() == null ? new byte[0]
+                                : each.getContent().getBytes(StandardCharsets.UTF_8));
+                    }
+                }
+            }
+            return output.toByteArray();
+        } catch (Exception e) {
+            throw new NacosException(NacosException.SERVER_ERROR,
+                "Failed to create skill well-known archive: " + e.getMessage(), e);
+        }
+    }
+    
+    private void addZipEntry(ZipOutputStream zip, String path, byte[] bytes) throws Exception {
+        SkillUtils.validatePathSafety(path);
+        ZipEntry entry = new ZipEntry(path);
+        entry.setTime(STABLE_ZIP_ENTRY_TIME);
+        zip.putNextEntry(entry);
+        zip.write(bytes);
+        zip.closeEntry();
+    }
+    
+    private String fileUrl(String skillName, String file) {
+        return encodePathSegment(skillName) + "/" + encodePath(file);
+    }
+    
+    private String archiveUrl(String skillName) {
+        return encodePathSegment(skillName) + ZIP_SUFFIX;
+    }
+    
+    private String encodePath(String path) {
+        String[] segments = path.split("/");
+        StringBuilder result = new StringBuilder();
+        for (String each : segments) {
+            if (result.length() > 0) {
+                result.append('/');
+            }
+            result.append(encodePathSegment(each));
+        }
+        return result.toString();
+    }
+    
+    private String encodePathSegment(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+    
+    private String sha256Digest(byte[] bytes) throws NacosException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+            StringBuilder result = new StringBuilder(DIGEST_SHA256_PREFIX);
+            for (byte each : hash) {
+                result.append(String.format("%02x", each & 0xff));
+            }
+            return result.toString();
+        } catch (Exception e) {
+            throw new NacosException(NacosException.SERVER_ERROR,
+                "Failed to calculate skill well-known digest: " + e.getMessage(), e);
+        }
     }
     
     private long safeDownloadCount(SkillSummary summary) {
         return summary.getDownloadCount() == null ? 0L : summary.getDownloadCount();
     }
     
-    private record ExportableSkill(SkillSummary summary, Skill skill, List<String> files) {
+    private enum WellKnownIndexVersion {
+        
+        V0_1_0,
+        
+        V0_2_0
+    }
+    
+    private record ExportableSkill(SkillSummary summary, Skill skill, String version,
+        List<String> files) {
     }
 }

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/controller/SkillsRegistryControllerTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/controller/SkillsRegistryControllerTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,20 +61,26 @@ class SkillsRegistryControllerTest {
     
     private MockMvc mockMvc;
     
+    private static final String SCHEMA_0_2 =
+        "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+    
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(skillsRegistryController).build();
     }
     
     @Test
-    void testGetIndex() throws Exception {
+    void testGetAgentSkillsIndex() throws Exception {
         WellKnownSkillEntry entry = new WellKnownSkillEntry();
         entry.setName("demo-skill");
         entry.setDescription("demo");
-        entry.setFiles(List.of("SKILL.md", "docs/guide.md"));
+        entry.setType("archive");
+        entry.setUrl("demo-skill.zip");
+        entry.setDigest("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
         WellKnownSkillsIndex index = new WellKnownSkillsIndex();
+        index.setSchema(SCHEMA_0_2);
         index.setSkills(List.of(entry));
-        when(nacosSkillsRegistryService.buildIndex("public")).thenReturn(index);
+        when(nacosSkillsRegistryService.buildAgentSkillsIndex("public")).thenReturn(index);
         
         String content = mockMvc.perform(
             MockMvcRequestBuilders.get("/registry/public/.well-known/agent-skills/index.json"))
@@ -83,8 +90,34 @@ class SkillsRegistryControllerTest {
             .getContentAsString();
         
         WellKnownSkillsIndex response = JacksonUtils.toObj(content, WellKnownSkillsIndex.class);
+        assertEquals(SCHEMA_0_2, response.getSchema());
         assertEquals(1, response.getSkills().size());
         assertEquals("demo-skill", response.getSkills().get(0).getName());
+        assertEquals("archive", response.getSkills().get(0).getType());
+        assertEquals("demo-skill.zip", response.getSkills().get(0).getUrl());
+    }
+    
+    @Test
+    void testGetLegacySkillsIndex() throws Exception {
+        WellKnownSkillEntry entry = new WellKnownSkillEntry();
+        entry.setName("demo-skill");
+        entry.setDescription("demo");
+        entry.setFiles(List.of("SKILL.md", "docs/guide.md"));
+        WellKnownSkillsIndex index = new WellKnownSkillsIndex();
+        index.setSkills(List.of(entry));
+        when(nacosSkillsRegistryService.buildLegacySkillsIndex("public")).thenReturn(index);
+        
+        String content = mockMvc.perform(
+            MockMvcRequestBuilders.get("/registry/public/.well-known/skills/index.json"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+        
+        WellKnownSkillsIndex response = JacksonUtils.toObj(content, WellKnownSkillsIndex.class);
+        assertEquals(1, response.getSkills().size());
+        assertEquals(List.of("SKILL.md", "docs/guide.md"),
+            response.getSkills().get(0).getFiles());
     }
     
     @Test
@@ -125,6 +158,22 @@ class SkillsRegistryControllerTest {
             .getContentAsString();
         
         assertTrue(content.contains("demo-skill"));
+    }
+    
+    @Test
+    void testGetSkillArchive() throws Exception {
+        when(nacosSkillsRegistryService.getSkillArchiveContent("public", "demo-skill"))
+            .thenReturn("zip".getBytes());
+        
+        byte[] content = mockMvc.perform(
+            MockMvcRequestBuilders
+                .get("/registry/public/.well-known/agent-skills/demo-skill.zip"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsByteArray();
+        
+        assertEquals("zip", new String(content, StandardCharsets.UTF_8));
     }
     
     @Test

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/service/NacosSkillsRegistryServiceTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/service/NacosSkillsRegistryServiceTest.java
@@ -32,9 +32,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipInputStream;
 
 import static com.alibaba.nacos.ai.constant.Constants.Skills.SEARCH_ACCURATE;
 import static com.alibaba.nacos.ai.constant.Constants.Skills.SEARCH_BLUR;
@@ -43,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -59,6 +65,9 @@ class NacosSkillsRegistryServiceTest {
     @Mock
     private SkillIndexManifestService skillIndexManifestService;
     
+    private static final String SCHEMA_0_2 =
+        "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+    
     private NacosSkillsRegistryService service;
     
     @BeforeEach
@@ -67,7 +76,7 @@ class NacosSkillsRegistryServiceTest {
     }
     
     @Test
-    void testBuildIndexFiltersBinarySkill() throws Exception {
+    void testBuildLegacyIndexFiltersBinarySkill() throws Exception {
         Page<SkillSummary> page = new Page<>();
         page.setPagesAvailable(1);
         page.setPageItems(
@@ -85,12 +94,48 @@ class NacosSkillsRegistryServiceTest {
             .thenReturn(
                 buildBinarySkill("binary-skill"));
         
-        WellKnownSkillsIndex result = service.buildIndex("public");
+        WellKnownSkillsIndex result = service.buildLegacySkillsIndex("public");
         
         assertNotNull(result);
+        assertNull(result.getSchema());
         assertEquals(1, result.getSkills().size());
         assertEquals("text-skill", result.getSkills().get(0).getName());
         assertEquals(List.of("SKILL.md", "docs/guide.md"), result.getSkills().get(0).getFiles());
+    }
+    
+    @Test
+    void testBuildAgentSkillsIndexUsesVersion020Shape() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        page.setPageItems(List.of(buildSummary("a-simple-skill", 3L),
+            buildSummary("z-archive-skill", 5L)));
+        when(skillOperationService.listSkills(eq("public"), eq((String) null), eq(SEARCH_BLUR),
+            eq("download_count"), eq(1), eq(100))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "a-simple-skill"))
+            .thenReturn(buildManifest("1.0.0"));
+        when(skillIndexManifestService.query("public", "z-archive-skill"))
+            .thenReturn(buildManifest("1.2.0"));
+        when(skillOperationService.getSkillVersionDetail("public", "a-simple-skill", "1.0.0"))
+            .thenReturn(buildSimpleSkill("a-simple-skill"));
+        when(skillOperationService.getSkillVersionDetail("public", "z-archive-skill", "1.2.0"))
+            .thenReturn(buildTextSkill("z-archive-skill"));
+        
+        WellKnownSkillsIndex result = service.buildAgentSkillsIndex("public");
+        
+        assertEquals(SCHEMA_0_2, result.getSchema());
+        assertEquals(2, result.getSkills().size());
+        assertEquals("a-simple-skill", result.getSkills().get(0).getName());
+        assertEquals("skill-md", result.getSkills().get(0).getType());
+        assertEquals("a-simple-skill/SKILL.md", result.getSkills().get(0).getUrl());
+        assertEquals("1.0.0", result.getSkills().get(0).getVersion());
+        assertEquals(sha256("a-simple-skill"), result.getSkills().get(0).getDigest());
+        assertNull(result.getSkills().get(0).getFiles());
+        assertEquals("z-archive-skill", result.getSkills().get(1).getName());
+        assertEquals("archive", result.getSkills().get(1).getType());
+        assertEquals("z-archive-skill.zip", result.getSkills().get(1).getUrl());
+        assertEquals("1.2.0", result.getSkills().get(1).getVersion());
+        assertTrue(result.getSkills().get(1).getDigest().startsWith("sha256:"));
+        assertNull(result.getSkills().get(1).getFiles());
     }
     
     @Test
@@ -139,6 +184,25 @@ class NacosSkillsRegistryServiceTest {
         assertNull(missing);
     }
     
+    @Test
+    void testGetSkillArchiveContentUsesDownloadAndRootArchive() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        page.setPageItems(List.of(buildSummary("demo-skill", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq("demo-skill"), eq(SEARCH_ACCURATE),
+            eq("download_count"), eq(1), eq(1))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "demo-skill"))
+            .thenReturn(buildManifest("v1"));
+        when(skillOperationService.downloadSkillVersion("public", "demo-skill", "v1"))
+            .thenReturn(buildTextSkill("demo-skill"));
+        
+        byte[] zipBytes = service.getSkillArchiveContent("public", "demo-skill");
+        
+        assertZipEntryContains(zipBytes, "SKILL.md", "name: demo-skill");
+        assertZipEntryContains(zipBytes, "docs/guide.md", "guide");
+        verify(skillOperationService).downloadSkillVersion("public", "demo-skill", "v1");
+    }
+    
     private SkillSummary buildSummary(String name, Long downloadCount) {
         SkillSummary result = new SkillSummary();
         result.setNamespaceId("public");
@@ -173,6 +237,16 @@ class NacosSkillsRegistryServiceTest {
         return result;
     }
     
+    private Skill buildSimpleSkill(String name) {
+        Skill result = new Skill();
+        result.setNamespaceId("public");
+        result.setName(name);
+        result.setDescription(name + " description");
+        result.setSkillMd(
+            "---\nname: " + name + "\ndescription: " + name + " description\n---\n\n# " + name);
+        return result;
+    }
+    
     private Skill buildBinarySkill(String name) {
         Skill result = buildTextSkill(name);
         SkillResource binary = new SkillResource();
@@ -184,5 +258,33 @@ class NacosSkillsRegistryServiceTest {
         binary.setMetadata(metadata);
         result.setResource(Map.of("assets::logo.png", binary));
         return result;
+    }
+    
+    private String sha256(String skillName) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(buildSimpleSkill(skillName).getSkillMd()
+            .getBytes(StandardCharsets.UTF_8));
+        StringBuilder result = new StringBuilder("sha256:");
+        for (byte each : hash) {
+            result.append(String.format("%02x", each & 0xff));
+        }
+        return result.toString();
+    }
+    
+    private void assertZipEntryContains(byte[] zipBytes, String entryName, String expected)
+        throws Exception {
+        try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(zipBytes),
+            StandardCharsets.UTF_8)) {
+            java.util.zip.ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (entryName.equals(entry.getName())) {
+                    ByteArrayOutputStream output = new ByteArrayOutputStream();
+                    zip.transferTo(output);
+                    assertTrue(output.toString(StandardCharsets.UTF_8).contains(expected));
+                    return;
+                }
+            }
+        }
+        throw new AssertionError("Zip entry not found: " + entryName);
     }
 }

--- a/specs/en/ai/ai-registry-adaptor-spec.md
+++ b/specs/en/ai/ai-registry-adaptor-spec.md
@@ -113,13 +113,32 @@ discovery endpoints compatible with skills CLI and well-known registry usage:
 
 | Method | Path | Behavior |
 | --- | --- | --- |
-| `GET` | `/registry/{namespaceId}/.well-known/agent-skills/index.json` | Returns the namespace skill index. |
-| `GET` | `/registry/{namespaceId}/.well-known/skills/index.json` | Alias for the namespace skill index. |
+| `GET` | `/registry/{namespaceId}/.well-known/agent-skills/index.json` | Returns the namespace Skill index in Agent Skills discovery v0.2.0 shape. |
+| `GET` | `/registry/{namespaceId}/.well-known/skills/index.json` | Returns the namespace Skill index in legacy v0.1-compatible shape. |
 | `GET` | `/registry/{namespaceId}/api/search` | Searches exportable skills and returns CLI-compatible search results. |
 | `GET` | `/registry/{namespaceId}/.well-known/agent-skills/{skillName}/SKILL.md` | Returns the exported `SKILL.md`. |
 | `GET` | `/registry/{namespaceId}/.well-known/skills/{skillName}/SKILL.md` | Alias for the exported `SKILL.md`. |
+| `GET` | `/registry/{namespaceId}/.well-known/agent-skills/{skillName}.zip` | Returns an exported Skill archive for v0.2.0 `archive` entries. |
+| `GET` | `/registry/{namespaceId}/.well-known/skills/{skillName}.zip` | Archive alias for clients that already resolved the legacy base path. |
 | `GET` | `/registry/{namespaceId}/.well-known/agent-skills/{skillName}/**` | Returns exported text resources. |
 | `GET` | `/registry/{namespaceId}/.well-known/skills/{skillName}/**` | Alias for exported text resources. |
+
+The `/.well-known/agent-skills/index.json` endpoint is the primary Skill
+well-known discovery surface. It must return a top-level `$schema` value of
+`https://schemas.agentskills.io/discovery/0.2.0/schema.json`. Each entry must
+include `name`, `description`, `type`, `url`, and `digest`. Nacos should use
+`type=skill-md` when the Skill contains only `SKILL.md`, with `url` pointing to
+`{skillName}/SKILL.md`. If the Skill has exported supporting text resources,
+Nacos should use `type=archive`, with `url` pointing to `{skillName}.zip`.
+`digest` is the SHA-256 digest of the raw artifact bytes in the
+`sha256:{hex}` format. Nacos may include non-standard extension fields such as
+the resolved latest `version`; clients must ignore unknown fields according to
+the discovery protocol.
+
+The `/.well-known/skills/index.json` endpoint remains a legacy compatibility
+surface. It omits `$schema` and returns each Skill with a `files` array so
+v0.1-compatible clients can continue to fetch `SKILL.md` and text resources
+from `/{skillName}/{file}` paths.
 
 The adaptor exports only skills that are suitable for public-style discovery:
 

--- a/specs/zh-cn/ai/ai-registry-adaptor-spec.md
+++ b/specs/zh-cn/ai/ai-registry-adaptor-spec.md
@@ -97,13 +97,29 @@ registry 用法的 Skill discovery 端点：
 
 | 方法 | 路径 | 行为 |
 | --- | --- | --- |
-| `GET` | `/registry/{namespaceId}/.well-known/agent-skills/index.json` | 返回 namespace 下的 Skill index。 |
-| `GET` | `/registry/{namespaceId}/.well-known/skills/index.json` | Skill index 的别名。 |
+| `GET` | `/registry/{namespaceId}/.well-known/agent-skills/index.json` | 以 Agent Skills discovery v0.2.0 形态返回 namespace 下的 Skill index。 |
+| `GET` | `/registry/{namespaceId}/.well-known/skills/index.json` | 以 legacy v0.1 兼容形态返回 namespace 下的 Skill index。 |
 | `GET` | `/registry/{namespaceId}/api/search` | 搜索可导出的 Skills，返回 CLI 兼容搜索结果。 |
 | `GET` | `/registry/{namespaceId}/.well-known/agent-skills/{skillName}/SKILL.md` | 返回导出的 `SKILL.md`。 |
 | `GET` | `/registry/{namespaceId}/.well-known/skills/{skillName}/SKILL.md` | 导出 `SKILL.md` 的别名。 |
+| `GET` | `/registry/{namespaceId}/.well-known/agent-skills/{skillName}.zip` | 为 v0.2.0 `archive` 条目返回导出的 Skill archive。 |
+| `GET` | `/registry/{namespaceId}/.well-known/skills/{skillName}.zip` | 为已经解析到 legacy base path 的客户端提供 archive 别名。 |
 | `GET` | `/registry/{namespaceId}/.well-known/agent-skills/{skillName}/**` | 返回导出的文本资源。 |
 | `GET` | `/registry/{namespaceId}/.well-known/skills/{skillName}/**` | 导出文本资源的别名。 |
+
+`/.well-known/agent-skills/index.json` 是主要的 Skill well-known discovery surface。它必须返回
+顶层 `$schema` 字段，取值为
+`https://schemas.agentskills.io/discovery/0.2.0/schema.json`。每个条目必须包含
+`name`、`description`、`type`、`url` 和 `digest`。当 Skill 只包含 `SKILL.md`
+时，Nacos 应使用 `type=skill-md`，并将 `url` 指向 `{skillName}/SKILL.md`；
+当 Skill 包含可导出的文本资源时，Nacos 应使用 `type=archive`，并将 `url` 指向
+`{skillName}.zip`。`digest` 是 artifact 原始字节的 SHA-256 摘要，格式为
+`sha256:{hex}`。Nacos 可以包含已解析 latest `version` 等非标准扩展字段；按照 discovery
+协议，客户端必须忽略未知字段。
+
+`/.well-known/skills/index.json` 保留为 legacy 兼容面。它不返回 `$schema`，并继续以
+`files` 数组描述每个 Skill，使 v0.1 兼容客户端可以继续从 `/{skillName}/{file}` 路径获取
+`SKILL.md` 和文本资源。
 
 适配器只导出适合公开发现语义的 Skills：
 


### PR DESCRIPTION
## Summary
- expose /.well-known/agent-skills/index.json with Agent Skills discovery v0.2.0 metadata, including schema, type, url, digest, and resolved version extension
- keep /.well-known/skills/index.json as the legacy v0.1 files-array compatibility surface
- add Skill ZIP artifact downloads for archive entries and update adapter specs/tests

## Tests
- source ~/Documents/switch17.sh && ./mvnw -pl ai-registry-adaptor spotless:apply spotless:check
- source ~/Documents/switch17.sh && ./mvnw -pl ai-registry-adaptor test
- source ~/Documents/switch17.sh && ./mvnw -pl ai-registry-adaptor -DskipTests apache-rat:check spotbugs:check