### PR TITLE
[ISSUE #15087] Upgrade safe dependencies and enable default AI importers

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
@@ -388,6 +388,7 @@ public class ConsoleConfigController {
      * @return Result containing a map of the clone status.
      * @throws NacosException If a Nacos-specific error occurs.
      */
+    @Since("3.0.0")
     @PostMapping("/clone")
     @Secured(action = ActionTypes.WRITE, signType = SignType.CONFIG, apiType = ApiType.CONSOLE_API,
         tags = {

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -391,12 +391,12 @@ nacos.istio.mcp.server.enabled=false
 # Optional: allow legacy MCP import APIs to fetch user-provided URLs when reopened.
 #nacos.ai.resource.import.allow-user-url=false
 # Optional: enable the built-in official MCP registry import source. Source id: mcp-official.
-#nacos.plugin.ai.importer.mcp.official.enabled=true
+nacos.plugin.ai.importer.mcp.official.enabled=true
 # Optional: enable the built-in Skill well-known import source. Configure the registry root URL first.
 #nacos.plugin.ai.importer.skills.well-known.enabled=true
 #nacos.plugin.ai.importer.skills.well-known.url=https://developers.cloudflare.com
 # Optional: enable the built-in skills.sh import source. Source id: skills-sh.
-#nacos.plugin.ai.importer.skills.skills-sh.enabled=true
+nacos.plugin.ai.importer.skills.skills-sh.enabled=true
 # Optional: allow non-HTTPS or private-network endpoints only for controlled deployments.
 #nacos.plugin.ai.importer.<preset>.allow-http=false
 #nacos.plugin.ai.importer.<preset>.allow-private-network=false

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProvider.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProvider.java
@@ -87,7 +87,7 @@ public class DefaultAiResourceImportSourceProvider implements AiResourceImportSo
     }
     
     private AiResourceImportSource loadOfficialMcpSource(Properties properties) {
-        if (!getBoolean(properties, MCP_OFFICIAL_PREFIX + "enabled", false)) {
+        if (!getBoolean(properties, MCP_OFFICIAL_PREFIX + "enabled", true)) {
             return null;
         }
         AiResourceImportSource result = new AiResourceImportSource();
@@ -133,7 +133,7 @@ public class DefaultAiResourceImportSourceProvider implements AiResourceImportSo
     }
     
     private AiResourceImportSource loadSkillsShSource(Properties properties) {
-        if (!getBoolean(properties, SKILLS_SH_PREFIX + "enabled", false)) {
+        if (!getBoolean(properties, SKILLS_SH_PREFIX + "enabled", true)) {
             return null;
         }
         AiResourceImportSource result = new AiResourceImportSource();

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProviderTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportSourceProviderTest.java
@@ -40,9 +40,22 @@ class DefaultAiResourceImportSourceProviderTest {
         new DefaultAiResourceImportSourceProvider();
     
     @Test
+    void testLoadDefaultEnabledSources() throws Exception {
+        List<AiResourceImportSource> sources = toList(provider.loadSources(new Properties()));
+        
+        assertEquals(2, sources.size());
+        assertEquals("mcp-official", sources.get(0).getSourceId());
+        assertEquals(McpRegistryImportServiceBuilder.IMPORTER_TYPE,
+            sources.get(0).getPluginName());
+        assertEquals("skills-sh", sources.get(1).getSourceId());
+        assertEquals(SkillsShImportServiceBuilder.IMPORTER_TYPE, sources.get(1).getPluginName());
+    }
+    
+    @Test
     void testLoadOfficialMcpSourceWithDefaultEndpoint() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("nacos.plugin.ai.importer.mcp.official.enabled", "true");
+        properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "false");
         
         List<AiResourceImportSource> sources = toList(provider.loadSources(properties));
         
@@ -60,6 +73,8 @@ class DefaultAiResourceImportSourceProviderTest {
     @Test
     void testLoadSkillWellKnownSourceFromUrl() throws Exception {
         Properties properties = new Properties();
+        properties.setProperty("nacos.plugin.ai.importer.mcp.official.enabled", "false");
+        properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "false");
         properties.setProperty("nacos.plugin.ai.importer.skills.well-known.enabled", "true");
         properties.setProperty("nacos.plugin.ai.importer.skills.well-known.url",
             "https://developers.cloudflare.com");
@@ -80,6 +95,8 @@ class DefaultAiResourceImportSourceProviderTest {
     @Test
     void testLoadSkillWellKnownRejectsMissingUrl() {
         Properties properties = new Properties();
+        properties.setProperty("nacos.plugin.ai.importer.mcp.official.enabled", "false");
+        properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "false");
         properties.setProperty("nacos.plugin.ai.importer.skills.well-known.enabled", "true");
         
         assertThrows(NacosException.class, () -> provider.loadSources(properties));
@@ -88,6 +105,7 @@ class DefaultAiResourceImportSourceProviderTest {
     @Test
     void testLoadSkillsShSourceWithDefaultEndpoint() throws Exception {
         Properties properties = new Properties();
+        properties.setProperty("nacos.plugin.ai.importer.mcp.official.enabled", "false");
         properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "true");
         
         List<AiResourceImportSource> sources = toList(provider.loadSources(properties));
@@ -105,6 +123,7 @@ class DefaultAiResourceImportSourceProviderTest {
     @Test
     void testLoadSourceSecurityOptions() throws Exception {
         Properties properties = new Properties();
+        properties.setProperty("nacos.plugin.ai.importer.mcp.official.enabled", "false");
         properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "true");
         properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.allow-http", "true");
         properties.setProperty("nacos.plugin.ai.importer.skills.skills-sh.allow-private-network",

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3.java
@@ -183,6 +183,7 @@ public class UserControllerV3 {
      * @throws IllegalArgumentException if user not exist or oldPassword is incorrect
      * @since 1.2.0
      */
+    @Since("3.0.0")
     @PutMapping
     @Secured(resource = AuthConstants.UPDATE_PASSWORD_ENTRY_POINT, action = ActionTypes.WRITE,
         tags = {

--- a/plugin-default-impl/nacos-oidc-auth-plugin/pom.xml
+++ b/plugin-default-impl/nacos-oidc-auth-plugin/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>9.37.3</version>
+            <version>9.37.4</version>
         </dependency>
 
         <!-- Caffeine for JWKS caching -->

--- a/pom.xml
+++ b/pom.xml
@@ -128,11 +128,11 @@
         
         <!-- dependency version -->
         <nacos.logback.adapter.version>1.1.4</nacos.logback.adapter.version>
-        <spring-boot-dependencies.version>3.5.13</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>3.5.14</spring-boot-dependencies.version>
         <commons-io.version>2.14.0</commons-io.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <slf4j-api.version>2.0.13</slf4j-api.version>
-        <logback.version>1.5.12</logback.version>
+        <logback.version>1.5.32</logback.version>
         <log4j.version>2.25.4</log4j.version>
         
         <mysql-connector-java.version>8.2.0</mysql-connector-java.version>
@@ -155,7 +155,7 @@
         <SnakeYaml.version>2.0</SnakeYaml.version>
         <kubernetes.client.version>22.0.0</kubernetes.client.version>
         <junit5.version>5.10.2</junit5.version>
-        <mcp.version>0.17.0</mcp.version>
+        <mcp.version>0.18.2</mcp.version>
         <ojdbc.version>19.7.0.0</ojdbc.version>
 
         <!-- Maven Central Portal -->
@@ -163,7 +163,7 @@
 
         <!-- Override micrometer version for Spring Boot 3.5.x compatibility,
              see https://github.com/alibaba/nacos/issues/15033 -->
-        <micrometer.version>1.15.10</micrometer.version>
+        <micrometer.version>1.15.11</micrometer.version>
         
         <!-- native -->
         <native-maven-plugin.version>0.10.2</native-maven-plugin.version>


### PR DESCRIPTION
## What is the purpose of the change

Fixes #15087.

This PR enables the built-in official MCP and skills.sh AI import sources by default, upgrades safe dependency patch versions, and fills missing v3 API @Since metadata.

## Brief changelog

- Enable official MCP and skills.sh AI import sources by default in code and application.properties.
- Upgrade Spring Boot 3.5.14, Logback 1.5.32, Micrometer 1.15.11, Nimbus JOSE JWT 9.37.4, and MCP SDK 0.18.2 to stay on the Jackson 2 line.
- Add missing @Since("3.0.0") annotations for console config clone and v3 user update APIs.

## Verifying this change

- mvn -pl plugin-default-impl/nacos-default-ai-importer-plugin spotless:apply spotless:check test -DskipITs
- mvn -pl console -DskipTests dependency:tree -Dincludes=tools.jackson.core,com.fasterxml.jackson.core,io.modelcontextprotocol.sdk
- mvn -pl console -am -DskipTests compile
- mvn -pl plugin-default-impl/nacos-oidc-auth-plugin -am -DskipTests compile
- mvn -pl console,plugin-default-impl/nacos-default-auth-plugin spotless:apply spotless:check -DskipTests
- mvn -pl console,plugin-default-impl/nacos-default-auth-plugin -am -DskipTests compile
- mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests