### PR TITLE
[ISSUE #14695] Support tagv2 gray rules

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
+++ b/api/src/main/java/com/alibaba/nacos/api/common/Constants.java
@@ -228,6 +228,10 @@ public class Constants {
     
     public static final String CLUSTER_NAME_PATTERN_STRING = "^[0-9a-zA-Z-]+$";
     
+    public static final String TAG_V2 = "tagv2";
+    
+    public static final String TAG_V2_PREFIX = "tagv2_";
+    
     /**
      * millisecond.
      */

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3.java
@@ -102,6 +102,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.alibaba.nacos.api.common.Constants.TAG_V2;
 import static com.alibaba.nacos.config.server.utils.RequestUtil.getRemoteIp;
 
 /**
@@ -452,6 +453,122 @@ public class ConfigControllerV3 {
         } else {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "Config is not in beta.");
+        }
+    }
+    
+    /**
+     * Publish gray configuration.
+     */
+    @PostMapping("/gray")
+    @TpsControl(pointName = "ConfigPublish")
+    @Secured(action = ActionTypes.WRITE, signType = SignType.CONFIG, apiType = ApiType.ADMIN_API)
+    public Result<Boolean> publishGray(HttpServletRequest request, ConfigFormV3 configForm,
+        @RequestParam(value = "grayType", required = false, defaultValue = TAG_V2) String grayType,
+        @RequestParam(value = "grayMatchRuleExp", required = false) String grayMatchRuleExp)
+        throws NacosException {
+        configForm.validateWithContent();
+        final boolean namespaceTransferred =
+            NamespaceUtil.isNeedTransferNamespace(configForm.getNamespaceId());
+        configForm
+            .setNamespaceId(NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId()));
+        if (StringUtils.isNotBlank(grayMatchRuleExp)) {
+            configForm.setGrayRuleExp(grayMatchRuleExp);
+        }
+        validateGrayForm(configForm);
+        ParamUtils.checkParam(configForm.getDataId(), configForm.getGroup(), "datumId",
+            configForm.getContent());
+        
+        if (StringUtils.isBlank(configForm.getSrcUser())) {
+            configForm.setSrcUser(RequestUtil.getSrcUserName(request));
+        }
+        if (!ConfigType.isValidType(configForm.getType())) {
+            configForm.setType(ConfigType.getDefaultType().getType());
+        }
+        
+        String encryptedDataKeyFinal = configForm.getEncryptedDataKey();
+        if (StringUtils.isBlank(encryptedDataKeyFinal)) {
+            Pair<String, String> pair = EncryptionHandler.encryptHandler(configForm.getDataId(),
+                configForm.getContent());
+            configForm.setContent(pair.getSecond());
+            encryptedDataKeyFinal = pair.getFirst();
+        }
+        configForm.setEncryptedDataKey(encryptedDataKeyFinal);
+        
+        ConfigRequestInfo configRequestInfo = new ConfigRequestInfo();
+        configRequestInfo.setSrcIp(RequestUtil.getRemoteIp(request));
+        configRequestInfo.setSrcType(Constants.HTTP);
+        configRequestInfo.setRequestIpApp(RequestUtil.getAppName(request));
+        configRequestInfo.setCasMd5(request.getHeader("casMd5"));
+        configRequestInfo.setNamespaceTransferred(namespaceTransferred);
+        
+        return Result.success(
+            configOperationService.publishConfigGray(grayType, configForm, configRequestInfo));
+    }
+    
+    /**
+     * Query gray configuration.
+     */
+    @GetMapping("/gray")
+    @Secured(action = ActionTypes.READ, signType = SignType.CONFIG, apiType = ApiType.ADMIN_API)
+    public Result<ConfigGrayInfo> queryGray(ConfigFormV3 configForm,
+        @RequestParam("grayName") String grayName)
+        throws NacosApiException {
+        configForm.validate();
+        validateGrayName(grayName);
+        String namespaceId = NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId());
+        ConfigInfoGrayWrapper grayConfig =
+            configInfoGrayPersistService.findConfigInfo4Gray(configForm.getDataId(),
+                configForm.getGroupName(), namespaceId, grayName);
+        if (Objects.isNull(grayConfig)) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                "Config gray version not found.");
+        }
+        String encryptedDataKey = grayConfig.getEncryptedDataKey();
+        Pair<String, String> pair =
+            EncryptionHandler.decryptHandler(configForm.getDataId(), encryptedDataKey,
+                grayConfig.getContent());
+        grayConfig.setContent(pair.getSecond());
+        return Result.success(ResponseUtil.transferToConfigGrayInfo(grayConfig));
+    }
+    
+    /**
+     * Remove gray configuration.
+     */
+    @DeleteMapping("/gray")
+    @Secured(action = ActionTypes.WRITE, signType = SignType.CONFIG, apiType = ApiType.ADMIN_API)
+    public Result<Boolean> stopGray(HttpServletRequest request, ConfigFormV3 configForm,
+        @RequestParam("grayName") String grayName) throws NacosApiException {
+        configForm.validate();
+        validateGrayName(grayName);
+        String namespaceId = NamespaceUtil.processNamespaceParameter(configForm.getNamespaceId());
+        String clientIp = getRemoteIp(request);
+        String srcUser = RequestUtil.getSrcUserName(request);
+        return Result.success(
+            configOperationService.deleteConfig(configForm.getDataId(), configForm.getGroupName(),
+                namespaceId, grayName, clientIp, srcUser, Constants.HTTP));
+    }
+    
+    private void validateGrayForm(ConfigFormV3 configForm) throws NacosApiException {
+        validateGrayName(configForm.getGrayName());
+        if (StringUtils.isBlank(configForm.getGrayRuleExp())) {
+            throw new NacosApiException(HttpStatus.BAD_REQUEST.value(), ErrorCode.PARAMETER_MISSING,
+                "Required parameter 'grayRuleExp' type String is not present");
+        }
+        if (StringUtils.isBlank(configForm.getGrayVersion())) {
+            throw new NacosApiException(HttpStatus.BAD_REQUEST.value(), ErrorCode.PARAMETER_MISSING,
+                "Required parameter 'grayVersion' type String is not present");
+        }
+    }
+    
+    private void validateGrayName(String grayName) throws NacosApiException {
+        if (StringUtils.isBlank(grayName)) {
+            throw new NacosApiException(HttpStatus.BAD_REQUEST.value(), ErrorCode.PARAMETER_MISSING,
+                "Required parameter 'grayName' type String is not present");
+        }
+        if (!ParamUtils.isValid(grayName.trim())) {
+            throw new NacosApiException(HttpStatus.BAD_REQUEST.value(),
+                ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "invalid grayName : " + grayName);
         }
     }
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/model/gray/AbstractTagMatchGrayRule.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/gray/AbstractTagMatchGrayRule.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model.gray;
+
+import com.alibaba.nacos.api.exception.NacosException;
+
+/**
+ * description.
+ *
+ * @author rong
+ * @date 2024-03-13 14:31
+ */
+public abstract class AbstractTagMatchGrayRule extends AbstractGrayRule {
+    
+    protected static final String EQUAL_PATTERN = "=";
+    
+    protected static final String KEY_PATTERN = "[a-zA-Z0-9-_:\\.]+";
+    
+    protected static final String VALUE_SPLITER_PATTERN = ",";
+    
+    protected static final String VALUE_PATTERN =
+        KEY_PATTERN + "(\\s*" + VALUE_SPLITER_PATTERN + "\\s*" + KEY_PATTERN + ")*";
+    
+    public AbstractTagMatchGrayRule() {
+        super();
+    }
+    
+    public AbstractTagMatchGrayRule(String rawGrayRuleExp, int priority) {
+        super(rawGrayRuleExp, priority);
+    }
+    
+    protected void isPatternMatch(String rawString, String pattern) throws NacosException {
+        if (!rawString.matches(pattern)) {
+            throw new NacosException(NacosException.INVALID_PARAM,
+                String.format(
+                    "tagv2 gray rule parse failed: " + "raw string [%s] doesn't match pattern[%s].",
+                    rawString, pattern));
+        }
+    }
+    
+    /**
+     * Check whether another tag match gray rule has the same expression, priority, type and version.
+     *
+     * @param obj another object.
+     * @return true if equals.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof AbstractTagMatchGrayRule) {
+            AbstractTagMatchGrayRule other = (AbstractTagMatchGrayRule) obj;
+            return this.rawGrayRuleExp.equals(other.rawGrayRuleExp)
+                && this.priority == other.priority && this.getType()
+                    .equals(other.getType())
+                && this.getVersion().equals(other.getVersion());
+        }
+        return false;
+    }
+}

--- a/config/src/main/java/com/alibaba/nacos/config/server/model/gray/multitag/MultiTagMatchGrayRule.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/gray/multitag/MultiTagMatchGrayRule.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model.gray.multitag;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.config.server.model.gray.AbstractTagMatchGrayRule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.alibaba.nacos.api.common.Constants.TAG_V2;
+
+/**
+ * tag v2 gray rule.
+ *
+ * @author rong
+ */
+public class MultiTagMatchGrayRule extends AbstractTagMatchGrayRule {
+    
+    private List<TagV2GrayRuleItem> ruleItems;
+    
+    public static final String TYPE_TAGV2 = TAG_V2;
+    
+    public static final String VERSION_1_1_0 = "1.1.0";
+    
+    private static final String ELEM_PATTERN =
+        "\\s*" + KEY_PATTERN + "\\s*" + EQUAL_PATTERN + "\\s*" + VALUE_PATTERN + "\\s*";
+    
+    private static final String JOINT_PATTERN = "(\\|\\||&&)";
+    
+    private static final String EXPRESSION_PATTERN =
+        "^" + ELEM_PATTERN + "(" + JOINT_PATTERN + ELEM_PATTERN + ")*$";
+    
+    public MultiTagMatchGrayRule() {
+        super();
+    }
+    
+    public MultiTagMatchGrayRule(String rawGrayRuleExp, int priority) {
+        super(rawGrayRuleExp, priority);
+    }
+    
+    @Override
+    protected void parse(String rawRule) throws NacosException {
+        this.isPatternMatch(rawRule, EXPRESSION_PATTERN);
+        String[] splitSubExpressionByOrArray = rawRule.trim()
+            .split(MultiTagMatchGrayRule.TagV2GrayRuleJoint.OR_REGEXP.getExpression());
+        for (String s : splitSubExpressionByOrArray) {
+            if (StringUtils.isBlank(s)) {
+                continue;
+            }
+            //each subExpression is jointed by one or multi "&&"
+            String[] splitSubExpressionByAndArray = s.trim()
+                .split(MultiTagMatchGrayRule.TagV2GrayRuleJoint.AND_REGEXP.getExpression());
+            for (int andIndex = 0; andIndex < splitSubExpressionByAndArray.length; andIndex++) {
+                if (StringUtils.isBlank(splitSubExpressionByAndArray[andIndex])) {
+                    continue;
+                }
+                String[] keyValueArray =
+                    splitSubExpressionByAndArray[andIndex].trim().split(EQUAL_PATTERN);
+                if (keyValueArray.length != 2) {
+                    throw new NacosException(NacosException.INVALID_PARAM, String.format(
+                        "tagv2 gray rule parse failed: key and value's[%s] doesn't match pattern[%s].",
+                        splitSubExpressionByAndArray[andIndex],
+                        KEY_PATTERN + EQUAL_PATTERN + VALUE_PATTERN));
+                }
+                isPatternMatch(keyValueArray[0].trim(), KEY_PATTERN);
+                isPatternMatch(keyValueArray[1].trim(), VALUE_PATTERN);
+                Set<String> values =
+                    Arrays.stream(keyValueArray[1].split(VALUE_SPLITER_PATTERN)).map(String::trim)
+                        .filter(StringUtils::isNotBlank).collect(Collectors.toSet());
+                MultiTagMatchGrayRule.TagV2GrayRuleItem tagV2GrayRuleItem =
+                    new MultiTagMatchGrayRule.TagV2GrayRuleItem(
+                        keyValueArray[0].trim(), values);
+                if (andIndex == 0) {
+                    tagV2GrayRuleItem.setJoint(MultiTagMatchGrayRule.TagV2GrayRuleJoint.OR);
+                }
+                if (this.ruleItems == null) {
+                    this.ruleItems = new ArrayList<>();
+                }
+                ruleItems.add(tagV2GrayRuleItem);
+            }
+        }
+    }
+    
+    /**
+     * this rule will match labelsMap.
+     *
+     * @param labelsMap labels map.
+     * @return true if match. false if not match.
+     * @date 2024/2/6
+     */
+    public boolean match(Map<String, String> labelsMap) {
+        if (ruleItems.isEmpty() || labelsMap == null || labelsMap.isEmpty()) {
+            return false;
+        }
+        ArrayList<TagV2GrayRuleItem> localRuleItems =
+            ruleItems.stream().map(TagV2GrayRuleItem::clone)
+                .collect(Collectors.toCollection(ArrayList::new));
+        int result = 0;
+        int tempResult = 0;
+        boolean subRuleMatchFlag = true;
+        HashSet<String> tempKeyExistSet = new HashSet<>();
+        
+        for (int index = 0; index < localRuleItems.size(); index++) {
+            if (result > 0) {
+                return true;
+            }
+            TagV2GrayRuleItem curTagV2GrayRuleItem = localRuleItems.get(index);
+            
+            if (curTagV2GrayRuleItem.getJoint() == TagV2GrayRuleJoint.AND) {
+                //if AND, will consider the current ruleItem belong to this subRule.
+                
+                //if one of the items in the subRule is not match, will continue to next subRule.
+                if (!subRuleMatchFlag) {
+                    continue;
+                }
+                
+                //if the key has already existed in this subRule,
+                // another item with the same key appears which will be considered as a syntax error.
+                if (tempKeyExistSet.contains(curTagV2GrayRuleItem.getKey())) {
+                    subRuleMatchFlag = false;
+                    continue;
+                } else {
+                    tempKeyExistSet.add(curTagV2GrayRuleItem.getKey());
+                }
+                
+                //check current item
+                if (!curTagV2GrayRuleItem.match(labelsMap.get(curTagV2GrayRuleItem.getKey()))) {
+                    subRuleMatchFlag = false;
+                }
+                tempResult++;
+            } else if (curTagV2GrayRuleItem.getJoint() == TagV2GrayRuleJoint.OR) {
+                //if OR, will consider the current ruleItem belong to the next subRule,
+                // and this subRule contains items between [subRuleBeginIndex, index).
+                
+                //only when subRuleMatchFlag is true, update result.
+                if (subRuleMatchFlag) {
+                    result = Math.max(result, tempResult);
+                }
+                curTagV2GrayRuleItem.setJoint(TagV2GrayRuleJoint.AND);
+                subRuleMatchFlag = true;
+                tempKeyExistSet.clear();
+                index--;
+            }
+        }
+        if (subRuleMatchFlag) {
+            return Math.max(result, tempResult) > 0;
+        }
+        return result > 0;
+    }
+    
+    /**
+     * check this TagV2GrayRule is valid or not.
+     *
+     * @return true if valid. false if not valid.
+     * @date 2024/2/7
+     */
+    public boolean isValid() {
+        if (!super.isValid()) {
+            return false;
+        }
+        if (ruleItems.isEmpty()) {
+            return true;
+        }
+        HashSet<String> tempKeyExistSet = new HashSet<>();
+        
+        ArrayList<TagV2GrayRuleItem> localRuleItems =
+            ruleItems.stream().map(TagV2GrayRuleItem::clone)
+                .collect(Collectors.toCollection(ArrayList::new));
+        for (int index = 0; index < localRuleItems.size(); index++) {
+            TagV2GrayRuleItem curTagV2GrayRuleItem = localRuleItems.get(index);
+            
+            if (!curTagV2GrayRuleItem.isValid()) {
+                return false;
+            }
+            
+            if (curTagV2GrayRuleItem.getJoint() == TagV2GrayRuleJoint.AND) {
+                //if AND, will consider the current ruleItem belong to this subRule.
+                
+                //if the key has already existed in this subRule,
+                // another item with the same key appears which will be considered as a syntax error.
+                if (tempKeyExistSet.contains(curTagV2GrayRuleItem.getKey())) {
+                    return false;
+                } else {
+                    tempKeyExistSet.add(curTagV2GrayRuleItem.getKey());
+                }
+            } else if (curTagV2GrayRuleItem.getJoint() == TagV2GrayRuleJoint.OR) {
+                //if OR, will consider the current ruleItem belong to the next subRule,
+                // and this subRule contains items between [subRuleBeginIndex, index).
+                
+                //only when subRuleMatchFlag is true, update result.
+                curTagV2GrayRuleItem.setJoint(TagV2GrayRuleJoint.AND);
+                tempKeyExistSet.clear();
+                index--;
+            }
+        }
+        return true;
+    }
+    
+    @Override
+    public String getType() {
+        return TYPE_TAGV2;
+    }
+    
+    @Override
+    public String getVersion() {
+        return VERSION_1_1_0;
+    }
+    
+    /**
+     * tag v2 gray rule item.
+     *
+     * @author rong
+     */
+    public static class TagV2GrayRuleItem implements Cloneable {
+        
+        public String key;
+        
+        public TagV2GrayRuleOperator operator = TagV2GrayRuleOperator.IN;
+        
+        public final Set<String> values = new HashSet<>();
+        
+        public TagV2GrayRuleJoint joint = TagV2GrayRuleJoint.AND;
+        
+        public TagV2GrayRuleItem(String key) {
+            this.key = key;
+        }
+        
+        public TagV2GrayRuleItem(String key, Set<String> values) {
+            this.key = key;
+            this.values.addAll(values);
+        }
+        
+        /**
+         * judge if value is match the rule.
+         *
+         * @param value value
+         * @return boolean true if match, false otherwise.
+         * @date 2024/2/8
+         */
+        public boolean match(String value) {
+            switch (operator) {
+                case IN:
+                    if (null == value) {
+                        return false;
+                    } else {
+                        return values.contains(value);
+                    }
+                case NOT_IN:
+                    if (null == value) {
+                        return false;
+                    } else {
+                        return !values.contains(value);
+                    }
+                case EXIST:
+                    return value != null;
+                case NOT_EXIST:
+                    return value == null;
+                default:
+            }
+            return false;
+        }
+        
+        /**
+         * judge if rule is valid.
+         *
+         * @return boolean true if valid, false otherwise.
+         * @throws NacosException if invalid.
+         * @date 2024/2/8
+         */
+        public boolean isValid() {
+            return !StringUtils.isBlank(key);
+        }
+        
+        public static TagV2GrayRuleItemBuilder builder() {
+            return new TagV2GrayRuleItemBuilder();
+        }
+        
+        public String getKey() {
+            return key;
+        }
+        
+        public void setKey(String key) {
+            this.key = key;
+        }
+        
+        public TagV2GrayRuleOperator getOperator() {
+            return operator;
+        }
+        
+        public void setOperator(TagV2GrayRuleOperator operator) {
+            this.operator = operator;
+        }
+        
+        public Set<String> getValues() {
+            return values;
+        }
+        
+        public TagV2GrayRuleJoint getJoint() {
+            return joint;
+        }
+        
+        public void setJoint(TagV2GrayRuleJoint joint) {
+            this.joint = joint;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TagV2GrayRuleItem)) {
+                return false;
+            }
+            TagV2GrayRuleItem that = (TagV2GrayRuleItem) o;
+            return Objects.equals(key, that.key) && operator == that.operator
+                && values.size() == that.values.size()
+                && values.containsAll(that.values) && joint == that.joint;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, operator, values, joint);
+        }
+        
+        @Override
+        public String toString() {
+            return "{" + "key='" + key + '\'' + ", operator=" + operator + ", values=" + values
+                + ", joint=" + joint
+                + '}';
+        }
+        
+        @Override
+        public TagV2GrayRuleItem clone() {
+            try {
+                TagV2GrayRuleItem clone = (TagV2GrayRuleItem) super.clone();
+                clone.setKey(key);
+                clone.setJoint(joint);
+                clone.setOperator(operator);
+                clone.getValues().addAll(values);
+                return clone;
+            } catch (CloneNotSupportedException e) {
+                throw new AssertionError();
+            }
+        }
+        
+        public static final class TagV2GrayRuleItemBuilder {
+            
+            private final TagV2GrayRuleItem item;
+            
+            private TagV2GrayRuleItemBuilder() {
+                item = new TagV2GrayRuleItem(null);
+            }
+            
+            public TagV2GrayRuleItemBuilder key(String key) {
+                item.key = key;
+                return this;
+            }
+            
+            public TagV2GrayRuleItem build() {
+                return item;
+            }
+        }
+    }
+    
+    /**
+     * tag v2 gray rule joint.
+     *
+     * @author rong
+     */
+    public enum TagV2GrayRuleJoint {
+        
+        /**
+         * and.
+         */
+        AND("&&", "AND"),
+        
+        /**
+         * or.
+         */
+        OR("||", "OR"),
+        
+        /**
+         * and regexp.
+         */
+        AND_REGEXP("&&", "AND_REGEXP"),
+        
+        /**
+         * or regexp.
+         */
+        OR_REGEXP("\\|\\|", "OR_REGEXP");
+        
+        public final String expression;
+        
+        public final String name;
+        
+        TagV2GrayRuleJoint(String expression, String name) {
+            this.expression = expression;
+            this.name = name;
+        }
+        
+        public String getExpression() {
+            return expression;
+        }
+        
+        public String getName() {
+            return name;
+        }
+    }
+    
+    /**
+     * tag v2 gray rule operator.
+     *
+     * @author rong
+     */
+    public enum TagV2GrayRuleOperator {
+        
+        /**
+         * in.
+         */
+        IN("in", "IN"),
+        
+        /**
+         * not in.
+         */
+        NOT_IN("not in", "NOT_IN"),
+        
+        /**
+         * exist.
+         */
+        EXIST("exist", "EXIST"),
+        
+        /**
+         * not exist.
+         */
+        NOT_EXIST("not exist", "NOT_EXIST");
+        
+        public final String expression;
+        
+        public final String name;
+        
+        TagV2GrayRuleOperator(String expression, String name) {
+            this.expression = expression;
+            this.name = name;
+        }
+    }
+}

