### PR TITLE
Stabilize auth and agent spec cache tests

### DIFF
--- a/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentSpecCacheHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentSpecCacheHolderTest.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.common.notify.listener.Subscriber;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -41,6 +42,7 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -55,7 +57,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class NacosAgentSpecCacheHolderTest {
     
-    private static final String SPEC_NAME = "test-agent";
+    private static final AtomicLong SPEC_SEQUENCE = new AtomicLong();
     
     @Mock
     private AiClientProxy aiClientProxy;
@@ -64,8 +66,12 @@ class NacosAgentSpecCacheHolderTest {
     
     private final List<MockAgentSpecEventSubscriber> registeredSubscribers = new ArrayList<>();
     
+    private String specName;
+    
     @BeforeEach
-    void setUp() {
+    void setUp(TestInfo testInfo) {
+        specName = testInfo.getTestMethod().orElseThrow().getName() + "-"
+            + SPEC_SEQUENCE.incrementAndGet();
         Properties properties = new Properties();
         properties.put(AiConstants.AI_AGENTSPEC_CACHE_UPDATE_INTERVAL, "60000");
         NotifyCenter.registerToPublisher(AgentSpecChangedEvent.class, 16384);
@@ -86,23 +92,23 @@ class NacosAgentSpecCacheHolderTest {
     @Test
     void queryAgentSpecShouldReturnAgentSpec() throws Exception {
         AgentSpec spec = new AgentSpec();
-        spec.setName(SPEC_NAME);
+        spec.setName(specName);
         AgentSpecQueryResponse response = new AgentSpecQueryResponse(spec, "md5a", "1.0.0");
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenReturn(response);
         
-        AgentSpec result = cacheHolder.queryAgentSpec(SPEC_NAME);
+        AgentSpec result = cacheHolder.queryAgentSpec(specName);
         
         assertNotNull(result);
-        assertEquals(SPEC_NAME, result.getName());
+        assertEquals(specName, result.getName());
     }
     
     @Test
     void queryAgentSpecShouldReturnNullWhenNotFound() throws Exception {
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenThrow(new NacosException(NacosException.NOT_FOUND, "not found"));
         
-        AgentSpec result = cacheHolder.queryAgentSpec(SPEC_NAME);
+        AgentSpec result = cacheHolder.queryAgentSpec(specName);
         
         assertNull(result);
     }
@@ -114,10 +120,10 @@ class NacosAgentSpecCacheHolderTest {
     
     @Test
     void subscribeAgentSpecShouldReturnNullAndScheduleWhenNotFound() throws Exception {
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenThrow(new NacosException(NacosException.NOT_FOUND, "not found"));
         
-        AgentSpec result = cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        AgentSpec result = cacheHolder.subscribeAgentSpec(specName);
         
         assertNull(result);
         assertEquals(1, getUpdateTaskMap().size());
@@ -126,16 +132,16 @@ class NacosAgentSpecCacheHolderTest {
     @Test
     void subscribeAgentSpecShouldCacheButNotPublishEvent() throws Exception {
         AgentSpec spec = new AgentSpec();
-        spec.setName(SPEC_NAME);
+        spec.setName(specName);
         AgentSpecQueryResponse response = new AgentSpecQueryResponse(spec, "md5a", "1.0.0");
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenReturn(response);
         MockAgentSpecEventSubscriber subscriber = registerMockSubscriber();
         
-        AgentSpec result = cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        AgentSpec result = cacheHolder.subscribeAgentSpec(specName);
         
         assertNotNull(result);
-        assertEquals("md5a", getMd5Cache().get(SPEC_NAME));
+        assertEquals("md5a", getMd5Cache().get(specName));
         // Initial subscribe must NOT publish event; the caller (NacosAiService)
         // is responsible for the first listener notification to avoid double-invocation.
         assertFalse(subscriber.await(200),
@@ -151,19 +157,19 @@ class NacosAgentSpecCacheHolderTest {
     @Test
     void updaterShouldIgnoreWhenNotModified() throws Exception {
         AgentSpec spec = new AgentSpec();
-        spec.setName(SPEC_NAME);
+        spec.setName(specName);
         AgentSpecQueryResponse response = new AgentSpecQueryResponse(spec, "md5a", "1.0.0");
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenReturn(response);
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, "md5a"))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, "md5a"))
             .thenThrow(new NacosException(NacosException.NOT_MODIFIED, "up to date"));
-        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        cacheHolder.subscribeAgentSpec(specName);
         MockAgentSpecEventSubscriber subscriber = registerMockSubscriber();
         
         Runnable updater = getOnlyUpdater();
         updater.run();
         
-        assertEquals("md5a", getMd5Cache().get(SPEC_NAME));
+        assertEquals("md5a", getMd5Cache().get(specName));
         assertFalse(subscriber.await(200));
         assertFalse(subscriber.invokedMark.get());
     }
@@ -171,42 +177,42 @@ class NacosAgentSpecCacheHolderTest {
     @Test
     void updaterShouldEvictCacheWhenNotFound() throws Exception {
         AgentSpec spec = new AgentSpec();
-        spec.setName(SPEC_NAME);
+        spec.setName(specName);
         AgentSpecQueryResponse response = new AgentSpecQueryResponse(spec, "md5a", "1.0.0");
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenReturn(response);
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, "md5a"))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, "md5a"))
             .thenThrow(new NacosException(NacosException.NOT_FOUND, "not found"));
-        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        cacheHolder.subscribeAgentSpec(specName);
         MockAgentSpecEventSubscriber subscriber = registerMockSubscriber();
         
         Runnable updater = getOnlyUpdater();
         updater.run();
         
-        assertNull(getMd5Cache().get(SPEC_NAME));
+        assertNull(getMd5Cache().get(specName));
         assertFalse(subscriber.await(200));
     }
     
     @Test
     void updaterShouldPublishEventWhenMd5Changed() throws Exception {
         AgentSpec spec1 = new AgentSpec();
-        spec1.setName(SPEC_NAME);
+        spec1.setName(specName);
         AgentSpec spec2 = new AgentSpec();
-        spec2.setName(SPEC_NAME);
+        spec2.setName(specName);
         spec2.setDescription("updated");
         AgentSpecQueryResponse first = new AgentSpecQueryResponse(spec1, "md5a", "1.0.0");
         AgentSpecQueryResponse second = new AgentSpecQueryResponse(spec2, "md5b", "1.0.1");
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenReturn(first);
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, "md5a"))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, "md5a"))
             .thenReturn(second);
-        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        cacheHolder.subscribeAgentSpec(specName);
         MockAgentSpecEventSubscriber subscriber = registerMockSubscriber();
         
         Runnable updater = getOnlyUpdater();
         updater.run();
         
-        assertEquals("md5b", getMd5Cache().get(SPEC_NAME));
+        assertEquals("md5b", getMd5Cache().get(specName));
         assertTrue(subscriber.await(5000));
         assertTrue(subscriber.invokedMark.get());
     }
