### PR TITLE
Improve low-cost naming module unit test coverage

### DIFF
--- a/naming/src/test/java/com/alibaba/nacos/naming/consistency/persistent/impl/BatchReadWriteRequestTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/consistency/persistent/impl/BatchReadWriteRequestTest.java
@@ -58,4 +58,11 @@ class BatchReadWriteRequestTest {
         assertArrayEquals(new byte[] {7}, request.getKeys().get(0));
         assertArrayEquals(new byte[] {8}, request.getValues().get(0));
     }
+    
+    @Test
+    void testOldDataOperationDescriptions() {
+        assertEquals("Write", OldDataOperation.Write.getDesc());
+        assertEquals("Read", OldDataOperation.Read.getDesc());
+        assertEquals("Delete", OldDataOperation.Delete.getDesc());
+    }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/constants/NamingConstantsTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/constants/NamingConstantsTest.java
@@ -14,31 +14,20 @@
  * limitations under the License.
  */
 
-package com.alibaba.nacos.naming;
+package com.alibaba.nacos.naming.constants;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.springframework.boot.SpringApplication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class NamingAppTest {
+class NamingConstantsTest {
     
     @Test
-    void testNewInstance() {
-        assertEquals(NamingApp.class, new NamingApp().getClass());
-    }
-    
-    @Test
-    void testMainStartsSpringApplication() {
-        String[] args = new String[] {"--server.port=0"};
-        
-        try (MockedStatic<SpringApplication> mockedSpringApplication =
-            Mockito.mockStatic(SpringApplication.class)) {
-            NamingApp.main(args);
-            
-            mockedSpringApplication.verify(() -> SpringApplication.run(NamingApp.class, args));
-        }
+    void testDefaultConstructors() {
+        assertEquals(Constants.class, new Constants().getClass());
+        assertEquals(ClientConstants.class, new ClientConstants().getClass());
+        assertEquals(PushConstants.class, new PushConstants().getClass());
+        assertEquals(RequestConstant.class, new RequestConstant().getClass());
+        assertEquals(FieldsConstants.class, new FieldsConstants().getClass());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceControllerV3Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/controllers/v3/InstanceControllerV3Test.java
@@ -52,9 +52,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -85,11 +87,14 @@ class InstanceControllerV3Test extends BaseTest {
     
     private volatile Class<? extends Event> eventReceivedClass;
     
+    private CountDownLatch eventLatch;
+    
     @BeforeEach
     public void before() {
         super.before();
         ReflectionTestUtils.setField(instanceControllerV3, "instanceService", instanceService);
         mockmvc = MockMvcBuilders.standaloneSetup(instanceControllerV3).build();
+        eventLatch = new CountDownLatch(1);
         
         subscriber = new SmartSubscriber() {
             
@@ -103,6 +108,7 @@ class InstanceControllerV3Test extends BaseTest {
             @Override
             public void onEvent(Event event) {
                 eventReceivedClass = event.getClass();
+                eventLatch.countDown();
             }
         };
         NotifyCenter.registerSubscriber(subscriber);
@@ -188,7 +194,7 @@ class InstanceControllerV3Test extends BaseTest {
         
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("ok", result.getData());
-        TimeUnit.SECONDS.sleep(1);
+        assertTrue(eventLatch.await(5, TimeUnit.SECONDS));
         assertEquals(UpdateInstanceTraceEvent.class, eventReceivedClass);
     }
     

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/ClusterOperatorV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/ClusterOperatorV2ImplTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,5 +56,12 @@ class ClusterOperatorV2ImplTest {
             "clusterName_test", clusterMetadata);
         verify(metadataOperateServiceMock).addClusterMetadata(any(Service.class), anyString(),
             any(ClusterMetadata.class));
+    }
+    
+    @Test
+    void testUpdateClusterMetadataThrowsWhenServiceMissing() {
+        assertThrows(NacosException.class,
+            () -> clusterOperatorV2Impl.updateClusterMetadata("missing_namespace", "missing_group",
+                "missing_service", "clusterName_test", clusterMetadata));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/HealthOperatorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/HealthOperatorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.AbstractHealthChecker;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HealthOperatorTest {
+    
+    @Test
+    void testDefaultUpdateParsesFullServiceName() throws NacosException {
+        RecordingHealthOperator healthOperator = new RecordingHealthOperator();
+        
+        healthOperator.updateHealthStatusForPersistentInstance("namespace", "group@@service",
+            "cluster", "1.1.1.1", 8848, true);
+        
+        assertEquals("namespace", healthOperator.namespace);
+        assertEquals("group", healthOperator.groupName);
+        assertEquals("service", healthOperator.serviceName);
+        assertEquals("cluster", healthOperator.clusterName);
+        assertEquals("1.1.1.1", healthOperator.ip);
+        assertEquals(8848, healthOperator.port);
+        assertEquals(true, healthOperator.healthy);
+    }
+    
+    private static class RecordingHealthOperator implements HealthOperator {
+        
+        private String namespace;
+        
+        private String groupName;
+        
+        private String serviceName;
+        
+        private String clusterName;
+        
+        private String ip;
+        
+        private int port;
+        
+        private boolean healthy;
+        
+        @Override
+        public void updateHealthStatusForPersistentInstance(String namespace, String groupName,
+            String serviceName,
+            String clusterName, String ip, int port, boolean healthy) {
+            this.namespace = namespace;
+            this.groupName = groupName;
+            this.serviceName = serviceName;
+            this.clusterName = clusterName;
+            this.ip = ip;
+            this.port = port;
+            this.healthy = healthy;
+        }
+        
+        @Override
+        public Map<String, AbstractHealthChecker> checkers() {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/InstanceOperatorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/InstanceOperatorTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 1999-2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.naming.healthcheck.RsInfo;
+import com.alibaba.nacos.naming.pojo.InstanceOperationInfo;
+import com.alibaba.nacos.naming.pojo.Subscriber;
+import com.alibaba.nacos.naming.pojo.instance.BeatInfoInstanceBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class InstanceOperatorTest {
+    
+    @Test
+    @SuppressWarnings("deprecation")
+    void testDeprecatedDefaultMethodsDelegateWithParsedServiceName() throws Exception {
+        CapturingInstanceOperator operator = new CapturingInstanceOperator();
+        Instance instance = new Instance();
+        InstancePatchObject patchObject = new InstancePatchObject("cluster", "1.1.1.1", 8848);
+        Subscriber subscriber = new Subscriber();
+        
+        operator.removeInstance("namespace", "group@@service", instance);
+        assertDelegated(operator, "remove", "namespace", "group", "service");
+        assertSame(instance, operator.instance);
+        
+        operator.updateInstance("namespace", "group@@service", instance);
+        assertDelegated(operator, "update", "namespace", "group", "service");
+        assertSame(instance, operator.instance);
+        
+        operator.patchInstance("namespace", "group@@service", patchObject);
+        assertDelegated(operator, "patch", "namespace", "group", "service");
+        assertSame(patchObject, operator.patchObject);
+        
+        ServiceInfo actualServiceInfo = operator.listInstance("namespace", "group@@service",
+            subscriber, "cluster", true);
+        assertSame(operator.serviceInfo, actualServiceInfo);
+        assertDelegated(operator, "list", "namespace", "group", "service");
+        assertSame(subscriber, operator.subscriber);
+        assertEquals("cluster", operator.cluster);
+        assertEquals(true, operator.healthOnly);
+        
+        Instance actualInstance = operator.getInstance("namespace", "group@@service", "cluster",
+            "1.1.1.1", 8848);
+        assertSame(operator.instance, actualInstance);
+        assertDelegated(operator, "get", "namespace", "group", "service");
+        assertEquals("cluster", operator.cluster);
+        assertEquals("1.1.1.1", operator.ip);
+        assertEquals(8848, operator.port);
+    }
+    
+    private void assertDelegated(CapturingInstanceOperator operator, String operation,
+        String namespaceId, String groupName, String serviceName) {
+        assertEquals(operation, operator.operation);
+        assertEquals(namespaceId, operator.namespaceId);
+        assertEquals(groupName, operator.groupName);
+        assertEquals(serviceName, operator.serviceName);
+    }
+    
+    private static class CapturingInstanceOperator implements InstanceOperator {
+        
+        private final ServiceInfo serviceInfo = new ServiceInfo("group@@service");
+        
+        private String operation;
+        
+        private String namespaceId;
+        
+        private String groupName;
+        
+        private String serviceName;
+        
+        private Instance instance;
+        
+        private InstancePatchObject patchObject;
+        
+        private Subscriber subscriber;
+        
+        private String cluster;
+        
+        private boolean healthOnly;
+        
+        private String ip;
+        
+        private int port;
+        
+        @Override
+        public void registerInstance(String namespaceId, String groupName, String serviceName,
+            Instance instance) {
+        }
+        
+        @Override
+        public void removeInstance(String namespaceId, String groupName, String serviceName,
+            Instance instance) {
+            capture("remove", namespaceId, groupName, serviceName);
+            this.instance = instance;
+        }
+        
+        @Override
+        public void updateInstance(String namespaceId, String groupName, String serviceName,
+            Instance instance) {
+            capture("update", namespaceId, groupName, serviceName);
+            this.instance = instance;
+        }
+        
+        @Override
+        public void patchInstance(String namespaceId, String groupName, String serviceName,
+            InstancePatchObject patchObject) {
+            capture("patch", namespaceId, groupName, serviceName);
+            this.patchObject = patchObject;
+        }
+        
+        @Override
+        public ServiceInfo listInstance(String namespaceId, String groupName, String serviceName,
+            Subscriber subscriber, String cluster, boolean healthOnly) {
+            capture("list", namespaceId, groupName, serviceName);
+            this.subscriber = subscriber;
+            this.cluster = cluster;
+            this.healthOnly = healthOnly;
+            return serviceInfo;
+        }
+        
+        @Override
+        public Instance getInstance(String namespaceId, String groupName, String serviceName,
+            String cluster, String ip, int port) {
+            capture("get", namespaceId, groupName, serviceName);
+            this.cluster = cluster;
+            this.ip = ip;
+            this.port = port;
+            return instance;
+        }
+        
+        @Override
+        public int handleBeat(String namespaceId, String groupName, String serviceName, String ip,
+            int port, String cluster, RsInfo clientBeat, BeatInfoInstanceBuilder builder) {
+            return 0;
+        }
+        
+        @Override
+        public long getHeartBeatInterval(String namespaceId, String serviceName, String ip,
+            int port, String cluster) {
+            return 0;
+        }
+        
+        @Override
+        public List<? extends Instance> listAllInstances(String namespaceId, String serviceName) {
+            return List.of();
+        }
+        
+        @Override
+        public List<String> batchUpdateMetadata(String namespaceId,
+            InstanceOperationInfo instanceOperationInfo, Map<String, String> metadata) {
+            return List.of();
+        }
+        
+        @Override
+        public List<String> batchDeleteMetadata(String namespaceId,
+            InstanceOperationInfo instanceOperationInfo, Map<String, String> metadata) {
+            return List.of();
+        }
+        
+        private void capture(String operation, String namespaceId, String groupName,
+            String serviceName) {
+            this.operation = operation;
+            this.namespaceId = namespaceId;
+            this.groupName = groupName;
+            this.serviceName = serviceName;
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/cleaner/AbstractNamingCleanerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/cleaner/AbstractNamingCleanerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.cleaner;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class AbstractNamingCleanerTest {
+    
+    @Test
+    void testRunSwallowsCleanException() {
+        AbstractNamingCleaner cleaner = new AbstractNamingCleaner() {
+            
+            @Override
+            public String getType() {
+                return "test";
+            }
+            
+            @Override
+            public void doClean() {
+                throw new RuntimeException("mock");
+            }
+        };
+        
+        assertDoesNotThrow(cleaner::run);
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/ClientAttributesTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/ClientAttributesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ClientAttributesTest {
+    
+    @Test
+    void testAccessorsAndDefaultValue() {
+        ClientAttributes attributes = new ClientAttributes();
+        Map<String, Object> values = new HashMap<>();
+        values.put("version", "1.0.0");
+        attributes.setClientAttributes(values);
+        attributes.addClientAttribute("app", "nacos");
+        
+        assertSame(values, attributes.getClientAttributes());
+        assertEquals("1.0.0", attributes.getClientAttribute("version"));
+        assertEquals("nacos", attributes.getClientAttribute("app", "default"));
+        assertEquals("default", attributes.getClientAttribute("missing", "default"));
+    }
+    
+    @Test
+    void testGetClientAttributeReturnsNullWhenMapUnavailable() {
+        ClientAttributes attributes = new ClientAttributes();
+        attributes.setClientAttributes(null);
+        
+        assertNull(attributes.getClientAttribute("missing"));
+    }
+    
+    @Test
+    void testSetClientAttributesSupportsImmutableMap() {
+        ClientAttributes attributes = new ClientAttributes();
+        attributes.setClientAttributes(Collections.singletonMap("key", "value"));
+        
+        assertEquals("value", attributes.getClientAttribute("key"));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/ClientManagerDelegateTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/client/manager/ClientManagerDelegateTest.java
@@ -17,6 +17,8 @@
 package com.alibaba.nacos.naming.core.v2.client.manager;
 
 import com.alibaba.nacos.naming.consistency.ephemeral.distro.v2.DistroClientVerifyInfo;
+import com.alibaba.nacos.naming.core.v2.client.Client;
+import com.alibaba.nacos.naming.core.v2.client.ClientAttributes;
 import com.alibaba.nacos.naming.core.v2.client.manager.impl.ConnectionBasedClientManager;
 import com.alibaba.nacos.naming.core.v2.client.manager.impl.EphemeralIpPortClientManager;
 import com.alibaba.nacos.naming.core.v2.client.manager.impl.PersistentIpPortClientManager;
@@ -33,6 +35,7 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -136,5 +139,33 @@ class ClientManagerDelegateTest {
         assertTrue(actual.contains(connectionId));
         assertTrue(actual.contains(ephemeralIpPortId));
         assertTrue(actual.contains(persistentIpPortId));
+    }
+    
+    @Test
+    void testDelegateLifecycleForConnectionClient() {
+        ClientAttributes attributes = new ClientAttributes();
+        Client client = mock(Client.class);
+        when(client.getClientId()).thenReturn(connectionId);
+        when(connectionBasedClientManager.clientConnected(connectionId, attributes))
+            .thenReturn(true);
+        when(connectionBasedClientManager.clientConnected(client)).thenReturn(true);
+        when(connectionBasedClientManager.syncClientConnected(connectionId, attributes))
+            .thenReturn(true);
+        when(connectionBasedClientManager.clientDisconnected(connectionId)).thenReturn(true);
+        when(connectionBasedClientManager.isResponsibleClient(client)).thenReturn(true);
+        
+        assertTrue(delegate.clientConnected(connectionId, attributes));
+        assertTrue(delegate.clientConnected(client));
+        assertTrue(delegate.syncClientConnected(connectionId, attributes));
+        assertTrue(delegate.clientDisconnected(connectionId));
+        assertTrue(delegate.isResponsibleClient(client));
+        
+        verify(connectionBasedClientManager).clientConnected(connectionId, attributes);
+        verify(connectionBasedClientManager).clientConnected(client);
+        verify(connectionBasedClientManager).syncClientConnected(connectionId, attributes);
+        verify(connectionBasedClientManager).clientDisconnected(connectionId);
+        verify(connectionBasedClientManager).isResponsibleClient(client);
+        verify(ephemeralIpPortClientManager, never()).clientConnected(connectionId, attributes);
+        verify(persistentIpPortClientManager, never()).clientConnected(connectionId, attributes);
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationServiceTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/service/ClientOperationServiceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.core.v2.service;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.alibaba.nacos.naming.pojo.Subscriber;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.alibaba.nacos.naming.constants.Constants.CUSTOM_INSTANCE_ID;
+import static com.alibaba.nacos.naming.constants.Constants.PUBLISH_INSTANCE_ENABLE;
+import static com.alibaba.nacos.naming.constants.Constants.PUBLISH_INSTANCE_WEIGHT;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientOperationServiceTest {
+    
+    private final ClientOperationService clientOperationService = new MockClientOperationService();
+    
+    @Test
+    void testSubscribeAndUnsubscribeDefaultMethods() {
+        Service service = Service.newService("namespace", "group", "service");
+        Subscriber subscriber = new Subscriber();
+        
+        assertDoesNotThrow(
+            () -> clientOperationService.subscribeService(service, subscriber, "client"));
+        assertDoesNotThrow(
+            () -> clientOperationService.unsubscribeService(service, subscriber, "client"));
+    }
+    
+    @Test
+    void testGetPublishInfoWithCustomAttributesAndDefaultCluster() {
+        Instance instance = new Instance();
+        instance.setIp("1.1.1.1");
+        instance.setPort(8848);
+        instance.setMetadata(Collections.singletonMap("k", "v"));
+        instance.setInstanceId("instanceId");
+        instance.setWeight(2.0D);
+        instance.setEnabled(false);
+        instance.setHealthy(true);
+        
+        InstancePublishInfo actual = clientOperationService.getPublishInfo(instance);
+        
+        assertEquals("1.1.1.1", actual.getIp());
+        assertEquals(8848, actual.getPort());
+        assertTrue(actual.isHealthy());
+        assertEquals(UtilsAndCommons.DEFAULT_CLUSTER_NAME, actual.getCluster());
+        assertEquals("v", actual.getExtendDatum().get("k"));
+        assertEquals("instanceId", actual.getExtendDatum().get(CUSTOM_INSTANCE_ID));
+        assertEquals(2.0D, actual.getExtendDatum().get(PUBLISH_INSTANCE_WEIGHT));
+        assertFalse((Boolean) actual.getExtendDatum().get(PUBLISH_INSTANCE_ENABLE));
+    }
+    
+    private static class MockClientOperationService implements ClientOperationService {
+        
+        @Override
+        public void registerInstance(Service service, Instance instance, String clientId)
+            throws NacosException {
+        }
+        
+        @Override
+        public void batchRegisterInstance(Service service, List<Instance> instances,
+            String clientId) {
+        }
+        
+        @Override
+        public void deregisterInstance(Service service, Instance instance, String clientId) {
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/RsInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/RsInfoTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RsInfoTest {
+    
+    @Test
+    void testAccessorsAndToString() {
+        RsInfo rsInfo = new RsInfo();
+        rsInfo.setAk("ak");
+        rsInfo.setServiceName("service");
+        rsInfo.setCluster("cluster");
+        rsInfo.setIp("1.1.1.1");
+        rsInfo.setPort(8848);
+        rsInfo.setLoad(1.0D);
+        rsInfo.setCpu(2.0D);
+        rsInfo.setRt(3.0D);
+        rsInfo.setQps(4.0D);
+        rsInfo.setMem(5.0D);
+        rsInfo.setWeight(6.0D);
+        rsInfo.setEphemeral(false);
+        rsInfo.setMetadata(Collections.singletonMap("k", "v"));
+        
+        assertEquals("ak", rsInfo.getAk());
+        assertEquals("service", rsInfo.getServiceName());
+        assertEquals("cluster", rsInfo.getCluster());
+        assertEquals("1.1.1.1", rsInfo.getIp());
+        assertEquals(8848, rsInfo.getPort());
+        assertEquals(1.0D, rsInfo.getLoad());
+        assertEquals(2.0D, rsInfo.getCpu());
+        assertEquals(3.0D, rsInfo.getRt());
+        assertEquals(4.0D, rsInfo.getQps());
+        assertEquals(5.0D, rsInfo.getMem());
+        assertEquals(6.0D, rsInfo.getWeight());
+        assertFalse(rsInfo.isEphemeral());
+        assertEquals(Collections.singletonMap("k", "v"), rsInfo.getMetadata());
+        assertTrue(rsInfo.toString().contains("\"ak\":\"ak\""));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatCheckTaskV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatCheckTaskV2Test.java
@@ -40,10 +40,12 @@ import org.springframework.context.ConfigurableApplicationContext;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -95,6 +97,11 @@ class ClientBeatCheckTaskV2Test {
     @Test
     void testTaskKey() {
         assertEquals(KeyBuilder.buildServiceMetaKey(CLIENT_ID, "true"), beatCheckTask.taskKey());
+    }
+    
+    @Test
+    void testGetGlobalConfig() {
+        assertEquals(globalConfig, beatCheckTask.getGlobalConfig());
     }
     
     @Test
@@ -172,6 +179,21 @@ class ClientBeatCheckTaskV2Test {
         assertFalse(
             client.getInstancePublishInfo(Service.newService(NAMESPACE, GROUP_NAME, SERVICE_NAME))
                 .isHealthy());
+    }
+    
+    @Test
+    void testDoHealthCheckSwallowsClientException() {
+        IpPortBasedClient mockClient = mock(IpPortBasedClient.class);
+        when(mockClient.getResponsibleId()).thenReturn(CLIENT_ID);
+        when(mockClient.getAllPublishedService()).thenThrow(new RuntimeException("mock"));
+        ClientBeatCheckTaskV2 task = new ClientBeatCheckTaskV2(mockClient);
+        
+        assertDoesNotThrow(task::doHealthCheck);
+    }
+    
+    @Test
+    void testAfterIntercept() {
+        assertDoesNotThrow(beatCheckTask::afterIntercept);
     }
     
     private HealthCheckInstancePublishInfo injectInstance(boolean healthy, long heartbeatTime) {

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatProcessorV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/ClientBeatProcessorV2Test.java
@@ -21,7 +21,10 @@ import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.pojo.HealthCheckInstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.healthcheck.RsInfo;
+import com.alibaba.nacos.naming.misc.Loggers;
 import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,6 +68,25 @@ class ClientBeatProcessorV2Test {
         
         assertTrue(instance.isHealthy());
         assertTrue(instance.getLastHeartBeatTime() > 1L);
+    }
+    
+    @Test
+    void testRunWithDebugLogEnabled() {
+        Logger logger = (Logger) Loggers.EVT_LOG;
+        Level oldLevel = logger.getLevel();
+        logger.setLevel(Level.DEBUG);
+        try {
+            HealthCheckInstancePublishInfo instance = newInstance(IP, PORT, false);
+            instance.setLastHeartBeatTime(1L);
+            ClientBeatProcessorV2 processor = newProcessor(instance, newRsInfo(IP, PORT));
+            
+            processor.run();
+            
+            assertTrue(instance.isHealthy());
+            assertTrue(instance.getLastHeartBeatTime() > 1L);
+        } finally {
+            logger.setLevel(oldLevel);
+        }
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/InstanceEnableBeatCheckInterceptorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/heartbeat/InstanceEnableBeatCheckInterceptorTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.heartbeat;
+
+import com.alibaba.nacos.naming.core.v2.metadata.InstanceMetadata;
+import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
+import com.alibaba.nacos.naming.core.v2.pojo.HealthCheckInstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.alibaba.nacos.sys.utils.ApplicationUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceEnableBeatCheckInterceptorTest {
+    
+    private static final Service SERVICE = Service.newService("namespace", "group", "service");
+    
+    private static final String IP = "1.1.1.1";
+    
+    private static final int PORT = 10000;
+    
+    @Mock
+    private NamingMetadataManager metadataManager;
+    
+    @Mock
+    private ConfigurableApplicationContext applicationContext;
+    
+    private InstanceEnableBeatCheckInterceptor interceptor;
+    
+    @BeforeEach
+    void setUp() {
+        lenient().when(applicationContext.getBean(NamingMetadataManager.class))
+            .thenReturn(metadataManager);
+        ApplicationUtils.injectContext(applicationContext);
+        interceptor = new InstanceEnableBeatCheckInterceptor();
+    }
+    
+    @Test
+    void testInterceptUsesMetadataExtendDataFirst() {
+        HealthCheckInstancePublishInfo instance = newInstance();
+        InstanceMetadata metadata = new InstanceMetadata();
+        metadata.getExtendData().put(UtilsAndCommons.ENABLE_CLIENT_BEAT, "true");
+        instance.getExtendDatum().put(UtilsAndCommons.ENABLE_CLIENT_BEAT, false);
+        when(metadataManager.getInstanceMetadata(SERVICE, instance.getMetadataId()))
+            .thenReturn(Optional.of(metadata));
+        
+        assertTrue(interceptor.intercept(new InstanceBeatCheckTask(null, SERVICE, instance)));
+    }
+    
+    @Test
+    void testInterceptUsesInstanceExtendDataWhenMetadataMissing() {
+        HealthCheckInstancePublishInfo instance = newInstance();
+        instance.getExtendDatum().put(UtilsAndCommons.ENABLE_CLIENT_BEAT, "true");
+        when(metadataManager.getInstanceMetadata(SERVICE, instance.getMetadataId()))
+            .thenReturn(Optional.empty());
+        
+        assertTrue(interceptor.intercept(new InstanceBeatCheckTask(null, SERVICE, instance)));
+    }
+    
+    @Test
+    void testInterceptReturnsFalseWhenNoBeatSetting() {
+        HealthCheckInstancePublishInfo instance = newInstance();
+        when(metadataManager.getInstanceMetadata(SERVICE, instance.getMetadataId()))
+            .thenReturn(Optional.empty());
+        
+        assertFalse(interceptor.intercept(new InstanceBeatCheckTask(null, SERVICE, instance)));
+    }
+    
+    @Test
+    void testOrder() {
+        assertTrue(interceptor.order() < Integer.MIN_VALUE + 2);
+    }
+    
+    private HealthCheckInstancePublishInfo newInstance() {
+        HealthCheckInstancePublishInfo result = new HealthCheckInstancePublishInfo(IP, PORT);
+        result.setCluster(UtilsAndCommons.DEFAULT_CLUSTER_NAME);
+        return result;
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/HealthCheckTaskV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/HealthCheckTaskV2Test.java
@@ -18,19 +18,26 @@ package com.alibaba.nacos.naming.healthcheck.v2;
 
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.healthcheck.HealthCheckReactor;
+import com.alibaba.nacos.naming.healthcheck.v2.processor.HealthCheckProcessorV2Delegate;
 import com.alibaba.nacos.naming.misc.SwitchDomain;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,6 +45,8 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -61,14 +70,30 @@ class HealthCheckTaskV2Test {
     @Mock
     private Service service;
     
+    @Mock
+    private InstancePublishInfo instancePublishInfo;
+    
+    @Mock
+    private HealthCheckProcessorV2Delegate processorDelegate;
+    
     @BeforeEach
     void setUp() {
+        ReflectionTestUtils.setField(HealthCheckTaskV2.class, "switchDomain", null);
+        ReflectionTestUtils.setField(HealthCheckTaskV2.class, "metadataManager", null);
         ApplicationUtils.injectContext(context);
         when(context.getBean(SwitchDomain.class)).thenReturn(switchDomain);
         when(switchDomain.getTcpHealthParams()).thenReturn(new SwitchDomain.TcpHealthParams());
         when(context.getBean(NamingMetadataManager.class)).thenReturn(new NamingMetadataManager());
+        when(context.getBean(HealthCheckProcessorV2Delegate.class)).thenReturn(processorDelegate);
         healthCheckTaskV2 = new HealthCheckTaskV2(ipPortBasedClient);
         EnvUtil.setEnvironment(new MockEnvironment());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        ReflectionTestUtils.setField(HealthCheckTaskV2.class, "switchDomain", null);
+        ReflectionTestUtils.setField(HealthCheckTaskV2.class, "metadataManager", null);
+        ApplicationUtils.injectContext(null);
     }
     
     @Test
@@ -77,6 +102,7 @@ class HealthCheckTaskV2Test {
         
         healthCheckTaskV2.setCheckRtWorst(1);
         healthCheckTaskV2.setCheckRtLastLast(1);
+        healthCheckTaskV2.setCancelled(true);
         assertEquals(1, healthCheckTaskV2.getCheckRtWorst());
         assertEquals(1, healthCheckTaskV2.getCheckRtLastLast());
         
@@ -115,5 +141,51 @@ class HealthCheckTaskV2Test {
     @Test
     void testAfterIntercept() {
         healthCheckTaskV2.afterIntercept();
+    }
+    
+    @Test
+    void testDoHealthCheckProcessesEnabledService() {
+        when(ipPortBasedClient.getAllPublishedService()).thenReturn(returnService());
+        when(service.getGroupedServiceName()).thenReturn("group@@service");
+        when(switchDomain.isHealthCheckEnabled("group@@service")).thenReturn(true);
+        when(ipPortBasedClient.getInstancePublishInfo(service)).thenReturn(instancePublishInfo);
+        healthCheckTaskV2.setCancelled(true);
+        
+        healthCheckTaskV2.doHealthCheck();
+        
+        verify(processorDelegate).process(eq(healthCheckTaskV2), eq(service), any());
+    }
+    
+    @Test
+    void testDoHealthCheckCatchesProcessorFailure() {
+        when(ipPortBasedClient.getAllPublishedService()).thenReturn(returnService());
+        when(service.getGroupedServiceName()).thenReturn("group@@service");
+        when(switchDomain.isHealthCheckEnabled("group@@service")).thenReturn(true);
+        when(ipPortBasedClient.getInstancePublishInfo(service)).thenReturn(instancePublishInfo);
+        when(context.getBean(HealthCheckProcessorV2Delegate.class))
+            .thenThrow(new RuntimeException("failed"));
+        healthCheckTaskV2.setCancelled(true);
+        
+        healthCheckTaskV2.doHealthCheck();
+        
+        verify(ipPortBasedClient).getClientId();
+    }
+    
+    @Test
+    void testDoHealthCheckSchedulesNextCheckAndUpdatesLastRt() {
+        when(ipPortBasedClient.getAllPublishedService()).thenReturn(Collections.emptyList());
+        healthCheckTaskV2.setCheckRtNormalized(1000);
+        healthCheckTaskV2.setCheckRtWorst(10);
+        healthCheckTaskV2.setCheckRtLast(20);
+        healthCheckTaskV2.setCheckRtLastLast(10);
+        
+        try (MockedStatic<HealthCheckReactor> reactor =
+            Mockito.mockStatic(HealthCheckReactor.class)) {
+            healthCheckTaskV2.doHealthCheck();
+            
+            reactor.verify(() -> HealthCheckReactor.scheduleCheck(healthCheckTaskV2));
+        }
+        
+        assertEquals(20, healthCheckTaskV2.getCheckRtLastLast());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/interceptor/AbstractNamingInterceptorChainTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/interceptor/AbstractNamingInterceptorChainTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.interceptor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractNamingInterceptorChainTest {
+    
+    @Test
+    void testAddInterceptorSortsAndSkipsUnsupportedInterceptor() {
+        TestChain chain = new TestChain();
+        TestInterceptor last = new TestInterceptor(10, true, false);
+        TestInterceptor skipped = new TestInterceptor(1, false, true);
+        chain.addInterceptor(last);
+        chain.addInterceptor(skipped);
+        
+        assertEquals(skipped, chain.interceptors().get(0));
+        assertEquals(last, chain.interceptors().get(1));
+        
+        TestInterceptable object = new TestInterceptable();
+        chain.doInterceptor(object);
+        
+        assertFalse(skipped.intercepted);
+        assertTrue(last.intercepted);
+        assertTrue(object.passed);
+        assertFalse(object.afterIntercepted);
+    }
+    
+    @Test
+    void testDoInterceptorStopsWhenIntercepted() {
+        TestChain chain = new TestChain();
+        TestInterceptor first = new TestInterceptor(1, true, true);
+        TestInterceptor second = new TestInterceptor(2, true, false);
+        chain.addInterceptor(first);
+        chain.addInterceptor(second);
+        
+        TestInterceptable object = new TestInterceptable();
+        chain.doInterceptor(object);
+        
+        assertTrue(first.intercepted);
+        assertFalse(second.intercepted);
+        assertFalse(object.passed);
+        assertTrue(object.afterIntercepted);
+    }
+    
+    private static class TestChain extends AbstractNamingInterceptorChain<TestInterceptable> {
+        
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        TestChain() {
+            super((Class) NacosNamingInterceptor.class);
+        }
+        
+        List<NacosNamingInterceptor<TestInterceptable>> interceptors() {
+            return getInterceptors();
+        }
+    }
+    
+    private static class TestInterceptable implements Interceptable {
+        
+        private boolean passed;
+        
+        private boolean afterIntercepted;
+        
+        @Override
+        public void passIntercept() {
+            passed = true;
+        }
+        
+        @Override
+        public void afterIntercept() {
+            afterIntercepted = true;
+        }
+    }
+    
+    private static class TestInterceptor implements NacosNamingInterceptor<TestInterceptable> {
+        
+        private final int order;
+        
+        private final boolean supportType;
+        
+        private final boolean interceptResult;
+        
+        private boolean intercepted;
+        
+        TestInterceptor(int order, boolean supportType, boolean interceptResult) {
+            this.order = order;
+            this.supportType = supportType;
+            this.interceptResult = interceptResult;
+        }
+        
+        @Override
+        public boolean isInterceptType(Class<?> type) {
+            return supportType;
+        }
+        
+        @Override
+        public boolean intercept(TestInterceptable object) {
+            intercepted = true;
+            return interceptResult;
+        }
+        
+        @Override
+        public int order() {
+            return order;
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/HttpClientManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/HttpClientManagerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.nio.AsyncClientConnectionManager;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.pool.PoolStats;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HttpClientManagerTest {
+    
+    @Test
+    void testMonitorHealthCheckPoolRunsWithPoolingManager() throws Exception {
+        PoolingAsyncClientConnectionManager manager =
+            mock(PoolingAsyncClientConnectionManager.class);
+        HttpRoute route = new HttpRoute(new HttpHost("http", "127.0.0.1", 8848));
+        when(manager.getRoutes()).thenReturn(Collections.singleton(route));
+        when(manager.getStats(route)).thenReturn(new PoolStats(1, 2, 3, 4));
+        when(manager.getTotalStats()).thenReturn(new PoolStats(4, 3, 2, 1));
+        
+        newMonitorHealthCheckPool(manager).run();
+        
+        verify(manager).closeExpired();
+        verify(manager).getStats(route);
+        verify(manager).getTotalStats();
+    }
+    
+    @Test
+    void testMonitorHealthCheckPoolSwallowsCastFailure() throws Exception {
+        AsyncClientConnectionManager manager = mock(AsyncClientConnectionManager.class);
+        
+        assertDoesNotThrow(() -> newMonitorHealthCheckPool(manager).run());
+    }
+    
+    private Runnable newMonitorHealthCheckPool(AsyncClientConnectionManager manager)
+        throws Exception {
+        Class<?> clazz =
+            Class.forName("com.alibaba.nacos.naming.misc.HttpClientManager$MonitorHealthCheckPool");
+        Constructor<?> constructor =
+            clazz.getDeclaredConstructor(AsyncClientConnectionManager.class);
+        constructor.setAccessible(true);
+        return (Runnable) constructor.newInstance(manager);
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/HttpClientTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/HttpClientTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.misc;
+
+import com.alibaba.nacos.common.http.Callback;
+import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.plugin.auth.constant.Constants;
+import com.alibaba.nacos.sys.env.EnvUtil;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HttpClientTest {
+    
+    private static final String INVALID_URL = "nacos://invalid";
+    
+    @BeforeAll
+    static void beforeAll() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty(Constants.Auth.NACOS_CORE_AUTH_ENABLED, "false");
+        environment.setProperty(Constants.Auth.NACOS_CORE_AUTH_ADMIN_ENABLED, "false");
+        EnvUtil.setEnvironment(environment);
+    }
+    
+    @Test
+    void testRequestWrappersReturnErrorForUnsupportedUrl() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "nacos");
+        
+        assertServerError(HttpClient.httpGet(INVALID_URL, Arrays.asList("h1", "v1"), params));
+        assertServerError(HttpClient.httpDelete(INVALID_URL, Arrays.asList("h2", "v2"), params));
+        assertServerError(HttpClient.httpPost(INVALID_URL, Arrays.asList("h3", "v3"), params));
+        assertServerError(HttpClient.request(INVALID_URL, Arrays.asList("h4", "v4"), params,
+            "body", 1, 1, StandardCharsets.UTF_8.name(), "PATCH"));
+    }
+    
+    @Test
+    void testLargeBodyRequestsReturnErrorForUnsupportedUrl() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("header", "value");
+        
+        assertServerError(HttpClient.httpPutLarge(INVALID_URL, headers, "body".getBytes(
+            StandardCharsets.UTF_8)));
+        assertServerError(HttpClient.httpGetLarge(INVALID_URL, headers, "body"));
+        assertServerError(HttpClient.httpPostLarge(INVALID_URL, headers, "body"));
+    }
+    
+    @Test
+    void testAsyncHttpRequestRejectsUnsupportedMethod() {
+        RuntimeException exception = assertThrows(RuntimeException.class,
+            () -> HttpClient.asyncHttpRequest(INVALID_URL, Arrays.asList("h", "v"),
+                Collections.singletonMap("key", "value"), new NoopCallback(), "PATCH"));
+        
+        assertEquals("not supported method:PATCH", exception.getMessage());
+    }
+    
+    @Test
+    void testAsyncRequestWrappersDelegateToRestTemplate() {
+        NoopCallback callback = new NoopCallback();
+        Map<String, String> headers = Collections.singletonMap("h", "v");
+        byte[] body = "body".getBytes(StandardCharsets.UTF_8);
+        
+        assertDoesNotThrow(() -> HttpClient.asyncHttpGet(INVALID_URL, Arrays.asList("h1", "v1"),
+            Collections.singletonMap("key", "value"), callback));
+        assertDoesNotThrow(() -> HttpClient.asyncHttpPost(INVALID_URL, Arrays.asList("h2", "v2"),
+            Collections.singletonMap("key", "value"), callback));
+        assertDoesNotThrow(() -> HttpClient.asyncHttpDelete(INVALID_URL,
+            Arrays.asList("h3", "v3"), Collections.singletonMap("key", "value"), callback));
+        assertDoesNotThrow(() -> HttpClient.asyncHttpPostLarge(INVALID_URL,
+            Arrays.asList("h4", "v4"), "body", callback));
+        assertDoesNotThrow(() -> HttpClient.asyncHttpPostLarge(INVALID_URL,
+            Arrays.asList("h5", "v5"), body, callback));
+        assertDoesNotThrow(() -> HttpClient.asyncHttpDeleteLarge(INVALID_URL,
+            Arrays.asList("h6", "v6"), "body", callback));
+        assertDoesNotThrow(() -> HttpClient.asyncHttpPutLarge(INVALID_URL, headers, body,
+            callback));
+    }
+    
+    @Test
+    void testTranslateParameterMapUsesFirstValue() {
+        Map<String, String[]> parameterMap = new HashMap<>();
+        parameterMap.put("name", new String[] {"nacos", "ignored"});
+        
+        Map<String, String> result = HttpClient.translateParameterMap(parameterMap);
+        
+        assertEquals("nacos", result.get("name"));
+    }
+    
+    private void assertServerError(RestResult<String> result) {
+        assertEquals(500, result.getCode());
+        assertTrue(result.getMessage().contains("nacos"));
+    }
+    
+    private static class NoopCallback implements Callback<String> {
+        
+        @Override
+        public void onReceive(RestResult<String> result) {
+        }
+        
+        @Override
+        public void onError(Throwable throwable) {
+        }
+        
+        @Override
+        public void onCancel() {
+        }
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/NamingMiscConstructorsTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/NamingMiscConstructorsTest.java
@@ -14,31 +14,16 @@
  * limitations under the License.
  */
 
-package com.alibaba.nacos.naming;
+package com.alibaba.nacos.naming.misc;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.springframework.boot.SpringApplication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class NamingAppTest {
+class NamingMiscConstructorsTest {
     
     @Test
-    void testNewInstance() {
-        assertEquals(NamingApp.class, new NamingApp().getClass());
-    }
-    
-    @Test
-    void testMainStartsSpringApplication() {
-        String[] args = new String[] {"--server.port=0"};
-        
-        try (MockedStatic<SpringApplication> mockedSpringApplication =
-            Mockito.mockStatic(SpringApplication.class)) {
-            NamingApp.main(args);
-            
-            mockedSpringApplication.verify(() -> SpringApplication.run(NamingApp.class, args));
-        }
+    void testSwitchEntryConstructor() {
+        assertEquals(SwitchEntry.class, new SwitchEntry().getClass());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/misc/SwitchManagerTest.java
@@ -16,23 +16,48 @@
 
 package com.alibaba.nacos.naming.misc;
 
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.ByteUtils;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.consistency.SerializeFactory;
+import com.alibaba.nacos.consistency.Serializer;
 import com.alibaba.nacos.consistency.cp.CPProtocol;
+import com.alibaba.nacos.consistency.entity.ReadRequest;
+import com.alibaba.nacos.consistency.entity.Response;
+import com.alibaba.nacos.consistency.entity.WriteRequest;
 import com.alibaba.nacos.core.distributed.ProtocolManager;
+import com.alibaba.nacos.naming.consistency.Datum;
+import com.alibaba.nacos.naming.consistency.KeyBuilder;
+import com.alibaba.nacos.naming.consistency.persistent.impl.BatchReadResponse;
+import com.alibaba.nacos.naming.consistency.persistent.impl.BatchWriteRequest;
+import com.alibaba.nacos.naming.consistency.persistent.impl.OldDataOperation;
+import com.alibaba.nacos.naming.pojo.Record;
+import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,11 +73,20 @@ class SwitchManagerTest {
     @Mock
     private CPProtocol cpProtocol;
     
+    private Serializer serializer;
+    
+    @TempDir
+    private Path tempDir;
+    
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         switchDomain = new SwitchDomain();
+        serializer = SerializeFactory.getSerializer("JSON");
         when(protocolManager.getCpProtocol()).thenReturn(cpProtocol);
         switchManager = new SwitchManager(switchDomain, protocolManager);
+        Files.createDirectories(tempDir.resolve("data"));
+        ReflectionTestUtils.setField(switchManager, "dataFile",
+            tempDir.resolve("data").resolve(KeyBuilder.getSwitchDomainKey()).toFile());
     }
     
     @Test
@@ -65,6 +99,17 @@ class SwitchManagerTest {
     void testUpdatePushVersionWithValidPythonValue() throws Exception {
         switchManager.update(SwitchEntry.PUSH_VERSION, "python:3.1.0", true);
         assertEquals("3.1.0", switchDomain.getPushVersionOfPython());
+    }
+    
+    @Test
+    void testUpdatePushVersionWithOtherSupportedClients() throws Exception {
+        switchManager.update(SwitchEntry.PUSH_VERSION, "c:1.0.13", true);
+        switchManager.update(SwitchEntry.PUSH_VERSION, "go:1.2.3", true);
+        switchManager.update(SwitchEntry.PUSH_VERSION, "csharp:2.3.4", true);
+        
+        assertEquals("1.0.13", switchDomain.getPushVersionOfC());
+        assertEquals("1.2.3", switchDomain.getPushVersionOfGo());
+        assertEquals("2.3.4", switchDomain.getPushVersionOfCsharp());
     }
     
     @Test
@@ -133,6 +178,143 @@ class SwitchManagerTest {
     }
     
     @Test
+    void testUpdateNumericAndBooleanSwitches() throws Exception {
+        switchManager.update(SwitchEntry.DISTRO_THRESHOLD, "0.9", true);
+        switchManager.update(SwitchEntry.CLIENT_BEAT_INTERVAL, "12345", true);
+        switchManager.update(SwitchEntry.PUSH_CACHE_MILLIS, "10000", true);
+        switchManager.update(SwitchEntry.DEFAULT_CACHE_MILLIS, "1000", true);
+        switchManager.update(SwitchEntry.DISTRO, "false", true);
+        switchManager.update(SwitchEntry.PUSH_ENABLED, "false", true);
+        switchManager.update(SwitchEntry.SERVICE_STATUS_SYNC_PERIOD, "5000", true);
+        switchManager.update(SwitchEntry.SERVER_STATUS_SYNC_PERIOD, "15000", true);
+        switchManager.update(SwitchEntry.HEALTH_CHECK_TIMES, "7", true);
+        switchManager.update(SwitchEntry.DISABLE_ADD_IP, "true", true);
+        switchManager.update(SwitchEntry.SEND_BEAT_ONLY, "true", true);
+        switchManager.update(SwitchEntry.DEFAULT_INSTANCE_EPHEMERAL, "false", true);
+        switchManager.update(SwitchEntry.DISTRO_SERVER_EXPIRED_MILLIS, "30000", true);
+        switchManager.update(SwitchEntry.LIGHT_BEAT_ENABLED, "false", true);
+        switchManager.update(SwitchEntry.AUTO_CHANGE_HEALTH_CHECK_ENABLED, "false", true);
+        
+        assertEquals(0.9F, switchDomain.getDistroThreshold());
+        assertEquals(12345L, switchDomain.getClientBeatInterval());
+        assertEquals(10000L, switchDomain.getDefaultPushCacheMillis());
+        assertEquals(1000L, switchDomain.getDefaultCacheMillis());
+        assertFalse(switchDomain.isDistroEnabled());
+        assertFalse(switchDomain.isPushEnabled());
+        assertEquals(5000L, switchDomain.getServiceStatusSynchronizationPeriodMillis());
+        assertEquals(15000L, switchDomain.getServerStatusSynchronizationPeriodMillis());
+        assertEquals(7, switchDomain.getCheckTimes());
+        assertTrue(switchDomain.isDisableAddIP());
+        assertTrue(switchDomain.isSendBeatOnly());
+        assertFalse(switchDomain.isDefaultInstanceEphemeral());
+        assertEquals(30000L, switchDomain.getDistroServerExpiredMillis());
+        assertFalse(switchDomain.isLightBeatEnabled());
+        assertFalse(switchDomain.isAutoChangeHealthCheckEnabled());
+    }
+    
+    @Test
+    void testUpdateNumericSwitchesRejectTooSmallValues() {
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.DISTRO_THRESHOLD, "0", true));
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.PUSH_CACHE_MILLIS, "9999", true));
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.DEFAULT_CACHE_MILLIS, "999", true));
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.SERVICE_STATUS_SYNC_PERIOD, "4999", true));
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.SERVER_STATUS_SYNC_PERIOD, "999", true));
+    }
+    
+    @Test
+    void testUpdateCollectionAndStatusSwitches() throws Exception {
+        switchManager.update(SwitchEntry.MASTERS, "1.1.1.1:8848,2.2.2.2:8848", true);
+        switchManager.update(SwitchEntry.LIMITED_URL_MAP, "/nacos:403,/health:200", true);
+        switchManager.update(SwitchEntry.OVERRIDDEN_SERVER_STATUS, "UP", true);
+        
+        assertEquals(2, switchDomain.getMasters().size());
+        assertEquals(Integer.valueOf(403), switchDomain.getLimitedUrlMap().get("/nacos"));
+        assertEquals(Integer.valueOf(200), switchDomain.getLimitedUrlMap().get("/health"));
+        assertEquals("UP", switchDomain.getOverriddenServerStatus());
+        
+        switchManager.update(SwitchEntry.OVERRIDDEN_SERVER_STATUS, Constants.NULL_STRING, true);
+        assertEquals("", switchDomain.getOverriddenServerStatus());
+    }
+    
+    @Test
+    void testUpdateLimitedUrlMapRejectsInvalidValues() {
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.LIMITED_URL_MAP, "/nacos", true));
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.LIMITED_URL_MAP, ":200", true));
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.LIMITED_URL_MAP, "/nacos:0", true));
+    }
+    
+    @Test
+    void testUpdateHealthParams() throws Exception {
+        SwitchDomain.HttpHealthParams httpHealthParams = new SwitchDomain.HttpHealthParams();
+        httpHealthParams.setMin(600);
+        httpHealthParams.setMax(4000);
+        httpHealthParams.setFactor(0.5F);
+        SwitchDomain.TcpHealthParams tcpHealthParams = new SwitchDomain.TcpHealthParams();
+        tcpHealthParams.setMin(700);
+        tcpHealthParams.setMax(5000);
+        tcpHealthParams.setFactor(0.6F);
+        SwitchDomain.MysqlHealthParams mysqlHealthParams = new SwitchDomain.MysqlHealthParams();
+        mysqlHealthParams.setMin(2500);
+        
+        switchManager.update(SwitchEntry.HTTP_HEALTH_PARAMS, JacksonUtils.toJson(httpHealthParams),
+            true);
+        switchManager.update(SwitchEntry.TCP_HEALTH_PARAMS, JacksonUtils.toJson(tcpHealthParams),
+            true);
+        switchManager.update(SwitchEntry.MYSQL_HEALTH_PARAMS,
+            JacksonUtils.toJson(mysqlHealthParams),
+            true);
+        
+        assertEquals(600, switchDomain.getHttpHealthParams().getMin());
+        assertEquals(5000, switchDomain.getTcpHealthParams().getMax());
+        assertEquals(2500, switchDomain.getMysqlHealthParams().getMin());
+    }
+    
+    @Test
+    void testUpdateHealthParamsRejectsInvalidValues() {
+        SwitchDomain.HttpHealthParams tooSmallMin = new SwitchDomain.HttpHealthParams();
+        tooSmallMin.setMin(499);
+        SwitchDomain.HttpHealthParams tooSmallMax = new SwitchDomain.HttpHealthParams();
+        tooSmallMax.setMax(2999);
+        SwitchDomain.HttpHealthParams malformedFactor = new SwitchDomain.HttpHealthParams();
+        malformedFactor.setFactor(1.1F);
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.HTTP_HEALTH_PARAMS,
+                JacksonUtils.toJson(tooSmallMin), true));
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.HTTP_HEALTH_PARAMS,
+                JacksonUtils.toJson(tooSmallMax), true));
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.HTTP_HEALTH_PARAMS,
+                JacksonUtils.toJson(malformedFactor), true));
+        assertThrows(IllegalArgumentException.class,
+            () -> switchManager.update(SwitchEntry.HTTP_HEALTH_PARAMS, "{", true));
+    }
+    
+    @Test
+    void testUpdateWithConsistencySubmitsWriteRequest() throws Exception {
+        switchManager.update(SwitchEntry.CLIENT_BEAT_INTERVAL, "6000", false);
+        
+        verify(cpProtocol).write(any(WriteRequest.class));
+    }
+    
+    @Test
+    void testUpdateWithConsistencyThrowsNacosExceptionWhenWriteFails() throws Exception {
+        when(cpProtocol.write(any(WriteRequest.class))).thenThrow(new RuntimeException("failed"));
+        
+        assertThrows(NacosException.class,
+            () -> switchManager.update(SwitchEntry.CLIENT_BEAT_INTERVAL, "6000", false));
+    }
+    
+    @Test
     void testUpdateHealthCheckEnabledWithLegacyCheckEntry() throws Exception {
         assertTrue(switchDomain.isHealthCheckEnabled());
         switchManager.update(SwitchEntry.CHECK, "false", true);
@@ -176,5 +358,134 @@ class SwitchManagerTest {
         assertTrue(switchDomain.isHealthCheckEnabled("service"));
         
         assertTrue(switchDomain.toString().contains("\"defaultPushCacheMillis\":1234"));
+    }
+    
+    @Test
+    void testOnRequestReturnsSwitchDomainData() {
+        ReadRequest request = ReadRequest.newBuilder().setData(ByteString.copyFrom(
+            serializer.serialize(Collections.singletonList(ByteUtils.toBytes(KeyBuilder
+                .getSwitchDomainKey())))))
+            .build();
+        
+        Response response = switchManager.onRequest(request);
+        BatchReadResponse batchResponse =
+            serializer.deserialize(response.getData().toByteArray(), BatchReadResponse.class);
+        
+        assertTrue(response.getSuccess());
+        assertEquals(1, batchResponse.getKeys().size());
+    }
+    
+    @Test
+    void testOnRequestReturnsErrorForInvalidPayload() {
+        ReadRequest request =
+            ReadRequest.newBuilder().setData(ByteString.copyFromUtf8("invalid")).build();
+        
+        Response response = switchManager.onRequest(request);
+        
+        assertFalse(response.getSuccess());
+    }
+    
+    @Test
+    void testOnRequestRejectsNonSwitchDomainKey() {
+        ReadRequest request = ReadRequest.newBuilder().setData(
+            ByteString.copyFrom(serializer.serialize(Collections.singletonList(ByteUtils
+                .toBytes("other")))))
+            .build();
+        
+        Response response = switchManager.onRequest(request);
+        
+        assertFalse(response.getSuccess());
+        assertEquals("not switch domain key", response.getErrMsg());
+    }
+    
+    @Test
+    void testOnRequestAcceptsMultipleKeysAsLegacyBehavior() {
+        ReadRequest request = ReadRequest.newBuilder().setData(ByteString.copyFrom(
+            serializer.serialize(Arrays.asList(ByteUtils.toBytes(KeyBuilder.getSwitchDomainKey()),
+                ByteUtils.toBytes("other")))))
+            .build();
+        
+        Response response = switchManager.onRequest(request);
+        
+        assertTrue(response.getSuccess());
+    }
+    
+    @Test
+    void testOnApplyUpdatesSwitchDomain() {
+        SwitchDomain newSwitchDomain = new SwitchDomain();
+        newSwitchDomain.setClientBeatInterval(9000L);
+        BatchWriteRequest batchWriteRequest = new BatchWriteRequest();
+        batchWriteRequest.append(ByteUtils.toBytes(KeyBuilder.getSwitchDomainKey()),
+            serializer.serialize(Datum.createDatum(KeyBuilder.getSwitchDomainKey(),
+                newSwitchDomain)));
+        WriteRequest request = WriteRequest.newBuilder().setOperation(OldDataOperation.Write
+            .getDesc()).setData(ByteString.copyFrom(serializer.serialize(batchWriteRequest)))
+            .build();
+        
+        Response response = switchManager.onApply(request);
+        
+        assertTrue(response.getSuccess());
+        assertEquals(9000L, switchDomain.getClientBeatInterval());
+    }
+    
+    @Test
+    void testOnApplyRejectsNonSwitchDomainKey() {
+        BatchWriteRequest batchWriteRequest = new BatchWriteRequest();
+        batchWriteRequest.append(ByteUtils.toBytes("other"), new byte[] {1});
+        WriteRequest request = WriteRequest.newBuilder().setOperation(OldDataOperation.Write
+            .getDesc()).setData(ByteString.copyFrom(serializer.serialize(batchWriteRequest)))
+            .build();
+        
+        Response response = switchManager.onApply(request);
+        
+        assertFalse(response.getSuccess());
+        assertEquals("not switch domain key", response.getErrMsg());
+    }
+    
+    @Test
+    void testOnApplyRejectsNonSwitchDomainDatum() {
+        BatchWriteRequest batchWriteRequest = new BatchWriteRequest();
+        batchWriteRequest.append(ByteUtils.toBytes(KeyBuilder.getSwitchDomainKey()),
+            serializer.serialize(Datum.createDatum(KeyBuilder.getSwitchDomainKey(), null)));
+        WriteRequest request = WriteRequest.newBuilder().setOperation(OldDataOperation.Write
+            .getDesc()).setData(ByteString.copyFrom(serializer.serialize(batchWriteRequest)))
+            .build();
+        
+        Response response = switchManager.onApply(request);
+        
+        assertFalse(response.getSuccess());
+        assertEquals("datum is not switch domain", response.getErrMsg());
+    }
+    
+    @Test
+    void testSnapshotAccessorsAndOperations() throws Exception {
+        assertSame(switchDomain, switchManager.getSwitchDomain());
+        assertEquals(1, switchManager.loadSnapshotOperate().size());
+        
+        switchManager.loadSnapshot(tempDir.resolve("missing").toString());
+        
+        Path snapshotDir = Files.createDirectory(tempDir.resolve("snapshot"));
+        SwitchDomain snapshotDomain = new SwitchDomain();
+        snapshotDomain.setClientBeatInterval(16000L);
+        Files.write(snapshotDir.resolve(KeyBuilder.getSwitchDomainKey()),
+            serializer.serialize(Datum.createDatum(KeyBuilder.getSwitchDomainKey(),
+                snapshotDomain)));
+        
+        switchManager.loadSnapshot(snapshotDir.toString());
+        assertEquals(16000L, switchDomain.getClientBeatInterval());
+        
+        Path backupDir = tempDir.resolve("backup");
+        switchManager.dumpSnapshot(backupDir.toString());
+        assertTrue(Files.exists(backupDir.resolve(KeyBuilder.getSwitchDomainKey())));
+    }
+    
+    private static class MockRecord implements Record {
+        
+        private static final long serialVersionUID = 1L;
+        
+        @Override
+        public String getChecksum() {
+            return "mock";
+        }
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/model/form/NamingFormTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/model/form/NamingFormTest.java
@@ -261,6 +261,7 @@ class NamingFormTest {
         assertEquals(Constants.DEFAULT_GROUP, form.getGroupName());
         assertEquals("", form.getConsistencyType());
         assertEquals("", form.getInstances());
+        assertEquals(form, form);
         assertEquals(form, same);
         assertEquals(form.hashCode(), same.hashCode());
         assertNotEquals(form, different);

--- a/naming/src/test/java/com/alibaba/nacos/naming/pojo/SubscriberTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/pojo/SubscriberTest.java
@@ -29,6 +29,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SubscriberTest {
     
     @Test
+    void testDefaultConstructor() {
+        Subscriber subscriber = new Subscriber();
+        
+        assertNotNull(subscriber);
+    }
+    
+    @Test
     void subscriberBeanTest() {
         Subscriber subscriber =
             new Subscriber("127.0.0.1:8080", "agent", "app", "127.0.0.1", "public", "test", 0);

--- a/naming/src/test/java/com/alibaba/nacos/naming/pojo/SubscriberTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/pojo/SubscriberTest.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SubscriberTest {
     
@@ -58,5 +60,32 @@ class SubscriberTest {
         assertEquals("agent", subscriberList.get(0).getAgent());
         assertEquals("public", subscriberList.get(0).getNamespaceId());
         assertEquals("test", subscriberList.get(0).getServiceName());
+    }
+    
+    @Test
+    void testEqualsHashCodeAndToString() {
+        Subscriber subscriber =
+            new Subscriber("127.0.0.1:8080", "agent", "app", "127.0.0.1", "public", "test", 8080,
+                "cluster");
+        Subscriber same =
+            new Subscriber("127.0.0.1:8080", "agent", "app", "127.0.0.1", "public", "test", 8848,
+                "anotherCluster");
+        Subscriber other =
+            new Subscriber("127.0.0.2:8080", "agent", "app", "127.0.0.2", "public", "test", 8080);
+        
+        assertEquals(subscriber, subscriber);
+        assertEquals(subscriber, same);
+        assertEquals(subscriber.hashCode(), same.hashCode());
+        assertNotEquals(subscriber, other);
+        assertNotEquals(subscriber, null);
+        assertNotEquals(subscriber, "subscriber");
+        assertTrue(subscriber.toString().contains("127.0.0.1:8080"));
+        assertEquals(8080, subscriber.getPort());
+        assertEquals("cluster", subscriber.getCluster());
+        
+        subscriber.setPort(8848);
+        subscriber.setCluster("newCluster");
+        assertEquals(8848, subscriber.getPort());
+        assertEquals("newCluster", subscriber.getCluster());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/ClientInfoTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/ClientInfoTest.java
@@ -50,6 +50,22 @@ class ClientInfoTest {
     }
     
     @Test
+    void testGetClientInfoForCsharp() {
+        String userAgent = getUserAgent(ClientInfo.ClientTypeDescription.CSHARP_CLIENT);
+        ClientInfo actual = new ClientInfo(userAgent);
+        assertEquals(ClientInfo.ClientType.CSHARP, actual.type);
+        assertEquals(testVersionString, actual.version.toString());
+    }
+    
+    @Test
+    void testGetClientInfoForPhp() {
+        String userAgent = getUserAgent(ClientInfo.ClientTypeDescription.PHP_CLIENT);
+        ClientInfo actual = new ClientInfo(userAgent);
+        assertEquals(ClientInfo.ClientType.PHP, actual.type);
+        assertEquals(testVersionString, actual.version.toString());
+    }
+    
+    @Test
     void testGetClientInfoForCpp() {
         String userAgent = getUserAgent(ClientInfo.ClientTypeDescription.CPP_CLIENT);
         ClientInfo actual = new ClientInfo(userAgent);
@@ -103,6 +119,13 @@ class ClientInfoTest {
         
         assertEquals(ClientInfo.ClientType.JAVA, actual.type);
         assertEquals("0.0.0", actual.version.toString());
+    }
+    
+    @Test
+    void testNewClientTypeDescription() {
+        ClientInfo.ClientTypeDescription actual = new ClientInfo.ClientTypeDescription();
+        
+        assertEquals(ClientInfo.ClientTypeDescription.class, actual.getClass());
     }
     
     private String getUserAgent(String client) {

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/NamingFuzzyWatchSyncNotifierTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/NamingFuzzyWatchSyncNotifierTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.naming.push;
 
+import com.alibaba.nacos.api.naming.remote.request.NamingFuzzyWatchSyncRequest;
 import com.alibaba.nacos.api.naming.utils.NamingUtils;
 import com.alibaba.nacos.common.utils.FuzzyGroupKeyPattern;
 import com.alibaba.nacos.naming.core.v2.event.client.ClientOperationEvent;
@@ -29,10 +30,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 import static com.alibaba.nacos.naming.push.NamingFuzzyWatchSyncNotifier.BATCH_SIZE;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -184,5 +188,19 @@ public class NamingFuzzyWatchSyncNotifierTest {
         verify(fuzzyWatchPushDelayTaskEngine, times(1)).addTask(anyString(),
             any(FuzzyWatchSyncNotifyTask.class));
         
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    void testDivideServiceByBatchReturnsEmptySetForEmptyContext() throws Exception {
+        Method method = NamingFuzzyWatchSyncNotifier.class
+            .getDeclaredMethod("divideServiceByBatch", java.util.Collection.class);
+        method.setAccessible(true);
+        
+        Set<Set<NamingFuzzyWatchSyncRequest.Context>> actual =
+            (Set<Set<NamingFuzzyWatchSyncRequest.Context>>) method.invoke(
+                namingFuzzyWatchSyncNotifier, Collections.emptySet());
+        
+        assertTrue(actual.isEmpty());
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/executor/PushExecutorRpcImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/executor/PushExecutorRpcImplTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.naming.push.v2.executor;
 
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.api.naming.remote.request.NamingFuzzyWatchSyncRequest;
 import com.alibaba.nacos.api.naming.remote.request.NotifySubscriberRequest;
 import com.alibaba.nacos.api.remote.PushCallBack;
 import com.alibaba.nacos.core.remote.RpcPushService;
@@ -46,8 +47,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PushExecutorRpcImplTest {
@@ -83,8 +84,8 @@ class PushExecutorRpcImplTest {
         pushExecutor = new PushExecutorRpcImpl(pushService);
         EnvUtil.setEnvironment(new MockEnvironment());
         ApplicationUtils.injectContext(context);
-        when(context.getBean(SelectorManager.class)).thenReturn(selectorManager);
-        when(selectorManager.select(any(), any(), any())).then(
+        lenient().when(context.getBean(SelectorManager.class)).thenReturn(selectorManager);
+        lenient().when(selectorManager.select(any(), any(), any())).then(
             (Answer<List<Instance>>) invocationOnMock -> invocationOnMock.getArgument(2));
     }
     
@@ -101,6 +102,17 @@ class PushExecutorRpcImplTest {
                 eq(GlobalExecutor.getCallbackExecutor()));
         pushExecutor.doPushWithCallback(rpcClientId, subscriber, pushData, pushCallBack);
         verify(pushCallBack).onSuccess();
+    }
+    
+    @Test
+    void testDoFuzzyWatchNotifyPushWithCallback() {
+        NamingFuzzyWatchSyncRequest request = new NamingFuzzyWatchSyncRequest();
+        PushCallBack callBack = org.mockito.Mockito.mock(PushCallBack.class);
+        
+        pushExecutor.doFuzzyWatchNotifyPushWithCallBack(rpcClientId, request, callBack);
+        
+        verify(pushService).pushWithCallback(eq(rpcClientId), eq(request), eq(callBack),
+            eq(GlobalExecutor.getCallbackExecutor()));
     }
     
     private class CallbackAnswer implements Answer<Void> {

--- a/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FixturePushExecutor.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/push/v2/task/FixturePushExecutor.java
@@ -35,6 +35,8 @@ public class FixturePushExecutor implements PushExecutor {
     @Override
     public void doPushWithCallback(String clientId, Subscriber subscriber, PushDataWrapper data,
         NamingPushCallback callBack) {
+        callBack.getTimeout();
+        callBack.setActualServiceInfo(data.getOriginalData());
         if (shouldSuccess) {
             callBack.onSuccess();
         } else {

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/ClientAttributesFilterTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/ClientAttributesFilterTest.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -95,6 +96,16 @@ class ClientAttributesFilterTest {
     }
     
     @Test
+    void testDoFilterForRegisterV2Uri() throws IOException {
+        when(request.getRequestURI()).thenReturn(
+            UtilsAndCommons.NACOS_SERVER_CONTEXT + UtilsAndCommons.DEFAULT_NACOS_NAMING_CONTEXT_V2
+                + UtilsAndCommons.NACOS_NAMING_INSTANCE_CONTEXT);
+        when(request.getMethod()).thenReturn("POST");
+        
+        filter.doFilter(request, response, new MockFilterChain(servlet, new MockRegisterFilter()));
+    }
+    
+    @Test
     void testDoFilterForBeatUri() throws IOException {
         when(request.getParameter("ip")).thenReturn("127.0.0.1");
         when(request.getParameter("port")).thenReturn("8848");
@@ -106,6 +117,58 @@ class ClientAttributesFilterTest {
         when(request.getMethod()).thenReturn("PUT");
         filter.doFilter(request, response, new MockFilterChain());
         verify(client).setAttributes(any(ClientAttributes.class));
+    }
+    
+    @Test
+    void testDoFilterForBeatUriSkipsWhenRequestVersionMissing() throws IOException {
+        RequestContextHolder.getContext().getBasicContext().setUserAgent(null);
+        when(request.getParameter("encoding")).thenReturn("utf-8");
+        when(request.getParameter("ip")).thenReturn("127.0.0.1");
+        when(request.getParameter("port")).thenReturn("8848");
+        when(clientManager.getClient("127.0.0.1:8848#true")).thenReturn(client);
+        when(request.getRequestURI()).thenReturn(
+            UtilsAndCommons.NACOS_SERVER_CONTEXT + UtilsAndCommons.NACOS_NAMING_CONTEXT
+                + UtilsAndCommons.NACOS_NAMING_INSTANCE_CONTEXT + "/beat");
+        when(request.getMethod()).thenReturn("PUT");
+        
+        filter.doFilter(request, response, new MockFilterChain());
+        
+        verify(client, never()).setAttributes(any(ClientAttributes.class));
+    }
+    
+    @Test
+    void testDoFilterForBeatUriSkipsWhenClientAlreadyHasVersion() throws IOException {
+        ClientAttributes clientAttributes = new ClientAttributes();
+        clientAttributes.addClientAttribute(HttpHeaderConsts.CLIENT_VERSION_HEADER, "old");
+        when(client.getClientAttributes()).thenReturn(clientAttributes);
+        when(request.getParameter("encoding")).thenReturn("utf-8");
+        when(request.getParameter("ip")).thenReturn("127.0.0.1");
+        when(request.getParameter("port")).thenReturn("8848");
+        when(clientManager.getClient("127.0.0.1:8848#true")).thenReturn(client);
+        when(request.getRequestURI()).thenReturn(
+            UtilsAndCommons.NACOS_SERVER_CONTEXT + UtilsAndCommons.DEFAULT_NACOS_NAMING_CONTEXT_V2
+                + UtilsAndCommons.NACOS_NAMING_INSTANCE_CONTEXT + "/beat");
+        when(request.getMethod()).thenReturn("PUT");
+        
+        filter.doFilter(request, response, new MockFilterChain());
+        
+        verify(client, never()).setAttributes(any(ClientAttributes.class));
+    }
+    
+    @Test
+    void testDoFilterSwallowsAttributeHandlingException() throws IOException, ServletException {
+        when(request.getParameter("encoding")).thenReturn("utf-8");
+        when(request.getParameter("ip")).thenReturn("127.0.0.1");
+        when(request.getParameter("port")).thenReturn("invalid");
+        when(request.getRequestURI()).thenReturn(
+            UtilsAndCommons.NACOS_SERVER_CONTEXT + UtilsAndCommons.NACOS_NAMING_CONTEXT
+                + UtilsAndCommons.NACOS_NAMING_INSTANCE_CONTEXT + "/beat");
+        when(request.getMethod()).thenReturn("PUT");
+        FilterChain chain = org.mockito.Mockito.mock(FilterChain.class);
+        
+        filter.doFilter(request, response, chain);
+        
+        verify(chain).doFilter(request, response);
     }
     
     private static class MockRegisterFilter implements Filter {

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/ClientAttributesFilterTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/ClientAttributesFilterTest.java
@@ -43,8 +43,10 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -169,6 +171,19 @@ class ClientAttributesFilterTest {
         filter.doFilter(request, response, chain);
         
         verify(chain).doFilter(request, response);
+    }
+    
+    @Test
+    void testDoFilterWrapsServletException() throws IOException, ServletException {
+        when(request.getRequestURI()).thenReturn("/nacos/v1/other");
+        when(request.getMethod()).thenReturn("GET");
+        FilterChain chain = org.mockito.Mockito.mock(FilterChain.class);
+        doThrow(new ServletException("mock")).when(chain).doFilter(request, response);
+        
+        RuntimeException actual =
+            assertThrows(RuntimeException.class, () -> filter.doFilter(request, response, chain));
+        
+        assertTrue(actual.getCause() instanceof ServletException);
     }
     
     private static class MockRegisterFilter implements Filter {


### PR DESCRIPTION
## What is the purpose of the change

Improve naming module unit-test coverage by covering the remaining low-cost gaps in simple constructors, default method delegation, interceptors, heartbeat branches, push callbacks, and exception fallback paths.

## Brief changelog

* Add focused unit tests for naming constants, health/operator default methods, client operation defaults, interceptor chains, heartbeat checks, push callbacks, and lightweight POJO/constructor paths.
* Extend existing naming tests for additional branch and fallback coverage.

## Verifying this change

* `mvn spotless:check -pl naming`
* `mvn clean test -pl naming`
* Naming JaCoCo line coverage: 95.95% (`7694/8019`, missed `325`)

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
