### PR TITLE
[ISSUE #14981] Make config insertOrUpdate idempotent under concurrent publish

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -235,7 +235,14 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 findConfigInfoState(configInfo.getDataId(), configInfo.getGroup(),
                     configInfo.getTenant());
             if (configInfoState == null) {
-                return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                try {
+                    return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                } catch (DataIntegrityViolationException ive) {
+                    // A concurrent insert won the race between findConfigInfoState and
+                    // addConfigInfo (TOCTOU), so the row already exists now. Keep
+                    // insertOrUpdate idempotent by falling back to an update.
+                    return updateConfigInfo(configInfo, srcIp, srcUser, configAdvanceInfo);
+                }
             } else {
                 return updateConfigInfo(configInfo, srcIp, srcUser, configAdvanceInfo);
             }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
@@ -443,6 +443,82 @@ class ExternalConfigInfoPersistServiceImplTest {
     }
     
     @Test
+    void testInsertOrUpdateWhenConcurrentInsertConflictFallbackToUpdate() {
+        Map<String, Object> configAdvanceInfo = new HashMap<>();
+        configAdvanceInfo.put("config_tags", "tag1,tag2");
+        configAdvanceInfo.put("desc", "desc11");
+        configAdvanceInfo.put("use", "use2233");
+        configAdvanceInfo.put("effect", "effect222");
+        configAdvanceInfo.put("type", "type3");
+        configAdvanceInfo.put("schema", "schema");
+        
+        String dataId = "dataId";
+        String group = "group";
+        String tenant = "tenant";
+        String content = "content132456";
+        
+        ConfigInfo configInfo = new ConfigInfo(dataId, group, tenant, null, content);
+        String encryptedDataKey = "key34567";
+        configInfo.setEncryptedDataKey(encryptedDataKey);
+        
+        // mock config state: first null so insertOrUpdate chooses the add (insert) branch,
+        // then non-null after the conflict-triggered fallback update.
+        Mockito
+            .when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant}),
+                eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenReturn(null, new ConfigInfoStateWrapper());
+        
+        // mock the insert losing the TOCTOU race: a concurrent insert already committed the row,
+        // so the unique constraint is violated and Spring raises DataIntegrityViolationException.
+        long insertConfigInfoId = 12345678765L;
+        GeneratedKeyHolder generatedKeyHolder =
+            TestCaseUtils.createGeneratedKeyHolder(insertConfigInfoId);
+        externalStorageUtilsMockedStatic.when(ExternalStorageUtils::createKeyHolder)
+            .thenReturn(generatedKeyHolder);
+        Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class), any(KeyHolder.class)))
+            .thenThrow(new DataIntegrityViolationException("mock unique constraint violation"));
+        
+        ConfigAllInfo configAllInfo = new ConfigAllInfo();
+        configAllInfo.setDataId(dataId);
+        configAllInfo.setGroup(group);
+        configAllInfo.setTenant(tenant);
+        configAllInfo.setAppName("old_app");
+        configAllInfo.setMd5("old_md5");
+        configAllInfo.setId(insertConfigInfoId);
+        Mockito
+            .when(jdbcTemplate.queryForObject(anyString(), eq(new Object[] {dataId, group, tenant}),
+                eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(configAllInfo);
+        
+        String srcIp = "srcIp";
+        String srcUser = "srcUser";
+        String updateSql = externalConfigInfoPersistService.mapperManager
+            .findMapper(dataSourceService.getDataSourceType(), TableConstant.CONFIG_INFO)
+            .update(Arrays.asList("content", "md5", "src_ip", "src_user", "gmt_modified@NOW()",
+                "app_name", "c_desc", "c_use", "effect", "type", "c_schema",
+                "encrypted_data_key"),
+                Arrays.asList("data_id", "group_id", "tenant_id"));
+        Mockito.when(jdbcTemplate.update(eq(updateSql), eq(configInfo.getContent()),
+            eq(configInfo.getMd5()), eq(srcIp), eq(srcUser), eq(configAllInfo.getAppName()),
+            eq(configAdvanceInfo.get("desc")), eq(configAdvanceInfo.get("use")),
+            eq(configAdvanceInfo.get("effect")), eq(configAdvanceInfo.get("type")),
+            eq(configAdvanceInfo.get("schema")), eq(encryptedDataKey), eq(configInfo.getDataId()),
+            eq(configInfo.getGroup()), eq(tenant))).thenReturn(1);
+        
+        // must not propagate the conflict; should fall back to update and succeed.
+        externalConfigInfoPersistService.insertOrUpdate(srcIp, srcUser, configInfo,
+            configAdvanceInfo);
+        
+        // verify the fallback update statement was executed exactly once.
+        Mockito.verify(jdbcTemplate, times(1)).update(eq(updateSql), eq(configInfo.getContent()),
+            eq(configInfo.getMd5()), eq(srcIp), eq(srcUser), eq(configAllInfo.getAppName()),
+            eq(configAdvanceInfo.get("desc")), eq(configAdvanceInfo.get("use")),
+            eq(configAdvanceInfo.get("effect")), eq(configAdvanceInfo.get("type")),
+            eq(configAdvanceInfo.get("schema")), eq(encryptedDataKey), eq(configInfo.getDataId()),
+            eq(configInfo.getGroup()), eq(tenant));
+    }
+    
+    @Test
     void testUpdateConfigInfoReturnsFalseWhenOldConfigMissing() {
         ConfigInfo configInfo = new ConfigInfo("dataId", "group", "tenant", "app", "content");
         Mockito.when(jdbcTemplate.queryForObject(anyString(),


### PR DESCRIPTION
## What is the purpose of the change

Fixes #14981.

In a cluster using an external DB (PostgreSQL in the report), concurrent `publishConfig` calls for the same `dataId/group/tenant` can return a 500 with `duplicate key value violates unique constraint "uk_configinfo_datagrouptenant"`.

Root cause (confirmed by @shiyiyue1102 in the issue): `ExternalConfigInfoPersistServiceImpl.insertOrUpdate` uses a check-then-insert pattern (`findConfigInfoState` → `addConfigInfo`). Under concurrency two requests can both observe a `null` state and both attempt the INSERT; the loser violates the unique constraint and the resulting `DataIntegrityViolationException` propagates to the client as a 500.

The new-config branch in `ConfigOperationService` already catches this for `addConfigInfo`, but the `insertOrUpdate` (update-for-exist) path does not.

`addConfigInfo` and `updateConfigInfo` each run in their own transaction (`TransactionTemplate.execute`), so the failed insert is fully rolled back before the fallback update opens a fresh transaction — this avoids leaving the connection in an aborted-transaction state on PostgreSQL.

## Brief changelog

- `ExternalConfigInfoPersistServiceImpl.insertOrUpdate`: catch `DataIntegrityViolationException` from `addConfigInfo` and fall back to `updateConfigInfo`, keeping `insertOrUpdate` idempotent regardless of the caller.
- Add a regression unit test asserting that a unique-constraint violation on insert leads to a fallback update instead of propagating the exception.

## Scope / notes

- This PR targets the external-storage formal `insertOrUpdate` path, which is exactly the path reported in #14981 (external PostgreSQL cluster).
- The same check-then-insert pattern also exists in `insertOrUpdateCas` (external) and in the standalone-embedded `EmbeddedConfigInfoPersistServiceImpl`. Cluster embedded is not affected because writes are serialized through the Raft apply thread; standalone embedded executes writes directly and shares the pattern. These are intentionally left out of this single-purpose PR and can be addressed separately if maintainers prefer.

## Verifying this change

- `ExternalConfigInfoPersistServiceImplTest`: 83 tests pass.
- New test `testInsertOrUpdateWhenConcurrentInsertConflictFallbackToUpdate` mocks the insert raising `DataIntegrityViolationException` and verifies the update statement is executed instead of the exception escaping. Reverting the fix makes the new test fail with the same exception that causes the 500.
- `mvn -pl config spotless:check` passes.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (#14981).
* [x] Format the pull request title like `[ISSUE #123] Fix ...`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction.
* [x] Run basic checks (`spotless:check`) and unit tests for the affected module.