@@ -214,42 +220,42 @@ class NacosAgentSpecCacheHolderTest {
     @Test
     void unsubscribeAgentSpecShouldCancelTaskAndRemoveCache() throws Exception {
         AgentSpec spec = new AgentSpec();
-        spec.setName(SPEC_NAME);
+        spec.setName(specName);
         AgentSpecQueryResponse response = new AgentSpecQueryResponse(spec, "md5a", "1.0.0");
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenReturn(response);
-        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        cacheHolder.subscribeAgentSpec(specName);
         
-        cacheHolder.unsubscribeAgentSpec(SPEC_NAME);
+        cacheHolder.unsubscribeAgentSpec(specName);
         
         assertTrue(getUpdateTaskMap().isEmpty());
-        assertNull(getMd5Cache().get(SPEC_NAME));
-        verify(aiClientProxy, never()).queryAgentSpec(SPEC_NAME, null, null, "md5a");
+        assertNull(getMd5Cache().get(specName));
+        verify(aiClientProxy, never()).queryAgentSpec(specName, null, null, "md5a");
     }
     
     @Test
     void subscribeAgentSpecShouldThrowOnUnexpectedException() throws Exception {
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenThrow(new NacosException(NacosException.SERVER_ERROR, "server error"));
         
-        assertThrows(NacosException.class, () -> cacheHolder.subscribeAgentSpec(SPEC_NAME));
+        assertThrows(NacosException.class, () -> cacheHolder.subscribeAgentSpec(specName));
     }
     
     @Test
     void updaterShouldIgnoreGeneralExceptionAndKeepCache() throws Exception {
         AgentSpec spec = new AgentSpec();
-        spec.setName(SPEC_NAME);
+        spec.setName(specName);
         AgentSpecQueryResponse response = new AgentSpecQueryResponse(spec, "md5a", "1.0.0");
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, null))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, null))
             .thenReturn(response);
