### PR TITLE
Improve naming module unit test coverage

### DIFF
--- a/naming/src/test/java/com/alibaba/nacos/naming/NamingAppTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/NamingAppTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.boot.SpringApplication;
+
+class NamingAppTest {
+    
+    @Test
+    void testMainStartsSpringApplication() {
+        String[] args = new String[] {"--server.port=0"};
+        
+        try (MockedStatic<SpringApplication> mockedSpringApplication =
+            Mockito.mockStatic(SpringApplication.class)) {
+            NamingApp.main(args);
+            
+            mockedSpringApplication.verify(() -> SpringApplication.run(NamingApp.class, args));
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/cluster/NamingReadinessCheckServiceTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/cluster/NamingReadinessCheckServiceTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.cluster;
+
+import com.alibaba.nacos.api.common.Constants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NamingReadinessCheckServiceTest {
+    
+    @Mock
+    private ServerStatusManager serverStatusManager;
+    
+    private NamingReadinessCheckService readinessCheckService;
+    
+    @BeforeEach
+    void setUp() {
+        readinessCheckService = new NamingReadinessCheckService(serverStatusManager);
+    }
+    
+    @Test
+    void testReadinessWhenServerStatusUp() {
+        when(serverStatusManager.getServerStatus()).thenReturn(ServerStatus.UP);
+        
+        assertTrue(readinessCheckService.readiness());
+    }
+    
+    @Test
+    void testReadinessWhenServerStatusNotUp() {
+        when(serverStatusManager.getServerStatus()).thenReturn(ServerStatus.DOWN);
+        
+        assertFalse(readinessCheckService.readiness());
+    }
+    
+    @Test
+    void testReadinessWhenGetServerStatusThrowsException() {
+        when(serverStatusManager.getServerStatus()).thenThrow(new RuntimeException("failed"));
+        
+        assertFalse(readinessCheckService.readiness());
+    }
+    
+    @Test
+    void testGetModuleName() {
+        assertEquals(Constants.Naming.NAMING_MODULE, readinessCheckService.getModuleName());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/cluster/remote/request/RequestRegistryTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/cluster/remote/request/RequestRegistryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.cluster.remote.request;
+
+import com.alibaba.nacos.api.remote.Payload;
+import com.alibaba.nacos.core.cluster.remote.request.AbstractClusterRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RequestRegistryTest {
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new RequestRegistry());
+    }
+    
+    @Test
+    void testGetPayloads() {
+        Set<Class<? extends Payload>> payloads = RequestRegistry.getPayloads();
+        
+        assertEquals(2, payloads.size());
+        assertTrue(payloads.contains(AbstractClusterRequest.class));
+        assertTrue(payloads.contains(DistroDataRequest.class));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/cluster/remote/response/ResponseRegistryTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/cluster/remote/response/ResponseRegistryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.cluster.remote.response;
+
+import com.alibaba.nacos.api.remote.Payload;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResponseRegistryTest {
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new ResponseRegistry());
+    }
+    
+    @Test
+    void testGetPayloads() {
+        Set<Class<? extends Payload>> payloads = ResponseRegistry.getPayloads();
+        
+        assertEquals(1, payloads.size());
+        assertTrue(payloads.contains(DistroDataResponse.class));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/config/NamingEnabledFilterTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/config/NamingEnabledFilterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.config;
+
+import com.alibaba.nacos.naming.NamingApp;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NamingEnabledFilterTest {
+    
+    private NamingEnabledFilter filter;
+    
+    private String originalFunctionMode;
+    
+    @BeforeEach
+    void setUp() {
+        filter = new NamingEnabledFilter();
+        originalFunctionMode =
+            (String) ReflectionTestUtils.getField(EnvUtil.class, "functionModeType");
+    }
+    
+    @AfterEach
+    void tearDown() {
+        ReflectionTestUtils.setField(EnvUtil.class, "functionModeType", originalFunctionMode);
+    }
+    
+    @Test
+    void testGetResponsiblePackagePrefix() {
+        assertEquals(NamingApp.class.getPackage().getName(),
+            filter.getResponsiblePackagePrefix());
+    }
+    
+    @Test
+    void testIsExcludedWhenFunctionModeIsEmpty() {
+        ReflectionTestUtils.setField(EnvUtil.class, "functionModeType", "");
+        
+        assertFalse(filter.isExcluded("com.alibaba.nacos.naming.Test",
+            Collections.emptySet()));
+    }
+    
+    @Test
+    void testIsExcludedWhenFunctionModeAllowsNaming() {
+        String[] functionModes = new String[] {EnvUtil.FUNCTION_MODE_NAMING,
+            EnvUtil.FUNCTION_MODE_MICROSERVICE, EnvUtil.FUNCTION_MODE_AI};
+        for (String functionMode : functionModes) {
+            ReflectionTestUtils.setField(EnvUtil.class, "functionModeType", functionMode);
+            
+            assertFalse(filter.isExcluded("com.alibaba.nacos.naming.Test",
+                Collections.emptySet()));
+        }
+    }
+    
+    @Test
+    void testIsExcludedWhenFunctionModeDisablesNaming() {
+        ReflectionTestUtils.setField(EnvUtil.class, "functionModeType",
+            EnvUtil.FUNCTION_MODE_CONFIG);
+        
+        assertTrue(filter.isExcluded("com.alibaba.nacos.naming.Test", Collections.emptySet()));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/consistency/DatumTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/consistency/DatumTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.consistency;
+
+import com.alibaba.nacos.naming.pojo.Record;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+class DatumTest {
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCreateDatum() {
+        Record value = mock(Record.class);
+        
+        Datum<Record> datum = Datum.createDatum("datum-key", value);
+        
+        assertEquals("datum-key", datum.key);
+        assertSame(value, datum.value);
+        assertEquals(0L, datum.timestamp.get());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/consistency/KeyBuilderTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/consistency/KeyBuilderTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.consistency;
+
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KeyBuilderTest {
+    
+    @Test
+    void testBuildKeys() {
+        new KeyBuilder();
+        
+        assertEquals("com.alibaba.nacos.naming.domains.meta.namespace##group@@service",
+            KeyBuilder.buildServiceMetaKey("namespace", "group@@service"));
+        assertEquals("com.alibaba.nacos.naming.domains.meta." + UtilsAndCommons.SWITCH_DOMAIN_NAME,
+            KeyBuilder.getSwitchDomainKey());
+        assertTrue(KeyBuilder.matchSwitchKey(KeyBuilder.getSwitchDomainKey()));
+        assertFalse(KeyBuilder.matchSwitchKey("other"));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/consistency/ephemeral/distro/v2/DistroClientDataProcessorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/consistency/ephemeral/distro/v2/DistroClientDataProcessorTest.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.naming.core.v2.client.ClientAttributes;
 import com.alibaba.nacos.naming.core.v2.client.ClientSyncData;
 import com.alibaba.nacos.naming.core.v2.client.ClientSyncDatumSnapshot;
 import com.alibaba.nacos.naming.core.v2.client.impl.ConnectionBasedClient;
+import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.client.manager.ClientManager;
 import com.alibaba.nacos.naming.core.v2.event.client.ClientEvent;
 import com.alibaba.nacos.naming.core.v2.pojo.BatchInstanceData;
@@ -54,6 +55,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -237,6 +239,12 @@ class DistroClientDataProcessorTest {
     }
     
     @Test
+    void testProcessDataForUnsupportedOperation() {
+        distroData.setType(DataOperation.VERIFY);
+        assertFalse(distroClientDataProcessor.processData(distroData));
+    }
+    
+    @Test
     void testProcessDataForChangeClient() {
         distroData.setType(DataOperation.CHANGE);
         assertEquals(0L, client.getRevision());
@@ -245,6 +253,20 @@ class DistroClientDataProcessorTest {
         verify(clientManager).syncClientConnected(CLIENT_ID, clientSyncData.getAttributes());
         assertEquals(1L, client.getRevision());
         assertEquals(1, client.getAllPublishedService().size());
+    }
+    
+    @Test
+    void testProcessDataRemovesStaleService() {
+        Service staleService =
+            ServiceManager.getInstance().getSingleton(Service.newService("ns", "group",
+                "stale"));
+        client.addServiceInstance(staleService, new InstancePublishInfo("4.4.4.4", 2222));
+        assertTrue(client.getAllPublishedService().contains(staleService));
+        
+        distroData.setType(DataOperation.CHANGE);
+        distroClientDataProcessor.processData(distroData);
+        
+        assertFalse(client.getAllPublishedService().contains(staleService));
     }
     
     @Test
@@ -384,9 +406,28 @@ class DistroClientDataProcessorTest {
     }
     
     @Test
+    void testGetDistroDataWithoutClient() {
+        when(clientManager.getClient(CLIENT_ID)).thenReturn(null);
+        assertNull(distroClientDataProcessor.getDistroData(distroKey));
+    }
+    
+    @Test
     void testGetDatumSnapshot() {
         when(clientManager.allClientId()).thenReturn(Collections.singletonList(CLIENT_ID));
         DistroData actual = distroClientDataProcessor.getDatumSnapshot();
+        assertEquals(DataOperation.SNAPSHOT.name(), actual.getDistroKey().getResourceKey());
+        assertEquals(DistroClientDataProcessor.TYPE, actual.getDistroKey().getResourceType());
+    }
+    
+    @Test
+    void testGetDatumSnapshotSkipsUnavailableClients() {
+        Client persistentClient = new IpPortBasedClient("1.1.1.1:80#false", false);
+        when(clientManager.allClientId()).thenReturn(Arrays.asList("missing", "persistent"));
+        when(clientManager.getClient("missing")).thenReturn(null);
+        when(clientManager.getClient("persistent")).thenReturn(persistentClient);
+        
+        DistroData actual = distroClientDataProcessor.getDatumSnapshot();
+        
         assertEquals(DataOperation.SNAPSHOT.name(), actual.getDistroKey().getResourceKey());
         assertEquals(DistroClientDataProcessor.TYPE, actual.getDistroKey().getResourceType());
     }
@@ -401,5 +442,19 @@ class DistroClientDataProcessorTest {
         assertEquals(CLIENT_ID, list.iterator().next().getDistroKey().getResourceKey());
         assertEquals(DistroClientDataProcessor.TYPE,
             list.iterator().next().getDistroKey().getResourceType());
+    }
+    
+    @Test
+    void testGetVerifyDataSkipsUnavailableClients() {
+        Client persistentClient = new IpPortBasedClient("1.1.1.1:80#false", false);
+        Client irresponsibleClient = new ConnectionBasedClient("irresponsible", true, 0L);
+        when(clientManager.allClientId())
+            .thenReturn(Arrays.asList("missing", "persistent", "irresponsible"));
+        when(clientManager.getClient("missing")).thenReturn(null);
+        when(clientManager.getClient("persistent")).thenReturn(persistentClient);
+        when(clientManager.getClient("irresponsible")).thenReturn(irresponsibleClient);
+        when(clientManager.isResponsibleClient(irresponsibleClient)).thenReturn(false);
+        
+        assertNull(distroClientDataProcessor.getVerifyData());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/consistency/ephemeral/distro/v2/DistroClientTaskFailedHandlerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/consistency/ephemeral/distro/v2/DistroClientTaskFailedHandlerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.consistency.ephemeral.distro.v2;
+
+import com.alibaba.nacos.consistency.DataOperation;
+import com.alibaba.nacos.core.distributed.distro.entity.DistroKey;
+import com.alibaba.nacos.core.distributed.distro.task.DistroTaskEngineHolder;
+import com.alibaba.nacos.core.distributed.distro.task.delay.DistroDelayTask;
+import com.alibaba.nacos.core.distributed.distro.task.delay.DistroDelayTaskExecuteEngine;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DistroClientTaskFailedHandlerTest {
+    
+    @BeforeEach
+    void setUp() {
+        EnvUtil.setEnvironment(new MockEnvironment());
+    }
+    
+    @Test
+    void testRetryAddsDelayTask() {
+        DistroTaskEngineHolder taskEngineHolder = mock(DistroTaskEngineHolder.class);
+        DistroDelayTaskExecuteEngine delayTaskExecuteEngine =
+            mock(DistroDelayTaskExecuteEngine.class);
+        DistroKey distroKey = new DistroKey("resource", "type", "target");
+        DistroClientTaskFailedHandler handler = new DistroClientTaskFailedHandler(taskEngineHolder);
+        when(taskEngineHolder.getDelayTaskExecuteEngine()).thenReturn(delayTaskExecuteEngine);
+        
+        handler.retry(distroKey, DataOperation.ADD);
+        
+        verify(delayTaskExecuteEngine).addTask(eq(distroKey), any(DistroDelayTask.class));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/consistency/ephemeral/distro/v2/DistroClientTransportAgentTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/consistency/ephemeral/distro/v2/DistroClientTransportAgentTest.java
@@ -43,6 +43,7 @@ import org.mockito.quality.Strictness;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.mock.env.MockEnvironment;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -235,6 +236,25 @@ class DistroClientTransportAgentTest {
     }
     
     @Test
+    void testSyncDataWithCallbackReadsCallbackMetadata() throws NacosException {
+        when(memberManager.hasMember(member.getAddress())).thenReturn(true);
+        when(memberManager.find(member.getAddress())).thenReturn(member);
+        member.setState(NodeState.UP);
+        when(clusterRpcClientProxy.isRunning(member)).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+            RequestCallBack<Response> callback = invocationOnMock.getArgument(2);
+            assertNotNull(callback.getExecutor());
+            assertTrue(callback.getTimeout() > 0);
+            callback.onResponse(response);
+            return null;
+        }).when(clusterRpcClientProxy).asyncRequest(eq(member), any(), any());
+        
+        transportAgent.syncData(new DistroData(), member.getAddress(), distroCallback);
+        
+        verify(distroCallback).onSuccess();
+    }
+    
+    @Test
     void testSyncVerifyDataForMemberNonExist() throws NacosException {
         DistroData verifyData = new DistroData();
         verifyData.setDistroKey(new DistroKey());
@@ -385,6 +405,27 @@ class DistroClientTransportAgentTest {
         member.setState(NodeState.UP);
         when(clusterRpcClientProxy.isRunning(member)).thenReturn(true);
         transportAgent.syncVerifyData(verifyData, member.getAddress(), distroCallback);
+        verify(distroCallback).onSuccess();
+    }
+    
+    @Test
+    void testSyncVerifyDataWithCallbackReadsCallbackMetadata() throws NacosException {
+        DistroData verifyData = new DistroData();
+        verifyData.setDistroKey(new DistroKey("clientId", "type"));
+        when(memberManager.hasMember(member.getAddress())).thenReturn(true);
+        when(memberManager.find(member.getAddress())).thenReturn(member);
+        member.setState(NodeState.UP);
+        when(clusterRpcClientProxy.isRunning(member)).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+            RequestCallBack<Response> callback = invocationOnMock.getArgument(2);
+            assertNotNull(callback.getExecutor());
+            assertTrue(callback.getTimeout() > 0);
+            callback.onResponse(response);
+            return null;
+        }).when(clusterRpcClientProxy).asyncRequest(eq(member), any(), any());
+        
+        transportAgent.syncVerifyData(verifyData, member.getAddress(), distroCallback);
+        
         verify(distroCallback).onSuccess();
     }
     

--- a/naming/src/test/java/com/alibaba/nacos/naming/consistency/ephemeral/distro/v2/DistroClientVerifyInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/consistency/ephemeral/distro/v2/DistroClientVerifyInfoTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.consistency.ephemeral.distro.v2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DistroClientVerifyInfoTest {
+    
+    @Test
+    void testConstructorWithArguments() {
+        DistroClientVerifyInfo verifyInfo = new DistroClientVerifyInfo("client-id", 100L);
+        
+        assertEquals("client-id", verifyInfo.getClientId());
+        assertEquals(100L, verifyInfo.getRevision());
+    }
+    
+    @Test
+    void testAccessors() {
+        DistroClientVerifyInfo verifyInfo = new DistroClientVerifyInfo();
+        
+        verifyInfo.setClientId("client-id");
+        verifyInfo.setRevision(200L);
+        
+        assertEquals("client-id", verifyInfo.getClientId());
+        assertEquals(200L, verifyInfo.getRevision());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/consistency/persistent/impl/AbstractSnapshotOperationTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/consistency/persistent/impl/AbstractSnapshotOperationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.consistency.persistent.impl;
+
+import com.alibaba.nacos.consistency.snapshot.Reader;
+import com.alibaba.nacos.consistency.snapshot.Writer;
+import com.alibaba.nacos.core.distributed.raft.RaftConfig;
+import com.alibaba.nacos.core.distributed.raft.RaftSysConstants;
+import com.alibaba.nacos.core.distributed.raft.utils.RaftExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractSnapshotOperationTest {
+    
+    @BeforeEach
+    void setUp() {
+        RaftConfig config = new RaftConfig();
+        config.setVal(RaftSysConstants.RAFT_CORE_THREAD_NUM, "1");
+        config.setVal(RaftSysConstants.RAFT_CLI_SERVICE_THREAD_NUM, "1");
+        RaftExecutor.init(config);
+    }
+    
+    @Test
+    void testOnSnapshotSaveSuccess(@TempDir Path snapshotPath) throws Exception {
+        TestSnapshotOperation operation = new TestSnapshotOperation(true, null);
+        AtomicReference<Boolean> successRef = new AtomicReference<>();
+        AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        
+        operation.onSnapshotSave(new Writer(snapshotPath.toString()), (success, throwable) -> {
+            successRef.set(success);
+            throwableRef.set(throwable);
+            latch.countDown();
+        });
+        
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertTrue(successRef.get());
+        assertNull(throwableRef.get());
+        assertTrue(operation.writeCalled);
+    }
+    
+    @Test
+    void testOnSnapshotSaveFailure(@TempDir Path snapshotPath) throws Exception {
+        RuntimeException expected = new RuntimeException("test");
+        TestSnapshotOperation operation = new TestSnapshotOperation(false, expected);
+        AtomicReference<Boolean> successRef = new AtomicReference<>();
+        AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        
+        operation.onSnapshotSave(new Writer(snapshotPath.toString()), (success, throwable) -> {
+            successRef.set(success);
+            throwableRef.set(throwable);
+            latch.countDown();
+        });
+        
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertFalse(successRef.get());
+        assertSame(expected, throwableRef.get());
+        assertTrue(operation.writeCalled);
+    }
+    
+    private static class TestSnapshotOperation extends AbstractSnapshotOperation {
+        
+        private final boolean writeResult;
+        
+        private final RuntimeException writeException;
+        
+        private boolean writeCalled;
+        
+        TestSnapshotOperation(boolean writeResult, RuntimeException writeException) {
+            super(new ReentrantReadWriteLock());
+            this.writeResult = writeResult;
+            this.writeException = writeException;
+        }
+        
+        @Override
+        protected boolean writeSnapshot(Writer writer) {
+            writeCalled = true;
+            if (null != writeException) {
+                throw writeException;
+            }
+            return writeResult;
+        }
+        
+        @Override
+        protected boolean readSnapshot(Reader reader) {
+            return true;
+        }
+        
+        @Override
+        protected String getSnapshotSaveTag() {
+            return "test.save";
+        }
+        
+        @Override
+        protected String getSnapshotLoadTag() {
+            return "test.load";
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/consistency/persistent/impl/BatchReadWriteRequestTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/consistency/persistent/impl/BatchReadWriteRequestTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.consistency.persistent.impl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BatchReadWriteRequestTest {
+    
+    @Test
+    void testBatchReadResponseAppendAndSetters() {
+        BatchReadResponse response = new BatchReadResponse();
+        byte[] key = new byte[] {1};
+        byte[] value = new byte[] {2};
+        
+        response.append(key, value);
+        
+        assertArrayEquals(key, response.getKeys().get(0));
+        assertArrayEquals(value, response.getValues().get(0));
+        response.setKeys(Collections.singletonList(new byte[] {3}));
+        response.setValues(Collections.singletonList(new byte[] {4}));
+        assertEquals(1, response.getKeys().size());
+        assertArrayEquals(new byte[] {3}, response.getKeys().get(0));
+        assertArrayEquals(new byte[] {4}, response.getValues().get(0));
+    }
+    
+    @Test
+    void testBatchWriteRequestAppendAndSetters() {
+        BatchWriteRequest request = new BatchWriteRequest();
+        byte[] key = new byte[] {5};
+        byte[] value = new byte[] {6};
+        
+        request.append(key, value);
+        
+        assertArrayEquals(key, request.getKeys().get(0));
+        assertArrayEquals(value, request.getValues().get(0));
+        request.setKeys(Collections.singletonList(new byte[] {7}));
+        request.setValues(Collections.singletonList(new byte[] {8}));
+        assertEquals(1, request.getValues().size());
+        assertArrayEquals(new byte[] {7}, request.getKeys().get(0));
+        assertArrayEquals(new byte[] {8}, request.getValues().get(0));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/OperatorMetricsV1ControllerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/OperatorMetricsV1ControllerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.controllers;
+
+import com.alibaba.nacos.naming.cluster.ServerStatus;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OperatorMetricsV1ControllerTest {
+    
+    @Test
+    void testMetricsReturnsUpStatus() {
+        ObjectNode result = new OperatorMetricsV1Controller().metrics();
+        
+        assertEquals(ServerStatus.UP.name(), result.get("status").asText());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/ClientControllerV3Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/ClientControllerV3Test.java
@@ -16,8 +16,11 @@
 
 package com.alibaba.nacos.naming.controllers.v3;
 
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.naming.pojo.maintainer.ClientPublisherInfo;
 import com.alibaba.nacos.api.naming.pojo.maintainer.ClientServiceInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClientSubscriberInfo;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.naming.BaseTest;
 import com.alibaba.nacos.naming.core.ClientService;
@@ -27,7 +30,9 @@ import com.alibaba.nacos.naming.core.v2.client.manager.ClientManager;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.alibaba.nacos.naming.model.form.ClientServiceForm;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +53,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -129,6 +135,30 @@ class ClientControllerV3Test extends BaseTest {
     }
     
     @Test
+    void testGetSubscribeServiceList() throws Exception {
+        List<ClientServiceInfo> serviceList = new LinkedList<>();
+        serviceList.add(new ClientServiceInfo());
+        serviceList.get(0).setServiceName("test");
+        when(clientServiceV2Impl.getSubscribeServiceList("test1")).thenReturn(serviceList);
+        
+        Result<List<ClientServiceInfo>> actual =
+            clientControllerV3.getSubscribeServiceList("test1");
+        
+        assertEquals(1, actual.getData().size());
+        assertEquals("test", actual.getData().get(0).getServiceName());
+    }
+    
+    @Test
+    void testGetSubscribeServiceListWhenClientMissing() {
+        when(clientManager.contains("missing")).thenReturn(false);
+        
+        NacosApiException actual = assertThrows(NacosApiException.class,
+            () -> clientControllerV3.getSubscribeServiceList("missing"));
+        
+        assertEquals(404, actual.getErrCode());
+    }
+    
+    @Test
     void testGetPublishedClientList() throws Exception {
         String baseTestKey = "nacos-getPublishedClientList-test";
         // single instance
@@ -152,5 +182,39 @@ class ClientControllerV3Test extends BaseTest {
             .param("serviceName", baseTestKey).param("ip", "127.0.0.1").param("port", "8848");
         mockmvc.perform(mockHttpServletRequestBuilder)
             .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(1));
+    }
+    
+    @Test
+    void testGetSubscribeClientList() throws Exception {
+        ClientServiceForm clientServiceForm = new ClientServiceForm();
+        clientServiceForm.setNamespaceId("namespace");
+        clientServiceForm.setGroupName("group");
+        clientServiceForm.setServiceName("service");
+        clientServiceForm.setIp("127.0.0.1");
+        clientServiceForm.setPort(8848);
+        List<ClientSubscriberInfo> subscriberList = new LinkedList<>();
+        subscriberList.add(new ClientSubscriberInfo());
+        subscriberList.get(0).setClientId("test1");
+        when(clientServiceV2Impl.getSubscribeClientList("namespace", "group", "service",
+            "127.0.0.1", 8848)).thenReturn(subscriberList);
+        
+        Result<List<ClientSubscriberInfo>> actual =
+            clientControllerV3.getSubscribeClientList(clientServiceForm);
+        
+        assertEquals(1, actual.getData().size());
+        assertEquals("test1", actual.getData().get(0).getClientId());
+    }
+    
+    @Test
+    void testGetResponsibleServer4Client() {
+        ObjectNode responsibleServer = JacksonUtils.createEmptyJsonNode();
+        responsibleServer.put("responsibleServer", "server-a");
+        when(clientServiceV2Impl.getResponsibleServer4Client("127.0.0.1", "8848"))
+            .thenReturn(responsibleServer);
+        
+        Result<ObjectNode> actual =
+            clientControllerV3.getResponsibleServer4Client("127.0.0.1", "8848");
+        
+        assertEquals("server-a", actual.getData().get("responsibleServer").asText());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceControllerV3Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceControllerV3Test.java
@@ -28,15 +28,18 @@ import com.alibaba.nacos.common.trace.event.naming.UpdateInstanceTraceEvent;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.naming.BaseTest;
 import com.alibaba.nacos.naming.core.CatalogService;
+import com.alibaba.nacos.naming.core.InstancePatchObject;
 import com.alibaba.nacos.naming.core.InstanceOperatorClientImpl;
 import com.alibaba.nacos.naming.misc.UtilsAndCommons;
 import com.alibaba.nacos.naming.model.form.InstanceForm;
 import com.alibaba.nacos.naming.model.form.InstanceListForm;
 import com.alibaba.nacos.naming.model.form.InstanceMetadataBatchOperationForm;
+import com.alibaba.nacos.naming.pojo.InstanceOperationInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -217,10 +220,60 @@ class InstanceControllerV3Test extends BaseTest {
     }
     
     @Test
+    void batchDeleteInstanceMetadata() throws Exception {
+        
+        InstanceMetadataBatchOperationForm form = new InstanceMetadataBatchOperationForm();
+        form.setNamespaceId(TEST_NAMESPACE);
+        form.setGroupName("DEFAULT_GROUP");
+        form.setServiceName("test-service");
+        form.setConsistencyType("ephemeral");
+        form.setInstances("[{\"ip\":\"1.1.1.1\",\"port\":9870}]");
+        form.setMetadata(TEST_METADATA);
+        
+        ArrayList<String> ipList = new ArrayList<>();
+        ipList.add(TEST_IP);
+        ArgumentCaptor<InstanceOperationInfo> operationInfoCaptor =
+            ArgumentCaptor.forClass(InstanceOperationInfo.class);
+        when(instanceService.batchDeleteMetadata(eq(TEST_NAMESPACE), any(), any()))
+            .thenReturn(ipList);
+        
+        Result<InstanceMetadataBatchResult> result =
+            instanceControllerV3.batchDeleteInstanceMetadata(form);
+        
+        verify(instanceService).batchDeleteMetadata(eq(TEST_NAMESPACE),
+            operationInfoCaptor.capture(), any());
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        assertEquals(TEST_IP, result.getData().getUpdated().get(0));
+        assertEquals(Constants.DEFAULT_CLUSTER_NAME,
+            operationInfoCaptor.getValue().getInstances().get(0).getClusterName());
+    }
+    
+    @Test
+    void batchDeleteInstanceMetadataIgnoresInvalidInstances() throws Exception {
+        InstanceMetadataBatchOperationForm form = new InstanceMetadataBatchOperationForm();
+        form.setNamespaceId(TEST_NAMESPACE);
+        form.setGroupName("DEFAULT_GROUP");
+        form.setServiceName("test-service");
+        form.setConsistencyType("ephemeral");
+        form.setInstances("invalid");
+        form.setMetadata(TEST_METADATA);
+        when(instanceService.batchDeleteMetadata(eq(TEST_NAMESPACE), any(), any()))
+            .thenReturn(new ArrayList<>());
+        
+        Result<InstanceMetadataBatchResult> result =
+            instanceControllerV3.batchDeleteInstanceMetadata(form);
+        
+        verify(instanceService).batchDeleteMetadata(eq(TEST_NAMESPACE), any(), any());
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        assertEquals(0, result.getData().getUpdated().size());
+    }
+    
+    @Test
     void partialUpdateInstance() throws Exception {
         MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.put(
-            UtilsAndCommons.INSTANCE_CONTROLLER_V3_ADMIN_PATH).param("namespaceId", TEST_NAMESPACE)
-            .param("serviceName", TEST_SERVICE_NAME).param("ip", TEST_IP)
+            UtilsAndCommons.INSTANCE_CONTROLLER_V3_ADMIN_PATH + "/partial")
+            .param("namespaceId", TEST_NAMESPACE).param("serviceName", TEST_SERVICE_NAME)
+            .param("ip", TEST_IP)
             .param("cluster", TEST_CLUSTER_NAME)
             .param("port", "9999").param("healthy", "true").param("weight", "2.0")
             .param("enabled", "true")
@@ -228,6 +281,35 @@ class InstanceControllerV3Test extends BaseTest {
         String actualValue =
             mockmvc.perform(builder).andReturn().getResponse().getContentAsString();
         assertEquals("ok", JacksonUtils.toObj(actualValue).get("data").asText());
+    }
+    
+    @Test
+    void partialUpdateInstanceByControllerMethod() throws Exception {
+        InstanceForm instanceForm = new InstanceForm();
+        instanceForm.setNamespaceId(TEST_NAMESPACE);
+        instanceForm.setGroupName("DEFAULT_GROUP");
+        instanceForm.setServiceName("test-service");
+        instanceForm.setIp(TEST_IP);
+        instanceForm.setClusterName(TEST_CLUSTER_NAME);
+        instanceForm.setPort(9999);
+        instanceForm.setWeight(2.0);
+        instanceForm.setEnabled(true);
+        instanceForm.setMetadata(TEST_METADATA);
+        ArgumentCaptor<InstancePatchObject> patchObjectCaptor =
+            ArgumentCaptor.forClass(InstancePatchObject.class);
+        
+        Result<String> result = instanceControllerV3.partialUpdateInstance(instanceForm);
+        
+        verify(instanceService).patchInstance(eq(TEST_NAMESPACE), eq("DEFAULT_GROUP"),
+            eq("test-service"), patchObjectCaptor.capture());
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        assertEquals("ok", result.getData());
+        assertEquals(TEST_CLUSTER_NAME, patchObjectCaptor.getValue().getCluster());
+        assertEquals(TEST_IP, patchObjectCaptor.getValue().getIp());
+        assertEquals(9999, patchObjectCaptor.getValue().getPort());
+        assertEquals(2.0, patchObjectCaptor.getValue().getWeight());
+        assertEquals(true, patchObjectCaptor.getValue().getEnabled());
+        assertEquals("123", patchObjectCaptor.getValue().getMetadata().get("label"));
     }
     
     @Test
@@ -249,6 +331,34 @@ class InstanceControllerV3Test extends BaseTest {
         
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals(instance, result.getData().get(0));
+    }
+    
+    @Test
+    void listInstanceFiltersUnhealthyInstances() throws Exception {
+        Instance healthyInstance = new Instance();
+        healthyInstance.setIp("1.1.1.1");
+        healthyInstance.setHealthy(true);
+        Instance unhealthyInstance = new Instance();
+        unhealthyInstance.setIp("2.2.2.2");
+        unhealthyInstance.setHealthy(false);
+        List<Instance> expected = new LinkedList<>();
+        expected.add(healthyInstance);
+        expected.add(unhealthyInstance);
+        doReturn(expected).when(catalogService)
+            .listInstances(eq(TEST_NAMESPACE), eq(TEST_GROUP_NAME), eq("test-service"),
+                eq(TEST_CLUSTER_NAME));
+        InstanceListForm instanceForm = new InstanceListForm();
+        instanceForm.setNamespaceId(TEST_NAMESPACE);
+        instanceForm.setGroupName(TEST_GROUP_NAME);
+        instanceForm.setServiceName("test-service");
+        instanceForm.setClusterName(TEST_CLUSTER_NAME);
+        instanceForm.setHealthyOnly(true);
+        
+        Result<List<? extends Instance>> result = instanceControllerV3.list(instanceForm);
+        
+        assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
+        assertEquals(1, result.getData().size());
+        assertEquals(healthyInstance, result.getData().get(0));
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/OperatorControllerV3Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/OperatorControllerV3Test.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.naming.controllers.v3;
 
+import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.naming.pojo.maintainer.MetricsInfo;
@@ -34,8 +35,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 
 /**
  * OperatorControllerV3Test.
@@ -85,6 +88,22 @@ class OperatorControllerV3Test {
             e.printStackTrace();
             fail(e.getMessage());
         }
+    }
+    
+    @Test
+    void testUpdateSwitchesConvertsIllegalArgumentException() throws Exception {
+        UpdateSwitchForm updateSwitchForm = new UpdateSwitchForm();
+        updateSwitchForm.setDebug(true);
+        updateSwitchForm.setEntry("test");
+        updateSwitchForm.setValue("test");
+        doThrow(new IllegalArgumentException("bad switch")).when(operatorV2Impl)
+            .updateSwitch("test", "test", true);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> operatorControllerV3.updateSwitch(updateSwitchForm));
+        
+        assertEquals(ErrorCode.SERVER_ERROR.getCode(), exception.getDetailErrCode());
+        assertEquals("bad switch", exception.getErrMsg());
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/ServiceControllerV3Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/ServiceControllerV3Test.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.naming.pojo.maintainer.ServiceDetailInfo;
 import com.alibaba.nacos.api.naming.pojo.maintainer.ServiceView;
 import com.alibaba.nacos.api.naming.pojo.maintainer.SubscriberInfo;
+import com.alibaba.nacos.api.selector.Selector;
 import com.alibaba.nacos.common.notify.Event;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.notify.listener.SmartSubscriber;
@@ -51,6 +52,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -130,6 +132,41 @@ class ServiceControllerV3Test {
     }
     
     @Test
+    void testCreateWithSelector() throws Exception {
+        
+        ServiceForm serviceForm = new ServiceForm();
+        serviceForm.setNamespaceId(Constants.DEFAULT_NAMESPACE_ID);
+        serviceForm.setServiceName("service");
+        serviceForm.setGroupName(Constants.DEFAULT_GROUP);
+        serviceForm.setEphemeral(true);
+        serviceForm.setProtectThreshold(0.0F);
+        serviceForm.setMetadata("");
+        serviceForm.setSelector("{\"type\":\"mock\",\"expression\":\"key=value\"}");
+        when(selectorManager.parseSelector("mock", "key=value"))
+            .thenReturn(Mockito.mock(Selector.class));
+        
+        Result<String> actual = serviceControllerV3.create(serviceForm);
+        
+        verify(selectorManager).parseSelector("mock", "key=value");
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+        assertEquals("ok", actual.getData());
+    }
+    
+    @Test
+    void testCreateThrowsWhenSelectorMissingType() {
+        ServiceForm serviceForm = new ServiceForm();
+        serviceForm.setNamespaceId(Constants.DEFAULT_NAMESPACE_ID);
+        serviceForm.setServiceName("service");
+        serviceForm.setGroupName(Constants.DEFAULT_GROUP);
+        serviceForm.setEphemeral(true);
+        serviceForm.setProtectThreshold(0.0F);
+        serviceForm.setMetadata("");
+        serviceForm.setSelector("{\"expression\":\"key=value\"}");
+        
+        assertThrows(Exception.class, () -> serviceControllerV3.create(serviceForm));
+    }
+    
+    @Test
     void testRemove() throws Exception {
         ServiceForm serviceForm = new ServiceForm();
         serviceForm.setNamespaceId(Constants.DEFAULT_NAMESPACE_ID);
@@ -178,6 +215,27 @@ class ServiceControllerV3Test {
     }
     
     @Test
+    void testListWithInstances() throws Exception {
+        Page<ServiceDetailInfo> result = new Page<>();
+        result.getPageItems().add(new ServiceDetailInfo());
+        when(catalogServiceV2.pageListServiceDetail(Constants.DEFAULT_NAMESPACE_ID,
+            Constants.DEFAULT_GROUP, "serviceName", 1, 10)).thenReturn(result);
+        ServiceListForm serviceListForm = new ServiceListForm();
+        serviceListForm.setNamespaceId(Constants.DEFAULT_NAMESPACE_ID);
+        serviceListForm.setGroupNameParam(Constants.DEFAULT_GROUP);
+        serviceListForm.setServiceNameParam("serviceName");
+        serviceListForm.setWithInstances(true);
+        PageForm pageForm = new PageForm();
+        pageForm.setPageNo(1);
+        pageForm.setPageSize(10);
+        
+        Result<Object> actual = serviceControllerV3.list(serviceListForm, pageForm);
+        
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+        assertEquals(result, actual.getData());
+    }
+    
+    @Test
     void testUpdate() throws Exception {
         ServiceForm serviceForm = new ServiceForm();
         serviceForm.setNamespaceId(Constants.DEFAULT_NAMESPACE_ID);
@@ -195,6 +253,19 @@ class ServiceControllerV3Test {
         assertEquals("ok", actual.getData());
         TimeUnit.SECONDS.sleep(3);
         assertEquals(UpdateServiceTraceEvent.class, eventReceivedClass);
+    }
+    
+    @Test
+    void testUpdateThrowsWhenSelectorUnknown() {
+        ServiceForm serviceForm = new ServiceForm();
+        serviceForm.setNamespaceId(Constants.DEFAULT_NAMESPACE_ID);
+        serviceForm.setGroupName(Constants.DEFAULT_GROUP);
+        serviceForm.setServiceName("service");
+        serviceForm.setProtectThreshold(0.0f);
+        serviceForm.setMetadata("");
+        serviceForm.setSelector("{\"type\":\"mock\",\"expression\":\"key=value\"}");
+        
+        assertThrows(Exception.class, () -> serviceControllerV3.update(serviceForm));
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/CatalogServiceV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/CatalogServiceV2ImplTest.java
@@ -26,6 +26,7 @@ import com.alibaba.nacos.api.naming.pojo.maintainer.ServiceView;
 import com.alibaba.nacos.naming.constants.FieldsConstants;
 import com.alibaba.nacos.naming.core.v2.ServiceManager;
 import com.alibaba.nacos.naming.core.v2.index.ServiceStorage;
+import com.alibaba.nacos.naming.core.v2.metadata.ClusterMetadata;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
 import com.alibaba.nacos.naming.core.v2.metadata.ServiceMetadata;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
@@ -43,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -96,6 +98,24 @@ class CatalogServiceV2ImplTest {
         assertEquals("none", actual.getSelector().getType());
         assertEquals(0, actual.getMetadata().size());
         assertEquals(0.75, actual.getProtectThreshold(), 0.1);
+    }
+    
+    @Test
+    void testGetServiceDetailWithClusterMetadata() throws NacosException {
+        ServiceMetadata serviceMetadata = new ServiceMetadata();
+        ClusterMetadata clusterMetadata = new ClusterMetadata();
+        clusterMetadata.setHealthyCheckPort(8848);
+        clusterMetadata.setUseInstancePortForCheck(false);
+        serviceMetadata.getClusters().put("C", clusterMetadata);
+        Mockito.when(metadataManager.getServiceMetadata(Mockito.any()))
+            .thenReturn(Optional.of(serviceMetadata));
+        Mockito.when(serviceStorage.getClusters(Mockito.any()))
+            .thenReturn(Collections.singleton("C"));
+        
+        ServiceDetailInfo actual = catalogServiceV2Impl.getServiceDetail("A", "B", "C");
+        
+        assertEquals(8848, actual.getClusterMap().get("C").getHealthyCheckPort());
+        assertFalse(actual.getClusterMap().get("C").isUseInstancePortForCheck());
     }
     
     @Test
@@ -168,6 +188,27 @@ class CatalogServiceV2ImplTest {
     }
     
     @Test
+    void testListAllInstances() {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        Instance instance = new Instance();
+        instance.setIp("1.1.1.1");
+        serviceInfo.setHosts(Collections.singletonList(instance));
+        Mockito.when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        
+        List<? extends Instance> instances = catalogServiceV2Impl.listAllInstances("A", "B", "C");
+        
+        assertEquals(1, instances.size());
+    }
+    
+    @Test
+    void testListAllInstancesNonExistService() {
+        List<? extends Instance> instances =
+            catalogServiceV2Impl.listAllInstances("A", "B", "missing");
+        
+        assertEquals(0, instances.size());
+    }
+    
+    @Test
     void testPageListService() throws NacosException {
         ServiceInfo serviceInfo = new ServiceInfo();
         serviceInfo.setHosts(Collections.singletonList(new Instance()));
@@ -225,6 +266,33 @@ class CatalogServiceV2ImplTest {
     }
     
     @Test
+    void testPageListServiceWhenPageOutOfRange() throws NacosException {
+        ObjectNode obj =
+            (ObjectNode) catalogServiceV2Impl.pageListService("A", "B", "C", 3, 1, null, false);
+        
+        assertEquals(1, obj.get(FieldsConstants.COUNT).asInt());
+        assertEquals(0, obj.get(FieldsConstants.SERVICE_LIST).size());
+    }
+    
+    @Test
+    void testPageListServiceForPartialLastPage() throws NacosException {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        Mockito.when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        ServiceManager.getInstance()
+            .getSingleton(Service.newService("CatalogService", "CatalogService", "1"));
+        ServiceManager.getInstance()
+            .getSingleton(Service.newService("CatalogService", "CatalogService", "2"));
+        ServiceManager.getInstance()
+            .getSingleton(Service.newService("CatalogService", "CatalogService", "3"));
+        
+        ObjectNode obj = (ObjectNode) catalogServiceV2Impl.pageListService("CatalogService", "", "",
+            2, 2, null, false);
+        
+        assertEquals(3, obj.get(FieldsConstants.COUNT).asInt());
+        assertEquals(1, obj.get(FieldsConstants.SERVICE_LIST).size());
+    }
+    
+    @Test
     void testListService() throws NacosException {
         ServiceInfo serviceInfo = new ServiceInfo();
         Mockito.when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
@@ -248,6 +316,17 @@ class CatalogServiceV2ImplTest {
         assertEquals(serviceView.getName(), "2", "Service name should be '2' ");
         assertEquals("CatalogService", serviceView.getGroupName(),
             "Group name should be CatalogService");
+    }
+    
+    @Test
+    void testListServiceForIgnoreEmptyService() throws NacosException {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        Mockito.when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        
+        Page<ServiceView> result = catalogServiceV2Impl.listService("A", "B", "C", 1, 10, true);
+        
+        assertEquals(0, result.getTotalCount());
+        assertEquals(0, result.getPageItems().size());
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/ClientServiceImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/ClientServiceImplTest.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClientPublisherInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClientServiceInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClientSubscriberInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClientSummaryInfo;
+import com.alibaba.nacos.core.remote.Connection;
+import com.alibaba.nacos.core.remote.ConnectionManager;
+import com.alibaba.nacos.core.remote.ConnectionMeta;
+import com.alibaba.nacos.naming.core.v2.client.Client;
+import com.alibaba.nacos.naming.core.v2.client.impl.ConnectionBasedClient;
+import com.alibaba.nacos.naming.core.v2.client.manager.ClientManager;
+import com.alibaba.nacos.naming.core.v2.index.ClientServiceIndexesManager;
+import com.alibaba.nacos.naming.core.v2.pojo.BatchInstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.pojo.Subscriber;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link ClientServiceImpl} unit tests.
+ */
+@ExtendWith(MockitoExtension.class)
+class ClientServiceImplTest {
+    
+    private static final String NAMESPACE = "namespace";
+    
+    private static final String GROUP = "group";
+    
+    private static final String SERVICE_NAME = "service";
+    
+    @InjectMocks
+    private ClientServiceImpl clientService;
+    
+    @Mock
+    private ClientManager clientManager;
+    
+    @Mock
+    private ConnectionManager connectionManager;
+    
+    @Mock
+    private ClientServiceIndexesManager clientServiceIndexesManager;
+    
+    @Mock
+    private DistroMapper distroMapper;
+    
+    @Test
+    void testGetClientList() {
+        when(clientManager.allClientId())
+            .thenReturn(new LinkedHashSet<>(Arrays.asList("c1", "c2")));
+        
+        List<String> actual = clientService.getClientList();
+        
+        assertEquals(Arrays.asList("c1", "c2"), actual);
+    }
+    
+    @Test
+    void testGetClientDetailThrowsWhenClientMissing() {
+        when(clientManager.getClient("missing")).thenReturn(null);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> clientService.getClientDetail("missing"));
+        
+        assertEquals(NacosException.NOT_FOUND, exception.getErrCode());
+        assertTrue(exception.getErrMsg().contains("Client id missing not exist."));
+    }
+    
+    @Test
+    void testGetClientDetailForIpPortClient() throws NacosApiException {
+        Client client = mock(Client.class);
+        when(clientManager.getClient("ip-client")).thenReturn(client);
+        when(client.getClientId()).thenReturn("ip-client");
+        when(client.isEphemeral()).thenReturn(false);
+        when(client.getLastUpdatedTime()).thenReturn(123L);
+        
+        ClientSummaryInfo actual = clientService.getClientDetail("ip-client");
+        
+        assertEquals("ip-client", actual.getClientId());
+        assertEquals(false, actual.isEphemeral());
+        assertEquals(123L, actual.getLastUpdatedTime());
+        assertEquals("ipPort", actual.getClientType());
+        assertNull(actual.getConnectType());
+    }
+    
+    @Test
+    void testGetClientDetailForConnectionClient() throws NacosApiException {
+        ConnectionBasedClient client = mock(ConnectionBasedClient.class);
+        when(clientManager.getClient("connection-client")).thenReturn(client);
+        when(client.getClientId()).thenReturn("connection-client");
+        when(client.isEphemeral()).thenReturn(true);
+        when(client.getLastUpdatedTime()).thenReturn(456L);
+        ConnectionMeta meta = new ConnectionMeta("connection-client", "1.1.1.1", "2.2.2.2",
+            9848, 8848, "grpc", "3.2.1", "app", Collections.emptyMap());
+        Connection connection = mock(Connection.class);
+        when(connection.getMetaInfo()).thenReturn(meta);
+        when(connectionManager.getConnection("connection-client")).thenReturn(connection);
+        
+        ClientSummaryInfo actual = clientService.getClientDetail("connection-client");
+        
+        assertEquals("connection-client", actual.getClientId());
+        assertEquals(true, actual.isEphemeral());
+        assertEquals(456L, actual.getLastUpdatedTime());
+        assertEquals("connection", actual.getClientType());
+        assertEquals("grpc", actual.getConnectType());
+        assertEquals("app", actual.getAppName());
+        assertEquals("3.2.1", actual.getVersion());
+        assertEquals("1.1.1.1", actual.getClientIp());
+        assertEquals(9848, actual.getClientPort());
+    }
+    
+    @Test
+    void testGetPublishedServiceListAdapt() {
+        Service singleService = Service.newService(NAMESPACE, GROUP, "single");
+        Service batchService = Service.newService(NAMESPACE, GROUP, "batch");
+        Client client = mockPublishedClient("client", Arrays.asList(singleService, batchService),
+            Map.of(singleService, instance("1.1.1.1", 8848, "cluster-a"), batchService,
+                batch(instance("2.2.2.2", 9848, "cluster-b"),
+                    instance("3.3.3.3", 9849, "cluster-c"))));
+        when(clientManager.getClient("client")).thenReturn(client);
+        
+        List<ObjectNode> actual = clientService.getPublishedServiceListAdapt("client");
+        
+        assertEquals(3, actual.size());
+        assertPublishedNode(actual.get(0), "single", "1.1.1.1", 8848, "cluster-a");
+        assertPublishedNode(actual.get(1), "batch", "2.2.2.2", 9848, "cluster-b");
+        assertPublishedNode(actual.get(2), "batch", "3.3.3.3", 9849, "cluster-c");
+    }
+    
+    @Test
+    void testGetPublishedServiceList() {
+        Service singleService = Service.newService(NAMESPACE, GROUP, "single");
+        Service batchService = Service.newService(NAMESPACE, GROUP, "batch");
+        Client client = mockPublishedClient("client", Arrays.asList(singleService, batchService),
+            Map.of(singleService, instance("1.1.1.1", 8848, "cluster-a"), batchService,
+                batch(instance("2.2.2.2", 9848, "cluster-b"))));
+        when(clientManager.getClient("client")).thenReturn(client);
+        
+        List<ClientServiceInfo> actual = clientService.getPublishedServiceList("client");
+        
+        assertEquals(2, actual.size());
+        assertClientServiceInfo(actual.get(0), "single", "1.1.1.1", 8848, "cluster-a");
+        assertClientServiceInfo(actual.get(1), "batch", "2.2.2.2", 9848, "cluster-b");
+    }
+    
+    @Test
+    void testGetSubscribeServiceListAdapt() {
+        Service service = Service.newService(NAMESPACE, GROUP, SERVICE_NAME);
+        Subscriber subscriber = subscriber("1.1.1.1:8848", "agent", "app", "1.1.1.1", 8848);
+        Client client = mockSubscribeClient(service, subscriber);
+        when(clientManager.getClient("client")).thenReturn(client);
+        
+        List<ObjectNode> actual = clientService.getSubscribeServiceListAdapt("client");
+        
+        assertEquals(1, actual.size());
+        assertEquals(NAMESPACE, actual.get(0).get("namespace").asText());
+        assertEquals(GROUP, actual.get(0).get("group").asText());
+        assertEquals(SERVICE_NAME, actual.get(0).get("serviceName").asText());
+        assertEquals("app", actual.get(0).get("subscriberInfo").get("app").asText());
+        assertEquals("agent", actual.get(0).get("subscriberInfo").get("agent").asText());
+        assertEquals("1.1.1.1:8848", actual.get(0).get("subscriberInfo").get("addr").asText());
+    }
+    
+    @Test
+    void testGetSubscribeServiceList() {
+        Service service = Service.newService(NAMESPACE, GROUP, SERVICE_NAME);
+        Subscriber subscriber = subscriber("1.1.1.1:8848", "agent", "app", "1.1.1.1", 8848);
+        Client client = mockSubscribeClient(service, subscriber);
+        when(clientManager.getClient("client")).thenReturn(client);
+        
+        List<ClientServiceInfo> actual = clientService.getSubscribeServiceList("client");
+        
+        assertEquals(1, actual.size());
+        assertEquals(NAMESPACE, actual.get(0).getNamespaceId());
+        assertEquals(GROUP, actual.get(0).getGroupName());
+        assertEquals(SERVICE_NAME, actual.get(0).getServiceName());
+        assertEquals("1.1.1.1:8848", actual.get(0).getSubscriberInfo().getAddress());
+        assertEquals("agent", actual.get(0).getSubscriberInfo().getAgent());
+        assertEquals("app", actual.get(0).getSubscriberInfo().getAppName());
+    }
+    
+    @Test
+    void testGetPublishedClientListAdaptFiltersByIpAndPort() {
+        Service service = Service.newService(NAMESPACE, GROUP, SERVICE_NAME, true);
+        Client first = mockPublishedClient(instance("1.1.1.1", 8848, "cluster-a"));
+        Client second = mockPublishedClient(instance("4.4.4.4", 8848, "cluster-d"));
+        Client third = mockPublishedClient(batch(instance("1.1.1.1", 8848, "cluster-b"),
+            instance("1.1.1.1", 8849, "cluster-c")));
+        Client fourth = mockPublishedClient(instance("1.1.1.1", 8850, "cluster-e"));
+        when(clientServiceIndexesManager.getAllClientsRegisteredService(service))
+            .thenReturn(Arrays.asList("c1", "c2", "c3", "c4"));
+        when(clientManager.getClient("c1")).thenReturn(first);
+        when(clientManager.getClient("c2")).thenReturn(second);
+        when(clientManager.getClient("c3")).thenReturn(third);
+        when(clientManager.getClient("c4")).thenReturn(fourth);
+        when(first.getInstancePublishInfo(service)).thenReturn(instance("1.1.1.1", 8848,
+            "cluster-a"));
+        when(second.getInstancePublishInfo(service)).thenReturn(instance("4.4.4.4", 8848,
+            "cluster-d"));
+        when(third.getInstancePublishInfo(service)).thenReturn(batch(instance("1.1.1.1", 8848,
+            "cluster-b"), instance("1.1.1.1", 8849, "cluster-c")));
+        when(fourth.getInstancePublishInfo(service)).thenReturn(instance("1.1.1.1", 8850,
+            "cluster-e"));
+        
+        List<ObjectNode> actual = clientService.getPublishedClientList(NAMESPACE, GROUP,
+            SERVICE_NAME, true, "1.1.1.1", 8848);
+        
+        assertEquals(2, actual.size());
+        assertEquals("c1", actual.get(0).get("clientId").asText());
+        assertEquals("cluster-a", actual.get(0).get("cluster").asText());
+        assertEquals("c3", actual.get(1).get("clientId").asText());
+        assertEquals("cluster-b", actual.get(1).get("cluster").asText());
+    }
+    
+    @Test
+    void testGetPublishedClientListFiltersOptionalIpAndPort() {
+        Service service = Service.newService(NAMESPACE, GROUP, SERVICE_NAME);
+        Client first = mockPublishedClient(instance("1.1.1.1", 8848, "cluster-a"));
+        Client second = mockPublishedClient(batch(instance("2.2.2.2", 8848, "cluster-b"),
+            instance("3.3.3.3", 9848, "cluster-c")));
+        when(clientServiceIndexesManager.getAllClientsRegisteredService(service))
+            .thenReturn(Arrays.asList("c1", "c2"));
+        when(clientManager.getClient("c1")).thenReturn(first);
+        when(clientManager.getClient("c2")).thenReturn(second);
+        when(first.getInstancePublishInfo(service)).thenReturn(instance("1.1.1.1", 8848,
+            "cluster-a"));
+        when(second.getInstancePublishInfo(service)).thenReturn(batch(instance("2.2.2.2", 8848,
+            "cluster-b"), instance("3.3.3.3", 9848, "cluster-c")));
+        
+        List<ClientPublisherInfo> actual = clientService.getPublishedClientList(NAMESPACE, GROUP,
+            SERVICE_NAME, null, 8848);
+        
+        assertEquals(2, actual.size());
+        assertClientPublisherInfo(actual.get(0), "c1", "1.1.1.1", 8848, "cluster-a");
+        assertClientPublisherInfo(actual.get(1), "c2", "2.2.2.2", 8848, "cluster-b");
+        
+        List<ClientPublisherInfo> actualByIp = clientService.getPublishedClientList(NAMESPACE,
+            GROUP, SERVICE_NAME, "2.2.2.2", null);
+        
+        assertEquals(1, actualByIp.size());
+        assertClientPublisherInfo(actualByIp.get(0), "c2", "2.2.2.2", 8848, "cluster-b");
+    }
+    
+    @Test
+    void testGetSubscribeClientListAdaptFiltersByOptionalIpAndPort() {
+        Service service = Service.newService(NAMESPACE, GROUP, SERVICE_NAME, true);
+        Client first = mockSubscriberClient(service,
+            subscriber("1.1.1.1:8848", "agent-a", "app-a", "1.1.1.1", 8848));
+        Client second = mockSubscriberClient(service,
+            subscriber("2.2.2.2:9848", "agent-b", "app-b", "2.2.2.2", 9848));
+        when(clientServiceIndexesManager.getAllClientsSubscribeService(service))
+            .thenReturn(Arrays.asList("c1", "c2"));
+        when(clientManager.getClient("c1")).thenReturn(first);
+        when(clientManager.getClient("c2")).thenReturn(second);
+        
+        List<ObjectNode> actual = clientService.getSubscribeClientList(NAMESPACE, GROUP,
+            SERVICE_NAME, true, "1.1.1.1", null);
+        
+        assertEquals(1, actual.size());
+        assertEquals("c1", actual.get(0).get("clientId").asText());
+        assertEquals("1.1.1.1", actual.get(0).get("ip").asText());
+        assertEquals(8848, actual.get(0).get("port").asInt());
+        
+        List<ObjectNode> actualByPort = clientService.getSubscribeClientList(NAMESPACE, GROUP,
+            SERVICE_NAME, true, null, 9848);
+        
+        assertEquals(1, actualByPort.size());
+        assertEquals("c2", actualByPort.get(0).get("clientId").asText());
+        assertEquals("2.2.2.2", actualByPort.get(0).get("ip").asText());
+        assertEquals(9848, actualByPort.get(0).get("port").asInt());
+    }
+    
+    @Test
+    void testGetSubscribeClientListFiltersByOptionalIpAndPort() {
+        Service service = Service.newService(NAMESPACE, GROUP, SERVICE_NAME);
+        Client first = mockSubscriberClient(service,
+            subscriber("1.1.1.1:8848", "agent-a", "app-a", "1.1.1.1", 8848));
+        Client second = mockSubscriberClient(service,
+            subscriber("2.2.2.2:9848", "agent-b", "app-b", "2.2.2.2", 9848));
+        when(clientServiceIndexesManager.getAllClientsSubscribeService(service))
+            .thenReturn(Arrays.asList("c1", "c2"));
+        when(clientManager.getClient("c1")).thenReturn(first);
+        when(clientManager.getClient("c2")).thenReturn(second);
+        
+        List<ClientSubscriberInfo> actual = clientService.getSubscribeClientList(NAMESPACE, GROUP,
+            SERVICE_NAME, null, 9848);
+        
+        assertEquals(1, actual.size());
+        assertEquals("c2", actual.get(0).getClientId());
+        assertEquals("2.2.2.2:9848", actual.get(0).getAddress());
+        assertEquals("agent-b", actual.get(0).getAgent());
+        assertEquals("app-b", actual.get(0).getAppName());
+        
+        List<ClientSubscriberInfo> actualByIp = clientService.getSubscribeClientList(NAMESPACE,
+            GROUP, SERVICE_NAME, "1.1.1.1", null);
+        
+        assertEquals(1, actualByIp.size());
+        assertEquals("c1", actualByIp.get(0).getClientId());
+        assertEquals("1.1.1.1:8848", actualByIp.get(0).getAddress());
+    }
+    
+    @Test
+    void testGetResponsibleServer4Client() {
+        when(distroMapper.mapSrv("1.1.1.1:8848")).thenReturn("server-a");
+        
+        ObjectNode actual = clientService.getResponsibleServer4Client("1.1.1.1", "8848");
+        
+        assertEquals("server-a", actual.get("responsibleServer").asText());
+    }
+    
+    private Client mockPublishedClient(String clientId, List<Service> services,
+        Map<Service, InstancePublishInfo> publishInfos) {
+        Client client = mock(Client.class);
+        when(client.getAllPublishedService()).thenReturn(services);
+        publishInfos.forEach((service, publishInfo) -> when(client.getInstancePublishInfo(service))
+            .thenReturn(publishInfo));
+        return client;
+    }
+    
+    private Client mockPublishedClient(InstancePublishInfo publishInfo) {
+        Client client = mock(Client.class);
+        return client;
+    }
+    
+    private Client mockSubscribeClient(Service service, Subscriber subscriber) {
+        Client client = mock(Client.class);
+        when(client.getAllSubscribeService()).thenReturn(Collections.singletonList(service));
+        when(client.getSubscriber(service)).thenReturn(subscriber);
+        return client;
+    }
+    
+    private Client mockSubscriberClient(Service service, Subscriber subscriber) {
+        Client client = mock(Client.class);
+        when(client.getSubscriber(service)).thenReturn(subscriber);
+        return client;
+    }
+    
+    private InstancePublishInfo instance(String ip, int port, String cluster) {
+        InstancePublishInfo result = new InstancePublishInfo(ip, port);
+        result.setCluster(cluster);
+        return result;
+    }
+    
+    private BatchInstancePublishInfo batch(InstancePublishInfo... publishInfos) {
+        BatchInstancePublishInfo result = new BatchInstancePublishInfo();
+        result.setInstancePublishInfos(Arrays.asList(publishInfos));
+        return result;
+    }
+    
+    private Subscriber subscriber(String address, String agent, String app, String ip, int port) {
+        return new Subscriber(address, agent, app, ip, NAMESPACE, SERVICE_NAME, port);
+    }
+    
+    private void assertPublishedNode(ObjectNode actual, String serviceName, String ip, int port,
+        String cluster) {
+        assertEquals(NAMESPACE, actual.get("namespace").asText());
+        assertEquals(GROUP, actual.get("group").asText());
+        assertEquals(serviceName, actual.get("serviceName").asText());
+        assertEquals(ip, actual.get("registeredInstance").get("ip").asText());
+        assertEquals(port, actual.get("registeredInstance").get("port").asInt());
+        assertEquals(cluster, actual.get("registeredInstance").get("cluster").asText());
+    }
+    
+    private void assertClientServiceInfo(ClientServiceInfo actual, String serviceName, String ip,
+        int port, String cluster) {
+        assertEquals(NAMESPACE, actual.getNamespaceId());
+        assertEquals(GROUP, actual.getGroupName());
+        assertEquals(serviceName, actual.getServiceName());
+        assertEquals(ip, actual.getPublisherInfo().getIp());
+        assertEquals(port, actual.getPublisherInfo().getPort());
+        assertEquals(cluster, actual.getPublisherInfo().getClusterName());
+    }
+    
+    private void assertClientPublisherInfo(ClientPublisherInfo actual, String clientId, String ip,
+        int port, String cluster) {
+        assertEquals(clientId, actual.getClientId());
+        assertEquals(ip, actual.getIp());
+        assertEquals(port, actual.getPort());
+        assertEquals(cluster, actual.getClusterName());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/DistroMapperTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/DistroMapperTest.java
@@ -16,10 +16,14 @@
 
 package com.alibaba.nacos.naming.core;
 
+import com.alibaba.nacos.api.common.NodeState;
+import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.core.cluster.Member;
+import com.alibaba.nacos.core.cluster.MembersChangeEvent;
 import com.alibaba.nacos.core.cluster.ServerMemberManager;
 import com.alibaba.nacos.naming.misc.SwitchDomain;
 import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,11 +31,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.StandardEnvironment;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DistroMapperTest {
@@ -71,14 +79,125 @@ class DistroMapperTest {
         distroMapper = new DistroMapper(memberManager, switchDomain);
     }
     
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setIsStandalone(null);
+    }
+    
     @Test
     void testResponsible() {
         assertTrue(distroMapper.responsible(serviceName));
     }
     
     @Test
+    void testResponsibleReturnsFalseWhenHealthyListEmpty() {
+        EnvUtil.setIsStandalone(false);
+        
+        assertFalse(distroMapper.responsible(serviceName));
+    }
+    
+    @Test
+    void testResponsibleReturnsTrueWhenLocalAddressMissing() {
+        EnvUtil.setIsStandalone(false);
+        EnvUtil.setLocalAddress(ip4 + ":" + port);
+        distroMapper.onEvent(MembersChangeEvent.builder()
+            .members(Arrays.asList(member(ip1, NodeState.UP), member(ip2, NodeState.UP))).build());
+        
+        assertTrue(distroMapper.responsible(serviceName));
+    }
+    
+    @Test
+    void testResponsibleUsesHashRange() {
+        EnvUtil.setIsStandalone(false);
+        EnvUtil.setLocalAddress(ip2 + ":" + port);
+        distroMapper.onEvent(MembersChangeEvent.builder()
+            .members(Arrays.asList(member(ip1, NodeState.UP), member(ip2, NodeState.UP),
+                member(ip3, NodeState.UP)))
+            .build());
+        
+        assertTrue(distroMapper.responsible(tagForIndex(1, distroMapper.getHealthyList().size())));
+        assertFalse(distroMapper.responsible(tagForIndex(0, distroMapper.getHealthyList().size())));
+    }
+    
+    @Test
     void testMapSrv() {
         String server = distroMapper.mapSrv(serviceName);
         assertEquals(server, ip4);
+    }
+    
+    @Test
+    void testInitLoadsMembers() {
+        when(memberManager.allMembers()).thenReturn(Arrays.asList(member(ip2, NodeState.UP),
+            member(ip1, NodeState.UP)));
+        
+        try {
+            distroMapper.init();
+            
+            assertEquals(Arrays.asList(ip1 + ":" + port, ip2 + ":" + port),
+                distroMapper.getHealthyList());
+        } finally {
+            NotifyCenter.deregisterSubscriber(distroMapper);
+        }
+    }
+    
+    @Test
+    void testMapSrvSelectsHealthyServer() {
+        EnvUtil.setIsStandalone(false);
+        distroMapper.onEvent(MembersChangeEvent.builder()
+            .members(Arrays.asList(member(ip1, NodeState.UP), member(ip2, NodeState.UP),
+                member(ip3, NodeState.UP)))
+            .build());
+        
+        String server = distroMapper.mapSrv(serviceName);
+        
+        assertTrue(distroMapper.getHealthyList().contains(server));
+    }
+    
+    @Test
+    void testMapSrvReturnsLocalWhenDistroDisabled() {
+        EnvUtil.setLocalAddress(ip4 + ":" + port);
+        switchDomain.setDistroEnabled(false);
+        
+        assertEquals(ip4 + ":" + port, distroMapper.mapSrv(serviceName));
+    }
+    
+    @Test
+    void testMapSrvReturnsLocalWhenHashFails() {
+        EnvUtil.setLocalAddress(ip4 + ":" + port);
+        distroMapper.onEvent(MembersChangeEvent.builder()
+            .members(Collections.singletonList(member(ip1, NodeState.UP))).build());
+        
+        assertEquals(ip4 + ":" + port, distroMapper.mapSrv(null));
+    }
+    
+    @Test
+    void testOnEventKeepsUpAndSuspiciousMembersSorted() {
+        distroMapper.onEvent(MembersChangeEvent.builder()
+            .members(Arrays.asList(member(ip3, NodeState.SUSPICIOUS), member(ip2, NodeState.DOWN),
+                member(ip1, NodeState.UP)))
+            .build());
+        
+        assertEquals(Arrays.asList(ip1 + ":" + port, ip3 + ":" + port),
+            distroMapper.getHealthyList());
+    }
+    
+    @Test
+    void testIgnoreExpireEvent() {
+        assertTrue(distroMapper.ignoreExpireEvent());
+    }
+    
+    private Member member(String ip, NodeState state) {
+        return Member.builder().ip(ip).port(port).state(state).build();
+    }
+    
+    private String tagForIndex(int targetIndex, int size) {
+        for (int i = 0; i < 1000; i++) {
+            String tag = "tag" + i;
+            int actualIndex = Math.abs(tag.hashCode() % Integer.MAX_VALUE) % size;
+            if (actualIndex == targetIndex) {
+                return tag;
+            }
+        }
+        throw new IllegalStateException("cannot find target tag");
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/HealthOperatorV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/HealthOperatorV2ImplTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -178,6 +179,22 @@ class HealthOperatorV2ImplTest {
         assertFalse(actual.isEmpty());
     }
     
+    @Test
+    @SuppressWarnings("unchecked")
+    void testCheckersSkipsUnavailableChecker() throws Exception {
+        Field extendField = HealthCheckType.class.getDeclaredField("EXTEND");
+        extendField.setAccessible(true);
+        Map<String, Class<? extends AbstractHealthChecker>> extend =
+            (Map<String, Class<? extends AbstractHealthChecker>>) extendField.get(null);
+        extend.put(BrokenHealthChecker.TYPE, BrokenHealthChecker.class);
+        try {
+            Map<String, AbstractHealthChecker> actual = healthOperatorV2.checkers();
+            assertFalse(actual.containsKey(BrokenHealthChecker.TYPE));
+        } finally {
+            extend.remove(BrokenHealthChecker.TYPE);
+        }
+    }
+    
     private void givenNoneHealthCheckCluster() {
         ServiceMetadata metadata = new ServiceMetadata();
         Map<String, ClusterMetadata> clusterMap = new HashMap<>(2);
@@ -195,6 +212,15 @@ class HealthOperatorV2ImplTest {
         return null != service && namespace.equals(service.getNamespace())
             && groupName.equals(service.getGroup())
             && serviceName.equals(service.getName()) && !service.isEphemeral();
+    }
+    
+    private abstract static class BrokenHealthChecker extends AbstractHealthChecker {
+        
+        private static final String TYPE = "BROKEN";
+        
+        private BrokenHealthChecker() {
+            super(TYPE);
+        }
     }
     
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/HealthOperatorV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/HealthOperatorV2ImplTest.java
@@ -18,6 +18,7 @@
 package com.alibaba.nacos.naming.core;
 
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.AbstractHealthChecker;
 import com.alibaba.nacos.api.naming.pojo.healthcheck.HealthCheckType;
 import com.alibaba.nacos.naming.core.v2.client.impl.ConnectionBasedClient;
 import com.alibaba.nacos.naming.core.v2.client.manager.ClientManagerDelegate;
@@ -38,9 +39,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -99,6 +103,91 @@ class HealthOperatorV2ImplTest {
                 && "1.1.1.1".equals(instance.getIp())
                 && instance.getPort() == 8080 && "cluster-a".equals(instance.getClusterName())),
             anyString());
+    }
+    
+    @Test
+    void testUpdateHealthStatusThrowsWhenMetadataMissing() {
+        when(metadataManager
+            .getServiceMetadata(argThat(service -> isPersistentService(service, "A", "B", "C"))))
+            .thenReturn(Optional.empty());
+        
+        assertThrows(NacosException.class,
+            () -> healthOperatorV2.updateHealthStatusForPersistentInstance("A", "B", "C",
+                "cluster-a", "1.1.1.1", 8080, true));
+    }
+    
+    @Test
+    void testUpdateHealthStatusThrowsWhenClusterMissing() {
+        ServiceMetadata metadata = new ServiceMetadata();
+        when(metadataManager
+            .getServiceMetadata(argThat(service -> isPersistentService(service, "A", "B", "C"))))
+            .thenReturn(Optional.of(metadata));
+        
+        assertThrows(NacosException.class,
+            () -> healthOperatorV2.updateHealthStatusForPersistentInstance("A", "B", "C",
+                "cluster-a", "1.1.1.1", 8080, true));
+    }
+    
+    @Test
+    void testUpdateHealthStatusThrowsWhenCheckerStillWorking() {
+        ServiceMetadata metadata = new ServiceMetadata();
+        Map<String, ClusterMetadata> clusterMap = new HashMap<>(2);
+        ClusterMetadata cluster = Mockito.mock(ClusterMetadata.class);
+        clusterMap.put("cluster-a", cluster);
+        metadata.setClusters(clusterMap);
+        when(cluster.getHealthyCheckType()).thenReturn(HealthCheckType.TCP.name());
+        when(metadataManager
+            .getServiceMetadata(argThat(service -> isPersistentService(service, "A", "B", "C"))))
+            .thenReturn(Optional.of(metadata));
+        
+        assertThrows(NacosException.class,
+            () -> healthOperatorV2.updateHealthStatusForPersistentInstance("A", "B", "C",
+                "cluster-a", "1.1.1.1", 8080, true));
+    }
+    
+    @Test
+    void testUpdateHealthStatusReturnsWhenClientMissing() throws NacosException {
+        givenNoneHealthCheckCluster();
+        when(clientManager.getClient(anyString())).thenReturn(null);
+        
+        healthOperatorV2.updateHealthStatusForPersistentInstance("A", "B", "C", "cluster-a",
+            "1.1.1.1", 8080, true);
+        
+        verifyNoInteractions(clientOperationService);
+    }
+    
+    @Test
+    void testUpdateHealthStatusReturnsWhenInstanceMissing() throws NacosException {
+        givenNoneHealthCheckCluster();
+        ConnectionBasedClient client = Mockito.mock(ConnectionBasedClient.class);
+        when(clientManager.getClient(anyString())).thenReturn(client);
+        when(client.getInstancePublishInfo(
+            argThat(service -> isPersistentService(service, "A", "B", "C"))))
+            .thenReturn(null);
+        
+        healthOperatorV2.updateHealthStatusForPersistentInstance("A", "B", "C", "cluster-a",
+            "1.1.1.1", 8080, true);
+        
+        verifyNoInteractions(clientOperationService);
+    }
+    
+    @Test
+    void testCheckers() {
+        Map<String, AbstractHealthChecker> actual = healthOperatorV2.checkers();
+        
+        assertFalse(actual.isEmpty());
+    }
+    
+    private void givenNoneHealthCheckCluster() {
+        ServiceMetadata metadata = new ServiceMetadata();
+        Map<String, ClusterMetadata> clusterMap = new HashMap<>(2);
+        ClusterMetadata cluster = Mockito.mock(ClusterMetadata.class);
+        clusterMap.put("cluster-a", cluster);
+        metadata.setClusters(clusterMap);
+        when(cluster.getHealthyCheckType()).thenReturn(HealthCheckType.NONE.name());
+        when(metadataManager
+            .getServiceMetadata(argThat(service -> isPersistentService(service, "A", "B", "C"))))
+            .thenReturn(Optional.of(metadata));
     }
     
     private boolean isPersistentService(Service service, String namespace, String groupName,

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/InstanceOperatorClientImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/InstanceOperatorClientImplTest.java
@@ -239,6 +239,8 @@ class InstanceOperatorClientImplTest {
         patchObject.setMetadata(Collections.singletonMap("new", "value"));
         patchObject.setWeight(2.0D);
         patchObject.setEnabled(false);
+        patchObject.setHealthy(true);
+        assertTrue(patchObject.getHealthy());
         instanceOperatorClient.patchInstance("A", Constants.DEFAULT_GROUP, "B", patchObject);
         
         Mockito.verify(metadataOperateService).updateInstanceMetadata(Mockito.any(),

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/InstanceOperatorClientImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/InstanceOperatorClientImplTest.java
@@ -19,7 +19,9 @@ package com.alibaba.nacos.naming.core;
 
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.naming.NamingResponseCode;
+import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
 import com.alibaba.nacos.naming.core.v2.ServiceManager;
@@ -30,6 +32,7 @@ import com.alibaba.nacos.naming.core.v2.metadata.InstanceMetadata;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataOperateService;
 import com.alibaba.nacos.naming.core.v2.metadata.ServiceMetadata;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.core.v2.service.ClientOperationServiceProxy;
 import com.alibaba.nacos.naming.healthcheck.RsInfo;
@@ -54,6 +57,7 @@ import org.mockito.stubbing.Answer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -155,6 +159,16 @@ class InstanceOperatorClientImplTest {
     }
     
     @Test
+    void testRemoveInstanceIgnoresMissingClient() {
+        when(clientManager.contains(Mockito.anyString())).thenReturn(false);
+        
+        instanceOperatorClient.removeInstance("A", Constants.DEFAULT_GROUP, "B", new Instance());
+        
+        Mockito.verify(clientOperationService, Mockito.never())
+            .deregisterInstance(Mockito.any(), Mockito.any(), Mockito.anyString());
+    }
+    
+    @Test
     void testUpdateInstance() throws NacosException {
         Instance instance = new Instance();
         instance.setServiceName("C");
@@ -173,6 +187,16 @@ class InstanceOperatorClientImplTest {
         
         Mockito.verify(metadataOperateService).updateInstanceMetadata(Mockito.any(), Mockito.any(),
             Mockito.argThat(argument -> argument.getExtendData().isEmpty()));
+    }
+    
+    @Test
+    void testUpdateInstanceMissingServiceThrows() {
+        Instance instance = new Instance();
+        instance.setServiceName("missing");
+        
+        assertThrows(NacosApiException.class,
+            () -> instanceOperatorClient.updateInstance("A", Constants.DEFAULT_GROUP, "missing",
+                instance));
     }
     
     @Test
@@ -195,6 +219,36 @@ class InstanceOperatorClientImplTest {
     }
     
     @Test
+    void testPatchInstanceMergesExistingMetadata() throws NacosException {
+        Instance instance = new Instance();
+        instance.setIp("1.1.1.1");
+        instance.setPort(8848);
+        instance.setClusterName("C");
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setHosts(Collections.singletonList(instance));
+        when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        
+        InstanceMetadata instanceMetadata = new InstanceMetadata();
+        instanceMetadata.setWeight(1.5D);
+        instanceMetadata.setEnabled(true);
+        instanceMetadata.getExtendData().put("old", "value");
+        when(metadataManager.getInstanceMetadata(Mockito.any(), Mockito.anyString()))
+            .thenReturn(Optional.of(instanceMetadata));
+        
+        InstancePatchObject patchObject = new InstancePatchObject("C", "1.1.1.1", 8848);
+        patchObject.setMetadata(Collections.singletonMap("new", "value"));
+        patchObject.setWeight(2.0D);
+        patchObject.setEnabled(false);
+        instanceOperatorClient.patchInstance("A", Constants.DEFAULT_GROUP, "B", patchObject);
+        
+        Mockito.verify(metadataOperateService).updateInstanceMetadata(Mockito.any(),
+            Mockito.anyString(),
+            Mockito.argThat(argument -> argument.getExtendData().size() == 1
+                && "value".equals(argument.getExtendData().get("new"))
+                && argument.getWeight() == 2.0D && !argument.isEnabled()));
+    }
+    
+    @Test
     void testListInstance() {
         ServiceInfo serviceInfo = new ServiceInfo();
         serviceInfo.setGroupName("DEFAULT_GROUP");
@@ -213,6 +267,67 @@ class InstanceOperatorClientImplTest {
     }
     
     @Test
+    void testListInstanceWithoutSubscriberDoesNotSubscribe() {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setGroupName("DEFAULT_GROUP");
+        serviceInfo.setName("B");
+        when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        when(metadataManager.getServiceMetadata(Mockito.any()))
+            .thenReturn(Optional.of(new ServiceMetadata()));
+        
+        ServiceInfo result =
+            instanceOperatorClient.listInstance("A", Constants.DEFAULT_GROUP, "B", null, "C",
+                true);
+        
+        assertEquals("DEFAULT_GROUP@@B", result.getName());
+        Mockito.verify(clientOperationService, Mockito.never())
+            .subscribeService(Mockito.any(), Mockito.any(), Mockito.anyString());
+    }
+    
+    @Test
+    void testGetInstanceReturnsMatchedHost() throws NacosException {
+        Instance instance = new Instance();
+        instance.setIp("1.1.1.1");
+        instance.setPort(8848);
+        instance.setClusterName("C");
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setHosts(Collections.singletonList(instance));
+        when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        
+        Instance actual =
+            instanceOperatorClient.getInstance("A", Constants.DEFAULT_GROUP, "B", "C", "1.1.1.1",
+                8848);
+        
+        assertEquals(instance, actual);
+    }
+    
+    @Test
+    void testGetInstanceThrowsWhenHostsEmpty() {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setHosts(Collections.emptyList());
+        when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        
+        assertThrows(NacosApiException.class,
+            () -> instanceOperatorClient.getInstance("A", Constants.DEFAULT_GROUP, "B", "C",
+                "1.1.1.1", 8848));
+    }
+    
+    @Test
+    void testGetInstanceThrowsWhenHostNotMatched() {
+        Instance instance = new Instance();
+        instance.setIp("1.1.1.1");
+        instance.setPort(8848);
+        instance.setClusterName("C");
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setHosts(Collections.singletonList(instance));
+        when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        
+        assertThrows(NacosApiException.class,
+            () -> instanceOperatorClient.getInstance("A", Constants.DEFAULT_GROUP, "B", "D",
+                "1.1.1.1", 8848));
+    }
+    
+    @Test
     void testHandleBeat() throws NacosException {
         IpPortBasedClient ipPortBasedClient = Mockito.mock(IpPortBasedClient.class);
         when(clientManager.getClient(Mockito.anyString())).thenReturn(ipPortBasedClient);
@@ -228,6 +343,30 @@ class InstanceOperatorClientImplTest {
     }
     
     @Test
+    void testHandleBeatReturnsNotFoundWhenBeatMissing() throws NacosException {
+        when(clientManager.getClient(Mockito.anyString())).thenReturn(null);
+        
+        int result =
+            instanceOperatorClient.handleBeat("A", Constants.DEFAULT_GROUP, "C", "1.1.1.1", 8848,
+                "D", null, BeatInfoInstanceBuilder.newBuilder());
+        
+        assertEquals(NamingResponseCode.RESOURCE_NOT_FOUND, result);
+    }
+    
+    @Test
+    void testHandleBeatThrowsWhenServiceMissing() {
+        IpPortBasedClient ipPortBasedClient = Mockito.mock(IpPortBasedClient.class);
+        Service service = Service.newService("A", Constants.DEFAULT_GROUP, "missing");
+        when(clientManager.getClient(Mockito.anyString())).thenReturn(ipPortBasedClient);
+        when(ipPortBasedClient.getAllPublishedService())
+            .thenReturn(Collections.singletonList(service));
+        
+        assertThrows(NacosException.class,
+            () -> instanceOperatorClient.handleBeat("A", Constants.DEFAULT_GROUP, "missing",
+                "1.1.1.1", 8848, "D", null, BeatInfoInstanceBuilder.newBuilder()));
+    }
+    
+    @Test
     void testGetHeartBeatInterval() {
         InstanceMetadata instanceMetadata = new InstanceMetadata();
         Map<String, Object> map = new HashMap<>(2);
@@ -240,6 +379,36 @@ class InstanceOperatorClientImplTest {
         long interval = instanceOperatorClient.getHeartBeatInterval("A", "C", "1.1.1.1", 8848, "D");
         
         assertEquals(100L, interval);
+    }
+    
+    @Test
+    void testGetHeartBeatIntervalUsesMetadataValue() {
+        InstanceMetadata instanceMetadata = new InstanceMetadata();
+        instanceMetadata.getExtendData().put(PreservedMetadataKeys.HEART_BEAT_INTERVAL, "2000");
+        when(metadataManager.getInstanceMetadata(Mockito.any(), Mockito.anyString()))
+            .thenReturn(Optional.of(instanceMetadata));
+        
+        long interval = instanceOperatorClient.getHeartBeatInterval("A", "C", "1.1.1.1", 8848, "D");
+        
+        assertEquals(2000L, interval);
+    }
+    
+    @Test
+    void testGetHeartBeatIntervalUsesPublishedInstanceValue() {
+        InstanceMetadata instanceMetadata = new InstanceMetadata();
+        when(metadataManager.getInstanceMetadata(Mockito.any(), Mockito.anyString()))
+            .thenReturn(Optional.of(instanceMetadata));
+        IpPortBasedClient client = Mockito.mock(IpPortBasedClient.class);
+        InstancePublishInfo instancePublishInfo = new InstancePublishInfo("1.1.1.1", 8848);
+        instancePublishInfo.setCluster("D");
+        instancePublishInfo.getExtendDatum()
+            .put(PreservedMetadataKeys.HEART_BEAT_INTERVAL, "3000");
+        when(clientManager.getClient(Mockito.anyString())).thenReturn(client);
+        when(client.getInstancePublishInfo(Mockito.any())).thenReturn(instancePublishInfo);
+        
+        long interval = instanceOperatorClient.getHeartBeatInterval("A", "C", "1.1.1.1", 8848, "D");
+        
+        assertEquals(3000L, interval);
     }
     
     @Test
@@ -286,5 +455,32 @@ class InstanceOperatorClientImplTest {
                 new HashMap<>());
         
         assertEquals(1, res.size());
+    }
+    
+    @Test
+    void testBatchUpdateMetadataOnlyMatchesExplicitInstances() throws NacosException {
+        Instance matched = new Instance();
+        matched.setServiceName("C");
+        matched.setIp("1.1.1.1");
+        matched.setPort(8848);
+        matched.setClusterName("DEFAULT");
+        Instance missing = new Instance();
+        missing.setServiceName("C");
+        missing.setIp("2.2.2.2");
+        missing.setPort(8848);
+        missing.setClusterName("DEFAULT");
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setHosts(Collections.singletonList(matched));
+        when(serviceStorage.getData(Mockito.any())).thenReturn(serviceInfo);
+        
+        InstanceOperationInfo instanceOperationInfo =
+            new InstanceOperationInfo("C", null, Arrays.asList(matched, missing));
+        List<String> result =
+            instanceOperatorClient.batchUpdateMetadata("A", instanceOperationInfo,
+                Collections.singletonMap("k", "v"));
+        
+        assertEquals(1, result.size());
+        Mockito.verify(metadataOperateService, Mockito.times(1))
+            .updateInstanceMetadata(Mockito.any(), Mockito.anyString(), Mockito.any());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/OperatorV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/OperatorV2ImplTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core;
+
+import com.alibaba.nacos.naming.cluster.ServerStatus;
+import com.alibaba.nacos.naming.cluster.ServerStatusManager;
+import com.alibaba.nacos.naming.core.v2.client.Client;
+import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
+import com.alibaba.nacos.naming.core.v2.client.manager.ClientManager;
+import com.alibaba.nacos.naming.misc.SwitchDomain;
+import com.alibaba.nacos.naming.misc.SwitchManager;
+import com.alibaba.nacos.naming.model.vo.MetricsInfoVo;
+import com.alibaba.nacos.naming.monitor.MetricsMonitor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * {@link OperatorV2Impl} unit tests.
+ *
+ * @author Nacos
+ */
+@ExtendWith(MockitoExtension.class)
+class OperatorV2ImplTest {
+    
+    @InjectMocks
+    private OperatorV2Impl operatorV2;
+    
+    @Mock
+    private SwitchDomain switchDomain;
+    
+    @Mock
+    private SwitchManager switchManager;
+    
+    @Mock
+    private ServerStatusManager serverStatusManager;
+    
+    @Mock
+    private ClientManager clientManager;
+    
+    @AfterEach
+    void tearDown() {
+        MetricsMonitor.getDomCountMonitor().set(0);
+        MetricsMonitor.getIpCountMonitor().set(0);
+        MetricsMonitor.getSubscriberCount().set(0);
+    }
+    
+    @Test
+    void testSwitches() {
+        assertSame(switchDomain, operatorV2.switches());
+    }
+    
+    @Test
+    void testUpdateSwitch() throws Exception {
+        operatorV2.updateSwitch("pushEnabled", "false", true);
+        
+        Mockito.verify(switchManager).update("pushEnabled", "false", true);
+    }
+    
+    @Test
+    void testMetricsOnlyStatus() {
+        Mockito.when(serverStatusManager.getServerStatus()).thenReturn(ServerStatus.UP);
+        
+        MetricsInfoVo metricsInfo = operatorV2.metrics(true);
+        
+        assertEquals(ServerStatus.UP.name(), metricsInfo.getStatus());
+        assertNull(metricsInfo.getClientCount());
+    }
+    
+    @Test
+    void testMetricsCountsClients() {
+        Mockito.when(serverStatusManager.getServerStatus()).thenReturn(ServerStatus.UP);
+        Collection<String> clientIds =
+            Arrays.asList("connection-client", IpPortBasedClient.getClientId("1.1.1.1:8848", true),
+                IpPortBasedClient.getClientId("2.2.2.2:8848", false));
+        Mockito.when(clientManager.allClientId()).thenReturn(clientIds);
+        Client connectionClient = Mockito.mock(Client.class);
+        Client ephemeralClient = Mockito.mock(Client.class);
+        Client persistentClient = Mockito.mock(Client.class);
+        Mockito.when(clientManager.getClient("connection-client")).thenReturn(connectionClient);
+        Mockito.when(clientManager.getClient(IpPortBasedClient.getClientId("1.1.1.1:8848", true)))
+            .thenReturn(ephemeralClient);
+        Mockito.when(clientManager.getClient(IpPortBasedClient.getClientId("2.2.2.2:8848", false)))
+            .thenReturn(persistentClient);
+        Mockito.when(clientManager.isResponsibleClient(connectionClient)).thenReturn(true);
+        Mockito.when(clientManager.isResponsibleClient(ephemeralClient)).thenReturn(false);
+        Mockito.when(clientManager.isResponsibleClient(persistentClient)).thenReturn(true);
+        MetricsMonitor.getDomCountMonitor().set(7);
+        MetricsMonitor.getIpCountMonitor().set(8);
+        MetricsMonitor.getSubscriberCount().set(9);
+        
+        MetricsInfoVo metricsInfo = operatorV2.metrics(false);
+        
+        assertEquals(ServerStatus.UP.name(), metricsInfo.getStatus());
+        assertEquals(7, metricsInfo.getServiceCount());
+        assertEquals(8, metricsInfo.getInstanceCount());
+        assertEquals(9, metricsInfo.getSubscribeCount());
+        assertEquals(3, metricsInfo.getClientCount());
+        assertEquals(1, metricsInfo.getConnectionBasedClientCount());
+        assertEquals(1, metricsInfo.getEphemeralIpPortClientCount());
+        assertEquals(1, metricsInfo.getPersistentIpPortClientCount());
+        assertEquals(2, metricsInfo.getResponsibleClientCount());
+    }
+    
+    @Test
+    void testSetLogLevel() {
+        operatorV2.setLogLevel("naming-main", "INFO");
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/ServiceOperatorV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/ServiceOperatorV2ImplTest.java
@@ -18,7 +18,13 @@
 package com.alibaba.nacos.naming.core;
 
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClusterInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ServiceDetailInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.SubscriberInfo;
 import com.alibaba.nacos.naming.constants.FieldsConstants;
 import com.alibaba.nacos.naming.core.v2.ServiceManager;
 import com.alibaba.nacos.naming.core.v2.index.ServiceStorage;
@@ -27,6 +33,7 @@ import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataOperateService;
 import com.alibaba.nacos.naming.core.v2.metadata.ServiceMetadata;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.pojo.Subscriber;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +53,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * {@link ServiceOperatorV2Impl} unit tests.
@@ -67,6 +77,9 @@ class ServiceOperatorV2ImplTest {
     
     @Mock
     private ServiceStorage serviceStorage;
+    
+    @Mock
+    private SubscribeManager subscribeManager;
     
     @BeforeEach
     void setUp() throws IllegalAccessException {
@@ -97,10 +110,24 @@ class ServiceOperatorV2ImplTest {
     }
     
     @Test
+    void testCreateDuplicateServiceThrows() {
+        assertThrows(NacosApiException.class,
+            () -> serviceOperatorV2.create(Service.newService("A", "B", "C"),
+                new ServiceMetadata()));
+    }
+    
+    @Test
     void testUpdate() throws NacosException {
         serviceOperatorV2.update(Service.newService("A", "B", "C"), new ServiceMetadata());
         
         Mockito.verify(metadataOperateService).updateServiceMetadata(Mockito.any(), Mockito.any());
+    }
+    
+    @Test
+    void testUpdateMissingServiceThrows() {
+        assertThrows(NacosApiException.class,
+            () -> serviceOperatorV2.update(Service.newService("A", "B", "missing"),
+                new ServiceMetadata()));
     }
     
     @Test
@@ -112,6 +139,23 @@ class ServiceOperatorV2ImplTest {
         serviceOperatorV2.delete("A", "B@@C");
         
         Mockito.verify(metadataOperateService).deleteServiceMetadata(Mockito.any());
+    }
+    
+    @Test
+    void testDeleteMissingServiceThrows() {
+        assertThrows(NacosApiException.class,
+            () -> serviceOperatorV2.delete(Service.newService("A", "B", "missing")));
+    }
+    
+    @Test
+    void testDeleteNotEmptyServiceThrows() {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        Instance instance = new Instance();
+        serviceInfo.setHosts(Collections.singletonList(instance));
+        Mockito.when(serviceStorage.getPushData(Mockito.any())).thenReturn(serviceInfo);
+        
+        assertThrows(NacosApiException.class,
+            () -> serviceOperatorV2.delete(Service.newService("A", "B", "C")));
     }
     
     @Test
@@ -135,9 +179,59 @@ class ServiceOperatorV2ImplTest {
     }
     
     @Test
+    void testQueryServiceMissingThrows() {
+        assertThrows(NacosApiException.class,
+            () -> serviceOperatorV2.queryService("A", "B@@missing"));
+    }
+    
+    @Test
+    void testQueryServiceDetail() throws NacosException {
+        ClusterMetadata clusterMetadata = new ClusterMetadata();
+        clusterMetadata.setHealthyCheckPort(8080);
+        clusterMetadata.setUseInstancePortForCheck(false);
+        clusterMetadata.getExtendData().put("zone", "z1");
+        Map<String, ClusterMetadata> clusterMetadataMap = new HashMap<>(2);
+        clusterMetadataMap.put("D", clusterMetadata);
+        ServiceMetadata metadata = new ServiceMetadata();
+        metadata.setProtectThreshold(0.5F);
+        metadata.getExtendData().put("owner", "naming");
+        metadata.setClusters(clusterMetadataMap);
+        Mockito.when(metadataManager.getServiceMetadata(Mockito.any()))
+            .thenReturn(Optional.of(metadata));
+        Mockito.when(serviceStorage.getClusters(Mockito.any()))
+            .thenReturn(Collections.singleton("D"));
+        
+        ServiceDetailInfo serviceDetail =
+            serviceOperatorV2.queryService(Service.newService("A", "B", "C"));
+        
+        assertEquals("A", serviceDetail.getNamespaceId());
+        assertEquals("B", serviceDetail.getGroupName());
+        assertEquals("C", serviceDetail.getServiceName());
+        assertTrue(serviceDetail.isEphemeral());
+        assertEquals(0.5F, serviceDetail.getProtectThreshold());
+        assertEquals("naming", serviceDetail.getMetadata().get("owner"));
+        ClusterInfo clusterInfo = serviceDetail.getClusterMap().get("D");
+        assertFalse(clusterInfo.isUseInstancePortForCheck());
+        assertEquals(8080, clusterInfo.getHealthyCheckPort());
+        assertEquals("z1", clusterInfo.getMetadata().get("zone"));
+    }
+    
+    @Test
+    void testQueryServiceDetailMissingThrows() {
+        assertThrows(NacosApiException.class,
+            () -> serviceOperatorV2.queryService(Service.newService("A", "B", "missing")));
+    }
+    
+    @Test
     void testListService() throws NacosException {
         Collection<String> res = serviceOperatorV2.listService("A", "B", null);
         assertEquals(1, res.size());
+    }
+    
+    @Test
+    void testListServiceReturnsEmptyWhenNamespaceMissing() throws NacosException {
+        Collection<String> res = serviceOperatorV2.listService("missing", "B", null);
+        assertTrue(res.isEmpty());
     }
     
     @Test
@@ -149,5 +243,37 @@ class ServiceOperatorV2ImplTest {
     void testSearchServiceName() throws NacosException {
         Collection<String> res = serviceOperatorV2.searchServiceName("A", "");
         assertEquals(1, res.size());
+    }
+    
+    @Test
+    void testGetSubscribers() throws NacosException {
+        Subscriber subscriber =
+            new Subscriber("1.1.1.1:8848", "agent", "app", "1.1.1.1", "A", "B@@C", 8848);
+        Mockito.when(subscribeManager.getSubscribers(Mockito.any(), Mockito.eq(false)))
+            .thenReturn(Collections.singletonList(subscriber));
+        
+        Page<SubscriberInfo> page = serviceOperatorV2.getSubscribers("A", "C", "B", false, 1, 10);
+        
+        assertEquals(1, page.getTotalCount());
+        assertEquals(1, page.getPageItems().size());
+        SubscriberInfo subscriberInfo = page.getPageItems().get(0);
+        assertEquals("A", subscriberInfo.getNamespaceId());
+        assertEquals("B", subscriberInfo.getGroupName());
+        assertEquals("C", subscriberInfo.getServiceName());
+        assertEquals("app", subscriberInfo.getAppName());
+        assertEquals("agent", subscriberInfo.getAgent());
+        assertEquals("1.1.1.1", subscriberInfo.getIp());
+        assertEquals(8848, subscriberInfo.getPort());
+    }
+    
+    @Test
+    void testGetSubscribersReturnsEmptyWhenQueryFails() throws NacosException {
+        Mockito.when(subscribeManager.getSubscribers(Mockito.any(), Mockito.eq(true)))
+            .thenThrow(new RuntimeException("failed"));
+        
+        Page<SubscriberInfo> page = serviceOperatorV2.getSubscribers("A", "C", "B", true, 1, 10);
+        
+        assertTrue(page.getPageItems().isEmpty());
+        assertEquals(0, page.getTotalCount());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/ServiceOperatorV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/ServiceOperatorV2ImplTest.java
@@ -179,6 +179,19 @@ class ServiceOperatorV2ImplTest {
     }
     
     @Test
+    void testQueryServiceUsesDefaultClusterMetadata() throws NacosException {
+        Mockito.when(metadataManager.getServiceMetadata(Mockito.any()))
+            .thenReturn(Optional.of(new ServiceMetadata()));
+        Mockito.when(serviceStorage.getClusters(Mockito.any()))
+            .thenReturn(Collections.singleton("D"));
+        
+        ObjectNode objectNode = serviceOperatorV2.queryService("A", "B@@C");
+        
+        assertEquals("D", objectNode.get(FieldsConstants.CLUSTERS).get(0)
+            .get(FieldsConstants.NAME).asText());
+    }
+    
+    @Test
     void testQueryServiceMissingThrows() {
         assertThrows(NacosApiException.class,
             () -> serviceOperatorV2.queryService("A", "B@@missing"));
@@ -214,6 +227,19 @@ class ServiceOperatorV2ImplTest {
         assertFalse(clusterInfo.isUseInstancePortForCheck());
         assertEquals(8080, clusterInfo.getHealthyCheckPort());
         assertEquals("z1", clusterInfo.getMetadata().get("zone"));
+    }
+    
+    @Test
+    void testQueryServiceDetailUsesDefaultClusterMetadata() throws NacosException {
+        Mockito.when(metadataManager.getServiceMetadata(Mockito.any()))
+            .thenReturn(Optional.of(new ServiceMetadata()));
+        Mockito.when(serviceStorage.getClusters(Mockito.any()))
+            .thenReturn(Collections.singleton("D"));
+        
+        ServiceDetailInfo serviceDetail =
+            serviceOperatorV2.queryService(Service.newService("A", "B", "C"));
+        
+        assertTrue(serviceDetail.getClusterMap().containsKey("D"));
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/SubscribeManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/SubscribeManagerTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.naming.core;
 
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.pojo.Subscriber;
 import com.alibaba.nacos.naming.push.NamingSubscriberServiceAggregationImpl;
 import com.alibaba.nacos.naming.push.NamingSubscriberServiceLocalImpl;
@@ -28,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -121,5 +123,55 @@ class SubscribeManagerTest {
         } catch (Exception ignored) {
             
         }
+    }
+    
+    @Test
+    void getSubscribersByServiceNameWithEmptyAggregationReturnsEmptyList() {
+        Mockito.when(aggregation.getFuzzySubscribers("public", "group@@service"))
+            .thenReturn(Collections.emptyList());
+        
+        List<Subscriber> actual = subscribeManager.getSubscribers("group@@service", "public", true);
+        
+        assertEquals(0, actual.size());
+    }
+    
+    @Test
+    void getSubscribersByServiceWithLocalSubscribers() {
+        Service service = Service.newService("public", "group", "service");
+        Subscriber subscriber =
+            new Subscriber("127.0.0.1:8080", "test", "app", "127.0.0.1", "public",
+                "group@@service", 8080);
+        Mockito.when(local.getSubscribers(service))
+            .thenReturn(Collections.singletonList(subscriber));
+        
+        List<Subscriber> actual = subscribeManager.getSubscribers(service, false);
+        
+        assertEquals(1, actual.size());
+        assertEquals(subscriber, actual.get(0));
+    }
+    
+    @Test
+    void getSubscribersByServiceWithAggregationDeduplicatesSubscribers() {
+        Service service = Service.newService("public", "group", "service");
+        Subscriber subscriber =
+            new Subscriber("127.0.0.1:8080", "test", "app", "127.0.0.1", "public",
+                "group@@service", 8080);
+        Mockito.when(aggregation.getSubscribers(service))
+            .thenReturn(java.util.Arrays.asList(subscriber, subscriber));
+        
+        List<Subscriber> actual = subscribeManager.getSubscribers(service, true);
+        
+        assertEquals(1, actual.size());
+        assertEquals(subscriber, actual.get(0));
+    }
+    
+    @Test
+    void getSubscribersByServiceWithEmptyAggregationReturnsEmptyList() {
+        Service service = Service.newService("public", "group", "service");
+        Mockito.when(aggregation.getSubscribers(service)).thenReturn(Collections.emptyList());
+        
+        List<Subscriber> actual = subscribeManager.getSubscribers(service, true);
+        
+        assertEquals(0, actual.size());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/cleaner/ExpiredMetadataCleanerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/cleaner/ExpiredMetadataCleanerTest.java
@@ -25,11 +25,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -57,17 +61,46 @@ class ExpiredMetadataCleanerTest {
         
         set.add(expiredMetadataInfoMock);
         
-        when(metadataManagerMock.getExpiredMetadataInfos()).thenReturn(set);
-        when(expiredMetadataInfoMock.getCreateTime()).thenReturn(0L);
-        when(metadataManagerMock.containServiceMetadata(expiredMetadataInfoMock.getService()))
-            .thenReturn(true);
+        Mockito.lenient().when(metadataManagerMock.getExpiredMetadataInfos()).thenReturn(set);
+        Mockito.lenient().when(expiredMetadataInfoMock.getCreateTime()).thenReturn(0L);
+    }
+    
+    @Test
+    void testGetType() {
+        assertEquals("expiredMetadata", expiredMetadataCleaner.getType());
     }
     
     @Test
     void testDoClean() {
+        when(metadataManagerMock.containServiceMetadata(expiredMetadataInfoMock.getService()))
+            .thenReturn(true);
+        
         expiredMetadataCleaner.doClean();
+        
         verify(metadataManagerMock).getExpiredMetadataInfos();
         verify(metadataOperateServiceMock)
             .deleteServiceMetadata(expiredMetadataInfoMock.getService());
+    }
+    
+    @Test
+    void testDoCleanSkipsUnexpiredMetadata() {
+        when(expiredMetadataInfoMock.getCreateTime()).thenReturn(System.currentTimeMillis());
+        
+        expiredMetadataCleaner.doClean();
+        
+        verify(metadataOperateServiceMock, never()).deleteServiceMetadata(any());
+        verify(metadataOperateServiceMock, never()).deleteInstanceMetadata(any(), any());
+    }
+    
+    @Test
+    void testDoCleanRemovesInstanceMetadata() {
+        when(expiredMetadataInfoMock.getMetadataId()).thenReturn("1.1.1.1:8848");
+        when(metadataManagerMock.containInstanceMetadata(expiredMetadataInfoMock.getService(),
+            "1.1.1.1:8848")).thenReturn(true);
+        
+        expiredMetadataCleaner.doClean();
+        
+        verify(metadataOperateServiceMock)
+            .deleteInstanceMetadata(expiredMetadataInfoMock.getService(), "1.1.1.1:8848");
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/AbstractClientTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/AbstractClientTest.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.naming.core.v2.client;
 
+import com.alibaba.nacos.naming.core.v2.pojo.BatchInstanceData;
+import com.alibaba.nacos.naming.core.v2.pojo.BatchInstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.monitor.MetricsMonitor;
@@ -26,9 +28,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
@@ -115,6 +119,37 @@ class AbstractClientTest {
     }
     
     @Test
+    void generateSyncDataWithNormalAndBatchInstances() {
+        Service batchService = Service.newService("ns2", "group2", "batchService");
+        BatchInstancePublishInfo batchInstance = newBatchInstance();
+        abstractClient.addServiceInstance(service, instancePublishInfo);
+        abstractClient.addServiceInstance(batchService, batchInstance);
+        
+        ClientSyncData clientSyncData = abstractClient.generateSyncData();
+        BatchInstanceData batchInstanceData = clientSyncData.getBatchInstanceData();
+        
+        assertEquals(Collections.singletonList("ns1"), clientSyncData.getNamespaces());
+        assertEquals(Collections.singletonList("group1"), clientSyncData.getGroupNames());
+        assertEquals(Collections.singletonList("serviceName001"), clientSyncData.getServiceNames());
+        assertEquals(1, clientSyncData.getInstancePublishInfos().size());
+        assertEquals(Collections.singletonList("ns2"), batchInstanceData.getNamespaces());
+        assertEquals(Collections.singletonList("group2"), batchInstanceData.getGroupNames());
+        assertEquals(Collections.singletonList("batchService"),
+            batchInstanceData.getServiceNames());
+        assertSame(batchInstance, batchInstanceData.getBatchInstancePublishInfos().get(0));
+    }
+    
+    @Test
+    void removeServiceInstanceWithBatchInstance() {
+        BatchInstancePublishInfo batchInstance = newBatchInstance();
+        abstractClient.addServiceInstance(service, batchInstance);
+        
+        InstancePublishInfo removed = abstractClient.removeServiceInstance(service);
+        
+        assertSame(batchInstance, removed);
+    }
+    
+    @Test
     void release() {
         
         abstractClient.addServiceInstance(service, instancePublishInfo);
@@ -126,5 +161,22 @@ class AbstractClientTest {
         
         assertEquals(0, MetricsMonitor.getSubscriberCount().get());
         assertEquals(0, MetricsMonitor.getIpCountMonitor().get());
+    }
+    
+    @Test
+    void releaseWithBatchInstance() {
+        abstractClient.addServiceInstance(service, newBatchInstance());
+        assertEquals(1, MetricsMonitor.getIpCountMonitor().get());
+        
+        abstractClient.release();
+        
+        assertEquals(0, MetricsMonitor.getIpCountMonitor().get());
+    }
+    
+    private BatchInstancePublishInfo newBatchInstance() {
+        BatchInstancePublishInfo result = new BatchInstancePublishInfo();
+        result.setInstancePublishInfos(
+            Collections.singletonList(new InstancePublishInfo("127.0.0.2", 8891)));
+        return result;
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/factory/impl/EphemeralIpPortClientFactoryTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/factory/impl/EphemeralIpPortClientFactoryTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.client.factory.impl;
+
+import com.alibaba.nacos.naming.constants.ClientConstants;
+import com.alibaba.nacos.naming.core.v2.client.ClientAttributes;
+import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
+import org.junit.jupiter.api.Test;
+
+import static com.alibaba.nacos.naming.constants.ClientConstants.REVISION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EphemeralIpPortClientFactoryTest {
+    
+    private final EphemeralIpPortClientFactory factory = new EphemeralIpPortClientFactory();
+    
+    @Test
+    void testGetType() {
+        assertEquals(ClientConstants.EPHEMERAL_IP_PORT, factory.getType());
+    }
+    
+    @Test
+    void testNewClient() {
+        ClientAttributes attributes = new ClientAttributes();
+        attributes.addClientAttribute(REVISION, 7);
+        
+        IpPortBasedClient client = factory.newClient(
+            IpPortBasedClient.getClientId("1.1.1.1:8848", true), attributes);
+        
+        assertEquals("1.1.1.1:8848#true", client.getClientId());
+        assertTrue(client.isEphemeral());
+        assertSame(attributes, client.getClientAttributes());
+        assertEquals(7L, client.getRevision());
+    }
+    
+    @Test
+    void testNewSyncedClient() {
+        ClientAttributes attributes = new ClientAttributes();
+        attributes.addClientAttribute(REVISION, 8);
+        
+        IpPortBasedClient client = factory.newSyncedClient(
+            IpPortBasedClient.getClientId("1.1.1.1:8848", true), attributes);
+        
+        assertEquals("1.1.1.1:8848#true", client.getClientId());
+        assertTrue(client.isEphemeral());
+        assertSame(attributes, client.getClientAttributes());
+        assertEquals(8L, client.getRevision());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/factory/impl/PersistentIpPortClientFactoryTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/factory/impl/PersistentIpPortClientFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.client.factory.impl;
+
+import com.alibaba.nacos.naming.constants.ClientConstants;
+import com.alibaba.nacos.naming.core.v2.client.ClientAttributes;
+import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PersistentIpPortClientFactoryTest {
+    
+    private final PersistentIpPortClientFactory factory = new PersistentIpPortClientFactory();
+    
+    @Test
+    void testGetType() {
+        assertEquals(ClientConstants.PERSISTENT_IP_PORT, factory.getType());
+    }
+    
+    @Test
+    void testNewClient() {
+        ClientAttributes attributes = new ClientAttributes();
+        
+        IpPortBasedClient client = factory.newClient(
+            IpPortBasedClient.getClientId("1.1.1.1:8848", false), attributes);
+        
+        assertEquals("1.1.1.1:8848#false", client.getClientId());
+        assertFalse(client.isEphemeral());
+        assertSame(attributes, client.getClientAttributes());
+    }
+    
+    @Test
+    void testNewSyncedClient() {
+        ClientAttributes attributes = new ClientAttributes();
+        
+        IpPortBasedClient client = factory.newSyncedClient(
+            IpPortBasedClient.getClientId("1.1.1.1:8848", false), attributes);
+        
+        assertEquals("1.1.1.1:8848#false", client.getClientId());
+        assertFalse(client.isEphemeral());
+        assertSame(attributes, client.getClientAttributes());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/impl/IpPortBasedClientTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/impl/IpPortBasedClientTest.java
@@ -18,6 +18,8 @@ package com.alibaba.nacos.naming.core.v2.client.impl;
 
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.healthcheck.HealthCheckReactor;
+import com.alibaba.nacos.naming.healthcheck.v2.HealthCheckTaskV2;
 import com.alibaba.nacos.naming.misc.ClientConfig;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -26,13 +28,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class IpPortBasedClientTest {
@@ -77,6 +86,11 @@ class IpPortBasedClientTest {
     }
     
     @Test
+    void testIsExpireReturnsFalseBeforeTimeout() {
+        assertFalse(ipPortBasedClient.isExpire(System.currentTimeMillis()));
+    }
+    
+    @Test
     void testGetAllInstancePublishInfo() {
         ipPortBasedClient.addServiceInstance(service, instancePublishInfo);
         Collection<InstancePublishInfo> allInstancePublishInfo =
@@ -95,6 +109,37 @@ class IpPortBasedClientTest {
     void testConstructor0() {
         IpPortBasedClient client = new IpPortBasedClient(clientId, true);
         assertEquals(0, client.getRevision());
+    }
+    
+    @Test
+    void testPersistentReleaseCancelsHealthCheckTask() {
+        IpPortBasedClient client = new IpPortBasedClient("127.0.0.1:80#false", false);
+        HealthCheckTaskV2 healthCheckTaskV2 = mock(HealthCheckTaskV2.class);
+        ReflectionTestUtils.setField(client, "healthCheckTaskV2", healthCheckTaskV2);
+        
+        client.release();
+        
+        verify(healthCheckTaskV2).setCancelled(true);
+    }
+    
+    @Test
+    void testPersistentInitSchedulesHealthCheckTask() {
+        IpPortBasedClient client = new IpPortBasedClient("127.0.0.1:80#false", false);
+        
+        try (MockedStatic<HealthCheckReactor> mockedHealthCheckReactor =
+            mockStatic(HealthCheckReactor.class)) {
+            client.init();
+            
+            mockedHealthCheckReactor.verify(
+                () -> HealthCheckReactor.scheduleCheck(any(HealthCheckTaskV2.class)));
+        }
+    }
+    
+    @Test
+    void testPutServiceInstance() {
+        ipPortBasedClient.putServiceInstance(service, instancePublishInfo);
+        
+        assertEquals(1, ipPortBasedClient.getAllInstancePublishInfo().size());
     }
     
     @AfterEach

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/impl/ConnectionBasedClientManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/impl/ConnectionBasedClientManagerTest.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.core.remote.Connection;
 import com.alibaba.nacos.core.remote.ConnectionMeta;
 import com.alibaba.nacos.naming.consistency.ephemeral.distro.v2.DistroClientVerifyInfo;
 import com.alibaba.nacos.naming.constants.ClientConstants;
+import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.client.ClientAttributes;
 import com.alibaba.nacos.naming.core.v2.client.impl.ConnectionBasedClient;
 import com.alibaba.nacos.sys.env.EnvUtil;
@@ -35,11 +36,16 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.lang.reflect.Constructor;
 import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -107,8 +113,80 @@ class ConnectionBasedClientManagerTest {
     }
     
     @Test
+    void testGetClient() {
+        assertNotNull(connectionBasedClientManager.getClient(connectionId));
+    }
+    
+    @Test
+    void testClientConnectedIgnoresNonNamingConnection() {
+        Connection configConnection = mock(Connection.class);
+        ConnectionMeta configConnectionMeta = mock(ConnectionMeta.class);
+        when(configConnection.getMetaInfo()).thenReturn(configConnectionMeta);
+        when(configConnectionMeta.getLabel(RemoteConstants.LABEL_MODULE)).thenReturn("config");
+        
+        connectionBasedClientManager.clientConnected(configConnection);
+        
+        assertEquals(1, connectionBasedClientManager.allClientId().size());
+    }
+    
+    @Test
+    void testClientDisconnectedIgnoresNonNamingConnection() {
+        Connection configConnection = mock(Connection.class);
+        ConnectionMeta configConnectionMeta = mock(ConnectionMeta.class);
+        when(configConnection.getMetaInfo()).thenReturn(configConnectionMeta);
+        when(configConnectionMeta.getLabel(RemoteConstants.LABEL_MODULE)).thenReturn("config");
+        
+        connectionBasedClientManager.clientDisConnected(configConnection);
+        
+        assertTrue(connectionBasedClientManager.contains(connectionId));
+    }
+    
+    @Test
+    void testClientDisconnectedWithoutClient() {
+        assertTrue(connectionBasedClientManager.clientDisconnected("missing"));
+    }
+    
+    @Test
     void testIsResponsibleClient() {
         assertTrue(connectionBasedClientManager.isResponsibleClient(client));
+    }
+    
+    @Test
+    void testIsResponsibleClientWithOtherClientType() {
+        assertFalse(connectionBasedClientManager.isResponsibleClient(mock(Client.class)));
+    }
+    
+    @Test
+    void testVerifyClientWithDifferentRevision() {
+        String verifyClientId = "verifyClientId";
+        ConnectionBasedClient verifyClient = mock(ConnectionBasedClient.class);
+        when(verifyClient.getClientId()).thenReturn(verifyClientId);
+        when(verifyClient.getRevision()).thenReturn(1L);
+        connectionBasedClientManager.clientConnected(verifyClient);
+        
+        assertFalse(
+            connectionBasedClientManager
+                .verifyClient(new DistroClientVerifyInfo(verifyClientId, 2L)));
+    }
+    
+    @Test
+    void testExpiredClientCleaner() throws Exception {
+        String expiredClientId = "expiredClientId";
+        ConnectionBasedClient expiredClient = mock(ConnectionBasedClient.class);
+        when(expiredClient.getClientId()).thenReturn(expiredClientId);
+        when(expiredClient.isNative()).thenReturn(true);
+        when(expiredClient.isExpire(anyLong())).thenReturn(true);
+        connectionBasedClientManager.clientConnected(expiredClient);
+        Constructor<?> constructor =
+            Class.forName(ConnectionBasedClientManager.class.getName() + "$ExpiredClientCleaner")
+                .getDeclaredConstructor(ConnectionBasedClientManager.class);
+        constructor.setAccessible(true);
+        Runnable cleaner = (Runnable) constructor.newInstance(connectionBasedClientManager);
+        
+        cleaner.run();
+        
+        assertFalse(connectionBasedClientManager.contains(expiredClientId));
+        verify(expiredClient).release();
     }
     
     @AfterEach

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/impl/EphemeralIpPortClientManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/impl/EphemeralIpPortClientManagerTest.java
@@ -16,12 +16,14 @@
 
 package com.alibaba.nacos.naming.core.v2.client.manager.impl;
 
+import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.naming.consistency.ephemeral.distro.v2.DistroClientVerifyInfo;
 import com.alibaba.nacos.naming.constants.ClientConstants;
 import com.alibaba.nacos.naming.core.DistroMapper;
 import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.client.ClientAttributes;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.misc.SwitchDomain;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,12 +36,16 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.lang.reflect.Constructor;
 import java.util.Collection;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -139,5 +145,36 @@ class EphemeralIpPortClientManagerTest {
             .verifyClient(new DistroClientVerifyInfo(syncedClientId, 1)));
         assertTrue(ephemeralIpPortClientManager
             .verifyClient(new DistroClientVerifyInfo(syncedClientId, 5120)));
+    }
+    
+    @Test
+    void testExpiredClientCleanerKeepsActiveSubscriberClient() throws Exception {
+        EphemeralIpPortClientManager clientManager = mock(EphemeralIpPortClientManager.class);
+        IpPortBasedClient activeClient = mock(IpPortBasedClient.class);
+        String activeClientId = "127.0.0.1:8848#true";
+        when(clientManager.allClientId()).thenReturn(Collections.singleton(activeClientId));
+        when(clientManager.getClient(activeClientId)).thenReturn(activeClient);
+        when(activeClient.isEphemeral()).thenReturn(true);
+        when(activeClient.getLastUpdatedTime())
+            .thenReturn(System.currentTimeMillis() - Constants.DEFAULT_IP_DELETE_TIMEOUT - 1);
+        when(activeClient.getAllPublishedService()).thenReturn(Collections.emptySet());
+        when(activeClient.getAllSubscribeService()).thenReturn(
+            Collections.singleton(Service.newService("namespace", "group", "service", true)));
+        when(switchDomain.getDefaultPushCacheMillis()).thenReturn(Long.MAX_VALUE);
+        
+        newExpiredClientCleaner(clientManager).run();
+        
+        verify(clientManager, never()).clientDisconnected(activeClientId);
+    }
+    
+    private Runnable newExpiredClientCleaner(EphemeralIpPortClientManager clientManager)
+        throws Exception {
+        Class<?> cleanerClass = Class.forName(EphemeralIpPortClientManager.class.getName()
+            + "$ExpiredClientCleaner");
+        Constructor<?> constructor =
+            cleanerClass.getDeclaredConstructor(EphemeralIpPortClientManager.class,
+                SwitchDomain.class);
+        constructor.setAccessible(true);
+        return (Runnable) constructor.newInstance(clientManager, switchDomain);
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/impl/EphemeralIpPortClientManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/impl/EphemeralIpPortClientManagerTest.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -99,6 +100,25 @@ class EphemeralIpPortClientManagerTest {
         assertTrue(ephemeralIpPortClientManager.contains(syncedClientId));
         String unUsedClientId = "127.0.0.1:8888#true";
         assertFalse(ephemeralIpPortClientManager.contains(unUsedClientId));
+    }
+    
+    @Test
+    void testClientConnectedWithAttributes() {
+        String clientId = "127.0.0.1:8081#true";
+        
+        assertTrue(ephemeralIpPortClientManager.clientConnected(clientId, attributes));
+        
+        assertTrue(ephemeralIpPortClientManager.contains(clientId));
+    }
+    
+    @Test
+    void testClientDisconnectedWhenMissing() {
+        assertTrue(ephemeralIpPortClientManager.clientDisconnected("missing"));
+    }
+    
+    @Test
+    void testIsResponsibleClientReturnsFalseForOtherClientType() {
+        assertFalse(ephemeralIpPortClientManager.isResponsibleClient(mock(Client.class)));
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/impl/PersistentIpPortClientManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/impl/PersistentIpPortClientManagerTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.naming.core.v2.client.manager.impl;
 
 import com.alibaba.nacos.naming.consistency.ephemeral.distro.v2.DistroClientVerifyInfo;
 import com.alibaba.nacos.naming.core.v2.client.ClientAttributes;
+import com.alibaba.nacos.naming.core.v2.client.factory.ClientFactory;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,8 +34,11 @@ import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,10 +74,38 @@ class PersistentIpPortClientManagerTest {
     }
     
     @Test
+    @SuppressWarnings("unchecked")
+    void testClientConnectedByClientId() {
+        String factoryClientId = "127.0.0.1:8848#false";
+        ClientFactory<IpPortBasedClient> clientFactory = mock(ClientFactory.class);
+        IpPortBasedClient factoryClient = mock(IpPortBasedClient.class);
+        when(clientFactory.newClient(factoryClientId, clientAttributes)).thenReturn(factoryClient);
+        when(factoryClient.getClientId()).thenReturn(factoryClientId);
+        ReflectionTestUtils.setField(persistentIpPortClientManager, "clientFactory", clientFactory);
+        
+        assertTrue(
+            persistentIpPortClientManager.clientConnected(factoryClientId, clientAttributes));
+        
+        assertSame(factoryClient, persistentIpPortClientManager.getClient(factoryClientId));
+    }
+    
+    @Test
     void testContains() {
         assertTrue(persistentIpPortClientManager.contains(clientId));
         String unUsedClientId = "127.0.0.1:8888#true";
         assertFalse(persistentIpPortClientManager.contains(unUsedClientId));
+    }
+    
+    @Test
+    void testGetClient() {
+        assertSame(client, persistentIpPortClientManager.getClient(clientId));
+    }
+    
+    @Test
+    void testShowClients() {
+        assertTrue(persistentIpPortClientManager.showClients().containsKey(clientId));
+        assertThrows(UnsupportedOperationException.class,
+            () -> persistentIpPortClientManager.showClients().clear());
     }
     
     @Test
@@ -102,6 +135,30 @@ class PersistentIpPortClientManagerTest {
         Collection<String> allClientIds = persistentIpPortClientManager.allClientId();
         assertEquals(1, allClientIds.size());
         assertTrue(allClientIds.contains(snapshotClientId));
+    }
+    
+    @Test
+    void testAddSyncClient() {
+        when(snapshotClient.getClientId()).thenReturn(snapshotClientId);
+        
+        persistentIpPortClientManager.addSyncClient(snapshotClient);
+        
+        assertSame(snapshotClient, persistentIpPortClientManager.getClient(snapshotClientId));
+    }
+    
+    @Test
+    void testRemoveAndRelease() {
+        persistentIpPortClientManager.removeAndRelease(clientId);
+        
+        assertFalse(persistentIpPortClientManager.contains(clientId));
+        verify(client).release();
+    }
+    
+    @Test
+    void testRemoveAndReleaseWithoutClient() {
+        persistentIpPortClientManager.removeAndRelease("missing");
+        
+        assertTrue(persistentIpPortClientManager.contains(clientId));
     }
     
     @AfterEach

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/event/client/ClientEventTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/event/client/ClientEventTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.event.client;
+
+import com.alibaba.nacos.naming.core.v2.client.Client;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientEventTest {
+    
+    @Test
+    void testClientChangedEventReturnsClient() {
+        Client client = Mockito.mock(Client.class);
+        
+        ClientEvent.ClientChangedEvent actual = new ClientEvent.ClientChangedEvent(client);
+        
+        assertSame(client, actual.getClient());
+    }
+    
+    @Test
+    void testClientDisconnectEventReturnsNativeFlag() {
+        Client client = Mockito.mock(Client.class);
+        
+        ClientEvent.ClientDisconnectEvent nativeEvent =
+            new ClientEvent.ClientDisconnectEvent(client, true);
+        ClientEvent.ClientDisconnectEvent remoteEvent =
+            new ClientEvent.ClientDisconnectEvent(client, false);
+        
+        assertSame(client, nativeEvent.getClient());
+        assertTrue(nativeEvent.isNative());
+        assertFalse(remoteEvent.isNative());
+    }
+    
+    @Test
+    void testClientVerifyFailedEventReturnsFields() {
+        ClientEvent.ClientVerifyFailedEvent actual =
+            new ClientEvent.ClientVerifyFailedEvent("clientId", "targetServer");
+        
+        assertEquals("clientId", actual.getClientId());
+        assertEquals("targetServer", actual.getTargetServer());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/event/metadata/MetadataEventTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/event/metadata/MetadataEventTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.event.metadata;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MetadataEventTest {
+    
+    @Test
+    void testServiceMetadataEventReturnsFields() {
+        Service service = Service.newService("namespace", "group", "service");
+        
+        MetadataEvent.ServiceMetadataEvent actual =
+            new MetadataEvent.ServiceMetadataEvent(service, true);
+        
+        assertSame(service, actual.getService());
+        assertTrue(actual.isExpired());
+    }
+    
+    @Test
+    void testInstanceMetadataEventReturnsFields() {
+        Service service = Service.newService("namespace", "group", "service");
+        
+        MetadataEvent.InstanceMetadataEvent actual =
+            new MetadataEvent.InstanceMetadataEvent(service, "metadataId", false);
+        
+        assertSame(service, actual.getService());
+        assertEquals("metadataId", actual.getMetadataId());
+        assertFalse(actual.isExpired());
+    }
+    
+    @Test
+    void testServiceInfoChangeEventRenewsServiceUpdateTime() {
+        Service service = Service.newService("namespace", "group", "service");
+        long before = service.getLastUpdatedTime();
+        
+        InfoChangeEvent.ServiceInfoChangeEvent actual =
+            new InfoChangeEvent.ServiceInfoChangeEvent(service);
+        
+        assertSame(service, actual.getService());
+        assertTrue(service.getLastUpdatedTime() >= before);
+    }
+    
+    @Test
+    void testInstanceInfoChangeEventReturnsFields() {
+        Service service = Service.newService("namespace", "group", "service");
+        Instance instance = new Instance();
+        
+        InfoChangeEvent.InstanceInfoChangeEvent actual =
+            new InfoChangeEvent.InstanceInfoChangeEvent(service, instance);
+        
+        assertSame(service, actual.getService());
+        assertSame(instance, actual.getInstance());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/event/publisher/NamingEventPublisherTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/event/publisher/NamingEventPublisherTest.java
@@ -16,22 +16,29 @@
 
 package com.alibaba.nacos.naming.core.v2.event.publisher;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.common.notify.listener.SmartSubscriber;
 import com.alibaba.nacos.common.notify.listener.Subscriber;
 import com.alibaba.nacos.common.utils.ThreadUtils;
+import com.alibaba.nacos.naming.misc.Loggers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NamingEventPublisherTest {
@@ -86,6 +93,19 @@ class NamingEventPublisherTest {
     }
     
     @Test
+    void testAddAndRemoveSubscriberWithSubscribeType() {
+        when(subscriber.subscribeType()).thenReturn(TestEvent.TestEvent1.class);
+        TestEvent.TestEvent1 testEvent1 = new TestEvent.TestEvent1();
+        
+        namingEventPublisher.addSubscriber(subscriber);
+        namingEventPublisher.removeSubscriber(subscriber);
+        namingEventPublisher.publish(testEvent1);
+        ThreadUtils.sleep(500L);
+        
+        verify(subscriber, never()).onEvent(testEvent1);
+    }
+    
+    @Test
     void testPublishOverFlow() {
         TestEvent testEvent = new TestEvent();
         for (int i = 0; i < Byte.SIZE; i++) {
@@ -94,6 +114,73 @@ class NamingEventPublisherTest {
         namingEventPublisher.addSubscriber(subscriber, TestEvent.class);
         namingEventPublisher.publish(testEvent);
         verify(subscriber, atLeastOnce()).onEvent(testEvent);
+    }
+    
+    @Test
+    void testNotifySubscriberWithExecutor() {
+        TestEvent testEvent = new TestEvent();
+        when(subscriber.executor()).thenReturn(Runnable::run);
+        
+        namingEventPublisher.notifySubscriber(subscriber, testEvent);
+        
+        verify(subscriber).onEvent(testEvent);
+    }
+    
+    @Test
+    void testNotifySubscriberWhenDebugEnabled() {
+        Logger eventLogger = (Logger) Loggers.EVT_LOG;
+        Level originalLevel = eventLogger.getLevel();
+        try {
+            eventLogger.setLevel(Level.DEBUG);
+            TestEvent testEvent = new TestEvent();
+            
+            namingEventPublisher.notifySubscriber(subscriber, testEvent);
+            
+            verify(subscriber).onEvent(testEvent);
+        } finally {
+            eventLogger.setLevel(originalLevel);
+        }
+    }
+    
+    @Test
+    void testHandleEventWithoutSubscriberWhenDebugEnabled() {
+        Logger eventLogger = (Logger) Loggers.EVT_LOG;
+        Level originalLevel = eventLogger.getLevel();
+        try {
+            eventLogger.setLevel(Level.DEBUG);
+            namingEventPublisher.addSubscriber(subscriber, TestEvent.TestEvent1.class);
+            
+            namingEventPublisher.publish(new TestEvent.TestEvent2());
+            ThreadUtils.sleep(2000L);
+            
+            assertThat(namingEventPublisher.currentEventSize(), is(0L));
+        } finally {
+            eventLogger.setLevel(originalLevel);
+        }
+    }
+    
+    @Test
+    void testNotifySubscriberCatchesCallbackException() {
+        TestEvent testEvent = new TestEvent();
+        Mockito.doThrow(new RuntimeException("callback failed")).when(subscriber)
+            .onEvent(testEvent);
+        
+        assertDoesNotThrow(() -> namingEventPublisher.notifySubscriber(subscriber, testEvent));
+    }
+    
+    @Test
+    void testPublishBeforeInitThrowsException() {
+        NamingEventPublisher publisher = new NamingEventPublisher();
+        
+        assertThrows(IllegalStateException.class, () -> publisher.publish(new TestEvent()));
+    }
+    
+    @Test
+    void testRunCatchesUnexpectedException() {
+        NamingEventPublisher publisher = new NamingEventPublisher();
+        publisher.addSubscriber(subscriber, TestEvent.class);
+        
+        assertDoesNotThrow(publisher::run);
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/event/publisher/NamingEventPublisherTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/event/publisher/NamingEventPublisherTest.java
@@ -184,6 +184,18 @@ class NamingEventPublisherTest {
     }
     
     @Test
+    void testRunHandlesInterruptedTake() throws Exception {
+        namingEventPublisher.addSubscriber(subscriber, TestEvent.class);
+        ThreadUtils.sleep(200L);
+        
+        namingEventPublisher.shutdown();
+        namingEventPublisher.interrupt();
+        ThreadUtils.sleep(200L);
+        
+        assertThat(namingEventPublisher.currentEventSize(), is(0L));
+    }
+    
+    @Test
     void getStatus() throws NacosException {
         namingEventPublisher.publish(new TestEvent());
         namingEventPublisher.publish(new TestEvent.TestEvent1());

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/ClientServiceIndexesManagerTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.naming.core.v2.index;
 import com.alibaba.nacos.common.notify.Event;
 import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.event.client.ClientOperationEvent;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,9 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class ClientServiceIndexesManagerTest {
@@ -92,6 +95,15 @@ class ClientServiceIndexesManagerTest {
     }
     
     @Test
+    void testGetAllClientsRegisteredServiceWithoutIndex() {
+        Collection<String> actual =
+            clientServiceIndexesManager.getAllClientsRegisteredService(Mockito.mock(Service.class));
+        
+        assertNotNull(actual);
+        assertTrue(actual.isEmpty());
+    }
+    
+    @Test
     void testGetAllClientsSubscribeService() {
         
         Collection<String> allClientsSubscribeService =
@@ -99,6 +111,15 @@ class ClientServiceIndexesManagerTest {
         
         assertNotNull(allClientsSubscribeService);
         assertEquals(1, allClientsSubscribeService.size());
+    }
+    
+    @Test
+    void testGetAllClientsSubscribeServiceWithoutIndex() {
+        Collection<String> actual =
+            clientServiceIndexesManager.getAllClientsSubscribeService(Mockito.mock(Service.class));
+        
+        assertNotNull(actual);
+        assertTrue(actual.isEmpty());
     }
     
     @Test
@@ -127,6 +148,25 @@ class ClientServiceIndexesManagerTest {
     }
     
     @Test
+    void testRemovePublisherIndexesByEmptyServiceRemovesEmptyIndex()
+        throws NoSuchFieldException, IllegalAccessException {
+        Class<ClientServiceIndexesManager> clientServiceIndexesManagerClass =
+            ClientServiceIndexesManager.class;
+        Field publisherIndexesField =
+            clientServiceIndexesManagerClass.getDeclaredField("publisherIndexes");
+        publisherIndexesField.setAccessible(true);
+        ConcurrentMap<Service, Set<String>> publisherIndexes =
+            (ConcurrentMap<Service, Set<String>>) publisherIndexesField.get(
+                clientServiceIndexesManager);
+        Service emptyService = Mockito.mock(Service.class);
+        publisherIndexes.put(emptyService, new HashSet<>());
+        
+        clientServiceIndexesManager.removePublisherIndexesByEmptyService(emptyService);
+        
+        assertFalse(publisherIndexes.containsKey(emptyService));
+    }
+    
+    @Test
     void testSubscribeTypes() {
         List<Class<? extends Event>> classes = clientServiceIndexesManager.subscribeTypes();
         
@@ -145,6 +185,24 @@ class ClientServiceIndexesManagerTest {
         
         Mockito.verify(clientOperationEvent).getService();
         Mockito.verify(clientOperationEvent).getClientId();
+    }
+    
+    @Test
+    void testOnClientReleaseEventRemovesIndexes() {
+        Mockito.when(client.getClientId()).thenReturn(NACOS);
+        Mockito.when(client.getAllSubscribeService()).thenReturn(Collections.singleton(service));
+        Mockito.when(client.getAllPublishedService()).thenReturn(Collections.singleton(service));
+        Mockito.when(client.getInstancePublishInfo(service))
+            .thenReturn(new InstancePublishInfo("1.1.1.1", 8848));
+        Mockito.when(service.getNamespace()).thenReturn("public");
+        Mockito.when(service.getGroup()).thenReturn("group");
+        Mockito.when(service.getName()).thenReturn("service");
+        
+        clientServiceIndexesManager
+            .onEvent(new ClientOperationEvent.ClientReleaseEvent(client, true));
+        
+        assertTrue(clientServiceIndexesManager.getAllClientsSubscribeService(service).isEmpty());
+        assertTrue(clientServiceIndexesManager.getAllClientsRegisteredService(service).isEmpty());
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/NamingFuzzyWatchContextServiceTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/NamingFuzzyWatchContextServiceTest.java
@@ -18,12 +18,16 @@ package com.alibaba.nacos.naming.core.v2.index;
 
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.utils.NamingUtils;
+import com.alibaba.nacos.common.notify.Event;
+import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.FuzzyGroupKeyPattern;
+import com.alibaba.nacos.core.utils.GlobalExecutor;
 import com.alibaba.nacos.naming.core.v2.ServiceManager;
 import com.alibaba.nacos.naming.core.v2.client.impl.ConnectionBasedClient;
 import com.alibaba.nacos.naming.core.v2.event.client.ClientOperationEvent;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.misc.GlobalConfig;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,14 +35,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static com.alibaba.nacos.api.common.Constants.ServiceChangedType.ADD_SERVICE;
 import static com.alibaba.nacos.api.common.Constants.ServiceChangedType.DELETE_SERVICE;
 import static com.alibaba.nacos.api.model.v2.ErrorCode.FUZZY_WATCH_PATTERN_OVER_LIMIT;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +102,29 @@ public class NamingFuzzyWatchContextServiceTest {
         Assertions.assertFalse(
             strings.contains(NamingUtils.getServiceKey("namespace", "group", "12service")));
         
+    }
+    
+    @Test
+    void testInit() {
+        EnvUtil.setEnvironment(new MockEnvironment());
+        try (MockedStatic<GlobalExecutor> globalExecutorMockedStatic =
+            Mockito.mockStatic(GlobalExecutor.class);
+            MockedStatic<NotifyCenter> notifyCenterMockedStatic =
+                Mockito.mockStatic(NotifyCenter.class)) {
+            globalExecutorMockedStatic.when(() -> GlobalExecutor
+                .scheduleWithFixDelayByCommon(any(Runnable.class), eq(30000L)))
+                .thenAnswer(invocation -> {
+                    invocation.getArgument(0, Runnable.class).run();
+                    return null;
+                });
+            
+            namingFuzzyWatchContextService.init();
+            
+            globalExecutorMockedStatic.verify(() -> GlobalExecutor
+                .scheduleWithFixDelayByCommon(any(Runnable.class), eq(30000L)));
+            notifyCenterMockedStatic.verify(
+                () -> NotifyCenter.registerSubscriber(namingFuzzyWatchContextService));
+        }
     }
     
     @Test
@@ -189,6 +220,99 @@ public class NamingFuzzyWatchContextServiceTest {
             namingFuzzyWatchContextService.syncServiceContext(serviceDRemove, DELETE_SERVICE);
         Assertions.assertFalse(needNotify2Remove);
         
+    }
+    
+    @Test
+    void testSyncServiceContextReturnsFalseForUnsupportedChangedType() {
+        boolean needNotify = namingFuzzyWatchContextService.syncServiceContext(
+            Service.newService("namespace", "group", "service", true), "UPDATE_SERVICE");
+        
+        Assertions.assertFalse(needNotify);
+    }
+    
+    @Test
+    void testSubscribeTypes() {
+        List<Class<? extends Event>> subscribeTypes =
+            namingFuzzyWatchContextService.subscribeTypes();
+        
+        Assertions.assertEquals(1, subscribeTypes.size());
+        Assertions.assertTrue(
+            subscribeTypes.contains(ClientOperationEvent.ClientReleaseEvent.class));
+    }
+    
+    @Test
+    void testSyncServiceContextSkipsAddWhenLimitReached() throws NacosException {
+        tMockedStatic.when(() -> GlobalConfig.getMaxPatternCount()).thenReturn(20);
+        tMockedStatic.when(() -> GlobalConfig.getMaxMatchedServiceCount()).thenReturn(1);
+        Set<Service> serviceSet = new HashSet<>();
+        serviceSet.add(Service.newService("namespace", "group0", "service0", true));
+        when(serviceManager.getSingletons(eq("namespace"))).thenReturn(serviceSet);
+        String groupKeyPattern =
+            FuzzyGroupKeyPattern.generatePattern("service*", "group*", "namespace");
+        namingFuzzyWatchContextService.syncFuzzyWatcherContext(groupKeyPattern, "connection");
+        
+        boolean needNotify = namingFuzzyWatchContextService.syncServiceContext(
+            Service.newService("namespace", "group1", "service1", true), ADD_SERVICE);
+        
+        Assertions.assertFalse(needNotify);
+        Assertions.assertEquals(1,
+            namingFuzzyWatchContextService.matchServiceKeys(groupKeyPattern).size());
+    }
+    
+    @Test
+    void testReachToUpLimitAndMakeupMissingPattern() throws NacosException {
+        tMockedStatic.when(() -> GlobalConfig.getMaxPatternCount()).thenReturn(20);
+        tMockedStatic.when(() -> GlobalConfig.getMaxMatchedServiceCount()).thenReturn(1);
+        String missingPattern =
+            FuzzyGroupKeyPattern.generatePattern("missing*", "group*", "namespace");
+        
+        Assertions.assertFalse(namingFuzzyWatchContextService.reachToUpLimit(missingPattern));
+        namingFuzzyWatchContextService.makeupMatchedGroupKeys(missingPattern);
+        
+        Set<Service> serviceSet = new HashSet<>();
+        serviceSet.add(Service.newService("namespace", "group", "service", true));
+        when(serviceManager.getSingletons(eq("namespace"))).thenReturn(serviceSet);
+        String groupKeyPattern =
+            FuzzyGroupKeyPattern.generatePattern("service*", "group*", "namespace");
+        namingFuzzyWatchContextService.syncFuzzyWatcherContext(groupKeyPattern, "connection");
+        
+        Assertions.assertTrue(namingFuzzyWatchContextService.reachToUpLimit(groupKeyPattern));
+    }
+    
+    @Test
+    void testMakeupMatchedGroupKeysCompletesWithoutReachingLimit() throws NacosException {
+        tMockedStatic.when(() -> GlobalConfig.getMaxPatternCount()).thenReturn(20);
+        tMockedStatic.when(() -> GlobalConfig.getMaxMatchedServiceCount()).thenReturn(10);
+        Set<Service> serviceSet = new HashSet<>();
+        serviceSet.add(Service.newService("namespace", "group", "service", true));
+        when(serviceManager.getSingletons(eq("namespace"))).thenReturn(serviceSet);
+        String groupKeyPattern =
+            FuzzyGroupKeyPattern.generatePattern("service*", "group*", "namespace");
+        namingFuzzyWatchContextService.syncFuzzyWatcherContext(groupKeyPattern, "connection");
+        
+        namingFuzzyWatchContextService.makeupMatchedGroupKeys(groupKeyPattern);
+        
+        Assertions.assertEquals(1,
+            namingFuzzyWatchContextService.matchServiceKeys(groupKeyPattern).size());
+    }
+    
+    @Test
+    void testTrimContextWarnsWhenNearLimit() throws NacosException {
+        tMockedStatic.when(() -> GlobalConfig.getMaxPatternCount()).thenReturn(20);
+        tMockedStatic.when(() -> GlobalConfig.getMaxMatchedServiceCount()).thenReturn(10);
+        Set<Service> serviceSet = new HashSet<>();
+        for (int i = 0; i < 8; i++) {
+            serviceSet.add(Service.newService("namespace", "group" + i, "service" + i, true));
+        }
+        when(serviceManager.getSingletons(eq("namespace"))).thenReturn(serviceSet);
+        String groupKeyPattern =
+            FuzzyGroupKeyPattern.generatePattern("service*", "group*", "namespace");
+        namingFuzzyWatchContextService.syncFuzzyWatcherContext(groupKeyPattern, "connection");
+        
+        namingFuzzyWatchContextService.trimFuzzyWatchContext();
+        
+        Assertions.assertEquals(8,
+            namingFuzzyWatchContextService.matchServiceKeys(groupKeyPattern).size());
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/NamingFuzzyWatchContextServiceTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/NamingFuzzyWatchContextServiceTest.java
@@ -39,9 +39,11 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
 
 import static com.alibaba.nacos.api.common.Constants.ServiceChangedType.ADD_SERVICE;
 import static com.alibaba.nacos.api.common.Constants.ServiceChangedType.DELETE_SERVICE;
@@ -316,6 +318,26 @@ public class NamingFuzzyWatchContextServiceTest {
     }
     
     @Test
+    @SuppressWarnings("unchecked")
+    void testTrimContextIgnoresRuntimeException() throws Exception {
+        String groupKeyPattern =
+            FuzzyGroupKeyPattern.generatePattern("service*", "group*", "namespace");
+        ConcurrentMap<String, Set<String>> matchedServiceKeysMap =
+            (ConcurrentMap<String, Set<String>>) getFieldValue("matchedServiceKeysMap");
+        ConcurrentMap<String, Set<String>> watchedClientsMap =
+            (ConcurrentMap<String, Set<String>>) getFieldValue("watchedClientsMap");
+        Set<String> brokenMatchedServiceKeys = Mockito.mock(Set.class);
+        when(brokenMatchedServiceKeys.size()).thenThrow(new RuntimeException("mock error"));
+        Set<String> watchedClients = new HashSet<>();
+        watchedClients.add("connection");
+        matchedServiceKeysMap.put(groupKeyPattern, brokenMatchedServiceKeys);
+        watchedClientsMap.put(groupKeyPattern, watchedClients);
+        
+        Assertions.assertDoesNotThrow(
+            () -> namingFuzzyWatchContextService.trimFuzzyWatchContext());
+    }
+    
+    @Test
     void testMakeupContextOnOverLoad() throws NacosException {
         
         tMockedStatic.when(() -> GlobalConfig.getMaxPatternCount()).thenReturn(20);
@@ -396,5 +418,11 @@ public class NamingFuzzyWatchContextServiceTest {
             namingFuzzyWatchContextService.matchServiceKeys(groupKeyPattern);
         Assertions.assertEquals(0, matchServiceKeys4.size());
         
+    }
+    
+    private Object getFieldValue(String fieldName) throws ReflectiveOperationException {
+        Field field = NamingFuzzyWatchContextService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(namingFuzzyWatchContextService);
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/ServiceStorageTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/index/ServiceStorageTest.java
@@ -18,11 +18,16 @@ package com.alibaba.nacos.naming.core.v2.index;
 
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.naming.core.v2.ServiceManager;
+import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.client.manager.ClientManagerDelegate;
+import com.alibaba.nacos.naming.core.v2.metadata.InstanceMetadata;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
+import com.alibaba.nacos.naming.core.v2.pojo.BatchInstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.misc.SwitchDomain;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -43,6 +49,7 @@ import java.util.concurrent.ConcurrentMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class ServiceStorageTest {
@@ -92,6 +99,11 @@ class ServiceStorageTest {
         infoConcurrentMap.put(SERVICE, serviceInfo);
     }
     
+    @AfterEach
+    void tearDown() {
+        ServiceManager.getInstance().removeSingleton(SERVICE);
+    }
+    
     @Test
     void testGetClusters() {
         Set<String> clusters = serviceStorage.getClusters(SERVICE);
@@ -115,6 +127,38 @@ class ServiceStorageTest {
         
         Mockito.verify(switchDomain).getDefaultPushCacheMillis();
         assertNotNull(pushData);
+    }
+    
+    @Test
+    void testGetPushDataBuildsInstancesFromIndex() {
+        ServiceManager.getInstance().getSingleton(SERVICE);
+        InstancePublishInfo normalInstance = instance("1.1.1.1", 8848, "clusterA");
+        InstancePublishInfo batchInstance = instance("2.2.2.2", 8848, "clusterB");
+        BatchInstancePublishInfo batchInstancePublishInfo = new BatchInstancePublishInfo();
+        batchInstancePublishInfo.setInstancePublishInfos(Collections.singletonList(batchInstance));
+        Client clientA = client(normalInstance);
+        Client clientB = client(batchInstancePublishInfo);
+        Mockito.when(clientServiceIndexesManager.getAllClientsRegisteredService(Mockito.any()))
+            .thenReturn(new HashSet<>(Arrays.asList("clientA", "clientB", "missing")));
+        Mockito.when(clientManagerDelegate.getClient("clientA")).thenReturn(clientA);
+        Mockito.when(clientManagerDelegate.getClient("clientB")).thenReturn(clientB);
+        Mockito.when(clientManagerDelegate.getClient("missing")).thenReturn(null);
+        InstanceMetadata instanceMetadata = new InstanceMetadata();
+        instanceMetadata.setWeight(2.0D);
+        instanceMetadata.setEnabled(false);
+        Mockito.when(namingMetadataManager.getInstanceMetadata(Mockito.any(), Mockito.anyString()))
+            .thenReturn(Optional.empty());
+        Mockito.when(namingMetadataManager.getInstanceMetadata(Mockito.any(),
+            Mockito.eq(normalInstance.getMetadataId()))).thenReturn(Optional.of(instanceMetadata));
+        
+        ServiceInfo pushData = serviceStorage.getPushData(SERVICE);
+        
+        assertEquals(2, pushData.getHosts().size());
+        assertTrue(serviceStorage.getClusters(SERVICE).contains("clusterA"));
+        assertTrue(serviceStorage.getClusters(SERVICE).contains("clusterB"));
+        assertTrue(pushData.getHosts().stream()
+            .anyMatch(instance -> "1.1.1.1".equals(instance.getIp()) && !instance.isEnabled()
+                && instance.getWeight() == 2.0D));
     }
     
     @Test
@@ -177,6 +221,18 @@ class ServiceStorageTest {
         Mockito.verify(namingMetadataManager).getInstanceMetadata(SERVICE,
             instancePublishInfo.getMetadataId());
         assertNotNull(instance);
+    }
+    
+    private Client client(InstancePublishInfo instancePublishInfo) {
+        Client result = Mockito.mock(Client.class);
+        Mockito.when(result.getInstancePublishInfo(Mockito.any())).thenReturn(instancePublishInfo);
+        return result;
+    }
+    
+    private InstancePublishInfo instance(String ip, int port, String cluster) {
+        InstancePublishInfo result = new InstancePublishInfo(ip, port);
+        result.setCluster(cluster);
+        return result;
     }
     
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ClusterMetadataTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ClusterMetadataTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.metadata;
+
+import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Http;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Tcp;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ClusterMetadataTest {
+    
+    @Test
+    void testSetHealthChecker() {
+        ClusterMetadata clusterMetadata = new ClusterMetadata();
+        Http healthChecker = new Http();
+        
+        clusterMetadata.setHealthChecker(healthChecker);
+        
+        assertEquals(Tcp.TYPE, clusterMetadata.getHealthyCheckType());
+        assertSame(healthChecker, clusterMetadata.getHealthChecker());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ExpiredMetadataInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ExpiredMetadataInfoTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.metadata;
+
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExpiredMetadataInfoTest {
+    
+    @Test
+    void testExpiredServiceMetadataInfo() {
+        Service service = Service.newService("namespace", "group", "service");
+        ExpiredMetadataInfo info = ExpiredMetadataInfo.newExpiredServiceMetadata(service);
+        
+        assertEquals(service, info.getService());
+        assertNull(info.getMetadataId());
+        assertTrue(info.getCreateTime() > 0);
+        assertTrue(info.toString().contains("service="));
+    }
+    
+    @Test
+    void testEqualsAndHashCode() {
+        Service service = Service.newService("namespace", "group", "service");
+        ExpiredMetadataInfo instanceInfo =
+            ExpiredMetadataInfo.newExpiredInstanceMetadata(service, "1.1.1.1:8848");
+        ExpiredMetadataInfo same =
+            ExpiredMetadataInfo.newExpiredInstanceMetadata(service, "1.1.1.1:8848");
+        ExpiredMetadataInfo different =
+            ExpiredMetadataInfo.newExpiredInstanceMetadata(service, "1.1.1.2:8848");
+        
+        assertEquals("1.1.1.1:8848", instanceInfo.getMetadataId());
+        assertEquals(instanceInfo, instanceInfo);
+        assertEquals(instanceInfo, same);
+        assertEquals(instanceInfo.hashCode(), same.hashCode());
+        assertNotEquals(instanceInfo, different);
+        assertNotEquals(instanceInfo, new Object());
+        assertFalse(instanceInfo.equals(null));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/InstanceMetadataProcessorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/InstanceMetadataProcessorTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.metadata;
+
+import com.alibaba.nacos.consistency.DataOperation;
+import com.alibaba.nacos.consistency.SerializeFactory;
+import com.alibaba.nacos.consistency.Serializer;
+import com.alibaba.nacos.consistency.cp.CPProtocol;
+import com.alibaba.nacos.consistency.cp.RequestProcessor4CP;
+import com.alibaba.nacos.consistency.entity.ReadRequest;
+import com.alibaba.nacos.consistency.entity.Response;
+import com.alibaba.nacos.consistency.entity.WriteRequest;
+import com.alibaba.nacos.consistency.snapshot.SnapshotOperation;
+import com.alibaba.nacos.core.distributed.ProtocolManager;
+import com.alibaba.nacos.naming.constants.Constants;
+import com.alibaba.nacos.naming.core.v2.ServiceManager;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceMetadataProcessorTest {
+    
+    private static final String NAMESPACE = "namespace";
+    
+    private static final String GROUP = "group";
+    
+    private static final String SERVICE_NAME = "service";
+    
+    private static final String INSTANCE_TAG = "1.1.1.1:8848:DEFAULT";
+    
+    private static final Service SERVICE = Service.newService(NAMESPACE, GROUP, SERVICE_NAME);
+    
+    @Mock
+    private NamingMetadataManager namingMetadataManager;
+    
+    @Mock
+    private ProtocolManager protocolManager;
+    
+    @Mock
+    private CPProtocol cpProtocol;
+    
+    private InstanceMetadataProcessor instanceMetadataProcessor;
+    
+    private final Serializer serializer = SerializeFactory.getDefault();
+    
+    @BeforeEach
+    void setUp() {
+        Mockito.when(protocolManager.getCpProtocol()).thenReturn(cpProtocol);
+        
+        instanceMetadataProcessor =
+            new InstanceMetadataProcessor(namingMetadataManager, protocolManager);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        ServiceManager.getInstance().removeSingleton(SERVICE);
+    }
+    
+    @Test
+    void testConstructorRegistersProcessor() {
+        ArgumentCaptor<Collection<RequestProcessor4CP>> captor =
+            ArgumentCaptor.forClass(Collection.class);
+        
+        verify(cpProtocol).addRequestProcessors(captor.capture());
+        Collection<RequestProcessor4CP> processors = captor.getValue();
+        
+        assertEquals(1, processors.size());
+        assertSame(instanceMetadataProcessor, processors.iterator().next());
+    }
+    
+    @Test
+    void testLoadSnapshotOperate() {
+        List<SnapshotOperation> snapshotOperations =
+            instanceMetadataProcessor.loadSnapshotOperate();
+        
+        assertNotNull(snapshotOperations);
+        assertEquals(1, snapshotOperations.size());
+    }
+    
+    @Test
+    void testOnRequest() {
+        Response response = instanceMetadataProcessor.onRequest(ReadRequest.getDefaultInstance());
+        
+        assertNull(response);
+    }
+    
+    @Test
+    void testOnApplyAddAndChangeUpdatesInstanceMetadata() {
+        MetadataOperation<InstanceMetadata> metadataOperation = buildMetadataOperation();
+        
+        Response addResponse =
+            instanceMetadataProcessor
+                .onApply(buildWriteRequest(DataOperation.ADD, metadataOperation));
+        Response changeResponse =
+            instanceMetadataProcessor
+                .onApply(buildWriteRequest(DataOperation.CHANGE, metadataOperation));
+        
+        Service singleton = ServiceManager.getInstance().getSingleton(SERVICE);
+        assertTrue(addResponse.getSuccess());
+        assertTrue(changeResponse.getSuccess());
+        verify(namingMetadataManager, times(2))
+            .updateInstanceMetadata(Mockito.eq(singleton), Mockito.eq(INSTANCE_TAG),
+                Mockito.any(InstanceMetadata.class));
+    }
+    
+    @Test
+    void testOnApplyDeleteRemovesInstanceMetadata() {
+        MetadataOperation<InstanceMetadata> metadataOperation = buildMetadataOperation();
+        
+        Response response =
+            instanceMetadataProcessor
+                .onApply(buildWriteRequest(DataOperation.DELETE, metadataOperation));
+        
+        Service singleton = ServiceManager.getInstance().getSingleton(SERVICE);
+        assertTrue(response.getSuccess());
+        verify(namingMetadataManager).removeInstanceMetadata(singleton, INSTANCE_TAG);
+    }
+    
+    @Test
+    void testOnApplyUnsupportedOperationReturnsFailedResponse() {
+        Response response =
+            instanceMetadataProcessor
+                .onApply(buildWriteRequest(DataOperation.VERIFY, buildMetadataOperation()));
+        
+        assertFalse(response.getSuccess());
+        assertEquals("Unsupported operation VERIFY", response.getErrMsg());
+    }
+    
+    @Test
+    void testOnApplyDeserializeFailureReturnsFailedResponse() {
+        WriteRequest request = WriteRequest.newBuilder()
+            .setOperation(DataOperation.ADD.name()).setData(ByteString.copyFromUtf8("invalid"))
+            .build();
+        
+        Response response = instanceMetadataProcessor.onApply(request);
+        
+        assertFalse(response.getSuccess());
+        assertNotNull(response.getErrMsg());
+    }
+    
+    @Test
+    void testGroup() {
+        String group = instanceMetadataProcessor.group();
+        
+        assertEquals(Constants.INSTANCE_METADATA, group);
+    }
+    
+    private MetadataOperation<InstanceMetadata> buildMetadataOperation() {
+        MetadataOperation<InstanceMetadata> result = new MetadataOperation<>();
+        result.setNamespace(NAMESPACE);
+        result.setGroup(GROUP);
+        result.setServiceName(SERVICE_NAME);
+        result.setTag(INSTANCE_TAG);
+        result.setMetadata(new InstanceMetadata());
+        return result;
+    }
+    
+    private WriteRequest buildWriteRequest(DataOperation operation,
+        MetadataOperation<InstanceMetadata> metadataOperation) {
+        return WriteRequest.newBuilder().setOperation(operation.name())
+            .setData(ByteString.copyFrom(serializer.serialize(metadataOperation))).build();
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/InstanceMetadataSnapshotOperationTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/InstanceMetadataSnapshotOperationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.metadata;
+
+import com.alibaba.nacos.consistency.SerializeFactory;
+import com.alibaba.nacos.consistency.Serializer;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceMetadataSnapshotOperationTest {
+    
+    private static final Service SERVICE = Service.newService("namespace", "group", "name");
+    
+    @Mock
+    private NamingMetadataManager namingMetadataManager;
+    
+    private InstanceMetadataSnapshotOperation snapshotOperation;
+    
+    @BeforeEach
+    void setUp() {
+        Map<Service, ConcurrentMap<String, InstanceMetadata>> snapshot =
+            new ConcurrentHashMap<>();
+        ConcurrentMap<String, InstanceMetadata> instanceMetadata = new ConcurrentHashMap<>();
+        instanceMetadata.put("1.1.1.1:8848", new InstanceMetadata());
+        snapshot.put(SERVICE, instanceMetadata);
+        Mockito.lenient().when(namingMetadataManager.getInstanceMetadataSnapshot())
+            .thenReturn(snapshot);
+        snapshotOperation =
+            new InstanceMetadataSnapshotOperation(namingMetadataManager,
+                new ReentrantReadWriteLock());
+    }
+    
+    @Test
+    void testDumpSnapshot() {
+        InputStream inputStream = snapshotOperation.dumpSnapshot();
+        
+        assertNotNull(inputStream);
+    }
+    
+    @Test
+    void testLoadSnapshot() {
+        ConcurrentMap<Service, ConcurrentMap<String, InstanceMetadata>> snapshot =
+            new ConcurrentHashMap<>();
+        ConcurrentMap<String, InstanceMetadata> instanceMetadata = new ConcurrentHashMap<>();
+        instanceMetadata.put("1.1.1.1:8848", new InstanceMetadata());
+        snapshot.put(SERVICE, instanceMetadata);
+        Serializer serializer = SerializeFactory.getDefault();
+        
+        snapshotOperation.loadSnapshot(serializer.serialize(snapshot));
+        
+        Mockito.verify(namingMetadataManager)
+            .loadInstanceMetadataSnapshot(Mockito.any(ConcurrentMap.class));
+    }
+    
+    @Test
+    void testGetSnapshotArchive() {
+        assertEquals("instance_metadata.zip", snapshotOperation.getSnapshotArchive());
+    }
+    
+    @Test
+    void testGetSnapshotSaveTag() {
+        assertEquals(InstanceMetadataSnapshotOperation.class.getSimpleName() + ".SAVE",
+            snapshotOperation.getSnapshotSaveTag());
+    }
+    
+    @Test
+    void testGetSnapshotLoadTag() {
+        assertEquals(InstanceMetadataSnapshotOperation.class.getSimpleName() + ".LOAD",
+            snapshotOperation.getSnapshotLoadTag());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataManagerTest.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.common.notify.Event;
 import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.event.client.ClientEvent;
 import com.alibaba.nacos.naming.core.v2.event.metadata.MetadataEvent;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -126,6 +128,14 @@ class NamingMetadataManagerTest {
     }
     
     @Test
+    void testGetInstanceMetadataWhenServiceMissing() {
+        Optional<InstanceMetadata> instanceMetadata =
+            namingMetadataManager.getInstanceMetadata(Mockito.mock(Service.class), METADATA_ID);
+        
+        assertFalse(instanceMetadata.isPresent());
+    }
+    
+    @Test
     void testUpdateServiceMetadata() throws NoSuchFieldException, IllegalAccessException {
         
         ServiceMetadata serviceMetadata = new ServiceMetadata();
@@ -160,6 +170,20 @@ class NamingMetadataManagerTest {
     }
     
     @Test
+    void testUpdateInstanceMetadataWhenServiceMissing() {
+        Service newService = Mockito.mock(Service.class);
+        InstanceMetadata newInstanceMetadata = new InstanceMetadata();
+        
+        namingMetadataManager.updateInstanceMetadata(newService, "newMetadataId",
+            newInstanceMetadata);
+        
+        Optional<InstanceMetadata> optional =
+            namingMetadataManager.getInstanceMetadata(newService, "newMetadataId");
+        assertTrue(optional.isPresent());
+        assertEquals(newInstanceMetadata, optional.get());
+    }
+    
+    @Test
     void testRemoveServiceMetadata() {
         
         namingMetadataManager.removeServiceMetadata(service);
@@ -187,6 +211,15 @@ class NamingMetadataManagerTest {
     }
     
     @Test
+    void testRemoveInstanceMetadataWhenServiceMissing() {
+        Service missingService = Mockito.mock(Service.class);
+        
+        namingMetadataManager.removeInstanceMetadata(missingService, METADATA_ID);
+        
+        assertEquals(1, namingMetadataManager.getInstanceMetadataSnapshot().size());
+    }
+    
+    @Test
     void testGetServiceMetadataSnapshot() {
         Map<Service, ServiceMetadata> serviceMetadataSnapshot =
             namingMetadataManager.getServiceMetadataSnapshot();
@@ -209,6 +242,19 @@ class NamingMetadataManagerTest {
             namingMetadataManager.getServiceMetadataSnapshot();
         
         assertEquals(0, serviceMetadataSnapshot.size());
+    }
+    
+    @Test
+    void testLoadServiceMetadataSnapshotWithService() {
+        ConcurrentMap<Service, ServiceMetadata> snapshot = new ConcurrentHashMap<>();
+        Service snapshotService = Service.newService("namespace", "group", "name", true);
+        ServiceMetadata snapshotMetadata = new ServiceMetadata();
+        snapshot.put(snapshotService, snapshotMetadata);
+        
+        namingMetadataManager.loadServiceMetadataSnapshot(snapshot);
+        
+        assertEquals(snapshotMetadata,
+            namingMetadataManager.getServiceMetadata(snapshotService).orElse(null));
     }
     
     @Test
@@ -251,5 +297,19 @@ class NamingMetadataManagerTest {
         
         namingMetadataManager.onEvent(clientDisconnectEvent);
         Mockito.verify(clientDisconnectEvent).getClient();
+    }
+    
+    @Test
+    void testOnClientDisconnectEventWithPublishedService() {
+        Mockito.when(clientDisconnectEvent.getClient()).thenReturn(client);
+        Mockito.when(client.getAllPublishedService())
+            .thenReturn(Collections.singletonList(service));
+        InstancePublishInfo publishInfo = Mockito.mock(InstancePublishInfo.class);
+        Mockito.when(publishInfo.getMetadataId()).thenReturn(METADATA_ID);
+        Mockito.when(client.getInstancePublishInfo(service)).thenReturn(publishInfo);
+        
+        namingMetadataManager.onEvent(clientDisconnectEvent);
+        
+        assertEquals(1, namingMetadataManager.getExpiredMetadataInfos().size());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataOperateServiceTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/NamingMetadataOperateServiceTest.java
@@ -17,17 +17,30 @@
 package com.alibaba.nacos.naming.core.v2.metadata;
 
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.consistency.DataOperation;
 import com.alibaba.nacos.consistency.cp.CPProtocol;
+import com.alibaba.nacos.consistency.entity.Response;
+import com.alibaba.nacos.consistency.entity.WriteRequest;
 import com.alibaba.nacos.core.distributed.ProtocolManager;
+import com.alibaba.nacos.naming.constants.Constants;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class NamingMetadataOperateServiceTest {
@@ -110,5 +123,51 @@ class NamingMetadataOperateServiceTest {
             Mockito.verify(service).getGroup();
             Mockito.verify(service).getName();
         });
+    }
+    
+    @Test
+    void testSubmitMetadataOperationsSuccessfully() throws Exception {
+        Mockito.when(cpProtocol.write(any(WriteRequest.class)))
+            .thenReturn(Response.newBuilder().setSuccess(true).build());
+        Service realService = Service.newService("namespace", "group", "service", false);
+        
+        namingMetadataOperateService.updateServiceMetadata(realService, new ServiceMetadata());
+        namingMetadataOperateService.deleteServiceMetadata(realService);
+        namingMetadataOperateService.updateInstanceMetadata(realService, "metadataId",
+            new InstanceMetadata());
+        namingMetadataOperateService.deleteInstanceMetadata(realService, "metadataId");
+        namingMetadataOperateService.addClusterMetadata(realService, "cluster",
+            new ClusterMetadata());
+        
+        ArgumentCaptor<WriteRequest> requestCaptor = ArgumentCaptor.forClass(WriteRequest.class);
+        verify(cpProtocol, times(5)).write(requestCaptor.capture());
+        List<WriteRequest> requests = requestCaptor.getAllValues();
+        assertEquals(
+            Arrays.asList(Constants.SERVICE_METADATA, Constants.SERVICE_METADATA,
+                Constants.INSTANCE_METADATA, Constants.INSTANCE_METADATA,
+                Constants.SERVICE_METADATA),
+            Arrays.asList(requests.get(0).getGroup(), requests.get(1).getGroup(),
+                requests.get(2).getGroup(), requests.get(3).getGroup(),
+                requests.get(4).getGroup()));
+        assertEquals(
+            Arrays.asList(DataOperation.CHANGE.name(), DataOperation.DELETE.name(),
+                DataOperation.CHANGE.name(), DataOperation.DELETE.name(),
+                DataOperation.ADD.name()),
+            Arrays.asList(requests.get(0).getOperation(), requests.get(1).getOperation(),
+                requests.get(2).getOperation(), requests.get(3).getOperation(),
+                requests.get(4).getOperation()));
+    }
+    
+    @Test
+    void testSubmitMetadataOperationWithFailedResponse() throws Exception {
+        Mockito.when(cpProtocol.write(any(WriteRequest.class)))
+            .thenReturn(Response.newBuilder().setSuccess(false).setErrMsg("raft failed").build());
+        Service realService = Service.newService("namespace", "group", "service");
+        
+        NacosRuntimeException actual = assertThrows(NacosRuntimeException.class,
+            () -> namingMetadataOperateService.updateServiceMetadata(realService,
+                new ServiceMetadata()));
+        
+        assertTrue(actual.getMessage().contains("do metadata operation failed"));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ServiceMetadataProcessorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ServiceMetadataProcessorTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.naming.core.v2.metadata;
 
 import com.alibaba.nacos.consistency.SerializeFactory;
 import com.alibaba.nacos.consistency.Serializer;
+import com.alibaba.nacos.consistency.DataOperation;
 import com.alibaba.nacos.consistency.cp.CPProtocol;
 import com.alibaba.nacos.consistency.entity.ReadRequest;
 import com.alibaba.nacos.consistency.entity.Response;
@@ -30,27 +31,42 @@ import com.alibaba.nacos.naming.core.v2.index.ServiceStorage;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
 import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ServiceMetadataProcessorTest {
+    
+    private static final String NAMESPACE = "namespace";
+    
+    private static final String GROUP = "group";
+    
+    private static final String SERVICE_NAME = "nacos";
+    
+    private static final Service SERVICE = Service.newService(NAMESPACE, GROUP, SERVICE_NAME);
     
     @Mock
     private NamingMetadataManager namingMetadataManager;
@@ -69,6 +85,8 @@ class ServiceMetadataProcessorTest {
     
     private ServiceMetadataProcessor serviceMetadataProcessor;
     
+    private final Serializer serializer = SerializeFactory.getDefault();
+    
     @BeforeEach
     void setUp() throws Exception {
         Mockito.when(protocolManager.getCpProtocol()).thenReturn(cpProtocol);
@@ -76,6 +94,11 @@ class ServiceMetadataProcessorTest {
         
         serviceMetadataProcessor =
             new ServiceMetadataProcessor(namingMetadataManager, protocolManager, serviceStorage);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        ServiceManager.getInstance().removeSingleton(SERVICE);
     }
     
     @Test
@@ -151,9 +174,99 @@ class ServiceMetadataProcessorTest {
     }
     
     @Test
+    void testOnApplyAddMergesClusterIntoExistingMetadata() {
+        ServiceMetadata currentMetadata = new ServiceMetadata();
+        ClusterMetadata currentClusterMetadata = new ClusterMetadata();
+        currentMetadata.getClusters().put("old", currentClusterMetadata);
+        ClusterMetadata newClusterMetadata = new ClusterMetadata();
+        newClusterMetadata.setHealthyCheckPort(8080);
+        ServiceMetadata addedMetadata = new ServiceMetadata();
+        addedMetadata.getClusters().put("new", newClusterMetadata);
+        Mockito.when(namingMetadataManager.getServiceMetadata(SERVICE))
+            .thenReturn(Optional.of(currentMetadata));
+        
+        Response response = serviceMetadataProcessor.onApply(
+            buildWriteRequest(DataOperation.ADD, buildMetadataOperation(addedMetadata)));
+        
+        assertTrue(response.getSuccess());
+        assertSame(currentClusterMetadata, currentMetadata.getClusters().get("old"));
+        assertEquals(8080, currentMetadata.getClusters().get("new").getHealthyCheckPort());
+        verify(namingMetadataManager, never()).updateServiceMetadata(any(Service.class),
+            any(ServiceMetadata.class));
+    }
+    
+    @Test
+    void testOnApplyChangeMergesExistingMetadata() {
+        ServiceMetadata currentMetadata = new ServiceMetadata();
+        currentMetadata.setEphemeral(false);
+        ClusterMetadata currentClusterMetadata = new ClusterMetadata();
+        currentMetadata.getClusters().put("old", currentClusterMetadata);
+        ServiceMetadata changedMetadata = new ServiceMetadata();
+        changedMetadata.setEphemeral(true);
+        changedMetadata.setProtectThreshold(0.7F);
+        changedMetadata.setExtendData(Collections.singletonMap("k", "v"));
+        Mockito.when(namingMetadataManager.getServiceMetadata(SERVICE))
+            .thenReturn(Optional.of(currentMetadata));
+        
+        Response response = serviceMetadataProcessor.onApply(
+            buildWriteRequest(DataOperation.CHANGE, buildMetadataOperation(changedMetadata)));
+        
+        ArgumentCaptor<ServiceMetadata> metadataCaptor =
+            ArgumentCaptor.forClass(ServiceMetadata.class);
+        assertTrue(response.getSuccess());
+        verify(namingMetadataManager).updateServiceMetadata(any(Service.class),
+            metadataCaptor.capture());
+        ServiceMetadata mergedMetadata = metadataCaptor.getValue();
+        assertFalse(mergedMetadata.isEphemeral());
+        assertEquals(0.7F, mergedMetadata.getProtectThreshold());
+        assertEquals(Collections.singletonMap("k", "v"), mergedMetadata.getExtendData());
+        assertSame(currentClusterMetadata, mergedMetadata.getClusters().get("old"));
+    }
+    
+    @Test
+    void testOnApplyDeleteWithoutSingletonRemovesRequestedService() {
+        MetadataOperation<ServiceMetadata> metadataOperation =
+            buildMetadataOperation(new ServiceMetadata());
+        
+        Response response = serviceMetadataProcessor.onApply(
+            buildWriteRequest(DataOperation.DELETE, metadataOperation));
+        
+        assertTrue(response.getSuccess());
+        verify(namingMetadataManager).removeServiceMetadata(SERVICE);
+        verify(serviceStorage).removeData(SERVICE);
+    }
+    
+    @Test
+    void testOnApplyDeserializeFailureReturnsFailedResponse() {
+        WriteRequest request = WriteRequest.newBuilder().setOperation(DataOperation.ADD.name())
+            .setData(ByteString.copyFromUtf8("invalid")).build();
+        
+        Response response = serviceMetadataProcessor.onApply(request);
+        
+        assertFalse(response.getSuccess());
+        assertNotNull(response.getErrMsg());
+    }
+    
+    @Test
     void testGroup() {
         String group = serviceMetadataProcessor.group();
         
         assertEquals(Constants.SERVICE_METADATA, group);
+    }
+    
+    private MetadataOperation<ServiceMetadata> buildMetadataOperation(
+        ServiceMetadata serviceMetadata) {
+        MetadataOperation<ServiceMetadata> result = new MetadataOperation<>();
+        result.setMetadata(serviceMetadata);
+        result.setServiceName(SERVICE_NAME);
+        result.setNamespace(NAMESPACE);
+        result.setGroup(GROUP);
+        return result;
+    }
+    
+    private WriteRequest buildWriteRequest(DataOperation operation,
+        MetadataOperation<ServiceMetadata> metadataOperation) {
+        return WriteRequest.newBuilder().setOperation(operation.name())
+            .setData(ByteString.copyFrom(serializer.serialize(metadataOperation))).build();
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ServiceMetadataSnapshotOperationTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ServiceMetadataSnapshotOperationTest.java
@@ -18,10 +18,15 @@ package com.alibaba.nacos.naming.core.v2.metadata;
 
 import com.alibaba.nacos.consistency.SerializeFactory;
 import com.alibaba.nacos.consistency.Serializer;
+import com.alibaba.nacos.consistency.snapshot.LocalFileMeta;
+import com.alibaba.nacos.consistency.snapshot.Reader;
+import com.alibaba.nacos.consistency.snapshot.Writer;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -29,7 +34,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.io.InputStream;
-import java.util.HashMap;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -37,6 +43,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 // todo remove this
@@ -50,7 +58,7 @@ class ServiceMetadataSnapshotOperationTest {
     
     @BeforeEach
     void setUp() throws Exception {
-        Map<Service, ServiceMetadata> map = new HashMap<>();
+        Map<Service, ServiceMetadata> map = new ConcurrentHashMap<>();
         map.put(Service.newService("namespace", "group", "name"), new ServiceMetadata());
         Mockito.when(namingMetadataManager.getServiceMetadataSnapshot()).thenReturn(map);
         serviceMetadataSnapshotOperation = new ServiceMetadataSnapshotOperation(
@@ -100,5 +108,65 @@ class ServiceMetadataSnapshotOperationTest {
         
         assertEquals(snapshotLoadTag,
             ServiceMetadataSnapshotOperation.class.getSimpleName() + ".LOAD");
+    }
+    
+    @Test
+    void testWriteSnapshotAddsArchiveWithChecksum(@TempDir Path tempDir) throws Exception {
+        Writer writer = mockSnapshotWriter(tempDir);
+        ArgumentCaptor<LocalFileMeta> metaCaptor = ArgumentCaptor.forClass(LocalFileMeta.class);
+        Mockito.when(writer.addFile(Mockito.eq("service_metadata.zip"), metaCaptor.capture()))
+            .thenReturn(true);
+        
+        boolean result = serviceMetadataSnapshotOperation.writeSnapshot(writer);
+        
+        assertTrue(result);
+        assertTrue(Files.exists(tempDir.resolve("service_metadata.zip")));
+        assertNotNull(metaCaptor.getValue().get("checksum"));
+    }
+    
+    @Test
+    void testReadSnapshotLoadsArchiveWhenChecksumMatches(@TempDir Path tempDir) throws Exception {
+        LocalFileMeta meta = writeSnapshot(tempDir);
+        Reader reader = mockSnapshotReader(tempDir, meta);
+        
+        boolean result = serviceMetadataSnapshotOperation.readSnapshot(reader);
+        
+        assertTrue(result);
+        Mockito.verify(namingMetadataManager)
+            .loadServiceMetadataSnapshot(Mockito.any(ConcurrentMap.class));
+    }
+    
+    @Test
+    void testReadSnapshotThrowsWhenChecksumMismatch(@TempDir Path tempDir) throws Exception {
+        writeSnapshot(tempDir);
+        LocalFileMeta wrongMeta = new LocalFileMeta();
+        wrongMeta.append("checksum", "wrong");
+        Reader reader = mockSnapshotReader(tempDir, wrongMeta);
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> serviceMetadataSnapshotOperation.readSnapshot(reader));
+    }
+    
+    private LocalFileMeta writeSnapshot(Path tempDir) throws Exception {
+        Writer writer = mockSnapshotWriter(tempDir);
+        ArgumentCaptor<LocalFileMeta> metaCaptor = ArgumentCaptor.forClass(LocalFileMeta.class);
+        Mockito.when(writer.addFile(Mockito.eq("service_metadata.zip"), metaCaptor.capture()))
+            .thenReturn(true);
+        
+        serviceMetadataSnapshotOperation.writeSnapshot(writer);
+        return metaCaptor.getValue();
+    }
+    
+    private Writer mockSnapshotWriter(Path tempDir) {
+        Writer result = Mockito.mock(Writer.class);
+        Mockito.when(result.getPath()).thenReturn(tempDir.toString());
+        return result;
+    }
+    
+    private Reader mockSnapshotReader(Path tempDir, LocalFileMeta meta) {
+        Reader result = Mockito.mock(Reader.class);
+        Mockito.when(result.getPath()).thenReturn(tempDir.toString());
+        Mockito.when(result.getFileMeta("service_metadata.zip")).thenReturn(meta);
+        return result;
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ServiceMetadataTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/metadata/ServiceMetadataTest.java
@@ -134,4 +134,37 @@ class ServiceMetadataTest {
         boolean equals = serviceMetadata1.equals(serviceMetadata2);
         assertFalse(equals);
     }
+    
+    @Test
+    void testEqualsSameObject() {
+        assertTrue(serviceMetadata.equals(serviceMetadata));
+    }
+    
+    @Test
+    void testEqualsWithDifferentType() {
+        assertFalse(serviceMetadata.equals("metadata"));
+    }
+    
+    @Test
+    void testEqualsAndHashCodeWithSameState() {
+        ServiceMetadata serviceMetadata1 = new ServiceMetadata();
+        ServiceMetadata serviceMetadata2 = new ServiceMetadata();
+        Selector selector = new NoneSelector();
+        Map<String, String> extendData = new HashMap<>();
+        extendData.put("k", "v");
+        Map<String, ClusterMetadata> clusters = new HashMap<>();
+        clusters.put("DEFAULT", clusterMetadata);
+        
+        serviceMetadata1.setSelector(selector);
+        serviceMetadata1.setProtectThreshold(1.0F);
+        serviceMetadata1.setExtendData(extendData);
+        serviceMetadata1.setClusters(clusters);
+        serviceMetadata2.setSelector(selector);
+        serviceMetadata2.setProtectThreshold(1.0F);
+        serviceMetadata2.setExtendData(new HashMap<>(extendData));
+        serviceMetadata2.setClusters(new HashMap<>(clusters));
+        
+        assertTrue(serviceMetadata1.equals(serviceMetadata2));
+        assertEquals(serviceMetadata1.hashCode(), serviceMetadata2.hashCode());
+    }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/BatchInstanceDataTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/BatchInstanceDataTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.pojo;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class BatchInstanceDataTest {
+    
+    @Test
+    void testConstructWithArguments() {
+        List<String> namespaces = Collections.singletonList("namespace");
+        List<String> groupNames = Collections.singletonList("group");
+        List<String> serviceNames = Collections.singletonList("service");
+        List<BatchInstancePublishInfo> batchInfos =
+            Collections.singletonList(new BatchInstancePublishInfo());
+        
+        BatchInstanceData data =
+            new BatchInstanceData(namespaces, groupNames, serviceNames, batchInfos);
+        
+        assertSame(namespaces, data.getNamespaces());
+        assertSame(groupNames, data.getGroupNames());
+        assertSame(serviceNames, data.getServiceNames());
+        assertSame(batchInfos, data.getBatchInstancePublishInfos());
+    }
+    
+    @Test
+    void testSettersAndGetters() {
+        BatchInstanceData data = new BatchInstanceData();
+        List<String> namespaces = Collections.singletonList("namespace");
+        List<String> groupNames = Collections.singletonList("group");
+        List<String> serviceNames = Collections.singletonList("service");
+        List<BatchInstancePublishInfo> batchInfos =
+            Collections.singletonList(new BatchInstancePublishInfo());
+        
+        data.setNamespaces(namespaces);
+        data.setGroupNames(groupNames);
+        data.setServiceNames(serviceNames);
+        data.setBatchInstancePublishInfos(batchInfos);
+        
+        assertEquals(namespaces, data.getNamespaces());
+        assertEquals(groupNames, data.getGroupNames());
+        assertEquals(serviceNames, data.getServiceNames());
+        assertEquals(batchInfos, data.getBatchInstancePublishInfos());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/BatchInstancePublishInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/BatchInstancePublishInfoTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.pojo;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BatchInstancePublishInfoTest {
+    
+    @Test
+    void testEqualsAndHashCode() {
+        InstancePublishInfo instance = new InstancePublishInfo("1.1.1.1", 8848);
+        BatchInstancePublishInfo first = new BatchInstancePublishInfo();
+        first.setInstancePublishInfos(Collections.singletonList(instance));
+        BatchInstancePublishInfo second = new BatchInstancePublishInfo();
+        second.setInstancePublishInfos(Collections.singletonList(instance));
+        
+        assertEquals(first, first);
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/HealthCheckInstancePublishInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/HealthCheckInstancePublishInfoTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.pojo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HealthCheckInstancePublishInfoTest {
+    
+    @Test
+    void testHealthCheckStateAndCounters() {
+        HealthCheckInstancePublishInfo instance = new HealthCheckInstancePublishInfo("1.1.1.1",
+            8848);
+        instance.setLastHeartBeatTime(123L);
+        instance.initHealthCheck();
+        
+        assertEquals(123L, instance.getLastHeartBeatTime());
+        assertTrue(instance.tryStartCheck());
+        assertFalse(instance.tryStartCheck());
+        instance.finishCheck();
+        assertTrue(instance.tryStartCheck());
+        instance.getOkCount().set(3);
+        instance.getFailCount().set(5);
+        instance.resetOkCount();
+        instance.resetFailCount();
+        instance.setCheckRt(100L);
+        
+        assertEquals(0, instance.getOkCount().get());
+        assertEquals(0, instance.getFailCount().get());
+        Object healthCheckStatus = ReflectionTestUtils.getField(instance, "healthCheckStatus");
+        assertEquals(100L, ReflectionTestUtils.getField(healthCheckStatus, "checkRt"));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/InstancePublishInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/InstancePublishInfoTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.pojo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InstancePublishInfoTest {
+    
+    @Test
+    void testMetadataIdAndEqualsOtherType() {
+        InstancePublishInfo instancePublishInfo = new InstancePublishInfo("1.1.1.1", 8848);
+        instancePublishInfo.setCluster("cluster");
+        
+        assertEquals("1.1.1.1:8848:cluster", instancePublishInfo.getMetadataId());
+        assertTrue(instancePublishInfo.equals(instancePublishInfo));
+        assertFalse(instancePublishInfo.equals("other"));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/ServiceTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/pojo/ServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.pojo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceTest {
+    
+    @Test
+    void testAccessorsAndRevision() {
+        Service service = Service.newService("namespace", "group", "name", false);
+        
+        assertEquals("namespace", service.getNamespace());
+        assertEquals("group", service.getGroup());
+        assertEquals("name", service.getName());
+        assertFalse(service.isEphemeral());
+        assertEquals(0L, service.getRevision());
+        service.incrementRevision();
+        assertEquals(1L, service.getRevision());
+    }
+    
+    @Test
+    void testGroupedNames() {
+        Service service = Service.newService("namespace", "group", "name");
+        
+        assertEquals("group@@name", service.getGroupedServiceName());
+        assertEquals("namespace@@group@@name", service.getNameSpaceGroupedServiceName());
+    }
+    
+    @Test
+    void testEquals() {
+        Service service = Service.newService("namespace", "group", "name");
+        
+        assertTrue(service.equals(Service.newService("namespace", "group", "name", false)));
+        assertFalse(service.equals("service"));
+        assertFalse(service.equals(Service.newService("namespace", "group", "other")));
+    }
+    
+    @Test
+    void testHashCodeAndToString() {
+        Service service = Service.newService("namespace", "group", "name");
+        
+        assertEquals(Service.newService("namespace", "group", "name").hashCode(),
+            service.hashCode());
+        assertTrue(service.toString().contains("namespace='namespace'"));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationServiceProxyTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationServiceProxyTest.java
@@ -31,6 +31,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.Collections;
+
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -116,6 +118,28 @@ class ClientOperationServiceProxyTest {
             persistentIpPortId);
         verify(ephemeralClientOperationServiceImpl, never()).deregisterInstance(service,
             persistentInstance, persistentIpPortId);
+    }
+    
+    @Test
+    void testBatchRegisterEphemeralInstance() {
+        clientOperationServiceProxy.batchRegisterInstance(service,
+            Collections.singletonList(ephemeralInstance), ephemeralIpPortId);
+        
+        verify(ephemeralClientOperationServiceImpl).batchRegisterInstance(service,
+            Collections.singletonList(ephemeralInstance), ephemeralIpPortId);
+        verify(persistentClientOperationServiceImpl, never()).batchRegisterInstance(service,
+            Collections.singletonList(ephemeralInstance), ephemeralIpPortId);
+    }
+    
+    @Test
+    void testBatchRegisterPersistentInstance() {
+        clientOperationServiceProxy.batchRegisterInstance(service,
+            Collections.singletonList(persistentInstance), persistentIpPortId);
+        
+        verify(persistentClientOperationServiceImpl).batchRegisterInstance(service,
+            Collections.singletonList(persistentInstance), persistentIpPortId);
+        verify(ephemeralClientOperationServiceImpl, never()).batchRegisterInstance(service,
+            Collections.singletonList(persistentInstance), persistentIpPortId);
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/impl/EphemeralClientOperationServiceImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/impl/EphemeralClientOperationServiceImplTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.naming.core.v2.service.impl;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.naming.core.v2.ServiceManager;
 import com.alibaba.nacos.naming.core.v2.client.Client;
 import com.alibaba.nacos.naming.core.v2.client.impl.ConnectionBasedClient;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
@@ -150,6 +151,32 @@ class EphemeralClientOperationServiceImplTest {
         ephemeralClientOperationServiceImpl.batchRegisterInstance(service, instances,
             connectionBasedClientId);
         assertTrue(connectionBasedClient.getAllPublishedService().contains(service));
+    }
+    
+    @Test
+    void testBatchRegisterPersistentInstance() {
+        Service persistentService = Service.newService("public", "G", "persistent", false);
+        assertThrows(NacosRuntimeException.class,
+            () -> ephemeralClientOperationServiceImpl.batchRegisterInstance(persistentService,
+                new ArrayList<>(), ipPortBasedClientId));
+    }
+    
+    @Test
+    void testDeregisterNonExistService() {
+        Service nonExistService = Service.newService("public", "G", "nonExist");
+        ephemeralClientOperationServiceImpl.deregisterInstance(nonExistService, instance,
+            ipPortBasedClientId);
+        assertFalse(ipPortBasedClient.getAllPublishedService().contains(nonExistService));
+    }
+    
+    @Test
+    void testDeregisterWithoutPublishedInstance() {
+        Service singleton =
+            ServiceManager.getInstance().getSingleton(Service.newService("public", "G",
+                "emptyPublished"));
+        ephemeralClientOperationServiceImpl.deregisterInstance(singleton, instance,
+            ipPortBasedClientId);
+        assertFalse(ipPortBasedClient.getAllPublishedService().contains(singleton));
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/impl/PersistentClientOperationServiceImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/impl/PersistentClientOperationServiceImplTest.java
@@ -30,6 +30,7 @@ import com.alibaba.nacos.consistency.snapshot.Writer;
 import com.alibaba.nacos.core.distributed.ProtocolManager;
 import com.alibaba.nacos.naming.core.v2.ServiceManager;
 import com.alibaba.nacos.naming.core.v2.client.Client;
+import com.alibaba.nacos.naming.core.v2.client.ClientAttributes;
 import com.alibaba.nacos.naming.core.v2.client.ClientSyncData;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.client.manager.impl.PersistentIpPortClientManager;
@@ -60,6 +61,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -155,6 +157,26 @@ class PersistentClientOperationServiceImplTest {
     }
     
     @Test
+    void testDeregisterInstanceWrapsProtocolException() throws Exception {
+        Mockito.doThrow(new Exception("write failed")).when(cpProtocol)
+            .write(any(WriteRequest.class));
+        
+        assertThrows(NacosRuntimeException.class,
+            () -> persistentClientOperationServiceImpl.deregisterInstance(service, instance,
+                clientId));
+    }
+    
+    @Test
+    void testRegisterInstanceWrapsProtocolException() throws Exception {
+        Mockito.doThrow(new Exception("write failed")).when(cpProtocol)
+            .write(any(WriteRequest.class));
+        
+        assertThrows(NacosRuntimeException.class,
+            () -> persistentClientOperationServiceImpl.registerInstance(service, instance,
+                clientId));
+    }
+    
+    @Test
     void updateInstance() throws Exception {
         Field clientManagerField =
             PersistentClientOperationServiceImpl.class.getDeclaredField("clientManager");
@@ -162,6 +184,45 @@ class PersistentClientOperationServiceImplTest {
         // Test register instance
         persistentClientOperationServiceImpl.updateInstance(service, instance, clientId);
         verify(cpProtocol).write(any(WriteRequest.class));
+    }
+    
+    @Test
+    void testUpdateEphemeralInstanceThrowsException() {
+        when(service.isEphemeral()).thenReturn(true);
+        
+        assertThrows(NacosRuntimeException.class,
+            () -> persistentClientOperationServiceImpl.updateInstance(service, instance,
+                clientId));
+    }
+    
+    @Test
+    void testUpdateInstanceWrapsProtocolException() throws Exception {
+        Mockito.doThrow(new Exception("write failed")).when(cpProtocol)
+            .write(any(WriteRequest.class));
+        
+        assertThrows(NacosRuntimeException.class,
+            () -> persistentClientOperationServiceImpl.updateInstance(service, instance,
+                clientId));
+    }
+    
+    @Test
+    void testBatchRegisterInstanceNoop() {
+        persistentClientOperationServiceImpl.batchRegisterInstance(service,
+            Collections.singletonList(instance), clientId);
+    }
+    
+    @Test
+    void testInstanceStoreRequestAccessors() {
+        PersistentClientOperationServiceImpl.InstanceStoreRequest request =
+            new PersistentClientOperationServiceImpl.InstanceStoreRequest();
+        
+        request.setService(service);
+        request.setInstance(instance);
+        request.setClientId(clientId);
+        
+        assertSame(service, request.getService());
+        assertSame(instance, request.getInstance());
+        assertSame(clientId, request.getClientId());
     }
     
     @Test
@@ -243,6 +304,94 @@ class PersistentClientOperationServiceImplTest {
         response = persistentClientOperationServiceImpl.onApply(writeRequest);
         assertTrue(response.getSuccess());
         assertTrue(ServiceManager.getInstance().containSingleton(service1));
+    }
+    
+    @Test
+    void testOnApplyReturnsFailureWhenDeserializeThrowsException() {
+        Mockito.when(serializer.deserialize(Mockito.any()))
+            .thenThrow(new RuntimeException("deserialize failed"));
+        
+        Response response = persistentClientOperationServiceImpl.onApply(
+            WriteRequest.newBuilder().setOperation(DataOperation.ADD.name()).build());
+        
+        assertFalse(response.getSuccess());
+    }
+    
+    @Test
+    void testOnApplyRegisterConnectsMissingClient() {
+        PersistentClientOperationServiceImpl.InstanceStoreRequest request =
+            new PersistentClientOperationServiceImpl.InstanceStoreRequest();
+        Service service1 = Service.newService("A", "B", "C");
+        request.setService(service1);
+        request.setClientId(clientId);
+        request.setInstance(new Instance());
+        Mockito.when(serializer.deserialize(Mockito.any())).thenReturn(request);
+        Mockito.when(clientManager.contains(clientId)).thenReturn(false);
+        Mockito.when(clientManager.getClient(clientId)).thenReturn(ipPortBasedClient);
+        
+        Response response = persistentClientOperationServiceImpl.onApply(
+            WriteRequest.newBuilder().setOperation(DataOperation.ADD.name()).build());
+        
+        assertTrue(response.getSuccess());
+        verify(clientManager).clientConnected(eq(clientId), any(ClientAttributes.class));
+    }
+    
+    @Test
+    void testOnApplyDeregisterReturnsWhenClientMissing() {
+        PersistentClientOperationServiceImpl.InstanceStoreRequest request =
+            new PersistentClientOperationServiceImpl.InstanceStoreRequest();
+        Service service1 = Service.newService("A", "B", "C");
+        request.setService(service1);
+        request.setClientId(clientId);
+        Mockito.when(serializer.deserialize(Mockito.any())).thenReturn(request);
+        Mockito.when(clientManager.getClient(clientId)).thenReturn(null);
+        
+        Response response = persistentClientOperationServiceImpl.onApply(
+            WriteRequest.newBuilder().setOperation(DataOperation.DELETE.name()).build());
+        
+        assertTrue(response.getSuccess());
+        verify(clientManager, times(0)).clientDisconnected(clientId);
+    }
+    
+    @Test
+    void testOnApplyDeregisterDisconnectsEmptyClient() {
+        PersistentClientOperationServiceImpl.InstanceStoreRequest request =
+            new PersistentClientOperationServiceImpl.InstanceStoreRequest();
+        Service service1 = Service.newService("A", "B", "C");
+        request.setService(service1);
+        request.setClientId(clientId);
+        Mockito.when(serializer.deserialize(Mockito.any())).thenReturn(request);
+        Mockito.when(clientManager.getClient(clientId)).thenReturn(ipPortBasedClient);
+        Mockito.when(ipPortBasedClient.getAllPublishedService())
+            .thenReturn(Collections.emptyList());
+        
+        Response response = persistentClientOperationServiceImpl.onApply(
+            WriteRequest.newBuilder().setOperation(DataOperation.DELETE.name()).build());
+        
+        assertTrue(response.getSuccess());
+        verify(clientManager).clientDisconnected(clientId);
+    }
+    
+    @Test
+    void testOnApplyDeregisterPublishesRemovedInstanceMetadata() {
+        PersistentClientOperationServiceImpl.InstanceStoreRequest request =
+            new PersistentClientOperationServiceImpl.InstanceStoreRequest();
+        Service service1 = Service.newService("A", "B", "C");
+        InstancePublishInfo removedInstance = instanceInfo("10.0.0.7", 8848);
+        request.setService(service1);
+        request.setClientId(clientId);
+        Mockito.when(serializer.deserialize(Mockito.any())).thenReturn(request);
+        Mockito.when(clientManager.getClient(clientId)).thenReturn(ipPortBasedClient);
+        Mockito.when(ipPortBasedClient.removeServiceInstance(any(Service.class)))
+            .thenReturn(removedInstance);
+        Mockito.when(ipPortBasedClient.getAllPublishedService())
+            .thenReturn(Collections.singleton(service1));
+        
+        Response response = persistentClientOperationServiceImpl.onApply(
+            WriteRequest.newBuilder().setOperation(DataOperation.DELETE.name()).build());
+        
+        assertTrue(response.getSuccess());
+        verify(clientManager, times(0)).clientDisconnected(clientId);
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/impl/PersistentClientOperationServiceImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/impl/PersistentClientOperationServiceImplTest.java
@@ -24,30 +24,47 @@ import com.alibaba.nacos.consistency.cp.CPProtocol;
 import com.alibaba.nacos.consistency.entity.ReadRequest;
 import com.alibaba.nacos.consistency.entity.Response;
 import com.alibaba.nacos.consistency.entity.WriteRequest;
+import com.alibaba.nacos.consistency.snapshot.Reader;
+import com.alibaba.nacos.consistency.snapshot.SnapshotOperation;
+import com.alibaba.nacos.consistency.snapshot.Writer;
 import com.alibaba.nacos.core.distributed.ProtocolManager;
 import com.alibaba.nacos.naming.core.v2.ServiceManager;
+import com.alibaba.nacos.naming.core.v2.client.Client;
+import com.alibaba.nacos.naming.core.v2.client.ClientSyncData;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.client.manager.impl.PersistentIpPortClientManager;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.pojo.Subscriber;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -104,6 +121,16 @@ class PersistentClientOperationServiceImplTest {
             new PersistentClientOperationServiceImpl(clientManager);
         serializerField.set(persistentClientOperationServiceImpl, serializer);
         
+    }
+    
+    @AfterEach
+    void tearDown() {
+        ApplicationUtils.injectContext(null);
+        ServiceManager.getInstance().removeSingleton(Service.newService("A", "B", "C"));
+        removeSnapshotSingleton("changed");
+        removeSnapshotSingleton("added");
+        removeSnapshotSingleton("removed");
+        removeSnapshotSingleton("dead");
     }
     
     @Test
@@ -216,5 +243,127 @@ class PersistentClientOperationServiceImplTest {
         response = persistentClientOperationServiceImpl.onApply(writeRequest);
         assertTrue(response.getSuccess());
         assertTrue(ServiceManager.getInstance().containSingleton(service1));
+    }
+    
+    @Test
+    void testPersistentInstanceSnapshotOperationWriteAndReadSnapshot(@TempDir Path snapshotDir) {
+        SnapshotOperation snapshotOperation =
+            persistentClientOperationServiceImpl.loadSnapshotOperate().iterator().next();
+        byte[] snapshotBytes = new byte[] {1, 2, 3};
+        IpPortBasedClient dumpClient = Mockito.mock(IpPortBasedClient.class);
+        ClientSyncData dumpData = buildSyncData("alive-client", "changed",
+            instanceInfo("10.0.0.1", 8848));
+        Map<String, IpPortBasedClient> clients = new HashMap<>();
+        clients.put("alive-client", dumpClient);
+        when(clientManager.showClients()).thenReturn(clients);
+        when(dumpClient.generateSyncData()).thenReturn(dumpData);
+        when(serializer.serialize(any(ConcurrentHashMap.class))).thenReturn(snapshotBytes);
+        Writer writer = new Writer(snapshotDir.toString());
+        
+        Boolean writeResult =
+            ReflectionTestUtils.invokeMethod(snapshotOperation, "writeSnapshot", writer);
+        
+        assertTrue(writeResult);
+        assertTrue(writer.listFiles().containsKey("persistent_instance.zip"));
+        
+        ConcurrentHashMap<String, ClientSyncData> snapshotData = new ConcurrentHashMap<>();
+        InstancePublishInfo changedInfo = instanceInfo("10.0.0.2", 8848);
+        InstancePublishInfo addedInfo = instanceInfo("10.0.0.3", 8848);
+        snapshotData.put("alive-client",
+            buildSyncData("alive-client", new String[] {"changed", "added"},
+                new InstancePublishInfo[] {changedInfo, addedInfo}));
+        mockSnapshotLoadClients();
+        when(serializer.deserialize(any(byte[].class))).thenReturn(snapshotData);
+        Reader reader = new Reader(snapshotDir.toString(), writer.listFiles());
+        
+        boolean readResult = snapshotOperation.onSnapshotLoad(reader);
+        
+        assertTrue(readResult);
+        verify(clientManager).showClients();
+        verify(clientManager).removeAndRelease("dead-client");
+        verify(clientManager, times(0)).removeAndRelease("missing-client");
+        IpPortBasedClient aliveClient =
+            (IpPortBasedClient) clientManager.getClient("alive-client");
+        verify(aliveClient, times(2)).putServiceInstance(any(Service.class),
+            any(InstancePublishInfo.class));
+        verify(aliveClient)
+            .removeServiceInstance(argThat(service -> "removed".equals(service.getName())));
+        verify(aliveClient).getAllPublishedService();
+    }
+    
+    @Test
+    void testPersistentInstanceSnapshotOperationAddSyncDataAndTags() {
+        SnapshotOperation snapshotOperation =
+            persistentClientOperationServiceImpl.loadSnapshotOperate().iterator().next();
+        IpPortBasedClient newClient = Mockito.mock(IpPortBasedClient.class);
+        when(newClient.getClientId()).thenReturn("new-client");
+        ClientSyncData syncData = buildSyncData("new-client", new String[] {"added", "changed"},
+            new InstancePublishInfo[] {instanceInfo("10.0.0.5", 8848),
+                instanceInfo("10.0.0.6", 8848)});
+        Map.Entry<String, ClientSyncData> entry =
+            new AbstractMap.SimpleEntry<>("new-client", syncData);
+        
+        ReflectionTestUtils.invokeMethod(snapshotOperation, "addSyncDataToClient", entry,
+            newClient);
+        ReflectionTestUtils.invokeMethod(snapshotOperation, "removeDeadClient",
+            Collections.singleton("new-client"), Collections.emptyList());
+        String saveTag = ReflectionTestUtils.invokeMethod(snapshotOperation, "getSnapshotSaveTag");
+        String loadTag = ReflectionTestUtils.invokeMethod(snapshotOperation, "getSnapshotLoadTag");
+        
+        verify(newClient, times(2)).putServiceInstance(any(Service.class),
+            any(InstancePublishInfo.class));
+        verify(clientManager).addSyncClient(newClient);
+        assertTrue(saveTag.endsWith(".SAVE"));
+        assertTrue(loadTag.endsWith(".LOAD"));
+    }
+    
+    private void mockSnapshotLoadClients() {
+        IpPortBasedClient aliveClient = Mockito.mock(IpPortBasedClient.class);
+        Service changedService = snapshotService("changed");
+        Service removedService = snapshotService("removed");
+        when(aliveClient.getAllPublishedService())
+            .thenReturn(Arrays.asList(changedService, removedService));
+        when(aliveClient.getInstancePublishInfo(any(Service.class)))
+            .thenReturn(instanceInfo("10.0.0.9", 8848));
+        when(aliveClient.getClientId()).thenReturn("alive-client");
+        Client deadClient = Mockito.mock(Client.class);
+        Service deadService = snapshotService("dead");
+        when(deadClient.getAllPublishedService()).thenReturn(Collections.singleton(deadService));
+        when(deadClient.getInstancePublishInfo(eq(deadService)))
+            .thenReturn(instanceInfo("10.0.0.4", 8848));
+        when(deadClient.getClientId()).thenReturn("dead-client");
+        when(clientManager.allClientId())
+            .thenReturn(Arrays.asList("alive-client", "dead-client", "missing-client"));
+        when(clientManager.getClient("alive-client")).thenReturn(aliveClient);
+        when(clientManager.getClient("dead-client")).thenReturn(deadClient);
+        when(clientManager.getClient("missing-client")).thenReturn(null);
+    }
+    
+    private ClientSyncData buildSyncData(String clientId, String serviceName,
+        InstancePublishInfo instancePublishInfo) {
+        return buildSyncData(clientId, new String[] {serviceName},
+            new InstancePublishInfo[] {instancePublishInfo});
+    }
+    
+    private ClientSyncData buildSyncData(String clientId, String[] serviceNames,
+        InstancePublishInfo[] instancePublishInfos) {
+        return new ClientSyncData(clientId, Collections.nCopies(serviceNames.length, "snapshot"),
+            Collections.nCopies(serviceNames.length, "group"), Arrays.asList(serviceNames),
+            Arrays.asList(instancePublishInfos), null);
+    }
+    
+    private InstancePublishInfo instanceInfo(String ip, int port) {
+        InstancePublishInfo result = new InstancePublishInfo(ip, port);
+        result.setHealthy(true);
+        result.setCluster("DEFAULT");
+        return result;
+    }
+    
+    private Service snapshotService(String serviceName) {
+        return Service.newService("snapshot", "group", serviceName, false);
+    }
+    
+    private void removeSnapshotSingleton(String serviceName) {
+        ServiceManager.getInstance().removeSingleton(snapshotService(serviceName));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/exception/ResponseExceptionHandlerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/exception/ResponseExceptionHandlerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.exception;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResponseExceptionHandlerTest {
+    
+    private final ResponseExceptionHandler handler = new ResponseExceptionHandler();
+    
+    @Test
+    void testHandleNacosException() {
+        ResponseEntity<String> response =
+            handler.handleNacosException(new NacosException(403, "no permission"));
+        
+        assertEquals(403, response.getStatusCode().value());
+        assertEquals("no permission", response.getBody());
+    }
+    
+    @Test
+    void testHandleNacosRuntimeException() {
+        ResponseEntity<String> response =
+            handler.handleNacosRuntimeException(new NacosRuntimeException(500, "failed"));
+        
+        assertEquals(500, response.getStatusCode().value());
+        assertTrue(response.getBody().contains("failed"));
+    }
+    
+    @Test
+    void testHandleParameterError() {
+        ResponseEntity<String> response =
+            handler.handleParameterError(new IllegalArgumentException("bad argument"));
+        
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("bad argument", response.getBody());
+    }
+    
+    @Test
+    void testHandleMissingParams() {
+        MissingServletRequestParameterException exception =
+            new MissingServletRequestParameterException("namespaceId", "String");
+        
+        ResponseEntity<String> response = handler.handleMissingParams(exception);
+        
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Parameter 'namespaceId' is missing", response.getBody());
+    }
+    
+    @Test
+    void testHandleException() {
+        ResponseEntity<String> response = handler.handleException(new Exception("unexpected"));
+        
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertTrue(response.getBody().contains("unexpected"));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/HealthCheckReactorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/HealthCheckReactorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck;
+
+import com.alibaba.nacos.naming.healthcheck.heartbeat.BeatCheckTask;
+import com.alibaba.nacos.naming.misc.GlobalExecutor;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HealthCheckReactorTest {
+    
+    private Map<String, ScheduledFuture> futureMap;
+    
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() throws Exception {
+        EnvUtil.setEnvironment(new MockEnvironment());
+        Field futureMapField = HealthCheckReactor.class.getDeclaredField("futureMap");
+        futureMapField.setAccessible(true);
+        futureMap = (Map<String, ScheduledFuture>) futureMapField.get(null);
+        futureMap.clear();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        futureMap.clear();
+    }
+    
+    @Test
+    void testConstruct() {
+        new HealthCheckReactor();
+    }
+    
+    @Test
+    void testScheduleCheckWithRawBeatTask() {
+        BeatCheckTask task = mock(BeatCheckTask.class);
+        ScheduledFuture<?> future = mock(ScheduledFuture.class);
+        when(task.taskKey()).thenReturn("rawBeat");
+        try (MockedStatic<GlobalExecutor> globalExecutor =
+            Mockito.mockStatic(GlobalExecutor.class)) {
+            globalExecutor.when(() -> GlobalExecutor.scheduleNamingHealth(same(task), eq(5000L),
+                eq(5000L),
+                eq(TimeUnit.MILLISECONDS)))
+                .thenReturn(future);
+            
+            HealthCheckReactor.scheduleCheck(task);
+            
+            globalExecutor.verify(() -> GlobalExecutor.scheduleNamingHealth(same(task), eq(5000L),
+                eq(5000L), eq(TimeUnit.MILLISECONDS)));
+        }
+    }
+    
+    @Test
+    void testCancelCheckCatchesException() {
+        BeatCheckTask task = mock(BeatCheckTask.class);
+        ScheduledFuture<?> future = mock(ScheduledFuture.class);
+        when(task.taskKey()).thenReturn("cancel");
+        when(future.cancel(true)).thenThrow(new RuntimeException("failed"));
+        futureMap.put("cancel", future);
+        
+        HealthCheckReactor.cancelCheck(task);
+        
+        verify(future).cancel(true);
+        assertTrue(futureMap.containsKey("cancel"));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/extend/HealthCheckExtendProviderTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/extend/HealthCheckExtendProviderTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.naming.healthcheck.extend;
 
 import com.alibaba.nacos.api.naming.pojo.healthcheck.AbstractHealthChecker;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Tcp;
 import com.alibaba.nacos.naming.healthcheck.v2.processor.HealthCheckProcessorV2;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class HealthCheckExtendProviderTest {
@@ -57,5 +60,22 @@ class HealthCheckExtendProviderTest {
     @Test
     void init() {
         healthCheckExtendProvider.init();
+    }
+    
+    @Test
+    void testInitWithDuplicateCheckerType() {
+        Collection<AbstractHealthChecker> checkers = new ArrayList<>();
+        checkers.add(new Tcp());
+        ReflectionTestUtils.setField(healthCheckExtendProvider, "checkers", checkers);
+        
+        assertThrows(RuntimeException.class, () -> healthCheckExtendProvider.init());
+    }
+    
+    @Test
+    void testInitWithUnmatchedProcessorAndChecker() {
+        ReflectionTestUtils.setField(healthCheckExtendProvider, "checkers",
+            new ArrayList<AbstractHealthChecker>());
+        
+        assertThrows(RuntimeException.class, () -> healthCheckExtendProvider.init());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/extend/HealthCheckProcessorExtendV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/extend/HealthCheckProcessorExtendV2Test.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.SingletonBeanRegistry;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -31,6 +33,11 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,5 +70,37 @@ class HealthCheckProcessorExtendV2Test {
         verify(registry).registerSingleton(
             healthCheckProcessorExtendV2.lowerFirstChar(mysqlProcessor.getClass().getSimpleName()),
             mysqlProcessor);
+    }
+    
+    @Test
+    void testLowerFirstChar() {
+        assertEquals("mysqlHealthCheckProcessor",
+            healthCheckProcessorExtendV2.lowerFirstChar("MysqlHealthCheckProcessor"));
+    }
+    
+    @Test
+    void testLowerFirstCharWithBlankName() {
+        assertThrows(IllegalArgumentException.class,
+            () -> healthCheckProcessorExtendV2.lowerFirstChar(""));
+    }
+    
+    @Test
+    void testSetBeanFactoryWithSingletonRegistry() {
+        HealthCheckProcessorExtendV2 processorExtend = new HealthCheckProcessorExtendV2();
+        ConfigurableListableBeanFactory beanFactory =
+            mock(ConfigurableListableBeanFactory.class);
+        
+        processorExtend.setBeanFactory(beanFactory);
+        
+        assertSame(beanFactory, ReflectionTestUtils.getField(processorExtend, "registry"));
+    }
+    
+    @Test
+    void testSetBeanFactoryWithOtherBeanFactory() {
+        HealthCheckProcessorExtendV2 processorExtend = new HealthCheckProcessorExtendV2();
+        
+        processorExtend.setBeanFactory(mock(BeanFactory.class));
+        
+        assertNull(ReflectionTestUtils.getField(processorExtend, "registry"));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/extend/HealthCheckProcessorExtendV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/extend/HealthCheckProcessorExtendV2Test.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class HealthCheckProcessorExtendV2Test {
@@ -70,6 +71,16 @@ class HealthCheckProcessorExtendV2Test {
         verify(registry).registerSingleton(
             healthCheckProcessorExtendV2.lowerFirstChar(mysqlProcessor.getClass().getSimpleName()),
             mysqlProcessor);
+    }
+    
+    @Test
+    void addProcessorThrowsWhenDuplicateTypeFound() {
+        when(mysqlProcessor.getType()).thenReturn("MYSQL");
+        Set<String> origin = new HashSet<>();
+        origin.add("MYSQL");
+        
+        assertThrows(RuntimeException.class,
+            () -> healthCheckProcessorExtendV2.addProcessor(origin));
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatProcessorV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatProcessorV2Test.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.heartbeat;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
+import com.alibaba.nacos.naming.core.v2.pojo.HealthCheckInstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.healthcheck.RsInfo;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientBeatProcessorV2Test {
+    
+    private static final String NAMESPACE = "namespace";
+    
+    private static final String GROUP_NAME = "group";
+    
+    private static final String SERVICE_NAME = "service";
+    
+    private static final String GROUPED_SERVICE_NAME =
+        GROUP_NAME + Constants.SERVICE_INFO_SPLITER + SERVICE_NAME;
+    
+    private static final String IP = "1.1.1.1";
+    
+    private static final int PORT = 10000;
+    
+    @Test
+    void testRunMarksUnhealthyInstanceHealthy() {
+        HealthCheckInstancePublishInfo instance = newInstance(IP, PORT, false);
+        instance.setLastHeartBeatTime(1L);
+        ClientBeatProcessorV2 processor = newProcessor(instance, newRsInfo(IP, PORT));
+        
+        processor.run();
+        
+        assertTrue(instance.isHealthy());
+        assertTrue(instance.getLastHeartBeatTime() > 1L);
+    }
+    
+    @Test
+    void testRunRefreshesHealthyInstanceHeartbeat() {
+        HealthCheckInstancePublishInfo instance = newInstance(IP, PORT, true);
+        instance.setLastHeartBeatTime(1L);
+        ClientBeatProcessorV2 processor = newProcessor(instance, newRsInfo(IP, PORT));
+        
+        processor.run();
+        
+        assertTrue(instance.isHealthy());
+        assertTrue(instance.getLastHeartBeatTime() > 1L);
+    }
+    
+    @Test
+    void testRunIgnoresDifferentPort() {
+        HealthCheckInstancePublishInfo instance = newInstance(IP, PORT, false);
+        instance.setLastHeartBeatTime(1L);
+        ClientBeatProcessorV2 processor = newProcessor(instance, newRsInfo(IP, PORT + 1));
+        
+        processor.run();
+        
+        assertEquals(1L, instance.getLastHeartBeatTime());
+        assertFalse(instance.isHealthy());
+    }
+    
+    private ClientBeatProcessorV2 newProcessor(HealthCheckInstancePublishInfo instance,
+        RsInfo rsInfo) {
+        IpPortBasedClient client = new IpPortBasedClient(
+            IpPortBasedClient.getClientId(IP + ":" + PORT, true), true);
+        client.addServiceInstance(
+            Service.newService(NAMESPACE, GROUP_NAME, SERVICE_NAME, true), instance);
+        return new ClientBeatProcessorV2(NAMESPACE, rsInfo, client);
+    }
+    
+    private HealthCheckInstancePublishInfo newInstance(String ip, int port, boolean healthy) {
+        HealthCheckInstancePublishInfo result = new HealthCheckInstancePublishInfo(ip, port);
+        result.setHealthy(healthy);
+        result.setCluster(UtilsAndCommons.DEFAULT_CLUSTER_NAME);
+        return result;
+    }
+    
+    private RsInfo newRsInfo(String ip, int port) {
+        RsInfo result = new RsInfo();
+        result.setIp(ip);
+        result.setPort(port);
+        result.setCluster(UtilsAndCommons.DEFAULT_CLUSTER_NAME);
+        result.setServiceName(GROUPED_SERVICE_NAME);
+        result.setEphemeral(true);
+        return result;
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatUpdateTaskTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatUpdateTaskTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.heartbeat;
+
+import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
+import com.alibaba.nacos.naming.core.v2.pojo.HealthCheckInstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientBeatUpdateTaskTest {
+    
+    @Test
+    void testRunUpdatesAllInstancesHeartbeatTime() {
+        IpPortBasedClient client = new IpPortBasedClient(
+            IpPortBasedClient.getClientId("1.1.1.1:8848", true), true);
+        HealthCheckInstancePublishInfo instance =
+            new HealthCheckInstancePublishInfo("1.1.1.1", 8848);
+        instance.setLastHeartBeatTime(1L);
+        client.addServiceInstance(Service.newService("namespace", "group", "service", true),
+            instance);
+        
+        new ClientBeatUpdateTask(client).run();
+        
+        assertTrue(instance.getLastHeartBeatTime() > 1L);
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/InstanceBeatCheckTaskTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/InstanceBeatCheckTaskTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.heartbeat;
+
+import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
+import com.alibaba.nacos.naming.core.v2.pojo.HealthCheckInstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceBeatCheckTaskTest {
+    
+    @Mock
+    private IpPortBasedClient client;
+    
+    @Mock
+    private HealthCheckInstancePublishInfo instancePublishInfo;
+    
+    private final Service service = Service.newService("namespace", "group", "service");
+    
+    @Test
+    void testGettersAndAfterIntercept() {
+        InstanceBeatCheckTask task = new InstanceBeatCheckTask(client, service,
+            instancePublishInfo);
+        
+        task.afterIntercept();
+        
+        assertSame(client, task.getClient());
+        assertSame(service, task.getService());
+        assertSame(instancePublishInfo, task.getInstancePublishInfo());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ServiceEnableBeatCheckInterceptorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ServiceEnableBeatCheckInterceptorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.heartbeat;
+
+import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
+import com.alibaba.nacos.naming.core.v2.metadata.ServiceMetadata;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.alibaba.nacos.sys.utils.ApplicationUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ServiceEnableBeatCheckInterceptorTest {
+    
+    private final Service service = Service.newService("namespace", "group", "service");
+    
+    private ServiceEnableBeatCheckInterceptor interceptor;
+    
+    @Mock
+    private NamingMetadataManager metadataManager;
+    
+    @Mock
+    private ConfigurableApplicationContext applicationContext;
+    
+    @Mock
+    private InstanceBeatCheckTask task;
+    
+    @BeforeEach
+    void setUp() {
+        ApplicationUtils.injectContext(applicationContext);
+        interceptor = new ServiceEnableBeatCheckInterceptor();
+    }
+    
+    @Test
+    void testInterceptType() {
+        assertTrue(interceptor.isInterceptType(InstanceBeatCheckTask.class));
+        assertFalse(interceptor.isInterceptType(Object.class));
+    }
+    
+    @Test
+    void testOrder() {
+        assertEquals(Integer.MIN_VALUE, interceptor.order());
+    }
+    
+    @Test
+    void testInterceptWhenMetadataMissing() {
+        mockMetadata(Optional.empty());
+        
+        assertFalse(interceptor.intercept(task));
+    }
+    
+    @Test
+    void testInterceptWhenEnableClientBeatMissing() {
+        mockMetadata(Optional.of(new ServiceMetadata()));
+        
+        assertFalse(interceptor.intercept(task));
+    }
+    
+    @Test
+    void testInterceptWhenEnableClientBeatTrue() {
+        ServiceMetadata metadata = new ServiceMetadata();
+        metadata.getExtendData().put(UtilsAndCommons.ENABLE_CLIENT_BEAT, "true");
+        mockMetadata(Optional.of(metadata));
+        
+        assertTrue(interceptor.intercept(task));
+    }
+    
+    @Test
+    void testInterceptWhenEnableClientBeatFalse() {
+        ServiceMetadata metadata = new ServiceMetadata();
+        metadata.getExtendData().put(UtilsAndCommons.ENABLE_CLIENT_BEAT, "false");
+        mockMetadata(Optional.of(metadata));
+        
+        assertFalse(interceptor.intercept(task));
+    }
+    
+    private void mockMetadata(Optional<ServiceMetadata> metadata) {
+        when(applicationContext.getBean(NamingMetadataManager.class)).thenReturn(metadataManager);
+        when(task.getService()).thenReturn(service);
+        when(metadataManager.getServiceMetadata(service)).thenReturn(metadata);
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/interceptor/HealthCheckTaskInterceptWrapperTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/interceptor/HealthCheckTaskInterceptWrapperTest.java
@@ -24,7 +24,9 @@ import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
 import com.alibaba.nacos.naming.core.v2.pojo.HealthCheckInstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.healthcheck.NacosHealthCheckTask;
 import com.alibaba.nacos.naming.healthcheck.heartbeat.ClientBeatCheckTaskV2;
+import com.alibaba.nacos.naming.interceptor.NacosNamingInterceptorChain;
 import com.alibaba.nacos.naming.misc.GlobalConfig;
 import com.alibaba.nacos.naming.misc.SwitchDomain;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
@@ -37,11 +39,15 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.context.ConfigurableApplicationContext;
 
+import java.lang.reflect.Field;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -183,6 +189,24 @@ class HealthCheckTaskInterceptWrapperTest {
         assertFalse(
             client.getInstancePublishInfo(Service.newService(NAMESPACE, GROUP_NAME, SERVICE_NAME))
                 .isHealthy());
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    void testRunSwallowsInterceptorException() throws Exception {
+        NacosHealthCheckTask task = mock(NacosHealthCheckTask.class);
+        when(task.getTaskId()).thenReturn("task");
+        HealthCheckTaskInterceptWrapper wrapper = new HealthCheckTaskInterceptWrapper(task);
+        NacosNamingInterceptorChain<NacosHealthCheckTask> interceptorChain =
+            mock(NacosNamingInterceptorChain.class);
+        doThrow(new RuntimeException("mock error")).when(interceptorChain).doInterceptor(task);
+        Field field = HealthCheckTaskInterceptWrapper.class.getDeclaredField("interceptorChain");
+        field.setAccessible(true);
+        field.set(wrapper, interceptorChain);
+        
+        assertDoesNotThrow(wrapper::run);
+        
+        verify(task).getTaskId();
     }
     
     private HealthCheckInstancePublishInfo injectInstance(boolean healthy, long heartbeatTime) {

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckCommonV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckCommonV2Test.java
@@ -98,6 +98,26 @@ class HealthCheckCommonV2Test {
     }
     
     @Test
+    void testReEvaluateCheckRtUpdatesBest() {
+        when(healthCheckTaskV2.getCheckRtBest()).thenReturn(10L);
+        when(healthParams.getMax()).thenReturn(100);
+        
+        healthCheckCommonV2.reEvaluateCheckRt(1L, healthCheckTaskV2, healthParams);
+        
+        verify(healthCheckTaskV2).setCheckRtBest(1L);
+    }
+    
+    @Test
+    void testReEvaluateCheckRtUsesMin() {
+        when(healthParams.getMax()).thenReturn(100);
+        when(healthParams.getMin()).thenReturn(10);
+        
+        healthCheckCommonV2.reEvaluateCheckRt(1L, healthCheckTaskV2, healthParams);
+        
+        verify(healthCheckTaskV2).setCheckRtNormalized(10L);
+    }
+    
+    @Test
     void testCheckOk() {
         healthCheckCommonV2.checkOk(healthCheckTaskV2, service, "test checkOk");
         

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckCommonV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckCommonV2Test.java
@@ -19,7 +19,9 @@ package com.alibaba.nacos.naming.healthcheck.v2.processor;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.pojo.HealthCheckInstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.core.DistroMapper;
 import com.alibaba.nacos.naming.healthcheck.v2.HealthCheckTaskV2;
+import com.alibaba.nacos.naming.healthcheck.v2.PersistentHealthStatusSynchronizer;
 import com.alibaba.nacos.naming.misc.SwitchDomain;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,11 +30,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,14 +59,28 @@ class HealthCheckCommonV2Test {
     @Mock
     private HealthCheckInstancePublishInfo healthCheckInstancePublishInfo;
     
+    @Mock
+    private DistroMapper distroMapper;
+    
+    @Mock
+    private SwitchDomain switchDomain;
+    
+    @Mock
+    private PersistentHealthStatusSynchronizer healthStatusSynchronizer;
+    
     private HealthCheckCommonV2 healthCheckCommonV2;
     
     @BeforeEach
     void setUp() {
         healthCheckCommonV2 = new HealthCheckCommonV2();
+        ReflectionTestUtils.setField(healthCheckCommonV2, "distroMapper", distroMapper);
+        ReflectionTestUtils.setField(healthCheckCommonV2, "switchDomain", switchDomain);
+        ReflectionTestUtils.setField(healthCheckCommonV2, "healthStatusSynchronizer",
+            healthStatusSynchronizer);
         when(healthCheckTaskV2.getClient()).thenReturn(ipPortBasedClient);
         when(ipPortBasedClient.getInstancePublishInfo(service))
             .thenReturn(healthCheckInstancePublishInfo);
+        when(healthCheckInstancePublishInfo.getOkCount()).thenReturn(new AtomicInteger());
         when(healthCheckInstancePublishInfo.getFailCount()).thenReturn(new AtomicInteger());
     }
     
@@ -119,5 +137,93 @@ class HealthCheckCommonV2Test {
         verify(healthCheckInstancePublishInfo).getCluster();
         verify(healthCheckInstancePublishInfo).resetOkCount();
         verify(healthCheckInstancePublishInfo).finishCheck();
+    }
+    
+    @Test
+    void testCheckOkChangesHealthWhenThresholdReached() {
+        HealthCheckInstancePublishInfo instance = newHealthCheckInstance(false);
+        mockHealthyCheckContext(instance, 1, true, false, true);
+        
+        healthCheckCommonV2.checkOk(healthCheckTaskV2, service, "ok");
+        
+        verify(healthStatusSynchronizer).instanceHealthStatusChange(true, ipPortBasedClient,
+            service, instance);
+    }
+    
+    @Test
+    void testCheckOkOnlyIncreasesOkCountBeforeThreshold() {
+        HealthCheckInstancePublishInfo instance = newHealthCheckInstance(false);
+        mockHealthyCheckContext(instance, 2, true, false, true);
+        
+        healthCheckCommonV2.checkOk(healthCheckTaskV2, service, "ok");
+        
+        verifyNoInteractions(healthStatusSynchronizer);
+    }
+    
+    @Test
+    void testCheckFailChangesHealthWhenThresholdReached() {
+        HealthCheckInstancePublishInfo instance = newHealthCheckInstance(true);
+        mockHealthyCheckContext(instance, 1, true, false, true);
+        
+        healthCheckCommonV2.checkFail(healthCheckTaskV2, service, "fail");
+        
+        verify(healthStatusSynchronizer).instanceHealthStatusChange(false, ipPortBasedClient,
+            service, instance);
+    }
+    
+    @Test
+    void testCheckFailOnlyIncreasesFailCountBeforeThreshold() {
+        HealthCheckInstancePublishInfo instance = newHealthCheckInstance(true);
+        mockHealthyCheckContext(instance, 2, true, false, true);
+        
+        healthCheckCommonV2.checkFail(healthCheckTaskV2, service, "fail");
+        
+        verifyNoInteractions(healthStatusSynchronizer);
+    }
+    
+    @Test
+    void testCheckFailNowChangesHealthImmediately() {
+        HealthCheckInstancePublishInfo instance = newHealthCheckInstance(true);
+        mockHealthyCheckContext(instance, 2, true, false, true);
+        
+        healthCheckCommonV2.checkFailNow(healthCheckTaskV2, service, "fail now");
+        
+        verify(healthStatusSynchronizer).instanceHealthStatusChange(false, ipPortBasedClient,
+            service, instance);
+    }
+    
+    @Test
+    void testCheckReturnsWhenInstanceMissing() {
+        when(ipPortBasedClient.getInstancePublishInfo(service)).thenReturn(null);
+        
+        healthCheckCommonV2.checkOk(healthCheckTaskV2, service, "missing");
+        healthCheckCommonV2.checkFail(healthCheckTaskV2, service, "missing");
+        healthCheckCommonV2.checkFailNow(healthCheckTaskV2, service, "missing");
+        
+        verifyNoInteractions(healthStatusSynchronizer);
+    }
+    
+    private HealthCheckInstancePublishInfo newHealthCheckInstance(boolean healthy) {
+        HealthCheckInstancePublishInfo result = new HealthCheckInstancePublishInfo("1.1.1.1",
+            8848);
+        result.setHealthy(healthy);
+        result.setCluster("DEFAULT");
+        result.initHealthCheck();
+        return result;
+    }
+    
+    private void mockHealthyCheckContext(HealthCheckInstancePublishInfo instance, int checkTimes,
+        boolean healthCheckEnabled, boolean cancelled, boolean responsible) {
+        when(ipPortBasedClient.getInstancePublishInfo(service)).thenReturn(instance);
+        when(ipPortBasedClient.getResponsibleId()).thenReturn("1.1.1.1:8848");
+        when(service.getGroupedServiceName()).thenReturn("DEFAULT_GROUP@@service");
+        when(service.getNamespace()).thenReturn("public");
+        when(service.getGroup()).thenReturn("DEFAULT_GROUP");
+        when(service.getName()).thenReturn("service");
+        when(switchDomain.getCheckTimes()).thenReturn(checkTimes);
+        when(switchDomain.isHealthCheckEnabled("DEFAULT_GROUP@@service"))
+            .thenReturn(healthCheckEnabled);
+        when(healthCheckTaskV2.isCancelled()).thenReturn(cancelled);
+        when(distroMapper.responsible("1.1.1.1:8848")).thenReturn(responsible);
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckProcessorV2DelegateTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckProcessorV2DelegateTest.java
@@ -33,6 +33,7 @@ import org.springframework.mock.env.MockEnvironment;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -58,6 +59,9 @@ class HealthCheckProcessorV2DelegateTest {
     
     @Mock
     private ClusterMetadata clusterMetadata;
+    
+    @Mock
+    private HealthCheckProcessorV2 noneHealthCheckProcessor;
     
     private HealthCheckProcessorV2Delegate healthCheckProcessorV2Delegate;
     
@@ -97,6 +101,18 @@ class HealthCheckProcessorV2DelegateTest {
         
         verify(clusterMetadata).getHealthyCheckType();
         verify(healthCheckTaskV2).getClient();
+    }
+    
+    @Test
+    void testProcessFallbackToNoneProcessor() {
+        when(noneHealthCheckProcessor.getType()).thenReturn(NoneHealthCheckProcessor.TYPE);
+        when(clusterMetadata.getHealthyCheckType()).thenReturn("UNKNOWN");
+        healthCheckProcessorV2Delegate.addProcessor(
+            Collections.singletonList(noneHealthCheckProcessor));
+        
+        healthCheckProcessorV2Delegate.process(healthCheckTaskV2, service, clusterMetadata);
+        
+        verify(noneHealthCheckProcessor).process(healthCheckTaskV2, service, clusterMetadata);
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HttpHealthCheckProcessorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HttpHealthCheckProcessorTest.java
@@ -39,6 +39,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,6 +47,8 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -99,6 +102,40 @@ class HttpHealthCheckProcessorTest {
         
         verify(healthCheckTaskV2).getClient();
         verify(healthCheckInstancePublishInfo).tryStartCheck();
+    }
+    
+    @Test
+    void testProcessReturnsWhenInstanceMissing() {
+        when(ipPortBasedClient.getInstancePublishInfo(service)).thenReturn(null);
+        
+        httpHealthCheckProcessor.process(healthCheckTaskV2, service, clusterMetadata);
+        
+        verify(healthCheckTaskV2).getClient();
+    }
+    
+    @Test
+    void testProcessReevaluatesWhenPreviousCheckStillRunning() {
+        when(healthCheckInstancePublishInfo.tryStartCheck()).thenReturn(false);
+        when(healthCheckTaskV2.getCheckRtNormalized()).thenReturn(10L);
+        
+        httpHealthCheckProcessor.process(healthCheckTaskV2, service, clusterMetadata);
+        
+        verify(healthCheckCommon).reEvaluateCheckRt(20L, healthCheckTaskV2,
+            switchDomain.getHttpHealthParams());
+    }
+    
+    @Test
+    void testProcessHandlesHealthCheckerFailure() {
+        when(healthCheckInstancePublishInfo.tryStartCheck()).thenReturn(true);
+        
+        httpHealthCheckProcessor.process(healthCheckTaskV2, service, clusterMetadata);
+        
+        verify(healthCheckInstancePublishInfo)
+            .setCheckRt(switchDomain.getHttpHealthParams().getMax());
+        verify(healthCheckCommon).checkFail(eq(healthCheckTaskV2), eq(service),
+            startsWith("http:error:"));
+        verify(healthCheckCommon).reEvaluateCheckRt(switchDomain.getHttpHealthParams().getMax(),
+            healthCheckTaskV2, switchDomain.getHttpHealthParams());
     }
     
     @Test
@@ -165,6 +202,20 @@ class HttpHealthCheckProcessorTest {
     }
     
     @Test
+    void testOnReceiveWithMovedTemp()
+        throws NoSuchMethodException, IllegalAccessException, InvocationTargetException,
+        InstantiationException {
+        Object objects = newCallback();
+        int code = HttpURLConnection.HTTP_MOVED_TEMP;
+        when(restResult.getCode()).thenReturn(code);
+        Method onReceive = objects.getClass().getMethod("onReceive", RestResult.class);
+        onReceive.invoke(objects, restResult);
+        
+        verify(healthCheckCommon).checkFail(healthCheckTaskV2, service,
+            "http:" + restResult.getCode());
+    }
+    
+    @Test
     void testOnReceiveWithNotFound()
         throws NoSuchMethodException, IllegalAccessException, InvocationTargetException,
         InstantiationException, InterruptedException {
@@ -211,15 +262,8 @@ class HttpHealthCheckProcessorTest {
     @Test
     void testOnError() throws NoSuchMethodException, IllegalAccessException,
         InvocationTargetException, InstantiationException {
-        Class<HttpHealthCheckProcessor> healthCheckProcessorClass = HttpHealthCheckProcessor.class;
-        Class<?>[] classes = healthCheckProcessorClass.getDeclaredClasses();
-        Class<?> aClass = Arrays.stream(classes).findFirst().get();
-        Constructor<?> constructor = aClass.getConstructor(HttpHealthCheckProcessor.class,
-            HealthCheckInstancePublishInfo.class,
-            HealthCheckTaskV2.class, Service.class);
-        Object objects = constructor.newInstance(httpHealthCheckProcessor,
-            healthCheckInstancePublishInfo, healthCheckTaskV2, service);
-        Method onReceive = aClass.getMethod("onError", Throwable.class);
+        Object objects = newCallback();
+        Method onReceive = objects.getClass().getMethod("onError", Throwable.class);
         onReceive.invoke(objects, connectException);
         
         verify(healthCheckCommon).checkFailNow(healthCheckTaskV2, service,
@@ -227,5 +271,54 @@ class HttpHealthCheckProcessorTest {
         verify(healthCheckCommon).reEvaluateCheckRt(switchDomain.getHttpHealthParams().getMax(),
             healthCheckTaskV2,
             switchDomain.getHttpHealthParams());
+    }
+    
+    @Test
+    void testOnErrorWithTimeoutException()
+        throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
+        InstantiationException {
+        Object objects = newCallback();
+        when(healthCheckTaskV2.getCheckRtNormalized()).thenReturn(10L);
+        Method onReceive = objects.getClass().getMethod("onError", Throwable.class);
+        onReceive.invoke(objects, new SocketTimeoutException("timeout"));
+        
+        verify(healthCheckCommon).checkFail(healthCheckTaskV2, service, "http:timeout");
+        verify(healthCheckCommon).reEvaluateCheckRt(20L, healthCheckTaskV2,
+            switchDomain.getHttpHealthParams());
+    }
+    
+    @Test
+    void testOnErrorWithGenericException()
+        throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
+        InstantiationException {
+        Object objects = newCallback();
+        Method onReceive = objects.getClass().getMethod("onError", Throwable.class);
+        onReceive.invoke(objects, new IllegalStateException("broken"));
+        
+        verify(healthCheckCommon).checkFail(healthCheckTaskV2, service, "http:error:broken");
+        verify(healthCheckCommon).reEvaluateCheckRt(switchDomain.getHttpHealthParams().getMax(),
+            healthCheckTaskV2, switchDomain.getHttpHealthParams());
+    }
+    
+    @Test
+    void testOnCancel()
+        throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
+        InstantiationException {
+        Object objects = newCallback();
+        Method onCancel = objects.getClass().getMethod("onCancel");
+        
+        onCancel.invoke(objects);
+    }
+    
+    private Object newCallback() throws NoSuchMethodException, InvocationTargetException,
+        InstantiationException, IllegalAccessException {
+        Class<HttpHealthCheckProcessor> healthCheckProcessorClass = HttpHealthCheckProcessor.class;
+        Class<?>[] classes = healthCheckProcessorClass.getDeclaredClasses();
+        Class<?> aClass = Arrays.stream(classes).findFirst().get();
+        Constructor<?> constructor = aClass.getConstructor(HttpHealthCheckProcessor.class,
+            HealthCheckInstancePublishInfo.class,
+            HealthCheckTaskV2.class, Service.class);
+        return constructor.newInstance(httpHealthCheckProcessor, healthCheckInstancePublishInfo,
+            healthCheckTaskV2, service);
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/NoneHealthCheckProcessorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/NoneHealthCheckProcessorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.v2.processor;
+
+import com.alibaba.nacos.api.naming.pojo.healthcheck.HealthCheckType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NoneHealthCheckProcessorTest {
+    
+    private final NoneHealthCheckProcessor processor = new NoneHealthCheckProcessor();
+    
+    @Test
+    void testProcessDoesNothing() {
+        assertDoesNotThrow(() -> processor.process(null, null, null));
+    }
+    
+    @Test
+    void testGetType() {
+        assertEquals(HealthCheckType.NONE.name(), processor.getType());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/ClientConfigTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/ClientConfigTest.java
@@ -64,4 +64,13 @@ class ClientConfigTest {
         ClientConfig clientConfig = declaredConstructor.newInstance();
         assertEquals(EXPIRED_TIME, clientConfig.getClientExpiredTime());
     }
+    
+    @Test
+    void testSetClientExpiredTime() {
+        clientConfig.setClientExpiredTime(EXPIRED_TIME);
+        
+        assertEquals(EXPIRED_TIME, clientConfig.getClientExpiredTime());
+        
+        clientConfig.setClientExpiredTime(ClientConstants.DEFAULT_CLIENT_EXPIRED_TIME);
+    }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/GlobalConfigTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/GlobalConfigTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GlobalConfigTest {
+    
+    @BeforeEach
+    void setUp() {
+        EnvUtil.setEnvironment(new MockEnvironment());
+    }
+    
+    @Test
+    void testDefaultConfig() {
+        GlobalConfig globalConfig = new GlobalConfig();
+        
+        assertFalse(globalConfig.isDataWarmup());
+        assertTrue(globalConfig.isExpireInstance());
+        assertEquals(60000L, GlobalConfig.getEmptyServiceCleanInterval());
+        assertEquals(60000L, GlobalConfig.getEmptyServiceExpiredTime());
+        assertEquals(5000L, GlobalConfig.getExpiredMetadataCleanInterval());
+        assertEquals(60000L, GlobalConfig.getExpiredMetadataExpiredTime());
+        assertEquals(20, GlobalConfig.getMaxPatternCount());
+        assertEquals(500, GlobalConfig.getMaxMatchedServiceCount());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/GlobalExecutorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/GlobalExecutorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GlobalExecutorTest {
+    
+    @BeforeAll
+    static void setUpBeforeClass() {
+        EnvUtil.setEnvironment(new MockEnvironment());
+    }
+    
+    @Test
+    void testConstructorAndRegisterServerStatusUpdater() throws Exception {
+        assertNotNull(new GlobalExecutor());
+        CountDownLatch latch = new CountDownLatch(1);
+        
+        GlobalExecutor.registerServerStatusUpdater(stoppingRunnable(latch));
+        
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+    }
+    
+    @Test
+    void testExecuteAndInvokeTasks() throws Exception {
+        CountDownLatch latch = new CountDownLatch(2);
+        
+        GlobalExecutor.executeMysqlCheckTask(latch::countDown);
+        GlobalExecutor.executeTcpSuperSense(latch::countDown);
+        List<Future<String>> futures = GlobalExecutor.invokeAllTcpSuperSenseTask(
+            Collections.singletonList(() -> "ok"));
+        
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertEquals("ok", futures.get(0).get());
+    }
+    
+    @Test
+    void testScheduleTasks() throws Exception {
+        CountDownLatch latch = new CountDownLatch(4);
+        
+        GlobalExecutor.scheduleTcpSuperSenseTask(latch::countDown, 1, TimeUnit.MILLISECONDS);
+        GlobalExecutor.scheduleRetransmitter(latch::countDown, 1, TimeUnit.MILLISECONDS);
+        GlobalExecutor.schedulePerformanceLogger(stoppingRunnable(latch), 0, 1, TimeUnit.DAYS);
+        GlobalExecutor.scheduleExpiredClientCleaner(stoppingRunnable(latch), 0, 1,
+            TimeUnit.DAYS);
+        
+        assertTrue(latch.await(2, TimeUnit.SECONDS));
+    }
+    
+    private Runnable stoppingRunnable(CountDownLatch latch) {
+        return () -> {
+            latch.countDown();
+            throw new IllegalStateException("stop scheduled task");
+        };
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/GracefulShutdownListenerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/GracefulShutdownListenerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+class GracefulShutdownListenerTest {
+    
+    @Test
+    void testFailedDestroysDispatcher() throws Exception {
+        NamingExecuteTaskDispatcher dispatcher = mock(NamingExecuteTaskDispatcher.class);
+        try (MockedStatic<NamingExecuteTaskDispatcher> mocked =
+            mockStatic(NamingExecuteTaskDispatcher.class)) {
+            mocked.when(NamingExecuteTaskDispatcher::getInstance).thenReturn(dispatcher);
+            
+            new GracefulShutdownListener().failed(null, new RuntimeException("failed"));
+            
+            verify(dispatcher).destroy();
+        }
+    }
+    
+    @Test
+    void testFailedIgnoresDestroyException() throws Exception {
+        NamingExecuteTaskDispatcher dispatcher = mock(NamingExecuteTaskDispatcher.class);
+        doThrow(new Exception("destroy failed")).when(dispatcher).destroy();
+        try (MockedStatic<NamingExecuteTaskDispatcher> mocked =
+            mockStatic(NamingExecuteTaskDispatcher.class)) {
+            mocked.when(NamingExecuteTaskDispatcher::getInstance).thenReturn(dispatcher);
+            
+            assertDoesNotThrow(
+                () -> new GracefulShutdownListener().failed(null, new RuntimeException("failed")));
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/LoggersTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/LoggersTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LoggersTest {
+    
+    private final Map<Logger, Level> originalLevels = new LinkedHashMap<>();
+    
+    @BeforeEach
+    void setUp() {
+        remember(Loggers.PUSH);
+        remember(Loggers.CHECK_RT);
+        remember(Loggers.SRV_LOG);
+        remember(Loggers.EVT_LOG);
+        remember(Loggers.RAFT);
+        remember(Loggers.DISTRO);
+        remember(Loggers.PERFORMANCE_LOG);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        originalLevels.forEach(Logger::setLevel);
+    }
+    
+    @Test
+    void testSetLogLevelForKnownNames() {
+        assertSetLevel("naming-push", Loggers.PUSH, Level.DEBUG);
+        assertSetLevel("naming-rt", Loggers.CHECK_RT, Level.INFO);
+        assertSetLevel("naming-server", Loggers.SRV_LOG, Level.WARN);
+        assertSetLevel("naming-event", Loggers.EVT_LOG, Level.ERROR);
+        assertSetLevel("naming-raft", Loggers.RAFT, Level.TRACE);
+        assertSetLevel("naming-distro", Loggers.DISTRO, Level.OFF);
+        assertSetLevel("naming-performance", Loggers.PERFORMANCE_LOG, Level.toLevel("ALL"));
+    }
+    
+    @Test
+    void testSetLogLevelForUnknownNameDoesNothing() {
+        Logger pushLogger = (Logger) Loggers.PUSH;
+        pushLogger.setLevel(null);
+        
+        Loggers.setLogLevel("unknown", Level.ERROR.toString());
+        
+        assertNull(pushLogger.getLevel());
+    }
+    
+    @Test
+    void testConstruct() {
+        assertNotNull(new Loggers());
+    }
+    
+    private void remember(org.slf4j.Logger logger) {
+        Logger logbackLogger = (Logger) logger;
+        originalLevels.put(logbackLogger, logbackLogger.getLevel());
+    }
+    
+    private void assertSetLevel(String logName, org.slf4j.Logger logger, Level level) {
+        Loggers.setLogLevel(logName, level.toString());
+        assertEquals(level, ((Logger) logger).getLevel());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/NamingExecuteTaskDispatcherTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/NamingExecuteTaskDispatcherTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class NamingExecuteTaskDispatcherTest {
+    
+    @Test
+    void testDestroy() throws Exception {
+        Constructor<NamingExecuteTaskDispatcher> constructor =
+            NamingExecuteTaskDispatcher.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        NamingExecuteTaskDispatcher dispatcher = constructor.newInstance();
+        
+        assertNotNull(dispatcher.workersStatus());
+        dispatcher.destroy();
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/NamingTraceEventInitializerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/NamingTraceEventInitializerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import com.alibaba.nacos.common.trace.event.naming.NamingTraceEvent;
+import com.alibaba.nacos.core.trace.NacosCombinedTraceSubscriber;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NamingTraceEventInitializerTest {
+    
+    @Test
+    void testRegisterSubscriberForNamingEvent() {
+        try (MockedConstruction<NacosCombinedTraceSubscriber> mockedConstruction =
+            Mockito.mockConstruction(NacosCombinedTraceSubscriber.class, (mock,
+                context) -> assertEquals(NamingTraceEvent.class, context.arguments().get(0)))) {
+            new NamingTraceEventInitializer().registerSubscriberForNamingEvent();
+            
+            assertEquals(1, mockedConstruction.constructed().size());
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchDomainSnapshotOperationTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchDomainSnapshotOperationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import com.alibaba.nacos.consistency.Serializer;
+import com.alibaba.nacos.consistency.snapshot.LocalFileMeta;
+import com.alibaba.nacos.consistency.snapshot.Reader;
+import com.alibaba.nacos.consistency.snapshot.Writer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SwitchDomainSnapshotOperationTest {
+    
+    private static final String SNAPSHOT_DIR = "naming_persistent";
+    
+    private static final String SNAPSHOT_ARCHIVE = "naming_persistent.zip";
+    
+    @Mock
+    private SwitchManager switchManager;
+    
+    @Mock
+    private Serializer serializer;
+    
+    @Test
+    void testWriteAndReadSnapshot(@TempDir Path snapshotPath) {
+        SwitchDomainSnapshotOperation operation = newSnapshotOperation();
+        Writer writer = new Writer(snapshotPath.toString());
+        
+        Boolean writeResult = ReflectionTestUtils.invokeMethod(operation, "writeSnapshot", writer);
+        
+        assertTrue(writeResult);
+        assertTrue(writer.listFiles().containsKey(SNAPSHOT_ARCHIVE));
+        verify(switchManager).dumpSnapshot(snapshotPath.resolve(SNAPSHOT_DIR).toString());
+        assertFalse(Files.exists(snapshotPath.resolve(SNAPSHOT_DIR)));
+        
+        Reader reader = new Reader(snapshotPath.toString(), writer.listFiles());
+        assertTrue(operation.onSnapshotLoad(reader));
+        
+        verify(switchManager).loadSnapshot(snapshotPath.resolve(SNAPSHOT_DIR).toString());
+        assertFalse(Files.exists(snapshotPath.resolve(SNAPSHOT_DIR)));
+    }
+    
+    @Test
+    void testReadSnapshotReturnsFalseForChecksumMismatch(@TempDir Path snapshotPath) {
+        SwitchDomainSnapshotOperation operation = newSnapshotOperation();
+        Writer writer = new Writer(snapshotPath.toString());
+        ReflectionTestUtils.invokeMethod(operation, "writeSnapshot", writer);
+        LocalFileMeta badMeta = new LocalFileMeta().append("checksum", "bad");
+        Reader reader = new Reader(snapshotPath.toString(),
+            Collections.singletonMap(SNAPSHOT_ARCHIVE, badMeta));
+        
+        assertFalse(operation.onSnapshotLoad(reader));
+        
+        verify(switchManager, times(0)).loadSnapshot(eq(Paths.get(snapshotPath.toString(),
+            SNAPSHOT_DIR).toString()));
+    }
+    
+    @Test
+    void testSnapshotTags() {
+        SwitchDomainSnapshotOperation operation = newSnapshotOperation();
+        
+        String saveTag = ReflectionTestUtils.invokeMethod(operation, "getSnapshotSaveTag");
+        String loadTag = ReflectionTestUtils.invokeMethod(operation, "getSnapshotLoadTag");
+        
+        assertTrue(saveTag.endsWith(".SAVE"));
+        assertTrue(loadTag.endsWith(".LOAD"));
+    }
+    
+    private SwitchDomainSnapshotOperation newSnapshotOperation() {
+        return new SwitchDomainSnapshotOperation(new ReentrantReadWriteLock(), switchManager,
+            serializer);
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
@@ -24,6 +24,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -148,5 +153,28 @@ class SwitchManagerTest {
     @Test
     void testHealthCheckEnabledEntryConstantValue() {
         assertEquals("healthCheckEnabled", SwitchEntry.HEALTH_CHECK_ENABLED);
+    }
+    
+    @Test
+    void testSwitchDomainDirectAccessors() {
+        switchDomain.update(new SwitchDomain());
+        
+        Map<String, Integer> weights = new HashMap<>();
+        weights.put("service", 7);
+        switchDomain.setAdWeightMap(weights);
+        assertEquals(7, switchDomain.getAdWeight("service"));
+        
+        switchDomain.setDefaultPushCacheMillis(1234L);
+        assertEquals(1234L, switchDomain.getPushCacheMillis("service"));
+        
+        switchDomain.setHealthCheckEnabled(false);
+        assertFalse(switchDomain.isHealthCheckEnabled("service"));
+        
+        Set<String> whiteList = new HashSet<>();
+        whiteList.add("service");
+        switchDomain.setHealthCheckWhiteList(whiteList);
+        assertTrue(switchDomain.isHealthCheckEnabled("service"));
+        
+        assertTrue(switchDomain.toString().contains("\"defaultPushCacheMillis\":1234"));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/UtilsAndCommonsTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/UtilsAndCommonsTest.java
@@ -22,6 +22,7 @@ import org.springframework.mock.env.MockEnvironment;
 import static com.alibaba.nacos.naming.misc.UtilsAndCommons.DEFAULT_NACOS_NAMING_CONTEXT;
 import static com.alibaba.nacos.naming.misc.UtilsAndCommons.NACOS_NAMING_CONTEXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UtilsAndCommonsTest {
@@ -47,5 +48,17 @@ class UtilsAndCommonsTest {
         assertEquals(0, UtilsAndCommons.shakeUp(null, 1));
         char[] chars = new char[] {2325, 9, 30, 12, 2};
         assertEquals(0, UtilsAndCommons.shakeUp(new String(chars), 1));
+    }
+    
+    @Test
+    void testParseMetadataWithInvalidPair() {
+        assertThrows(Exception.class, () -> UtilsAndCommons.parseMetadata("invalid"));
+    }
+    
+    @Test
+    void testAssembleFullServiceName() {
+        assertNotNull(new UtilsAndCommons());
+        assertEquals("namespace##service",
+            UtilsAndCommons.assembleFullServiceName("namespace", "service"));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/model/form/InstanceListFormTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/model/form/InstanceListFormTest.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.api.exception.api.NacosApiException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class InstanceListFormTest {
@@ -55,5 +56,27 @@ class InstanceListFormTest {
     void testValidateThrowsExceptionWhenServiceNameIsBlank() {
         InstanceListForm form = new InstanceListForm();
         assertThrows(NacosApiException.class, () -> form.validate());
+    }
+    
+    @Test
+    void testObjectMethods() throws NacosApiException {
+        InstanceListForm form = createForm("service");
+        InstanceListForm same = createForm("service");
+        InstanceListForm different = createForm("other");
+        form.validate();
+        same.validate();
+        
+        assertEquals(form, form);
+        assertEquals(form, same);
+        assertEquals(form.hashCode(), same.hashCode());
+        assertNotEquals(form, different);
+        assertNotEquals(form, null);
+        assertNotEquals(form, new Object());
+    }
+    
+    private InstanceListForm createForm(String serviceName) {
+        InstanceListForm form = new InstanceListForm();
+        form.setServiceName(serviceName);
+        return form;
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/model/form/NamingFormTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/model/form/NamingFormTest.java
@@ -194,6 +194,7 @@ class NamingFormTest {
         assertTrue(form.getHealthy());
         assertEquals(1.0, form.getWeight());
         assertTrue(form.getEnabled());
+        assertEquals(form, form);
         assertEquals(form, same);
         assertEquals(form.hashCode(), same.hashCode());
         assertNotEquals(form, different);

--- a/naming/src/test/java/com/alibaba/nacos/naming/model/form/NamingFormTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/model/form/NamingFormTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.model.form;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NamingFormTest {
+    
+    @Test
+    void testClientServiceFormValidateFillsDefaults() throws NacosApiException {
+        ClientServiceForm form = new ClientServiceForm();
+        form.setServiceName("service");
+        form.setIp("1.1.1.1");
+        form.setPort(8848);
+        
+        form.validate();
+        
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, form.getNamespaceId());
+        assertEquals(Constants.DEFAULT_GROUP, form.getGroupName());
+        assertEquals("service", form.getServiceName());
+        assertEquals("1.1.1.1", form.getIp());
+        assertEquals(8848, form.getPort());
+    }
+    
+    @Test
+    void testClientServiceFormValidateThrowsWhenServiceNameBlank() {
+        ClientServiceForm form = new ClientServiceForm();
+        
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testServiceListFormValidateFillsBlankNamespace() throws NacosApiException {
+        ServiceListForm form = new ServiceListForm();
+        form.setNamespaceId("");
+        form.setGroupNameParam("group");
+        form.setServiceNameParam("service");
+        form.setIgnoreEmptyService(true);
+        form.setWithInstances(true);
+        
+        form.validate();
+        
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, form.getNamespaceId());
+        assertEquals("group", form.getGroupNameParam());
+        assertEquals("service", form.getServiceNameParam());
+        assertTrue(form.isIgnoreEmptyService());
+        assertTrue(form.isWithInstances());
+    }
+    
+    @Test
+    void testUpdateClusterFormValidateRequiredParametersAndDefaults() throws NacosApiException {
+        assertThrows(NacosApiException.class, new UpdateClusterForm()::validate);
+        assertThrows(NacosApiException.class, () -> {
+            UpdateClusterForm form = new UpdateClusterForm();
+            form.setServiceName("service");
+            form.validate();
+        });
+        assertThrows(NacosApiException.class, () -> {
+            UpdateClusterForm form = new UpdateClusterForm();
+            form.setServiceName("service");
+            form.setClusterName("cluster");
+            form.validate();
+        });
+        assertThrows(NacosApiException.class, () -> {
+            UpdateClusterForm form = createUpdateClusterForm();
+            form.setUseInstancePort4Check(null);
+            form.validate();
+        });
+        assertThrows(NacosApiException.class, () -> {
+            UpdateClusterForm form = createUpdateClusterForm();
+            form.setHealthChecker("");
+            form.validate();
+        });
+        
+        UpdateClusterForm form = createUpdateClusterForm();
+        form.setNamespaceId("");
+        form.setGroupName("");
+        form.validate();
+        
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, form.getNamespaceId());
+        assertEquals(Constants.DEFAULT_GROUP, form.getGroupName());
+        assertEquals("", form.getMetadata());
+        assertEquals("service", form.getServiceName());
+        assertEquals("cluster", form.getClusterName());
+        assertEquals(80, form.getCheckPort());
+        assertTrue(form.isUseInstancePort4Check());
+        assertEquals("{}", form.getHealthChecker());
+    }
+    
+    @Test
+    void testUpdateSwitchFormValidateAndObjectMethods() throws NacosApiException {
+        assertThrows(NacosApiException.class, new UpdateSwitchForm()::validate);
+        assertThrows(NacosApiException.class, () -> {
+            UpdateSwitchForm form = new UpdateSwitchForm();
+            form.setEntry("entry");
+            form.validate();
+        });
+        
+        UpdateSwitchForm form = createUpdateSwitchForm("entry", "value", true);
+        UpdateSwitchForm same = createUpdateSwitchForm("entry", "value", true);
+        UpdateSwitchForm different = createUpdateSwitchForm("entry", "other", true);
+        form.validate();
+        
+        assertTrue(form.getDebug());
+        assertEquals("entry", form.getEntry());
+        assertEquals("value", form.getValue());
+        assertEquals(form, form);
+        assertEquals(form, same);
+        assertEquals(form.hashCode(), same.hashCode());
+        assertNotEquals(form, different);
+        assertNotEquals(form, null);
+        assertNotEquals(form, new Object());
+        assertTrue(form.toString().contains("entry='entry'"));
+    }
+    
+    @Test
+    void testServiceFormValidateAndObjectMethods() throws NacosApiException {
+        assertThrows(NacosApiException.class, new ServiceForm()::validate);
+        
+        ServiceForm form = createServiceForm("service");
+        ServiceForm same = createServiceForm("service");
+        ServiceForm different = createServiceForm("other");
+        form.validate();
+        same.validate();
+        
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, form.getNamespaceId());
+        assertEquals(Constants.DEFAULT_GROUP, form.getGroupName());
+        assertFalse(form.getEphemeral());
+        assertEquals(0.0F, form.getProtectThreshold());
+        assertEquals("", form.getMetadata());
+        assertEquals("", form.getSelector());
+        assertEquals(form, form);
+        assertEquals(form, same);
+        assertEquals(form.hashCode(), same.hashCode());
+        assertNotEquals(form, different);
+        assertNotEquals(form, null);
+        assertNotEquals(form, new Object());
+        assertTrue(form.toString().contains("serviceName='service'"));
+    }
+    
+    @Test
+    void testInstanceFormValidateAndObjectMethods() throws NacosApiException {
+        assertThrows(NacosApiException.class, new InstanceForm()::validate);
+        assertThrows(NacosApiException.class, () -> {
+            InstanceForm form = createInstanceForm();
+            form.setIp("");
+            form.validate();
+        });
+        assertThrows(NacosApiException.class, () -> {
+            InstanceForm form = createInstanceForm();
+            form.setPort(null);
+            form.validate();
+        });
+        
+        InstanceForm form = createInstanceForm();
+        InstanceForm same = createInstanceForm();
+        InstanceForm different = createInstanceForm();
+        different.setEphemeral(false);
+        form.validate();
+        same.validate();
+        
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, form.getNamespaceId());
+        assertEquals(Constants.DEFAULT_GROUP, form.getGroupName());
+        assertEquals(UtilsAndCommons.DEFAULT_CLUSTER_NAME, form.getClusterName());
+        assertTrue(form.getHealthy());
+        assertEquals(1.0, form.getWeight());
+        assertTrue(form.getEnabled());
+        assertEquals(form, same);
+        assertEquals(form.hashCode(), same.hashCode());
+        assertNotEquals(form, different);
+        assertNotEquals(form, null);
+        assertNotEquals(form, new Object());
+        assertTrue(form.toString().contains("serviceName='service'"));
+    }
+    
+    @Test
+    void testUpdateHealthFormValidateAndObjectMethods() throws NacosApiException {
+        assertThrows(NacosApiException.class, new UpdateHealthForm()::validate);
+        assertThrows(NacosApiException.class, () -> {
+            UpdateHealthForm form = createUpdateHealthForm();
+            form.setServiceName("");
+            form.validate();
+        });
+        assertThrows(NacosApiException.class, () -> {
+            UpdateHealthForm form = createUpdateHealthForm();
+            form.setIp("");
+            form.validate();
+        });
+        assertThrows(NacosApiException.class, () -> {
+            UpdateHealthForm form = createUpdateHealthForm();
+            form.setPort(null);
+            form.validate();
+        });
+        
+        UpdateHealthForm form = createUpdateHealthForm();
+        UpdateHealthForm same = createUpdateHealthForm();
+        UpdateHealthForm different = createUpdateHealthForm();
+        different.setHealthy(false);
+        form.validate();
+        same.validate();
+        
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, form.getNamespaceId());
+        assertEquals(Constants.DEFAULT_GROUP, form.getGroupName());
+        assertEquals(UtilsAndCommons.DEFAULT_CLUSTER_NAME, form.getClusterName());
+        assertEquals(form, same);
+        assertEquals(form.hashCode(), same.hashCode());
+        assertNotEquals(form, different);
+        assertNotEquals(form, null);
+        assertNotEquals(form, new Object());
+        assertTrue(form.toString().contains("healthy=true"));
+    }
+    
+    @Test
+    void testInstanceMetadataBatchOperationFormValidateAndObjectMethods()
+        throws NacosApiException {
+        assertThrows(NacosApiException.class, new InstanceMetadataBatchOperationForm()::validate);
+        assertThrows(NacosApiException.class, () -> {
+            InstanceMetadataBatchOperationForm form = createMetadataBatchForm();
+            form.setMetadata("");
+            form.validate();
+        });
+        
+        InstanceMetadataBatchOperationForm form = createMetadataBatchForm();
+        InstanceMetadataBatchOperationForm same = createMetadataBatchForm();
+        InstanceMetadataBatchOperationForm different = createMetadataBatchForm();
+        different.setInstances("[{}]");
+        form.validate();
+        same.validate();
+        
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, form.getNamespaceId());
+        assertEquals(Constants.DEFAULT_GROUP, form.getGroupName());
+        assertEquals("", form.getConsistencyType());
+        assertEquals("", form.getInstances());
+        assertEquals(form, same);
+        assertEquals(form.hashCode(), same.hashCode());
+        assertNotEquals(form, different);
+        assertNotEquals(form, null);
+        assertNotEquals(form, new Object());
+        assertTrue(form.toString().contains("metadata='metadata'"));
+    }
+    
+    private UpdateClusterForm createUpdateClusterForm() {
+        UpdateClusterForm form = new UpdateClusterForm();
+        form.setServiceName("service");
+        form.setClusterName("cluster");
+        form.setCheckPort(80);
+        form.setUseInstancePort4Check(true);
+        form.setHealthChecker("{}");
+        return form;
+    }
+    
+    private UpdateSwitchForm createUpdateSwitchForm(String entry, String value, boolean debug) {
+        UpdateSwitchForm form = new UpdateSwitchForm();
+        form.setEntry(entry);
+        form.setValue(value);
+        form.setDebug(debug);
+        return form;
+    }
+    
+    private ServiceForm createServiceForm(String serviceName) {
+        ServiceForm form = new ServiceForm();
+        form.setServiceName(serviceName);
+        return form;
+    }
+    
+    private InstanceForm createInstanceForm() {
+        InstanceForm form = new InstanceForm();
+        form.setServiceName("service");
+        form.setIp("1.1.1.1");
+        form.setPort(8848);
+        form.setMetadata("metadata");
+        form.setEphemeral(true);
+        return form;
+    }
+    
+    private UpdateHealthForm createUpdateHealthForm() {
+        UpdateHealthForm form = new UpdateHealthForm();
+        form.setHealthy(true);
+        form.setServiceName("service");
+        form.setIp("1.1.1.1");
+        form.setPort(8848);
+        return form;
+    }
+    
+    private InstanceMetadataBatchOperationForm createMetadataBatchForm() {
+        InstanceMetadataBatchOperationForm form = new InstanceMetadataBatchOperationForm();
+        form.setServiceName("service");
+        form.setMetadata("metadata");
+        return form;
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/model/form/NamingFormTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/model/form/NamingFormTest.java
@@ -108,6 +108,12 @@ class NamingFormTest {
         assertEquals(80, form.getCheckPort());
         assertTrue(form.isUseInstancePort4Check());
         assertEquals("{}", form.getHealthChecker());
+        
+        UpdateClusterForm metadataForm = createUpdateClusterForm();
+        metadataForm.setMetadata("metadata");
+        metadataForm.validate();
+        
+        assertEquals("metadata", metadataForm.getMetadata());
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/model/form/UpdateHealthFormTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/model/form/UpdateHealthFormTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.model.form;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UpdateHealthFormTest {
+    
+    @Test
+    void testEqualsSameInstance() {
+        UpdateHealthForm updateHealthForm = new UpdateHealthForm();
+        
+        assertTrue(updateHealthForm.equals(updateHealthForm));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/model/vo/NamingModelVoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/model/vo/NamingModelVoTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.model.vo;
+
+import com.alibaba.nacos.api.naming.pojo.maintainer.MetricsInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("deprecation")
+class NamingModelVoTest {
+    
+    @Test
+    void testMetricsInfoVoAccessorsAndTransfer() {
+        MetricsInfoVo source = new MetricsInfoVo();
+        source.setStatus("UP");
+        source.setServiceCount(1);
+        source.setInstanceCount(2);
+        source.setSubscribeCount(3);
+        source.setClientCount(4);
+        source.setConnectionBasedClientCount(5);
+        source.setEphemeralIpPortClientCount(6);
+        source.setPersistentIpPortClientCount(7);
+        source.setResponsibleClientCount(8);
+        source.setCpu(0.1F);
+        source.setLoad(0.2F);
+        source.setMem(0.3F);
+        
+        assertEquals("UP", source.getStatus());
+        assertEquals(1, source.getServiceCount());
+        assertEquals(2, source.getInstanceCount());
+        assertEquals(3, source.getSubscribeCount());
+        assertEquals(4, source.getClientCount());
+        assertEquals(5, source.getConnectionBasedClientCount());
+        assertEquals(6, source.getEphemeralIpPortClientCount());
+        assertEquals(7, source.getPersistentIpPortClientCount());
+        assertEquals(8, source.getResponsibleClientCount());
+        assertEquals(0.1F, source.getCpu());
+        assertEquals(0.2F, source.getLoad());
+        assertEquals(0.3F, source.getMem());
+        
+        MetricsInfo actual = MetricsInfoVo.toNewMetricsInfo(source);
+        assertEquals(source.getStatus(), actual.getStatus());
+        assertEquals(source.getServiceCount(), actual.getServiceCount());
+        assertEquals(source.getInstanceCount(), actual.getInstanceCount());
+        assertEquals(source.getSubscribeCount(), actual.getSubscribeCount());
+        assertEquals(source.getClientCount(), actual.getClientCount());
+        assertEquals(source.getConnectionBasedClientCount(),
+            actual.getConnectionBasedClientCount());
+        assertEquals(source.getEphemeralIpPortClientCount(),
+            actual.getEphemeralIpPortClientCount());
+        assertEquals(source.getPersistentIpPortClientCount(),
+            actual.getPersistentIpPortClientCount());
+        assertEquals(source.getResponsibleClientCount(), actual.getResponsibleClientCount());
+    }
+    
+    @Test
+    void testInstanceDetailInfoVoAccessors() {
+        InstanceDetailInfoVo actual = new InstanceDetailInfoVo();
+        actual.setServiceName("service");
+        actual.setIp("1.1.1.1");
+        actual.setPort(8848);
+        actual.setClusterName("cluster");
+        actual.setWeight(1.5);
+        actual.setHealthy(true);
+        actual.setInstanceId("instanceId");
+        actual.setMetadata(Collections.singletonMap("k", "v"));
+        
+        assertEquals("service", actual.getServiceName());
+        assertEquals("1.1.1.1", actual.getIp());
+        assertEquals(8848, actual.getPort());
+        assertEquals("cluster", actual.getClusterName());
+        assertEquals(1.5, actual.getWeight());
+        assertEquals(true, actual.getHealthy());
+        assertEquals("instanceId", actual.getInstanceId());
+        assertEquals("v", actual.getMetadata().get("k"));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/MetricsMonitorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/MetricsMonitorTest.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.core.monitor.NacosMeterRegistryCenter;
 import com.alibaba.nacos.naming.core.v2.pojo.BatchInstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +36,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -100,5 +102,31 @@ class MetricsMonitorTest {
         newTest.setInstancePublishInfos(newInstances);
         MetricsMonitor.incrementIpCountWithBatchRegister(new InstancePublishInfo(), newTest);
         assertEquals(2, MetricsMonitor.getIpCountMonitor().get());
+    }
+    
+    @Test
+    void testDecrementIpCountWithBatchRegister() {
+        BatchInstancePublishInfo batchInstancePublishInfo = new BatchInstancePublishInfo();
+        List<InstancePublishInfo> instancePublishInfos = new LinkedList<>();
+        instancePublishInfos.add(new InstancePublishInfo());
+        instancePublishInfos.add(new InstancePublishInfo());
+        batchInstancePublishInfo.setInstancePublishInfos(instancePublishInfos);
+        MetricsMonitor.getIpCountMonitor().set(3);
+        
+        MetricsMonitor.decrementIpCountWithBatchRegister(batchInstancePublishInfo);
+        
+        assertEquals(1, MetricsMonitor.getIpCountMonitor().get());
+    }
+    
+    @Test
+    void testLeaderStatusAndExceptionCounters() {
+        MetricsMonitor.getLeaderStatusMonitor().set(1L);
+        Counter diskException = MetricsMonitor.getDiskException();
+        Counter leaderSendBeatFailedException =
+            MetricsMonitor.getLeaderSendBeatFailedException();
+        
+        assertEquals(1L, MetricsMonitor.getLeaderStatusMonitor().get());
+        assertNotNull(diskException);
+        assertNotNull(leaderSendBeatFailedException);
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/NamingDynamicMeterRefreshServiceTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/NamingDynamicMeterRefreshServiceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.monitor;
+
+import com.alibaba.nacos.core.monitor.NacosMeterRegistryCenter;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NamingDynamicMeterRefreshServiceTest {
+    
+    private final NamingDynamicMeterRefreshService refreshService =
+        new NamingDynamicMeterRefreshService();
+    
+    private ConfigurableEnvironment cachedEnvironment;
+    
+    private SimpleMeterRegistry simpleMeterRegistry;
+    
+    @BeforeEach
+    void setUp() {
+        cachedEnvironment = EnvUtil.getEnvironment();
+        EnvUtil.setEnvironment(new MockEnvironment());
+        simpleMeterRegistry = new SimpleMeterRegistry();
+        NacosMeterRegistryCenter.getMeterRegistry(
+            NacosMeterRegistryCenter.TOPN_SERVICE_CHANGE_REGISTRY).add(simpleMeterRegistry);
+        MetricsMonitor.getServiceChangeCount().reset();
+        NacosMeterRegistryCenter.clear(NacosMeterRegistryCenter.TOPN_SERVICE_CHANGE_REGISTRY);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        MetricsMonitor.getServiceChangeCount().reset();
+        NacosMeterRegistryCenter.clear(NacosMeterRegistryCenter.TOPN_SERVICE_CHANGE_REGISTRY);
+        EnvUtil.setEnvironment(cachedEnvironment);
+    }
+    
+    @Test
+    void testRefreshTopnServiceChangeCountRegistersGauge() {
+        Service service = Service.newService("namespace", "group", "service");
+        MetricsMonitor.getServiceChangeCount().set(service, 7);
+        
+        refreshService.refreshTopnServiceChangeCount();
+        
+        CompositeMeterRegistry registry = NacosMeterRegistryCenter.getMeterRegistry(
+            NacosMeterRegistryCenter.TOPN_SERVICE_CHANGE_REGISTRY);
+        Gauge gauge = registry.find("service_change_count")
+            .tag("service",
+                "namespace" + UtilsAndCommons.NAMESPACE_SERVICE_CONNECTOR
+                    + service.getGroupedServiceName())
+            .gauge();
+        assertNotNull(gauge);
+        assertEquals(7D, gauge.value());
+    }
+    
+    @Test
+    void testResetTopnServiceChangeCountClearsCounter() {
+        MetricsMonitor.getServiceChangeCount()
+            .set(Service.newService("namespace", "group", "service"), 3);
+        
+        refreshService.resetTopnServiceChangeCount();
+        
+        assertTrue(MetricsMonitor.getServiceChangeCount().getCounterOfTopN(10).isEmpty());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/NamingTpsMonitorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/NamingTpsMonitorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.monitor;
+
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class NamingTpsMonitorTest {
+    
+    @Test
+    void testGetInstanceReturnsSingleton() {
+        EnvUtil.setEnvironment(new MockEnvironment());
+        
+        assertSame(NamingTpsMonitor.getInstance(), NamingTpsMonitor.getInstance());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/PerformanceLoggerThreadTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/PerformanceLoggerThreadTest.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.core.distributed.distro.monitor.DistroRecordsHolder;
 import com.alibaba.nacos.naming.consistency.ephemeral.distro.v2.DistroClientDataProcessor;
 import com.alibaba.nacos.naming.core.v2.ServiceManager;
 import com.alibaba.nacos.naming.misc.GlobalExecutor;
+import com.alibaba.nacos.naming.misc.NamingExecuteTaskDispatcher;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import org.springframework.mock.env.MockEnvironment;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -111,5 +113,21 @@ class PerformanceLoggerThreadTest {
         assertEquals(0, MetricsMonitor.getTotalPushCountForAvg().get());
         assertEquals(0, MetricsMonitor.getTotalPushCostForAvg().get());
         assertEquals(-1, MetricsMonitor.getMaxPushCostMonitor().get());
+    }
+    
+    @Test
+    void testPerformanceLogTaskRunCatchesException() {
+        NamingExecuteTaskDispatcher dispatcher = Mockito.mock(NamingExecuteTaskDispatcher.class);
+        Mockito.when(dispatcher.workersStatus()).thenThrow(new RuntimeException("failed"));
+        PerformanceLoggerThread performanceLoggerThread = new PerformanceLoggerThread();
+        PerformanceLoggerThread.PerformanceLogTask task =
+            performanceLoggerThread.new PerformanceLogTask();
+        
+        try (MockedStatic<NamingExecuteTaskDispatcher> mockedDispatcher =
+            Mockito.mockStatic(NamingExecuteTaskDispatcher.class)) {
+            mockedDispatcher.when(NamingExecuteTaskDispatcher::getInstance).thenReturn(dispatcher);
+            
+            assertDoesNotThrow(task::run);
+        }
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/PerformanceLoggerThreadTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/PerformanceLoggerThreadTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.monitor;
+
+import com.alibaba.nacos.core.distributed.distro.monitor.DistroRecord;
+import com.alibaba.nacos.core.distributed.distro.monitor.DistroRecordsHolder;
+import com.alibaba.nacos.naming.consistency.ephemeral.distro.v2.DistroClientDataProcessor;
+import com.alibaba.nacos.naming.core.v2.ServiceManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PerformanceLoggerThreadTest {
+    
+    @AfterEach
+    void tearDown() {
+        MetricsMonitor.resetAll();
+        MetricsMonitor.getDomCountMonitor().set(0);
+        MetricsMonitor.getIpCountMonitor().set(0);
+        MetricsMonitor.getSubscriberCount().set(0);
+    }
+    
+    @Test
+    void testRefreshMetricsResetsHealthAndPushMetrics() {
+        MetricsMonitor.getHttpHealthCheckMonitor().set(1);
+        MetricsMonitor.getMysqlHealthCheckMonitor().set(2);
+        MetricsMonitor.getTcpHealthCheckMonitor().set(3);
+        MetricsMonitor.incrementPush();
+        MetricsMonitor.incrementFailPush();
+        MetricsMonitor.incrementEmptyPush();
+        
+        new PerformanceLoggerThread().refreshMetrics();
+        
+        assertEquals(0, MetricsMonitor.getHttpHealthCheckMonitor().get());
+        assertEquals(0, MetricsMonitor.getMysqlHealthCheckMonitor().get());
+        assertEquals(0, MetricsMonitor.getTcpHealthCheckMonitor().get());
+        assertEquals(0, MetricsMonitor.getTotalPushMonitor().get());
+        assertEquals(0, MetricsMonitor.getFailedPushMonitor().get());
+        assertEquals(0, MetricsMonitor.getEmptyPushMonitor().get());
+    }
+    
+    @Test
+    void testCollectMetricsUpdatesServiceCountAndAvgPushCost() {
+        MetricsMonitor.incrementPushCost(10);
+        MetricsMonitor.incrementPushCost(20);
+        PerformanceLoggerThread performanceLoggerThread = new PerformanceLoggerThread();
+        
+        performanceLoggerThread.collectMetrics();
+        
+        assertEquals(ServiceManager.getInstance().size(),
+            MetricsMonitor.getDomCountMonitor().get());
+        assertEquals(15, MetricsMonitor.getAvgPushCostMonitor().get());
+    }
+    
+    @Test
+    void testPerformanceLogTaskRunResetsRollingPushMetrics() {
+        MetricsMonitor.getIpCountMonitor().set(2);
+        MetricsMonitor.getSubscriberCount().set(3);
+        MetricsMonitor.getMaxPushCostMonitor().set(99);
+        MetricsMonitor.incrementPush();
+        MetricsMonitor.incrementFailPush();
+        MetricsMonitor.incrementPushCost(30);
+        DistroRecord distroRecord =
+            DistroRecordsHolder.getInstance().getRecord(DistroClientDataProcessor.TYPE);
+        distroRecord.syncSuccess();
+        distroRecord.syncFail();
+        distroRecord.verifyFail();
+        PerformanceLoggerThread performanceLoggerThread = new PerformanceLoggerThread();
+        PerformanceLoggerThread.PerformanceLogTask task =
+            performanceLoggerThread.new PerformanceLogTask();
+        
+        task.run();
+        
+        assertEquals(0, MetricsMonitor.getTotalPushCountForAvg().get());
+        assertEquals(0, MetricsMonitor.getTotalPushCostForAvg().get());
+        assertEquals(-1, MetricsMonitor.getMaxPushCostMonitor().get());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/PerformanceLoggerThreadTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/PerformanceLoggerThreadTest.java
@@ -20,10 +20,19 @@ import com.alibaba.nacos.core.distributed.distro.monitor.DistroRecord;
 import com.alibaba.nacos.core.distributed.distro.monitor.DistroRecordsHolder;
 import com.alibaba.nacos.naming.consistency.ephemeral.distro.v2.DistroClientDataProcessor;
 import com.alibaba.nacos.naming.core.v2.ServiceManager;
+import com.alibaba.nacos.naming.misc.GlobalExecutor;
+import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 class PerformanceLoggerThreadTest {
     
@@ -33,6 +42,19 @@ class PerformanceLoggerThreadTest {
         MetricsMonitor.getDomCountMonitor().set(0);
         MetricsMonitor.getIpCountMonitor().set(0);
         MetricsMonitor.getSubscriberCount().set(0);
+    }
+    
+    @Test
+    void testInitSchedulesPerformanceLogger() {
+        EnvUtil.setEnvironment(new MockEnvironment());
+        try (MockedStatic<GlobalExecutor> mockedGlobalExecutor =
+            Mockito.mockStatic(GlobalExecutor.class)) {
+            
+            new PerformanceLoggerThread().init();
+            
+            mockedGlobalExecutor.verify(() -> GlobalExecutor.schedulePerformanceLogger(
+                any(Runnable.class), eq(30L), eq(60L), eq(TimeUnit.SECONDS)));
+        }
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/collector/NamingMetricsCollectorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/collector/NamingMetricsCollectorTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.monitor.collector;
+
+import com.alibaba.nacos.common.notify.EventPublisher;
+import com.alibaba.nacos.common.notify.NotifyCenter;
+import com.alibaba.nacos.naming.core.v2.client.Client;
+import com.alibaba.nacos.naming.core.v2.client.manager.impl.ConnectionBasedClientManager;
+import com.alibaba.nacos.naming.core.v2.client.manager.impl.EphemeralIpPortClientManager;
+import com.alibaba.nacos.naming.core.v2.client.manager.impl.PersistentIpPortClientManager;
+import com.alibaba.nacos.naming.core.v2.event.service.ServiceEvent;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.monitor.MetricsMonitor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class NamingMetricsCollectorTest {
+    
+    private ScheduledExecutorService originalSubAndPubExecutor;
+    
+    private ScheduledExecutorService originalServiceEventQueueExecutor;
+    
+    private EventPublisher originalSubscribedPublisher;
+    
+    private EventPublisher originalChangedPublisher;
+    
+    @AfterEach
+    void tearDown() {
+        if (originalSubAndPubExecutor != null) {
+            ReflectionTestUtils.setField(NamingSubAndPubMetricsCollector.class, "executorService",
+                originalSubAndPubExecutor);
+        }
+        if (originalServiceEventQueueExecutor != null) {
+            ReflectionTestUtils.setField(ServiceEventQueueSizeMetricsCollector.class,
+                "executorService",
+                originalServiceEventQueueExecutor);
+        }
+        restorePublisher(ServiceEvent.ServiceSubscribedEvent.class, originalSubscribedPublisher);
+        restorePublisher(ServiceEvent.ServiceChangedEvent.class, originalChangedPublisher);
+        MetricsMonitor.getNamingSubscriber("v1").set(0);
+        MetricsMonitor.getNamingPublisher("v1").set(0);
+        MetricsMonitor.getNamingSubscriber("v2").set(0);
+        MetricsMonitor.getNamingPublisher("v2").set(0);
+        MetricsMonitor.getServiceSubscribedEventQueueSize().set(0);
+        MetricsMonitor.getServiceChangedEventQueueSize().set(0);
+    }
+    
+    @Test
+    void testNamingSubAndPubMetricsCollectorCollectsClientMetrics() throws Exception {
+        ScheduledExecutorService executorService = Mockito.mock(ScheduledExecutorService.class);
+        AtomicReference<Runnable> scheduledTask = mockScheduleWithFixedDelay(executorService);
+        originalSubAndPubExecutor =
+            (ScheduledExecutorService) ReflectionTestUtils.getField(
+                NamingSubAndPubMetricsCollector.class,
+                "executorService");
+        runNoopOnOriginalExecutor(originalSubAndPubExecutor);
+        ReflectionTestUtils.setField(NamingSubAndPubMetricsCollector.class, "executorService",
+            executorService);
+        
+        EphemeralIpPortClientManager ephemeralManager =
+            Mockito.mock(EphemeralIpPortClientManager.class);
+        PersistentIpPortClientManager persistentManager =
+            Mockito.mock(PersistentIpPortClientManager.class);
+        ConnectionBasedClientManager connectionManager =
+            Mockito.mock(ConnectionBasedClientManager.class);
+        Client ephemeralClient = mockClient(2, 1);
+        Client persistentClient = mockClient(1, 2);
+        Client connectionClient = mockClient(3, 4);
+        Mockito.when(ephemeralManager.allClientId())
+            .thenReturn(Arrays.asList("ephemeral", "missing"));
+        Mockito.when(ephemeralManager.getClient("ephemeral")).thenReturn(ephemeralClient);
+        Mockito.when(persistentManager.allClientId())
+            .thenReturn(Collections.singletonList("persistent"));
+        Mockito.when(persistentManager.getClient("persistent")).thenReturn(persistentClient);
+        Mockito.when(connectionManager.allClientId())
+            .thenReturn(Collections.singletonList("connection"));
+        Mockito.when(connectionManager.getClient("connection")).thenReturn(connectionClient);
+        
+        new NamingSubAndPubMetricsCollector(connectionManager, ephemeralManager, persistentManager);
+        assertNotNull(scheduledTask.get());
+        scheduledTask.get().run();
+        
+        assertEquals(3, MetricsMonitor.getNamingPublisher("v1").get());
+        assertEquals(3, MetricsMonitor.getNamingSubscriber("v1").get());
+        assertEquals(3, MetricsMonitor.getNamingPublisher("v2").get());
+        assertEquals(4, MetricsMonitor.getNamingSubscriber("v2").get());
+        Mockito.verify(executorService)
+            .scheduleWithFixedDelay(Mockito.any(Runnable.class), Mockito.eq(5L), Mockito.eq(5L),
+                Mockito.eq(TimeUnit.SECONDS));
+    }
+    
+    @Test
+    void testServiceEventQueueSizeMetricsCollectorCollectsPublisherQueueSize() throws Exception {
+        ScheduledExecutorService executorService = Mockito.mock(ScheduledExecutorService.class);
+        AtomicReference<Runnable> scheduledTask = mockScheduleWithFixedDelay(executorService);
+        originalServiceEventQueueExecutor =
+            (ScheduledExecutorService) ReflectionTestUtils.getField(
+                ServiceEventQueueSizeMetricsCollector.class,
+                "executorService");
+        runNoopOnOriginalExecutor(originalServiceEventQueueExecutor);
+        ReflectionTestUtils.setField(ServiceEventQueueSizeMetricsCollector.class, "executorService",
+            executorService);
+        EventPublisher subscribedPublisher = Mockito.mock(EventPublisher.class);
+        EventPublisher changedPublisher = Mockito.mock(EventPublisher.class);
+        Mockito.when(subscribedPublisher.currentEventSize()).thenReturn(7L);
+        Mockito.when(changedPublisher.currentEventSize()).thenReturn(11L);
+        replacePublisher(ServiceEvent.ServiceSubscribedEvent.class, subscribedPublisher);
+        replacePublisher(ServiceEvent.ServiceChangedEvent.class, changedPublisher);
+        
+        new ServiceEventQueueSizeMetricsCollector();
+        assertNotNull(scheduledTask.get());
+        scheduledTask.get().run();
+        
+        assertEquals(7, MetricsMonitor.getServiceSubscribedEventQueueSize().get());
+        assertEquals(11, MetricsMonitor.getServiceChangedEventQueueSize().get());
+        Mockito.verify(executorService)
+            .scheduleWithFixedDelay(Mockito.any(Runnable.class), Mockito.eq(2L), Mockito.eq(2L),
+                Mockito.eq(TimeUnit.SECONDS));
+    }
+    
+    @SuppressWarnings("unchecked")
+    private AtomicReference<Runnable> mockScheduleWithFixedDelay(
+        ScheduledExecutorService executorService) {
+        AtomicReference<Runnable> scheduledTask = new AtomicReference<>();
+        ScheduledFuture<Object> future = Mockito.mock(ScheduledFuture.class);
+        Answer<ScheduledFuture<Object>> captureTaskAnswer = invocation -> {
+            scheduledTask.set(invocation.getArgument(0));
+            return future;
+        };
+        Mockito.when(executorService.scheduleWithFixedDelay(Mockito.any(Runnable.class),
+            Mockito.anyLong(), Mockito.anyLong(), Mockito.any(TimeUnit.class)))
+            .thenAnswer(captureTaskAnswer);
+        return scheduledTask;
+    }
+    
+    private Client mockClient(int publishedCount, int subscribedCount) {
+        Client result = Mockito.mock(Client.class);
+        Mockito.when(result.getAllPublishedService()).thenReturn(mockServices(publishedCount));
+        Mockito.when(result.getAllSubscribeService()).thenReturn(mockServices(subscribedCount));
+        return result;
+    }
+    
+    private void runNoopOnOriginalExecutor(ScheduledExecutorService executorService)
+        throws Exception {
+        executorService.submit(() -> "done").get(5, TimeUnit.SECONDS);
+    }
+    
+    private Collection<Service> mockServices(int count) {
+        Collection<Service> result = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            result.add(Service.newService("namespace", "group", "service" + i));
+        }
+        return result;
+    }
+    
+    private void replacePublisher(Class<? extends ServiceEvent> eventClass,
+        EventPublisher eventPublisher) {
+        Map<String, EventPublisher> publisherMap = NotifyCenter.getPublisherMap();
+        if (ServiceEvent.ServiceSubscribedEvent.class.equals(eventClass)) {
+            originalSubscribedPublisher = publisherMap.get(eventClass.getCanonicalName());
+        } else {
+            originalChangedPublisher = publisherMap.get(eventClass.getCanonicalName());
+        }
+        publisherMap.put(eventClass.getCanonicalName(), eventPublisher);
+    }
+    
+    private void restorePublisher(Class<? extends ServiceEvent> eventClass,
+        EventPublisher originalPublisher) {
+        Map<String, EventPublisher> publisherMap = NotifyCenter.getPublisherMap();
+        if (originalPublisher == null) {
+            publisherMap.remove(eventClass.getCanonicalName());
+        } else {
+            publisherMap.put(eventClass.getCanonicalName(), originalPublisher);
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/collector/NamingMetricsCollectorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/collector/NamingMetricsCollectorTest.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.naming.core.v2.client.manager.impl.PersistentIpPortClie
 import com.alibaba.nacos.naming.core.v2.event.service.ServiceEvent;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.monitor.MetricsMonitor;
+import com.alibaba.nacos.naming.push.v2.NamingSubscriberServiceV2Impl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,6 +54,8 @@ class NamingMetricsCollectorTest {
     
     private ScheduledExecutorService originalServiceEventQueueExecutor;
     
+    private ScheduledExecutorService originalPushPendingTaskExecutor;
+    
     private EventPublisher originalSubscribedPublisher;
     
     private EventPublisher originalChangedPublisher;
@@ -68,6 +71,11 @@ class NamingMetricsCollectorTest {
                 "executorService",
                 originalServiceEventQueueExecutor);
         }
+        if (originalPushPendingTaskExecutor != null) {
+            ReflectionTestUtils.setField(PushPendingTaskCountMetricsCollector.class,
+                "executorService",
+                originalPushPendingTaskExecutor);
+        }
         restorePublisher(ServiceEvent.ServiceSubscribedEvent.class, originalSubscribedPublisher);
         restorePublisher(ServiceEvent.ServiceChangedEvent.class, originalChangedPublisher);
         MetricsMonitor.getNamingSubscriber("v1").set(0);
@@ -76,6 +84,7 @@ class NamingMetricsCollectorTest {
         MetricsMonitor.getNamingPublisher("v2").set(0);
         MetricsMonitor.getServiceSubscribedEventQueueSize().set(0);
         MetricsMonitor.getServiceChangedEventQueueSize().set(0);
+        MetricsMonitor.getPushPendingTaskCount().set(0);
     }
     
     @Test
@@ -146,6 +155,32 @@ class NamingMetricsCollectorTest {
         
         assertEquals(7, MetricsMonitor.getServiceSubscribedEventQueueSize().get());
         assertEquals(11, MetricsMonitor.getServiceChangedEventQueueSize().get());
+        Mockito.verify(executorService)
+            .scheduleWithFixedDelay(Mockito.any(Runnable.class), Mockito.eq(2L), Mockito.eq(2L),
+                Mockito.eq(TimeUnit.SECONDS));
+    }
+    
+    @Test
+    void testPushPendingTaskCountMetricsCollectorCollectsPendingTaskCount() throws Exception {
+        ScheduledExecutorService executorService = Mockito.mock(ScheduledExecutorService.class);
+        AtomicReference<Runnable> scheduledTask = mockScheduleWithFixedDelay(executorService);
+        originalPushPendingTaskExecutor =
+            (ScheduledExecutorService) ReflectionTestUtils.getField(
+                PushPendingTaskCountMetricsCollector.class,
+                "executorService");
+        runNoopOnOriginalExecutor(originalPushPendingTaskExecutor);
+        ReflectionTestUtils.setField(PushPendingTaskCountMetricsCollector.class,
+            "executorService",
+            executorService);
+        NamingSubscriberServiceV2Impl namingSubscriberService =
+            Mockito.mock(NamingSubscriberServiceV2Impl.class);
+        Mockito.when(namingSubscriberService.getPushPendingTaskCount()).thenReturn(17);
+        
+        new PushPendingTaskCountMetricsCollector(namingSubscriberService);
+        assertNotNull(scheduledTask.get());
+        scheduledTask.get().run();
+        
+        assertEquals(17, MetricsMonitor.getPushPendingTaskCount().get());
         Mockito.verify(executorService)
             .scheduleWithFixedDelay(Mockito.any(Runnable.class), Mockito.eq(2L), Mockito.eq(2L),
                 Mockito.eq(TimeUnit.SECONDS));

--- a/naming/src/test/java/com/alibaba/nacos/naming/paramcheck/NamingHttpParamExtractorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/paramcheck/NamingHttpParamExtractorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.paramcheck;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.common.paramcheck.ParamInfo;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.naming.healthcheck.RsInfo;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NamingHttpParamExtractorTest {
+    
+    @Test
+    void testDefaultExtractorUsesAliasesAndSplitGroupServiceName() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("namespaceId", "namespace");
+        request.addParameter("serviceNameParam", "group@@service");
+        request.addParameter("groupNameParam", "fallbackGroup");
+        request.addParameter("ip", "1.1.1.1");
+        request.addParameter("checkPort", "8848");
+        request.addParameter("cluster", "clusterA");
+        request.addParameter("metadata", "env=dev,zone=hangzhou");
+        
+        List<ParamInfo> actual = new NamingDefaultHttpParamExtractor().extractParam(request);
+        
+        assertEquals(1, actual.size());
+        ParamInfo paramInfo = actual.get(0);
+        assertEquals("namespace", paramInfo.getNamespaceId());
+        assertEquals("group", paramInfo.getGroup());
+        assertEquals("service", paramInfo.getServiceName());
+        assertEquals("1.1.1.1", paramInfo.getIp());
+        assertEquals("8848", paramInfo.getPort());
+        assertEquals("clusterA", paramInfo.getCluster());
+        assertEquals("dev", paramInfo.getMetadata().get("env"));
+        assertEquals("hangzhou", paramInfo.getMetadata().get("zone"));
+    }
+    
+    @Test
+    void testDefaultExtractorUsesPrimaryParameters() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("namespaceId", "namespace");
+        request.addParameter("serviceName", "service");
+        request.addParameter("groupName", "group");
+        request.addParameter("port", "8848");
+        request.addParameter("clusterName", "clusterA");
+        
+        ParamInfo actual = new NamingDefaultHttpParamExtractor().extractParam(request).get(0);
+        
+        assertEquals("namespace", actual.getNamespaceId());
+        assertEquals("group", actual.getGroup());
+        assertEquals("service", actual.getServiceName());
+        assertEquals("8848", actual.getPort());
+        assertEquals("clusterA", actual.getCluster());
+    }
+    
+    @Test
+    void testInstanceListExtractorSplitsGroupServiceName() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("namespaceId", "namespace");
+        request.addParameter("serviceName", "group@@service");
+        request.addParameter("groupName", "ignoredGroup");
+        request.addParameter("clusters", "clusterA,clusterB");
+        
+        ParamInfo actual = new NamingInstanceListHttpParamExtractor().extractParam(request).get(0);
+        
+        assertEquals("namespace", actual.getNamespaceId());
+        assertEquals("group", actual.getGroup());
+        assertEquals("service", actual.getServiceName());
+        assertEquals("clusterA,clusterB", actual.getClusters());
+    }
+    
+    @Test
+    void testInstanceBeatExtractorAddsBeatParamInfo() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("namespaceId", "namespace");
+        request.addParameter("serviceName", "group@@service");
+        request.addParameter("ip", "1.1.1.1");
+        request.addParameter("port", "8848");
+        request.addParameter("beat", JacksonUtils.toJson(createBeat()));
+        
+        List<ParamInfo> actual = new NamingInstanceBeatHttpParamExtractor().extractParam(request);
+        
+        assertEquals(2, actual.size());
+        assertEquals("group", actual.get(0).getGroup());
+        assertEquals("service", actual.get(0).getServiceName());
+        assertEquals("1.1.1.1", actual.get(0).getIp());
+        assertEquals("8848", actual.get(0).getPort());
+        assertEquals("2.2.2.2", actual.get(1).getIp());
+        assertEquals("9848", actual.get(1).getPort());
+        assertEquals("beatCluster", actual.get(1).getCluster());
+    }
+    
+    @Test
+    void testInstanceMetadataBatchExtractorAddsInstanceParamInfos() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("namespaceId", "namespace");
+        request.addParameter("serviceName", "group@@service");
+        request.addParameter("metadata", "version=1.0");
+        request.addParameter("instances",
+            JacksonUtils.toJson(Collections.singletonList(createInstance())));
+        
+        List<ParamInfo> actual =
+            new NamingInstanceMetadataBatchHttpParamExtractor().extractParam(request);
+        
+        assertEquals(2, actual.size());
+        assertEquals("namespace", actual.get(0).getNamespaceId());
+        assertEquals("group", actual.get(0).getGroup());
+        assertEquals("service", actual.get(0).getServiceName());
+        assertEquals("1.0", actual.get(0).getMetadata().get("version"));
+        assertEquals("3.3.3.3", actual.get(1).getIp());
+        assertEquals("10848", actual.get(1).getPort());
+        assertEquals("instanceCluster", actual.get(1).getCluster());
+    }
+    
+    private RsInfo createBeat() {
+        RsInfo beat = new RsInfo();
+        beat.setIp("2.2.2.2");
+        beat.setPort(9848);
+        beat.setCluster("beatCluster");
+        return beat;
+    }
+    
+    private Instance createInstance() {
+        Instance instance = new Instance();
+        instance.setIp("3.3.3.3");
+        instance.setPort(10848);
+        instance.setClusterName("instanceCluster");
+        return instance;
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/pojo/LegacyNamingPojoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/pojo/LegacyNamingPojoTest.java
@@ -106,6 +106,17 @@ class LegacyNamingPojoTest {
         assertEquals(metadata, info.getMetadata());
     }
     
+    @Test
+    void testServiceNameViewAccessors() {
+        ServiceNameView view = new ServiceNameView();
+        
+        view.setCount(2);
+        view.setServices(Collections.singletonList("group@@service"));
+        
+        assertEquals(2, view.getCount());
+        assertEquals(Collections.singletonList("group@@service"), view.getServices());
+    }
+    
     private Instance createInstance() {
         Instance instance = new Instance();
         instance.setIp("1.1.1.1");

--- a/naming/src/test/java/com/alibaba/nacos/naming/pojo/LegacyNamingPojoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/pojo/LegacyNamingPojoTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.pojo;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.AbstractHealthChecker;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("deprecation")
+class LegacyNamingPojoTest {
+    
+    @Test
+    void testClusterInfoFromMaintainerClusterInfo() {
+        com.alibaba.nacos.api.naming.pojo.maintainer.ClusterInfo source =
+            new com.alibaba.nacos.api.naming.pojo.maintainer.ClusterInfo();
+        source.setClusterName("cluster");
+        source.setHealthChecker(new AbstractHealthChecker.None());
+        source.setMetadata(Collections.singletonMap("env", "test"));
+        source.setHosts(Collections.singletonList(createInstance()));
+        
+        ClusterInfo actual = ClusterInfo.from(source);
+        
+        assertEquals("cluster", actual.getClusterName());
+        assertSame(source.getHealthChecker(), actual.getHealthChecker());
+        assertEquals("test", actual.getMetadata().get("env"));
+        assertEquals(1, actual.getHosts().size());
+        IpAddressInfo host = actual.getHosts().get(0);
+        assertEquals("1.1.1.1", host.getIp());
+        assertEquals(8848, host.getPort());
+        assertEquals(2.0, host.getWeight());
+        assertEquals("v1", host.getMetadata().get("version"));
+        assertTrue(host.isEnabled());
+        assertFalse(host.isValid());
+    }
+    
+    @Test
+    void testServiceDetailInfoFromMaintainerServiceDetailInfo() {
+        com.alibaba.nacos.api.naming.pojo.maintainer.ClusterInfo clusterInfo =
+            new com.alibaba.nacos.api.naming.pojo.maintainer.ClusterInfo();
+        clusterInfo.setClusterName("cluster");
+        clusterInfo.setMetadata(Collections.singletonMap("cluster", "metadata"));
+        clusterInfo.setHosts(Collections.singletonList(createInstance()));
+        com.alibaba.nacos.api.naming.pojo.maintainer.ServiceDetailInfo source =
+            new com.alibaba.nacos.api.naming.pojo.maintainer.ServiceDetailInfo();
+        source.setNamespaceId("namespace");
+        source.setServiceName("service");
+        source.setGroupName("group");
+        source.setMetadata(Collections.singletonMap("service", "metadata"));
+        source.setProtectThreshold(0.8F);
+        source.setEphemeral(true);
+        source.setClusterMap(Collections.singletonMap("cluster", clusterInfo));
+        
+        ServiceDetailInfo actual = ServiceDetailInfo.from(source);
+        
+        assertEquals("namespace", actual.getNamespace());
+        assertEquals("service", actual.getServiceName());
+        assertEquals("group", actual.getGroupName());
+        assertEquals("metadata", actual.getMetadata().get("service"));
+        assertEquals(0.8F, actual.getProtectThreshold());
+        assertTrue(actual.isEphemeral());
+        assertEquals(1, actual.getClusterMap().size());
+        assertEquals("cluster", actual.getClusterMap().get("cluster").getClusterName());
+    }
+    
+    @Test
+    void testIpAddressInfoAccessors() {
+        IpAddressInfo info = new IpAddressInfo();
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("k", "v");
+        
+        info.setValid(true);
+        info.setEnabled(true);
+        info.setIp("1.1.1.1");
+        info.setPort(8848);
+        info.setWeight(1.5);
+        info.setMetadata(metadata);
+        
+        assertTrue(info.isValid());
+        assertTrue(info.isEnabled());
+        assertEquals("1.1.1.1", info.getIp());
+        assertEquals(8848, info.getPort());
+        assertEquals(1.5, info.getWeight());
+        assertEquals(metadata, info.getMetadata());
+    }
+    
+    private Instance createInstance() {
+        Instance instance = new Instance();
+        instance.setIp("1.1.1.1");
+        instance.setPort(8848);
+        instance.setWeight(2.0);
+        instance.setMetadata(Collections.singletonMap("version", "v1"));
+        instance.setEnabled(true);
+        instance.setHealthy(false);
+        return instance;
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/pojo/ServiceDetailInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/pojo/ServiceDetailInfoTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.pojo;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.naming.selector.NoneSelector;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@SuppressWarnings("deprecation")
+class ServiceDetailInfoTest {
+    
+    @Test
+    void testSelectorGetter() {
+        ServiceDetailInfo serviceDetailInfo = new ServiceDetailInfo();
+        NoneSelector<Instance> selector = new NoneSelector<>();
+        
+        serviceDetailInfo.setSelector(selector);
+        
+        assertSame(selector, serviceDetailInfo.getSelector());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/pojo/instance/InstanceIdGeneratorManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/pojo/instance/InstanceIdGeneratorManagerTest.java
@@ -26,10 +26,12 @@ import org.springframework.mock.env.MockEnvironment;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import static com.alibaba.nacos.api.common.Constants.SNOWFLAKE_INSTANCE_ID_GENERATOR;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,5 +66,16 @@ class InstanceIdGeneratorManagerTest {
         instance.setPort(1000);
         assertThat(InstanceIdGeneratorManager.generateInstanceId(instance),
             is("1.1.1.1#1000#cluster#service"));
+    }
+    
+    @Test
+    void testGenerateInstanceIdWithUnknownGenerator() {
+        Instance instance = new Instance();
+        Map<String, String> metaData = new HashMap<>(1);
+        metaData.put(PreservedMetadataKeys.INSTANCE_ID_GENERATOR, "unknown");
+        instance.setMetadata(metaData);
+        
+        assertThrows(NoSuchElementException.class,
+            () -> InstanceIdGeneratorManager.generateInstanceId(instance));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/ClientInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/ClientInfoTest.java
@@ -97,6 +97,14 @@ class ClientInfoTest {
         assertEquals("0.0.0", actual.version.toString());
     }
     
+    @Test
+    void testGetClientInfoWithoutVersionMarker() {
+        ClientInfo actual = new ClientInfo(ClientInfo.ClientTypeDescription.JAVA_CLIENT);
+        
+        assertEquals(ClientInfo.ClientType.JAVA, actual.type);
+        assertEquals("0.0.0", actual.version.toString());
+    }
+    
     private String getUserAgent(String client) {
         return client + ":v" + testVersionString;
     }

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/NamingSubscriberServiceAggregationImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/NamingSubscriberServiceAggregationImplTest.java
@@ -16,25 +16,38 @@
 
 package com.alibaba.nacos.naming.push;
 
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.api.naming.pojo.maintainer.SubscriberInfo;
+import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.core.cluster.Member;
 import com.alibaba.nacos.core.cluster.ServerMemberManager;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.misc.HttpClient;
 import com.alibaba.nacos.naming.pojo.Subscriber;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,15 +67,17 @@ class NamingSubscriberServiceAggregationImplTest {
     @Mock
     private NamingSubscriberServiceLocalImpl local;
     
-    @Mock
-    private ConfigurableEnvironment environment;
-    
     private HashMap<String, Member> members;
     
     private NamingSubscriberServiceAggregationImpl aggregation;
     
+    private ConfigurableEnvironment cachedEnvironment;
+    
     @BeforeEach
     void setUp() throws Exception {
+        cachedEnvironment = EnvUtil.getEnvironment();
+        EnvUtil.setEnvironment(new MockEnvironment());
+        EnvUtil.setContextPath("/nacos");
         aggregation = new NamingSubscriberServiceAggregationImpl(local, memberManager);
         Subscriber subscriber = new Subscriber("local", "", "", "", namespace, serviceName, 0);
         when(local.getSubscribers(namespace, serviceName))
@@ -76,6 +91,12 @@ class NamingSubscriberServiceAggregationImplTest {
         when(memberManager.getServerList()).thenReturn(members);
     }
     
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(cachedEnvironment);
+        EnvUtil.setContextPath(null);
+    }
+    
     @Test
     void testGetSubscribersByStringWithLocal() {
         Collection<Subscriber> actual = aggregation.getSubscribers(namespace, serviceName);
@@ -85,7 +106,15 @@ class NamingSubscriberServiceAggregationImplTest {
     
     @Test
     void testGetSubscribersByStringWithRemote() {
-        // TODO
+        mockRemoteCluster();
+        try (MockedStatic<HttpClient> httpClient = Mockito.mockStatic(HttpClient.class)) {
+            httpClient.when(() -> HttpClient.httpGet(anyString(), anyList(), anyMap()))
+                .thenReturn(successRemoteResponse());
+            
+            Collection<Subscriber> actual = aggregation.getSubscribers(namespace, serviceName);
+            
+            assertSubscribersWithRemote(actual);
+        }
     }
     
     @Test
@@ -97,7 +126,15 @@ class NamingSubscriberServiceAggregationImplTest {
     
     @Test
     void testGetSubscribersByServiceWithRemote() {
-        // TODO
+        mockRemoteCluster();
+        try (MockedStatic<HttpClient> httpClient = Mockito.mockStatic(HttpClient.class)) {
+            httpClient.when(() -> HttpClient.httpGet(anyString(), anyList(), anyMap()))
+                .thenReturn(successRemoteResponse());
+            
+            Collection<Subscriber> actual = aggregation.getSubscribers(service);
+            
+            assertSubscribersWithRemote(actual);
+        }
     }
     
     @Test
@@ -112,5 +149,67 @@ class NamingSubscriberServiceAggregationImplTest {
         Collection<Subscriber> actual = aggregation.getFuzzySubscribers(service);
         assertEquals(1, actual.size());
         assertEquals("local", actual.iterator().next().getAddrStr());
+    }
+    
+    @Test
+    void testGetFuzzySubscribersByStringWithRemoteFailure() {
+        mockRemoteCluster();
+        try (MockedStatic<HttpClient> httpClient = Mockito.mockStatic(HttpClient.class)) {
+            httpClient.when(() -> HttpClient.httpGet(anyString(), anyList(), anyMap()))
+                .thenReturn(new RestResult<>(500, "error", ""));
+            
+            Collection<Subscriber> actual = aggregation.getFuzzySubscribers(namespace, serviceName);
+            
+            assertEquals(1, actual.size());
+            assertEquals("local", actual.iterator().next().getAddrStr());
+        }
+    }
+    
+    @Test
+    void testGetFuzzySubscribersByServiceWithRemoteFailure() {
+        mockRemoteCluster();
+        try (MockedStatic<HttpClient> httpClient = Mockito.mockStatic(HttpClient.class)) {
+            httpClient.when(() -> HttpClient.httpGet(anyString(), anyList(), anyMap()))
+                .thenReturn(new RestResult<>(500, "error", ""));
+            
+            Collection<Subscriber> actual = aggregation.getFuzzySubscribers(service);
+            
+            assertEquals(1, actual.size());
+            assertEquals("local", actual.iterator().next().getAddrStr());
+        }
+    }
+    
+    private void mockRemoteCluster() {
+        Member remoteMember = Mockito.mock(Member.class);
+        when(remoteMember.getAddress()).thenReturn("127.0.0.2:8848");
+        members.put("2", remoteMember);
+        when(memberManager.getServerList()).thenReturn(members);
+        when(memberManager.allMembersWithoutSelf())
+            .thenReturn(Collections.singletonList(remoteMember));
+    }
+    
+    private RestResult<String> successRemoteResponse() {
+        SubscriberInfo remoteSubscriber = new SubscriberInfo();
+        remoteSubscriber.setNamespaceId(namespace);
+        remoteSubscriber.setServiceName("S");
+        remoteSubscriber.setGroupName("G");
+        remoteSubscriber.setIp("remote");
+        remoteSubscriber.setPort(8080);
+        remoteSubscriber.setAgent("remote-agent");
+        remoteSubscriber.setAppName("remote-app");
+        Page<SubscriberInfo> page = new Page<>();
+        page.setPageItems(Collections.singletonList(remoteSubscriber));
+        return new RestResult<>(200, "success", JacksonUtils.toJson(Result.success(page)));
+    }
+    
+    private void assertSubscribersWithRemote(Collection<Subscriber> actual) {
+        assertEquals(2, actual.size());
+        Subscriber remoteSubscriber = actual.stream()
+            .filter(each -> "remote:8080".equals(each.getAddrStr())).findFirst().orElseThrow();
+        assertEquals("remote-agent", remoteSubscriber.getAgent());
+        assertEquals("remote-app", remoteSubscriber.getApp());
+        assertEquals(namespace, remoteSubscriber.getNamespaceId());
+        assertEquals(serviceName, remoteSubscriber.getServiceName());
+        assertEquals(8080, remoteSubscriber.getPort());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/NamingSubscriberServiceLocalImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/NamingSubscriberServiceLocalImplTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.push;
+
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.pojo.Subscriber;
+import com.alibaba.nacos.naming.push.v2.NamingSubscriberServiceV2Impl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NamingSubscriberServiceLocalImplTest {
+    
+    private static final String NAMESPACE = "namespace";
+    
+    private static final String GROUPED_SERVICE_NAME = "group@@service";
+    
+    private static final Service SERVICE = Service.newService(NAMESPACE, "group", "service");
+    
+    @Mock
+    private NamingSubscriberServiceV2Impl namingSubscriberServiceV2;
+    
+    @Mock
+    private Subscriber subscriber;
+    
+    private NamingSubscriberServiceLocalImpl serviceLocal;
+    
+    @BeforeEach
+    void setUp() {
+        serviceLocal = new NamingSubscriberServiceLocalImpl(namingSubscriberServiceV2);
+    }
+    
+    @Test
+    void testGetSubscribersByNamespaceAndServiceName() {
+        Set<Subscriber> source = sourceSubscribers();
+        when(namingSubscriberServiceV2.getSubscribers(NAMESPACE, GROUPED_SERVICE_NAME))
+            .thenReturn(source);
+        
+        Collection<Subscriber> actual =
+            serviceLocal.getSubscribers(NAMESPACE, GROUPED_SERVICE_NAME);
+        
+        assertCopiedSubscribers(source, actual);
+    }
+    
+    @Test
+    void testGetSubscribersByService() {
+        Set<Subscriber> source = sourceSubscribers();
+        when(namingSubscriberServiceV2.getSubscribers(SERVICE)).thenReturn(source);
+        
+        Collection<Subscriber> actual = serviceLocal.getSubscribers(SERVICE);
+        
+        assertCopiedSubscribers(source, actual);
+    }
+    
+    @Test
+    void testGetFuzzySubscribersByNamespaceAndServiceName() {
+        Set<Subscriber> source = sourceSubscribers();
+        when(namingSubscriberServiceV2.getFuzzySubscribers(NAMESPACE, GROUPED_SERVICE_NAME))
+            .thenReturn(source);
+        
+        Collection<Subscriber> actual =
+            serviceLocal.getFuzzySubscribers(NAMESPACE, GROUPED_SERVICE_NAME);
+        
+        assertCopiedSubscribers(source, actual);
+    }
+    
+    @Test
+    void testGetFuzzySubscribersByService() {
+        Set<Subscriber> source = sourceSubscribers();
+        when(namingSubscriberServiceV2.getFuzzySubscribers(SERVICE)).thenReturn(source);
+        
+        Collection<Subscriber> actual = serviceLocal.getFuzzySubscribers(SERVICE);
+        
+        assertCopiedSubscribers(source, actual);
+    }
+    
+    private Set<Subscriber> sourceSubscribers() {
+        return new HashSet<>(Collections.singleton(subscriber));
+    }
+    
+    private void assertCopiedSubscribers(Set<Subscriber> source,
+        Collection<Subscriber> actual) {
+        assertEquals(source, actual);
+        assertNotSame(source, actual);
+        actual.clear();
+        assertFalse(source.isEmpty());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/NamingSubscriberServiceV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/NamingSubscriberServiceV2ImplTest.java
@@ -36,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -135,5 +136,46 @@ class NamingSubscriberServiceV2ImplTest {
             new ServiceEvent.ServiceChangedEvent(service,
                 Constants.ServiceChangedType.ADD_SERVICE));
         verify(delayTaskEngine).addTask(eq(service), any(PushDelayTask.class));
+    }
+    
+    @Test
+    void testOnSubscribedEvent() {
+        subscriberService.onEvent(
+            new ServiceEvent.ServiceSubscribedEvent(service, testClientId));
+        
+        verify(delayTaskEngine).addTask(eq(service), any(PushDelayTask.class));
+    }
+    
+    @Test
+    void testGetPushPendingTaskCount() {
+        when(delayTaskEngine.size()).thenReturn(7);
+        
+        assertEquals(7, subscriberService.getPushPendingTaskCount());
+    }
+    
+    @Test
+    void testGetFuzzySubscribersFiltersGroupMismatch() {
+        Service groupMismatch = Service.newService("N", "OTHER", "S");
+        when(indexesManager.getSubscribedService())
+            .thenReturn(Collections.singletonList(groupMismatch));
+        
+        Collection<Subscriber> actual =
+            subscriberService.getFuzzySubscribers("N", service.getGroupedServiceName());
+        
+        assertEquals(0, actual.size());
+    }
+    
+    @Test
+    void testGetFuzzySubscribersUsesParallelStreamForLargeServiceSet() {
+        Collection<Service> services = new ArrayList<>();
+        for (int i = 0; i <= 100; i++) {
+            services.add(Service.newService("OTHER", "G", "S" + i));
+        }
+        when(indexesManager.getSubscribedService()).thenReturn(services);
+        
+        Collection<Subscriber> actual =
+            subscriberService.getFuzzySubscribers("N", service.getGroupedServiceName());
+        
+        assertEquals(0, actual.size());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/PushDataWrapperTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/PushDataWrapperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.push.v2;
+
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.naming.core.v2.metadata.ServiceMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PushDataWrapperTest {
+    
+    @Test
+    void testProcessedPushData() {
+        ServiceMetadata serviceMetadata = new ServiceMetadata();
+        ServiceInfo serviceInfo = new ServiceInfo("G@@S");
+        PushDataWrapper pushDataWrapper = new PushDataWrapper(serviceMetadata, serviceInfo);
+        
+        assertSame(serviceMetadata, pushDataWrapper.getServiceMetadata());
+        assertSame(serviceInfo, pushDataWrapper.getOriginalData());
+        assertFalse(pushDataWrapper.getProcessedPushData("missing").isPresent());
+        
+        pushDataWrapper.addProcessedPushData("processed", "data");
+        Optional<String> processed = pushDataWrapper.getProcessedPushData("processed");
+        
+        assertTrue(processed.isPresent());
+        assertEquals("data", processed.get());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/executor/PushExecutorDelegateTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/executor/PushExecutorDelegateTest.java
@@ -17,24 +17,34 @@
 package com.alibaba.nacos.naming.push.v2.executor;
 
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.api.naming.remote.request.AbstractFuzzyWatchNotifyRequest;
+import com.alibaba.nacos.api.remote.PushCallBack;
 import com.alibaba.nacos.naming.core.v2.metadata.ServiceMetadata;
 import com.alibaba.nacos.naming.pojo.Subscriber;
 import com.alibaba.nacos.naming.push.v2.PushDataWrapper;
 import com.alibaba.nacos.naming.push.v2.task.NamingPushCallback;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PushExecutorDelegateTest {
     
     private final String rpcClientId = UUID.randomUUID().toString();
+    
+    private final Set<SpiPushExecutor> addedPushExecutors = new HashSet<>();
     
     @Mock
     private PushExecutorRpcImpl pushExecutorRpc;
@@ -44,6 +54,15 @@ class PushExecutorDelegateTest {
     
     @Mock
     private NamingPushCallback pushCallBack;
+    
+    @Mock
+    private AbstractFuzzyWatchNotifyRequest watchNotifyRequest;
+    
+    @Mock
+    private PushCallBack fuzzyWatchPushCallBack;
+    
+    @Mock
+    private SpiPushExecutor spiPushExecutor;
     
     private PushDataWrapper pushdata;
     
@@ -58,6 +77,11 @@ class PushExecutorDelegateTest {
         delegate = new PushExecutorDelegate(pushExecutorRpc);
     }
     
+    @AfterEach
+    void tearDown() throws Exception {
+        getPushExecutors().removeAll(addedPushExecutors);
+    }
+    
     @Test
     void testDoPushForRpc() {
         delegate.doPush(rpcClientId, subscriber, pushdata);
@@ -68,5 +92,41 @@ class PushExecutorDelegateTest {
     void doPushWithCallbackForRpc() {
         delegate.doPushWithCallback(rpcClientId, subscriber, pushdata, pushCallBack);
         verify(pushExecutorRpc).doPushWithCallback(rpcClientId, subscriber, pushdata, pushCallBack);
+    }
+    
+    @Test
+    void testDoFuzzyWatchNotifyPushWithCallBackForRpc() {
+        delegate.doFuzzyWatchNotifyPushWithCallBack(rpcClientId, watchNotifyRequest,
+            fuzzyWatchPushCallBack);
+        
+        verify(pushExecutorRpc).doFuzzyWatchNotifyPushWithCallBack(rpcClientId, watchNotifyRequest,
+            fuzzyWatchPushCallBack);
+    }
+    
+    @Test
+    void testDoPushForSpiExecutor() throws Exception {
+        when(spiPushExecutor.isInterest(rpcClientId, subscriber)).thenReturn(true);
+        registerSpiPushExecutor(spiPushExecutor);
+        
+        delegate.doPush(rpcClientId, subscriber, pushdata);
+        delegate.doPushWithCallback(rpcClientId, subscriber, pushdata, pushCallBack);
+        
+        verify(spiPushExecutor).doPush(rpcClientId, subscriber, pushdata);
+        verify(spiPushExecutor).doPushWithCallback(rpcClientId, subscriber, pushdata, pushCallBack);
+        verify(pushExecutorRpc, never()).doPush(rpcClientId, subscriber, pushdata);
+        verify(pushExecutorRpc, never()).doPushWithCallback(rpcClientId, subscriber, pushdata,
+            pushCallBack);
+    }
+    
+    private void registerSpiPushExecutor(SpiPushExecutor spiPushExecutor) throws Exception {
+        getPushExecutors().add(spiPushExecutor);
+        addedPushExecutors.add(spiPushExecutor);
+    }
+    
+    @SuppressWarnings("unchecked")
+    private Set<SpiPushExecutor> getPushExecutors() throws Exception {
+        Field pushExecutors = SpiImplPushExecutorHolder.class.getDeclaredField("pushExecutors");
+        pushExecutors.setAccessible(true);
+        return (Set<SpiPushExecutor>) pushExecutors.get(SpiImplPushExecutorHolder.getInstance());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/hook/PushResultTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/hook/PushResultTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.push.v2.hook;
+
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.pojo.Subscriber;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PushResultTest {
+    
+    private final Service service = Service.newService("namespace", "group", "service");
+    
+    private final ServiceInfo serviceInfo = new ServiceInfo("group@@service");
+    
+    private final Subscriber subscriber =
+        new Subscriber("1.1.1.1:8848", "agent", "app", "1.1.1.1", "namespace",
+            "group@@service", 8848);
+    
+    @Test
+    void testPushSuccessResult() {
+        PushResult result = PushResult.pushSuccess(service, "client", serviceInfo, subscriber, 1L,
+            2L, 3L, true);
+        
+        assertTrue(result.isPushSuccess());
+        assertSame(service, result.getService());
+        assertSame(serviceInfo, result.getData());
+        assertSame(subscriber, result.getSubscriber());
+        assertNull(result.getException());
+    }
+    
+    @Test
+    void testPushFailedResult() {
+        RuntimeException exception = new RuntimeException("failed");
+        PushResult result = PushResult.pushFailed(service, "client", serviceInfo, subscriber, 1L,
+            exception, false);
+        
+        assertFalse(result.isPushSuccess());
+        assertSame(exception, result.getException());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchChangeNotifyExecuteTaskTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchChangeNotifyExecuteTaskTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.push.v2.task;
+
+import com.alibaba.nacos.api.naming.remote.request.AbstractFuzzyWatchNotifyRequest;
+import com.alibaba.nacos.api.naming.remote.request.NamingFuzzyWatchChangeNotifyRequest;
+import com.alibaba.nacos.api.remote.PushCallBack;
+import com.alibaba.nacos.common.task.AbstractDelayTask;
+import com.alibaba.nacos.naming.push.v2.NoRequiredRetryException;
+import com.alibaba.nacos.naming.push.v2.PushConfig;
+import com.alibaba.nacos.naming.push.v2.executor.PushExecutor;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+
+import static com.alibaba.nacos.api.common.Constants.ServiceChangedType.ADD_SERVICE;
+import static com.alibaba.nacos.naming.push.v2.task.FuzzyWatchPushDelayTaskEngine.getTaskKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FuzzyWatchChangeNotifyExecuteTaskTest {
+    
+    private static final String SERVICE_KEY = "namespace@@group@@service";
+    
+    private static final String CLIENT_ID = "connection-1";
+    
+    @Mock
+    private FuzzyWatchPushDelayTaskEngine delayTaskEngine;
+    
+    @Mock
+    private PushExecutor pushExecutor;
+    
+    private ConfigurableEnvironment cachedEnvironment;
+    
+    @BeforeEach
+    void setUp() {
+        cachedEnvironment = EnvUtil.getEnvironment();
+        EnvUtil.setEnvironment(new MockEnvironment());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(cachedEnvironment);
+    }
+    
+    @Test
+    void testRunPushesChangeNotifyRequest() {
+        when(delayTaskEngine.getPushExecutor()).thenReturn(pushExecutor);
+        FuzzyWatchChangeNotifyExecuteTask task =
+            new FuzzyWatchChangeNotifyExecuteTask(delayTaskEngine, SERVICE_KEY, ADD_SERVICE,
+                CLIENT_ID);
+        ArgumentCaptor<AbstractFuzzyWatchNotifyRequest> requestCaptor =
+            ArgumentCaptor.forClass(AbstractFuzzyWatchNotifyRequest.class);
+        ArgumentCaptor<PushCallBack> callbackCaptor = ArgumentCaptor.forClass(PushCallBack.class);
+        
+        task.run();
+        
+        verify(pushExecutor).doFuzzyWatchNotifyPushWithCallBack(eq(CLIENT_ID),
+            requestCaptor.capture(), callbackCaptor.capture());
+        NamingFuzzyWatchChangeNotifyRequest request =
+            assertInstanceOf(NamingFuzzyWatchChangeNotifyRequest.class,
+                requestCaptor.getValue());
+        assertEquals(SERVICE_KEY, request.getServiceKey());
+        assertEquals(ADD_SERVICE, request.getChangedType());
+        assertEquals(PushConfig.getInstance().getPushTaskTimeout(),
+            callbackCaptor.getValue().getTimeout());
+    }
+    
+    @Test
+    void testCallbackSuccessAndFailRetryBehavior() {
+        when(delayTaskEngine.getPushExecutor()).thenReturn(pushExecutor);
+        PushCallBack callback = captureCallback();
+        
+        callback.onSuccess();
+        callback.onFail(new NoRequiredRetryException());
+        verify(delayTaskEngine, never()).addTask(anyString(), any(AbstractDelayTask.class));
+        
+        callback.onFail(new RuntimeException("push failed"));
+        
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<FuzzyWatchChangeNotifyTask> taskCaptor =
+            ArgumentCaptor.forClass(FuzzyWatchChangeNotifyTask.class);
+        verify(delayTaskEngine).addTask(keyCaptor.capture(), taskCaptor.capture());
+        FuzzyWatchChangeNotifyTask retryTask = taskCaptor.getValue();
+        assertEquals(SERVICE_KEY, retryTask.getServiceKey());
+        assertEquals(ADD_SERVICE, retryTask.getChangedType());
+        assertEquals(CLIENT_ID, retryTask.getClientId());
+        assertEquals(PushConfig.getInstance().getPushTaskRetryDelay(), retryTask.getDelay());
+        assertEquals(getTaskKey(retryTask), keyCaptor.getValue());
+    }
+    
+    private PushCallBack captureCallback() {
+        FuzzyWatchChangeNotifyExecuteTask task =
+            new FuzzyWatchChangeNotifyExecuteTask(delayTaskEngine, SERVICE_KEY, ADD_SERVICE,
+                CLIENT_ID);
+        ArgumentCaptor<PushCallBack> callbackCaptor = ArgumentCaptor.forClass(PushCallBack.class);
+        task.run();
+        verify(pushExecutor).doFuzzyWatchNotifyPushWithCallBack(eq(CLIENT_ID),
+            any(AbstractFuzzyWatchNotifyRequest.class), callbackCaptor.capture());
+        return callbackCaptor.getValue();
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchChangeNotifyTaskTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchChangeNotifyTaskTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.push.v2.task;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FuzzyWatchChangeNotifyTaskTest {
+    
+    @Test
+    void testGettersAndMerge() {
+        FuzzyWatchChangeNotifyTask task =
+            new FuzzyWatchChangeNotifyTask("serviceKey", "ADD_SERVICE", "clientId", 100L);
+        
+        task.merge(new FuzzyWatchChangeNotifyTask("oldServiceKey", "DELETE_SERVICE", "oldClient",
+            10L));
+        
+        assertEquals("serviceKey", task.getServiceKey());
+        assertEquals("ADD_SERVICE", task.getChangedType());
+        assertEquals("clientId", task.getClientId());
+        assertEquals(100L, task.getDelay());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchPushDelayTaskEngineTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchPushDelayTaskEngineTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.push.v2.task;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.common.task.AbstractDelayTask;
+import com.alibaba.nacos.common.task.NacosTask;
+import com.alibaba.nacos.common.task.NacosTaskProcessor;
+import com.alibaba.nacos.naming.misc.NamingExecuteTaskDispatcher;
+import com.alibaba.nacos.naming.misc.SwitchDomain;
+import com.alibaba.nacos.naming.push.v2.executor.PushExecutorDelegate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static com.alibaba.nacos.api.common.Constants.FUZZY_WATCH_INIT_NOTIFY;
+import static com.alibaba.nacos.api.common.Constants.ServiceChangedType.ADD_SERVICE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FuzzyWatchPushDelayTaskEngineTest {
+    
+    private static final String SERVICE_KEY = "namespace@@group@@service";
+    
+    private static final String CLIENT_ID = "connection-1";
+    
+    @Mock
+    private PushExecutorDelegate pushExecutor;
+    
+    @Mock
+    private SwitchDomain switchDomain;
+    
+    @Mock
+    private NacosTaskProcessor processor;
+    
+    @Mock
+    private NamingExecuteTaskDispatcher dispatcher;
+    
+    private TestFuzzyWatchPushDelayTaskEngine executeEngine;
+    
+    @BeforeEach
+    void setUp() {
+        executeEngine = new TestFuzzyWatchPushDelayTaskEngine(pushExecutor, switchDomain);
+    }
+    
+    @AfterEach
+    void tearDown() throws NacosException {
+        executeEngine.shutdown();
+    }
+    
+    @Test
+    void testConstructAndGetPushExecutor() {
+        assertSame(pushExecutor, executeEngine.getPushExecutor());
+    }
+    
+    @Test
+    void testProcessTasksSkippedWhenPushDisabled() {
+        when(switchDomain.isPushEnabled()).thenReturn(false);
+        TestDelayTask task = new TestDelayTask();
+        executeEngine.addProcessor("key", processor);
+        executeEngine.addTask("key", task);
+        
+        executeEngine.processTasksForTest();
+        
+        assertEquals(1, executeEngine.size());
+        verify(processor, never()).process(any(NacosTask.class));
+    }
+    
+    @Test
+    void testProcessTasksWhenPushEnabled() {
+        when(switchDomain.isPushEnabled()).thenReturn(true);
+        when(processor.process(any(NacosTask.class))).thenReturn(true);
+        TestDelayTask task = new TestDelayTask();
+        executeEngine.addProcessor("key", processor);
+        executeEngine.addTask("key", task);
+        
+        executeEngine.processTasksForTest();
+        
+        assertTrue(executeEngine.isEmpty());
+        verify(processor).process(task);
+    }
+    
+    @Test
+    void testDefaultProcessorDispatchesChangeNotifyTask() {
+        try (MockedStatic<NamingExecuteTaskDispatcher> mockedDispatcher =
+            Mockito.mockStatic(NamingExecuteTaskDispatcher.class)) {
+            mockedDispatcher.when(NamingExecuteTaskDispatcher::getInstance)
+                .thenReturn(dispatcher);
+            FuzzyWatchChangeNotifyTask task =
+                new FuzzyWatchChangeNotifyTask(SERVICE_KEY, ADD_SERVICE, CLIENT_ID, 0L);
+            
+            assertTrue(executeEngine.getProcessor("unknown").process(task));
+            
+            verify(dispatcher).dispatchAndExecuteTask(eq(
+                FuzzyWatchPushDelayTaskEngine.getTaskKey(task)),
+                any(FuzzyWatchChangeNotifyExecuteTask.class));
+        }
+    }
+    
+    @Test
+    void testDefaultProcessorDispatchesSyncNotifyTask() {
+        try (MockedStatic<NamingExecuteTaskDispatcher> mockedDispatcher =
+            Mockito.mockStatic(NamingExecuteTaskDispatcher.class)) {
+            mockedDispatcher.when(NamingExecuteTaskDispatcher::getInstance)
+                .thenReturn(dispatcher);
+            FuzzyWatchSyncNotifyTask task =
+                new FuzzyWatchSyncNotifyTask(CLIENT_ID, "group@@service*",
+                    FUZZY_WATCH_INIT_NOTIFY, Collections.emptySet(), 0L);
+            task.setCurrentBatch(2);
+            
+            assertTrue(executeEngine.getProcessor("unknown").process(task));
+            
+            verify(dispatcher).dispatchAndExecuteTask(eq(
+                FuzzyWatchPushDelayTaskEngine.getTaskKey(task)),
+                any(FuzzyWatchSyncNotifyExecuteTask.class));
+        }
+    }
+    
+    @Test
+    void testDefaultProcessorIgnoresUnknownTask() {
+        assertTrue(executeEngine.getProcessor("unknown").process(new UnknownTask()));
+    }
+    
+    @Test
+    void testGetTaskKey() {
+        FuzzyWatchChangeNotifyTask changeTask =
+            new FuzzyWatchChangeNotifyTask(SERVICE_KEY, ADD_SERVICE, CLIENT_ID, 0L);
+        FuzzyWatchSyncNotifyTask syncTask =
+            new FuzzyWatchSyncNotifyTask(CLIENT_ID, "group@@service*",
+                FUZZY_WATCH_INIT_NOTIFY, Collections.emptySet(), 0L);
+        syncTask.setCurrentBatch(2);
+        
+        assertEquals("fwcnT-connection-1namespace@@group@@service",
+            FuzzyWatchPushDelayTaskEngine.getTaskKey(changeTask));
+        assertEquals("fwsnT-" + FUZZY_WATCH_INIT_NOTIFY + "-connection-1group@@service*-2",
+            FuzzyWatchPushDelayTaskEngine.getTaskKey(syncTask));
+        assertThrows(NacosRuntimeException.class,
+            () -> FuzzyWatchPushDelayTaskEngine.getTaskKey(new UnknownTask()));
+    }
+    
+    private static class TestFuzzyWatchPushDelayTaskEngine
+        extends FuzzyWatchPushDelayTaskEngine {
+        
+        TestFuzzyWatchPushDelayTaskEngine(PushExecutorDelegate pushExecutor,
+            SwitchDomain switchDomain) {
+            super(pushExecutor, switchDomain);
+        }
+        
+        void processTasksForTest() {
+            super.processTasks();
+        }
+    }
+    
+    private static class TestDelayTask extends AbstractDelayTask {
+        
+        TestDelayTask() {
+            setTaskInterval(0L);
+            setLastProcessTime(0L);
+        }
+        
+        @Override
+        public void merge(AbstractDelayTask task) {
+        }
+    }
+    
+    private static class UnknownTask implements NacosTask {
+        
+        @Override
+        public boolean shouldProcess() {
+            return true;
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchSyncNotifyTaskTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchSyncNotifyTaskTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.naming.push.v2.task;
 import com.alibaba.nacos.api.naming.remote.request.NamingFuzzyWatchSyncRequest;
 import com.alibaba.nacos.common.task.AbstractDelayTask;
 import com.alibaba.nacos.common.task.BatchTaskCounter;
+import com.alibaba.nacos.naming.push.v2.PushConfig;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -90,6 +91,17 @@ class FuzzyWatchSyncNotifyTaskTest {
         assertTrue(task.getSyncServiceKeys().contains(contextA));
         assertTrue(task.getSyncServiceKeys().contains(contextB));
         assertEquals(50L, task.getLastProcessTime());
+    }
+    
+    @Test
+    void testCallbackTimeout() {
+        FuzzyWatchSyncNotifyTask task =
+            new FuzzyWatchSyncNotifyTask("client", "group@@service*",
+                FUZZY_WATCH_INIT_NOTIFY, null, 100L);
+        FuzzyWatchSyncNotifyCallback callback =
+            new FuzzyWatchSyncNotifyCallback(task, new BatchTaskCounter(1), null);
+        
+        assertEquals(PushConfig.getInstance().getPushTaskTimeout(), callback.getTimeout());
     }
     
     private NamingFuzzyWatchSyncRequest.Context context(String serviceKey) {

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchSyncNotifyTaskTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FuzzyWatchSyncNotifyTaskTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.push.v2.task;
+
+import com.alibaba.nacos.api.naming.remote.request.NamingFuzzyWatchSyncRequest;
+import com.alibaba.nacos.common.task.AbstractDelayTask;
+import com.alibaba.nacos.common.task.BatchTaskCounter;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.alibaba.nacos.api.common.Constants.FUZZY_WATCH_INIT_NOTIFY;
+import static com.alibaba.nacos.api.common.Constants.ServiceChangedType.ADD_SERVICE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FuzzyWatchSyncNotifyTaskTest {
+    
+    @Test
+    void testConstructWithNullSyncServiceKeys() {
+        FuzzyWatchSyncNotifyTask task =
+            new FuzzyWatchSyncNotifyTask("client", "group@@service*",
+                FUZZY_WATCH_INIT_NOTIFY, null, 100L);
+        BatchTaskCounter batchTaskCounter = new BatchTaskCounter(1);
+        task.setBatchTaskCounter(batchTaskCounter);
+        task.setTotalBatch(3);
+        task.setCurrentBatch(2);
+        
+        assertEquals("client", task.getClientId());
+        assertEquals("group@@service*", task.getPattern());
+        assertEquals(FUZZY_WATCH_INIT_NOTIFY, task.getSyncType());
+        assertTrue(task.getSyncServiceKeys().isEmpty());
+        assertEquals(100L, task.getTaskInterval());
+        assertSame(batchTaskCounter, task.getBatchTaskCounter());
+        assertEquals(3, task.getTotalBatch());
+        assertEquals(2, task.getCurrentBatch());
+        assertTrue(task.getExecuteStartTime() > 0L);
+    }
+    
+    @Test
+    void testMergeIgnoresOtherTaskType() {
+        NamingFuzzyWatchSyncRequest.Context context = context("serviceA");
+        Set<NamingFuzzyWatchSyncRequest.Context> contexts =
+            new HashSet<>(Collections.singleton(context));
+        FuzzyWatchSyncNotifyTask task =
+            new FuzzyWatchSyncNotifyTask("client", "group@@service*",
+                FUZZY_WATCH_INIT_NOTIFY, contexts, 100L);
+        
+        task.merge(new UnknownDelayTask());
+        
+        assertEquals(1, task.getSyncServiceKeys().size());
+        assertTrue(task.getSyncServiceKeys().contains(context));
+    }
+    
+    @Test
+    void testMergeAddsServiceKeysAndKeepsEarlierProcessTime() {
+        NamingFuzzyWatchSyncRequest.Context contextA = context("serviceA");
+        NamingFuzzyWatchSyncRequest.Context contextB = context("serviceB");
+        FuzzyWatchSyncNotifyTask task =
+            new FuzzyWatchSyncNotifyTask("client", "group@@service*",
+                FUZZY_WATCH_INIT_NOTIFY,
+                new HashSet<>(Collections.singleton(contextA)), 100L);
+        FuzzyWatchSyncNotifyTask oldTask =
+            new FuzzyWatchSyncNotifyTask("client", "group@@service*",
+                FUZZY_WATCH_INIT_NOTIFY,
+                new HashSet<>(Collections.singleton(contextB)), 100L);
+        task.setLastProcessTime(200L);
+        oldTask.setLastProcessTime(50L);
+        
+        task.merge(oldTask);
+        
+        assertEquals(2, task.getSyncServiceKeys().size());
+        assertTrue(task.getSyncServiceKeys().contains(contextA));
+        assertTrue(task.getSyncServiceKeys().contains(contextB));
+        assertEquals(50L, task.getLastProcessTime());
+    }
+    
+    private NamingFuzzyWatchSyncRequest.Context context(String serviceKey) {
+        return NamingFuzzyWatchSyncRequest.Context.build(serviceKey, ADD_SERVICE);
+    }
+    
+    private static class UnknownDelayTask extends AbstractDelayTask {
+        
+        @Override
+        public void merge(AbstractDelayTask task) {
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/PushDelayTaskTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/PushDelayTaskTest.java
@@ -83,6 +83,21 @@ class PushDelayTaskTest {
     }
     
     @Test
+    void testMergeIgnoreOtherDelayTask() {
+        singlePushTask.merge(new AbstractDelayTask() {
+            
+            @Override
+            public void merge(AbstractDelayTask task) {
+            }
+        });
+        
+        assertFalse(singlePushTask.isPushToAll());
+        assertNotNull(singlePushTask.getTargetClients());
+        assertEquals(1, singlePushTask.getTargetClients().size());
+        assertTrue(singlePushTask.getTargetClients().contains(singleTargetClientId));
+    }
+    
+    @Test
     void testMergeAllToAll() throws InterruptedException {
         PushDelayTask oldTask = pushToAllTask;
         TimeUnit.MILLISECONDS.sleep(10);

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/PushExecuteTaskTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/PushExecuteTaskTest.java
@@ -119,6 +119,32 @@ class PushExecuteTaskTest {
     }
     
     @Test
+    void testRunSkipWhenClientDisconnected() {
+        PushDelayTask delayTask = new PushDelayTask(service, 0L);
+        PushExecuteTask executeTask =
+            new PushExecuteTask(service, delayTaskExecuteEngine, delayTask);
+        when(clientManager.getClient(clientId)).thenReturn(null);
+        
+        executeTask.run();
+        
+        assertEquals(0, MetricsMonitor.getTotalPushMonitor().get());
+        verify(delayTaskExecuteEngine, never()).addTask(eq(service), any(PushDelayTask.class));
+    }
+    
+    @Test
+    void testRunSkipWhenSubscriberMissing() {
+        PushDelayTask delayTask = new PushDelayTask(service, 0L);
+        PushExecuteTask executeTask =
+            new PushExecuteTask(service, delayTaskExecuteEngine, delayTask);
+        when(client.getSubscriber(service)).thenReturn(null);
+        
+        executeTask.run();
+        
+        assertEquals(0, MetricsMonitor.getTotalPushMonitor().get());
+        verify(delayTaskExecuteEngine, never()).addTask(eq(service), any(PushDelayTask.class));
+    }
+    
+    @Test
     void testRunFailedWithHandleException() {
         PushDelayTask delayTask = new PushDelayTask(service, 0L);
         PushExecuteTask executeTask =

--- a/naming/src/test/java/com/alibaba/nacos/naming/remote/rpc/handler/DistroDataRequestHandlerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/remote/rpc/handler/DistroDataRequestHandlerTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static com.alibaba.nacos.consistency.DataOperation.ADD;
+import static com.alibaba.nacos.consistency.DataOperation.CHANGE;
 import static com.alibaba.nacos.consistency.DataOperation.DELETE;
 import static com.alibaba.nacos.consistency.DataOperation.QUERY;
 import static com.alibaba.nacos.consistency.DataOperation.SNAPSHOT;
@@ -88,5 +89,45 @@ class DistroDataRequestHandlerTest {
         DistroDataResponse response4 =
             distroDataRequestHandler.handle(distroDataRequest, requestMeta);
         assertNull(response4.getDistroData());
+    }
+    
+    @Test
+    void testHandleVerifySuccess() throws NacosException {
+        Mockito.when(distroProtocol.onVerify(Mockito.any(), Mockito.eq("1.1.1.1")))
+            .thenReturn(true);
+        DistroDataRequest distroDataRequest = new DistroDataRequest();
+        distroDataRequest.setDataOperation(VERIFY);
+        RequestMeta requestMeta = new RequestMeta();
+        requestMeta.setClientIp("1.1.1.1");
+        
+        DistroDataResponse response =
+            distroDataRequestHandler.handle(distroDataRequest, requestMeta);
+        
+        assertEquals(ResponseCode.SUCCESS.getCode(), response.getResultCode());
+    }
+    
+    @Test
+    void testHandleChangeSuccess() throws NacosException {
+        Mockito.when(distroProtocol.onReceive(Mockito.any())).thenReturn(true);
+        DistroDataRequest distroDataRequest = new DistroDataRequest();
+        distroDataRequest.setDataOperation(CHANGE);
+        distroDataRequest.setDistroData(new DistroData());
+        
+        DistroDataResponse response =
+            distroDataRequestHandler.handle(distroDataRequest, new RequestMeta());
+        
+        assertEquals(ResponseCode.SUCCESS.getCode(), response.getResultCode());
+    }
+    
+    @Test
+    void testHandleException() throws NacosException {
+        DistroDataRequest distroDataRequest = new DistroDataRequest();
+        
+        DistroDataResponse response =
+            distroDataRequestHandler.handle(distroDataRequest, new RequestMeta());
+        
+        assertEquals(ResponseCode.FAIL.getCode(), response.getResultCode());
+        assertEquals(ResponseCode.FAIL.getCode(), response.getErrorCode());
+        assertEquals("handle distro request with exception", response.getMessage());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/remote/rpc/handler/NamingFuzzyWatchRequestHandlerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/remote/rpc/handler/NamingFuzzyWatchRequestHandlerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.remote.rpc.handler;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.remote.request.NamingFuzzyWatchRequest;
+import com.alibaba.nacos.api.naming.remote.response.NamingFuzzyWatchResponse;
+import com.alibaba.nacos.api.remote.request.RequestMeta;
+import com.alibaba.nacos.common.notify.NotifyCenter;
+import com.alibaba.nacos.naming.core.v2.event.client.ClientOperationEvent;
+import com.alibaba.nacos.naming.core.v2.index.NamingFuzzyWatchContextService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static com.alibaba.nacos.api.common.Constants.WATCH_TYPE_CANCEL_WATCH;
+import static com.alibaba.nacos.api.common.Constants.WATCH_TYPE_WATCH;
+import static com.alibaba.nacos.api.model.v2.ErrorCode.FUZZY_WATCH_PATTERN_MATCH_COUNT_OVER_LIMIT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class NamingFuzzyWatchRequestHandlerTest {
+    
+    private static final String GROUP_KEY_PATTERN = "namespace@@group@@service*";
+    
+    private static final String CONNECTION_ID = "connection-1";
+    
+    @Mock
+    private NamingFuzzyWatchContextService namingFuzzyWatchContextService;
+    
+    private NamingFuzzyWatchRequestHandler handler;
+    
+    private RequestMeta requestMeta;
+    
+    @BeforeEach
+    void setUp() {
+        handler = new NamingFuzzyWatchRequestHandler(namingFuzzyWatchContextService);
+        requestMeta = new RequestMeta();
+        requestMeta.setConnectionId(CONNECTION_ID);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        NotifyCenter.deregisterPublisher(ClientOperationEvent.ClientFuzzyWatchEvent.class);
+    }
+    
+    @Test
+    void testHandleWatchReturnsSuccess() throws Exception {
+        NamingFuzzyWatchRequest request = buildRequest(WATCH_TYPE_WATCH);
+        Mockito.when(namingFuzzyWatchContextService.reachToUpLimit(GROUP_KEY_PATTERN))
+            .thenReturn(false);
+        
+        NamingFuzzyWatchResponse response = handler.handle(request, requestMeta);
+        
+        assertTrue(response.isSuccess());
+        Mockito.verify(namingFuzzyWatchContextService)
+            .syncFuzzyWatcherContext(GROUP_KEY_PATTERN, CONNECTION_ID);
+        Mockito.verify(namingFuzzyWatchContextService).reachToUpLimit(GROUP_KEY_PATTERN);
+    }
+    
+    @Test
+    void testHandleWatchReturnsServiceErrorWhenSyncContextFails() throws Exception {
+        NamingFuzzyWatchRequest request = buildRequest(WATCH_TYPE_WATCH);
+        Mockito.doThrow(new NacosException(100, "sync failed"))
+            .when(namingFuzzyWatchContextService)
+            .syncFuzzyWatcherContext(GROUP_KEY_PATTERN, CONNECTION_ID);
+        
+        NamingFuzzyWatchResponse response = handler.handle(request, requestMeta);
+        
+        assertFalse(response.isSuccess());
+        assertEquals(100, response.getErrorCode());
+        assertEquals("sync failed", response.getMessage());
+        Mockito.verify(namingFuzzyWatchContextService, Mockito.never())
+            .reachToUpLimit(GROUP_KEY_PATTERN);
+    }
+    
+    @Test
+    void testHandleWatchReturnsLimitErrorWhenReachUpperLimit() throws Exception {
+        NamingFuzzyWatchRequest request = buildRequest(WATCH_TYPE_WATCH);
+        Mockito.when(namingFuzzyWatchContextService.reachToUpLimit(GROUP_KEY_PATTERN))
+            .thenReturn(true);
+        
+        NamingFuzzyWatchResponse response = handler.handle(request, requestMeta);
+        
+        assertFalse(response.isSuccess());
+        assertEquals(FUZZY_WATCH_PATTERN_MATCH_COUNT_OVER_LIMIT.getCode(),
+            response.getErrorCode());
+        assertEquals(FUZZY_WATCH_PATTERN_MATCH_COUNT_OVER_LIMIT.getMsg(),
+            response.getMessage());
+    }
+    
+    @Test
+    void testHandleCancelWatchReturnsSuccess() throws Exception {
+        NamingFuzzyWatchRequest request = buildRequest(WATCH_TYPE_CANCEL_WATCH);
+        
+        NamingFuzzyWatchResponse response = handler.handle(request, requestMeta);
+        
+        assertTrue(response.isSuccess());
+        Mockito.verify(namingFuzzyWatchContextService)
+            .removeFuzzyWatchContext(GROUP_KEY_PATTERN, CONNECTION_ID);
+    }
+    
+    @Test
+    void testHandleUnsupportedWatchTypeThrowsException() {
+        NamingFuzzyWatchRequest request = buildRequest("unknown");
+        
+        NacosException exception =
+            assertThrows(NacosException.class, () -> handler.handle(request, requestMeta));
+        
+        assertEquals(NacosException.INVALID_PARAM, exception.getErrCode());
+        assertEquals("Unsupported request type unknown", exception.getErrMsg());
+    }
+    
+    private NamingFuzzyWatchRequest buildRequest(String watchType) {
+        NamingFuzzyWatchRequest result =
+            new NamingFuzzyWatchRequest(GROUP_KEY_PATTERN, watchType);
+        result.setInitializing(true);
+        result.setReceivedGroupKeys(Collections.singleton("namespace@@group@@service"));
+        return result;
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/selector/LabelSelectorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/selector/LabelSelectorTest.java
@@ -17,10 +17,19 @@
 
 package com.alibaba.nacos.naming.selector;
 
+import com.alibaba.nacos.api.cmdb.pojo.Entity;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.selector.Selector;
+import com.alibaba.nacos.api.selector.context.CmdbContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,5 +60,101 @@ class LabelSelectorTest {
         assertEquals(2, labelSelector.getLabels().size());
         assertTrue(labelSelector.getLabels().contains("A"));
         assertTrue(labelSelector.getLabels().contains("B"));
+    }
+    
+    @Test
+    void testSelectReturnsAllProvidersWhenLabelsEmpty() {
+        LabelSelector<Instance> labelSelector = new LabelSelector<>();
+        List<CmdbContext.CmdbInstance<Instance>> providers = Arrays.asList(
+            cmdbInstance("1.1.1.1", labels("zone", "A")), cmdbInstance("2.2.2.2",
+                labels("zone", "B")));
+        CmdbContext<Instance> context =
+            cmdbContext(cmdbInstance("0.0.0.0", labels("zone", "A")), providers);
+        
+        List<Instance> result = labelSelector.select(context);
+        
+        assertEquals(2, result.size());
+        assertEquals("1.1.1.1", result.get(0).getIp());
+        assertEquals("2.2.2.2", result.get(1).getIp());
+    }
+    
+    @Test
+    void testSelectReturnsMatchedProviders() {
+        LabelSelector<Instance> labelSelector = new LabelSelector<>();
+        labelSelector.setLabels(Collections.singleton("zone"));
+        List<CmdbContext.CmdbInstance<Instance>> providers = Arrays.asList(
+            cmdbInstance("1.1.1.1", labels("zone", "A")),
+            cmdbInstance("2.2.2.2", labels("zone", "B")));
+        CmdbContext<Instance> context =
+            cmdbContext(cmdbInstance("0.0.0.0", labels("zone", "A")), providers);
+        
+        List<Instance> result = labelSelector.select(context);
+        
+        assertEquals(1, result.size());
+        assertEquals("1.1.1.1", result.get(0).getIp());
+    }
+    
+    @Test
+    void testSelectFallsBackToAllProvidersWhenNoProviderMatched() {
+        LabelSelector<Instance> labelSelector = new LabelSelector<>();
+        labelSelector.setLabels(Collections.singleton("zone"));
+        CmdbContext.CmdbInstance<Instance> providerWithoutEntity =
+            cmdbInstance("1.1.1.1", labels("zone", "A"));
+        providerWithoutEntity.setEntity(null);
+        List<CmdbContext.CmdbInstance<Instance>> providers = Arrays.asList(providerWithoutEntity,
+            cmdbInstance("2.2.2.2", null));
+        CmdbContext<Instance> context =
+            cmdbContext(cmdbInstance("0.0.0.0", labels("zone", "A")), providers);
+        
+        List<Instance> result = labelSelector.select(context);
+        
+        assertEquals(2, result.size());
+    }
+    
+    @Test
+    void testSelectFallsBackToAllProvidersWhenConsumerLabelBlank() {
+        LabelSelector<Instance> labelSelector = new LabelSelector<>();
+        labelSelector.setLabels(Collections.singleton("zone"));
+        List<CmdbContext.CmdbInstance<Instance>> providers = Collections
+            .singletonList(cmdbInstance("1.1.1.1", labels("zone", "A")));
+        CmdbContext<Instance> context =
+            cmdbContext(cmdbInstance("0.0.0.0", labels("zone", "")), providers);
+        
+        List<Instance> result = labelSelector.select(context);
+        
+        assertEquals(1, result.size());
+        assertEquals("1.1.1.1", result.get(0).getIp());
+    }
+    
+    @Test
+    void testGetType() {
+        LabelSelector<Instance> labelSelector = new LabelSelector<>();
+        
+        assertEquals("label", labelSelector.getType());
+    }
+    
+    private CmdbContext<Instance> cmdbContext(CmdbContext.CmdbInstance<Instance> consumer,
+        List<CmdbContext.CmdbInstance<Instance>> providers) {
+        CmdbContext<Instance> result = new CmdbContext<>();
+        result.setConsumer(consumer);
+        result.setProviders(providers);
+        return result;
+    }
+    
+    private CmdbContext.CmdbInstance<Instance> cmdbInstance(String ip, Map<String, String> labels) {
+        Instance instance = new Instance();
+        instance.setIp(ip);
+        Entity entity = new Entity();
+        entity.setLabels(labels);
+        CmdbContext.CmdbInstance<Instance> result = new CmdbContext.CmdbInstance<>();
+        result.setInstance(instance);
+        result.setEntity(entity);
+        return result;
+    }
+    
+    private Map<String, String> labels(String key, String value) {
+        Map<String, String> result = new HashMap<>();
+        result.put(key, value);
+        return result;
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/selector/NoneSelectorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/selector/NoneSelectorTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * {@link NoneSelector} unit tests.
@@ -38,5 +39,12 @@ class NoneSelectorTest {
         NoneSelector<Instance> noneSelector = new NoneSelector<>();
         List<Instance> providers = Collections.emptyList();
         assertEquals(providers, noneSelector.select(providers));
+    }
+    
+    @Test
+    void testParse() throws Exception {
+        NoneSelector<Instance> noneSelector = new NoneSelector<>();
+        
+        assertSame(noneSelector, noneSelector.parse("condition"));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/selector/SelectorManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/selector/SelectorManagerTest.java
@@ -23,8 +23,10 @@ import com.alibaba.nacos.api.selector.Selector;
 import com.alibaba.nacos.api.selector.context.SelectorContextBuilder;
 import com.alibaba.nacos.consistency.SerializeFactory;
 import com.alibaba.nacos.consistency.Serializer;
+import com.alibaba.nacos.common.spi.NacosServiceLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -38,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
 
 /**
  * {@link SelectorManager} unit test.
@@ -93,6 +96,21 @@ class SelectorManagerTest {
         
         assertEquals(3, contextBuilders.size());
         assertEquals(3, selectorTypes.size());
+    }
+    
+    @Test
+    void testInitSkipsSelectorWithoutDefaultConstructor() {
+        Map<String, Class<? extends Selector>> selectorTypes = new HashMap<>();
+        ReflectionTestUtils.setField(selectorManager, "selectorTypes", selectorTypes);
+        try (MockedStatic<NacosServiceLoader> mockedLoader =
+            mockStatic(NacosServiceLoader.class)) {
+            mockedLoader.when(() -> NacosServiceLoader.load(Selector.class))
+                .thenReturn(Collections.singletonList(new NoDefaultConstructorSelector("broken")));
+            
+            ReflectionTestUtils.invokeMethod(selectorManager, "initSelectorTypes");
+        }
+        
+        assertTrue(selectorTypes.isEmpty());
     }
     
     @Test
@@ -167,5 +185,36 @@ class SelectorManagerTest {
         List<Instance> result = selectorManager.select(selector, "1.1.1.1", providers);
         
         assertSame(providers, result);
+    }
+    
+    private static class NoDefaultConstructorSelector implements Selector<Object, Object, Object> {
+        
+        private static final long serialVersionUID = -240945908940366348L;
+        
+        private final String type;
+        
+        NoDefaultConstructorSelector(String type) {
+            this.type = type;
+        }
+        
+        @Override
+        public Selector<Object, Object, Object> parse(Object expression) {
+            return this;
+        }
+        
+        @Override
+        public Object select(Object context) {
+            return context;
+        }
+        
+        @Override
+        public String getType() {
+            return type;
+        }
+        
+        @Override
+        public String getContextType() {
+            return "broken";
+        }
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/selector/SelectorManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/selector/SelectorManagerTest.java
@@ -20,15 +20,23 @@ package com.alibaba.nacos.naming.selector;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.selector.Selector;
+import com.alibaba.nacos.api.selector.context.SelectorContextBuilder;
 import com.alibaba.nacos.consistency.SerializeFactory;
 import com.alibaba.nacos.consistency.Serializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -62,6 +70,44 @@ class SelectorManagerTest {
     }
     
     @Test
+    void testParseSelectorReturnsNullWhenTypeBlankOrUnknown() throws NacosException {
+        assertNull(selectorManager.parseSelector("", "key=value"));
+        assertNull(selectorManager.parseSelector("unknown", "key=value"));
+    }
+    
+    @Test
+    void testInitSkipsDuplicateContextBuildersAndSelectors() {
+        Map<String, SelectorContextBuilder> contextBuilders = new HashMap<>();
+        contextBuilders.put("MOCK_CMDB", Mockito.mock(SelectorContextBuilder.class));
+        contextBuilders.put("CMDB", Mockito.mock(SelectorContextBuilder.class));
+        contextBuilders.put("NONE", Mockito.mock(SelectorContextBuilder.class));
+        ReflectionTestUtils.setField(selectorManager, "contextBuilders", contextBuilders);
+        Map<String, Class<? extends Selector>> selectorTypes = new HashMap<>();
+        selectorTypes.put("mock", MockSelector.class);
+        selectorTypes.put("label", LabelSelector.class);
+        selectorTypes.put("none", NoneSelector.class);
+        ReflectionTestUtils.setField(selectorManager, "selectorTypes", selectorTypes);
+        
+        ReflectionTestUtils.invokeMethod(selectorManager, "initSelectorContextBuilders");
+        ReflectionTestUtils.invokeMethod(selectorManager, "initSelectorTypes");
+        
+        assertEquals(3, contextBuilders.size());
+        assertEquals(3, selectorTypes.size());
+    }
+    
+    @Test
+    void testParseSelectorThrowsWhenParseFailed() {
+        Map<String, Class<? extends Selector>> selectorTypes = new HashMap<>();
+        selectorTypes.put("mock", MockSelector.class);
+        ReflectionTestUtils.setField(selectorManager, "selectorTypes", selectorTypes);
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> selectorManager.parseSelector("mock", "invalid"));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+    }
+    
+    @Test
     void testSelect() throws NacosException {
         Selector selector = selectorManager.parseSelector("mock", "key=value");
         Instance instance = new Instance();
@@ -89,5 +135,37 @@ class SelectorManagerTest {
         List<Instance> instances2 = selectorManager.select(hessianSelector, "1.1.1.1", providers);
         assertEquals(1, instances2.size());
         assertEquals("2.2.2.2", instances2.get(0).getIp());
+    }
+    
+    @Test
+    void testSelectReturnsProvidersWhenSelectorIsNullOrContextBuilderMissing()
+        throws NacosException {
+        Instance instance = new Instance();
+        instance.setIp("2.2.2.2");
+        List<Instance> providers = Collections.singletonList(instance);
+        Selector selector = new MockSelector().parse("key=value");
+        SelectorManager emptySelectorManager = new SelectorManager();
+        
+        assertSame(providers, selectorManager.select(null, "1.1.1.1", providers));
+        assertSame(providers, emptySelectorManager.select(selector, "1.1.1.1", providers));
+    }
+    
+    @Test
+    void testSelectReturnsProvidersWhenContextBuilderThrows() {
+        Instance instance = new Instance();
+        instance.setIp("2.2.2.2");
+        List<Instance> providers = Collections.singletonList(instance);
+        Selector selector = Mockito.mock(Selector.class);
+        SelectorContextBuilder contextBuilder = Mockito.mock(SelectorContextBuilder.class);
+        Map<String, SelectorContextBuilder> contextBuilders = new HashMap<>();
+        contextBuilders.put("broken", contextBuilder);
+        ReflectionTestUtils.setField(selectorManager, "contextBuilders", contextBuilders);
+        Mockito.when(selector.getContextType()).thenReturn("broken");
+        Mockito.when(contextBuilder.build(Mockito.anyString(), Mockito.anyList()))
+            .thenThrow(new RuntimeException("broken"));
+        
+        List<Instance> result = selectorManager.select(selector, "1.1.1.1", providers);
+        
+        assertSame(providers, result);
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/selector/context/CmdbSelectorContextBuilderTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/selector/context/CmdbSelectorContextBuilderTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.alibaba.nacos.naming.selector.context;
+
+import com.alibaba.nacos.api.cmdb.pojo.Entity;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.selector.context.CmdbContext;
+import com.alibaba.nacos.cmdb.service.CmdbReader;
+import com.alibaba.nacos.sys.utils.ApplicationUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.Arrays;
+
+import static com.alibaba.nacos.api.cmdb.pojo.PreservedEntityTypes.ip;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class CmdbSelectorContextBuilderTest {
+    
+    @Mock
+    private ConfigurableApplicationContext applicationContext;
+    
+    @Mock
+    private CmdbReader cmdbReader;
+    
+    private CmdbSelectorContextBuilder<Instance> contextBuilder;
+    
+    @BeforeEach
+    void setUp() {
+        ApplicationUtils.injectContext(applicationContext);
+        contextBuilder = new CmdbSelectorContextBuilder<>();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        ApplicationUtils.injectContext(null);
+    }
+    
+    @Test
+    void testBuildWithProviders() {
+        Mockito.when(applicationContext.getBean(CmdbReader.class)).thenReturn(cmdbReader);
+        Entity consumerEntity = new Entity();
+        Entity providerEntity1 = new Entity();
+        Entity providerEntity2 = new Entity();
+        Mockito.when(cmdbReader.queryEntity("1.1.1.1", ip.name())).thenReturn(consumerEntity);
+        Mockito.when(cmdbReader.queryEntity("2.2.2.2", ip.name())).thenReturn(providerEntity1);
+        Mockito.when(cmdbReader.queryEntity("3.3.3.3", ip.name())).thenReturn(providerEntity2);
+        Instance provider1 = instance("2.2.2.2");
+        Instance provider2 = instance("3.3.3.3");
+        
+        CmdbContext<Instance> context =
+            contextBuilder.build("1.1.1.1", Arrays.asList(provider1, provider2));
+        
+        assertEquals("1.1.1.1", context.getConsumer().getInstance().getIp());
+        assertSame(consumerEntity, context.getConsumer().getEntity());
+        assertEquals(2, context.getProviders().size());
+        assertSame(provider1, context.getProviders().get(0).getInstance());
+        assertSame(providerEntity1, context.getProviders().get(0).getEntity());
+        assertSame(provider2, context.getProviders().get(1).getInstance());
+        assertSame(providerEntity2, context.getProviders().get(1).getEntity());
+    }
+    
+    @Test
+    void testBuildWithNullProviders() {
+        Mockito.when(applicationContext.getBean(CmdbReader.class)).thenReturn(cmdbReader);
+        Entity consumerEntity = new Entity();
+        Mockito.when(cmdbReader.queryEntity("1.1.1.1", ip.name())).thenReturn(consumerEntity);
+        
+        CmdbContext<Instance> context = contextBuilder.build("1.1.1.1", null);
+        
+        assertEquals("1.1.1.1", context.getConsumer().getInstance().getIp());
+        assertSame(consumerEntity, context.getConsumer().getEntity());
+        assertTrue(context.getProviders().isEmpty());
+    }
+    
+    @Test
+    void testGetContextType() {
+        assertEquals("CMDB", contextBuilder.getContextType());
+    }
+    
+    private Instance instance(String ip) {
+        Instance result = new Instance();
+        result.setIp(ip);
+        return result;
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/selector/interpreter/ExpressionInterpreterTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/selector/interpreter/ExpressionInterpreterTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.selector.interpreter;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExpressionInterpreterTest {
+    
+    @Test
+    void testNewInstance() {
+        ExpressionInterpreter expressionInterpreter = new ExpressionInterpreter();
+        
+        assertEquals(ExpressionInterpreter.class, expressionInterpreter.getClass());
+    }
+    
+    @Test
+    void testParseExpressionWhenBlank() throws NacosException {
+        Set<String> actual = ExpressionInterpreter.parseExpression(" ");
+        
+        assertTrue(actual.isEmpty());
+    }
+    
+    @Test
+    void testParseExpressionWithMultipleLabels() throws NacosException {
+        Set<String> actual = ExpressionInterpreter.parseExpression(
+            "CONSUMER.label.zone = PROVIDER.label.zone & CONSUMER.label.version = PROVIDER.label.version");
+        
+        assertEquals(2, actual.size());
+        assertTrue(actual.contains("zone"));
+        assertTrue(actual.contains("version"));
+    }
+    
+    @Test
+    void testGetTerms() {
+        List<String> actual =
+            ExpressionInterpreter.getTerms("CONSUMER.label.zone=PROVIDER.label.zone");
+        
+        assertEquals(3, actual.size());
+        assertEquals("CONSUMER.label.zone", actual.get(0));
+        assertEquals("=", actual.get(1));
+        assertEquals("PROVIDER.label.zone", actual.get(2));
+    }
+    
+    @Test
+    void testParseExpressionThrowsWhenConsumerPrefixInvalid() {
+        assertThrows(NacosException.class,
+            () -> ExpressionInterpreter.parseExpression("CONSUMER.zone=PROVIDER.label.zone"));
+    }
+    
+    @Test
+    void testParseExpressionThrowsWhenMissingConnector() {
+        assertThrows(NacosException.class,
+            () -> ExpressionInterpreter.parseExpression("CONSUMER.label.zone"));
+    }
+    
+    @Test
+    void testParseExpressionThrowsWhenInnerConnectorInvalid() {
+        assertThrows(NacosException.class,
+            () -> ExpressionInterpreter.parseExpression(
+                "CONSUMER.label.zone&PROVIDER.label.zone"));
+    }
+    
+    @Test
+    void testParseExpressionThrowsWhenProviderPrefixInvalid() {
+        assertThrows(NacosException.class,
+            () -> ExpressionInterpreter.parseExpression("CONSUMER.label.zone=PROVIDER.zone"));
+    }
+    
+    @Test
+    void testParseExpressionThrowsWhenLabelMismatch() {
+        assertThrows(NacosException.class,
+            () -> ExpressionInterpreter.parseExpression(
+                "CONSUMER.label.zone=PROVIDER.label.version"));
+    }
+    
+    @Test
+    void testParseExpressionThrowsWhenOuterConnectorInvalid() {
+        assertThrows(NacosException.class,
+            () -> ExpressionInterpreter.parseExpression(
+                "CONSUMER.label.zone=PROVIDER.label.zone=CONSUMER.label.version=PROVIDER.label.version"));
+    }
+    
+    @Test
+    void testSkipEmptySkipsBlankTerms() throws Exception {
+        int actual = (int) invokePrivateStatic("skipEmpty",
+            new Class[] {List.class, int.class}, List.of("", "CONSUMER.label.zone"), 0);
+        
+        assertEquals(1, actual);
+    }
+    
+    @Test
+    void testCheckOuterSyntaxReturnsEndWhenOnlyBlankTerms() throws Exception {
+        int actual = (int) invokePrivateStatic("checkOuterSyntax",
+            new Class[] {List.class, int.class}, List.of(""), 0);
+        
+        assertEquals(1, actual);
+    }
+    
+    @Test
+    void testCheckInnerSyntaxReturnsInvalidWhenNoConsumerTerm() throws Exception {
+        int actual = (int) invokePrivateStatic("checkInnerSyntax",
+            new Class[] {List.class, int.class}, List.of(), 0);
+        
+        assertEquals(-1, actual);
+    }
+    
+    @Test
+    void testCheckInnerSyntaxReturnsInvalidWhenProviderMissing() throws Exception {
+        int actual = (int) invokePrivateStatic("checkInnerSyntax",
+            new Class[] {List.class, int.class}, List.of("CONSUMER.label.zone", "="), 0);
+        
+        assertEquals(-1, actual);
+    }
+    
+    private Object invokePrivateStatic(String methodName, Class<?>[] parameterTypes,
+        Object... args) throws Exception {
+        Method method = ExpressionInterpreter.class.getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(null, args);
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/utils/DistroUtilsTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/utils/DistroUtilsTest.java
@@ -23,11 +23,13 @@ import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 
 import static com.alibaba.nacos.api.common.Constants.DEFAULT_CLUSTER_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests for {@link DistroUtils}.
@@ -142,6 +144,17 @@ class DistroUtilsTest {
             DistroUtils.buildUniqueString(client));
         assertEquals(775352583L, DistroUtils.stringHash(client));
         assertEquals("82d8e086a880f088320349b895b22948", DistroUtils.checksum(client));
+    }
+    
+    @Test
+    void testNonIpPortBasedClientReturnsDefaultValues() {
+        Client client = Mockito.mock(Client.class);
+        
+        assertEquals(DistroUtils.class, new DistroUtils().getClass());
+        assertEquals(0, DistroUtils.hash(client));
+        assertEquals(0, DistroUtils.stringHash(client));
+        assertEquals("0", DistroUtils.checksum(client));
+        assertNull(DistroUtils.buildUniqueString(client));
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/utils/InstanceUtilTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/utils/InstanceUtilTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.naming.utils;
 
 import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.naming.constants.Constants;
 import com.alibaba.nacos.naming.core.v2.metadata.InstanceMetadata;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
@@ -33,7 +34,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class InstanceUtilTest {
     
@@ -52,6 +55,27 @@ class InstanceUtilTest {
     void testParseToApiInstance() {
         Instance instance = InstanceUtil.parseToApiInstance(service, instancePublishInfo);
         assertNotNull(instance);
+    }
+    
+    @Test
+    void testParseToApiInstanceWithExtendedDatum() {
+        Map<String, Object> extendDatum = instancePublishInfo.getExtendDatum();
+        extendDatum.put(Constants.CUSTOM_INSTANCE_ID, "custom-id");
+        extendDatum.put(Constants.PUBLISH_INSTANCE_ENABLE, false);
+        extendDatum.put(Constants.PUBLISH_INSTANCE_WEIGHT, 2.5D);
+        extendDatum.put("zone", "hangzhou");
+        extendDatum.put("empty", null);
+        instancePublishInfo.setHealthy(true);
+        instancePublishInfo.setCluster("cluster");
+        
+        Instance instance = InstanceUtil.parseToApiInstance(service, instancePublishInfo);
+        
+        assertEquals("custom-id", instance.getInstanceId());
+        assertFalse(instance.isEnabled());
+        assertEquals(2.5D, instance.getWeight());
+        assertEquals("hangzhou", instance.getMetadata().get("zone"));
+        assertNull(instance.getMetadata().get("empty"));
+        assertEquals("cluster", instance.getClusterName());
     }
     
     @Test
@@ -92,6 +116,7 @@ class InstanceUtilTest {
     
     @Test
     void testSetInstanceIdIfEmpty() {
+        InstanceUtil.setInstanceIdIfEmpty(null, "test");
         Instance instance = new Instance();
         instance.setIp("1.1.1.1");
         instance.setPort(8890);
@@ -110,6 +135,7 @@ class InstanceUtilTest {
     
     @Test
     void testBatchSetInstanceIdIfEmpty() {
+        InstanceUtil.batchSetInstanceIdIfEmpty(null, "test");
         final List<Instance> instances = new ArrayList<>();
         Instance instance1 = new Instance();
         instance1.setServiceName("test");
@@ -124,5 +150,10 @@ class InstanceUtilTest {
         assertNotNull(instance1.getInstanceId());
         assertNotNull(instance2.getInstanceId());
         assertNotNull(instance3.getInstanceId());
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new InstanceUtil());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/utils/NamingRequestUtilTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/utils/NamingRequestUtilTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.naming.utils;
 
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.remote.request.RequestMeta;
 import com.alibaba.nacos.core.context.RequestContextHolder;
 import org.junit.jupiter.api.AfterEach;
@@ -29,6 +30,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,5 +82,14 @@ class NamingRequestUtilTest {
         assertEquals("1.1.1.1", NamingRequestUtil.getSourceIpForGrpcRequest(meta));
         RequestContextHolder.getContext().getBasicContext().getAddressContext().setRemoteIp(null);
         assertEquals("3.3.3.3", NamingRequestUtil.getSourceIpForGrpcRequest(meta));
+    }
+    
+    @Test
+    void testCheckWeight() throws NacosException {
+        new NamingRequestUtil();
+        NamingRequestUtil.checkWeight(1.0D);
+        
+        assertThrows(NacosException.class, () -> NamingRequestUtil.checkWeight(10001.0D));
+        assertThrows(NacosException.class, () -> NamingRequestUtil.checkWeight(-1.0D));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/utils/ServiceUtilTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/utils/ServiceUtilTest.java
@@ -16,12 +16,43 @@
 
 package com.alibaba.nacos.naming.utils;
 
+import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClusterInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ServiceDetailInfo;
+import com.alibaba.nacos.naming.constants.FieldsConstants;
+import com.alibaba.nacos.naming.core.v2.metadata.ServiceMetadata;
+import com.alibaba.nacos.naming.pojo.Subscriber;
+import com.alibaba.nacos.naming.selector.SelectorManager;
+import com.alibaba.nacos.sys.utils.ApplicationUtils;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.context.ConfigurableApplicationContext;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ServiceUtilTest {
+    
+    @AfterEach
+    void tearDown() {
+        ApplicationUtils.injectContext(null);
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new ServiceUtil());
+    }
     
     @Test
     void testSelectInstances() {
@@ -32,5 +63,158 @@ class ServiceUtilTest {
         serviceInfo.setAllIps(false);
         ServiceInfo cluster = ServiceUtil.selectInstances(serviceInfo, "cluster");
         assertNotNull(cluster);
+    }
+    
+    @Test
+    void testTransferToConsoleResult() {
+        ServiceDetailInfo serviceDetailInfo = new ServiceDetailInfo();
+        serviceDetailInfo.setServiceName("serviceName");
+        serviceDetailInfo.setGroupName("groupName");
+        serviceDetailInfo.setProtectThreshold(0.7F);
+        serviceDetailInfo.setMetadata(Collections.singletonMap("owner", "naming"));
+        ClusterInfo clusterInfo = new ClusterInfo();
+        clusterInfo.setHealthyCheckPort(8080);
+        clusterInfo.setUseInstancePortForCheck(false);
+        clusterInfo.setMetadata(Collections.singletonMap("zone", "z1"));
+        Map<String, ClusterInfo> clusterMap = new HashMap<>(1);
+        clusterMap.put("clusterA", clusterInfo);
+        serviceDetailInfo.setClusterMap(clusterMap);
+        
+        ObjectNode result = (ObjectNode) ServiceUtil.transferToConsoleResult(serviceDetailInfo);
+        
+        ObjectNode service = (ObjectNode) result.get(FieldsConstants.SERVICE);
+        assertEquals("serviceName", service.get(FieldsConstants.NAME).asText());
+        assertEquals("groupName", service.get(FieldsConstants.GROUP_NAME).asText());
+        assertEquals("naming", service.get(FieldsConstants.METADATA).get("owner").asText());
+        ObjectNode cluster = (ObjectNode) result.get(FieldsConstants.CLUSTERS).get(0);
+        assertEquals("clusterA", cluster.get(FieldsConstants.NAME).asText());
+        assertEquals(8080, cluster.get("defaultCheckPort").asInt());
+        assertFalse(cluster.get("useIpPort4Check").asBoolean());
+        assertEquals("z1", cluster.get(FieldsConstants.METADATA).get("zone").asText());
+    }
+    
+    @Test
+    void testPageServiceName() {
+        List<String> services = Arrays.asList("group@@serviceA", "serviceB", "group@@serviceC");
+        
+        assertEquals(Arrays.asList("serviceA", "serviceB"),
+            ServiceUtil.pageServiceName(1, 2, services));
+        assertEquals(Collections.singletonList("serviceC"),
+            ServiceUtil.pageServiceName(2, 2, services));
+        assertTrue(ServiceUtil.pageServiceName(3, 2, services).isEmpty());
+        assertEquals(Collections.singletonList("serviceA"),
+            ServiceUtil.pageServiceName(0, 1, services));
+    }
+    
+    @Test
+    void testSelectInstancesByHealthEnabledAndCluster() {
+        Instance healthyEnabled = instance("1.1.1.1", "clusterA", true, true);
+        Instance unhealthyEnabled = instance("1.1.1.2", "clusterA", false, true);
+        Instance healthyDisabled = instance("1.1.1.3", "clusterB", true, false);
+        ServiceInfo serviceInfo = serviceInfo(healthyEnabled, unhealthyEnabled, healthyDisabled);
+        
+        assertEquals(2, ServiceUtil.selectHealthyInstances(serviceInfo).getHosts().size());
+        assertEquals(2, ServiceUtil.selectEnabledInstances(serviceInfo).getHosts().size());
+        assertEquals(2, ServiceUtil.selectInstances(serviceInfo, "clusterA").getHosts().size());
+        assertEquals(Collections.singletonList(healthyEnabled),
+            ServiceUtil.selectInstances(serviceInfo, "clusterA", true).getHosts());
+        assertEquals(Collections.singletonList(healthyEnabled),
+            ServiceUtil.selectInstances(serviceInfo, "clusterA", true, true).getHosts());
+    }
+    
+    @Test
+    void testSelectInstancesWithHealthyProtectionBySubscriber() {
+        ServiceInfo serviceInfo =
+            serviceInfo(instance("1.1.1.1", "clusterA", true, true),
+                instance("1.1.1.2", "clusterB", false, true));
+        Subscriber subscriber =
+            new Subscriber("2.2.2.2:8848", "agent", "app", "2.2.2.2", "namespaceId",
+                "groupName@@serviceName", 8848, "clusterA");
+        
+        ServiceInfo result =
+            ServiceUtil.selectInstancesWithHealthyProtection(serviceInfo, null, subscriber);
+        
+        assertEquals(1, result.getHosts().size());
+        assertEquals("clusterA", result.getHosts().get(0).getClusterName());
+    }
+    
+    @Test
+    void testSelectInstancesWithHealthyProtectionWithoutMetadata() {
+        ServiceInfo serviceInfo =
+            serviceInfo(instance("1.1.1.1", "clusterA", true, true),
+                instance("1.1.1.2", "clusterB", false, true));
+        
+        ServiceInfo result =
+            ServiceUtil.selectInstancesWithHealthyProtection(serviceInfo, null, "clusterA", false,
+                false, "2.2.2.2");
+        
+        assertFalse(result.isReachProtectionThreshold());
+        assertEquals(1, result.getHosts().size());
+        assertEquals("clusterA", result.getHosts().get(0).getClusterName());
+    }
+    
+    @Test
+    void testSelectInstancesWithHealthyProtection() {
+        ServiceInfo serviceInfo =
+            serviceInfo(instance("1.1.1.1", "clusterA", true, true),
+                instance("1.1.1.2", "clusterA", false, true));
+        ServiceMetadata serviceMetadata = new ServiceMetadata();
+        serviceMetadata.setProtectThreshold(0.6F);
+        SelectorManager selectorManager = Mockito.mock(SelectorManager.class);
+        ConfigurableApplicationContext context = Mockito.mock(ConfigurableApplicationContext.class);
+        ApplicationUtils.injectContext(context);
+        Mockito.when(context.getBean(SelectorManager.class)).thenReturn(selectorManager);
+        Mockito.when(selectorManager.select(Mockito.any(), Mockito.eq("2.2.2.2"),
+            Mockito.anyList())).thenAnswer(invocation -> invocation.getArgument(2));
+        
+        ServiceInfo result =
+            ServiceUtil.selectInstancesWithHealthyProtection(serviceInfo, serviceMetadata,
+                "clusterA", false, false, "2.2.2.2");
+        
+        assertTrue(result.isReachProtectionThreshold());
+        assertEquals(2, result.getHosts().size());
+        assertTrue(result.getHosts().stream().allMatch(Instance::isHealthy));
+    }
+    
+    @Test
+    void testSelectInstancesWithHealthyProtectionRecomputesAfterSelector() {
+        Instance healthy = instance("1.1.1.1", "clusterA", true, true);
+        Instance unhealthy = instance("1.1.1.2", "clusterA", false, true);
+        ServiceInfo serviceInfo =
+            serviceInfo(healthy, unhealthy, instance("1.1.1.3", "clusterA", false, true));
+        ServiceMetadata serviceMetadata = new ServiceMetadata();
+        serviceMetadata.setProtectThreshold(-1F);
+        SelectorManager selectorManager = Mockito.mock(SelectorManager.class);
+        ConfigurableApplicationContext context = Mockito.mock(ConfigurableApplicationContext.class);
+        ApplicationUtils.injectContext(context);
+        Mockito.when(context.getBean(SelectorManager.class)).thenReturn(selectorManager);
+        Mockito.when(selectorManager.select(Mockito.any(), Mockito.eq("2.2.2.2"),
+            Mockito.anyList())).thenReturn(Arrays.asList(healthy, unhealthy));
+        
+        ServiceInfo result =
+            ServiceUtil.selectInstancesWithHealthyProtection(serviceInfo, serviceMetadata,
+                "clusterA", false, false, "2.2.2.2");
+        
+        assertFalse(result.isReachProtectionThreshold());
+        assertEquals(Arrays.asList(healthy, unhealthy), result.getHosts());
+    }
+    
+    private ServiceInfo serviceInfo(Instance... instances) {
+        ServiceInfo result = new ServiceInfo();
+        result.setGroupName("groupName");
+        result.setName("serviceName");
+        result.setCacheMillis(1000L);
+        result.setHosts(Arrays.asList(instances));
+        return result;
+    }
+    
+    private Instance instance(String ip, String cluster, boolean healthy, boolean enabled) {
+        Instance result = new Instance();
+        result.setIp(ip);
+        result.setPort(8848);
+        result.setClusterName(cluster);
+        result.setHealthy(healthy);
+        result.setEnabled(enabled);
+        return result;
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/DistroIpPortTagGeneratorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/DistroIpPortTagGeneratorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.web;
+
+import com.alibaba.nacos.core.utils.ReuseHttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DistroIpPortTagGeneratorTest {
+    
+    @Test
+    void testGetResponsibleTagIgnoresInvalidBeat() throws Exception {
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        servletRequest.addParameter("beat", "{");
+        ReuseHttpServletRequest request = new ReuseHttpServletRequest(servletRequest);
+        
+        String responsibleTag = new DistroIpPortTagGenerator().getResponsibleTag(request);
+        
+        assertEquals("null:0", responsibleTag);
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/NamingConfigTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/NamingConfigTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.web;
+
+import com.alibaba.nacos.core.code.ControllerMethodsCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class NamingConfigTest {
+    
+    private ControllerMethodsCache methodsCache;
+    
+    private NamingConfig namingConfig;
+    
+    @BeforeEach
+    void setUp() {
+        methodsCache = mock(ControllerMethodsCache.class);
+        namingConfig = new NamingConfig(methodsCache);
+    }
+    
+    @Test
+    void testInit() {
+        namingConfig.init();
+        
+        verify(methodsCache).initClassMethod("com.alibaba.nacos.naming.controllers");
+    }
+    
+    @Test
+    void testDistroFilterRegistration() {
+        FilterRegistrationBean<DistroFilter> registration =
+            namingConfig.distroFilterRegistration();
+        
+        assertInstanceOf(DistroFilter.class, registration.getFilter());
+        assertEquals("distroFilter", registration.getFilterName());
+        assertEquals(7, registration.getOrder());
+        assertEquals(1, registration.getUrlPatterns().size());
+        assertEquals("/v1/ns/*", registration.getUrlPatterns().iterator().next());
+    }
+    
+    @Test
+    void testServiceNameFilterRegistration() {
+        FilterRegistrationBean<ServiceNameFilter> registration =
+            namingConfig.serviceNameFilterRegistration();
+        
+        assertInstanceOf(ServiceNameFilter.class, registration.getFilter());
+        assertEquals("serviceNameFilter", registration.getFilterName());
+        assertEquals(5, registration.getOrder());
+        assertEquals(1, registration.getUrlPatterns().size());
+        assertEquals("/v1/ns/*", registration.getUrlPatterns().iterator().next());
+    }
+    
+    @Test
+    void testTrafficReviseFilterRegistration() {
+        FilterRegistrationBean<TrafficReviseFilter> registration =
+            namingConfig.trafficReviseFilterRegistration();
+        
+        assertInstanceOf(TrafficReviseFilter.class, registration.getFilter());
+        assertEquals("trafficReviseFilter", registration.getFilterName());
+        assertEquals(1, registration.getOrder());
+        assertEquals(1, registration.getUrlPatterns().size());
+        assertEquals("/v1/ns/*", registration.getUrlPatterns().iterator().next());
+    }
+    
+    @Test
+    void testClientAttributesFilterRegistration() {
+        FilterRegistrationBean<ClientAttributesFilter> registration =
+            namingConfig.clientAttributesFilterRegistration();
+        
+        assertInstanceOf(ClientAttributesFilter.class, registration.getFilter());
+        assertEquals("clientAttributes_filter", registration.getFilterName());
+        assertEquals(8, registration.getOrder());
+        assertEquals(2, registration.getUrlPatterns().size());
+    }
+    
+    @Test
+    void testFilterBeans() {
+        assertNotNull(namingConfig.distroFilter());
+        assertNotNull(namingConfig.trafficReviseFilter());
+        assertNotNull(namingConfig.serviceNameFilter());
+        assertNotNull(namingConfig.clientAttributesFilter());
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/NamingWebFilterTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/NamingWebFilterTest.java
@@ -115,6 +115,21 @@ class NamingWebFilterTest {
     }
     
     @Test
+    void testTrafficReviseFilterContinuesWhenLimitedUrlNotMatched() throws Exception {
+        TrafficReviseFilter filter =
+            trafficReviseFilter(ServerStatus.UP, null,
+                Collections.singletonMap("/nacos/v1/ns/other", 429));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        request.setQueryString("serviceName=test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        
+        filter.doFilter(request, response, chain);
+        
+        verify(chain).doFilter(same(request), same(response));
+    }
+    
+    @Test
     void testTrafficReviseFilterPassesWhenServerUp() throws Exception {
         TrafficReviseFilter filter =
             trafficReviseFilter(ServerStatus.UP, null, Collections.emptyMap());
@@ -179,6 +194,19 @@ class NamingWebFilterTest {
         
         assertEquals(HttpServletResponse.SC_SERVICE_UNAVAILABLE, response.getStatus());
         assertTrue(response.getContentAsString().contains("detailed error message: warmup"));
+    }
+    
+    @Test
+    void testTrafficReviseFilterRejectsUnavailableServerWithoutDetail() throws Exception {
+        TrafficReviseFilter filter =
+            trafficReviseFilter(ServerStatus.DOWN, Optional.empty(), Collections.emptyMap());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        filter.doFilter(request, response, mock(FilterChain.class));
+        
+        assertEquals(HttpServletResponse.SC_SERVICE_UNAVAILABLE, response.getStatus());
+        assertTrue(response.getContentAsString().contains("please try again later"));
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/NamingWebFilterTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/NamingWebFilterTest.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.web;
+
+import com.alibaba.nacos.api.naming.CommonParams;
+import com.alibaba.nacos.common.constant.HttpHeaderConsts;
+import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.core.code.ControllerMethodsCache;
+import com.alibaba.nacos.core.utils.ReuseHttpServletRequest;
+import com.alibaba.nacos.naming.cluster.ServerStatus;
+import com.alibaba.nacos.naming.cluster.ServerStatusManager;
+import com.alibaba.nacos.naming.core.DistroMapper;
+import com.alibaba.nacos.naming.healthcheck.RsInfo;
+import com.alibaba.nacos.naming.misc.HttpClient;
+import com.alibaba.nacos.naming.misc.SwitchDomain;
+import com.alibaba.nacos.sys.env.Constants;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NamingWebFilterTest {
+    
+    @Test
+    void testServiceNameFilterAddsDefaultGroup() throws Exception {
+        ServiceNameFilter filter = new ServiceNameFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        request.addParameter(CommonParams.SERVICE_NAME, " service ");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicReference<ServletRequest> filteredRequest = new AtomicReference<>();
+        
+        filter.doFilter(request, response, new CaptureRequestChain(filteredRequest));
+        
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertEquals("DEFAULT_GROUP@@service",
+            filteredRequest.get().getParameter(CommonParams.SERVICE_NAME));
+    }
+    
+    @Test
+    void testServiceNameFilterKeepsGroupedServiceName() throws Exception {
+        ServiceNameFilter filter = new ServiceNameFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        request.addParameter(CommonParams.SERVICE_NAME, "group@@service");
+        request.addParameter(CommonParams.GROUP_NAME, "ignored");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicReference<ServletRequest> filteredRequest = new AtomicReference<>();
+        
+        filter.doFilter(request, response, new CaptureRequestChain(filteredRequest));
+        
+        assertEquals("group@@service",
+            filteredRequest.get().getParameter(CommonParams.SERVICE_NAME));
+    }
+    
+    @Test
+    void testTrafficReviseFilterLimitsConfiguredUrl() throws Exception {
+        TrafficReviseFilter filter =
+            trafficReviseFilter(null, null, Collections.singletonMap("/nacos/v1/ns/instance", 429));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        request.setQueryString("serviceName=test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        
+        filter.doFilter(request, response, chain);
+        
+        assertEquals(429, response.getStatus());
+        verify(chain, never()).doFilter(any(), any());
+    }
+    
+    @Test
+    void testTrafficReviseFilterPassesWhenServerUp() throws Exception {
+        TrafficReviseFilter filter =
+            trafficReviseFilter(ServerStatus.UP, null, Collections.emptyMap());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        
+        filter.doFilter(request, response, chain);
+        
+        verify(chain).doFilter(same(request), same(response));
+    }
+    
+    @Test
+    void testTrafficReviseFilterPassesPeerServerRequest() throws Exception {
+        TrafficReviseFilter filter =
+            trafficReviseFilter(ServerStatus.DOWN, null, Collections.emptyMap());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        request.addHeader(HttpHeaderConsts.USER_AGENT_HEADER, Constants.NACOS_SERVER_HEADER);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        
+        filter.doFilter(request, response, chain);
+        
+        verify(chain).doFilter(same(request), same(response));
+    }
+    
+    @Test
+    void testTrafficReviseFilterAllowsWriteOnlyPost() throws Exception {
+        TrafficReviseFilter filter =
+            trafficReviseFilter(ServerStatus.WRITE_ONLY, null, Collections.emptyMap());
+        MockHttpServletRequest request =
+            new MockHttpServletRequest("POST", "/nacos/v1/ns/instance");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        
+        filter.doFilter(request, response, chain);
+        
+        verify(chain).doFilter(same(request), same(response));
+    }
+    
+    @Test
+    void testTrafficReviseFilterAllowsReadOnlyGet() throws Exception {
+        TrafficReviseFilter filter =
+            trafficReviseFilter(ServerStatus.READ_ONLY, null, Collections.emptyMap());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        
+        filter.doFilter(request, response, chain);
+        
+        verify(chain).doFilter(same(request), same(response));
+    }
+    
+    @Test
+    void testTrafficReviseFilterRejectsUnavailableServerWithDetail() throws Exception {
+        TrafficReviseFilter filter =
+            trafficReviseFilter(ServerStatus.DOWN, Optional.of("warmup"), Collections.emptyMap());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        filter.doFilter(request, response, mock(FilterChain.class));
+        
+        assertEquals(HttpServletResponse.SC_SERVICE_UNAVAILABLE, response.getStatus());
+        assertTrue(response.getContentAsString().contains("detailed error message: warmup"));
+    }
+    
+    @Test
+    void testDistroIpPortTagGeneratorUsesDirectIpAndPort() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("ip", " 1.1.1.1 ");
+        request.addParameter("port", " 8848 ");
+        
+        String actual = new DistroIpPortTagGenerator()
+            .getResponsibleTag(new ReuseHttpServletRequest(request));
+        
+        assertEquals("1.1.1.1:8848", actual);
+    }
+    
+    @Test
+    void testDistroIpPortTagGeneratorUsesBeatFallback() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RsInfo beat = new RsInfo();
+        beat.setIp("2.2.2.2");
+        beat.setPort(9848);
+        request.addParameter("beat", JacksonUtils.toJson(beat));
+        
+        String actual = new DistroIpPortTagGenerator()
+            .getResponsibleTag(new ReuseHttpServletRequest(request));
+        
+        assertEquals("2.2.2.2:9848", actual);
+    }
+    
+    @Test
+    void testDistroTagGeneratorImplDelegatesToIpPortGenerator() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("ip", "1.1.1.1");
+        
+        String actual = new DistroTagGeneratorImpl()
+            .getResponsibleTag(new ReuseHttpServletRequest(request));
+        
+        assertEquals("1.1.1.1:0", actual);
+    }
+    
+    @Test
+    void testDistroFilterPassesWhenMethodNotCanDistro() throws Exception {
+        DistroFilter filter = distroFilter();
+        ControllerMethodsCache methodsCache =
+            (ControllerMethodsCache) ReflectionTestUtils.getField(filter, "controllerMethodsCache");
+        Method method = FilterMethodHolder.class.getDeclaredMethod("plainMethod");
+        when(methodsCache.getMethod(any())).thenReturn(method);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        
+        filter.doFilter(request, response, chain);
+        
+        verify(chain).doFilter(any(ReuseHttpServletRequest.class), same(response));
+    }
+    
+    @Test
+    void testDistroFilterPassesWhenCurrentServerResponsible() throws Exception {
+        DistroFilter filter = distroFilter();
+        ControllerMethodsCache methodsCache =
+            (ControllerMethodsCache) ReflectionTestUtils.getField(filter, "controllerMethodsCache");
+        DistroTagGenerator tagGenerator =
+            (DistroTagGenerator) ReflectionTestUtils.getField(filter, "distroTagGenerator");
+        DistroMapper distroMapper =
+            (DistroMapper) ReflectionTestUtils.getField(filter, "distroMapper");
+        when(methodsCache.getMethod(any())).thenReturn(canDistroMethod());
+        when(tagGenerator.getResponsibleTag(any())).thenReturn("1.1.1.1:8848");
+        when(distroMapper.responsible("1.1.1.1:8848")).thenReturn(true);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        
+        filter.doFilter(request, response, chain);
+        
+        verify(chain).doFilter(any(ReuseHttpServletRequest.class), same(response));
+    }
+    
+    @Test
+    void testDistroFilterRejectsPeerRedirect() throws Exception {
+        DistroFilter filter = distroFilter();
+        stubCanDistroNotResponsible(filter);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/instance");
+        request.addHeader(HttpHeaderConsts.USER_AGENT_HEADER, "Nacos-Server:v3");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        filter.doFilter(request, response, mock(FilterChain.class));
+        
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.getStatus());
+        assertTrue(response.getErrorMessage().contains("receive invalid redirect request"));
+    }
+    
+    @Test
+    void testDistroFilterReturnsNotImplementedWhenMethodMissing() throws Exception {
+        DistroFilter filter = distroFilter();
+        ControllerMethodsCache methodsCache =
+            (ControllerMethodsCache) ReflectionTestUtils.getField(filter, "controllerMethodsCache");
+        when(methodsCache.getMethod(any())).thenReturn(null);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/ns/missing");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        
+        filter.doFilter(request, response, mock(FilterChain.class));
+        
+        assertEquals(HttpServletResponse.SC_NOT_IMPLEMENTED, response.getStatus());
+        assertTrue(response.getErrorMessage().contains("no such api:GET:/nacos/v1/ns/missing"));
+    }
+    
+    @Test
+    void testDistroFilterProxiesToMappedServer() throws Exception {
+        DistroFilter filter = distroFilter();
+        DistroMapper distroMapper = stubCanDistroNotResponsible(filter);
+        when(distroMapper.mapSrv("1.1.1.1:8848")).thenReturn("2.2.2.2:8848");
+        MockHttpServletRequest request =
+            new MockHttpServletRequest("POST", "/nacos/v1/ns/instance");
+        request.setContent("body".getBytes(StandardCharsets.UTF_8));
+        request.addHeader("X-Test", "value");
+        request.addParameter("ip", "1.1.1.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        RestResult<String> result = new RestResult<>(200, "ok", "proxied");
+        
+        ConfigurableEnvironment cachedEnvironment = EnvUtil.getEnvironment();
+        EnvUtil.setEnvironment(new MockEnvironment());
+        try {
+            try (MockedStatic<HttpClient> httpClient = mockStatic(HttpClient.class)) {
+                httpClient.when(() -> HttpClient.translateParameterMap(anyMap()))
+                    .thenCallRealMethod();
+                httpClient.when(() -> HttpClient.request(anyString(), anyList(), anyMap(),
+                    anyString(), anyInt(), anyInt(), anyString(), eq("POST")))
+                    .thenReturn(result);
+                filter.doFilter(request, response, mock(FilterChain.class));
+            }
+        } finally {
+            EnvUtil.setEnvironment(cachedEnvironment);
+        }
+        
+        assertEquals(HttpServletResponse.SC_OK, response.getStatus());
+        assertEquals("proxied", response.getContentAsString());
+    }
+    
+    private TrafficReviseFilter trafficReviseFilter(ServerStatus serverStatus,
+        Optional<String> errorMsg, Map<String, Integer> limitedUrlMap) {
+        TrafficReviseFilter filter = new TrafficReviseFilter();
+        ServerStatusManager serverStatusManager = mock(ServerStatusManager.class);
+        SwitchDomain switchDomain = mock(SwitchDomain.class);
+        when(switchDomain.getLimitedUrlMap()).thenReturn(limitedUrlMap);
+        if (serverStatus != null) {
+            when(serverStatusManager.getServerStatus()).thenReturn(serverStatus);
+        }
+        if (errorMsg != null) {
+            when(serverStatusManager.getErrorMsg()).thenReturn(errorMsg);
+        }
+        ReflectionTestUtils.setField(filter, "serverStatusManager", serverStatusManager);
+        ReflectionTestUtils.setField(filter, "switchDomain", switchDomain);
+        return filter;
+    }
+    
+    private DistroFilter distroFilter() {
+        DistroFilter filter = new DistroFilter();
+        ReflectionTestUtils.setField(filter, "controllerMethodsCache",
+            mock(ControllerMethodsCache.class));
+        ReflectionTestUtils.setField(filter, "distroMapper", mock(DistroMapper.class));
+        ReflectionTestUtils.setField(filter, "distroTagGenerator", mock(DistroTagGenerator.class));
+        return filter;
+    }
+    
+    private DistroMapper stubCanDistroNotResponsible(DistroFilter filter) throws Exception {
+        ControllerMethodsCache methodsCache =
+            (ControllerMethodsCache) ReflectionTestUtils.getField(filter, "controllerMethodsCache");
+        DistroTagGenerator tagGenerator =
+            (DistroTagGenerator) ReflectionTestUtils.getField(filter, "distroTagGenerator");
+        DistroMapper distroMapper =
+            (DistroMapper) ReflectionTestUtils.getField(filter, "distroMapper");
+        when(methodsCache.getMethod(any())).thenReturn(canDistroMethod());
+        when(tagGenerator.getResponsibleTag(any())).thenReturn("1.1.1.1:8848");
+        when(distroMapper.responsible("1.1.1.1:8848")).thenReturn(false);
+        return distroMapper;
+    }
+    
+    private Method canDistroMethod() throws NoSuchMethodException {
+        return FilterMethodHolder.class.getDeclaredMethod("canDistroMethod");
+    }
+    
+    private static class CaptureRequestChain implements FilterChain {
+        
+        private final AtomicReference<ServletRequest> filteredRequest;
+        
+        CaptureRequestChain(AtomicReference<ServletRequest> filteredRequest) {
+            this.filteredRequest = filteredRequest;
+        }
+        
+        @Override
+        public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse) {
+            filteredRequest.set(servletRequest);
+        }
+    }
+    
+    private static class FilterMethodHolder {
+        
+        @CanDistro
+        void canDistroMethod() {
+        }
+        
+        void plainMethod() {
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/ServiceNameFilterTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/ServiceNameFilterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.web;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.naming.CommonParams;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+
+class ServiceNameFilterTest {
+    
+    private final ServiceNameFilter serviceNameFilter = new ServiceNameFilter();
+    
+    @Test
+    void testDoFilterAddsDefaultGroup() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter(CommonParams.SERVICE_NAME, " service ");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicReference<ServletRequest> actualRequest = new AtomicReference<>();
+        FilterChain filterChain =
+            (servletRequest, servletResponse) -> actualRequest.set(servletRequest);
+        
+        serviceNameFilter.doFilter(request, response, filterChain);
+        
+        assertNotNull(actualRequest.get());
+        assertEquals(Constants.DEFAULT_GROUP + Constants.SERVICE_INFO_SPLITER + "service",
+            ((HttpServletRequest) actualRequest.get()).getParameter(CommonParams.SERVICE_NAME));
+    }
+    
+    @Test
+    void testDoFilterSendsBadRequestWhenServiceNameInvalid() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter(CommonParams.SERVICE_NAME, "@@service");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+        
+        serviceNameFilter.doFilter(request, response, filterChain);
+        
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.getStatus());
+    }
+    
+    @Test
+    void testDoFilterSendsInternalServerErrorWhenExceptionThrown() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+        Mockito.when(request.getParameter(CommonParams.SERVICE_NAME))
+            .thenThrow(new RuntimeException("boom"));
+        
+        serviceNameFilter.doFilter(request, response, filterChain);
+        
+        Mockito.verify(response).sendError(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR),
+            contains("boom"));
+    }
+}


### PR DESCRIPTION
Summary: add focused unit tests across naming event, metadata, utility, monitor, distro, fuzzy watch, and defensive branches to raise naming line coverage. Testing: mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn; mvn test -pl naming.