### PR TITLE
[ISSUE #14981] Fix concurrent publishConfig race condition for PostgreSQL

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -235,11 +235,21 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 findConfigInfoState(configInfo.getDataId(), configInfo.getGroup(),
                     configInfo.getTenant());
             if (configInfoState == null) {
-                return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                try {
+                    return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                } catch (DataIntegrityViolationException e) {
+                    // Concurrent insert: another thread already inserted the record.
+                    // Fall back to update for idempotency. (#14981)
+                    LogUtil.DEFAULT_LOG.warn(
+                        "Insert config failed due to unique constraint, fall back to update. "
+                            + "dataId={}, group={}, tenant={}",
+                        configInfo.getDataId(), configInfo.getGroup(), configInfo.getTenant());
+                    return updateConfigInfo(configInfo, srcIp, srcUser, configAdvanceInfo);
+                }
             } else {
                 return updateConfigInfo(configInfo, srcIp, srcUser, configAdvanceInfo);
             }
-            
+
         } catch (Exception exception) {
             LogUtil.FATAL_LOG.error("[db-error] try to update or add config failed, {}",
                 exception.getMessage(),
@@ -247,7 +257,7 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
             throw exception;
         }
     }
-    
+
     @Override
     public ConfigOperateResult insertOrUpdateCas(String srcIp, String srcUser,
         ConfigInfo configInfo,
@@ -257,11 +267,21 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 findConfigInfoState(configInfo.getDataId(), configInfo.getGroup(),
                     configInfo.getTenant());
             if (configInfoState == null) {
-                return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                try {
+                    return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                } catch (DataIntegrityViolationException e) {
+                    // Concurrent insert: another thread already inserted the record.
+                    // Fall back to update for idempotency. (#14981)
+                    LogUtil.DEFAULT_LOG.warn(
+                        "Insert config failed due to unique constraint, fall back to update. "
+                            + "dataId={}, group={}, tenant={}",
+                        configInfo.getDataId(), configInfo.getGroup(), configInfo.getTenant());
+                    return updateConfigInfoCas(configInfo, srcIp, srcUser, configAdvanceInfo);
+                }
             } else {
                 return updateConfigInfoCas(configInfo, srcIp, srcUser, configAdvanceInfo);
             }
-            
+
         } catch (Exception exception) {
             LogUtil.FATAL_LOG.error("[db-error] try to update or add config failed, {}",
                 exception.getMessage(),


### PR DESCRIPTION
## Fixes
- Fixes #14981

## Description

In a Nacos cluster using PostgreSQL as the database backend, concurrent calls to the `publishConfig` API for the same `dataId`, `group`, and `tenant` occasionally result in a 500 Internal Server Error due to `UniqueIndexConflict`.

### Root Cause

`ExternalConfigInfoPersistServiceImpl.insertOrUpdate()` uses a **check-then-act** pattern:

1. `SELECT` to check if the config exists
2. If not exists → `INSERT`
3. If exists → `UPDATE`

Under high concurrency, two threads can both find "not exists" and both attempt `INSERT`. The second one hits the unique constraint (`uk_configinfo_datagrouptenant`) and throws `DataIntegrityViolationException`.

For MySQL, this is typically handled by `ON DUPLICATE KEY UPDATE` or automatic retry in some deployments. PostgreSQL has no such fallback.

### Fix

Catch `DataIntegrityViolationException` on INSERT and fall back to UPDATE, making the operation idempotent across all database backends (MySQL, PostgreSQL, Oracle, etc.).

**Before:**
```
check → INSERT → throw exception ❌
```

**After:**
```
check → INSERT → unique constraint violated → UPDATE ✓
```

## Changes

| File | Description |
|------|-------------|
| `ExternalConfigInfoPersistServiceImpl.java` | Add fallback to UPDATE on INSERT duplicate key violation (+25/-5 lines) |

## Testing

- Checkstyle: 0 violations
- Compile: PASS

This fix makes `insertOrUpdate` and `insertOrUpdateCas` idempotent under concurrent access without requiring application-level retries.