-        when(aiClientProxy.queryAgentSpec(SPEC_NAME, null, null, "md5a"))
+        when(aiClientProxy.queryAgentSpec(specName, null, null, "md5a"))
             .thenThrow(new NacosException(NacosException.SERVER_ERROR, "server error"));
-        cacheHolder.subscribeAgentSpec(SPEC_NAME);
+        cacheHolder.subscribeAgentSpec(specName);
         
         Runnable updater = getOnlyUpdater();
         updater.run();
         
-        assertNotNull(getMd5Cache().get(SPEC_NAME));
+        assertNotNull(getMd5Cache().get(specName));
         assertEquals(1, getUpdateTaskMap().size());
     }
     
@@ -273,7 +279,7 @@ class NacosAgentSpecCacheHolderTest {
     }
     
     private MockAgentSpecEventSubscriber registerMockSubscriber() {
-        MockAgentSpecEventSubscriber subscriber = new MockAgentSpecEventSubscriber();
+        MockAgentSpecEventSubscriber subscriber = new MockAgentSpecEventSubscriber(specName);
         NotifyCenter.registerSubscriber(subscriber);
         registeredSubscribers.add(subscriber);
         return subscriber;
@@ -282,11 +288,19 @@ class NacosAgentSpecCacheHolderTest {
     private static class MockAgentSpecEventSubscriber
         extends Subscriber<AgentSpecChangedEvent> {
         
+        private final String expectedAgentSpecName;
         private final AtomicBoolean invokedMark = new AtomicBoolean(false);
         private volatile CountDownLatch latch = new CountDownLatch(1);
         
+        MockAgentSpecEventSubscriber(String expectedAgentSpecName) {
+            this.expectedAgentSpecName = expectedAgentSpecName;
+        }
+        
         @Override
         public void onEvent(AgentSpecChangedEvent event) {
+            if (!expectedAgentSpecName.equals(event.getAgentSpecName())) {
+                return;
+            }
             invokedMark.set(true);
             latch.countDown();
         }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/utils/RemoteServerUtil.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/utils/RemoteServerUtil.java
@@ -38,11 +38,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class RemoteServerUtil {
     
+    private static final String DEFAULT_REMOTE_SERVER_CONTEXT_PATH = "/nacos";
+    
     private static List<String> serverAddresses = new LinkedList<>();
     
     private static AtomicInteger index = new AtomicInteger();
     
-    private static String remoteServerContextPath = "/nacos";
+    private static String remoteServerContextPath = DEFAULT_REMOTE_SERVER_CONTEXT_PATH;
     
     static {
         readRemoteServerAddress();
@@ -51,8 +53,12 @@ public class RemoteServerUtil {
     }
     
     private static void initRemoteServerContextPath() {
+        if (EnvUtil.getEnvironment() == null) {
+            return;
+        }
         remoteServerContextPath =
-            EnvUtil.getProperty("nacos.console.remote.server.context-path", "/nacos");
+            EnvUtil.getProperty("nacos.console.remote.server.context-path",
+                DEFAULT_REMOTE_SERVER_CONTEXT_PATH);
     }
     
     private static void registerWatcher() {


### PR DESCRIPTION
## Summary
- guard RemoteServerUtil static initialization when EnvUtil has no Spring environment
- isolate AgentSpec cache holder test events with per-test agent spec names

## Tests
- mvn -pl plugin-default-impl/nacos-default-auth-plugin -am -Dtest=RemoteServerUtilTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl client -am -Dtest=NacosAgentSpecCacheHolderTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl client,plugin-default-impl/nacos-default-auth-plugin spotless:apply spotless:check