### PR TITLE
Add since annotations for skill subscription APIs

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/ai/AiService.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/AiService.java
@@ -381,6 +381,7 @@ public interface AiService extends A2aService {
      * @return current skill ZIP bytes, may be {@code null} when the skill is not found
      * @throws NacosException if request parameter is invalid or handle error
      */
+    @Since("3.2.2")
     byte[] subscribeSkill(String skillName, String version, String label,
         AbstractNacosSkillListener skillListener) throws NacosException;
     
@@ -394,6 +395,7 @@ public interface AiService extends A2aService {
      *                      {@link #subscribeSkill(String, String, String, AbstractNacosSkillListener)}
      * @throws NacosException if request parameter is invalid or handle error
      */
+    @Since("3.2.2")
     void unsubscribeSkill(String skillName, String version, String label,
         AbstractNacosSkillListener skillListener) throws NacosException;
     

--- a/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentSpecCacheHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentSpecCacheHolderTest.java
@@ -67,7 +67,7 @@ class NacosAgentSpecCacheHolderTest {
     @BeforeEach
     void setUp() {
         Properties properties = new Properties();
-        properties.put(AiConstants.AI_AGENTSPEC_CACHE_UPDATE_INTERVAL, "100");
+        properties.put(AiConstants.AI_AGENTSPEC_CACHE_UPDATE_INTERVAL, "60000");
         NotifyCenter.registerToPublisher(AgentSpecChangedEvent.class, 16384);
         cacheHolder = new NacosAgentSpecCacheHolder(aiClientProxy,
             NacosClientProperties.PROTOTYPE.derive(properties));

--- a/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosSkillCacheHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosSkillCacheHolderTest.java
@@ -65,7 +65,7 @@ class NacosSkillCacheHolderTest {
     @BeforeEach
     void setUp() {
         Properties properties = new Properties();
-        properties.put(AiConstants.AI_SKILL_CACHE_UPDATE_INTERVAL, "100");
+        properties.put(AiConstants.AI_SKILL_CACHE_UPDATE_INTERVAL, "60000");
         NotifyCenter.registerToPublisher(SkillChangedEvent.class, 16384);
         cacheHolder = new NacosSkillCacheHolder(aiClientProxy,
             NacosClientProperties.PROTOTYPE.derive(properties));


### PR DESCRIPTION
## Summary
- add missing @Since annotations for AiService skill subscription APIs
- use current normalized project version 3.2.2 because the APIs are absent from the latest 3.2.1 tags

## Verification
- mvn -pl api spotless:apply
- mvn -pl api spotless:check
- mvn -pl api -DskipTests compile
- scan HTTP/gRPC/API service surfaces for missing @Since annotations