--- a/config/src/main/java/com/alibaba/nacos/config/server/model/gray/singletag/SingleTagMatchGrayRule.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/gray/singletag/SingleTagMatchGrayRule.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 1999-2023 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model.gray.singletag;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.config.server.model.gray.AbstractTagMatchGrayRule;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.alibaba.nacos.api.common.Constants.TAG_V2;
+
+/**
+ * Single tag match gray rule.单标签匹配规则.
+ *
+ * @author shiyiyue
+ */
+public class SingleTagMatchGrayRule extends AbstractTagMatchGrayRule {
+    
+    private String tagKey;
+    
+    private Set<String> tagValueSet;
+    
+    private static final int KEY_VALUE_ARRAY_LENGTH = 2;
+    
+    private static final String EXPRESSION_PATTERN =
+        "^\\s*" + KEY_PATTERN + "\\s*" + EQUAL_PATTERN + "\\s*" + VALUE_PATTERN + "\\s*$";
+    
+    public SingleTagMatchGrayRule() {
+        super();
+    }
+    
+    public SingleTagMatchGrayRule(String rawGrayRuleExp, int priority) {
+        super(rawGrayRuleExp, priority);
+    }
+    
+    /**
+     * parse rule, accept key=value1,value2,value3.
+     *
+     * @param rawRule raw rule
+     */
+    @Override
+    protected void parse(String rawRule) throws NacosException {
+        this.isPatternMatch(rawRule, EXPRESSION_PATTERN);
+        String[] keyValueArray = rawRule.trim().split(EQUAL_PATTERN);
+        if (keyValueArray.length != KEY_VALUE_ARRAY_LENGTH) {
+            throw new NacosException(NacosException.INVALID_PARAM, String.format(
+                "gray rule parse failed: raw rule[%s] doesn't match pattern[%s].",
+                rawRule, KEY_PATTERN + EQUAL_PATTERN + VALUE_PATTERN));
+        }
+        isPatternMatch(keyValueArray[0].trim(), KEY_PATTERN);
+        isPatternMatch(keyValueArray[1].trim(), VALUE_PATTERN);
+        this.tagKey = keyValueArray[0].trim();
+        this.tagValueSet = Arrays.stream(keyValueArray[1].trim().split(VALUE_SPLITER_PATTERN))
+            .map(String::trim).filter(StringUtils::isNotBlank).collect(Collectors.toSet());
+    }
+    
+    @Override
+    public boolean match(Map<String, String> labels) {
+        if (labels.containsKey(tagKey) && tagValueSet.contains(labels.get(tagKey))) {
+            return true;
+        }
+        return false;
+    }
+    
+    public static final String TYPE_TAGV2 = TAG_V2;
+    
+    public static final String VERSION_1_0_0 = "1.0.0";
+    
+    @Override
+    public String getType() {
+        return TYPE_TAGV2;
+    }
+    
+    @Override
+    public String getVersion() {
+        return VERSION_1_0_0;
+    }
+}

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigOperationService.java
@@ -199,7 +199,7 @@ public class ConfigOperationService {
      * @throws NacosException NacosException.
      * @date 2024/2/5
      */
-    private Boolean publishConfigGray(String grayType, ConfigForm configForm,
+    public Boolean publishConfigGray(String grayType, ConfigForm configForm,
         ConfigRequestInfo configRequestInfo)
         throws NacosException {
         configForm

--- a/config/src/main/resources/META-INF/services/com.alibaba.nacos.config.server.model.gray.GrayRule
+++ b/config/src/main/resources/META-INF/services/com.alibaba.nacos.config.server.model.gray.GrayRule
@@ -18,3 +18,5 @@
 
 com.alibaba.nacos.config.server.model.gray.BetaGrayRule
 com.alibaba.nacos.config.server.model.gray.TagGrayRule
+com.alibaba.nacos.config.server.model.gray.singletag.SingleTagMatchGrayRule
+com.alibaba.nacos.config.server.model.gray.multitag.MultiTagMatchGrayRule

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigControllerV3Test.java
@@ -30,6 +30,7 @@ import com.alibaba.nacos.config.server.model.ConfigAllInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfo;
 import com.alibaba.nacos.config.server.model.ConfigInfoGrayWrapper;
 import com.alibaba.nacos.config.server.model.ConfigMetadata;
+import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
 import com.alibaba.nacos.config.server.model.event.ConfigDataChangeEvent;
 import com.alibaba.nacos.config.server.service.ConfigDetailService;
 import com.alibaba.nacos.config.server.service.ConfigMigrateService;
@@ -48,6 +49,7 @@ import jakarta.servlet.ServletContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -372,6 +374,81 @@ class ConfigControllerV3Test {
             "{\"type\":\"beta\",\"version\":\"1.0.0\",\"expr\":\"127.0.0.1,127.0.0.2\",\"priority\":-1000}",
             resConfigInfoBetaWrapper.getGrayRule());
         
+    }
+    
+    @Test
+    void testPublishGray() throws Exception {
+        when(configOperationService.publishConfigGray(anyString(), any(), any())).thenReturn(true);
+        MockHttpServletRequestBuilder builder =
+            MockMvcRequestBuilders.post(Constants.CONFIG_ADMIN_V3_PATH + "/gray")
+                .param("dataId", "test").param("groupName", "test").param("namespaceId", "")
+                .param("content", "gray")
+                .param("grayName", "tagv2_gray").param("grayType", "tagv2")
+                .param("grayMatchRuleExp", "region=hz&&env=prod").param("grayVersion", "1.1.0")
+                .param("grayPriority", "1").param("type", "");
+        
+        String actualValue =
+            mockmvc.perform(builder).andReturn().getResponse().getContentAsString();
+        String code = JacksonUtils.toObj(actualValue).get("code").toString();
+        String data = JacksonUtils.toObj(actualValue).get("data").toString();
+        
+        assertEquals("0", code);
+        assertEquals("true", data);
+        ArgumentCaptor<ConfigRequestInfo> requestInfoCaptor =
+            ArgumentCaptor.forClass(ConfigRequestInfo.class);
+        Mockito.verify(configOperationService).publishConfigGray(eq("tagv2"), any(),
+            requestInfoCaptor.capture());
+        assertEquals(Constants.HTTP, requestInfoCaptor.getValue().getSrcType());
+    }
+    
+    @Test
+    void testQueryGray() throws Exception {
+        ConfigInfoGrayWrapper configInfoGrayWrapper = new ConfigInfoGrayWrapper();
+        configInfoGrayWrapper.setDataId("test");
+        configInfoGrayWrapper.setGroup("test");
+        configInfoGrayWrapper.setContent("gray");
+        configInfoGrayWrapper.setGrayName("tagv2_gray");
+        configInfoGrayWrapper.setGrayRule(
+            "{\"type\":\"tagv2\",\"version\":\"1.1.0\",\"expr\":\"region=hz&&env=prod\",\"priority\":1}");
+        when(configInfoGrayPersistService.findConfigInfo4Gray("test", "test", "public",
+            "tagv2_gray")).thenReturn(
+                configInfoGrayWrapper);
+        
+        MockHttpServletRequestBuilder builder =
+            MockMvcRequestBuilders.get(Constants.CONFIG_ADMIN_V3_PATH + "/gray")
+                .param("dataId", "test").param("groupName", "test").param("namespaceId", "")
+                .param("grayName", "tagv2_gray");
+        
+        String actualValue =
+            mockmvc.perform(builder).andReturn().getResponse().getContentAsString();
+        String code = JacksonUtils.toObj(actualValue).get("code").toString();
+        String data = JacksonUtils.toObj(actualValue).get("data").toString();
+        ConfigGrayInfo result = JacksonUtils.toObj(data, ConfigGrayInfo.class);
+        
+        assertEquals("0", code);
+        assertEquals(configInfoGrayWrapper.getDataId(), result.getDataId());
+        assertEquals(configInfoGrayWrapper.getGroup(), result.getGroupName());
+        assertEquals(configInfoGrayWrapper.getContent(), result.getContent());
+        assertEquals(configInfoGrayWrapper.getGrayName(), result.getGrayName());
+    }
+    
+    @Test
+    void testStopGray() throws Exception {
+        when(configOperationService.deleteConfig(anyString(), anyString(), anyString(), anyString(),
+            any(), any(),
+            any())).thenReturn(true);
+        MockHttpServletRequestBuilder builder =
+            MockMvcRequestBuilders.delete(Constants.CONFIG_ADMIN_V3_PATH + "/gray")
+                .param("dataId", "test").param("groupName", "test").param("namespaceId", "")
+                .param("grayName", "tagv2_gray");
+        
+        String actualValue =
+            mockmvc.perform(builder).andReturn().getResponse().getContentAsString();
+        String code = JacksonUtils.toObj(actualValue).get("code").toString();
+        String data = JacksonUtils.toObj(actualValue).get("data").toString();
+        
+        assertEquals("0", code);
+        assertEquals("true", data);
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/gray/GrayRuleManagerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/gray/GrayRuleManagerTest.java
@@ -17,13 +17,17 @@
 package com.alibaba.nacos.config.server.model.gray;
 
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.config.server.model.gray.multitag.MultiTagMatchGrayRule;
+import com.alibaba.nacos.config.server.model.gray.singletag.SingleTagMatchGrayRule;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.Map;
 
+import static com.alibaba.nacos.api.common.Constants.TAG_V2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -52,6 +56,24 @@ class GrayRuleManagerTest {
         assertNotNull(rule);
         assertTrue(rule instanceof TagGrayRule);
         assertEquals("myTag", rule.getRawGrayRuleExp());
+    }
+    
+    @Test
+    void constructSingleTagV2RuleBySpi() {
+        ConfigGrayPersistInfo persistInfo = new ConfigGrayPersistInfo(TAG_V2,
+            SingleTagMatchGrayRule.VERSION_1_0_0, "region=hz", 1);
+        
+        assertInstanceOf(SingleTagMatchGrayRule.class,
+            GrayRuleManager.constructGrayRule(persistInfo));
+    }
+    
+    @Test
+    void constructMultiTagV2RuleBySpi() {
+        ConfigGrayPersistInfo persistInfo = new ConfigGrayPersistInfo(TAG_V2,
+            MultiTagMatchGrayRule.VERSION_1_1_0, "region=hz&&env=prod", 1);
+        
+        assertInstanceOf(MultiTagMatchGrayRule.class,
+            GrayRuleManager.constructGrayRule(persistInfo));
     }
     
     @Test

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/gray/multitag/MultiTagMatchGrayRuleTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/gray/multitag/MultiTagMatchGrayRuleTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model.gray.multitag;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MultiTagMatchGrayRuleTest {
+    
+    @Test
+    void matchWithAndExpression() {
+        MultiTagMatchGrayRule rule = new MultiTagMatchGrayRule("region=hz&&env=prod", 1);
+        Map<String, String> labels = new HashMap<>();
+        labels.put("region", "hz");
+        labels.put("env", "prod");
+        
+        assertTrue(rule.isValid());
+        assertTrue(rule.match(labels));
+    }
+    
+    @Test
+    void matchWithOrExpressionAndMultiValues() {
+        MultiTagMatchGrayRule rule =
+            new MultiTagMatchGrayRule("region=hz&&env=prod,pre||tenant=vip", 1);
+        Map<String, String> labels = new HashMap<>();
+        labels.put("tenant", "vip");
+        
+        assertTrue(rule.match(labels));
+        
+        labels.clear();
+        labels.put("region", "hz");
+        labels.put("env", "pre");
+        assertTrue(rule.match(labels));
+    }
+    
+    @Test
+    void notMatchWhenAndExpressionMissesOneLabel() {
+        MultiTagMatchGrayRule rule = new MultiTagMatchGrayRule("region=hz&&env=prod", 1);
+        Map<String, String> labels = new HashMap<>();
+        labels.put("region", "hz");
+        
+        assertFalse(rule.match(labels));
+    }
+    
+    @Test
+    void invalidWhenSameKeyAppearsInOneAndExpression() {
+        MultiTagMatchGrayRule rule = new MultiTagMatchGrayRule("region=hz&&region=sh", 1);
+        
+        assertFalse(rule.isValid());
+    }
+    
+    @Test
+    void equalRuleItemsHaveSameHashCode() {
+        MultiTagMatchGrayRule.TagV2GrayRuleItem item =
+            new MultiTagMatchGrayRule.TagV2GrayRuleItem("region",
+                new HashSet<>(Arrays.asList("hz", "sh")));
+        MultiTagMatchGrayRule.TagV2GrayRuleItem sameItem =
+            new MultiTagMatchGrayRule.TagV2GrayRuleItem("region",
+                new HashSet<>(Arrays.asList("sh", "hz")));
+        
+        assertEquals(item, sameItem);
+        assertEquals(item.hashCode(), sameItem.hashCode());
+    }
+}

--- a/config/src/test/java/com/alibaba/nacos/config/server/model/gray/singletag/SingleTagMatchGrayRuleTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/model/gray/singletag/SingleTagMatchGrayRuleTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.model.gray.singletag;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SingleTagMatchGrayRuleTest {
+    
+    @Test
+    void matchWhenLabelValueInRuleValues() {
+        SingleTagMatchGrayRule rule = new SingleTagMatchGrayRule("region=hz,sh", 1);
+        Map<String, String> labels = new HashMap<>();
+        labels.put("region", "hz");
+        
+        assertTrue(rule.isValid());
+        assertTrue(rule.match(labels));
+    }
+    
+    @Test
+    void notMatchWhenLabelMissingOrValueNotInRuleValues() {
+        SingleTagMatchGrayRule rule = new SingleTagMatchGrayRule("region=hz,sh", 1);
+        Map<String, String> labels = new HashMap<>();
+        labels.put("region", "bj");
+        
+        assertFalse(rule.match(labels));
+        assertFalse(rule.match(new HashMap<>()));
+    }
+    
+    @Test
+    void invalidWhenExpressionFormatInvalid() {
+        SingleTagMatchGrayRule rule = new SingleTagMatchGrayRule("region==hz", 1);
+        
+        assertFalse(rule.isValid());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Closes #14695.

This PR syncs the existing internal Nacos tagv2 gray rule implementation into the open-source config module, so the open-source and internal branches keep the same gray rule model and behavior.

This change keeps the query path compatible with the current open-source request model. It does not add HTTP request label query support in this PR; SDK/gRPC labels continue to flow through the existing connection labels path.

## Brief changelog

- Add tagv2 single-tag and multi-tag `GrayRule` implementations with SPI registration.
- Expose v3 admin gray config APIs for publish, query and delete.
- Reuse `ConfigOperationService.publishConfigGray` from the v3 admin controller.
- Add unit tests for tagv2 rule matching, SPI construction and v3 gray admin endpoints.

## Verifying this change

- `./mvnw -pl config -am -Dtest=SingleTagMatchGrayRuleTest,MultiTagMatchGrayRuleTest,GrayRuleManagerTest,ConfigControllerV3Test -Dsurefire.failIfNoSpecifiedTests=false test`
