### PR TITLE
fix(logging): bind Logger to the declaring class in four places

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/ReleaseMcpServerRequestHandler.java
@@ -55,7 +55,8 @@ import org.springframework.stereotype.Component;
 public class ReleaseMcpServerRequestHandler
     extends RequestHandler<ReleaseMcpServerRequest, ReleaseMcpServerResponse> {
     
-    private static final Logger LOGGER = LoggerFactory.getLogger(ReleaseMcpServerRequest.class);
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(ReleaseMcpServerRequestHandler.class);
     
     private final McpServerOperationService mcpServerOperationService;
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentRequestUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentRequestUtil.java
@@ -44,7 +44,7 @@ import java.util.Objects;
  */
 public class AgentRequestUtil {
     
-    private static final Logger LOGGER = LoggerFactory.getLogger(McpRequestUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AgentRequestUtil.class);
     
     /**
      * Parse Agent card request form to {@link AgentCard}.

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigFuzzyWatchGroupKeyHolder.java
@@ -72,7 +72,7 @@ import static com.alibaba.nacos.api.model.v2.ErrorCode.FUZZY_WATCH_PATTERN_OVER_
  */
 public class ConfigFuzzyWatchGroupKeyHolder extends SmartSubscriber implements Closeable {
     
-    private static final Logger LOGGER = LogUtils.logger(ClientWorker.class);
+    private static final Logger LOGGER = LogUtils.logger(ConfigFuzzyWatchGroupKeyHolder.class);
     
     private final ClientWorker.ConfigRpcTransportClient agent;
     

--- a/config/src/main/java/com/alibaba/nacos/config/server/model/ConfigCachePostProcessorDelegate.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/model/ConfigCachePostProcessorDelegate.java
@@ -31,7 +31,8 @@ import java.util.Collection;
  */
 public class ConfigCachePostProcessorDelegate {
     
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigCacheFactoryDelegate.class);
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(ConfigCachePostProcessorDelegate.class);
     
     private static ConfigCachePostProcessorDelegate instance =
         new ConfigCachePostProcessorDelegate();


### PR DESCRIPTION
## What is the purpose of the change

Four classes initialize their static `LOGGER` with a **different** class token than the class they are declared in. SLF4J/Logback derive the logger name from that token, so these classes log under the *wrong* logger name. The practical impact:

- Operators filtering logs or tuning log levels **by logger name** hit the wrong target (e.g. raising `ConfigFuzzyWatchGroupKeyHolder` to DEBUG actually has no effect — you'd have to touch `ClientWorker`).
- The logger name shown in each log line misattributes the source, misleading diagnosis.

| Class | Bound to (wrong) | Evidence |
|---|---|---|
| `client/.../ConfigFuzzyWatchGroupKeyHolder` | `ClientWorker.class` | 🔑 its symmetric sibling `NamingFuzzyWatchServiceListHolder` already binds to its own class |
| `ai/.../AgentRequestUtil` | `McpRequestUtil.class` | the sibling util in the same package it was copied from |
| `ai/.../ReleaseMcpServerRequestHandler` | `ReleaseMcpServerRequest.class` | the request DTO it handles, not the handler |
| `config/.../ConfigCachePostProcessorDelegate` | `ConfigCacheFactoryDelegate.class` | the neighboring delegate |

Each now binds to its own declaring class.

### Deliberately left unchanged

`common/.../DefaultPublisher` binds to `NotifyCenter.class` **on purpose** — it is the shared base publisher, its `LOGGER` is `protected` and inherited by `DefaultSharePublisher`, and the log lines use a `[NotifyCenter]` prefix. The whole notify subsystem intentionally logs under one name, so it is not touched.

## Brief changelog

- `ConfigFuzzyWatchGroupKeyHolder` — `LogUtils.logger(...)` now uses `ConfigFuzzyWatchGroupKeyHolder.class`
- `AgentRequestUtil` — `LoggerFactory.getLogger(...)` now uses `AgentRequestUtil.class`
- `ReleaseMcpServerRequestHandler` — now uses `ReleaseMcpServerRequestHandler.class`
- `ConfigCachePostProcessorDelegate` — now uses `ConfigCachePostProcessorDelegate.class`

## Verifying this change

This is a diagnostics-only change with no behavior impact (same nature as #15179 / #15194), so no unit test is added — the only observable difference is the logger name each class reports.

```
mvn -pl client,ai,config -am -B clean compile spotbugs:check checkstyle:check apache-rat:check spotless:check -DskipTests   # passes
```

Follow this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a Github issue filed for the change (usually before you start working on it).
- [x] Format the pull request title like `[ISSUE #123] ...`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction. (Diagnostics-only logger-name fix with no behavior change; no new branch to cover.)
- [x] Run `mvn -B clean package apache-rat:check checkstyle:check spotbugs:check -DskipTests` to make sure basic checks pass.