### PR TITLE
[ISSUE #14992] Add v3 naming APIs to DistroFilter

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/web/NamingConfig.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/web/NamingConfig.java
@@ -37,6 +37,8 @@ public class NamingConfig {
     
     private static final String URL_PATTERNS_V2 = "/v2/ns/*";
     
+    private static final String URL_PATTERNS_V3_CLIENT = "/v3/client/ns/*";
+    private static final String URL_PATTERNS_V3_ADMIN = "/v3/admin/ns/*";
     private static final String DISTRO_FILTER = "distroFilter";
     
     private static final String SERVICE_NAME_FILTER = "serviceNameFilter";
@@ -60,7 +62,7 @@ public class NamingConfig {
     public FilterRegistrationBean<DistroFilter> distroFilterRegistration() {
         FilterRegistrationBean<DistroFilter> registration = new FilterRegistrationBean<>();
         registration.setFilter(distroFilter());
-        registration.addUrlPatterns(URL_PATTERNS);
+        registration.addUrlPatterns(URL_PATTERNS, URL_PATTERNS_V3_CLIENT, URL_PATTERNS_V3_ADMIN);
         registration.setName(DISTRO_FILTER);
         registration.setOrder(7);
         return registration;

--- a/naming/src/test/java/com/alibaba/nacos/naming/web/NamingConfigTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/web/NamingConfigTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -54,8 +55,10 @@ class NamingConfigTest {
         assertInstanceOf(DistroFilter.class, registration.getFilter());
         assertEquals("distroFilter", registration.getFilterName());
         assertEquals(7, registration.getOrder());
-        assertEquals(1, registration.getUrlPatterns().size());
-        assertEquals("/v1/ns/*", registration.getUrlPatterns().iterator().next());
+        assertEquals(3, registration.getUrlPatterns().size());
+        assertTrue(registration.getUrlPatterns().contains("/v1/ns/*"));
+        assertTrue(registration.getUrlPatterns().contains("/v3/client/ns/*"));
+        assertTrue(registration.getUrlPatterns().contains("/v3/admin/ns/*"));
     }
     
     @Test


### PR DESCRIPTION
## Summary

- register DistroFilter for v3 client naming APIs
- register DistroFilter for v3 admin naming APIs that already use @CanDistro
- keep the fix limited to filter URL patterns and NamingConfig test coverage

## Testing

- mvn -pl naming spotless:check
- mvn -pl naming -am -Dtest=NamingConfigTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test
- git diff --check -- naming/src/main/java/com/alibaba/nacos/naming/web/NamingConfig.java naming/src/test/java/com/alibaba/nacos/naming/web/NamingConfigTest.java

Fixes #14992