### PR TITLE
Fix console namespace switching and filter namespaces by auth

### DIFF
--- a/console-ui/src/components/NameSpaceList/NameSpaceList.js
+++ b/console-ui/src/components/NameSpaceList/NameSpaceList.js
@@ -33,6 +33,7 @@ class NameSpaceList extends React.Component {
     locale: PropTypes.object,
     setNowNameSpace: PropTypes.func,
     namespaceCallBack: PropTypes.func,
+    history: PropTypes.object,
     title: PropTypes.string,
   };
 
@@ -97,9 +98,24 @@ class NameSpaceList extends React.Component {
     window.nownamespace = ns;
     window.namespaceShowName = nsName;
     window.namespaceDesc = nsDesc;
+    this.syncHistoryNamespace(ns, nsName);
 
     this.calleeParent(true);
     this.props.setNowNameSpace && this.props.setNowNameSpace(nsName, ns, nsDesc);
+  }
+
+  syncHistoryNamespace(ns, nsName) {
+    const { history } = this.props;
+    if (!history || !history.location || !history.replace) {
+      return;
+    }
+    const params = new URLSearchParams(history.location.search);
+    params.set('namespace', ns || '');
+    params.set('namespaceShowName', nsName || '');
+    history.replace({
+      pathname: history.location.pathname,
+      search: `?${params.toString()}`,
+    });
   }
 
   changeName(...value) {

--- a/console-ui/src/components/RegionGroup/RegionGroup.js
+++ b/console-ui/src/components/RegionGroup/RegionGroup.js
@@ -18,17 +18,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import $ from 'jquery';
 import { Button } from '@alifd/next';
+import { withRouter } from 'react-router-dom';
 import NameSpaceList from '../NameSpaceList';
 import { setParams, request } from '../../globalLib';
 import PageTitle from '../PageTitle';
 
 import './index.scss';
 
+@withRouter
 class RegionGroup extends React.Component {
   static propTypes = {
     url: PropTypes.string,
     left: PropTypes.any,
     right: PropTypes.any,
+    history: PropTypes.object,
     namespaceCallBack: PropTypes.func,
     setNowNameSpace: PropTypes.func,
   };
@@ -317,6 +320,7 @@ class RegionGroup extends React.Component {
           {this.props.namespaceCallBack && (
             <NameSpaceList
               ref={this.nameSpaceList}
+              history={this.props.history}
               namespaceCallBack={this.props.namespaceCallBack}
               setNowNameSpace={this.props.setNowNameSpace}
             />

--- a/console/src/main/java/com/alibaba/nacos/console/proxy/core/NamespaceProxy.java
+++ b/console/src/main/java/com/alibaba/nacos/console/proxy/core/NamespaceProxy.java
@@ -17,13 +17,25 @@
 
 package com.alibaba.nacos.console.proxy.core;
 
+import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.exception.NacosException;
-import com.alibaba.nacos.console.handler.core.NamespaceHandler;
 import com.alibaba.nacos.api.model.response.Namespace;
+import com.alibaba.nacos.auth.config.NacosAuthConfigHolder;
+import com.alibaba.nacos.console.handler.core.NamespaceHandler;
+import com.alibaba.nacos.core.context.RequestContextHolder;
 import com.alibaba.nacos.core.namespace.model.form.NamespaceForm;
+import com.alibaba.nacos.plugin.auth.api.IdentityContext;
+import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import com.alibaba.nacos.plugin.auth.spi.server.AuthPluginManager;
+import com.alibaba.nacos.plugin.auth.spi.server.AuthPluginService;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Proxy class for handling namespace operations.
@@ -32,27 +44,67 @@ import java.util.List;
  */
 @Service
 public class NamespaceProxy {
-    
+
     private final NamespaceHandler namespaceHandler;
-    
+
     public NamespaceProxy(NamespaceHandler namespaceHandler) {
         this.namespaceHandler = namespaceHandler;
     }
-    
+
     /**
      * Get namespace list.
      */
     public List<Namespace> getNamespaceList() throws NacosException {
-        return namespaceHandler.getNamespaceList();
+        List<Namespace> namespaceList = namespaceHandler.getNamespaceList();
+        if (!NacosAuthConfigHolder.getInstance().isAnyAuthEnabled(ApiType.CONSOLE_API.name())) {
+            return namespaceList;
+        }
+        IdentityContext identityContext =
+            RequestContextHolder.getContext().getAuthContext().getIdentityContext();
+        if (identityContext == null) {
+            return namespaceList;
+        }
+        Optional<AuthPluginService> authService = AuthPluginManager.getInstance()
+            .findAuthServiceSpiImpl(NacosAuthConfigHolder.getInstance().getNacosAuthSystemType());
+        if (authService.isEmpty()) {
+            return namespaceList;
+        }
+        Optional<Collection<String>> authorizedNamespaceIds;
+        try {
+            authorizedNamespaceIds = authService.get()
+                .getAuthorizedNamespaceIds(identityContext, getNamespaceIds(namespaceList),
+                    ActionTypes.READ);
+        } catch (Exception ignored) {
+            return namespaceList;
+        }
+        if (authorizedNamespaceIds.isEmpty()) {
+            return namespaceList;
+        }
+        Set<String> authorizedNamespaceIdSet = new HashSet<>(authorizedNamespaceIds.get());
+        List<Namespace> authorizedNamespaces = new ArrayList<>();
+        for (Namespace namespace : namespaceList) {
+            if (authorizedNamespaceIdSet.contains(namespace.getNamespace())) {
+                authorizedNamespaces.add(namespace);
+            }
+        }
+        return authorizedNamespaces;
     }
-    
+
+    private List<String> getNamespaceIds(List<Namespace> namespaceList) {
+        List<String> namespaceIds = new ArrayList<>();
+        for (Namespace namespace : namespaceList) {
+            namespaceIds.add(namespace.getNamespace());
+        }
+        return namespaceIds;
+    }
+
     /**
      * Get the specific namespace information.
      */
     public Namespace getNamespaceDetail(String namespaceId) throws NacosException {
         return namespaceHandler.getNamespaceDetail(namespaceId);
     }
-    
+
     /**
      * Create or update namespace.
      */
@@ -60,21 +112,21 @@ public class NamespaceProxy {
         throws NacosException {
         return namespaceHandler.createNamespace(namespaceId, namespaceName, namespaceDesc);
     }
-    
+
     /**
      * Edit namespace.
      */
     public Boolean updateNamespace(NamespaceForm namespaceForm) throws NacosException {
         return namespaceHandler.updateNamespace(namespaceForm);
     }
-    
+
     /**
      * Delete namespace.
      */
     public Boolean deleteNamespace(String namespaceId) throws NacosException {
         return namespaceHandler.deleteNamespace(namespaceId);
     }
-    
+
     /**
      * Check if namespace exists.
      */

--- a/console/src/test/java/com/alibaba/nacos/console/proxy/core/NamespaceProxyTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/proxy/core/NamespaceProxyTest.java
@@ -16,116 +16,191 @@
 
 package com.alibaba.nacos.console.proxy.core;
 
+import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.response.Namespace;
+import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
+import com.alibaba.nacos.auth.config.NacosAuthConfig;
+import com.alibaba.nacos.auth.config.NacosAuthConfigHolder;
 import com.alibaba.nacos.console.handler.core.NamespaceHandler;
+import com.alibaba.nacos.core.context.RequestContextHolder;
 import com.alibaba.nacos.core.namespace.model.form.NamespaceForm;
+import com.alibaba.nacos.plugin.auth.api.IdentityContext;
+import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import com.alibaba.nacos.plugin.auth.spi.server.AuthPluginManager;
+import com.alibaba.nacos.plugin.auth.spi.server.AuthPluginService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class NamespaceProxyTest {
-    
+
     private static final String NAMESPACE_ID = "testNamespaceId";
-    
+
     private static final String NAMESPACE_NAME = "testNamespaceName";
-    
+
     private static final String NAMESPACE_DESC = "testNamespaceDesc";
-    
+
+    private static final String AUTH_TYPE = "testNamespaceAuth";
+
     @Mock
     private NamespaceHandler namespaceHandler;
-    
+
+    @Mock
+    private NacosAuthConfig nacosAuthConfig;
+
+    @Mock
+    private AuthPluginService authPluginService;
+
+    private Map<String, NacosAuthConfig> cachedConfigMap;
+
     private NamespaceProxy namespaceProxy;
-    
+
     @BeforeEach
     public void setUp() {
         namespaceProxy = new NamespaceProxy(namespaceHandler);
     }
-    
+
+    /**
+     * Clean up auth test context.
+     */
+    @AfterEach
+    public void tearDown() {
+        if (cachedConfigMap != null) {
+            ReflectionTestUtils.setField(NacosAuthConfigHolder.getInstance(),
+                "nacosAuthConfigMap", cachedConfigMap);
+        }
+        Map<String, AuthPluginService> authServiceMap =
+            (Map<String, AuthPluginService>) ReflectionTestUtils.getField(
+                AuthPluginManager.getInstance(), "authServiceMap");
+        authServiceMap.remove(AUTH_TYPE);
+        PluginStateCheckerHolder.setInstance(null);
+        RequestContextHolder.removeContext();
+    }
+
     @Test
     public void getNamespaceDetail() throws NacosException {
         String namespaceId = "testNamespaceId";
         Namespace expectedNamespace = new Namespace();
         expectedNamespace.setNamespace(namespaceId);
         expectedNamespace.setNamespaceShowName("Test Namespace");
-        
+
         when(namespaceHandler.getNamespaceDetail(namespaceId)).thenReturn(expectedNamespace);
-        
+
         Namespace actualNamespace = namespaceProxy.getNamespaceDetail(namespaceId);
-        
+
         assertEquals(expectedNamespace.getNamespace(), actualNamespace.getNamespace());
         assertEquals(expectedNamespace.getNamespaceShowName(),
             actualNamespace.getNamespaceShowName());
     }
-    
+
     @Test
     public void getNamespaceList() throws NacosException {
         List<Namespace> expectedNamespaces =
             Arrays.asList(new Namespace("namespace1", "Namespace 1"),
                 new Namespace("namespace2", "Namespace 2"));
         when(namespaceHandler.getNamespaceList()).thenReturn(expectedNamespaces);
-        
+
         List<Namespace> actualNamespaces = namespaceProxy.getNamespaceList();
-        
+
         assertEquals(expectedNamespaces, actualNamespaces);
     }
-    
+
+    @Test
+    public void getNamespaceListFilterUnauthorizedNamespace() throws NacosException {
+        enableConsoleAuth();
+        List<Namespace> expectedNamespaces =
+            Arrays.asList(new Namespace("namespace1", "Namespace 1"),
+                new Namespace("namespace2", "Namespace 2"));
+        IdentityContext identityContext = new IdentityContext();
+        RequestContextHolder.getContext().getAuthContext().setIdentityContext(identityContext);
+        when(namespaceHandler.getNamespaceList()).thenReturn(expectedNamespaces);
+        when(authPluginService.getAuthorizedNamespaceIds(eq(identityContext),
+            eq(Arrays.asList("namespace1", "namespace2")),
+            eq(ActionTypes.READ))).thenReturn(Optional.of(Set.of("namespace1")));
+
+        List<Namespace> actualNamespaces = namespaceProxy.getNamespaceList();
+
+        assertEquals(1, actualNamespaces.size());
+        assertEquals("namespace1", actualNamespaces.get(0).getNamespace());
+    }
+
     @Test
     public void createNamespace() throws NacosException {
         when(namespaceHandler.createNamespace(NAMESPACE_ID, NAMESPACE_NAME, NAMESPACE_DESC))
             .thenReturn(true);
-        
+
         Boolean result =
             namespaceProxy.createNamespace(NAMESPACE_ID, NAMESPACE_NAME, NAMESPACE_DESC);
-        
+
         assertTrue(result);
         verify(namespaceHandler, times(1)).createNamespace(NAMESPACE_ID, NAMESPACE_NAME,
             NAMESPACE_DESC);
     }
-    
+
     @Test
     public void updateNamespace() throws NacosException {
         NamespaceForm namespaceForm =
             new NamespaceForm("namespaceId", "namespaceName", "namespaceDesc");
         when(namespaceHandler.updateNamespace(namespaceForm)).thenReturn(true);
-        
+
         Boolean result = namespaceProxy.updateNamespace(namespaceForm);
-        
+
         assertTrue(result);
         verify(namespaceHandler, times(1)).updateNamespace(namespaceForm);
     }
-    
+
     @Test
     public void deleteNamespace() throws NacosException {
         String namespaceId = "testNamespaceId";
         when(namespaceHandler.deleteNamespace(namespaceId)).thenReturn(true);
-        
+
         Boolean result = namespaceProxy.deleteNamespace(namespaceId);
-        
+
         assertTrue(result);
         verify(namespaceHandler, times(1)).deleteNamespace(namespaceId);
     }
-    
+
     @Test
     public void checkNamespaceIdExist() throws NacosException {
         when(namespaceHandler.checkNamespaceIdExist(NAMESPACE_ID)).thenReturn(true);
-        
+
         Boolean result = namespaceProxy.checkNamespaceIdExist(NAMESPACE_ID);
-        
+
         assertTrue(result);
         verify(namespaceHandler, times(1)).checkNamespaceIdExist(NAMESPACE_ID);
     }
-    
+
+    private void enableConsoleAuth() {
+        cachedConfigMap = (Map<String, NacosAuthConfig>) ReflectionTestUtils.getField(
+            NacosAuthConfigHolder.getInstance(), "nacosAuthConfigMap");
+        when(nacosAuthConfig.isAuthEnabled()).thenReturn(true);
+        when(nacosAuthConfig.getNacosAuthSystemType()).thenReturn(AUTH_TYPE);
+        ReflectionTestUtils.setField(NacosAuthConfigHolder.getInstance(), "nacosAuthConfigMap",
+            Map.of(ApiType.CONSOLE_API.name(), nacosAuthConfig));
+        Map<String, AuthPluginService> authServiceMap =
+            (Map<String, AuthPluginService>) ReflectionTestUtils.getField(
+                AuthPluginManager.getInstance(), "authServiceMap");
+        authServiceMap.put(AUTH_TYPE, authPluginService);
+        PluginStateCheckerHolder.setInstance((pluginType, pluginName) -> true);
+    }
+
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthPluginService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthPluginService.java
@@ -30,6 +30,9 @@ import com.alibaba.nacos.plugin.auth.exception.AccessException;
 import com.alibaba.nacos.plugin.auth.impl.authenticate.IAuthenticationManager;
 import com.alibaba.nacos.plugin.auth.impl.configuration.AuthConfigs;
 import com.alibaba.nacos.plugin.auth.impl.constant.AuthConstants;
+import com.alibaba.nacos.plugin.auth.impl.persistence.PermissionInfo;
+import com.alibaba.nacos.plugin.auth.impl.persistence.RoleInfo;
+import com.alibaba.nacos.plugin.auth.impl.roles.NacosRoleService;
 import com.alibaba.nacos.plugin.auth.impl.users.NacosUser;
 import com.alibaba.nacos.plugin.auth.spi.server.AuthPluginService;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
@@ -38,11 +41,18 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
 
+import static com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
 import static com.alibaba.nacos.plugin.auth.constant.Constants.Identity.IDENTITY_ID;
+import static com.alibaba.nacos.plugin.auth.constant.Constants.Resource.SPLITTER;
 
 /**
  * Nacos default auth plugin service implementation.
@@ -50,11 +60,11 @@ import static com.alibaba.nacos.plugin.auth.constant.Constants.Identity.IDENTITY
  * @author xiweng.yy
  */
 public class NacosAuthPluginService implements AuthPluginService {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(NacosAuthPluginService.class);
-    
+
     private static final List<String> IDENTITY_NAMES = new LinkedList<String>() {
-        
+
         {
             add(AuthConstants.AUTHORIZATION_HEADER);
             add(Constants.ACCESS_TOKEN);
@@ -62,22 +72,24 @@ public class NacosAuthPluginService implements AuthPluginService {
             add(AuthConstants.PARAM_PASSWORD);
         }
     };
-    
+
     protected IAuthenticationManager authenticationManager;
-    
+
     private volatile AuthConfigs authConfigs;
-    
+
+    private volatile NacosRoleService roleService;
+
     @Override
     public Collection<String> identityNames() {
         return IDENTITY_NAMES;
     }
-    
+
     @Override
     public boolean enableAuth(ActionTypes action, String type) {
         // enable all of action and type
         return true;
     }
-    
+
     @Override
     public AuthResult validateIdentity(IdentityContext identityContext, Resource resource) {
         try {
@@ -94,7 +106,7 @@ public class NacosAuthPluginService implements AuthPluginService {
             return AuthResult.failureResult(HttpStatus.UNAUTHORIZED.value(), e.getErrMsg());
         }
     }
-    
+
     private boolean isAnonymousAllowed(Resource resource) {
         if (resource == null || resource.getProperties() == null) {
             return false;
@@ -110,13 +122,13 @@ public class NacosAuthPluginService implements AuthPluginService {
             return false;
         }
     }
-    
+
     private void checkAuthConfigs() {
         if (null == authConfigs) {
             authConfigs = ApplicationUtils.getBean(AuthConfigs.class);
         }
     }
-    
+
     private NacosUser validateUser(IdentityContext identityContext) throws AccessException {
         checkNacosAuthManager();
         String token = resolveToken(identityContext);
@@ -132,7 +144,7 @@ public class NacosAuthPluginService implements AuthPluginService {
         identityContext.setParameter(IDENTITY_ID, nacosUser.getUserName());
         return nacosUser;
     }
-    
+
     private String resolveToken(IdentityContext identityContext) {
         String bearerToken =
             identityContext.getParameter(AuthConstants.AUTHORIZATION_HEADER, StringUtils.EMPTY);
@@ -140,10 +152,10 @@ public class NacosAuthPluginService implements AuthPluginService {
             && bearerToken.startsWith(AuthConstants.TOKEN_PREFIX)) {
             return bearerToken.substring(AuthConstants.TOKEN_PREFIX.length());
         }
-        
+
         return identityContext.getParameter(Constants.ACCESS_TOKEN, StringUtils.EMPTY);
     }
-    
+
     @Override
     public AuthResult validateAuthority(IdentityContext identityContext, Permission permission) {
         try {
@@ -154,19 +166,102 @@ public class NacosAuthPluginService implements AuthPluginService {
             return AuthResult.failureResult(HttpStatus.FORBIDDEN.value(), e.getErrMsg());
         }
     }
-    
+
+    @Override
+    public Optional<Collection<String>> getAuthorizedNamespaceIds(
+        IdentityContext identityContext, Collection<String> namespaceIds, ActionTypes action) {
+        NacosUser user = (NacosUser) identityContext.getParameter(AuthConstants.NACOS_USER_KEY);
+        if (user == null) {
+            return Optional.empty();
+        }
+        checkNacosRoleService();
+        if (user.isGlobalAdmin() || roleService.hasGlobalAdminRole(user.getUserName())) {
+            user.setGlobalAdmin(true);
+            return Optional.empty();
+        }
+        List<RoleInfo> roles = roleService.getRoles(user.getUserName());
+        if (roles == null || roles.isEmpty()) {
+            return Optional.of(new HashSet<>());
+        }
+        List<PermissionInfo> permissionList = roleService.getPermissions(getRoleNames(roles));
+        if (permissionList == null || permissionList.isEmpty()) {
+            return Optional.of(new HashSet<>());
+        }
+        return Optional.of(getAuthorizedNamespaces(namespaceIds, new LinkedHashSet<>(permissionList),
+            action));
+    }
+
+    private List<String> getRoleNames(List<RoleInfo> roles) {
+        List<String> roleNames = new LinkedList<>();
+        for (RoleInfo role : roles) {
+            roleNames.add(role.getRole());
+        }
+        return roleNames;
+    }
+
+    private Set<String> getAuthorizedNamespaces(Collection<String> namespaceIds,
+        Set<PermissionInfo> permissions, ActionTypes action) {
+        Set<String> candidateNamespaces = new HashSet<>(namespaceIds);
+        Set<String> authorizedNamespaces = new HashSet<>();
+        for (PermissionInfo permission : permissions) {
+            if (permission == null || StringUtils.isBlank(permission.getAction())
+                || !permission.getAction().contains(action.toString())) {
+                continue;
+            }
+            String namespacePattern = getNamespacePattern(permission.getResource());
+            if (StringUtils.isBlank(namespacePattern)) {
+                continue;
+            }
+            if (candidateNamespaces.contains(namespacePattern)) {
+                authorizedNamespaces.add(namespacePattern);
+                continue;
+            }
+            if (namespacePattern.contains("*")) {
+                addFuzzyAuthorizedNamespaces(namespacePattern, candidateNamespaces,
+                    authorizedNamespaces);
+            }
+        }
+        return authorizedNamespaces;
+    }
+
+    private void addFuzzyAuthorizedNamespaces(String namespacePattern, Set<String> candidateNamespaces,
+        Set<String> authorizedNamespaces) {
+        String regex = namespacePattern.replaceAll("\\*", ".*");
+        for (String namespaceId : candidateNamespaces) {
+            if (Pattern.matches(regex, namespaceId)) {
+                authorizedNamespaces.add(namespaceId);
+            }
+        }
+    }
+
+    private String getNamespacePattern(String permissionResource) {
+        if (StringUtils.isBlank(permissionResource)) {
+            return null;
+        }
+        String resource = permissionResource;
+        if (resource.startsWith(SPLITTER)) {
+            resource = DEFAULT_NAMESPACE_ID + resource;
+        }
+        int namespaceEndIndex = resource.indexOf(SPLITTER);
+        if (namespaceEndIndex < 0) {
+            return null;
+        }
+        String namespacePattern = resource.substring(0, namespaceEndIndex);
+        return StringUtils.isBlank(namespacePattern) ? DEFAULT_NAMESPACE_ID : namespacePattern;
+    }
+
     @Override
     public String getAuthServiceName() {
         return AuthConstants.AUTH_PLUGIN_TYPE;
     }
-    
+
     @Override
     public boolean isLoginEnabled() {
         return NacosAuthConfigHolder.getInstance()
             .getNacosAuthConfigByScope(ApiType.CONSOLE_API.name())
             .isAuthEnabled();
     }
-    
+
     /**
      * Only auth enabled and not global admin role existed.
      *
@@ -182,10 +277,16 @@ public class NacosAuthPluginService implements AuthPluginService {
             ApplicationUtils.getBean(IAuthenticationManager.class).hasGlobalAdminRole();
         return authEnabled && !hasGlobalAdminRole;
     }
-    
+
     protected void checkNacosAuthManager() {
         if (null == authenticationManager) {
             authenticationManager = ApplicationUtils.getBean(IAuthenticationManager.class);
+        }
+    }
+
+    private void checkNacosRoleService() {
+        if (null == roleService) {
+            roleService = ApplicationUtils.getBean(NacosRoleService.class);
         }
     }
 }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/EmbeddedPermissionPersistServiceImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/EmbeddedPermissionPersistServiceImpl.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.persistence.repository.embedded.operate.DatabaseOperate
 import com.alibaba.nacos.plugin.auth.impl.persistence.embedded.AuthEmbeddedPaginationHelperImpl;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,25 +35,25 @@ import static com.alibaba.nacos.plugin.auth.impl.persistence.AuthRowMapperManage
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
 public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistService {
-    
+
     private final DatabaseOperate databaseOperate;
-    
+
     private static final String PATTERN_STR = "*";
-    
+
     private static final String SQL_DERBY_ESCAPE_BACK_SLASH_FOR_LIKE = " ESCAPE '\\' ";
-    
+
     public EmbeddedPermissionPersistServiceImpl(DatabaseOperate databaseOperate) {
         this.databaseOperate = databaseOperate;
     }
-    
+
     @Override
     public Page<PermissionInfo> getPermissions(String role, int pageNo, int pageSize) {
         AuthPaginationHelper<PermissionInfo> helper = createPaginationHelper();
-        
+
         String sqlCountRows = "SELECT count(*) FROM permissions WHERE ";
-        
+
         String sqlFetchRows = "SELECT role,resource,action FROM permissions WHERE ";
-        
+
         String where = " role= ? ";
         List<String> params = new ArrayList<>();
         if (StringUtils.isNotBlank(role)) {
@@ -60,11 +61,11 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
         } else {
             where = " 1=1 ";
         }
-        
+
         Page<PermissionInfo> pageInfo =
             helper.fetchPage(sqlCountRows + where, sqlFetchRows + where, params.toArray(),
                 pageNo, pageSize, PERMISSION_ROW_MAPPER);
-        
+
         if (pageInfo == null) {
             pageInfo = new Page<>();
             pageInfo.setTotalCount(0);
@@ -72,7 +73,17 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
         }
         return pageInfo;
     }
-    
+
+    @Override
+    public List<PermissionInfo> getPermissions(Collection<String> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String sql = "SELECT role,resource,action FROM permissions WHERE role IN ("
+            + String.join(",", Collections.nCopies(roles.size(), "?")) + ")";
+        return databaseOperate.queryMany(sql, roles.toArray(), PERMISSION_ROW_MAPPER);
+    }
+
     /**
      * Execute ddd user permission operation.
      *
@@ -86,7 +97,7 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
         EmbeddedStorageContextHolder.addSqlContext(sql, role, resource, action);
         databaseOperate.blockUpdate();
     }
-    
+
     /**
      * Execute delete user permission operation.
      *
@@ -100,15 +111,15 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
         EmbeddedStorageContextHolder.addSqlContext(sql, role, resource, action);
         databaseOperate.blockUpdate();
     }
-    
+
     @Override
     public Page<PermissionInfo> findPermissionsLike4Page(String role, int pageNo, int pageSize) {
         AuthPaginationHelper<PermissionInfo> helper = createPaginationHelper();
-        
+
         String sqlCountRows = "SELECT count(*) FROM permissions ";
-        
+
         String sqlFetchRows = "SELECT role,resource,action FROM permissions ";
-        
+
         StringBuilder where = new StringBuilder(" WHERE 1=1");
         List<String> params = new ArrayList<>();
         if (StringUtils.isNotBlank(role)) {
@@ -116,11 +127,11 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
             where.append(SQL_DERBY_ESCAPE_BACK_SLASH_FOR_LIKE);
             params.add(generateLikeArgument(role));
         }
-        
+
         Page<PermissionInfo> pageInfo =
             helper.fetchPage(sqlCountRows + where, sqlFetchRows + where, params.toArray(),
                 pageNo, pageSize, PERMISSION_ROW_MAPPER);
-        
+
         if (pageInfo == null) {
             pageInfo = new Page<>();
             pageInfo.setTotalCount(0);
@@ -128,7 +139,7 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
         }
         return pageInfo;
     }
-    
+
     @Override
     public String generateLikeArgument(String s) {
         String underscore = "_";
@@ -143,7 +154,7 @@ public class EmbeddedPermissionPersistServiceImpl implements PermissionPersistSe
             return s;
         }
     }
-    
+
     @Override
     public <E> AuthPaginationHelper<E> createPaginationHelper() {
         return new AuthEmbeddedPaginationHelperImpl<>(databaseOperate);

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/ExternalPermissionPersistServiceImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/ExternalPermissionPersistServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -39,29 +40,29 @@ import static com.alibaba.nacos.plugin.auth.impl.persistence.AuthRowMapperManage
  * @author <a href="mailto:liaochuntao@live.com">liaochuntao</a>
  */
 public class ExternalPermissionPersistServiceImpl implements PermissionPersistService {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger("com.alibaba.nacos.persistence");
-    
+
     private JdbcTemplate jt;
-    
+
     private String dataSourceType = "";
-    
+
     private static final String PATTERN_STR = "*";
-    
+
     @PostConstruct
     protected void init() {
         DataSourceService dataSource = DynamicDataSource.getInstance().getDataSource();
         jt = dataSource.getJdbcTemplate();
         dataSourceType = dataSource.getDataSourceType();
     }
-    
+
     @Override
     public Page<PermissionInfo> getPermissions(String role, int pageNo, int pageSize) {
         AuthPaginationHelper<PermissionInfo> helper = createPaginationHelper();
-        
+
         String sqlCountRows = "SELECT count(*) FROM permissions WHERE ";
         String sqlFetchRows = "SELECT role,resource,action FROM permissions WHERE ";
-        
+
         String where = " role= ? ";
         List<String> params = new ArrayList<>();
         if (StringUtils.isNotBlank(role)) {
@@ -69,26 +70,41 @@ public class ExternalPermissionPersistServiceImpl implements PermissionPersistSe
         } else {
             where = " 1=1 ";
         }
-        
+
         try {
             Page<PermissionInfo> pageInfo =
                 helper.fetchPage(sqlCountRows + where, sqlFetchRows + where,
                     params.toArray(), pageNo, pageSize, PERMISSION_ROW_MAPPER);
-            
+
             if (pageInfo == null) {
                 pageInfo = new Page<>();
                 pageInfo.setTotalCount(0);
                 pageInfo.setPageItems(new ArrayList<>());
             }
-            
+
             return pageInfo;
-            
+
         } catch (CannotGetJdbcConnectionException e) {
             LOGGER.error("[db-error] " + e.toString(), e);
             throw e;
         }
     }
-    
+
+    @Override
+    public List<PermissionInfo> getPermissions(Collection<String> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String sql = "SELECT role,resource,action FROM permissions WHERE role IN ("
+            + String.join(",", Collections.nCopies(roles.size(), "?")) + ")";
+        try {
+            return jt.query(sql, roles.toArray(), PERMISSION_ROW_MAPPER);
+        } catch (CannotGetJdbcConnectionException e) {
+            LOGGER.error("[db-error] " + e, e);
+            throw e;
+        }
+    }
+
     /**
      * Execute add permission operation.
      *
@@ -98,9 +114,9 @@ public class ExternalPermissionPersistServiceImpl implements PermissionPersistSe
      */
     @Override
     public void addPermission(String role, String resource, String action) {
-        
+
         String sql = "INSERT INTO permissions (role, resource, action) VALUES (?, ?, ?)";
-        
+
         try {
             jt.update(sql, role, resource, action);
         } catch (CannotGetJdbcConnectionException e) {
@@ -108,7 +124,7 @@ public class ExternalPermissionPersistServiceImpl implements PermissionPersistSe
             throw e;
         }
     }
-    
+
     /**
      * Execute delete permission operation.
      *
@@ -118,7 +134,7 @@ public class ExternalPermissionPersistServiceImpl implements PermissionPersistSe
      */
     @Override
     public void deletePermission(String role, String resource, String action) {
-        
+
         String sql = "DELETE FROM permissions WHERE role=? AND resource=? AND action=?";
         try {
             jt.update(sql, role, resource, action);
@@ -127,40 +143,40 @@ public class ExternalPermissionPersistServiceImpl implements PermissionPersistSe
             throw e;
         }
     }
-    
+
     @Override
     public Page<PermissionInfo> findPermissionsLike4Page(String role, int pageNo, int pageSize) {
         AuthPaginationHelper<PermissionInfo> helper = createPaginationHelper();
-        
+
         String sqlCountRows = "SELECT count(*) FROM permissions ";
         String sqlFetchRows = "SELECT role,resource,action FROM permissions ";
-        
+
         StringBuilder where = new StringBuilder(" WHERE 1=1");
         List<String> params = new ArrayList<>();
         if (StringUtils.isNotBlank(role)) {
             where.append(" AND role LIKE ?");
             params.add(generateLikeArgument(role));
         }
-        
+
         try {
             Page<PermissionInfo> pageInfo =
                 helper.fetchPage(sqlCountRows + where, sqlFetchRows + where,
                     params.toArray(), pageNo, pageSize, PERMISSION_ROW_MAPPER);
-            
+
             if (pageInfo == null) {
                 pageInfo = new Page<>();
                 pageInfo.setTotalCount(0);
                 pageInfo.setPageItems(new ArrayList<>());
             }
-            
+
             return pageInfo;
-            
+
         } catch (CannotGetJdbcConnectionException e) {
             LOGGER.error("[db-error] " + e.toString(), e);
             throw e;
         }
     }
-    
+
     @Override
     public String generateLikeArgument(String s) {
         String underscore = "_";
@@ -175,7 +191,7 @@ public class ExternalPermissionPersistServiceImpl implements PermissionPersistSe
             return s;
         }
     }
-    
+
     @Override
     public <E> AuthPaginationHelper<E> createPaginationHelper() {
         return new AuthExternalPaginationHelperImpl<E>(jt, dataSourceType);

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/PermissionPersistService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/persistence/PermissionPersistService.java
@@ -18,6 +18,9 @@ package com.alibaba.nacos.plugin.auth.impl.persistence;
 
 import com.alibaba.nacos.api.model.Page;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Permission CRUD service.
  *
@@ -25,7 +28,7 @@ import com.alibaba.nacos.api.model.Page;
  * @since 1.2.0
  */
 public interface PermissionPersistService {
-    
+
     /**
      * get the permissions of role by page.
      *
@@ -35,7 +38,15 @@ public interface PermissionPersistService {
      * @return permissions page info
      */
     Page<PermissionInfo> getPermissions(String role, int pageNo, int pageSize);
-    
+
+    /**
+     * Get permissions of roles.
+     *
+     * @param roles roles
+     * @return permissions
+     */
+    List<PermissionInfo> getPermissions(Collection<String> roles);
+
     /**
      * assign permission to role.
      *
@@ -44,7 +55,7 @@ public interface PermissionPersistService {
      * @param action action
      */
     void addPermission(String role, String resource, String action);
-    
+
     /**
      * delete the role's permission.
      *
@@ -53,11 +64,11 @@ public interface PermissionPersistService {
      * @param action action
      */
     void deletePermission(String role, String resource, String action);
-    
+
     Page<PermissionInfo> findPermissionsLike4Page(String role, int pageNo, int pageSize);
-    
+
     String generateLikeArgument(String s);
-    
+
     /**
      * create Pagination utils.
      *

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleService.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleService.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.plugin.auth.impl.persistence.PermissionInfo;
 import com.alibaba.nacos.plugin.auth.impl.persistence.RoleInfo;
 import com.alibaba.nacos.plugin.auth.impl.users.NacosUser;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -31,7 +32,7 @@ import java.util.List;
  * @author xiweng.yy
  */
 public interface NacosRoleService {
-    
+
     /**
      * Determine if the user has permission of the resource.
      *
@@ -43,7 +44,7 @@ public interface NacosRoleService {
      * @return true if granted, false otherwise
      */
     boolean hasPermission(NacosUser nacosUser, Permission permission);
-    
+
     /**
      * Add permission to tole.
      *
@@ -52,7 +53,7 @@ public interface NacosRoleService {
      * @param action   action
      */
     void addPermission(String role, String resource, String action);
-    
+
     /**
      * Delete permission from role.
      *
@@ -61,7 +62,7 @@ public interface NacosRoleService {
      * @param action   action
      */
     void deletePermission(String role, String resource, String action);
-    
+
     /**
      * Get all permissions of the role.
      *
@@ -69,7 +70,15 @@ public interface NacosRoleService {
      * @return List of {@link PermissionInfo} for the role
      */
     List<PermissionInfo> getPermissions(String role);
-    
+
+    /**
+     * Get all permissions of roles.
+     *
+     * @param roles role names
+     * @return List of {@link PermissionInfo} for roles
+     */
+    List<PermissionInfo> getPermissions(Collection<String> roles);
+
     /**
      * Accurate search permissions by role name pattern.
      *
@@ -79,7 +88,7 @@ public interface NacosRoleService {
      * @return List of {@link RoleInfo} match role name pattern
      */
     Page<PermissionInfo> getPermissions(String role, int pageNo, int pageSize);
-    
+
     /**
      * Blur search permissions by role name pattern.
      *
@@ -89,7 +98,7 @@ public interface NacosRoleService {
      * @return List of {@link RoleInfo} match role name pattern
      */
     Page<PermissionInfo> findPermissions(String role, int pageNo, int pageSize);
-    
+
     /**
      * Judge whether the permission is duplicate.
      *
@@ -99,7 +108,7 @@ public interface NacosRoleService {
      * @return true if duplicate, false otherwise
      */
     Result<Boolean> isDuplicatePermission(String role, String resource, String action);
-    
+
     /**
      * Get All roles for target user.
      *
@@ -107,7 +116,7 @@ public interface NacosRoleService {
      * @return List of {@link RoleInfo} for target user
      */
     List<RoleInfo> getRoles(String username);
-    
+
     /**
      * Accurate search roles by role name pattern.
      *
@@ -118,7 +127,7 @@ public interface NacosRoleService {
      * @return List of {@link RoleInfo} match role name pattern
      */
     Page<RoleInfo> getRoles(String username, String role, int pageNo, int pageSize);
-    
+
     /**
      * Blur search roles by role name pattern.
      *
@@ -129,7 +138,7 @@ public interface NacosRoleService {
      * @return List of {@link RoleInfo} match role name pattern
      */
     Page<RoleInfo> findRoles(String username, String role, int pageNo, int pageSize);
-    
+
     /**
      * Blur search role names by role name pattern.
      *
@@ -137,14 +146,14 @@ public interface NacosRoleService {
      * @return List of {@link RoleInfo} match role name pattern
      */
     List<String> findRoleNames(String role);
-    
+
     /**
      * Get All roles in Nacos.
      *
      * @return List of {@link RoleInfo} in Nacos
      */
     List<RoleInfo> getAllRoles();
-    
+
     /**
      * Add role to user.
      *
@@ -152,7 +161,7 @@ public interface NacosRoleService {
      * @param username user name
      */
     void addRole(String role, String username);
-    
+
     /**
      * Delete Role from user.
      *
@@ -160,21 +169,21 @@ public interface NacosRoleService {
      * @param userName userName
      */
     void deleteRole(String role, String userName);
-    
+
     /**
      * Delete Role from Nacos.
      *
      * @param role role
      */
     void deleteRole(String role);
-    
+
     /**
      * Add role.
      *
      * @param username user name
      */
     void addAdminRole(String username);
-    
+
     /**
      * Check if user has admin role.
      *
@@ -182,7 +191,7 @@ public interface NacosRoleService {
      * @return true if user has admin role.
      */
     boolean hasGlobalAdminRole(String userName);
-    
+
     /**
      * Check if all user has at least one admin role.
      *

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceDirectImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceDirectImpl.java
@@ -27,7 +27,11 @@ import com.alibaba.nacos.plugin.auth.impl.persistence.RoleInfo;
 import com.alibaba.nacos.plugin.auth.impl.persistence.RolePersistService;
 import com.alibaba.nacos.plugin.auth.impl.users.NacosUserService;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Nacos builtin role service, implemented by directly access to database.
@@ -37,17 +41,17 @@ import java.util.List;
  */
 public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService
     implements NacosRoleService {
-    
+
     private static final int DEFAULT_PAGE_NO = 1;
-    
+
     private final AuthConfigs authConfigs;
-    
+
     private final RolePersistService rolePersistService;
-    
+
     private final NacosUserService userDetailsService;
-    
+
     private final PermissionPersistService permissionPersistService;
-    
+
     public NacosRoleServiceDirectImpl(AuthConfigs authConfigs,
         RolePersistService rolePersistService,
         NacosUserService userDetailsService, PermissionPersistService permissionPersistService) {
@@ -57,7 +61,7 @@ public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService
         this.userDetailsService = userDetailsService;
         this.permissionPersistService = permissionPersistService;
     }
-    
+
     @Override
     public List<RoleInfo> getRoles(String username) {
         List<RoleInfo> roleInfoList = getCachedRoleInfoMap().get(username);
@@ -73,7 +77,7 @@ public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService
         }
         return roleInfoList;
     }
-    
+
     @Override
     public Page<RoleInfo> getRoles(String username, String role, int pageNo, int pageSize) {
         Page<RoleInfo> roles =
@@ -83,7 +87,7 @@ public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService
         }
         return roles;
     }
-    
+
     @Override
     public List<RoleInfo> getAllRoles() {
         Page<RoleInfo> roleInfoPage =
@@ -94,7 +98,7 @@ public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService
         }
         return roleInfoPage.getPageItems();
     }
-    
+
     @Override
     public List<PermissionInfo> getPermissions(String role) {
         List<PermissionInfo> permissionInfoList = getCachedPermissionInfoMap().get(role);
@@ -110,7 +114,23 @@ public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService
         }
         return permissionInfoList;
     }
-    
+
+    @Override
+    public List<PermissionInfo> getPermissions(Collection<String> roles) {
+        if (CollectionUtils.isEmpty(roles)) {
+            return new ArrayList<>();
+        }
+        if (authConfigs.isCachingEnabled()) {
+            List<PermissionInfo> cachedPermissions = getCachedPermissions(roles);
+            if (cachedPermissions != null) {
+                return cachedPermissions;
+            }
+        }
+        List<PermissionInfo> permissionInfos = permissionPersistService.getPermissions(roles);
+        cachePermissions(permissionInfos);
+        return permissionInfos;
+    }
+
     @Override
     public Page<PermissionInfo> getPermissions(String role, int pageNo, int pageSize) {
         Page<PermissionInfo> pageInfo =
@@ -120,32 +140,56 @@ public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService
         }
         return pageInfo;
     }
-    
+
+    private List<PermissionInfo> getCachedPermissions(Collection<String> roles) {
+        List<PermissionInfo> permissionInfos = new ArrayList<>();
+        for (String role : roles) {
+            List<PermissionInfo> rolePermissions = getCachedPermissionInfoMap().get(role);
+            if (rolePermissions == null) {
+                return null;
+            }
+            permissionInfos.addAll(rolePermissions);
+        }
+        return permissionInfos;
+    }
+
+    private void cachePermissions(List<PermissionInfo> permissionInfos) {
+        if (!authConfigs.isCachingEnabled() || CollectionUtils.isEmpty(permissionInfos)) {
+            return;
+        }
+        Map<String, List<PermissionInfo>> groupedPermissions = new HashMap<>(16);
+        for (PermissionInfo permissionInfo : permissionInfos) {
+            groupedPermissions.computeIfAbsent(permissionInfo.getRole(), key -> new ArrayList<>())
+                .add(permissionInfo);
+        }
+        getCachedPermissionInfoMap().putAll(groupedPermissions);
+    }
+
     @Override
     public void addRole(String role, String username) {
         if (userDetailsService.getUser(username) == null) {
             throw new IllegalArgumentException("user '" + username + "' not found!");
         }
-        
+
         if (AuthConstants.GLOBAL_ADMIN_ROLE.equals(role)) {
             throw new IllegalArgumentException(
                 "role '" + AuthConstants.GLOBAL_ADMIN_ROLE + "' is not permitted to create!");
         }
-        
+
         if (AuthConstants.ANONYMOUS_ROLE.equals(role)) {
             throw new IllegalArgumentException(
                 "role '" + AuthConstants.ANONYMOUS_ROLE + "' is reserved by the system");
         }
-        
+
         if (isUserBoundToRole(role, username)) {
             throw new IllegalArgumentException(
                 "user '" + username + "' already bound to the role '" + role + "'!");
         }
-        
+
         rolePersistService.addRole(role, username);
         getCachedRoleSet().add(role);
     }
-    
+
     @Override
     public void addAdminRole(String username) {
         if (userDetailsService.getUser(username) == null) {
@@ -155,25 +199,25 @@ public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService
             throw new IllegalArgumentException(
                 "role '" + AuthConstants.GLOBAL_ADMIN_ROLE + "' already exist !");
         }
-        
+
         rolePersistService.addRole(AuthConstants.GLOBAL_ADMIN_ROLE, username);
         getCachedRoleSet().add(AuthConstants.GLOBAL_ADMIN_ROLE);
         authConfigs.setHasGlobalAdminRole(true);
     }
-    
+
     @Override
     public void deleteRole(String role, String userName) {
         rejectReservedRole(role);
         rolePersistService.deleteRole(role, userName);
     }
-    
+
     @Override
     public void deleteRole(String role) {
         rejectReservedRole(role);
         rolePersistService.deleteRole(role);
         getCachedRoleInfoMap().remove(role);
     }
-    
+
     @Override
     public void addPermission(String role, String resource, String action) {
         if (!getCachedRoleSet().contains(role)) {
@@ -181,27 +225,27 @@ public class NacosRoleServiceDirectImpl extends AbstractCheckedRoleService
         }
         permissionPersistService.addPermission(role, resource, action);
     }
-    
+
     @Override
     public void deletePermission(String role, String resource, String action) {
         permissionPersistService.deletePermission(role, resource, action);
     }
-    
+
     @Override
     public Page<RoleInfo> findRoles(String username, String role, int pageNo, int pageSize) {
         return rolePersistService.findRolesLike4Page(username, role, pageNo, pageSize);
     }
-    
+
     @Override
     public List<String> findRoleNames(String role) {
         return rolePersistService.findRolesLikeRoleName(role);
     }
-    
+
     @Override
     public Page<PermissionInfo> findPermissions(String role, int pageNo, int pageSize) {
         return permissionPersistService.findPermissionsLike4Page(role, pageNo, pageSize);
     }
-    
+
     boolean isUserBoundToRole(String role, String username) {
         Page<RoleInfo> roleInfoPage =
             rolePersistService.getRolesByUserNameAndRoleName(username, role, DEFAULT_PAGE_NO,

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceRemoteImpl.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/roles/NacosRoleServiceRemoteImpl.java
@@ -37,6 +37,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -46,19 +48,19 @@ import java.util.Map;
  */
 public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
     implements NacosRoleService {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(NacosRoleServiceRemoteImpl.class);
-    
+
     private final NacosRestTemplate nacosRestTemplate;
-    
+
     private final AuthConfigs authConfigs;
-    
+
     public NacosRoleServiceRemoteImpl(AuthConfigs authConfigs) {
         super(authConfigs);
         this.authConfigs = authConfigs;
         this.nacosRestTemplate = new DefaultHttpClientFactory(LOGGER).createNacosRestTemplate();
     }
-    
+
     @Override
     public void addPermission(String role, String resource, String action) {
         Map<String, String> body = Map.of("role", role, "resource", resource, "action", action);
@@ -74,7 +76,7 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
                 unpectedException.getMessage());
         }
     }
-    
+
     @Override
     public void deletePermission(String role, String resource, String action) {
         Query query = Query.newInstance().addParam("role", role).addParam("resource", resource)
@@ -91,7 +93,7 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
                 unpectedException.getMessage());
         }
     }
-    
+
     @Override
     public List<PermissionInfo> getPermissions(String role) {
         List<PermissionInfo> cached = getCachedPermissionInfoMap().get(role);
@@ -101,21 +103,46 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
         reload();
         return getCachedPermissionInfoMap().get(role);
     }
-    
+
+    @Override
+    public List<PermissionInfo> getPermissions(Collection<String> roles) {
+        List<PermissionInfo> permissionInfos = getCachedPermissions(roles);
+        if (permissionInfos != null) {
+            return permissionInfos;
+        }
+        reload();
+        return getCachedPermissions(roles);
+    }
+
     @Override
     public Page<PermissionInfo> getPermissions(String role, int pageNo, int pageSize) {
         Query query = Query.newInstance().addParam("role", role).addParam("pageNo", pageNo)
             .addParam("pageSize", pageSize).addParam("search", "accurate");
         return getPermissionInfoPageFromRemote(query);
     }
-    
+
+    private List<PermissionInfo> getCachedPermissions(Collection<String> roles) {
+        if (roles == null || roles.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<PermissionInfo> permissionInfos = new ArrayList<>();
+        for (String role : roles) {
+            List<PermissionInfo> rolePermissions = getCachedPermissionInfoMap().get(role);
+            if (rolePermissions == null) {
+                return null;
+            }
+            permissionInfos.addAll(rolePermissions);
+        }
+        return permissionInfos;
+    }
+
     @Override
     public Page<PermissionInfo> findPermissions(String role, int pageNo, int pageSize) {
         Query query = Query.newInstance().addParam("role", role).addParam("pageNo", pageNo)
             .addParam("pageSize", pageSize).addParam("search", "blur");
         return getPermissionInfoPageFromRemote(query);
     }
-    
+
     @Override
     public List<RoleInfo> getRoles(String username) {
         List<RoleInfo> cached = getCachedRoleInfoMap().get(username);
@@ -125,7 +152,7 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
         reload();
         return getCachedRoleInfoMap().get(username);
     }
-    
+
     @Override
     public Page<RoleInfo> getRoles(String username, String role, int pageNo, int pageSize) {
         Query query = Query.newInstance().addParam("username", username).addParam("role", role)
@@ -133,14 +160,14 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
             .addParam("search", "accurate");
         return getRoleInfoPageFromRemote(query);
     }
-    
+
     @Override
     public Page<RoleInfo> findRoles(String username, String role, int pageNo, int pageSize) {
         Query query = Query.newInstance().addParam("username", username).addParam("role", role)
             .addParam("pageNo", pageNo).addParam("pageSize", pageSize).addParam("search", "blur");
         return getRoleInfoPageFromRemote(query);
     }
-    
+
     @Override
     public List<String> findRoleNames(String role) {
         Query query = Query.newInstance().addParam("role", role);
@@ -160,13 +187,13 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
                 unpectedException.getMessage());
         }
     }
-    
+
     @Override
     public List<RoleInfo> getAllRoles() {
         return getRoles(StringUtils.EMPTY, StringUtils.EMPTY, DEFAULT_PAGE_NO, Integer.MAX_VALUE)
             .getPageItems();
     }
-    
+
     @Override
     public void addRole(String role, String username) {
         if (AuthConstants.GLOBAL_ADMIN_ROLE.equals(role)) {
@@ -191,7 +218,7 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
                 unpectedException.getMessage());
         }
     }
-    
+
     @Override
     public void deleteRole(String role, String userName) {
         rejectReservedRole(role);
@@ -208,7 +235,7 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
                 unpectedException.getMessage());
         }
     }
-    
+
     @Override
     public void deleteRole(String role) {
         rejectReservedRole(role);
@@ -226,7 +253,7 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
                 unpectedException.getMessage());
         }
     }
-    
+
     @Override
     public void addAdminRole(String username) {
         // if has global admin role, means already synced admin role to console cached.
@@ -238,12 +265,12 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
         getCachedRoleSet().add(AuthConstants.GLOBAL_ADMIN_ROLE);
         authConfigs.setHasGlobalAdminRole(true);
     }
-    
+
     private String buildRemotePermissionUrlPath(String apiPath) {
         return RequestUrlConstants.HTTP_PREFIX + RemoteServerUtil.getOneNacosServerAddress()
             + RemoteServerUtil.getRemoteServerContextPath() + apiPath;
     }
-    
+
     private Page<PermissionInfo> getPermissionInfoPageFromRemote(Query query) {
         try {
             HttpRestResult<String> httpResult = nacosRestTemplate.get(
@@ -261,12 +288,12 @@ public class NacosRoleServiceRemoteImpl extends AbstractCheckedRoleService
                 unpectedException.getMessage());
         }
     }
-    
+
     private String buildRemoteRoleUrlPath(String apiPath) {
         return RequestUrlConstants.HTTP_PREFIX + RemoteServerUtil.getOneNacosServerAddress()
             + RemoteServerUtil.getRemoteServerContextPath() + apiPath;
     }
-    
+
     private Page<RoleInfo> getRoleInfoPageFromRemote(Query query) {
         try {
             HttpRestResult<String> httpResult = nacosRestTemplate.get(

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthPluginServiceTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/NacosAuthPluginServiceTest.java
@@ -30,6 +30,9 @@ import com.alibaba.nacos.plugin.auth.exception.AccessException;
 import com.alibaba.nacos.plugin.auth.impl.authenticate.IAuthenticationManager;
 import com.alibaba.nacos.plugin.auth.impl.configuration.AuthConfigs;
 import com.alibaba.nacos.plugin.auth.impl.constant.AuthConstants;
+import com.alibaba.nacos.plugin.auth.impl.persistence.PermissionInfo;
+import com.alibaba.nacos.plugin.auth.impl.persistence.RoleInfo;
+import com.alibaba.nacos.plugin.auth.impl.roles.NacosRoleService;
 import com.alibaba.nacos.plugin.auth.impl.users.NacosUser;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,8 +45,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,15 +67,18 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NacosAuthPluginServiceTest {
-    
+
     @Mock
     private IAuthenticationManager authenticationManager;
-    
+
     @Mock
     private AuthConfigs authConfigs;
-    
+
+    @Mock
+    private NacosRoleService roleService;
+
     private NacosAuthPluginService authPluginService;
-    
+
     @BeforeEach
     void setUp() throws Exception {
         authPluginService = new NacosAuthPluginService();
@@ -78,8 +88,11 @@ class NacosAuthPluginServiceTest {
         Field acField = NacosAuthPluginService.class.getDeclaredField("authConfigs");
         acField.setAccessible(true);
         acField.set(authPluginService, authConfigs);
+        Field rsField = NacosAuthPluginService.class.getDeclaredField("roleService");
+        rsField.setAccessible(true);
+        rsField.set(authPluginService, roleService);
     }
-    
+
     @Test
     void testMetadataMethods() {
         assertTrue(authPluginService.identityNames().contains(AuthConstants.AUTHORIZATION_HEADER));
@@ -87,20 +100,20 @@ class NacosAuthPluginServiceTest {
         assertTrue(authPluginService.enableAuth(ActionTypes.READ, "naming"));
         assertEquals(AuthConstants.AUTH_PLUGIN_TYPE, authPluginService.getAuthServiceName());
     }
-    
+
     @Test
     void testValidateIdentityAnonymousAllowed() throws AccessException {
         when(authenticationManager.authenticate(any(), any()))
             .thenThrow(new AccessException("no credentials"));
         when(authConfigs.isAiAnonymousEnabled()).thenReturn(true);
-        
+
         Properties properties = new Properties();
         properties.setProperty(AuthConstants.TAG_ALLOW_ANONYMOUS, "true");
         Resource resource = new Resource("ns", "g", "name", "type", properties);
         IdentityContext identityContext = new IdentityContext();
-        
+
         AuthResult<?> result = authPluginService.validateIdentity(identityContext, resource);
-        
+
         assertTrue(result.isSuccess());
         assertInstanceOf(NacosUser.class, result.getData());
         assertEquals(AuthConstants.ANONYMOUS_USER, ((NacosUser) result.getData()).getUserName());
@@ -110,50 +123,50 @@ class NacosAuthPluginServiceTest {
         assertEquals(AuthConstants.ANONYMOUS_USER,
             identityContext.getParameter(Identity.IDENTITY_ID, ""));
     }
-    
+
     @Test
     void testValidateIdentityNoTagDenied() throws AccessException {
         when(authenticationManager.authenticate(any(), any()))
             .thenThrow(new AccessException("no credentials"));
-        
+
         Resource resource = new Resource("ns", "g", "name", "type", new Properties());
         IdentityContext identityContext = new IdentityContext();
-        
+
         AuthResult<?> result = authPluginService.validateIdentity(identityContext, resource);
-        
+
         assertFalse(result.isSuccess());
         assertEquals(HttpStatus.UNAUTHORIZED.value(), result.getErrorCode());
         verify(authenticationManager).authenticate(any(), any());
     }
-    
+
     @Test
     void testValidateIdentitySwitchOffDenied() throws AccessException {
         when(authenticationManager.authenticate(any(), any()))
             .thenThrow(new AccessException("no credentials"));
         when(authConfigs.isAiAnonymousEnabled()).thenReturn(false);
-        
+
         Properties properties = new Properties();
         properties.setProperty(AuthConstants.TAG_ALLOW_ANONYMOUS, "true");
         Resource resource = new Resource("ns", "g", "name", "type", properties);
         IdentityContext identityContext = new IdentityContext();
-        
+
         AuthResult<?> result = authPluginService.validateIdentity(identityContext, resource);
-        
+
         assertFalse(result.isSuccess());
         assertEquals(HttpStatus.UNAUTHORIZED.value(), result.getErrorCode());
     }
-    
+
     @Test
     void testValidateIdentityNormalUserSuccess() throws AccessException {
         NacosUser expectedUser = new NacosUser("realuser");
         when(authenticationManager.authenticate(anyString())).thenReturn(expectedUser);
-        
+
         IdentityContext identityContext = new IdentityContext();
         identityContext.setParameter(Constants.ACCESS_TOKEN, "jwt-token");
         Resource resource = Resource.EMPTY_RESOURCE;
-        
+
         AuthResult<?> result = authPluginService.validateIdentity(identityContext, resource);
-        
+
         assertTrue(result.isSuccess());
         assertEquals(expectedUser, result.getData());
         Object nacosUserInContext = identityContext.getParameter(AuthConstants.NACOS_USER_KEY);
@@ -162,7 +175,7 @@ class NacosAuthPluginServiceTest {
         assertEquals("realuser", identityContext.getParameter(Identity.IDENTITY_ID, ""));
         verify(authenticationManager).authenticate("jwt-token");
     }
-    
+
     @Test
     void testValidateIdentityUsesBearerToken() throws AccessException {
         NacosUser expectedUser = new NacosUser("bearerUser");
@@ -170,15 +183,15 @@ class NacosAuthPluginServiceTest {
         IdentityContext identityContext = new IdentityContext();
         identityContext.setParameter(AuthConstants.AUTHORIZATION_HEADER,
             AuthConstants.TOKEN_PREFIX + "jwt-token");
-        
+
         AuthResult<?> result =
             authPluginService.validateIdentity(identityContext, Resource.EMPTY_RESOURCE);
-        
+
         assertTrue(result.isSuccess());
         assertEquals(expectedUser, result.getData());
         verify(authenticationManager).authenticate("jwt-token");
     }
-    
+
     @Test
     void testValidateIdentityUsesUsernameAndPassword() throws AccessException {
         NacosUser expectedUser = new NacosUser("nacos");
@@ -186,27 +199,27 @@ class NacosAuthPluginServiceTest {
         IdentityContext identityContext = new IdentityContext();
         identityContext.setParameter(AuthConstants.PARAM_USERNAME, "nacos");
         identityContext.setParameter(AuthConstants.PARAM_PASSWORD, "password");
-        
+
         AuthResult<?> result =
             authPluginService.validateIdentity(identityContext, Resource.EMPTY_RESOURCE);
-        
+
         assertTrue(result.isSuccess());
         assertEquals(expectedUser, result.getData());
         verify(authenticationManager).authenticate("nacos", "password");
     }
-    
+
     @Test
     void testValidateIdentityRejectsNullResourceAndAnonymousConfigFailure()
         throws AccessException {
         when(authenticationManager.authenticate(any(), any()))
             .thenThrow(new AccessException("no credentials"));
-        
+
         AuthResult<?> nullResourceResult =
             authPluginService.validateIdentity(new IdentityContext(), null);
-        
+
         assertFalse(nullResourceResult.isSuccess());
         assertEquals(HttpStatus.UNAUTHORIZED.value(), nullResourceResult.getErrorCode());
-        
+
         Field acField;
         try {
             acField = NacosAuthPluginService.class.getDeclaredField("authConfigs");
@@ -220,11 +233,11 @@ class NacosAuthPluginServiceTest {
         Resource resource = new Resource("ns", "g", "name", "type", properties);
         AuthResult<?> missingConfigResult =
             authPluginService.validateIdentity(new IdentityContext(), resource);
-        
+
         assertFalse(missingConfigResult.isSuccess());
         assertEquals(HttpStatus.UNAUTHORIZED.value(), missingConfigResult.getErrorCode());
     }
-    
+
     @Test
     void testValidateIdentityLoadsAuthConfigsForAnonymousAccess() throws Exception {
         when(authenticationManager.authenticate(any(), any()))
@@ -236,40 +249,61 @@ class NacosAuthPluginServiceTest {
         Properties properties = new Properties();
         properties.setProperty(AuthConstants.TAG_ALLOW_ANONYMOUS, "true");
         Resource resource = new Resource("ns", "g", "name", "type", properties);
-        
+
         try (MockedStatic<ApplicationUtils> applicationUtils = mockStatic(ApplicationUtils.class)) {
             applicationUtils.when(() -> ApplicationUtils.getBean(AuthConfigs.class))
                 .thenReturn(authConfigs);
-            
+
             AuthResult<?> result =
                 authPluginService.validateIdentity(new IdentityContext(), resource);
-            
+
             assertTrue(result.isSuccess());
         }
     }
-    
+
     @Test
     void testValidateAuthoritySuccessAndFailure() throws AccessException {
         IdentityContext identityContext = new IdentityContext();
         NacosUser user = new NacosUser("nacos");
         identityContext.setParameter(AuthConstants.NACOS_USER_KEY, user);
         Permission permission = new Permission();
-        
+
         AuthResult<?> success = authPluginService.validateAuthority(identityContext, permission);
-        
+
         assertTrue(success.isSuccess());
         assertEquals(user, success.getData());
         verify(authenticationManager).authorize(permission, user);
-        
+
         doThrow(new AccessException("forbidden")).when(authenticationManager)
             .authorize(permission, user);
-        
+
         AuthResult<?> failure = authPluginService.validateAuthority(identityContext, permission);
-        
+
         assertFalse(failure.isSuccess());
         assertEquals(HttpStatus.FORBIDDEN.value(), failure.getErrorCode());
     }
-    
+
+    @Test
+    void testGetAuthorizedNamespaceIdsUsesRolePermissions() {
+        IdentityContext identityContext = new IdentityContext();
+        NacosUser user = new NacosUser("alice");
+        identityContext.setParameter(AuthConstants.NACOS_USER_KEY, user);
+        RoleInfo roleInfo = new RoleInfo();
+        roleInfo.setRole("reader");
+        PermissionInfo permissionInfo = new PermissionInfo();
+        permissionInfo.setResource("namespace1:" + Constants.DEFAULT_GROUP + ":ai/*");
+        permissionInfo.setAction("r");
+        when(roleService.hasGlobalAdminRole("alice")).thenReturn(false);
+        when(roleService.getRoles("alice")).thenReturn(Arrays.asList(roleInfo));
+        when(roleService.getPermissions(Arrays.asList("reader"))).thenReturn(Arrays.asList(permissionInfo));
+
+        Optional<Collection<String>> result = authPluginService.getAuthorizedNamespaceIds(
+            identityContext, Arrays.asList("namespace1", "namespace2"), ActionTypes.READ);
+
+        assertTrue(result.isPresent());
+        assertEquals(new HashSet<>(Arrays.asList("namespace1")), new HashSet<>(result.get()));
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     void testLoginEnabledAndAdminRequest() {
@@ -283,15 +317,15 @@ class NacosAuthPluginServiceTest {
             map.put(ApiType.CONSOLE_API.name(), consoleConfig);
             ReflectionTestUtils.setField(NacosAuthConfigHolder.getInstance(), "nacosAuthConfigMap",
                 map);
-            
+
             assertTrue(authPluginService.isLoginEnabled());
-            
+
             try (MockedStatic<ApplicationUtils> applicationUtils =
                 mockStatic(ApplicationUtils.class)) {
                 applicationUtils.when(() -> ApplicationUtils.getBean(IAuthenticationManager.class))
                     .thenReturn(authenticationManager);
                 when(authenticationManager.hasGlobalAdminRole()).thenReturn(false, true);
-                
+
                 assertTrue(authPluginService.isAdminRequest());
                 assertFalse(authPluginService.isAdminRequest());
             }

--- a/plugin/auth/src/main/java/com/alibaba/nacos/plugin/auth/spi/server/AuthPluginService.java
+++ b/plugin/auth/src/main/java/com/alibaba/nacos/plugin/auth/spi/server/AuthPluginService.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.exception.AccessException;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Auth service.
@@ -32,14 +33,14 @@ import java.util.Collection;
  * @author xiweng.yy
  */
 public interface AuthPluginService {
-    
+
     /**
      * Define which identity information needed from request. e.q: username, password, accessToken.
      *
      * @return identity names
      */
     Collection<String> identityNames();
-    
+
     /**
      * Judgement whether this plugin enable auth for this action and type.
      *
@@ -48,7 +49,7 @@ public interface AuthPluginService {
      * @return @return {@code true} if enable auth, otherwise {@code false}
      */
     boolean enableAuth(ActionTypes action, String type);
-    
+
     /**
      * To validate whether the identity context from request is legal or illegal.
      *
@@ -59,7 +60,7 @@ public interface AuthPluginService {
      */
     AuthResult validateIdentity(IdentityContext identityContext, Resource resource)
         throws AccessException;
-    
+
     /**
      * Validate the identity whether has the resource authority.
      *
@@ -70,14 +71,31 @@ public interface AuthPluginService {
      */
     AuthResult validateAuthority(IdentityContext identityContext, Permission permission)
         throws AccessException;
-    
+
+    /**
+     * Get namespaces that the identity can access.
+     *
+     * <p>Empty {@link Optional} means the plugin does not support namespace filtering, so callers should keep
+     * the original namespace list.
+     *
+     * @param identityContext where we can find the user information.
+     * @param namespaceIds    candidate namespace ids.
+     * @param action          action to auth.
+     * @return namespace ids that the identity can access, or empty optional if unsupported.
+     * @throws AccessException if authorization is failed
+     */
+    default Optional<Collection<String>> getAuthorizedNamespaceIds(IdentityContext identityContext,
+        Collection<String> namespaceIds, ActionTypes action) throws AccessException {
+        return Optional.empty();
+    }
+
     /**
      * AuthPluginService Name which for conveniently find AuthPluginService instance.
      *
      * @return AuthServiceName mark a AuthPluginService instance.
      */
     String getAuthServiceName();
-    
+
     /**
      * Is the plugin enable login.
      *
@@ -87,7 +105,7 @@ public interface AuthPluginService {
     default boolean isLoginEnabled() {
         return false;
     }
-    
+
     /**
      * Whether need administrator .
      *


### PR DESCRIPTION
## What changed
- Persist namespace selections into the current console route query so refresh keeps the selected namespace on skill pages.
- Add an optional auth-plugin batch API for namespace visibility.
- Implement namespace visibility for the default Nacos auth plugin using one user-role lookup and one batched role-permission lookup.
- Derive visible namespaces from the namespace segment in permission resources, only matching candidate namespaces for wildcard namespace patterns.
- Keep the original unfiltered namespace list for auth plugins that do not support batch namespace visibility.
- Add unit tests for console namespace filtering and default Nacos auth namespace visibility.

## Why
Skill pages only updated global namespace state before, so the URL did not carry the selected namespace after switching. The namespace dropdown also exposed every namespace even when Nacos auth users only had permission for a subset.

The filtering path avoids per-namespace authorization checks. In the default Nacos auth path it loads the current user's roles once, loads those roles' permissions in one batch query, and then computes namespace visibility in memory from permission resources.

## Validation
- mvn -pl plugin-default-impl/nacos-default-auth-plugin,console -am -Dtest=NacosAuthPluginServiceTest,NamespaceProxyTest,NacosRoleServiceDirectImplTest -Dsurefire.failIfNoSpecifiedTests=false test
- git diff --check