### PR TITLE
fix(15265): AI skill list rejects skillName used as a query condition.

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.nacos.ai.controller;
 
-import com.alibaba.nacos.api.annotation.Since;
 import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.form.AiResourceFilterableForm;
 import com.alibaba.nacos.ai.form.skills.admin.SkillBizTagsUpdateForm;
@@ -29,15 +28,17 @@ import com.alibaba.nacos.ai.form.skills.admin.SkillPublishForm;
 import com.alibaba.nacos.ai.form.skills.admin.SkillScopeForm;
 import com.alibaba.nacos.ai.form.skills.admin.SkillSubmitForm;
 import com.alibaba.nacos.ai.form.skills.admin.SkillUpdateForm;
-import com.alibaba.nacos.api.ai.model.skills.BatchUploadResult;
 import com.alibaba.nacos.ai.param.SkillHttpParamExtractor;
+import com.alibaba.nacos.ai.param.SkillListHttpParamExtractor;
 import com.alibaba.nacos.ai.service.skills.SkillOperationService;
 import com.alibaba.nacos.ai.service.skills.SkillUploadRequest;
 import com.alibaba.nacos.ai.utils.SkillRequestUtil;
+import com.alibaba.nacos.api.ai.model.skills.BatchUploadResult;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillMeta;
 import com.alibaba.nacos.api.ai.model.skills.SkillSummary;
 import com.alibaba.nacos.api.annotation.NacosApi;
+import com.alibaba.nacos.api.annotation.Since;
 import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
@@ -161,6 +162,7 @@ public class SkillAdminController {
     @GetMapping("/list")
     @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.ADMIN_API,
         tags = {ALLOW_ANONYMOUS})
