### PR TITLE
[ISSUE #14879] Add client OpenAPI integration tests

### DIFF
--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.common.http.param.Query;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -60,7 +61,7 @@ public abstract class OpenApiBaseITCase {
     @BeforeEach
     public void setUpOpenApiBase() throws Exception {
         logger = LoggerFactory.getLogger(getClass());
-        httpClient = HttpClientBuilder.create().build();
+        httpClient = HttpClientBuilder.create().disableAutomaticRetries().build();
         nacosRestTemplate = new NacosRestTemplate(logger,
                 new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
     }
@@ -99,8 +100,16 @@ public abstract class OpenApiBaseITCase {
         return getRaw(path + "?" + query.toQueryUrl());
     }
     
+    protected ByteResponse getRawBytes(String path, Query query) throws Exception {
+        return executeRawBytes(new HttpGet(url(path + "?" + query.toQueryUrl())));
+    }
+    
     protected HttpResponse postRaw(String path, Query query) throws Exception {
         return executeRaw(new HttpPost(url(path + "?" + query.toQueryUrl())));
+    }
+    
+    protected HttpResponse putRaw(String path, Query query) throws Exception {
+        return executeRaw(new HttpPut(url(path + "?" + query.toQueryUrl())));
     }
     
     protected HttpResponse deleteRaw(String path, Query query) throws Exception {
@@ -111,6 +120,18 @@ public abstract class OpenApiBaseITCase {
         HttpClientResponseHandler<HttpResponse> responseHandler = response -> {
             String body = null == response.getEntity() ? "" : EntityUtils.toString(response.getEntity());
             return new HttpResponse(response.getCode(), body);
+        };
+        return httpClient.execute(request, responseHandler);
+    }
+    
+    protected ByteResponse executeRawBytes(ClassicHttpRequest request) throws Exception {
+        HttpClientResponseHandler<ByteResponse> responseHandler = response -> {
+            byte[] body = null == response.getEntity() ? new byte[0] : EntityUtils.toByteArray(response.getEntity());
+            String contentType = null == response.getEntity() || null == response.getEntity().getContentType()
+                    ? null : response.getEntity().getContentType();
+            String contentDisposition = null == response.getFirstHeader("Content-Disposition") ? null
+                    : response.getFirstHeader("Content-Disposition").getValue();
+            return new ByteResponse(response.getCode(), body, contentType, contentDisposition);
         };
         return httpClient.execute(request, responseHandler);
     }
@@ -170,5 +191,8 @@ public abstract class OpenApiBaseITCase {
     }
     
     protected record HttpResponse(int code, String body) {
+    }
+    
+    protected record ByteResponse(int code, byte[] body, String contentType, String contentDisposition) {
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi;
+
+import com.alibaba.nacos.common.http.client.NacosRestTemplate;
+import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
+import com.alibaba.nacos.common.http.param.Query;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Shared standalone-server OpenAPI integration test infrastructure.
+ *
+ * @author xiweng.yy
+ */
+public abstract class OpenApiBaseITCase {
+    
+    protected static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
+    
+    protected static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
+    
+    protected static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
+    
+    protected CloseableHttpClient httpClient;
+    
+    protected NacosRestTemplate nacosRestTemplate;
+    
+    private final Deque<CleanupAction> cleanupActions = new ArrayDeque<>();
+    
+    private Logger logger;
+    
+    @BeforeEach
+    public void setUpOpenApiBase() throws Exception {
+        logger = LoggerFactory.getLogger(getClass());
+        httpClient = HttpClientBuilder.create().build();
+        nacosRestTemplate = new NacosRestTemplate(logger,
+                new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
+    }
+    
+    @AfterEach
+    public void tearDownOpenApiBase() throws Exception {
+        Exception failure = runCleanupActions();
+        failure = closeRestTemplate(failure);
+        failure = closeHttpClient(failure);
+        if (null != failure) {
+            throw failure;
+        }
+    }
+    
+    protected Logger logger() {
+        return logger;
+    }
+    
+    protected void addCleanup(CleanupAction cleanupAction) {
+        cleanupActions.addLast(cleanupAction);
+    }
+    
+    protected static String nacosPath(String apiPath) {
+        return "/nacos" + apiPath;
+    }
+    
+    protected static String url(String path) {
+        return BASE_URL + path;
+    }
+    
+    protected HttpResponse getRaw(String pathAndQuery) throws Exception {
+        return executeRaw(new HttpGet(url(pathAndQuery)));
+    }
+    
+    protected HttpResponse getRaw(String path, Query query) throws Exception {
+        return getRaw(path + "?" + query.toQueryUrl());
+    }
+    
+    protected HttpResponse postRaw(String path, Query query) throws Exception {
+        return executeRaw(new HttpPost(url(path + "?" + query.toQueryUrl())));
+    }
+    
+    protected HttpResponse deleteRaw(String path, Query query) throws Exception {
+        return executeRaw(new HttpDelete(url(path + "?" + query.toQueryUrl())));
+    }
+    
+    protected HttpResponse executeRaw(ClassicHttpRequest request) throws Exception {
+        HttpClientResponseHandler<HttpResponse> responseHandler = response -> {
+            String body = null == response.getEntity() ? "" : EntityUtils.toString(response.getEntity());
+            return new HttpResponse(response.getCode(), body);
+        };
+        return httpClient.execute(request, responseHandler);
+    }
+    
+    protected static void addIfNotBlank(Query query, String name, String value) {
+        if (null != value && !value.isBlank()) {
+            query.addParam(name, value);
+        }
+    }
+    
+    private Exception runCleanupActions() {
+        Exception failure = null;
+        while (!cleanupActions.isEmpty()) {
+            try {
+                cleanupActions.removeLast().run();
+            } catch (Exception e) {
+                failure = mergeFailure(failure, e);
+            }
+        }
+        return failure;
+    }
+    
+    private Exception closeRestTemplate(Exception failure) {
+        if (null != nacosRestTemplate) {
+            try {
+                nacosRestTemplate.close();
+            } catch (Exception e) {
+                failure = mergeFailure(failure, e);
+            }
+        }
+        return failure;
+    }
+    
+    private Exception closeHttpClient(Exception failure) {
+        if (null != httpClient) {
+            try {
+                httpClient.close();
+            } catch (Exception e) {
+                failure = mergeFailure(failure, e);
+            }
+        }
+        return failure;
+    }
+    
+    private Exception mergeFailure(Exception existing, Exception next) {
+        if (null == existing) {
+            return next;
+        }
+        existing.addSuppressed(next);
+        return existing;
+    }
+    
+    @FunctionalInterface
+    protected interface CleanupAction {
+        
+        void run() throws Exception;
+    }
+    
+    protected record HttpResponse(int code, String body) {
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AgentSpecClientOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AgentSpecClientOpenApiITCase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.client.ai;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the AI AgentSpec client Open API {@code GET /nacos/v3/client/ai/agentspecs}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: an online AgentSpec can be queried by latest, explicit version, and label with manifest
+ *     content and resource files preserved.</li>
+ *     <li>Boundary/validation: omitted namespaceId uses public; AgentSpec version resolution gives label priority over
+ *     explicit version; unknown label falls back to latest; missing name is rejected with HTTP 400.</li>
+ *     <li>Exception/error handling: absent AgentSpec and unknown explicit version return controlled not-found
+ *     responses instead of HTTP 500.</li>
+ * </ul>
+ *
+ * <p>Draft, update-draft, force-publish, label, and delete calls to {@code /nacos/v3/admin/ai/agentspecs} are helper
+ * calls only; this class keeps its assertions focused on the runtime client query contract.
+ *
+ * @author xiweng.yy
+ */
+public class AgentSpecClientOpenApiITCase extends AgentSpecOpenApiBaseITCase {
+    
+    @Test
+    public void testGetAgentSpecByLatestVersionAndLabel() throws Exception {
+        String name = randomAgentSpecName("agentspec");
+        publishAgentSpec(name, "1.0.0", null, "AgentSpec v1", "scenario-v1", "soul v1");
+        addCleanup(() -> deleteAgentSpec(name));
+        publishAgentSpec(name, "2.0.0", "1.0.0", "AgentSpec v2", "scenario-v2", "soul v2");
+        updateAgentSpecLabels(name, "{\"stable\":\"1.0.0\",\"latest\":\"2.0.0\"}");
+        
+        JsonNode latest = getAgentSpec(Query.newInstance().addParam("name", name));
+        assertAgentSpec(latest.get("data"), name, "2.0.0", "AgentSpec v2", "scenario-v2", "soul v2");
+        
+        JsonNode byVersion = getAgentSpec(Query.newInstance().addParam("name", name)
+                .addParam("version", "1.0.0"));
+        assertAgentSpec(byVersion.get("data"), name, "1.0.0", "AgentSpec v1", "scenario-v1", "soul v1");
+        
+        JsonNode byLabel = getAgentSpec(Query.newInstance().addParam("name", name)
+                .addParam("label", "stable"));
+        assertAgentSpec(byLabel.get("data"), name, "1.0.0", "AgentSpec v1", "scenario-v1", "soul v1");
+        
+        JsonNode labelWins = getAgentSpec(Query.newInstance().addParam("name", name)
+                .addParam("version", "2.0.0").addParam("label", "stable"));
+        assertAgentSpec(labelWins.get("data"), name, "1.0.0", "AgentSpec v1", "scenario-v1", "soul v1");
+    }
+    
+    @Test
+    public void testGetAgentSpecMissingNameReturnsBadRequest() throws Exception {
+        assertError(getRaw(AGENT_SPEC_CLIENT_PATH + "?namespaceId=" + DEFAULT_NAMESPACE), 400,
+                ErrorCode.PARAMETER_MISSING, "AgentSpec name is required");
+    }
+    
+    @Test
+    public void testGetAgentSpecUnknownResourceReturnsNotFoundResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("name", randomAgentSpecName("absent"));
+        assertError(getRaw(AGENT_SPEC_CLIENT_PATH, query), 404, ErrorCode.RESOURCE_NOT_FOUND,
+                "AgentSpec not found");
+    }
+    
+    @Test
+    public void testGetAgentSpecUnknownVersionAndLabelFallback() throws Exception {
+        String name = randomAgentSpecName("missing");
+        publishAgentSpec(name, "1.0.0", null, "Only AgentSpec", "only-scenario", "only soul");
+        addCleanup(() -> deleteAgentSpec(name));
+        
+        assertError(getRaw(AGENT_SPEC_CLIENT_PATH,
+                Query.newInstance().addParam("name", name).addParam("version", "9.9.9")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec version not online");
+        JsonNode unknownLabel = getAgentSpec(Query.newInstance().addParam("name", name)
+                .addParam("label", "missing"));
+        assertAgentSpec(unknownLabel.get("data"), name, "1.0.0", "Only AgentSpec", "only-scenario",
+                "only soul");
+    }
+    
+    private JsonNode getAgentSpec(Query query) throws Exception {
+        return getJsonOk(AGENT_SPEC_CLIENT_PATH, query);
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AgentSpecOpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AgentSpecOpenApiBaseITCase.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.client.ai;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Shared helpers for AgentSpec client OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class AgentSpecOpenApiBaseITCase extends AiOpenApiBaseITCase {
+    
+    protected static final String AGENT_SPEC_CLIENT_PATH = nacosPath(Constants.AgentSpecs.CLIENT_PATH);
+    
+    protected static final String AGENT_SPEC_ADMIN_PATH = nacosPath(Constants.AgentSpecs.ADMIN_PATH);
+    
+    protected void publishAgentSpec(String name, String version, String basedOnVersion, String description,
+            String scenario, String soulContent) throws Exception {
+        JsonNode draft = postFormOk(AGENT_SPEC_ADMIN_PATH + "/draft",
+                buildAgentSpecDraftForm(name, version, basedOnVersion));
+        assertEquals(version, draft.get("data").asText(), draft.toString());
+        JsonNode updated = putFormOk(AGENT_SPEC_ADMIN_PATH + "/draft",
+                buildAgentSpecUpdateForm(name, version, description, scenario, soulContent));
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("agentSpecName", name);
+        form.put("version", version);
+        form.put("updateLatestLabel", "true");
+        JsonNode published = postFormOk(AGENT_SPEC_ADMIN_PATH + "/force-publish", form);
+        assertEquals("ok", published.get("data").asText(), published.toString());
+    }
+    
+    protected void updateAgentSpecLabels(String name, String labels) throws Exception {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("agentSpecName", name);
+        form.put("labels", labels);
+        JsonNode root = putFormOk(AGENT_SPEC_ADMIN_PATH + "/labels", form);
+        assertEquals("ok", root.get("data").asText(), root.toString());
+    }
+    
+    protected void deleteAgentSpec(String name) throws Exception {
+        deleteQuietly(AGENT_SPEC_ADMIN_PATH, Query.newInstance().addParam("agentSpecName", name));
+    }
+    
+    protected String randomAgentSpecName(String scenario) {
+        return "oit-" + scenario + "-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+    
+    protected String randomAgentSpecSuffix() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+    
+    protected void assertAgentSpec(JsonNode data, String name, String version, String description,
+            String scenario, String soulContent) throws Exception {
+        assertNotNull(data);
+        assertEquals(DEFAULT_NAMESPACE, data.get("namespaceId").asText());
+        assertEquals(name, data.get("name").asText());
+        assertEquals(description, data.get("description").asText());
+        JsonNode content = JacksonUtils.toObj(data.get("content").asText());
+        assertEquals(name, content.get("worker").get("suggested_name").asText());
+        assertEquals(version, content.get("version").asText());
+        assertEquals(scenario, content.get("scenario").asText());
+        JsonNode resource = data.get("resource").get("config_SOUL__md");
+        assertNotNull(resource, data.toString());
+        assertEquals("SOUL.md", resource.get("name").asText());
+        assertEquals("config", resource.get("type").asText());
+        assertEquals(soulContent, resource.get("content").asText());
+    }
+    
+    private Map<String, String> buildAgentSpecDraftForm(String name, String version, String basedOnVersion) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("agentSpecName", name);
+        form.put("targetVersion", version);
+        if (null != basedOnVersion) {
+            form.put("basedOnVersion", basedOnVersion);
+        }
+        return form;
+    }
+    
+    private Map<String, String> buildAgentSpecUpdateForm(String name, String version, String description,
+            String scenario, String soulContent) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("agentSpecCard", buildAgentSpecCard(name, version, description, scenario, soulContent));
+        return form;
+    }
+    
+    private String buildAgentSpecCard(String name, String version, String description, String scenario,
+            String soulContent) {
+        Map<String, Object> card = new LinkedHashMap<>();
+        card.put("name", name);
+        card.put("description", description);
+        card.put("bizTags", "[\"openapi-it\"]");
+        card.put("content", buildManifestContent(name, version, scenario));
+        Map<String, Object> soul = new LinkedHashMap<>();
+        soul.put("name", "SOUL.md");
+        soul.put("type", "config");
+        soul.put("content", soulContent);
+        Map<String, Object> resources = new LinkedHashMap<>();
+        resources.put("config_SOUL__md", soul);
+        card.put("resource", resources);
+        return JacksonUtils.toJson(card);
+    }
+    
+    private String buildManifestContent(String name, String version, String scenario) {
+        Map<String, Object> worker = new LinkedHashMap<>();
+        worker.put("suggested_name", name);
+        Map<String, Object> manifest = new LinkedHashMap<>();
+        manifest.put("worker", worker);
+        manifest.put("version", version);
+        manifest.put("scenario", scenario);
+        return JacksonUtils.toJson(manifest);
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AgentSpecSearchClientOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AgentSpecSearchClientOpenApiITCase.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.client.ai;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the AI AgentSpec search Open API {@code GET /nacos/v3/client/ai/agentspecs/search}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: search returns enabled AgentSpecs with online versions, filters by keyword, and exposes
+ *     the expected page fields and basic AgentSpec information.</li>
+ *     <li>Boundary/validation: omitted namespaceId uses public; keyword is optional; pageNo and pageSize default when
+ *     omitted and reject non-positive values.</li>
+ *     <li>Exception/error handling: no-match search returns a successful empty page, while invalid pagination returns
+ *     HTTP 400 with a wrapped validation error instead of HTTP 500.</li>
+ * </ul>
+ *
+ * <p>Draft, update-draft, force-publish, and delete calls to {@code /nacos/v3/admin/ai/agentspecs} are helper calls
+ * only; this class keeps its assertions focused on the runtime client search contract.
+ *
+ * @author xiweng.yy
+ */
+public class AgentSpecSearchClientOpenApiITCase extends AgentSpecOpenApiBaseITCase {
+    
+    private static final String AGENT_SPEC_SEARCH_PATH = AGENT_SPEC_CLIENT_PATH + "/search";
+    
+    @Test
+    public void testSearchAgentSpecsByKeywordAndPagination() throws Exception {
+        String suffix = randomAgentSpecSuffix();
+        String firstName = "oit-search-a-" + suffix;
+        String secondName = "oit-search-b-" + suffix;
+        publishAgentSpec(firstName, "1.0.0", null, "Search AgentSpec A", "search-a", "soul a");
+        addCleanup(() -> deleteAgentSpec(firstName));
+        publishAgentSpec(secondName, "1.0.0", null, "Search AgentSpec B", "search-b", "soul b");
+        addCleanup(() -> deleteAgentSpec(secondName));
+        
+        JsonNode both = search(Query.newInstance().addParam("keyword", suffix));
+        JsonNode bothPage = both.get("data");
+        assertEquals(1, bothPage.get("pageNumber").asInt(), bothPage.toString());
+        assertEquals(2, bothPage.get("totalCount").asInt(), bothPage.toString());
+        assertContainsAgentSpec(bothPage, firstName, "Search AgentSpec A");
+        assertContainsAgentSpec(bothPage, secondName, "Search AgentSpec B");
+        
+        JsonNode paged = search(Query.newInstance().addParam("keyword", suffix)
+                .addParam("pageNo", "1").addParam("pageSize", "1"));
+        JsonNode pagedData = paged.get("data");
+        assertEquals(1, pagedData.get("pageNumber").asInt(), pagedData.toString());
+        assertEquals(2, pagedData.get("totalCount").asInt(), pagedData.toString());
+        assertEquals(2, pagedData.get("pagesAvailable").asInt(), pagedData.toString());
+        assertEquals(1, pagedData.get("pageItems").size(), pagedData.toString());
+        
+        JsonNode firstOnly = search(Query.newInstance().addParam("keyword", "search-a-" + suffix));
+        JsonNode firstOnlyPage = firstOnly.get("data");
+        assertEquals(1, firstOnlyPage.get("totalCount").asInt(), firstOnlyPage.toString());
+        assertContainsAgentSpec(firstOnlyPage, firstName, "Search AgentSpec A");
+        assertNotContainsAgentSpec(firstOnlyPage, secondName);
+    }
+    
+    @Test
+    public void testSearchAgentSpecsEmptyKeywordUsesPublicNamespace() throws Exception {
+        String name = randomAgentSpecName("open-search");
+        publishAgentSpec(name, "1.0.0", null, "Open Search AgentSpec", "open-search", "open soul");
+        addCleanup(() -> deleteAgentSpec(name));
+        
+        JsonNode root = search(Query.newInstance().addParam("pageNo", "1").addParam("pageSize", "500"));
+        JsonNode page = root.get("data");
+        assertEquals(1, page.get("pageNumber").asInt(), page.toString());
+        assertContainsAgentSpec(page, name, "Open Search AgentSpec");
+    }
+    
+    @Test
+    public void testSearchAgentSpecsNoMatchReturnsEmptyPage() throws Exception {
+        JsonNode root = search(Query.newInstance().addParam("keyword", "no-match-" + randomAgentSpecSuffix()));
+        JsonNode page = root.get("data");
+        assertEquals(1, page.get("pageNumber").asInt(), page.toString());
+        assertEquals(0, page.get("totalCount").asInt(), page.toString());
+        assertEquals(0, page.get("pagesAvailable").asInt(), page.toString());
+        assertEquals(0, page.get("pageItems").size(), page.toString());
+    }
+    
+    @Test
+    public void testSearchAgentSpecsInvalidPaginationReturnsBadRequest() throws Exception {
+        assertError(getRaw(AGENT_SPEC_SEARCH_PATH + "?pageNo=0"), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(AGENT_SPEC_SEARCH_PATH + "?pageSize=0"), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageSize");
+    }
+    
+    private JsonNode search(Query query) throws Exception {
+        return getJsonOk(AGENT_SPEC_SEARCH_PATH, query);
+    }
+    
+    private void assertContainsAgentSpec(JsonNode page, String name, String description) {
+        JsonNode found = findAgentSpec(page, name);
+        assertFalse(found.isMissingNode(), page.toString());
+        assertEquals(description, found.get("description").asText(), found.toString());
+    }
+    
+    private void assertNotContainsAgentSpec(JsonNode page, String name) {
+        assertTrue(findAgentSpec(page, name).isMissingNode(), page.toString());
+    }
+    
+    private JsonNode findAgentSpec(JsonNode page, String name) {
+        for (JsonNode item : page.get("pageItems")) {
+            if (name.equals(item.get("name").asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AiOpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AiOpenApiBaseITCase.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.client.ai;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shared helpers for AI client OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class AiOpenApiBaseITCase extends OpenApiBaseITCase {
+    
+    protected static final String DEFAULT_NAMESPACE = "public";
+    
+    protected JsonNode postFormOk(String path, Map<String, String> form) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), Header.EMPTY, form, String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
+                + restResult.getData() + ", message=" + restResult.getMessage());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+    
+    protected JsonNode postFormOk(String path, Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), Header.EMPTY, query,
+                Collections.emptyMap(), String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, body=" + restResult.getData());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+    
+    protected JsonNode putFormOk(String path, Map<String, String> form) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.putForm(url(path), Header.EMPTY, form, String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
+                + restResult.getData() + ", message=" + restResult.getMessage());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+    
+    protected JsonNode getJsonOk(String path, Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.get(url(path), Header.EMPTY, query, String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, body=" + restResult.getData());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+    
+    protected void deleteQuietly(String path, Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(path), Header.EMPTY, query, String.class);
+        if (!restResult.ok()) {
+            logger().warn("delete non-OK: path={} code={} body={}", path, restResult.getCode(), restResult.getData());
+        }
+    }
+    
+    protected void assertSuccess(JsonNode root) {
+        assertNotNull(root);
+        assertEquals(ErrorCode.SUCCESS.getCode(), root.get("code").asInt(), root.toString());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), root.get("message").asText(), root.toString());
+    }
+    
+    protected void assertError(HttpResponse response, int expectedStatus, ErrorCode expectedCode, String expectedData)
+            throws Exception {
+        assertEquals(expectedStatus, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertNotNull(root, response.body());
+        assertEquals(expectedCode.getCode(), root.get("code").asInt(), response.body());
+        assertNotNull(root.get("message").asText(), response.body());
+        assertTrue(root.get("data").asText().contains(expectedData), response.body());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/PromptClientOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/PromptClientOpenApiITCase.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.client.ai;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the AI prompt client Open API {@code GET /nacos/v3/client/ai/prompt}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: a prompt published through admin APIs can be queried by latest, explicit version, and
+ *     label, with promptKey, version, template, md5, and variables preserved.</li>
+ *     <li>Boundary/validation: omitted namespaceId uses the public namespace; explicit version has priority over
+ *     label; an unknown label falls back to latest; missing promptKey is rejected with HTTP 400; namespace values that
+ *     pass the deployed param filter but do not contain the resource return not found.</li>
+ *     <li>Exception/error handling: md5 conditional fetch returns HTTP 304; absent prompt and unknown version return
+ *     controlled not-found responses instead of HTTP 500.</li>
+ * </ul>
+ *
+ * <p>Draft, force-publish, label, and delete calls to {@code /nacos/v3/admin/ai/prompt} are helper calls only; this
+ * class keeps its assertions focused on the runtime client query contract.
+ *
+ * @author xiweng.yy
+ */
+public class PromptClientOpenApiITCase extends AiOpenApiBaseITCase {
+    
+    private static final String PROMPT_CLIENT_PATH = nacosPath(Constants.Prompt.CLIENT_PATH);
+    
+    private static final String PROMPT_ADMIN_PATH = nacosPath(Constants.Prompt.ADMIN_PATH);
+    
+    @Test
+    public void testQueryPromptByLatestVersionLabelAndMd5() throws Exception {
+        String promptKey = randomPromptKey("prompt");
+        publishPrompt(promptKey, "1.0.0", "Hello {{name}} from v1");
+        addCleanup(() -> deletePrompt(promptKey));
+        publishPrompt(promptKey, "2.0.0", "Hello {{name}} from v2");
+        updateLabels(promptKey, "{\"stable\":\"1.0.0\",\"latest\":\"2.0.0\"}");
+        
+        JsonNode latest = getPrompt(Query.newInstance().addParam("promptKey", promptKey));
+        JsonNode latestData = latest.get("data");
+        assertPrompt(latestData, promptKey, "2.0.0", "Hello {{name}} from v2");
+        assertEquals("name", latestData.get("variables").get(0).get("name").asText());
+        assertEquals("Nacos", latestData.get("variables").get(0).get("defaultValue").asText());
+        assertNotNull(latestData.get("md5").asText());
+        
+        JsonNode byVersion = getPrompt(Query.newInstance().addParam("promptKey", promptKey)
+                .addParam("version", "1.0.0"));
+        assertPrompt(byVersion.get("data"), promptKey, "1.0.0", "Hello {{name}} from v1");
+        
+        JsonNode byLabel = getPrompt(Query.newInstance().addParam("promptKey", promptKey)
+                .addParam("label", "stable"));
+        assertPrompt(byLabel.get("data"), promptKey, "1.0.0", "Hello {{name}} from v1");
+        
+        JsonNode versionWins = getPrompt(Query.newInstance().addParam("promptKey", promptKey)
+                .addParam("version", "2.0.0").addParam("label", "stable"));
+        assertPrompt(versionWins.get("data"), promptKey, "2.0.0", "Hello {{name}} from v2");
+        
+        HttpResponse notModified = getRaw(PROMPT_CLIENT_PATH,
+                Query.newInstance().addParam("promptKey", promptKey)
+                        .addParam("md5", latestData.get("md5").asText()));
+        assertEquals(304, notModified.code(), notModified.body());
+    }
+    
+    @Test
+    public void testQueryPromptMissingPromptKeyReturnsBadRequest() throws Exception {
+        assertError(getRaw(PROMPT_CLIENT_PATH + "?namespaceId=" + DEFAULT_NAMESPACE), 400,
+                ErrorCode.PARAMETER_MISSING, "promptKey");
+    }
+    
+    @Test
+    public void testQueryPromptUnknownNamespaceReturnsNotFoundResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("promptKey", "openapi_it_prompt_invalid_ns")
+                .addParam("namespaceId", "invalid namespace");
+        assertError(getRaw(PROMPT_CLIENT_PATH, query), 404, ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+    }
+    
+    @Test
+    public void testQueryPromptUnknownResourceReturnsNotFoundResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("promptKey", randomPromptKey("absent"));
+        assertError(getRaw(PROMPT_CLIENT_PATH, query), 404, ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+    }
+    
+    @Test
+    public void testQueryPromptUnknownVersionReturnsNotFoundAndUnknownLabelFallsBackLatest() throws Exception {
+        String promptKey = randomPromptKey("missing");
+        publishPrompt(promptKey, "1.0.0", "only version");
+        addCleanup(() -> deletePrompt(promptKey));
+        
+        assertError(getRaw(PROMPT_CLIENT_PATH,
+                Query.newInstance().addParam("promptKey", promptKey).addParam("version", "9.9.9")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Prompt version not online");
+        JsonNode unknownLabel = getPrompt(Query.newInstance().addParam("promptKey", promptKey)
+                .addParam("label", "missing"));
+        assertPrompt(unknownLabel.get("data"), promptKey, "1.0.0", "only version");
+    }
+    
+    private JsonNode getPrompt(Query query) throws Exception {
+        JsonNode root = getJsonOk(PROMPT_CLIENT_PATH, query);
+        assertNotNull(root.get("data"), root.toString());
+        return root;
+    }
+    
+    private void publishPrompt(String promptKey, String version, String template) throws Exception {
+        JsonNode draft = postFormOk(PROMPT_ADMIN_PATH + "/draft", buildPromptForm(promptKey, version, template));
+        assertEquals(version, draft.get("data").asText(), draft.toString());
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("promptKey", promptKey);
+        form.put("version", version);
+        form.put("updateLatestLabel", "true");
+        JsonNode published = postFormOk(PROMPT_ADMIN_PATH + "/force-publish", form);
+        assertEquals("ok", published.get("data").asText(), published.toString());
+    }
+    
+    private void updateLabels(String promptKey, String labels) throws Exception {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("promptKey", promptKey);
+        form.put("labels", labels);
+        JsonNode root = putFormOk(PROMPT_ADMIN_PATH + "/labels", form);
+        assertEquals("ok", root.get("data").asText(), root.toString());
+    }
+    
+    private void deletePrompt(String promptKey) throws Exception {
+        deleteQuietly(PROMPT_ADMIN_PATH, Query.newInstance().addParam("promptKey", promptKey));
+    }
+    
+    private Map<String, String> buildPromptForm(String promptKey, String version, String template) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("promptKey", promptKey);
+        form.put("targetVersion", version);
+        form.put("template", template);
+        form.put("variables", "[{\"name\":\"name\",\"defaultValue\":\"Nacos\",\"description\":\"target name\"}]");
+        form.put("commitMsg", "openapi prompt client it");
+        form.put("description", "prompt client openapi integration test");
+        form.put("bizTags", "openapi-it");
+        return form;
+    }
+    
+    private String randomPromptKey(String scenario) {
+        return "oit_" + scenario + "_" + UUID.randomUUID().toString().substring(0, 8);
+    }
+    
+    private void assertPrompt(JsonNode actual, String promptKey, String version, String template) {
+        assertNotNull(actual);
+        assertEquals(promptKey, actual.get("promptKey").asText());
+        assertEquals(version, actual.get("version").asText());
+        assertEquals(template, actual.get("template").asText());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/SkillClientOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/SkillClientOpenApiITCase.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.client.ai;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the AI skill client Open API {@code GET /nacos/v3/client/ai/skills}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: an online skill can be downloaded as a ZIP by latest, explicit version, and label; the
+ *     ZIP contains {@code SKILL.md}, normalized version front matter, and resource files.</li>
+ *     <li>Boundary/validation: omitted namespaceId uses public; explicit version has priority over label; missing
+ *     name and malformed name are rejected with HTTP 400; unknown version and unknown label are not resolved.</li>
+ *     <li>Exception/error handling: absent skill and unresolved version/label return controlled not-found JSON
+ *     responses instead of HTTP 500, while successful responses keep the binary ZIP contract.</li>
+ * </ul>
+ *
+ * <p>Draft, update-draft, force-publish, label, and delete calls to {@code /nacos/v3/admin/ai/skills} are helper calls
+ * only; this class keeps its assertions focused on the runtime client download contract.
+ *
+ * @author xiweng.yy
+ */
+public class SkillClientOpenApiITCase extends AiOpenApiBaseITCase {
+    
+    private static final String SKILL_CLIENT_PATH = nacosPath(Constants.Skills.CLIENT_PATH);
+    
+    private static final String SKILL_ADMIN_PATH = nacosPath(Constants.Skills.ADMIN_PATH);
+    
+    @Test
+    public void testDownloadSkillByLatestVersionAndLabel() throws Exception {
+        String skillName = randomSkillName("skill");
+        publishSkill(skillName, "1.0.0", null, "Use the v1 skill body.", "guide v1");
+        addCleanup(() -> deleteSkill(skillName));
+        publishSkill(skillName, "2.0.0", "1.0.0", "Use the v2 skill body.", "guide v2");
+        updateLabels(skillName, "{\"stable\":\"1.0.0\",\"latest\":\"2.0.0\"}");
+        
+        assertSkillZip(Query.newInstance().addParam("name", skillName), skillName, "2.0.0",
+                "Use the v2 skill body.", "guide v2");
+        assertSkillZip(Query.newInstance().addParam("name", skillName).addParam("version", "1.0.0"),
+                skillName, "1.0.0", "Use the v1 skill body.", "guide v1");
+        assertSkillZip(Query.newInstance().addParam("name", skillName).addParam("label", "stable"),
+                skillName, "1.0.0", "Use the v1 skill body.", "guide v1");
+        assertSkillZip(Query.newInstance().addParam("name", skillName).addParam("version", "2.0.0")
+                .addParam("label", "stable"), skillName, "2.0.0", "Use the v2 skill body.", "guide v2");
+    }
+    
+    @Test
+    public void testDownloadSkillMissingNameReturnsBadRequest() throws Exception {
+        assertError(getRaw(SKILL_CLIENT_PATH + "?namespaceId=" + DEFAULT_NAMESPACE), 400,
+                ErrorCode.PARAMETER_MISSING, "Skill name is required");
+    }
+    
+    @Test
+    public void testDownloadSkillInvalidNameReturnsBadRequest() throws Exception {
+        Query query = Query.newInstance().addParam("name", "invalid_name");
+        assertError(getRaw(SKILL_CLIENT_PATH, query), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "Skill name may only contain lowercase letters, numbers, and hyphens");
+    }
+    
+    @Test
+    public void testDownloadSkillUnknownResourceReturnsNotFoundResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("name", randomSkillName("absent"));
+        assertError(getRaw(SKILL_CLIENT_PATH, query), 404, ErrorCode.RESOURCE_NOT_FOUND, "Skill not found");
+    }
+    
+    @Test
+    public void testDownloadSkillUnknownVersionAndLabelReturnNotFoundResultBody() throws Exception {
+        String skillName = randomSkillName("missing");
+        publishSkill(skillName, "1.0.0", null, "Only one online skill body.", "guide");
+        addCleanup(() -> deleteSkill(skillName));
+        
+        assertError(getRaw(SKILL_CLIENT_PATH,
+                Query.newInstance().addParam("name", skillName).addParam("version", "9.9.9")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Skill version not found");
+        assertError(getRaw(SKILL_CLIENT_PATH,
+                Query.newInstance().addParam("name", skillName).addParam("label", "missing")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Skill version not found");
+    }
+    
+    private void publishSkill(String skillName, String version, String basedOnVersion, String body,
+            String guideContent) throws Exception {
+        if (null == basedOnVersion) {
+            JsonNode draft = postFormOk(SKILL_ADMIN_PATH + "/draft",
+                    buildSkillDraftForm(skillName, version, body, guideContent));
+            assertEquals(version, draft.get("data").asText(), draft.toString());
+        } else {
+            JsonNode draft = postFormOk(SKILL_ADMIN_PATH + "/draft",
+                    buildSkillForkForm(skillName, version, basedOnVersion));
+            assertEquals(version, draft.get("data").asText(), draft.toString());
+            JsonNode updated = putFormOk(SKILL_ADMIN_PATH + "/draft",
+                    buildSkillUpdateForm(skillName, body, guideContent));
+            assertEquals("ok", updated.get("data").asText(), updated.toString());
+        }
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("skillName", skillName);
+        form.put("version", version);
+        form.put("updateLatestLabel", "true");
+        JsonNode published = postFormOk(SKILL_ADMIN_PATH + "/force-publish", form);
+        assertEquals("ok", published.get("data").asText(), published.toString());
+    }
+    
+    private void updateLabels(String skillName, String labels) throws Exception {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("skillName", skillName);
+        form.put("labels", labels);
+        JsonNode root = putFormOk(SKILL_ADMIN_PATH + "/labels", form);
+        assertEquals("ok", root.get("data").asText(), root.toString());
+    }
+    
+    private void deleteSkill(String skillName) throws Exception {
+        deleteQuietly(SKILL_ADMIN_PATH, Query.newInstance().addParam("skillName", skillName));
+    }
+    
+    private Map<String, String> buildSkillDraftForm(String skillName, String version, String body,
+            String guideContent) {
+        Map<String, String> form = buildSkillUpdateForm(skillName, body, guideContent);
+        form.put("targetVersion", version);
+        return form;
+    }
+    
+    private Map<String, String> buildSkillForkForm(String skillName, String version, String basedOnVersion) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("skillName", skillName);
+        form.put("targetVersion", version);
+        form.put("basedOnVersion", basedOnVersion);
+        form.put("commitMsg", "openapi skill client it");
+        return form;
+    }
+    
+    private Map<String, String> buildSkillUpdateForm(String skillName, String body, String guideContent) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("skillCard", buildSkillCard(skillName, body, guideContent));
+        form.put("commitMsg", "openapi skill client it");
+        return form;
+    }
+    
+    private String buildSkillCard(String skillName, String body, String guideContent) {
+        Map<String, Object> card = new LinkedHashMap<>();
+        card.put("name", skillName);
+        card.put("description", "skill client openapi integration test");
+        card.put("skillMd", "---\nname: " + skillName
+                + "\ndescription: skill client openapi integration test\n---\n\n" + body);
+        Map<String, Object> guide = new LinkedHashMap<>();
+        guide.put("name", "guide.md");
+        guide.put("type", "references");
+        guide.put("content", guideContent);
+        Map<String, Object> resources = new LinkedHashMap<>();
+        resources.put("references::guide.md", guide);
+        card.put("resource", resources);
+        return JacksonUtils.toJson(card);
+    }
+    
+    private void assertSkillZip(Query query, String skillName, String version, String body, String guideContent)
+            throws Exception {
+        ByteResponse response = getRawBytes(SKILL_CLIENT_PATH, query);
+        assertEquals(200, response.code(), new String(response.body(), StandardCharsets.UTF_8));
+        assertNotNull(response.contentDisposition());
+        assertTrue(response.contentDisposition().contains(skillName + ".zip"),
+                response.contentDisposition());
+        Map<String, String> entries = unzipTextEntries(response.body());
+        String skillMd = entries.get(skillName + "/SKILL.md");
+        assertNotNull(skillMd, entries.keySet().toString());
+        assertTrue(skillMd.contains("name: " + skillName), skillMd);
+        assertTrue(skillMd.contains("version: " + version), skillMd);
+        assertTrue(skillMd.contains(body), skillMd);
+        assertEquals(guideContent, entries.get(skillName + "/references/guide.md"));
+    }
+    
+    private Map<String, String> unzipTextEntries(byte[] body) throws Exception {
+        Map<String, String> result = new LinkedHashMap<>();
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(body))) {
+            ZipEntry entry;
+            while (null != (entry = zis.getNextEntry())) {
+                if (!entry.isDirectory()) {
+                    result.put(entry.getName(), new String(readEntry(zis), StandardCharsets.UTF_8));
+                }
+            }
+        }
+        return result;
+    }
+    
+    private byte[] readEntry(ZipInputStream zis) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = zis.read(buffer)) != -1) {
+            output.write(buffer, 0, len);
+        }
+        return output.toByteArray();
+    }
+    
+    private String randomSkillName(String scenario) {
+        return "oit-" + scenario + "-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/config/ConfigOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/config/ConfigOpenApiITCase.java
@@ -20,26 +20,15 @@ import com.alibaba.nacos.api.config.remote.response.ConfigQueryResponse;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.http.HttpRestResult;
-import com.alibaba.nacos.common.http.client.NacosRestTemplate;
-import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.constant.Constants;
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
@@ -71,45 +60,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author xiweng.yy
  */
-public class ConfigOpenApiITCase {
+public class ConfigOpenApiITCase extends OpenApiBaseITCase {
     
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigOpenApiITCase.class);
+    private static final String CLIENT_CONFIG_PATH = nacosPath(Constants.CONFIG_V3_CLIENT_API_PATH);
     
-    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
-    
-    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
-    
-    private static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
-    
-    private static final String CLIENT_CONFIG_PATH = "/nacos" + Constants.CONFIG_V3_CLIENT_API_PATH;
-    
-    private static final String ADMIN_CONFIG_PATH = "/nacos" + Constants.CONFIG_ADMIN_V3_PATH;
+    private static final String ADMIN_CONFIG_PATH = nacosPath(Constants.CONFIG_ADMIN_V3_PATH);
     
     private static final String DEFAULT_NAMESPACE = "public";
     
     private static final String TEST_GROUP = "openapi_it_group";
     
-    private CloseableHttpClient httpClient;
-    
-    private NacosRestTemplate nacosRestTemplate;
-    
-    @BeforeEach
-    public void setUp() throws Exception {
-        httpClient = HttpClientBuilder.create().build();
-        nacosRestTemplate = new NacosRestTemplate(LOGGER,
-                new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
-    }
-    
-    @AfterEach
-    public void tearDown() throws Exception {
-        nacosRestTemplate.close();
-    }
-    
     @Test
     public void testGetConfigWhenNotExists() throws Exception {
         String dataId = "openapi_it_absent_" + UUID.randomUUID();
         HttpRestResult<String> httpResult = getConfig(dataId, TEST_GROUP, DEFAULT_NAMESPACE);
-        LOGGER.debug("getConfig result: {}", JacksonUtils.toJson(httpResult));
+        logger().debug("getConfig result: {}", JacksonUtils.toJson(httpResult));
         assertTrue(httpResult.ok(), "HTTP status should be 2xx");
         assertNotNull(httpResult.getData());
         Result<ConfigQueryResponse> actual = JacksonUtils.toObj(httpResult.getData(), new TypeReference<>() {
@@ -121,143 +86,121 @@ public class ConfigOpenApiITCase {
     public void testGetConfigSuccessAfterPublish() throws Exception {
         String dataId = "openapi_it_ok_" + UUID.randomUUID();
         String content = "hello-openapi-it-" + UUID.randomUUID();
-        try {
-            assertTrue(publishConfig(dataId, TEST_GROUP, "", content));
-            Result<ConfigQueryResponse> actual = null;
-            int retryTime = 10;
-            while (retryTime-- > 0) {
-                HttpRestResult<String> httpResult = getConfig(dataId, TEST_GROUP, DEFAULT_NAMESPACE);
-                assertTrue(httpResult.ok());
-                actual = JacksonUtils.toObj(httpResult.getData(), new TypeReference<>() {
-                });
-                if (ErrorCode.SUCCESS.getCode().equals(actual.getCode())) {
-                    break;
-                }
-                // After publish success, nacos will async cache into disk from storage.
-                TimeUnit.MILLISECONDS.sleep(100);
+        assertTrue(publishConfig(dataId, TEST_GROUP, "", content));
+        addCleanup(() -> deleteConfig(dataId, TEST_GROUP, ""));
+        Result<ConfigQueryResponse> actual = null;
+        int retryTime = 10;
+        while (retryTime-- > 0) {
+            HttpRestResult<String> httpResult = getConfig(dataId, TEST_GROUP, DEFAULT_NAMESPACE);
+            assertTrue(httpResult.ok());
+            actual = JacksonUtils.toObj(httpResult.getData(), new TypeReference<>() {
+            });
+            if (ErrorCode.SUCCESS.getCode().equals(actual.getCode())) {
+                break;
             }
-            assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode(), "Expected success after retry, but not still failed.");
-            assertNotNull(actual.getData());
-            assertEquals(content, actual.getData().getContent());
-            assertEquals(MD5Utils.md5Hex(content, StandardCharsets.UTF_8.name()), actual.getData().getMd5());
-            assertTrue(actual.getData().getLastModified() > 0L);
-            assertNotNull(actual.getData().getContentType());
-            assertFalse(actual.getData().isBeta());
-        } finally {
-            deleteConfig(dataId, TEST_GROUP, "");
+            // After publish success, nacos will async cache into disk from storage.
+            TimeUnit.MILLISECONDS.sleep(100);
         }
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode(), "Expected success after retry, but not still failed.");
+        assertNotNull(actual.getData());
+        assertEquals(content, actual.getData().getContent());
+        assertEquals(MD5Utils.md5Hex(content, StandardCharsets.UTF_8.name()), actual.getData().getMd5());
+        assertTrue(actual.getData().getLastModified() > 0L);
+        assertNotNull(actual.getData().getContentType());
+        assertFalse(actual.getData().isBeta());
     }
     
     @Test
     public void testGetConfigOmitNamespaceUsesPublic() throws Exception {
         String dataId = "openapi_it_public_" + UUID.randomUUID();
         String content = "ns-default";
-        try {
-            assertTrue(publishConfig(dataId, TEST_GROUP, "", content));
-            String url = BASE_URL + CLIENT_CONFIG_PATH;
-            Query query = Query.newInstance().addParam("dataId", dataId).addParam("groupName", TEST_GROUP);
-            Result<ConfigQueryResponse> actual = null;
-            int retryTime = 10;
-            while (retryTime-- > 0) {
-                HttpRestResult<String> httpResult = nacosRestTemplate.get(url, Header.EMPTY, query, String.class);
-                assertTrue(httpResult.ok());
-                actual = JacksonUtils.toObj(httpResult.getData(), new TypeReference<>() {
-                });
-                if (ErrorCode.SUCCESS.getCode().equals(actual.getCode())) {
-                    break;
-                }
-                // After publish success, nacos will async cache into disk from storage.
-                TimeUnit.MILLISECONDS.sleep(100);
+        assertTrue(publishConfig(dataId, TEST_GROUP, "", content));
+        addCleanup(() -> deleteConfig(dataId, TEST_GROUP, ""));
+        Query query = Query.newInstance().addParam("dataId", dataId).addParam("groupName", TEST_GROUP);
+        Result<ConfigQueryResponse> actual = null;
+        int retryTime = 10;
+        while (retryTime-- > 0) {
+            HttpRestResult<String> httpResult = nacosRestTemplate.get(url(CLIENT_CONFIG_PATH), Header.EMPTY, query,
+                    String.class);
+            assertTrue(httpResult.ok());
+            actual = JacksonUtils.toObj(httpResult.getData(), new TypeReference<>() {
+            });
+            if (ErrorCode.SUCCESS.getCode().equals(actual.getCode())) {
+                break;
             }
-            assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode(), "Expected success after retry, but not still failed.");
-            assertEquals(content, actual.getData().getContent());
-        } finally {
-            deleteConfig(dataId, TEST_GROUP, "");
+            // After publish success, nacos will async cache into disk from storage.
+            TimeUnit.MILLISECONDS.sleep(100);
         }
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode(), "Expected success after retry, but not still failed.");
+        assertEquals(content, actual.getData().getContent());
     }
     
     @Test
     public void testGetConfigWrongNamespaceNotFound() throws Exception {
         String dataId = "openapi_it_tenant_" + UUID.randomUUID();
         String alienNamespace = "openapi_it_other_ns_" + UUID.randomUUID();
-        try {
-            assertTrue(publishConfig(dataId, TEST_GROUP, "", "only-in-public"));
-            HttpRestResult<String> httpResult = getConfig(dataId, TEST_GROUP, alienNamespace);
-            assertTrue(httpResult.ok());
-            Result<ConfigQueryResponse> actual = JacksonUtils.toObj(httpResult.getData(), new TypeReference<>() {
-            });
-            assertEquals(ErrorCode.RESOURCE_NOT_FOUND.getCode(), actual.getCode());
-        } finally {
-            deleteConfig(dataId, TEST_GROUP, "");
-        }
+        assertTrue(publishConfig(dataId, TEST_GROUP, "", "only-in-public"));
+        addCleanup(() -> deleteConfig(dataId, TEST_GROUP, ""));
+        HttpRestResult<String> httpResult = getConfig(dataId, TEST_GROUP, alienNamespace);
+        assertTrue(httpResult.ok());
+        Result<ConfigQueryResponse> actual = JacksonUtils.toObj(httpResult.getData(), new TypeReference<>() {
+        });
+        assertEquals(ErrorCode.RESOURCE_NOT_FOUND.getCode(), actual.getCode());
     }
     
     @Test
     public void testGetConfigMissingDataIdReturnsBadRequest() throws Exception {
-        String url = BASE_URL + CLIENT_CONFIG_PATH;
         Query query = Query.newInstance().addParam("groupName", TEST_GROUP).addParam("namespaceId", DEFAULT_NAMESPACE);
-        assertPlainBadRequest(rawGet(url, query), "dataId");
+        assertPlainBadRequest(getRaw(CLIENT_CONFIG_PATH, query), "dataId");
     }
     
     @Test
     public void testGetConfigMissingGroupNameReturnsBadRequest() throws Exception {
-        String url = BASE_URL + CLIENT_CONFIG_PATH;
         Query query = Query.newInstance().addParam("dataId", "any").addParam("namespaceId", DEFAULT_NAMESPACE);
-        assertPlainBadRequest(rawGet(url, query), "groupName");
+        assertPlainBadRequest(getRaw(CLIENT_CONFIG_PATH, query), "groupName");
     }
     
     @Test
     public void testGetConfigLegacyGroupParameterDoesNotReplaceGroupName() throws Exception {
-        String url = BASE_URL + CLIENT_CONFIG_PATH;
         Query query = Query.newInstance().addParam("dataId", "any").addParam("group", TEST_GROUP)
                 .addParam("namespaceId", DEFAULT_NAMESPACE);
-        assertPlainBadRequest(rawGet(url, query), "groupName");
+        assertPlainBadRequest(getRaw(CLIENT_CONFIG_PATH, query), "groupName");
     }
     
     @Test
     public void testGetConfigInvalidNamespaceReturnsBadRequest() throws Exception {
-        String url = BASE_URL + CLIENT_CONFIG_PATH;
         Query query = Query.newInstance().addParam("dataId", "any").addParam("groupName", TEST_GROUP)
                 .addParam("namespaceId", "invalid namespace");
-        assertBadRequestResult(rawGet(url, query), ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceId");
+        assertBadRequestResult(getRaw(CLIENT_CONFIG_PATH, query), ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceId");
     }
     
     private HttpRestResult<String> getConfig(String dataId, String group, String namespace) throws Exception {
-        String url = BASE_URL + CLIENT_CONFIG_PATH;
         Query query = Query.newInstance().addParam("dataId", dataId).addParam("groupName", group)
                 .addParam("namespaceId", namespace);
-        return nacosRestTemplate.get(url, Header.EMPTY, query, String.class);
-    }
-    
-    private HttpResponse rawGet(String url, Query query) throws Exception {
-        HttpGet request = new HttpGet(url + "?" + query.toQueryUrl());
-        try (CloseableHttpResponse response = httpClient.execute(request)) {
-            String body = null == response.getEntity() ? "" : EntityUtils.toString(response.getEntity());
-            return new HttpResponse(response.getCode(), body);
-        }
+        return nacosRestTemplate.get(url(CLIENT_CONFIG_PATH), Header.EMPTY, query, String.class);
     }
     
     private void assertBadRequestResult(HttpResponse response, ErrorCode errorCode, String expectedData)
             throws Exception {
-        assertEquals(400, response.statusCode, response.body);
-        Result<String> actual = JacksonUtils.toObj(response.body, new TypeReference<>() {
+        assertEquals(400, response.code(), response.body());
+        Result<String> actual = JacksonUtils.toObj(response.body(), new TypeReference<>() {
         });
-        assertEquals(errorCode.getCode(), actual.getCode(), response.body);
-        assertNotNull(actual.getMessage(), response.body);
-        assertNotNull(actual.getData(), response.body);
-        assertTrue(actual.getData().contains(expectedData), response.body);
+        assertEquals(errorCode.getCode(), actual.getCode(), response.body());
+        assertNotNull(actual.getMessage(), response.body());
+        assertNotNull(actual.getData(), response.body());
+        assertTrue(actual.getData().contains(expectedData), response.body());
     }
     
     private void assertPlainBadRequest(HttpResponse response, String expectedField) {
-        assertEquals(400, response.statusCode, response.body);
-        assertTrue(response.body.contains("Required parameter"), response.body);
-        assertTrue(response.body.contains(expectedField), response.body);
+        assertEquals(400, response.code(), response.body());
+        assertTrue(response.body().contains("Required parameter"), response.body());
+        assertTrue(response.body().contains(expectedField), response.body());
     }
     
     private boolean publishConfig(String dataId, String groupName, String namespaceId, String content) throws Exception {
-        String url = BASE_URL + ADMIN_CONFIG_PATH;
         Map<String, String> form = buildPublishForm(dataId, groupName, namespaceId, content);
-        HttpRestResult<String> httpResult = nacosRestTemplate.postForm(url, Header.EMPTY, form, String.class);
+        HttpRestResult<String> httpResult = nacosRestTemplate.postForm(url(ADMIN_CONFIG_PATH), Header.EMPTY, form,
+                String.class);
         assertTrue(httpResult.ok(), "publish HTTP status should be 2xx, body=" + httpResult.getData());
         JsonNode root = JacksonUtils.toObj(httpResult.getData());
         assertNotNull(root);
@@ -266,12 +209,12 @@ public class ConfigOpenApiITCase {
     }
     
     private void deleteConfig(String dataId, String groupName, String namespaceId) throws Exception {
-        String url = BASE_URL + ADMIN_CONFIG_PATH;
         Query query = Query.newInstance().addParam("dataId", dataId).addParam("groupName", groupName)
                 .addParam("namespaceId", namespaceId).addParam("tag", "");
-        HttpRestResult<String> httpResult = nacosRestTemplate.delete(url, Header.EMPTY, query, String.class);
+        HttpRestResult<String> httpResult = nacosRestTemplate.delete(url(ADMIN_CONFIG_PATH), Header.EMPTY, query,
+                String.class);
         if (!httpResult.ok()) {
-            LOGGER.warn("deleteConfig non-OK: code={} body={}", httpResult.getCode(), httpResult.getData());
+            logger().warn("deleteConfig non-OK: code={} body={}", httpResult.getCode(), httpResult.getData());
         }
     }
     
@@ -295,8 +238,5 @@ public class ConfigOpenApiITCase {
         form.put("type", "");
         form.put("schema", "");
         return form;
-    }
-    
-    private record HttpResponse(int statusCode, String body) {
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/config/ConfigOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/config/ConfigOpenApiITCase.java
@@ -29,9 +29,12 @@ import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,18 +57,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@code GET /nacos/v3/client/cs/config}), aligned with
  * <a href="https://nacos.io/swagger/client/zh/api.json">Nacos HTTP 客户端 API</a>.
  *
- * <p><b>How this fits the new IT pipeline ({@code .github/workflows/it-new.yml})</b>
- * <ol>
- *     <li>Workflow builds the server distribution, patches {@code application.properties} (auth secrets / identity),
- *     starts standalone Nacos, then waits on console port {@code 8080}.</li>
- *     <li>{@code mvn clean verify -Pintegration-test} under {@code test/} runs Failsafe; {@code openapi-test} uses
- *     system properties {@code nacos.host} / {@code nacos.port} (default {@code 127.0.0.1:8848}) to call the
- *     <em>main</em> server port.</li>
- *     <li>Config is published and removed through the <em>admin</em> API ({@code /v3/admin/cs/config}), because the
- *     client API is read-only by design.</li>
- *     <li>With default {@code nacos.core.auth.enabled=false}, {@code @Secured} does not require a token; if your
- *     environment enables auth, extend these tests to attach {@code accessToken} like other IT modules.</li>
- * </ol>
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: a config published through the admin API can be queried through the client OpenAPI with
+ *     content, md5, lastModified, contentType, and beta response fields.</li>
+ *     <li>Boundary/validation: omitted {@code namespaceId} uses the public namespace; wrong namespace returns a wrapped
+ *     not-found result; {@code dataId} and {@code groupName} are required; v3 does not accept the legacy {@code group}
+ *     parameter as a replacement for {@code groupName}; invalid namespace values are rejected by parameter checking.</li>
+ *     <li>Exception/error handling: absent config returns HTTP 2xx with {@code RESOURCE_NOT_FOUND}; invalid namespace
+ *     returns HTTP 400 with wrapped {@code Result} fields; required-field validation currently returns controlled
+ *     HTTP 400 text from this controller path rather than HTTP 500.</li>
+ * </ul>
  *
  * @author xiweng.yy
  */
@@ -139,6 +141,7 @@ public class ConfigOpenApiITCase {
             assertEquals(content, actual.getData().getContent());
             assertEquals(MD5Utils.md5Hex(content, StandardCharsets.UTF_8.name()), actual.getData().getMd5());
             assertTrue(actual.getData().getLastModified() > 0L);
+            assertNotNull(actual.getData().getContentType());
             assertFalse(actual.getData().isBeta());
         } finally {
             deleteConfig(dataId, TEST_GROUP, "");
@@ -193,16 +196,30 @@ public class ConfigOpenApiITCase {
     public void testGetConfigMissingDataIdReturnsBadRequest() throws Exception {
         String url = BASE_URL + CLIENT_CONFIG_PATH;
         Query query = Query.newInstance().addParam("groupName", TEST_GROUP).addParam("namespaceId", DEFAULT_NAMESPACE);
-        HttpRestResult<String> httpResult = nacosRestTemplate.get(url, Header.EMPTY, query, String.class);
-        assertEquals(400, httpResult.getCode());
+        assertPlainBadRequest(rawGet(url, query), "dataId");
     }
     
     @Test
     public void testGetConfigMissingGroupNameReturnsBadRequest() throws Exception {
         String url = BASE_URL + CLIENT_CONFIG_PATH;
         Query query = Query.newInstance().addParam("dataId", "any").addParam("namespaceId", DEFAULT_NAMESPACE);
-        HttpRestResult<String> httpResult = nacosRestTemplate.get(url, Header.EMPTY, query, String.class);
-        assertEquals(400, httpResult.getCode());
+        assertPlainBadRequest(rawGet(url, query), "groupName");
+    }
+    
+    @Test
+    public void testGetConfigLegacyGroupParameterDoesNotReplaceGroupName() throws Exception {
+        String url = BASE_URL + CLIENT_CONFIG_PATH;
+        Query query = Query.newInstance().addParam("dataId", "any").addParam("group", TEST_GROUP)
+                .addParam("namespaceId", DEFAULT_NAMESPACE);
+        assertPlainBadRequest(rawGet(url, query), "groupName");
+    }
+    
+    @Test
+    public void testGetConfigInvalidNamespaceReturnsBadRequest() throws Exception {
+        String url = BASE_URL + CLIENT_CONFIG_PATH;
+        Query query = Query.newInstance().addParam("dataId", "any").addParam("groupName", TEST_GROUP)
+                .addParam("namespaceId", "invalid namespace");
+        assertBadRequestResult(rawGet(url, query), ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceId");
     }
     
     private HttpRestResult<String> getConfig(String dataId, String group, String namespace) throws Exception {
@@ -210,6 +227,31 @@ public class ConfigOpenApiITCase {
         Query query = Query.newInstance().addParam("dataId", dataId).addParam("groupName", group)
                 .addParam("namespaceId", namespace);
         return nacosRestTemplate.get(url, Header.EMPTY, query, String.class);
+    }
+    
+    private HttpResponse rawGet(String url, Query query) throws Exception {
+        HttpGet request = new HttpGet(url + "?" + query.toQueryUrl());
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            String body = null == response.getEntity() ? "" : EntityUtils.toString(response.getEntity());
+            return new HttpResponse(response.getCode(), body);
+        }
+    }
+    
+    private void assertBadRequestResult(HttpResponse response, ErrorCode errorCode, String expectedData)
+            throws Exception {
+        assertEquals(400, response.statusCode, response.body);
+        Result<String> actual = JacksonUtils.toObj(response.body, new TypeReference<>() {
+        });
+        assertEquals(errorCode.getCode(), actual.getCode(), response.body);
+        assertNotNull(actual.getMessage(), response.body);
+        assertNotNull(actual.getData(), response.body);
+        assertTrue(actual.getData().contains(expectedData), response.body);
+    }
+    
+    private void assertPlainBadRequest(HttpResponse response, String expectedField) {
+        assertEquals(400, response.statusCode, response.body);
+        assertTrue(response.body.contains("Required parameter"), response.body);
+        assertTrue(response.body.contains(expectedField), response.body);
     }
     
     private boolean publishConfig(String dataId, String groupName, String namespaceId, String content) throws Exception {
@@ -253,5 +295,8 @@ public class ConfigOpenApiITCase {
         form.put("type", "");
         form.put("schema", "");
         return form;
+    }
+    
+    private record HttpResponse(int statusCode, String body) {
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceDeregisterOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceDeregisterOpenApiITCase.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.client.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.http.client.NacosRestTemplate;
+import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
+import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the naming client Open API {@code DELETE /nacos/v3/client/ns/instance}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: deregistering an existing instance returns success and removes that instance from the
+ *     client list API.</li>
+ *     <li>Boundary/validation: omitted groupName and clusterName use default values; explicit groupName and clusterName
+ *     target only the requested instance identity; deregistering an absent instance is idempotent success; serviceName,
+ *     ip, and port are required.</li>
+ *     <li>Error handling: required-field and invalid clusterName failures return controlled HTTP 400 responses with
+ *     wrapped {@code Result} fields instead of HTTP 500.</li>
+ * </ul>
+ *
+ * <p>POST and GET list calls to {@code /nacos/v3/client/ns/instance} are helper calls only; this class keeps its
+ * assertions focused on the deregister API contract.
+ *
+ * @author xiweng.yy
+ */
+public class InstanceDeregisterOpenApiITCase {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceDeregisterOpenApiITCase.class);
+    
+    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
+    
+    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
+    
+    private static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
+    
+    private static final String INSTANCE_PATH =
+            "/nacos" + UtilsAndCommons.INSTANCE_V3_CLIENT_API_PATH;
+    
+    private static final String INSTANCE_LIST_PATH = INSTANCE_PATH + "/list";
+    
+    private static final String TEST_GROUP = "OPENAPI_IT_DEREGISTER_GROUP";
+    
+    private static final String TEST_CLUSTER = "openapi-it-deregister-cluster";
+    
+    private CloseableHttpClient httpClient;
+    
+    private NacosRestTemplate nacosRestTemplate;
+    
+    @BeforeEach
+    public void setUp() throws Exception {
+        httpClient = HttpClientBuilder.create().build();
+        nacosRestTemplate = new NacosRestTemplate(LOGGER,
+                new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
+    }
+    
+    @AfterEach
+    public void tearDown() throws Exception {
+        nacosRestTemplate.close();
+    }
+    
+    @Test
+    public void testDeregisterDefaultIdentityRemovesInstance() throws Exception {
+        String serviceName = "openapi-it-deregister-default-" + UUID.randomUUID();
+        String ip = "10.13.0.1";
+        int port = 9201;
+        register(serviceName, ip, port, UtilsAndCommons.DEFAULT_CLUSTER_NAME, null);
+        assertNotNull(waitUntilInstanceVisible(serviceName, null, UtilsAndCommons.DEFAULT_CLUSTER_NAME, ip, port));
+        
+        assertDeregisterOk(Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
+                .addParam("port", String.valueOf(port)));
+        
+        assertEventuallyAbsent(serviceName, null, UtilsAndCommons.DEFAULT_CLUSTER_NAME, ip, port);
+    }
+    
+    @Test
+    public void testDeregisterExplicitGroupAndClusterDoesNotRemoveOtherIdentity() throws Exception {
+        String serviceName = "openapi-it-deregister-isolated-" + UUID.randomUUID();
+        String targetIp = "10.13.0.2";
+        String otherIp = "10.13.0.3";
+        try {
+            register(serviceName, targetIp, 9202, TEST_CLUSTER, TEST_GROUP);
+            register(serviceName, otherIp, 9203, TEST_CLUSTER, null);
+            assertNotNull(waitUntilInstanceVisible(serviceName, TEST_GROUP, TEST_CLUSTER, targetIp, 9202));
+            assertNotNull(waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, otherIp, 9203));
+            
+            assertDeregisterOk(baseInstanceQuery(serviceName, targetIp, 9202).addParam("groupName", TEST_GROUP)
+                    .addParam("clusterName", TEST_CLUSTER));
+            
+            assertEventuallyAbsent(serviceName, TEST_GROUP, TEST_CLUSTER, targetIp, 9202);
+            assertNotNull(waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, otherIp, 9203));
+        } finally {
+            deregisterQuietly(serviceName, targetIp, 9202, TEST_CLUSTER, TEST_GROUP);
+            deregisterQuietly(serviceName, otherIp, 9203, TEST_CLUSTER, null);
+        }
+    }
+    
+    @Test
+    public void testDeregisterAbsentInstanceReturnsSuccess() throws Exception {
+        String serviceName = "openapi-it-deregister-absent-" + UUID.randomUUID();
+        Result<String> actual = deregister(baseInstanceQuery(serviceName, "10.13.0.4", 9204)
+                .addParam("clusterName", TEST_CLUSTER));
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+        assertEquals("ok", actual.getData());
+    }
+    
+    @Test
+    public void testDeregisterMissingServiceNameReturnsBadRequestResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("ip", "10.13.0.5").addParam("port", "9205");
+        assertBadRequest(query, ErrorCode.PARAMETER_MISSING, "serviceName");
+    }
+    
+    @Test
+    public void testDeregisterMissingIpReturnsBadRequestResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("serviceName", "openapi-it-deregister-missing-ip")
+                .addParam("port", "9206");
+        assertBadRequest(query, ErrorCode.PARAMETER_MISSING, "ip");
+    }
+    
+    @Test
+    public void testDeregisterMissingPortReturnsBadRequestResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("serviceName", "openapi-it-deregister-missing-port")
+                .addParam("ip", "10.13.0.7");
+        assertBadRequest(query, ErrorCode.PARAMETER_MISSING, "port");
+    }
+    
+    @Test
+    public void testDeregisterInvalidClusterNameReturnsBadRequestResultBody() throws Exception {
+        Query query = baseInstanceQuery("openapi-it-deregister-bad-cluster", "10.13.0.8", 9208)
+                .addParam("clusterName", "cluster1,cluster2");
+        assertBadRequest(query, ErrorCode.PARAMETER_VALIDATE_ERROR, "cluster");
+    }
+    
+    private void register(String serviceName, String ip, int port, String clusterName,
+            String groupName) throws Exception {
+        Query query = baseInstanceQuery(serviceName, ip, port).addParam("clusterName", clusterName);
+        addIfNotBlank(query, "groupName", groupName);
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(BASE_URL + INSTANCE_PATH,
+                Header.EMPTY, query, Collections.emptyMap(), String.class);
+        assertTrue(restResult.ok(), "register HTTP status should be 2xx, body=" + restResult.getData());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertEquals(ErrorCode.SUCCESS.getCode(), root.get("code").asInt(), restResult.getData());
+    }
+    
+    private void assertDeregisterOk(Query query) throws Exception {
+        Result<String> actual = deregister(query);
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+        assertEquals("ok", actual.getData());
+    }
+    
+    private Result<String> deregister(Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(BASE_URL + INSTANCE_PATH,
+                Header.EMPTY, query, String.class);
+        assertTrue(restResult.ok(), "deregister HTTP status should be 2xx, body=" + restResult.getData());
+        return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
+        });
+    }
+    
+    private void deregisterQuietly(String serviceName, String ip, int port, String clusterName,
+            String groupName) throws Exception {
+        Query query = baseInstanceQuery(serviceName, ip, port).addParam("clusterName", clusterName);
+        addIfNotBlank(query, "groupName", groupName);
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(BASE_URL + INSTANCE_PATH,
+                Header.EMPTY, query, String.class);
+        if (!restResult.ok()) {
+            LOGGER.warn("deregister instance non-OK: code={} body={}", restResult.getCode(),
+                    restResult.getData());
+        }
+    }
+    
+    private void assertBadRequest(Query query, ErrorCode errorCode, String expectedData) throws Exception {
+        HttpResponse response = deleteRaw(query);
+        assertEquals(400, response.code, response.body);
+        JsonNode root = JacksonUtils.toObj(response.body);
+        assertNotNull(root);
+        assertEquals(errorCode.getCode(), root.get("code").asInt(), response.body);
+        assertNotNull(root.get("message").asText(), response.body);
+        assertTrue(root.get("data").asText().contains(expectedData), response.body);
+    }
+    
+    private HttpResponse deleteRaw(Query query) throws Exception {
+        HttpDelete httpDelete = new HttpDelete(BASE_URL + INSTANCE_PATH + "?" + query.toQueryUrl());
+        try (CloseableHttpResponse response = httpClient.execute(httpDelete)) {
+            String body = null == response.getEntity() ? ""
+                    : EntityUtils.toString(response.getEntity());
+            return new HttpResponse(response.getCode(), body);
+        }
+    }
+    
+    private Instance waitUntilInstanceVisible(String serviceName, String groupName,
+            String clusterName, String ip, int port) throws Exception {
+        Result<List<Instance>> actual = null;
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            actual = listInstances(serviceName, groupName, clusterName);
+            Instance instance = findInstance(actual.getData(), ip, port);
+            if (null != instance) {
+                return instance;
+            }
+            // Registration is event-driven and may need a short propagation window.
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected registered instance to be visible, last result="
+                + JacksonUtils.toJson(actual));
+    }
+    
+    private void assertEventuallyAbsent(String serviceName, String groupName, String clusterName,
+            String ip, int port) throws Exception {
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            Result<List<Instance>> actual = listInstances(serviceName, groupName, clusterName);
+            if (null == findInstance(actual.getData(), ip, port)) {
+                return;
+            }
+            // Deregistration is event-driven and may need a short propagation window.
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected deregistered instance to be absent: " + ip + ":" + port);
+    }
+    
+    private Result<List<Instance>> listInstances(String serviceName, String groupName,
+            String clusterName) throws Exception {
+        Query query = Query.newInstance().addParam("serviceName", serviceName)
+                .addParam("clusterName", clusterName);
+        addIfNotBlank(query, "groupName", groupName);
+        HttpRestResult<String> restResult = nacosRestTemplate.get(BASE_URL + INSTANCE_LIST_PATH,
+                Header.EMPTY, query, String.class);
+        assertTrue(restResult.ok(), "list HTTP status should be 2xx, body=" + restResult.getData());
+        return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
+        });
+    }
+    
+    private static Query baseInstanceQuery(String serviceName, String ip, int port) {
+        return Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
+                .addParam("port", String.valueOf(port));
+    }
+    
+    private static void addIfNotBlank(Query query, String name, String value) {
+        if (null != value && !value.isBlank()) {
+            query.addParam(name, value);
+        }
+    }
+    
+    private static Instance findInstance(List<Instance> instances, String ip, int port) {
+        if (null == instances) {
+            return null;
+        }
+        for (Instance each : instances) {
+            if (ip.equals(each.getIp()) && port == each.getPort()) {
+                return each;
+            }
+        }
+        return null;
+    }
+    
+    private record HttpResponse(int code, String body) {
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceDeregisterOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceDeregisterOpenApiITCase.java
@@ -20,25 +20,14 @@ import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.common.http.HttpRestResult;
-import com.alibaba.nacos.common.http.client.NacosRestTemplate;
-import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.hc.client5.http.classic.methods.HttpDelete;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -69,40 +58,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author xiweng.yy
  */
-public class InstanceDeregisterOpenApiITCase {
-    
-    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceDeregisterOpenApiITCase.class);
-    
-    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
-    
-    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
-    
-    private static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
+public class InstanceDeregisterOpenApiITCase extends OpenApiBaseITCase {
     
     private static final String INSTANCE_PATH =
-            "/nacos" + UtilsAndCommons.INSTANCE_V3_CLIENT_API_PATH;
+            nacosPath(UtilsAndCommons.INSTANCE_V3_CLIENT_API_PATH);
     
     private static final String INSTANCE_LIST_PATH = INSTANCE_PATH + "/list";
     
     private static final String TEST_GROUP = "OPENAPI_IT_DEREGISTER_GROUP";
     
     private static final String TEST_CLUSTER = "openapi-it-deregister-cluster";
-    
-    private CloseableHttpClient httpClient;
-    
-    private NacosRestTemplate nacosRestTemplate;
-    
-    @BeforeEach
-    public void setUp() throws Exception {
-        httpClient = HttpClientBuilder.create().build();
-        nacosRestTemplate = new NacosRestTemplate(LOGGER,
-                new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
-    }
-    
-    @AfterEach
-    public void tearDown() throws Exception {
-        nacosRestTemplate.close();
-    }
     
     @Test
     public void testDeregisterDefaultIdentityRemovesInstance() throws Exception {
@@ -111,10 +76,10 @@ public class InstanceDeregisterOpenApiITCase {
         int port = 9201;
         register(serviceName, ip, port, UtilsAndCommons.DEFAULT_CLUSTER_NAME, null);
         assertNotNull(waitUntilInstanceVisible(serviceName, null, UtilsAndCommons.DEFAULT_CLUSTER_NAME, ip, port));
-        
+
         assertDeregisterOk(Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
                 .addParam("port", String.valueOf(port)));
-        
+
         assertEventuallyAbsent(serviceName, null, UtilsAndCommons.DEFAULT_CLUSTER_NAME, ip, port);
     }
     
@@ -123,21 +88,16 @@ public class InstanceDeregisterOpenApiITCase {
         String serviceName = "openapi-it-deregister-isolated-" + UUID.randomUUID();
         String targetIp = "10.13.0.2";
         String otherIp = "10.13.0.3";
-        try {
-            register(serviceName, targetIp, 9202, TEST_CLUSTER, TEST_GROUP);
-            register(serviceName, otherIp, 9203, TEST_CLUSTER, null);
-            assertNotNull(waitUntilInstanceVisible(serviceName, TEST_GROUP, TEST_CLUSTER, targetIp, 9202));
-            assertNotNull(waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, otherIp, 9203));
-            
-            assertDeregisterOk(baseInstanceQuery(serviceName, targetIp, 9202).addParam("groupName", TEST_GROUP)
-                    .addParam("clusterName", TEST_CLUSTER));
-            
-            assertEventuallyAbsent(serviceName, TEST_GROUP, TEST_CLUSTER, targetIp, 9202);
-            assertNotNull(waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, otherIp, 9203));
-        } finally {
-            deregisterQuietly(serviceName, targetIp, 9202, TEST_CLUSTER, TEST_GROUP);
-            deregisterQuietly(serviceName, otherIp, 9203, TEST_CLUSTER, null);
-        }
+        register(serviceName, targetIp, 9202, TEST_CLUSTER, TEST_GROUP);
+        register(serviceName, otherIp, 9203, TEST_CLUSTER, null);
+        assertNotNull(waitUntilInstanceVisible(serviceName, TEST_GROUP, TEST_CLUSTER, targetIp, 9202));
+        assertNotNull(waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, otherIp, 9203));
+
+        assertDeregisterOk(baseInstanceQuery(serviceName, targetIp, 9202).addParam("groupName", TEST_GROUP)
+                .addParam("clusterName", TEST_CLUSTER));
+
+        assertEventuallyAbsent(serviceName, TEST_GROUP, TEST_CLUSTER, targetIp, 9202);
+        assertNotNull(waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, otherIp, 9203));
     }
     
     @Test
@@ -181,11 +141,12 @@ public class InstanceDeregisterOpenApiITCase {
             String groupName) throws Exception {
         Query query = baseInstanceQuery(serviceName, ip, port).addParam("clusterName", clusterName);
         addIfNotBlank(query, "groupName", groupName);
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(BASE_URL + INSTANCE_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(INSTANCE_PATH),
                 Header.EMPTY, query, Collections.emptyMap(), String.class);
         assertTrue(restResult.ok(), "register HTTP status should be 2xx, body=" + restResult.getData());
         JsonNode root = JacksonUtils.toObj(restResult.getData());
         assertEquals(ErrorCode.SUCCESS.getCode(), root.get("code").asInt(), restResult.getData());
+        addCleanup(() -> deregisterQuietly(serviceName, ip, port, clusterName, groupName));
     }
     
     private void assertDeregisterOk(Query query) throws Exception {
@@ -196,7 +157,7 @@ public class InstanceDeregisterOpenApiITCase {
     }
     
     private Result<String> deregister(Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.delete(BASE_URL + INSTANCE_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(INSTANCE_PATH),
                 Header.EMPTY, query, String.class);
         assertTrue(restResult.ok(), "deregister HTTP status should be 2xx, body=" + restResult.getData());
         return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
@@ -207,31 +168,22 @@ public class InstanceDeregisterOpenApiITCase {
             String groupName) throws Exception {
         Query query = baseInstanceQuery(serviceName, ip, port).addParam("clusterName", clusterName);
         addIfNotBlank(query, "groupName", groupName);
-        HttpRestResult<String> restResult = nacosRestTemplate.delete(BASE_URL + INSTANCE_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(INSTANCE_PATH),
                 Header.EMPTY, query, String.class);
         if (!restResult.ok()) {
-            LOGGER.warn("deregister instance non-OK: code={} body={}", restResult.getCode(),
+            logger().warn("deregister instance non-OK: code={} body={}", restResult.getCode(),
                     restResult.getData());
         }
     }
     
     private void assertBadRequest(Query query, ErrorCode errorCode, String expectedData) throws Exception {
-        HttpResponse response = deleteRaw(query);
-        assertEquals(400, response.code, response.body);
-        JsonNode root = JacksonUtils.toObj(response.body);
+        HttpResponse response = deleteRaw(INSTANCE_PATH, query);
+        assertEquals(400, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
         assertNotNull(root);
-        assertEquals(errorCode.getCode(), root.get("code").asInt(), response.body);
-        assertNotNull(root.get("message").asText(), response.body);
-        assertTrue(root.get("data").asText().contains(expectedData), response.body);
-    }
-    
-    private HttpResponse deleteRaw(Query query) throws Exception {
-        HttpDelete httpDelete = new HttpDelete(BASE_URL + INSTANCE_PATH + "?" + query.toQueryUrl());
-        try (CloseableHttpResponse response = httpClient.execute(httpDelete)) {
-            String body = null == response.getEntity() ? ""
-                    : EntityUtils.toString(response.getEntity());
-            return new HttpResponse(response.getCode(), body);
-        }
+        assertEquals(errorCode.getCode(), root.get("code").asInt(), response.body());
+        assertNotNull(root.get("message").asText(), response.body());
+        assertTrue(root.get("data").asText().contains(expectedData), response.body());
     }
     
     private Instance waitUntilInstanceVisible(String serviceName, String groupName,
@@ -270,7 +222,7 @@ public class InstanceDeregisterOpenApiITCase {
         Query query = Query.newInstance().addParam("serviceName", serviceName)
                 .addParam("clusterName", clusterName);
         addIfNotBlank(query, "groupName", groupName);
-        HttpRestResult<String> restResult = nacosRestTemplate.get(BASE_URL + INSTANCE_LIST_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.get(url(INSTANCE_LIST_PATH),
                 Header.EMPTY, query, String.class);
         assertTrue(restResult.ok(), "list HTTP status should be 2xx, body=" + restResult.getData());
         return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
@@ -280,12 +232,6 @@ public class InstanceDeregisterOpenApiITCase {
     private static Query baseInstanceQuery(String serviceName, String ip, int port) {
         return Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
                 .addParam("port", String.valueOf(port));
-    }
-    
-    private static void addIfNotBlank(Query query, String name, String value) {
-        if (null != value && !value.isBlank()) {
-            query.addParam(name, value);
-        }
     }
     
     private static Instance findInstance(List<Instance> instances, String ip, int port) {
@@ -298,8 +244,5 @@ public class InstanceDeregisterOpenApiITCase {
             }
         }
         return null;
-    }
-    
-    private record HttpResponse(int code, String body) {
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceListOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceListOpenApiITCase.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.client.naming;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.http.client.NacosRestTemplate;
+import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
+import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the naming client Open API
+ * {@code GET /nacos/v3/client/ns/instance/list}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: registered enabled instances can be listed with
+ *     their ip, port, cluster, service, health, enabled, weight, and metadata.</li>
+ *     <li>Boundary/validation: omitted namespace, group, and clusterName use
+ *     defaults; explicit groupName isolates resources; clusterName filters
+ *     results; healthyOnly is accepted but not used by this Open API; missing
+ *     serviceName returns HTTP 400.</li>
+ *     <li>Error handling: unknown services return a successful empty data array,
+ *     and validation errors return a controlled {@code code/message/data}
+ *     response instead of HTTP 500.</li>
+ * </ul>
+ *
+ * <p>POST and DELETE calls to {@code /nacos/v3/client/ns/instance} are helper
+ * calls only; this class keeps its assertions focused on the list API contract.
+ *
+ * @author xiweng.yy
+ */
+public class InstanceListOpenApiITCase {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceListOpenApiITCase.class);
+    
+    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
+    
+    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
+    
+    private static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
+    
+    private static final String INSTANCE_PATH =
+            "/nacos" + UtilsAndCommons.INSTANCE_V3_CLIENT_API_PATH;
+    
+    private static final String INSTANCE_LIST_PATH = INSTANCE_PATH + "/list";
+    
+    private static final String TEST_CLUSTER = "openapi-it-cluster";
+    
+    private static final String CUSTOM_GROUP = "OPENAPI_IT_GROUP";
+    
+    private CloseableHttpClient httpClient;
+    
+    private NacosRestTemplate nacosRestTemplate;
+    
+    @BeforeEach
+    public void setUp() throws Exception {
+        httpClient = HttpClientBuilder.create().build();
+        nacosRestTemplate = new NacosRestTemplate(LOGGER,
+                new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
+    }
+    
+    @AfterEach
+    public void tearDown() throws Exception {
+        nacosRestTemplate.close();
+    }
+    
+    @Test
+    public void testListDefaultNamespaceAndGroupFiltersDisabledInstances() throws Exception {
+        String serviceName = "openapi-it-list-" + UUID.randomUUID();
+        String enabledIp = "10.11.0.1";
+        String disabledIp = "10.11.0.2";
+        String otherClusterIp = "10.11.0.3";
+        try {
+            assertRegisterOk(serviceName, enabledIp, 9001, TEST_CLUSTER, true);
+            assertRegisterOk(serviceName, disabledIp, 9002, TEST_CLUSTER, false);
+            assertRegisterOk(serviceName, otherClusterIp, 9003, "other-" + TEST_CLUSTER, true);
+            
+            Result<List<Instance>> actual = waitUntilInstanceVisible(serviceName, TEST_CLUSTER,
+                    enabledIp, 9001);
+            assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+            assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+            assertNotNull(actual.getData());
+            assertTrue(containsInstance(actual.getData(), enabledIp, 9001));
+            assertFalse(containsInstance(actual.getData(), disabledIp, 9002),
+                    "client list API should filter enabled=false instances");
+            assertFalse(containsInstance(actual.getData(), otherClusterIp, 9003),
+                    "client list API should filter by clusterName");
+            
+            Instance enabled = findInstance(actual.getData(), enabledIp, 9001);
+            assertEquals(TEST_CLUSTER, enabled.getClusterName());
+            assertEquals(Constants.DEFAULT_GROUP + "@@" + serviceName, enabled.getServiceName());
+            assertTrue(enabled.isHealthy());
+            assertTrue(enabled.isEnabled());
+            assertEquals(1.0, enabled.getWeight(), 0.0001);
+            assertEquals("openapi-it", enabled.getMetadata().get("source"));
+        } finally {
+            deregister(serviceName, enabledIp, 9001, TEST_CLUSTER, null);
+            deregister(serviceName, disabledIp, 9002, TEST_CLUSTER, null);
+            deregister(serviceName, otherClusterIp, 9003, "other-" + TEST_CLUSTER, null);
+        }
+    }
+    
+    @Test
+    public void testListWithoutClusterNameReturnsAllEnabledInstances() throws Exception {
+        String serviceName = "openapi-it-list-all-" + UUID.randomUUID();
+        String defaultClusterIp = "10.11.1.1";
+        String customClusterIp = "10.11.1.2";
+        String disabledIp = "10.11.1.3";
+        try {
+            assertRegisterOk(serviceName, defaultClusterIp, 9011,
+                    UtilsAndCommons.DEFAULT_CLUSTER_NAME, true);
+            assertRegisterOk(serviceName, customClusterIp, 9012, TEST_CLUSTER, true);
+            assertRegisterOk(serviceName, disabledIp, 9013, TEST_CLUSTER, false);
+            
+            Result<List<Instance>> actual = waitUntilInstanceVisible(serviceName, null,
+                    defaultClusterIp, 9011);
+            assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+            assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+            assertTrue(containsInstance(actual.getData(), defaultClusterIp, 9011));
+            assertTrue(containsInstance(actual.getData(), customClusterIp, 9012));
+            assertFalse(containsInstance(actual.getData(), disabledIp, 9013),
+                    "client list API should filter enabled=false instances without clusterName");
+        } finally {
+            deregister(serviceName, defaultClusterIp, 9011,
+                    UtilsAndCommons.DEFAULT_CLUSTER_NAME, null);
+            deregister(serviceName, customClusterIp, 9012, TEST_CLUSTER, null);
+            deregister(serviceName, disabledIp, 9013, TEST_CLUSTER, null);
+        }
+    }
+    
+    @Test
+    public void testListWithExplicitGroupNameIsolatesDefaultGroup() throws Exception {
+        String serviceName = "openapi-it-list-group-" + UUID.randomUUID();
+        String defaultGroupIp = "10.11.2.1";
+        String customGroupIp = "10.11.2.2";
+        try {
+            assertRegisterOk(serviceName, defaultGroupIp, 9021, TEST_CLUSTER, true);
+            assertRegisterOk(serviceName, customGroupIp, 9022, TEST_CLUSTER, true, CUSTOM_GROUP);
+            
+            Result<List<Instance>> defaultGroup = waitUntilInstanceVisible(serviceName,
+                    TEST_CLUSTER, defaultGroupIp, 9021);
+            assertTrue(containsInstance(defaultGroup.getData(), defaultGroupIp, 9021));
+            assertFalse(containsInstance(defaultGroup.getData(), customGroupIp, 9022));
+            
+            Result<List<Instance>> customGroup = waitUntilInstanceVisible(serviceName, CUSTOM_GROUP,
+                    TEST_CLUSTER, customGroupIp, 9022, null);
+            assertEquals(ErrorCode.SUCCESS.getCode(), customGroup.getCode());
+            assertEquals(ErrorCode.SUCCESS.getMsg(), customGroup.getMessage());
+            assertTrue(containsInstance(customGroup.getData(), customGroupIp, 9022));
+            assertFalse(containsInstance(customGroup.getData(), defaultGroupIp, 9021));
+            assertEquals(CUSTOM_GROUP + "@@" + serviceName,
+                    findInstance(customGroup.getData(), customGroupIp, 9022).getServiceName());
+        } finally {
+            deregister(serviceName, defaultGroupIp, 9021, TEST_CLUSTER, null);
+            deregister(serviceName, customGroupIp, 9022, TEST_CLUSTER, CUSTOM_GROUP);
+        }
+    }
+    
+    @Test
+    public void testListHealthyOnlyParameterDoesNotFilterOpenApiResult() throws Exception {
+        String serviceName = "openapi-it-list-healthy-" + UUID.randomUUID();
+        String healthyIp = "10.11.3.1";
+        String unhealthyIp = "10.11.3.2";
+        try {
+            assertRegisterOk(serviceName, healthyIp, 9031, TEST_CLUSTER, true, null, true);
+            assertRegisterOk(serviceName, unhealthyIp, 9032, TEST_CLUSTER, true, null, false);
+            
+            Result<List<Instance>> actual = waitUntilInstanceVisible(serviceName, null,
+                    TEST_CLUSTER, unhealthyIp, 9032, "true");
+            assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+            assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+            assertTrue(containsInstance(actual.getData(), healthyIp, 9031));
+            assertTrue(containsInstance(actual.getData(), unhealthyIp, 9032),
+                    "client list API passes healthOnly=false even when healthyOnly=true");
+            assertFalse(findInstance(actual.getData(), unhealthyIp, 9032).isHealthy());
+        } finally {
+            deregister(serviceName, healthyIp, 9031, TEST_CLUSTER, null);
+            deregister(serviceName, unhealthyIp, 9032, TEST_CLUSTER, null);
+        }
+    }
+    
+    @Test
+    public void testListUnknownServiceReturnsEmptySuccessResult() throws Exception {
+        Result<List<Instance>> actual = listInstances("openapi-it-absent-" + UUID.randomUUID(),
+                null, TEST_CLUSTER, null);
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+        assertNotNull(actual.getData());
+        assertTrue(actual.getData().isEmpty());
+    }
+    
+    @Test
+    public void testListMissingServiceNameReturnsBadRequestResultBody() throws Exception {
+        HttpResponse response = getRaw(INSTANCE_LIST_PATH + "?clusterName=" + TEST_CLUSTER);
+        assertEquals(400, response.code);
+        JsonNode root = JacksonUtils.toObj(response.body);
+        assertNotNull(root);
+        assertEquals(ErrorCode.PARAMETER_MISSING.getCode(), root.get("code").asInt(),
+                response.body);
+        assertTrue(root.get("message").asText().contains("parameter"));
+        assertTrue(root.get("data").asText().contains("serviceName"));
+    }
+    
+    private void assertRegisterOk(String serviceName, String ip, int port, String clusterName,
+            boolean enabled) throws Exception {
+        assertRegisterOk(serviceName, ip, port, clusterName, enabled, null);
+    }
+    
+    private void assertRegisterOk(String serviceName, String ip, int port, String clusterName,
+            boolean enabled, String groupName) throws Exception {
+        assertRegisterOk(serviceName, ip, port, clusterName, enabled, groupName, true);
+    }
+    
+    private void assertRegisterOk(String serviceName, String ip, int port, String clusterName,
+            boolean enabled, String groupName, boolean healthy) throws Exception {
+        Query query = buildInstanceQuery(serviceName, ip, port, clusterName, enabled, groupName,
+                healthy);
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(BASE_URL + INSTANCE_PATH,
+                Header.EMPTY, query, Collections.emptyMap(), String.class);
+        assertTrue(restResult.ok(),
+                "register HTTP status should be 2xx, body=" + restResult.getData());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertNotNull(root);
+        assertEquals(ErrorCode.SUCCESS.getCode(), root.get("code").asInt(), restResult.getData());
+        assertEquals("ok", root.get("data").asText());
+    }
+    
+    private void deregister(String serviceName, String ip, int port, String clusterName,
+            String groupName) throws Exception {
+        Query query = Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
+                .addParam("port", String.valueOf(port)).addParam("clusterName", clusterName);
+        addIfNotBlank(query, "groupName", groupName);
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(BASE_URL + INSTANCE_PATH,
+                Header.EMPTY, query, String.class);
+        if (!restResult.ok()) {
+            LOGGER.warn("deregister instance non-OK: code={} body={}", restResult.getCode(),
+                    restResult.getData());
+        }
+    }
+    
+    private Result<List<Instance>> waitUntilInstanceVisible(String serviceName, String clusterName,
+            String ip, int port) throws Exception {
+        return waitUntilInstanceVisible(serviceName, null, clusterName, ip, port, null);
+    }
+    
+    private Result<List<Instance>> waitUntilInstanceVisible(String serviceName, String groupName,
+            String clusterName, String ip, int port, String healthyOnly) throws Exception {
+        Result<List<Instance>> actual = null;
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            actual = listInstances(serviceName, groupName, clusterName, healthyOnly);
+            if (ErrorCode.SUCCESS.getCode().equals(actual.getCode())
+                    && containsInstance(actual.getData(), ip, port)) {
+                return actual;
+            }
+            // Registration is event-driven and may need a short propagation window.
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        return actual;
+    }
+    
+    private Result<List<Instance>> listInstances(String serviceName, String groupName,
+            String clusterName, String healthyOnly) throws Exception {
+        Query query = Query.newInstance().addParam("serviceName", serviceName);
+        addIfNotBlank(query, "groupName", groupName);
+        addIfNotBlank(query, "clusterName", clusterName);
+        addIfNotBlank(query, "healthyOnly", healthyOnly);
+        HttpRestResult<String> restResult = nacosRestTemplate.get(BASE_URL + INSTANCE_LIST_PATH,
+                Header.EMPTY, query, String.class);
+        assertTrue(restResult.ok(), "list HTTP status should be 2xx, body=" + restResult.getData());
+        return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
+        });
+    }
+    
+    private HttpResponse getRaw(String pathAndQuery) throws Exception {
+        HttpGet httpGet = new HttpGet(BASE_URL + pathAndQuery);
+        try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+            String body = null == response.getEntity() ? ""
+                    : EntityUtils.toString(response.getEntity());
+            return new HttpResponse(response.getCode(), body);
+        }
+    }
+    
+    private static Query buildInstanceQuery(String serviceName, String ip, int port,
+            String clusterName, boolean enabled, String groupName, boolean healthy) {
+        Query query = Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
+                .addParam("port", String.valueOf(port)).addParam("clusterName", clusterName)
+                .addParam("enabled", String.valueOf(enabled))
+                .addParam("healthy", String.valueOf(healthy))
+                .addParam("metadata", "source=openapi-it");
+        addIfNotBlank(query, "groupName", groupName);
+        return query;
+    }
+    
+    private static void addIfNotBlank(Query query, String name, String value) {
+        if (null != value && !value.isBlank()) {
+            query.addParam(name, value);
+        }
+    }
+    
+    private static boolean containsInstance(List<Instance> instances, String ip, int port) {
+        return null != findInstance(instances, ip, port);
+    }
+    
+    private static Instance findInstance(List<Instance> instances, String ip, int port) {
+        if (null == instances) {
+            return null;
+        }
+        for (Instance each : instances) {
+            if (ip.equals(each.getIp()) && port == each.getPort()) {
+                return each;
+            }
+        }
+        return null;
+    }
+    
+    private record HttpResponse(int code, String body) {
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceListOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceListOpenApiITCase.java
@@ -21,25 +21,14 @@ import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.common.http.HttpRestResult;
-import com.alibaba.nacos.common.http.client.NacosRestTemplate;
-import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -73,18 +62,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author xiweng.yy
  */
-public class InstanceListOpenApiITCase {
-    
-    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceListOpenApiITCase.class);
-    
-    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
-    
-    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
-    
-    private static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
+public class InstanceListOpenApiITCase extends OpenApiBaseITCase {
     
     private static final String INSTANCE_PATH =
-            "/nacos" + UtilsAndCommons.INSTANCE_V3_CLIENT_API_PATH;
+            nacosPath(UtilsAndCommons.INSTANCE_V3_CLIENT_API_PATH);
     
     private static final String INSTANCE_LIST_PATH = INSTANCE_PATH + "/list";
     
@@ -92,56 +73,33 @@ public class InstanceListOpenApiITCase {
     
     private static final String CUSTOM_GROUP = "OPENAPI_IT_GROUP";
     
-    private CloseableHttpClient httpClient;
-    
-    private NacosRestTemplate nacosRestTemplate;
-    
-    @BeforeEach
-    public void setUp() throws Exception {
-        httpClient = HttpClientBuilder.create().build();
-        nacosRestTemplate = new NacosRestTemplate(LOGGER,
-                new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
-    }
-    
-    @AfterEach
-    public void tearDown() throws Exception {
-        nacosRestTemplate.close();
-    }
-    
     @Test
     public void testListDefaultNamespaceAndGroupFiltersDisabledInstances() throws Exception {
         String serviceName = "openapi-it-list-" + UUID.randomUUID();
         String enabledIp = "10.11.0.1";
         String disabledIp = "10.11.0.2";
         String otherClusterIp = "10.11.0.3";
-        try {
-            assertRegisterOk(serviceName, enabledIp, 9001, TEST_CLUSTER, true);
-            assertRegisterOk(serviceName, disabledIp, 9002, TEST_CLUSTER, false);
-            assertRegisterOk(serviceName, otherClusterIp, 9003, "other-" + TEST_CLUSTER, true);
-            
-            Result<List<Instance>> actual = waitUntilInstanceVisible(serviceName, TEST_CLUSTER,
-                    enabledIp, 9001);
-            assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
-            assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
-            assertNotNull(actual.getData());
-            assertTrue(containsInstance(actual.getData(), enabledIp, 9001));
-            assertFalse(containsInstance(actual.getData(), disabledIp, 9002),
-                    "client list API should filter enabled=false instances");
-            assertFalse(containsInstance(actual.getData(), otherClusterIp, 9003),
-                    "client list API should filter by clusterName");
-            
-            Instance enabled = findInstance(actual.getData(), enabledIp, 9001);
-            assertEquals(TEST_CLUSTER, enabled.getClusterName());
-            assertEquals(Constants.DEFAULT_GROUP + "@@" + serviceName, enabled.getServiceName());
-            assertTrue(enabled.isHealthy());
-            assertTrue(enabled.isEnabled());
-            assertEquals(1.0, enabled.getWeight(), 0.0001);
-            assertEquals("openapi-it", enabled.getMetadata().get("source"));
-        } finally {
-            deregister(serviceName, enabledIp, 9001, TEST_CLUSTER, null);
-            deregister(serviceName, disabledIp, 9002, TEST_CLUSTER, null);
-            deregister(serviceName, otherClusterIp, 9003, "other-" + TEST_CLUSTER, null);
-        }
+        assertRegisterOk(serviceName, enabledIp, 9001, TEST_CLUSTER, true);
+        assertRegisterOk(serviceName, disabledIp, 9002, TEST_CLUSTER, false);
+        assertRegisterOk(serviceName, otherClusterIp, 9003, "other-" + TEST_CLUSTER, true);
+
+        Result<List<Instance>> actual = waitUntilInstanceVisible(serviceName, TEST_CLUSTER, enabledIp, 9001);
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+        assertNotNull(actual.getData());
+        assertTrue(containsInstance(actual.getData(), enabledIp, 9001));
+        assertFalse(containsInstance(actual.getData(), disabledIp, 9002),
+                "client list API should filter enabled=false instances");
+        assertFalse(containsInstance(actual.getData(), otherClusterIp, 9003),
+                "client list API should filter by clusterName");
+
+        Instance enabled = findInstance(actual.getData(), enabledIp, 9001);
+        assertEquals(TEST_CLUSTER, enabled.getClusterName());
+        assertEquals(Constants.DEFAULT_GROUP + "@@" + serviceName, enabled.getServiceName());
+        assertTrue(enabled.isHealthy());
+        assertTrue(enabled.isEnabled());
+        assertEquals(1.0, enabled.getWeight(), 0.0001);
+        assertEquals("openapi-it", enabled.getMetadata().get("source"));
     }
     
     @Test
@@ -150,26 +108,17 @@ public class InstanceListOpenApiITCase {
         String defaultClusterIp = "10.11.1.1";
         String customClusterIp = "10.11.1.2";
         String disabledIp = "10.11.1.3";
-        try {
-            assertRegisterOk(serviceName, defaultClusterIp, 9011,
-                    UtilsAndCommons.DEFAULT_CLUSTER_NAME, true);
-            assertRegisterOk(serviceName, customClusterIp, 9012, TEST_CLUSTER, true);
-            assertRegisterOk(serviceName, disabledIp, 9013, TEST_CLUSTER, false);
-            
-            Result<List<Instance>> actual = waitUntilInstanceVisible(serviceName, null,
-                    defaultClusterIp, 9011);
-            assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
-            assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
-            assertTrue(containsInstance(actual.getData(), defaultClusterIp, 9011));
-            assertTrue(containsInstance(actual.getData(), customClusterIp, 9012));
-            assertFalse(containsInstance(actual.getData(), disabledIp, 9013),
-                    "client list API should filter enabled=false instances without clusterName");
-        } finally {
-            deregister(serviceName, defaultClusterIp, 9011,
-                    UtilsAndCommons.DEFAULT_CLUSTER_NAME, null);
-            deregister(serviceName, customClusterIp, 9012, TEST_CLUSTER, null);
-            deregister(serviceName, disabledIp, 9013, TEST_CLUSTER, null);
-        }
+        assertRegisterOk(serviceName, defaultClusterIp, 9011, UtilsAndCommons.DEFAULT_CLUSTER_NAME, true);
+        assertRegisterOk(serviceName, customClusterIp, 9012, TEST_CLUSTER, true);
+        assertRegisterOk(serviceName, disabledIp, 9013, TEST_CLUSTER, false);
+
+        Result<List<Instance>> actual = waitUntilInstanceVisible(serviceName, null, defaultClusterIp, 9011);
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+        assertTrue(containsInstance(actual.getData(), defaultClusterIp, 9011));
+        assertTrue(containsInstance(actual.getData(), customClusterIp, 9012));
+        assertFalse(containsInstance(actual.getData(), disabledIp, 9013),
+                "client list API should filter enabled=false instances without clusterName");
     }
     
     @Test
@@ -177,27 +126,21 @@ public class InstanceListOpenApiITCase {
         String serviceName = "openapi-it-list-group-" + UUID.randomUUID();
         String defaultGroupIp = "10.11.2.1";
         String customGroupIp = "10.11.2.2";
-        try {
-            assertRegisterOk(serviceName, defaultGroupIp, 9021, TEST_CLUSTER, true);
-            assertRegisterOk(serviceName, customGroupIp, 9022, TEST_CLUSTER, true, CUSTOM_GROUP);
-            
-            Result<List<Instance>> defaultGroup = waitUntilInstanceVisible(serviceName,
-                    TEST_CLUSTER, defaultGroupIp, 9021);
-            assertTrue(containsInstance(defaultGroup.getData(), defaultGroupIp, 9021));
-            assertFalse(containsInstance(defaultGroup.getData(), customGroupIp, 9022));
-            
-            Result<List<Instance>> customGroup = waitUntilInstanceVisible(serviceName, CUSTOM_GROUP,
-                    TEST_CLUSTER, customGroupIp, 9022, null);
-            assertEquals(ErrorCode.SUCCESS.getCode(), customGroup.getCode());
-            assertEquals(ErrorCode.SUCCESS.getMsg(), customGroup.getMessage());
-            assertTrue(containsInstance(customGroup.getData(), customGroupIp, 9022));
-            assertFalse(containsInstance(customGroup.getData(), defaultGroupIp, 9021));
-            assertEquals(CUSTOM_GROUP + "@@" + serviceName,
-                    findInstance(customGroup.getData(), customGroupIp, 9022).getServiceName());
-        } finally {
-            deregister(serviceName, defaultGroupIp, 9021, TEST_CLUSTER, null);
-            deregister(serviceName, customGroupIp, 9022, TEST_CLUSTER, CUSTOM_GROUP);
-        }
+        assertRegisterOk(serviceName, defaultGroupIp, 9021, TEST_CLUSTER, true);
+        assertRegisterOk(serviceName, customGroupIp, 9022, TEST_CLUSTER, true, CUSTOM_GROUP);
+
+        Result<List<Instance>> defaultGroup = waitUntilInstanceVisible(serviceName, TEST_CLUSTER, defaultGroupIp, 9021);
+        assertTrue(containsInstance(defaultGroup.getData(), defaultGroupIp, 9021));
+        assertFalse(containsInstance(defaultGroup.getData(), customGroupIp, 9022));
+
+        Result<List<Instance>> customGroup = waitUntilInstanceVisible(serviceName, CUSTOM_GROUP, TEST_CLUSTER,
+                customGroupIp, 9022, null);
+        assertEquals(ErrorCode.SUCCESS.getCode(), customGroup.getCode());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), customGroup.getMessage());
+        assertTrue(containsInstance(customGroup.getData(), customGroupIp, 9022));
+        assertFalse(containsInstance(customGroup.getData(), defaultGroupIp, 9021));
+        assertEquals(CUSTOM_GROUP + "@@" + serviceName,
+                findInstance(customGroup.getData(), customGroupIp, 9022).getServiceName());
     }
     
     @Test
@@ -205,22 +148,17 @@ public class InstanceListOpenApiITCase {
         String serviceName = "openapi-it-list-healthy-" + UUID.randomUUID();
         String healthyIp = "10.11.3.1";
         String unhealthyIp = "10.11.3.2";
-        try {
-            assertRegisterOk(serviceName, healthyIp, 9031, TEST_CLUSTER, true, null, true);
-            assertRegisterOk(serviceName, unhealthyIp, 9032, TEST_CLUSTER, true, null, false);
-            
-            Result<List<Instance>> actual = waitUntilInstanceVisible(serviceName, null,
-                    TEST_CLUSTER, unhealthyIp, 9032, "true");
-            assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
-            assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
-            assertTrue(containsInstance(actual.getData(), healthyIp, 9031));
-            assertTrue(containsInstance(actual.getData(), unhealthyIp, 9032),
-                    "client list API passes healthOnly=false even when healthyOnly=true");
-            assertFalse(findInstance(actual.getData(), unhealthyIp, 9032).isHealthy());
-        } finally {
-            deregister(serviceName, healthyIp, 9031, TEST_CLUSTER, null);
-            deregister(serviceName, unhealthyIp, 9032, TEST_CLUSTER, null);
-        }
+        assertRegisterOk(serviceName, healthyIp, 9031, TEST_CLUSTER, true, null, true);
+        assertRegisterOk(serviceName, unhealthyIp, 9032, TEST_CLUSTER, true, null, false);
+
+        Result<List<Instance>> actual = waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, unhealthyIp, 9032,
+                "true");
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+        assertTrue(containsInstance(actual.getData(), healthyIp, 9031));
+        assertTrue(containsInstance(actual.getData(), unhealthyIp, 9032),
+                "client list API passes healthOnly=false even when healthyOnly=true");
+        assertFalse(findInstance(actual.getData(), unhealthyIp, 9032).isHealthy());
     }
     
     @Test
@@ -236,11 +174,11 @@ public class InstanceListOpenApiITCase {
     @Test
     public void testListMissingServiceNameReturnsBadRequestResultBody() throws Exception {
         HttpResponse response = getRaw(INSTANCE_LIST_PATH + "?clusterName=" + TEST_CLUSTER);
-        assertEquals(400, response.code);
-        JsonNode root = JacksonUtils.toObj(response.body);
+        assertEquals(400, response.code());
+        JsonNode root = JacksonUtils.toObj(response.body());
         assertNotNull(root);
         assertEquals(ErrorCode.PARAMETER_MISSING.getCode(), root.get("code").asInt(),
-                response.body);
+                response.body());
         assertTrue(root.get("message").asText().contains("parameter"));
         assertTrue(root.get("data").asText().contains("serviceName"));
     }
@@ -259,7 +197,7 @@ public class InstanceListOpenApiITCase {
             boolean enabled, String groupName, boolean healthy) throws Exception {
         Query query = buildInstanceQuery(serviceName, ip, port, clusterName, enabled, groupName,
                 healthy);
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(BASE_URL + INSTANCE_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(INSTANCE_PATH),
                 Header.EMPTY, query, Collections.emptyMap(), String.class);
         assertTrue(restResult.ok(),
                 "register HTTP status should be 2xx, body=" + restResult.getData());
@@ -267,6 +205,7 @@ public class InstanceListOpenApiITCase {
         assertNotNull(root);
         assertEquals(ErrorCode.SUCCESS.getCode(), root.get("code").asInt(), restResult.getData());
         assertEquals("ok", root.get("data").asText());
+        addCleanup(() -> deregister(serviceName, ip, port, clusterName, groupName));
     }
     
     private void deregister(String serviceName, String ip, int port, String clusterName,
@@ -274,10 +213,10 @@ public class InstanceListOpenApiITCase {
         Query query = Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
                 .addParam("port", String.valueOf(port)).addParam("clusterName", clusterName);
         addIfNotBlank(query, "groupName", groupName);
-        HttpRestResult<String> restResult = nacosRestTemplate.delete(BASE_URL + INSTANCE_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(INSTANCE_PATH),
                 Header.EMPTY, query, String.class);
         if (!restResult.ok()) {
-            LOGGER.warn("deregister instance non-OK: code={} body={}", restResult.getCode(),
+            logger().warn("deregister instance non-OK: code={} body={}", restResult.getCode(),
                     restResult.getData());
         }
     }
@@ -309,20 +248,11 @@ public class InstanceListOpenApiITCase {
         addIfNotBlank(query, "groupName", groupName);
         addIfNotBlank(query, "clusterName", clusterName);
         addIfNotBlank(query, "healthyOnly", healthyOnly);
-        HttpRestResult<String> restResult = nacosRestTemplate.get(BASE_URL + INSTANCE_LIST_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.get(url(INSTANCE_LIST_PATH),
                 Header.EMPTY, query, String.class);
         assertTrue(restResult.ok(), "list HTTP status should be 2xx, body=" + restResult.getData());
         return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
         });
-    }
-    
-    private HttpResponse getRaw(String pathAndQuery) throws Exception {
-        HttpGet httpGet = new HttpGet(BASE_URL + pathAndQuery);
-        try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
-            String body = null == response.getEntity() ? ""
-                    : EntityUtils.toString(response.getEntity());
-            return new HttpResponse(response.getCode(), body);
-        }
     }
     
     private static Query buildInstanceQuery(String serviceName, String ip, int port,
@@ -334,12 +264,6 @@ public class InstanceListOpenApiITCase {
                 .addParam("metadata", "source=openapi-it");
         addIfNotBlank(query, "groupName", groupName);
         return query;
-    }
-    
-    private static void addIfNotBlank(Query query, String name, String value) {
-        if (null != value && !value.isBlank()) {
-            query.addParam(name, value);
-        }
     }
     
     private static boolean containsInstance(List<Instance> instances, String ip, int port) {
@@ -356,8 +280,5 @@ public class InstanceListOpenApiITCase {
             }
         }
         return null;
-    }
-    
-    private record HttpResponse(int code, String body) {
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceRegisterOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceRegisterOpenApiITCase.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.client.naming;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.http.client.NacosRestTemplate;
+import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
+import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the naming client Open API {@code POST /nacos/v3/client/ns/instance}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: registering an instance returns success and the instance becomes visible through the
+ *     client list API with ip, port, serviceName, clusterName, healthy, enabled, weight, metadata, and ephemeral
+ *     state.</li>
+ *     <li>Boundary/validation: omitted namespaceId, groupName, clusterName, healthy, weight, and enabled use defaults;
+ *     explicit groupName, clusterName, healthy, weight, metadata, and ephemeral values are persisted; heartBeat=true is
+ *     accepted for existing instances but returns INSTANCE_NOT_FOUND for absent instances; serviceName, ip, and port are
+ *     required.</li>
+ *     <li>Error handling: invalid weight and clusterName return controlled HTTP 400 responses with wrapped
+ *     {@code Result} fields instead of HTTP 500.</li>
+ * </ul>
+ *
+ * <p>GET list and DELETE calls to {@code /nacos/v3/client/ns/instance} are helper calls only; this class keeps its
+ * assertions focused on the register API contract.
+ *
+ * @author xiweng.yy
+ */
+public class InstanceRegisterOpenApiITCase {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceRegisterOpenApiITCase.class);
+    
+    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
+    
+    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
+    
+    private static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
+    
+    private static final String INSTANCE_PATH =
+            "/nacos" + UtilsAndCommons.INSTANCE_V3_CLIENT_API_PATH;
+    
+    private static final String INSTANCE_LIST_PATH = INSTANCE_PATH + "/list";
+    
+    private static final String TEST_GROUP = "OPENAPI_IT_REGISTER_GROUP";
+    
+    private static final String TEST_CLUSTER = "openapi-it-register-cluster";
+    
+    private CloseableHttpClient httpClient;
+    
+    private NacosRestTemplate nacosRestTemplate;
+    
+    @BeforeEach
+    public void setUp() throws Exception {
+        httpClient = HttpClientBuilder.create().build();
+        nacosRestTemplate = new NacosRestTemplate(LOGGER,
+                new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
+    }
+    
+    @AfterEach
+    public void tearDown() throws Exception {
+        nacosRestTemplate.close();
+    }
+    
+    @Test
+    public void testRegisterWithDefaultValuesMakesInstanceDiscoverable() throws Exception {
+        String serviceName = "openapi-it-register-default-" + UUID.randomUUID();
+        String ip = "10.12.0.1";
+        int port = 9101;
+        try {
+            assertRegisterOk(Query.newInstance().addParam("serviceName", serviceName)
+                    .addParam("ip", ip).addParam("port", String.valueOf(port))
+                    .addParam("metadata", "source=openapi-it"));
+            
+            Instance actual = waitUntilInstanceVisible(serviceName, null,
+                    UtilsAndCommons.DEFAULT_CLUSTER_NAME, ip, port);
+            assertEquals(Constants.DEFAULT_GROUP + "@@" + serviceName, actual.getServiceName());
+            assertEquals(UtilsAndCommons.DEFAULT_CLUSTER_NAME, actual.getClusterName());
+            assertTrue(actual.isHealthy());
+            assertTrue(actual.isEnabled());
+            assertTrue(actual.isEphemeral());
+            assertEquals(1.0, actual.getWeight(), 0.0001);
+            assertEquals("openapi-it", actual.getMetadata().get("source"));
+        } finally {
+            deregister(serviceName, ip, port, UtilsAndCommons.DEFAULT_CLUSTER_NAME, null);
+        }
+    }
+    
+    @Test
+    public void testRegisterWithExplicitFieldsPersistsClientVisibleState() throws Exception {
+        String serviceName = "openapi-it-register-explicit-" + UUID.randomUUID();
+        String ip = "10.12.0.2";
+        int port = 9102;
+        try {
+            assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("groupName", TEST_GROUP)
+                    .addParam("clusterName", TEST_CLUSTER).addParam("healthy", "false")
+                    .addParam("enabled", "true").addParam("weight", "2.5")
+                    .addParam("metadata", "source=openapi-it,case=explicit"));
+            
+            Instance actual = waitUntilInstanceVisible(serviceName, TEST_GROUP, TEST_CLUSTER, ip, port);
+            assertEquals(TEST_GROUP + "@@" + serviceName, actual.getServiceName());
+            assertEquals(TEST_CLUSTER, actual.getClusterName());
+            assertFalse(actual.isHealthy());
+            assertTrue(actual.isEnabled());
+            assertEquals(2.5, actual.getWeight(), 0.0001);
+            assertEquals("explicit", actual.getMetadata().get("case"));
+        } finally {
+            deregister(serviceName, ip, port, TEST_CLUSTER, TEST_GROUP);
+        }
+    }
+    
+    @Test
+    public void testRegisterPersistentInstanceWhenEphemeralFalse() throws Exception {
+        String serviceName = "openapi-it-register-persistent-" + UUID.randomUUID();
+        String ip = "10.12.0.3";
+        int port = 9103;
+        try {
+            assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("clusterName", TEST_CLUSTER)
+                    .addParam("ephemeral", "false"));
+            
+            Instance actual = waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, ip, port);
+            assertFalse(actual.isEphemeral());
+        } finally {
+            deregister(serviceName, ip, port, TEST_CLUSTER, null);
+        }
+    }
+    
+    @Test
+    public void testHeartbeatExistingInstanceReturnsSuccess() throws Exception {
+        String serviceName = "openapi-it-register-heartbeat-" + UUID.randomUUID();
+        String ip = "10.12.0.4";
+        int port = 9104;
+        try {
+            assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("clusterName", TEST_CLUSTER));
+            assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("clusterName", TEST_CLUSTER)
+                    .addParam("heartBeat", "true"));
+            
+            Instance actual = waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, ip, port);
+            assertEquals(ip, actual.getIp());
+            assertEquals(port, actual.getPort());
+        } finally {
+            deregister(serviceName, ip, port, TEST_CLUSTER, null);
+        }
+    }
+    
+    @Test
+    public void testHeartbeatAbsentInstanceReturnsInstanceNotFoundResult() throws Exception {
+        String serviceName = "openapi-it-register-missing-heartbeat-" + UUID.randomUUID();
+        Query query = baseInstanceQuery(serviceName, "10.12.0.5", 9105).addParam("heartBeat", "true");
+        Result<String> actual = postInstance(query);
+        assertEquals(ErrorCode.INSTANCE_NOT_FOUND.getCode(), actual.getCode());
+        assertNotNull(actual.getMessage());
+    }
+    
+    @Test
+    public void testRegisterMissingServiceNameReturnsBadRequestResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("ip", "10.12.0.6").addParam("port", "9106");
+        assertBadRequest(query, ErrorCode.PARAMETER_MISSING, "serviceName");
+    }
+    
+    @Test
+    public void testRegisterMissingIpReturnsBadRequestResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("serviceName", "openapi-it-register-missing-ip")
+                .addParam("port", "9107");
+        assertBadRequest(query, ErrorCode.PARAMETER_MISSING, "ip");
+    }
+    
+    @Test
+    public void testRegisterMissingPortReturnsBadRequestResultBody() throws Exception {
+        Query query = Query.newInstance().addParam("serviceName", "openapi-it-register-missing-port")
+                .addParam("ip", "10.12.0.8");
+        assertBadRequest(query, ErrorCode.PARAMETER_MISSING, "port");
+    }
+    
+    @Test
+    public void testRegisterInvalidWeightReturnsBadRequestResultBody() throws Exception {
+        Query query = baseInstanceQuery("openapi-it-register-bad-weight", "10.12.0.9", 9109)
+                .addParam("weight", "10001");
+        assertBadRequest(query, ErrorCode.WEIGHT_ERROR, "weights range");
+    }
+    
+    @Test
+    public void testRegisterInvalidClusterNameReturnsBadRequestResultBody() throws Exception {
+        Query query = baseInstanceQuery("openapi-it-register-bad-cluster", "10.12.0.10", 9110)
+                .addParam("clusterName", "cluster1,cluster2");
+        assertBadRequest(query, ErrorCode.PARAMETER_VALIDATE_ERROR, "cluster");
+    }
+    
+    private void assertRegisterOk(Query query) throws Exception {
+        Result<String> actual = postInstance(query);
+        assertEquals(ErrorCode.SUCCESS.getCode(), actual.getCode());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), actual.getMessage());
+        assertEquals("ok", actual.getData());
+    }
+    
+    private Result<String> postInstance(Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(BASE_URL + INSTANCE_PATH,
+                Header.EMPTY, query, Collections.emptyMap(), String.class);
+        assertTrue(restResult.ok(), "register HTTP status should be 2xx, body=" + restResult.getData());
+        return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
+        });
+    }
+    
+    private void assertBadRequest(Query query, ErrorCode errorCode, String expectedData) throws Exception {
+        HttpResponse response = postRaw(query);
+        assertEquals(400, response.code, response.body);
+        JsonNode root = JacksonUtils.toObj(response.body);
+        assertNotNull(root);
+        assertEquals(errorCode.getCode(), root.get("code").asInt(), response.body);
+        assertNotNull(root.get("message").asText(), response.body);
+        assertTrue(root.get("data").asText().contains(expectedData), response.body);
+    }
+    
+    private HttpResponse postRaw(Query query) throws Exception {
+        HttpPost httpPost = new HttpPost(BASE_URL + INSTANCE_PATH + "?" + query.toQueryUrl());
+        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+            String body = null == response.getEntity() ? ""
+                    : EntityUtils.toString(response.getEntity());
+            return new HttpResponse(response.getCode(), body);
+        }
+    }
+    
+    private Instance waitUntilInstanceVisible(String serviceName, String groupName,
+            String clusterName, String ip, int port) throws Exception {
+        Result<List<Instance>> actual = null;
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            actual = listInstances(serviceName, groupName, clusterName);
+            Instance instance = findInstance(actual.getData(), ip, port);
+            if (null != instance) {
+                return instance;
+            }
+            // Registration is event-driven and may need a short propagation window.
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected registered instance to be visible, last result="
+                + JacksonUtils.toJson(actual));
+    }
+    
+    private Result<List<Instance>> listInstances(String serviceName, String groupName,
+            String clusterName) throws Exception {
+        Query query = Query.newInstance().addParam("serviceName", serviceName)
+                .addParam("clusterName", clusterName);
+        addIfNotBlank(query, "groupName", groupName);
+        HttpRestResult<String> restResult = nacosRestTemplate.get(BASE_URL + INSTANCE_LIST_PATH,
+                Header.EMPTY, query, String.class);
+        assertTrue(restResult.ok(), "list HTTP status should be 2xx, body=" + restResult.getData());
+        return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
+        });
+    }
+    
+    private void deregister(String serviceName, String ip, int port, String clusterName,
+            String groupName) throws Exception {
+        Query query = Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
+                .addParam("port", String.valueOf(port)).addParam("clusterName", clusterName);
+        addIfNotBlank(query, "groupName", groupName);
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(BASE_URL + INSTANCE_PATH,
+                Header.EMPTY, query, String.class);
+        if (!restResult.ok()) {
+            LOGGER.warn("deregister instance non-OK: code={} body={}", restResult.getCode(),
+                    restResult.getData());
+        }
+    }
+    
+    private static Query baseInstanceQuery(String serviceName, String ip, int port) {
+        return Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
+                .addParam("port", String.valueOf(port));
+    }
+    
+    private static void addIfNotBlank(Query query, String name, String value) {
+        if (null != value && !value.isBlank()) {
+            query.addParam(name, value);
+        }
+    }
+    
+    private static Instance findInstance(List<Instance> instances, String ip, int port) {
+        if (null == instances) {
+            return null;
+        }
+        for (Instance each : instances) {
+            if (ip.equals(each.getIp()) && port == each.getPort()) {
+                return each;
+            }
+        }
+        return null;
+    }
+    
+    private record HttpResponse(int code, String body) {
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceRegisterOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/naming/InstanceRegisterOpenApiITCase.java
@@ -21,25 +21,14 @@ import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.common.http.HttpRestResult;
-import com.alibaba.nacos.common.http.client.NacosRestTemplate;
-import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -72,18 +61,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author xiweng.yy
  */
-public class InstanceRegisterOpenApiITCase {
-    
-    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceRegisterOpenApiITCase.class);
-    
-    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
-    
-    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
-    
-    private static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
+public class InstanceRegisterOpenApiITCase extends OpenApiBaseITCase {
     
     private static final String INSTANCE_PATH =
-            "/nacos" + UtilsAndCommons.INSTANCE_V3_CLIENT_API_PATH;
+            nacosPath(UtilsAndCommons.INSTANCE_V3_CLIENT_API_PATH);
     
     private static final String INSTANCE_LIST_PATH = INSTANCE_PATH + "/list";
     
@@ -91,44 +72,23 @@ public class InstanceRegisterOpenApiITCase {
     
     private static final String TEST_CLUSTER = "openapi-it-register-cluster";
     
-    private CloseableHttpClient httpClient;
-    
-    private NacosRestTemplate nacosRestTemplate;
-    
-    @BeforeEach
-    public void setUp() throws Exception {
-        httpClient = HttpClientBuilder.create().build();
-        nacosRestTemplate = new NacosRestTemplate(LOGGER,
-                new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
-    }
-    
-    @AfterEach
-    public void tearDown() throws Exception {
-        nacosRestTemplate.close();
-    }
-    
     @Test
     public void testRegisterWithDefaultValuesMakesInstanceDiscoverable() throws Exception {
         String serviceName = "openapi-it-register-default-" + UUID.randomUUID();
         String ip = "10.12.0.1";
         int port = 9101;
-        try {
-            assertRegisterOk(Query.newInstance().addParam("serviceName", serviceName)
-                    .addParam("ip", ip).addParam("port", String.valueOf(port))
-                    .addParam("metadata", "source=openapi-it"));
-            
-            Instance actual = waitUntilInstanceVisible(serviceName, null,
-                    UtilsAndCommons.DEFAULT_CLUSTER_NAME, ip, port);
-            assertEquals(Constants.DEFAULT_GROUP + "@@" + serviceName, actual.getServiceName());
-            assertEquals(UtilsAndCommons.DEFAULT_CLUSTER_NAME, actual.getClusterName());
-            assertTrue(actual.isHealthy());
-            assertTrue(actual.isEnabled());
-            assertTrue(actual.isEphemeral());
-            assertEquals(1.0, actual.getWeight(), 0.0001);
-            assertEquals("openapi-it", actual.getMetadata().get("source"));
-        } finally {
-            deregister(serviceName, ip, port, UtilsAndCommons.DEFAULT_CLUSTER_NAME, null);
-        }
+        assertRegisterOk(Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
+                .addParam("port", String.valueOf(port)).addParam("metadata", "source=openapi-it"));
+        addCleanup(() -> deregister(serviceName, ip, port, UtilsAndCommons.DEFAULT_CLUSTER_NAME, null));
+
+        Instance actual = waitUntilInstanceVisible(serviceName, null, UtilsAndCommons.DEFAULT_CLUSTER_NAME, ip, port);
+        assertEquals(Constants.DEFAULT_GROUP + "@@" + serviceName, actual.getServiceName());
+        assertEquals(UtilsAndCommons.DEFAULT_CLUSTER_NAME, actual.getClusterName());
+        assertTrue(actual.isHealthy());
+        assertTrue(actual.isEnabled());
+        assertTrue(actual.isEphemeral());
+        assertEquals(1.0, actual.getWeight(), 0.0001);
+        assertEquals("openapi-it", actual.getMetadata().get("source"));
     }
     
     @Test
@@ -136,22 +96,18 @@ public class InstanceRegisterOpenApiITCase {
         String serviceName = "openapi-it-register-explicit-" + UUID.randomUUID();
         String ip = "10.12.0.2";
         int port = 9102;
-        try {
-            assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("groupName", TEST_GROUP)
-                    .addParam("clusterName", TEST_CLUSTER).addParam("healthy", "false")
-                    .addParam("enabled", "true").addParam("weight", "2.5")
-                    .addParam("metadata", "source=openapi-it,case=explicit"));
-            
-            Instance actual = waitUntilInstanceVisible(serviceName, TEST_GROUP, TEST_CLUSTER, ip, port);
-            assertEquals(TEST_GROUP + "@@" + serviceName, actual.getServiceName());
-            assertEquals(TEST_CLUSTER, actual.getClusterName());
-            assertFalse(actual.isHealthy());
-            assertTrue(actual.isEnabled());
-            assertEquals(2.5, actual.getWeight(), 0.0001);
-            assertEquals("explicit", actual.getMetadata().get("case"));
-        } finally {
-            deregister(serviceName, ip, port, TEST_CLUSTER, TEST_GROUP);
-        }
+        assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("groupName", TEST_GROUP)
+                .addParam("clusterName", TEST_CLUSTER).addParam("healthy", "false").addParam("enabled", "true")
+                .addParam("weight", "2.5").addParam("metadata", "source=openapi-it,case=explicit"));
+        addCleanup(() -> deregister(serviceName, ip, port, TEST_CLUSTER, TEST_GROUP));
+
+        Instance actual = waitUntilInstanceVisible(serviceName, TEST_GROUP, TEST_CLUSTER, ip, port);
+        assertEquals(TEST_GROUP + "@@" + serviceName, actual.getServiceName());
+        assertEquals(TEST_CLUSTER, actual.getClusterName());
+        assertFalse(actual.isHealthy());
+        assertTrue(actual.isEnabled());
+        assertEquals(2.5, actual.getWeight(), 0.0001);
+        assertEquals("explicit", actual.getMetadata().get("case"));
     }
     
     @Test
@@ -159,15 +115,12 @@ public class InstanceRegisterOpenApiITCase {
         String serviceName = "openapi-it-register-persistent-" + UUID.randomUUID();
         String ip = "10.12.0.3";
         int port = 9103;
-        try {
-            assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("clusterName", TEST_CLUSTER)
-                    .addParam("ephemeral", "false"));
-            
-            Instance actual = waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, ip, port);
-            assertFalse(actual.isEphemeral());
-        } finally {
-            deregister(serviceName, ip, port, TEST_CLUSTER, null);
-        }
+        assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("clusterName", TEST_CLUSTER)
+                .addParam("ephemeral", "false"));
+        addCleanup(() -> deregister(serviceName, ip, port, TEST_CLUSTER, null));
+
+        Instance actual = waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, ip, port);
+        assertFalse(actual.isEphemeral());
     }
     
     @Test
@@ -175,17 +128,14 @@ public class InstanceRegisterOpenApiITCase {
         String serviceName = "openapi-it-register-heartbeat-" + UUID.randomUUID();
         String ip = "10.12.0.4";
         int port = 9104;
-        try {
-            assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("clusterName", TEST_CLUSTER));
-            assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("clusterName", TEST_CLUSTER)
-                    .addParam("heartBeat", "true"));
-            
-            Instance actual = waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, ip, port);
-            assertEquals(ip, actual.getIp());
-            assertEquals(port, actual.getPort());
-        } finally {
-            deregister(serviceName, ip, port, TEST_CLUSTER, null);
-        }
+        assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("clusterName", TEST_CLUSTER));
+        addCleanup(() -> deregister(serviceName, ip, port, TEST_CLUSTER, null));
+        assertRegisterOk(baseInstanceQuery(serviceName, ip, port).addParam("clusterName", TEST_CLUSTER)
+                .addParam("heartBeat", "true"));
+
+        Instance actual = waitUntilInstanceVisible(serviceName, null, TEST_CLUSTER, ip, port);
+        assertEquals(ip, actual.getIp());
+        assertEquals(port, actual.getPort());
     }
     
     @Test
@@ -239,7 +189,7 @@ public class InstanceRegisterOpenApiITCase {
     }
     
     private Result<String> postInstance(Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(BASE_URL + INSTANCE_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(INSTANCE_PATH),
                 Header.EMPTY, query, Collections.emptyMap(), String.class);
         assertTrue(restResult.ok(), "register HTTP status should be 2xx, body=" + restResult.getData());
         return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
@@ -247,22 +197,13 @@ public class InstanceRegisterOpenApiITCase {
     }
     
     private void assertBadRequest(Query query, ErrorCode errorCode, String expectedData) throws Exception {
-        HttpResponse response = postRaw(query);
-        assertEquals(400, response.code, response.body);
-        JsonNode root = JacksonUtils.toObj(response.body);
+        HttpResponse response = postRaw(INSTANCE_PATH, query);
+        assertEquals(400, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
         assertNotNull(root);
-        assertEquals(errorCode.getCode(), root.get("code").asInt(), response.body);
-        assertNotNull(root.get("message").asText(), response.body);
-        assertTrue(root.get("data").asText().contains(expectedData), response.body);
-    }
-    
-    private HttpResponse postRaw(Query query) throws Exception {
-        HttpPost httpPost = new HttpPost(BASE_URL + INSTANCE_PATH + "?" + query.toQueryUrl());
-        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
-            String body = null == response.getEntity() ? ""
-                    : EntityUtils.toString(response.getEntity());
-            return new HttpResponse(response.getCode(), body);
-        }
+        assertEquals(errorCode.getCode(), root.get("code").asInt(), response.body());
+        assertNotNull(root.get("message").asText(), response.body());
+        assertTrue(root.get("data").asText().contains(expectedData), response.body());
     }
     
     private Instance waitUntilInstanceVisible(String serviceName, String groupName,
@@ -287,7 +228,7 @@ public class InstanceRegisterOpenApiITCase {
         Query query = Query.newInstance().addParam("serviceName", serviceName)
                 .addParam("clusterName", clusterName);
         addIfNotBlank(query, "groupName", groupName);
-        HttpRestResult<String> restResult = nacosRestTemplate.get(BASE_URL + INSTANCE_LIST_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.get(url(INSTANCE_LIST_PATH),
                 Header.EMPTY, query, String.class);
         assertTrue(restResult.ok(), "list HTTP status should be 2xx, body=" + restResult.getData());
         return JacksonUtils.toObj(restResult.getData(), new TypeReference<>() {
@@ -299,10 +240,10 @@ public class InstanceRegisterOpenApiITCase {
         Query query = Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
                 .addParam("port", String.valueOf(port)).addParam("clusterName", clusterName);
         addIfNotBlank(query, "groupName", groupName);
-        HttpRestResult<String> restResult = nacosRestTemplate.delete(BASE_URL + INSTANCE_PATH,
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(INSTANCE_PATH),
                 Header.EMPTY, query, String.class);
         if (!restResult.ok()) {
-            LOGGER.warn("deregister instance non-OK: code={} body={}", restResult.getCode(),
+            logger().warn("deregister instance non-OK: code={} body={}", restResult.getCode(),
                     restResult.getData());
         }
     }
@@ -310,12 +251,6 @@ public class InstanceRegisterOpenApiITCase {
     private static Query baseInstanceQuery(String serviceName, String ip, int port) {
         return Query.newInstance().addParam("serviceName", serviceName).addParam("ip", ip)
                 .addParam("port", String.valueOf(port));
-    }
-    
-    private static void addIfNotBlank(Query query, String name, String value) {
-        if (null != value && !value.isBlank()) {
-            query.addParam(name, value);
-        }
     }
     
     private static Instance findInstance(List<Instance> instances, String ip, int port) {
@@ -328,8 +263,5 @@ public class InstanceRegisterOpenApiITCase {
             }
         }
         return null;
-    }
-    
-    private record HttpResponse(int code, String body) {
     }
 }


### PR DESCRIPTION
## Summary
- add scenario-complete client OpenAPI ITs for config query and naming instance list/register/deregister
- add AI client OpenAPI ITs for Prompt, Skill, AgentSpec get, and AgentSpec search
- refactor shared OpenAPI IT setup for REST client lifecycle, URL helpers, binary responses, and cleanup actions

## Testing
- mvn -pl test/openapi-test spotless:check -DskipTests
- mvn -pl test/openapi-test -DskipTests test-compile
- mvn -pl test/openapi-test -Pintegration-test -Dit.test=PromptClientOpenApiITCase,SkillClientOpenApiITCase,AgentSpecClientOpenApiITCase,AgentSpecSearchClientOpenApiITCase verify