+    @ExtractorManager.Extractor(httpExtractor = SkillListHttpParamExtractor.class)
     public Result<Page<SkillSummary>> listSkills(SkillListForm skillListForm,
         AiResourceFilterableForm filterableForm, PageForm pageForm) throws NacosException {
         skillListForm.validate();

--- a/ai/src/main/java/com/alibaba/nacos/ai/param/SkillListHttpParamExtractor.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/param/SkillListHttpParamExtractor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.param;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.paramcheck.ParamInfo;
+import com.alibaba.nacos.core.paramcheck.AbstractHttpParamExtractor;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Nacos AI Skill list param extractor.
+ *
+ * @author nacos
+ */
+public class SkillListHttpParamExtractor extends AbstractHttpParamExtractor {
+    
+    private static final String SKILL_NAME_PARAM = "skillName";
+    
+    private static final String SEARCH_PARAM = "search";
+    
+    @Override
+    public List<ParamInfo> extractParam(HttpServletRequest request) throws NacosException {
+        ParamInfo paramInfo = new ParamInfo();
+        paramInfo.setNamespaceId(request.getParameter("namespaceId"));
+        String skillName = request.getParameter(SKILL_NAME_PARAM);
+        if (Constants.Skills.SEARCH_ACCURATE.equalsIgnoreCase(request.getParameter(SEARCH_PARAM))) {
+            paramInfo.setSkillName(skillName);
+        } else {
+            paramInfo.setSkillSearchName(skillName);
+        }
+        return Collections.singletonList(paramInfo);
+    }
+}

--- a/ai/src/main/resources/META-INF/services/com.alibaba.nacos.core.paramcheck.AbstractHttpParamExtractor
+++ b/ai/src/main/resources/META-INF/services/com.alibaba.nacos.core.paramcheck.AbstractHttpParamExtractor
@@ -17,3 +17,4 @@
 com.alibaba.nacos.ai.param.McpHttpParamExtractor
 com.alibaba.nacos.ai.param.AgentHttpParamExtractor
 com.alibaba.nacos.ai.param.SkillHttpParamExtractor
+com.alibaba.nacos.ai.param.SkillListHttpParamExtractor

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/SkillAdminControllerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/SkillAdminControllerTest.java
@@ -17,6 +17,9 @@
 package com.alibaba.nacos.ai.controller;
 
 import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.form.AiResourceFilterableForm;
+import com.alibaba.nacos.ai.form.skills.admin.SkillListForm;
+import com.alibaba.nacos.ai.param.SkillListHttpParamExtractor;
 import com.alibaba.nacos.ai.service.skills.SkillOperationService;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillMeta;
@@ -26,6 +29,8 @@ import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.core.model.form.PageForm;
+import com.alibaba.nacos.core.paramcheck.ExtractorManager;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.servlet.ServletException;
@@ -178,6 +183,17 @@ class SkillAdminControllerTest {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals(1, result.getData().getTotalCount());
+    }
+    
+    @Test
+    void testListSkillsUsesListParamExtractor() throws Exception {
+        ExtractorManager.Extractor extractor = SkillAdminController.class
+            .getMethod("listSkills", SkillListForm.class,
+                AiResourceFilterableForm.class, PageForm.class)
+            .getAnnotation(ExtractorManager.Extractor.class);
+        
+        assertNotNull(extractor);
+        assertEquals(SkillListHttpParamExtractor.class, extractor.httpExtractor());
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/param/SkillListHttpParamExtractorTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/param/SkillListHttpParamExtractorTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.param;
+
+import com.alibaba.nacos.ai.controller.SkillAdminController;
+import com.alibaba.nacos.ai.form.AiResourceFilterableForm;
+import com.alibaba.nacos.ai.form.skills.admin.SkillListForm;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.paramcheck.DefaultParamChecker;
+import com.alibaba.nacos.common.paramcheck.ParamCheckResponse;
+import com.alibaba.nacos.common.paramcheck.ParamInfo;
+import com.alibaba.nacos.core.code.ControllerMethodsCache;
+import com.alibaba.nacos.core.model.form.PageForm;
+import com.alibaba.nacos.core.paramcheck.ParamCheckerFilter;
+import com.alibaba.nacos.core.paramcheck.ServerParamCheckConfig;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SkillListHttpParamExtractorTest {
+    
+    private MockHttpServletRequest request;
+    
+    private SkillListHttpParamExtractor httpParamExtractor;
+    
+    @BeforeEach
+    void setUp() {
+        EnvUtil.setEnvironment(new StandardEnvironment());
+        httpParamExtractor = new SkillListHttpParamExtractor();
+        request = new MockHttpServletRequest();
+    }
+    
+    @Test
+    void extractParamShouldNotTreatSkillNameAsCanonicalResourceName() throws NacosException {
+        request.addParameter("namespaceId", "public");
+        request.addParameter("skillName", "test-");
+        
+        List<ParamInfo> actual = httpParamExtractor.extractParam(request);
+        
+        assertEquals(1, actual.size());
+        assertEquals("public", actual.get(0).getNamespaceId());
+        assertNull(actual.get(0).getSkillName());
+        assertEquals("test-", actual.get(0).getSkillSearchName());
+    }
+    
+    @Test
+    void fuzzySearchTermWithTrailingHyphenShouldPassGlobalParamCheck() throws NacosException {
+        request.addParameter("namespaceId", "public");
+        request.addParameter("skillName", "test-");
+        
+        List<ParamInfo> paramInfos = httpParamExtractor.extractParam(request);
+        ParamCheckResponse response = new DefaultParamChecker().checkParamInfoList(paramInfos);
+        
+        assertTrue(response.isSuccess());
+    }
+    
+    @Test
+    void fuzzySearchTermWithIllegalCharactersShouldFailGlobalParamCheck() throws NacosException {
+        request.addParameter("namespaceId", "public");
+        request.addParameter("skillName", "skill@name");
+        
+        List<ParamInfo> paramInfos = httpParamExtractor.extractParam(request);
+        ParamCheckResponse response = new DefaultParamChecker().checkParamInfoList(paramInfos);
+        
+        assertFalse(response.isSuccess());
+        assertEquals("Skill search name may only contain lowercase letters, numbers, and hyphens",
+            response.getMessage());
+    }
+    
+    @Test
+    void accurateSearchTermShouldBeTreatedAsCanonicalSkillName() throws NacosException {
+        request.addParameter("namespaceId", "public");
+        request.addParameter("skillName", "test-");
+        request.addParameter("search", "accurate");
+        
+        List<ParamInfo> actual = httpParamExtractor.extractParam(request);
+        
+        assertEquals(1, actual.size());
+        assertEquals("test-", actual.get(0).getSkillName());
+        assertNull(actual.get(0).getSkillSearchName());
+    }
+    
+    @Test
+    void accurateSearchTermWithTrailingHyphenShouldFailGlobalParamCheck() throws NacosException {
+        request.addParameter("namespaceId", "public");
+        request.addParameter("skillName", "test-");
+        request.addParameter("search", "accurate");
+        
+        List<ParamInfo> paramInfos = httpParamExtractor.extractParam(request);
+        ParamCheckResponse response = new DefaultParamChecker().checkParamInfoList(paramInfos);
+        
+        assertFalse(response.isSuccess());
+        assertEquals("Skill name may only contain lowercase letters, numbers, and hyphens, "
+            + "and must not start or end with a hyphen", response.getMessage());
+    }
+    
+    @Test
+    void paramCheckerFilterShouldAllowFuzzySearchTermWithTrailingHyphen() throws Exception {
+        request.addParameter("namespaceId", "public");
+        request.addParameter("skillName", "test-");
+        request.addParameter("search", "blur");
+        
+        FilterChain chain = mock(FilterChain.class);
+        MockHttpServletResponse response = doFilterThroughSkillListMethod(request, chain);
+        
+        assertEquals(200, response.getStatus());
+        verify(chain).doFilter(request, response);
+    }
+    
+    @Test
+    void paramCheckerFilterShouldRejectFuzzySearchTermWithIllegalCharacters() throws Exception {
+        request.addParameter("namespaceId", "public");
+        request.addParameter("skillName", "skill@name");
+        request.addParameter("search", "blur");
+        
+        FilterChain chain = mock(FilterChain.class);
+        MockHttpServletResponse response = doFilterThroughSkillListMethod(request, chain);
+        
+        assertEquals(400, response.getStatus());
+        verify(chain, never()).doFilter(request, response);
+    }
+    
+    @Test
+    void paramCheckerFilterShouldRejectAccurateSearchTermWithTrailingHyphen() throws Exception {
+        request.addParameter("namespaceId", "public");
+        request.addParameter("skillName", "test-");
+        request.addParameter("search", "accurate");
+        
+        FilterChain chain = mock(FilterChain.class);
+        MockHttpServletResponse response = doFilterThroughSkillListMethod(request, chain);
+        
+        assertEquals(400, response.getStatus());
+        verify(chain, never()).doFilter(request, response);
+    }
+    
+    private MockHttpServletResponse doFilterThroughSkillListMethod(MockHttpServletRequest request,
+        FilterChain chain)
+        throws NoSuchMethodException, ServletException, IOException {
+        request.setMethod("GET");
+        request.setRequestURI("/v3/admin/ai/skills/list");
+        ServerParamCheckConfig.getInstance().setParamCheckEnabled(true);
+        ServerParamCheckConfig.getInstance().setActiveParamChecker("default");
+        ControllerMethodsCache methodsCache = mock(ControllerMethodsCache.class);
+        Method method = SkillAdminController.class.getMethod("listSkills", SkillListForm.class,
+            AiResourceFilterableForm.class, PageForm.class);
+        when(methodsCache.getMethod(request)).thenReturn(method);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        new ParamCheckerFilter(methodsCache).doFilter(request, response, chain);
+        return response;
+    }
+}

--- a/common/src/main/java/com/alibaba/nacos/common/paramcheck/DefaultParamChecker.java
+++ b/common/src/main/java/com/alibaba/nacos/common/paramcheck/DefaultParamChecker.java
@@ -51,6 +51,8 @@ public class DefaultParamChecker extends AbstractParamChecker {
     
     private Pattern skillNamePattern;
     
+    private Pattern skillSearchNamePattern;
+    
     private static final String CHECKER_TYPE = "default";
     
     private static final String MAX_METADATA_LENGTH_PROP_NAME =
@@ -100,6 +102,8 @@ public class DefaultParamChecker extends AbstractParamChecker {
         this.mcpNamePattern = Pattern.compile(this.paramCheckRule.mcpNamePatternString);
         this.agentNamePattern = Pattern.compile(this.paramCheckRule.agentNamePatternString);
         this.skillNamePattern = Pattern.compile(this.paramCheckRule.skillNamePatternString);
+        this.skillSearchNamePattern =
+            Pattern.compile(this.paramCheckRule.skillSearchNamePatternString);
     }
     
     /**
@@ -174,6 +178,10 @@ public class DefaultParamChecker extends AbstractParamChecker {
             return paramCheckResponse;
         }
         paramCheckResponse = checkSkillNameFormat(paramInfo.getSkillName());
+        if (!paramCheckResponse.isSuccess()) {
+            return paramCheckResponse;
+        }
+        paramCheckResponse = checkSkillSearchNameFormat(paramInfo.getSkillSearchName());
         if (!paramCheckResponse.isSuccess()) {
             return paramCheckResponse;
         }
@@ -559,6 +567,39 @@ public class DefaultParamChecker extends AbstractParamChecker {
         if (skillName.contains("--")) {
             paramCheckResponse.setSuccess(false);
             paramCheckResponse.setMessage("Skill name must not contain consecutive hyphens (--)");
+            return paramCheckResponse;
+        }
+        paramCheckResponse.setSuccess(true);
+        return paramCheckResponse;
+    }
+    
+    /**
+     * Check skill search name format.
+     *
+     * @param skillSearchName skill search name
+     * @return the param check response
+     */
+    public ParamCheckResponse checkSkillSearchNameFormat(String skillSearchName) {
+        ParamCheckResponse paramCheckResponse = new ParamCheckResponse();
+        if (StringUtils.isBlank(skillSearchName)) {
+            paramCheckResponse.setSuccess(true);
+            return paramCheckResponse;
+        }
+        if (skillSearchName.length() > paramCheckRule.maxSkillNameLength) {
+            paramCheckResponse.setSuccess(false);
+            paramCheckResponse.setMessage("Skill search name must be 1-64 characters");
+            return paramCheckResponse;
+        }
+        if (!skillSearchNamePattern.matcher(skillSearchName).matches()) {
+            paramCheckResponse.setSuccess(false);
+            paramCheckResponse.setMessage(
+                "Skill search name may only contain lowercase letters, numbers, and hyphens");
+            return paramCheckResponse;
+        }
+        if (skillSearchName.contains("--")) {
+            paramCheckResponse.setSuccess(false);
+            paramCheckResponse
+                .setMessage("Skill search name must not contain consecutive hyphens (--)");
             return paramCheckResponse;
         }
         paramCheckResponse.setSuccess(true);

--- a/common/src/main/java/com/alibaba/nacos/common/paramcheck/ParamCheckRule.java
+++ b/common/src/main/java/com/alibaba/nacos/common/paramcheck/ParamCheckRule.java
@@ -63,6 +63,8 @@ public class ParamCheckRule {
     
     public String skillNamePatternString = "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$";
     
+    public String skillSearchNamePatternString = "^[a-z0-9-]+$";
+    
     public int maxSkillNameLength = 64;
     
     public String mcpNamePatternString = "^[a-zA-Z0-9-_\\/\\.]+$";

--- a/common/src/main/java/com/alibaba/nacos/common/paramcheck/ParamInfo.java
+++ b/common/src/main/java/com/alibaba/nacos/common/paramcheck/ParamInfo.java
@@ -53,6 +53,8 @@ public class ParamInfo {
     
     private String skillName;
     
+    private String skillSearchName;
+    
     public String getNamespaceShowName() {
         return namespaceShowName;
     }
@@ -163,5 +165,13 @@ public class ParamInfo {
     
     public void setSkillName(String skillName) {
         this.skillName = skillName;
+    }
+    
+    public String getSkillSearchName() {
+        return skillSearchName;
+    }
+    
+    public void setSkillSearchName(String skillSearchName) {
+        this.skillSearchName = skillSearchName;
     }
 }

--- a/common/src/test/java/com/alibaba/nacos/common/paramcheck/DefaultParamCheckerTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/paramcheck/DefaultParamCheckerTest.java
@@ -330,6 +330,13 @@ class DefaultParamCheckerTest {
         assertEquals(
             "Skill name may only contain lowercase letters, numbers, and hyphens, and must not start or end with a hyphen",
             actual.getMessage());
+        // Strict skill name should not start or end with hyphen
+        paramInfo.setSkillName("test-");
+        actual = paramChecker.checkParamInfoList(paramInfos);
+        assertFalse(actual.isSuccess());
+        assertEquals(
+            "Skill name may only contain lowercase letters, numbers, and hyphens, and must not start or end with a hyphen",
+            actual.getMessage());
         // Max Length
         paramInfo.setSkillName(buildStringLength(65));
         actual = paramChecker.checkParamInfoList(paramInfos);
@@ -344,6 +351,34 @@ class DefaultParamCheckerTest {
         paramInfo.setSkillName("skill-name1");
         actual = paramChecker.checkParamInfoList(paramInfos);
         assertTrue(actual.isSuccess());
+    }
+    
+    @Test
+    void testCheckParamInfoForSkillSearchName() {
+        ParamInfo paramInfo = new ParamInfo();
+        ArrayList<ParamInfo> paramInfos = new ArrayList<>();
+        paramInfos.add(paramInfo);
+        // Fuzzy search term should allow trailing hyphen
+        paramInfo.setSkillSearchName("test-");
+        ParamCheckResponse actual = paramChecker.checkParamInfoList(paramInfos);
+        assertTrue(actual.isSuccess());
+        // Pattern
+        paramInfo.setSkillSearchName("Skill_Name");
+        actual = paramChecker.checkParamInfoList(paramInfos);
+        assertFalse(actual.isSuccess());
+        assertEquals("Skill search name may only contain lowercase letters, numbers, and hyphens",
+            actual.getMessage());
+        // Max Length
+        paramInfo.setSkillSearchName(buildStringLength(65));
+        actual = paramChecker.checkParamInfoList(paramInfos);
+        assertFalse(actual.isSuccess());
+        assertEquals("Skill search name must be 1-64 characters", actual.getMessage());
+        // Consecutive hyphens
+        paramInfo.setSkillSearchName("test--skill");
+        actual = paramChecker.checkParamInfoList(paramInfos);
+        assertFalse(actual.isSuccess());
+        assertEquals("Skill search name must not contain consecutive hyphens (--)",
+            actual.getMessage());
     }
     
     @Test

--- a/common/src/test/java/com/alibaba/nacos/common/paramcheck/ParamInfoTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/paramcheck/ParamInfoTest.java
@@ -161,4 +161,13 @@ class ParamInfoTest {
         paramInfo.setSkillName("skill-123");
         assertEquals("skill-123", paramInfo.getSkillName());
     }
+    
+    @Test
+    @DisplayName("Getter and setter for skillSearchName should work correctly")
+    void testSkillSearchNameGetterSetter() {
+        ParamInfo paramInfo = new ParamInfo();
+        assertNull(paramInfo.getSkillSearchName());
+        paramInfo.setSkillSearchName("skill-");
+        assertEquals("skill-", paramInfo.getSkillSearchName());
+    }
 }

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
@@ -31,6 +31,7 @@ import com.alibaba.nacos.ai.form.skills.admin.SkillSubmitForm;
 import com.alibaba.nacos.ai.form.skills.admin.SkillUpdateForm;
 import com.alibaba.nacos.api.ai.model.skills.BatchUploadResult;
 import com.alibaba.nacos.ai.param.SkillHttpParamExtractor;
+import com.alibaba.nacos.ai.param.SkillListHttpParamExtractor;
 import com.alibaba.nacos.ai.service.skills.SkillUploadRequest;
 import com.alibaba.nacos.ai.utils.SkillRequestUtil;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
@@ -151,6 +152,7 @@ public class ConsoleSkillController {
     @Since("3.2.1")
     @GetMapping("/list")
     @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
+    @ExtractorManager.Extractor(httpExtractor = SkillListHttpParamExtractor.class)
     public Result<Page<SkillSummary>> listSkills(SkillListForm skillListForm,
         AiResourceFilterableForm filterableForm, PageForm pageForm) throws NacosException {
         skillListForm.validate();

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillControllerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillControllerTest.java
@@ -17,7 +17,10 @@
 package com.alibaba.nacos.console.controller.v3.ai;
 
 import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.form.AiResourceFilterableForm;
+import com.alibaba.nacos.ai.form.skills.admin.SkillListForm;
 import com.alibaba.nacos.ai.form.skills.admin.SkillPublishForm;
+import com.alibaba.nacos.ai.param.SkillListHttpParamExtractor;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillMeta;
 import com.alibaba.nacos.api.ai.model.skills.SkillSummary;
@@ -26,6 +29,8 @@ import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.console.proxy.ai.SkillProxy;
+import com.alibaba.nacos.core.model.form.PageForm;
+import com.alibaba.nacos.core.paramcheck.ExtractorManager;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -182,6 +187,17 @@ class ConsoleSkillControllerTest {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals(1, result.getData().getTotalCount());
+    }
+    
+    @Test
+    void testListSkillsUsesListParamExtractor() throws Exception {
+        ExtractorManager.Extractor extractor = ConsoleSkillController.class
+            .getMethod("listSkills", SkillListForm.class,
+                AiResourceFilterableForm.class, PageForm.class)
+            .getAnnotation(ExtractorManager.Extractor.class);
+        
+        assertNotNull(extractor);
+        assertEquals(SkillListHttpParamExtractor.class, extractor.httpExtractor());
     }
     
     @Test


### PR DESCRIPTION
… when it starts or ends with a hyphen.

Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

fix bug #15265 : AI skill list rejects skillName used as a query condition when it starts or ends with a hyphen

## Brief changelog

fix bug #15265 : AI skill list rejects skillName used as a query condition when it starts or ends with a hyphen

## Verifying this change

fix bug #15265 : AI skill list rejects skillName used as a query condition when it starts or ends with a hyphen