### PR TITLE
[ISSUE #14879] Add admin OpenAPI integration tests

### DIFF
--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
@@ -88,6 +88,16 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
     protected static final String ADMIN_SKILL_VERSION_DOWNLOAD_PATH =
             ADMIN_SKILL_PATH + "/version/download";
 
+    protected static final String ADMIN_AGENT_SPEC_PATH = nacosPath(Constants.AgentSpecs.ADMIN_PATH);
+
+    protected static final String ADMIN_AGENT_SPEC_LIST_PATH = ADMIN_AGENT_SPEC_PATH + "/list";
+
+    protected static final String ADMIN_AGENT_SPEC_VERSION_PATH =
+            ADMIN_AGENT_SPEC_PATH + "/version";
+
+    protected static final String ADMIN_AGENT_SPEC_VERSION_META_PATH =
+            ADMIN_AGENT_SPEC_PATH + "/version/meta";
+
     protected String randomAiName(String scenario) {
         return "oit-" + scenario + "-" + UUID.randomUUID().toString().substring(0, 8);
     }
@@ -437,6 +447,140 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         return result;
     }
 
+    protected Query agentSpecQuery(String agentSpecName) {
+        return Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("agentSpecName", agentSpecName);
+    }
+
+    protected Query agentSpecVersionQuery(String agentSpecName, String version) {
+        Query query = agentSpecQuery(agentSpecName);
+        addIfNotBlank(query, "version", version);
+        return query;
+    }
+
+    protected Map<String, String> agentSpecDraftForm(String agentSpecName, String targetVersion) {
+        Map<String, String> form = agentSpecQueryForm(agentSpecName);
+        form.put("targetVersion", targetVersion);
+        return form;
+    }
+
+    protected Map<String, String> agentSpecForkForm(String agentSpecName, String targetVersion,
+            String basedOnVersion) {
+        Map<String, String> form = agentSpecDraftForm(agentSpecName, targetVersion);
+        form.put("basedOnVersion", basedOnVersion);
+        return form;
+    }
+
+    protected Map<String, String> agentSpecUpdateForm(String agentSpecName, String version,
+            String description, String scenario, String soulContent) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("agentSpecCard", buildAgentSpecCard(agentSpecName, version, description,
+                scenario, soulContent));
+        return form;
+    }
+
+    protected Map<String, String> agentSpecPublishForm(String agentSpecName, String version) {
+        Map<String, String> form = agentSpecQueryForm(agentSpecName);
+        form.put("version", version);
+        form.put("updateLatestLabel", "true");
+        return form;
+    }
+
+    protected Map<String, String> agentSpecLabelsForm(String agentSpecName, String labels) {
+        Map<String, String> form = agentSpecQueryForm(agentSpecName);
+        form.put("labels", labels);
+        return form;
+    }
+
+    protected Map<String, String> agentSpecBizTagsForm(String agentSpecName, String bizTags) {
+        Map<String, String> form = agentSpecQueryForm(agentSpecName);
+        form.put("bizTags", bizTags);
+        return form;
+    }
+
+    protected Map<String, String> agentSpecScopeForm(String agentSpecName, String scope) {
+        Map<String, String> form = agentSpecQueryForm(agentSpecName);
+        form.put("scope", scope);
+        return form;
+    }
+
+    protected Map<String, String> agentSpecOnlineForm(String agentSpecName, String version,
+            String scope) {
+        Map<String, String> form = agentSpecQueryForm(agentSpecName);
+        addIfNotBlank(form, "version", version);
+        addIfNotBlank(form, "scope", scope);
+        return form;
+    }
+
+    protected void deleteAgentSpecQuietly(String agentSpecName) throws Exception {
+        deleteQuietly(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName));
+    }
+
+    protected void assertAgentSpecContent(JsonNode data, String agentSpecName, String version,
+            String description, String scenario, String soulContent) {
+        assertEquals(DEFAULT_NAMESPACE, data.get("namespaceId").asText(), data.toString());
+        assertEquals(agentSpecName, data.get("name").asText(), data.toString());
+        assertEquals(description, data.get("description").asText(), data.toString());
+        JsonNode manifest = JacksonUtils.toObj(data.get("content").asText());
+        assertEquals(agentSpecName, manifest.get("worker").get("suggested_name").asText(),
+                data.toString());
+        assertEquals(version, manifest.get("version").asText(), data.toString());
+        assertEquals(scenario, manifest.get("scenario").asText(), data.toString());
+        JsonNode resource = findSkillResource(data.get("resource"), "config", "SOUL.md");
+        assertNotNull(resource, data.toString());
+        assertEquals(soulContent, resource.get("content").asText(), data.toString());
+    }
+
+    protected void assertAgentSpecMetaContent(JsonNode data, String agentSpecName, String version,
+            String description, String scenario) {
+        assertEquals(DEFAULT_NAMESPACE, data.get("namespaceId").asText(), data.toString());
+        assertEquals(agentSpecName, data.get("name").asText(), data.toString());
+        assertEquals(description, data.get("description").asText(), data.toString());
+        JsonNode manifest = JacksonUtils.toObj(data.get("content").asText());
+        assertEquals(version, manifest.get("version").asText(), data.toString());
+        assertEquals(scenario, manifest.get("scenario").asText(), data.toString());
+        JsonNode resource = findSkillResource(data.get("resource"), "config", "SOUL.md");
+        assertNotNull(resource, data.toString());
+        assertTrue(resource.path("content").isNull() || resource.path("content").isMissingNode(),
+                data.toString());
+    }
+
+    protected JsonNode findAgentSpecVersionSummary(JsonNode agentSpecMeta, String version) {
+        for (JsonNode item : agentSpecMeta.get("versions")) {
+            if (version.equals(item.get("version").asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+
+    protected byte[] buildAgentSpecZip(String agentSpecName, String version, String description,
+            String scenario, String soulContent) throws Exception {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("manifest.json", buildAgentSpecManifest(agentSpecName, version, description,
+                scenario));
+        entries.put("config/SOUL.md", soulContent);
+        return zipEntries(entries);
+    }
+
+    protected byte[] buildAgentSpecSeedArchive(Map<String, String> agentSpecNameToScenario)
+            throws Exception {
+        Map<String, String> entries = new LinkedHashMap<>();
+        agentSpecNameToScenario.forEach((agentSpecName, scenario) -> {
+            String root = "openapi/" + agentSpecName;
+            entries.put(root + "/manifest.json", buildAgentSpecManifest(agentSpecName, "0.0.1",
+                    "uploaded seed " + agentSpecName, scenario));
+            entries.put(root + "/config/SOUL.md", "seed soul for " + agentSpecName);
+        });
+        return zipEntries(entries);
+    }
+
+    protected byte[] buildZipWithoutAgentSpecManifest() throws Exception {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("config/SOUL.md", "soul without manifest");
+        return zipEntries(entries);
+    }
+
     private String mcpServerSpecification(String mcpName, String version, String description) {
         Map<String, Object> versionDetail = new LinkedHashMap<>();
         versionDetail.put("version", version);
@@ -511,6 +655,13 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         return form;
     }
 
+    protected Map<String, String> agentSpecQueryForm(String agentSpecName) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("namespaceId", DEFAULT_NAMESPACE);
+        form.put("agentSpecName", agentSpecName);
+        return form;
+    }
+
     private String promptVariables() {
         Map<String, String> variable = new LinkedHashMap<>();
         variable.put("name", "name");
@@ -532,6 +683,36 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         resources.put("references::guide.md", guide);
         card.put("resource", resources);
         return JacksonUtils.toJson(card);
+    }
+
+    private String buildAgentSpecCard(String agentSpecName, String version, String description,
+            String scenario, String soulContent) {
+        Map<String, Object> card = new LinkedHashMap<>();
+        card.put("name", agentSpecName);
+        card.put("description", description);
+        card.put("bizTags", "[\"openapi-it\"]");
+        card.put("content", buildAgentSpecManifest(agentSpecName, version, description, scenario));
+        Map<String, Object> soul = new LinkedHashMap<>();
+        soul.put("name", "SOUL.md");
+        soul.put("type", "config");
+        soul.put("content", soulContent);
+        Map<String, Object> resources = new LinkedHashMap<>();
+        resources.put("config_SOUL__md", soul);
+        card.put("resource", resources);
+        return JacksonUtils.toJson(card);
+    }
+
+    private String buildAgentSpecManifest(String agentSpecName, String version, String description,
+            String scenario) {
+        Map<String, Object> worker = new LinkedHashMap<>();
+        worker.put("suggested_name", agentSpecName);
+        Map<String, Object> manifest = new LinkedHashMap<>();
+        manifest.put("version", version);
+        manifest.put("description", description);
+        manifest.put("scenario", scenario);
+        manifest.put("tags", Collections.singletonList("openapi-it"));
+        manifest.put("worker", worker);
+        return JacksonUtils.toJson(manifest);
     }
 
     private String skillMarkdown(String skillName, String version, String body) {

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
@@ -23,14 +23,21 @@ import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -71,6 +78,15 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
 
     protected static final String ADMIN_PROMPT_VERSION_DOWNLOAD_PATH =
             ADMIN_PROMPT_PATH + "/version/download";
+
+    protected static final String ADMIN_SKILL_PATH = nacosPath(Constants.Skills.ADMIN_PATH);
+
+    protected static final String ADMIN_SKILL_LIST_PATH = ADMIN_SKILL_PATH + "/list";
+
+    protected static final String ADMIN_SKILL_VERSION_PATH = ADMIN_SKILL_PATH + "/version";
+
+    protected static final String ADMIN_SKILL_VERSION_DOWNLOAD_PATH =
+            ADMIN_SKILL_PATH + "/version/download";
 
     protected String randomAiName(String scenario) {
         return "oit-" + scenario + "-" + UUID.randomUUID().toString().substring(0, 8);
@@ -256,6 +272,171 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         assertEquals("Nacos", data.get("variables").get(0).get("defaultValue").asText(), data.toString());
     }
 
+    protected Query skillQuery(String skillName) {
+        return Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("skillName", skillName);
+    }
+
+    protected Query skillVersionQuery(String skillName, String version) {
+        Query query = skillQuery(skillName);
+        addIfNotBlank(query, "version", version);
+        return query;
+    }
+
+    protected Map<String, String> skillDraftForm(String skillName, String version, String body,
+            String guideContent) {
+        Map<String, String> form = skillUpdateForm(skillName, body, guideContent);
+        form.put("namespaceId", DEFAULT_NAMESPACE);
+        form.put("targetVersion", version);
+        return form;
+    }
+
+    protected Map<String, String> skillForkForm(String skillName, String targetVersion,
+            String basedOnVersion) {
+        Map<String, String> form = skillQueryForm(skillName);
+        form.put("targetVersion", targetVersion);
+        form.put("basedOnVersion", basedOnVersion);
+        form.put("commitMsg", "openapi skill admin fork");
+        return form;
+    }
+
+    protected Map<String, String> skillUpdateForm(String skillName, String body,
+            String guideContent) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("skillName", skillName);
+        form.put("skillCard", buildSkillCard(skillName, body, guideContent));
+        form.put("commitMsg", "openapi skill admin it");
+        return form;
+    }
+
+    protected Map<String, String> skillPublishForm(String skillName, String version) {
+        Map<String, String> form = skillQueryForm(skillName);
+        form.put("version", version);
+        form.put("updateLatestLabel", "true");
+        return form;
+    }
+
+    protected Map<String, String> skillLabelsForm(String skillName, String labels) {
+        Map<String, String> form = skillQueryForm(skillName);
+        form.put("labels", labels);
+        return form;
+    }
+
+    protected Map<String, String> skillBizTagsForm(String skillName, String bizTags) {
+        Map<String, String> form = skillQueryForm(skillName);
+        form.put("bizTags", bizTags);
+        return form;
+    }
+
+    protected Map<String, String> skillScopeForm(String skillName, String scope) {
+        Map<String, String> form = skillQueryForm(skillName);
+        form.put("scope", scope);
+        return form;
+    }
+
+    protected Map<String, String> skillOnlineForm(String skillName, String version, String scope) {
+        Map<String, String> form = skillQueryForm(skillName);
+        addIfNotBlank(form, "version", version);
+        addIfNotBlank(form, "scope", scope);
+        return form;
+    }
+
+    protected void deleteSkillQuietly(String skillName) throws Exception {
+        deleteQuietly(ADMIN_SKILL_PATH, skillQuery(skillName));
+    }
+
+    protected void assertSkillContent(JsonNode data, String skillName, String version, String body,
+            String guideContent) {
+        assertEquals(DEFAULT_NAMESPACE, data.get("namespaceId").asText(), data.toString());
+        assertEquals(skillName, data.get("name").asText(), data.toString());
+        assertEquals("skill admin openapi integration test", data.get("description").asText(),
+                data.toString());
+        String skillMd = data.get("skillMd").asText();
+        assertTrue(skillMd.contains("name: " + skillName), skillMd);
+        assertTrue(skillMd.contains("version: " + version), skillMd);
+        assertTrue(skillMd.contains(body), skillMd);
+        JsonNode resource = findSkillResource(data.get("resource"), "references", "guide.md");
+        assertNotNull(resource, data.toString());
+        assertEquals("guide.md", resource.get("name").asText(), data.toString());
+        assertEquals("references", resource.get("type").asText(), data.toString());
+        assertEquals(guideContent, resource.get("content").asText(), data.toString());
+    }
+
+    protected JsonNode findSkillResource(JsonNode resources, String type, String name) {
+        if (null == resources || !resources.isObject()) {
+            return MissingNode.getInstance();
+        }
+        for (JsonNode resource : resources) {
+            if (name.equals(resource.get("name").asText())
+                    && type.equals(resource.get("type").asText())) {
+                return resource;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+
+    protected JsonNode findSkillVersionSummary(JsonNode skillMeta, String version) {
+        for (JsonNode item : skillMeta.get("versions")) {
+            if (version.equals(item.get("version").asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+
+    protected void assertSkillZip(ByteResponse response, String skillName, String version, String body,
+            String guideContent) throws Exception {
+        assertEquals(200, response.code(), new String(response.body(), StandardCharsets.UTF_8));
+        assertNotNull(response.contentDisposition());
+        assertTrue(response.contentDisposition().contains(skillName + ".zip"),
+                response.contentDisposition());
+        Map<String, String> entries = unzipTextEntries(response.body());
+        String skillMd = entries.get(skillName + "/SKILL.md");
+        assertNotNull(skillMd, entries.keySet().toString());
+        assertTrue(skillMd.contains("name: " + skillName), skillMd);
+        assertTrue(skillMd.contains("version: " + version), skillMd);
+        assertTrue(skillMd.contains(body), skillMd);
+        assertEquals(guideContent, entries.get(skillName + "/references/guide.md"));
+    }
+
+    protected byte[] buildSkillZip(String skillName, String version, String body,
+            String guideContent) throws Exception {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put("SKILL.md", skillMarkdown(skillName, version, body));
+        entries.put("references/guide.md", guideContent);
+        return zipEntries(entries);
+    }
+
+    protected byte[] buildMultiSkillZip(Map<String, String> skillNameToBody) throws Exception {
+        Map<String, String> entries = new LinkedHashMap<>();
+        skillNameToBody.forEach((skillName, body) -> {
+            entries.put(skillName + "/SKILL.md", skillMarkdown(skillName, "1.0.0", body));
+            entries.put(skillName + "/references/guide.md", "guide for " + skillName);
+        });
+        return zipEntries(entries);
+    }
+
+    protected byte[] buildPartiallyInvalidMultiSkillZip(String validSkillName, String validBody)
+            throws Exception {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put(validSkillName + "/SKILL.md", skillMarkdown(validSkillName, "1.0.0", validBody));
+        entries.put("invalid-skill/SKILL.md", "---\nname: {{{invalid yaml\n---\n\nBroken instructions");
+        return zipEntries(entries);
+    }
+
+    protected Map<String, String> unzipTextEntries(byte[] body) throws Exception {
+        Map<String, String> result = new LinkedHashMap<>();
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(body))) {
+            ZipEntry entry;
+            while (null != (entry = zis.getNextEntry())) {
+                if (!entry.isDirectory()) {
+                    result.put(entry.getName(), new String(readEntry(zis), StandardCharsets.UTF_8));
+                }
+            }
+        }
+        return result;
+    }
+
     private String mcpServerSpecification(String mcpName, String version, String description) {
         Map<String, Object> versionDetail = new LinkedHashMap<>();
         versionDetail.put("version", version);
@@ -323,11 +504,72 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         return form;
     }
 
+    protected Map<String, String> skillQueryForm(String skillName) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("namespaceId", DEFAULT_NAMESPACE);
+        form.put("skillName", skillName);
+        return form;
+    }
+
     private String promptVariables() {
         Map<String, String> variable = new LinkedHashMap<>();
         variable.put("name", "name");
         variable.put("defaultValue", "Nacos");
         variable.put("description", "target name");
         return JacksonUtils.toJson(Collections.singletonList(variable));
+    }
+
+    private String buildSkillCard(String skillName, String body, String guideContent) {
+        Map<String, Object> card = new LinkedHashMap<>();
+        card.put("name", skillName);
+        card.put("description", "skill admin openapi integration test");
+        card.put("skillMd", skillMarkdown(skillName, null, body));
+        Map<String, Object> guide = new LinkedHashMap<>();
+        guide.put("name", "guide.md");
+        guide.put("type", "references");
+        guide.put("content", guideContent);
+        Map<String, Object> resources = new LinkedHashMap<>();
+        resources.put("references::guide.md", guide);
+        card.put("resource", resources);
+        return JacksonUtils.toJson(card);
+    }
+
+    private String skillMarkdown(String skillName, String version, String body) {
+        StringBuilder result = new StringBuilder();
+        result.append("---\nname: ").append(skillName)
+                .append("\ndescription: skill admin openapi integration test\n");
+        if (null != version) {
+            result.append("version: ").append(version).append('\n');
+        }
+        result.append("---\n\n").append(body);
+        return result.toString();
+    }
+
+    private byte[] zipEntries(Map<String, String> entries) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(output)) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                zos.putNextEntry(new ZipEntry(entry.getKey()));
+                zos.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+        }
+        return output.toByteArray();
+    }
+
+    private byte[] readEntry(ZipInputStream zis) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = zis.read(buffer)) != -1) {
+            output.write(buffer, 0, len);
+        }
+        return output.toByteArray();
+    }
+
+    private void addIfNotBlank(Map<String, String> form, String name, String value) {
+        if (null != value && !value.isBlank()) {
+            form.put(name, value);
+        }
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
@@ -39,30 +39,47 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author xiweng.yy
  */
 public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
-    
+
     protected static final String DEFAULT_NAMESPACE = "public";
-    
+
     protected static final String ADMIN_A2A_PATH = nacosPath(Constants.A2A.ADMIN_PATH);
-    
+
     protected static final String ADMIN_A2A_LIST_PATH = ADMIN_A2A_PATH + "/list";
-    
+
     protected static final String ADMIN_A2A_VERSION_LIST_PATH = ADMIN_A2A_PATH + "/version/list";
-    
+
     protected static final String ADMIN_MCP_PATH = nacosPath(Constants.MCP_ADMIN_PATH);
-    
+
     protected static final String ADMIN_MCP_LIST_PATH = ADMIN_MCP_PATH + "/list";
-    
+
     protected static final String ADMIN_PIPELINE_PATH = nacosPath(Constants.Pipeline.ADMIN_PATH);
-    
+
     protected static final String ADMIN_PIPELINE_LIST_PATH = ADMIN_PIPELINE_PATH + Constants.Pipeline.LIST_SUBPATH;
-    
+
     protected static final String ADMIN_PIPELINE_DETAIL_PATH =
             ADMIN_PIPELINE_PATH + Constants.Pipeline.DETAIL_SUBPATH;
-    
+
+    protected static final String ADMIN_PROMPT_PATH = nacosPath(Constants.Prompt.ADMIN_PATH);
+
+    protected static final String ADMIN_PROMPT_LIST_PATH = ADMIN_PROMPT_PATH + "/list";
+
+    protected static final String ADMIN_PROMPT_VERSIONS_PATH = ADMIN_PROMPT_PATH + "/versions";
+
+    protected static final String ADMIN_PROMPT_GOVERNANCE_PATH = ADMIN_PROMPT_PATH + "/governance";
+
+    protected static final String ADMIN_PROMPT_VERSION_PATH = ADMIN_PROMPT_PATH + "/version";
+
+    protected static final String ADMIN_PROMPT_VERSION_DOWNLOAD_PATH =
+            ADMIN_PROMPT_PATH + "/version/download";
+
     protected String randomAiName(String scenario) {
         return "oit-" + scenario + "-" + UUID.randomUUID().toString().substring(0, 8);
     }
-    
+
+    protected String randomPromptKey(String scenario) {
+        return "oit_" + scenario + "_" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
     protected Query mcpIdentityQuery(String mcpName, String mcpId, String version) {
         Query query = Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE);
         addIfNotBlank(query, "mcpName", mcpName);
@@ -70,7 +87,7 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         addIfNotBlank(query, "version", version);
         return query;
     }
-    
+
     protected Map<String, String> mcpServerForm(String mcpName, String version, String description,
             String toolName, String resourceName) {
         Map<String, String> form = new LinkedHashMap<>();
@@ -81,11 +98,11 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         form.put("resourceSpecification", mcpResourceSpecification(resourceName));
         return form;
     }
-    
+
     protected void deleteMcpServerQuietly(String mcpName, String mcpId) throws Exception {
         deleteQuietly(ADMIN_MCP_PATH, mcpIdentityQuery(mcpName, mcpId, null));
     }
-    
+
     protected void assertMcpDetail(JsonNode data, String mcpName, String version, String description,
             String toolName, String resourceName) {
         assertEquals(DEFAULT_NAMESPACE, data.get("namespaceId").asText(), data.toString());
@@ -99,7 +116,7 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         assertEquals(resourceName, data.get("resourceSpec").get("resources").get(0).get("name").asText(),
                 data.toString());
     }
-    
+
     protected JsonNode findByName(JsonNode page, String fieldName, String expectedName) {
         for (JsonNode item : page.get("pageItems")) {
             if (expectedName.equals(item.get(fieldName).asText())) {
@@ -108,24 +125,24 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         }
         return MissingNode.getInstance();
     }
-    
+
     protected void assertPageContains(JsonNode page, String fieldName, String expectedName) {
         assertFalse(findByName(page, fieldName, expectedName).isMissingNode(), page.toString());
     }
-    
+
     protected void assertEmptyPageShape(JsonNode page) {
         assertTrue(page.get("pageNumber").asInt() >= 1, page.toString());
         assertTrue(page.get("pagesAvailable").asInt() >= 0, page.toString());
         assertTrue(page.get("totalCount").asInt() >= 0, page.toString());
         assertTrue(page.get("pageItems").isArray(), page.toString());
     }
-    
+
     protected Query queryFrom(Map<String, String> params) {
         Query query = Query.newInstance();
         params.forEach(query::addParam);
         return query;
     }
-    
+
     protected Map<String, String> buildAgentCardForm(String agentName, String version, String registrationType,
             String agentCard) {
         Map<String, String> form = new LinkedHashMap<>();
@@ -136,7 +153,7 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         form.put("agentCard", agentCard);
         return form;
     }
-    
+
     protected String buildLegacyAgentCard(String agentName, String version) {
         Map<String, Object> card = new LinkedHashMap<>();
         card.put("name", agentName);
@@ -149,7 +166,7 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         card.put("capabilities", agentCapabilities());
         return JacksonUtils.toJson(card);
     }
-    
+
     protected String buildV1AgentCard(String agentName, String version, String protocolVersion) {
         Map<String, Object> card = new LinkedHashMap<>();
         card.put("name", agentName);
@@ -160,7 +177,7 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         card.put("capabilities", agentCapabilities());
         return JacksonUtils.toJson(card);
     }
-    
+
     protected void deleteAgentQuietly(String agentName, String version, String registrationType) throws Exception {
         Query query = Query.newInstance().addParam("agentName", agentName)
                 .addParam("namespaceId", DEFAULT_NAMESPACE);
@@ -168,7 +185,77 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         addIfNotBlank(query, "registrationType", registrationType);
         deleteQuietly(ADMIN_A2A_PATH, query);
     }
-    
+
+    protected Query promptQuery(String promptKey) {
+        return Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("promptKey", promptKey);
+    }
+
+    protected Query promptVersionQuery(String promptKey, String version) {
+        Query query = promptQuery(promptKey);
+        addIfNotBlank(query, "version", version);
+        return query;
+    }
+
+    protected Map<String, String> promptDraftForm(String promptKey, String targetVersion,
+            String template, String description, String bizTags) {
+        Map<String, String> form = promptQueryForm(promptKey);
+        form.put("targetVersion", targetVersion);
+        form.put("template", template);
+        form.put("variables", promptVariables());
+        form.put("commitMsg", "openapi prompt admin it");
+        form.put("description", description);
+        form.put("bizTags", bizTags);
+        return form;
+    }
+
+    protected Map<String, String> promptUpdateDraftForm(String promptKey, String template) {
+        Map<String, String> form = promptQueryForm(promptKey);
+        form.put("template", template);
+        form.put("variables", promptVariables());
+        form.put("commitMsg", "openapi prompt admin update");
+        return form;
+    }
+
+    protected Map<String, String> promptPublishForm(String promptKey, String version) {
+        Map<String, String> form = promptQueryForm(promptKey);
+        form.put("version", version);
+        form.put("updateLatestLabel", "true");
+        return form;
+    }
+
+    protected Map<String, String> promptLabelsForm(String promptKey, String labels) {
+        Map<String, String> form = promptQueryForm(promptKey);
+        form.put("labels", labels);
+        return form;
+    }
+
+    protected Map<String, String> promptDescriptionForm(String promptKey, String description) {
+        Map<String, String> form = promptQueryForm(promptKey);
+        form.put("description", description);
+        return form;
+    }
+
+    protected Map<String, String> promptBizTagsForm(String promptKey, String bizTags) {
+        Map<String, String> form = promptQueryForm(promptKey);
+        form.put("bizTags", bizTags);
+        return form;
+    }
+
+    protected void deletePromptQuietly(String promptKey) throws Exception {
+        deleteQuietly(ADMIN_PROMPT_PATH, promptQuery(promptKey));
+    }
+
+    protected void assertPromptVersion(JsonNode data, String promptKey, String version, String status,
+            String template) {
+        assertEquals(promptKey, data.get("promptKey").asText(), data.toString());
+        assertEquals(version, data.get("version").asText(), data.toString());
+        assertEquals(status, data.get("status").asText(), data.toString());
+        assertEquals(template, data.get("template").asText(), data.toString());
+        assertEquals("name", data.get("variables").get(0).get("name").asText(), data.toString());
+        assertEquals("Nacos", data.get("variables").get(0).get("defaultValue").asText(), data.toString());
+    }
+
     private String mcpServerSpecification(String mcpName, String version, String description) {
         Map<String, Object> versionDetail = new LinkedHashMap<>();
         versionDetail.put("version", version);
@@ -184,7 +271,7 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         server.put("enabled", true);
         return JacksonUtils.toJson(server);
     }
-    
+
     private String mcpToolSpecification(String toolName) {
         Map<String, Object> textProperty = new LinkedHashMap<>();
         textProperty.put("type", "string");
@@ -201,7 +288,7 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         spec.put("tools", Collections.singletonList(tool));
         return JacksonUtils.toJson(spec);
     }
-    
+
     private String mcpResourceSpecification(String resourceName) {
         Map<String, Object> resource = new LinkedHashMap<>();
         resource.put("name", resourceName);
@@ -212,7 +299,7 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         spec.put("resources", Collections.singletonList(resource));
         return JacksonUtils.toJson(spec);
     }
-    
+
     private Map<String, Object> agentInterface(String agentName, String protocolBinding, String protocolVersion) {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("url", "https://example.com/" + agentName + "/" + protocolBinding.toLowerCase());
@@ -221,11 +308,26 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         result.put("transport", protocolBinding);
         return result;
     }
-    
+
     private Map<String, Object> agentCapabilities() {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("streaming", true);
         result.put("extendedAgentCard", true);
         return result;
+    }
+
+    protected Map<String, String> promptQueryForm(String promptKey) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("namespaceId", DEFAULT_NAMESPACE);
+        form.put("promptKey", promptKey);
+        return form;
+    }
+
+    private String promptVariables() {
+        Map<String, String> variable = new LinkedHashMap<>();
+        variable.put("name", "name");
+        variable.put("defaultValue", "Nacos");
+        variable.put("description", "target name");
+        return JacksonUtils.toJson(Collections.singletonList(variable));
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
@@ -98,6 +98,21 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
     protected static final String ADMIN_AGENT_SPEC_VERSION_META_PATH =
             ADMIN_AGENT_SPEC_PATH + "/version/meta";
 
+    protected static final String ADMIN_IMPORT_PATH =
+            nacosPath(Constants.AI_RESOURCE_IMPORT_ADMIN_PATH);
+
+    protected static final String ADMIN_IMPORT_SOURCES_PATH = ADMIN_IMPORT_PATH + "/sources";
+
+    protected static final String ADMIN_IMPORT_SEARCH_PATH = ADMIN_IMPORT_PATH + "/search";
+
+    protected static final String ADMIN_IMPORT_VALIDATE_PATH = ADMIN_IMPORT_PATH + "/validate";
+
+    protected static final String ADMIN_IMPORT_EXECUTE_PATH = ADMIN_IMPORT_PATH + "/execute";
+
+    protected static final String IMPORT_RESOURCE_TYPE_MCP = "mcp";
+
+    protected static final String IMPORT_RESOURCE_TYPE_SKILL = "skill";
+
     protected String randomAiName(String scenario) {
         return "oit-" + scenario + "-" + UUID.randomUUID().toString().substring(0, 8);
     }
@@ -554,6 +569,59 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         return MissingNode.getInstance();
     }
 
+    protected Query importSourceQuery(String resourceType) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "resourceType", resourceType);
+        return query;
+    }
+
+    protected Map<String, String> importSearchForm(String resourceType, String sourceId,
+            String query, Integer limit, String options) {
+        Map<String, String> form = importSourceForm(resourceType, sourceId);
+        addIfNotBlank(form, "query", query);
+        if (null != limit) {
+            form.put("limit", String.valueOf(limit));
+        }
+        addIfNotBlank(form, "options", options);
+        return form;
+    }
+
+    protected Map<String, String> importValidateForm(String resourceType, String sourceId,
+            String selectedItems, String options, boolean overwriteExisting) {
+        Map<String, String> form = importSourceForm(resourceType, sourceId);
+        addIfNotBlank(form, "selectedItems", selectedItems);
+        addIfNotBlank(form, "options", options);
+        form.put("overwriteExisting", String.valueOf(overwriteExisting));
+        return form;
+    }
+
+    protected Map<String, String> importExecuteForm(String resourceType, String sourceId,
+            String selectedItems, String options, boolean overwriteExisting,
+            boolean skipInvalid) {
+        Map<String, String> form = importValidateForm(resourceType, sourceId, selectedItems,
+                options, overwriteExisting);
+        form.put("skipInvalid", String.valueOf(skipInvalid));
+        form.put("validationToken", "openapi-it-token");
+        return form;
+    }
+
+    protected String importSelectedItemsJson(String externalId, String name, String version) {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("source", "openapi-it");
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("externalId", externalId);
+        item.put("name", name);
+        item.put("version", version);
+        item.put("metadata", metadata);
+        return JacksonUtils.toJson(Collections.singletonList(item));
+    }
+
+    protected String importOptionsJson() {
+        Map<String, String> options = new LinkedHashMap<>();
+        options.put("scenario", "openapi-it");
+        return JacksonUtils.toJson(options);
+    }
+
     protected byte[] buildAgentSpecZip(String agentSpecName, String version, String description,
             String scenario, String soulContent) throws Exception {
         Map<String, String> entries = new LinkedHashMap<>();
@@ -659,6 +727,14 @@ public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
         Map<String, String> form = new LinkedHashMap<>();
         form.put("namespaceId", DEFAULT_NAMESPACE);
         form.put("agentSpecName", agentSpecName);
+        return form;
+    }
+
+    protected Map<String, String> importSourceForm(String resourceType, String sourceId) {
+        Map<String, String> form = new LinkedHashMap<>();
+        addIfNotBlank(form, "namespaceId", DEFAULT_NAMESPACE);
+        addIfNotBlank(form, "resourceType", resourceType);
+        addIfNotBlank(form, "sourceId", sourceId);
         return form;
     }
 

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/AiAdminApiBaseITCase.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.ai;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shared helpers for AI admin OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class AiAdminApiBaseITCase extends OpenApiBaseITCase {
+    
+    protected static final String DEFAULT_NAMESPACE = "public";
+    
+    protected static final String ADMIN_A2A_PATH = nacosPath(Constants.A2A.ADMIN_PATH);
+    
+    protected static final String ADMIN_A2A_LIST_PATH = ADMIN_A2A_PATH + "/list";
+    
+    protected static final String ADMIN_A2A_VERSION_LIST_PATH = ADMIN_A2A_PATH + "/version/list";
+    
+    protected static final String ADMIN_MCP_PATH = nacosPath(Constants.MCP_ADMIN_PATH);
+    
+    protected static final String ADMIN_MCP_LIST_PATH = ADMIN_MCP_PATH + "/list";
+    
+    protected static final String ADMIN_PIPELINE_PATH = nacosPath(Constants.Pipeline.ADMIN_PATH);
+    
+    protected static final String ADMIN_PIPELINE_LIST_PATH = ADMIN_PIPELINE_PATH + Constants.Pipeline.LIST_SUBPATH;
+    
+    protected static final String ADMIN_PIPELINE_DETAIL_PATH =
+            ADMIN_PIPELINE_PATH + Constants.Pipeline.DETAIL_SUBPATH;
+    
+    protected String randomAiName(String scenario) {
+        return "oit-" + scenario + "-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+    
+    protected Query mcpIdentityQuery(String mcpName, String mcpId, String version) {
+        Query query = Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE);
+        addIfNotBlank(query, "mcpName", mcpName);
+        addIfNotBlank(query, "mcpId", mcpId);
+        addIfNotBlank(query, "version", version);
+        return query;
+    }
+    
+    protected Map<String, String> mcpServerForm(String mcpName, String version, String description,
+            String toolName, String resourceName) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("namespaceId", DEFAULT_NAMESPACE);
+        form.put("mcpName", mcpName);
+        form.put("serverSpecification", mcpServerSpecification(mcpName, version, description));
+        form.put("toolSpecification", mcpToolSpecification(toolName));
+        form.put("resourceSpecification", mcpResourceSpecification(resourceName));
+        return form;
+    }
+    
+    protected void deleteMcpServerQuietly(String mcpName, String mcpId) throws Exception {
+        deleteQuietly(ADMIN_MCP_PATH, mcpIdentityQuery(mcpName, mcpId, null));
+    }
+    
+    protected void assertMcpDetail(JsonNode data, String mcpName, String version, String description,
+            String toolName, String resourceName) {
+        assertEquals(DEFAULT_NAMESPACE, data.get("namespaceId").asText(), data.toString());
+        assertEquals(mcpName, data.get("name").asText(), data.toString());
+        assertEquals(version, data.get("version").asText(), data.toString());
+        assertEquals(description, data.get("description").asText(), data.toString());
+        assertEquals("stdio", data.get("protocol").asText(), data.toString());
+        assertEquals(version, data.get("versionDetail").get("version").asText(), data.toString());
+        assertEquals(toolName, data.get("toolSpec").get("tools").get(0).get("name").asText(),
+                data.toString());
+        assertEquals(resourceName, data.get("resourceSpec").get("resources").get(0).get("name").asText(),
+                data.toString());
+    }
+    
+    protected JsonNode findByName(JsonNode page, String fieldName, String expectedName) {
+        for (JsonNode item : page.get("pageItems")) {
+            if (expectedName.equals(item.get(fieldName).asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+    
+    protected void assertPageContains(JsonNode page, String fieldName, String expectedName) {
+        assertFalse(findByName(page, fieldName, expectedName).isMissingNode(), page.toString());
+    }
+    
+    protected void assertEmptyPageShape(JsonNode page) {
+        assertTrue(page.get("pageNumber").asInt() >= 1, page.toString());
+        assertTrue(page.get("pagesAvailable").asInt() >= 0, page.toString());
+        assertTrue(page.get("totalCount").asInt() >= 0, page.toString());
+        assertTrue(page.get("pageItems").isArray(), page.toString());
+    }
+    
+    protected Query queryFrom(Map<String, String> params) {
+        Query query = Query.newInstance();
+        params.forEach(query::addParam);
+        return query;
+    }
+    
+    protected Map<String, String> buildAgentCardForm(String agentName, String version, String registrationType,
+            String agentCard) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("agentName", agentName);
+        form.put("version", version);
+        form.put("namespaceId", DEFAULT_NAMESPACE);
+        form.put("registrationType", registrationType);
+        form.put("agentCard", agentCard);
+        return form;
+    }
+    
+    protected String buildLegacyAgentCard(String agentName, String version) {
+        Map<String, Object> card = new LinkedHashMap<>();
+        card.put("name", agentName);
+        card.put("version", version);
+        card.put("description", "legacy-" + agentName);
+        card.put("protocolVersion", "1.0");
+        card.put("preferredTransport", "JSONRPC");
+        card.put("url", "https://example.com/" + agentName + "/jsonrpc");
+        card.put("additionalInterfaces", Collections.singletonList(agentInterface(agentName, "GRPC", "1.0")));
+        card.put("capabilities", agentCapabilities());
+        return JacksonUtils.toJson(card);
+    }
+    
+    protected String buildV1AgentCard(String agentName, String version, String protocolVersion) {
+        Map<String, Object> card = new LinkedHashMap<>();
+        card.put("name", agentName);
+        card.put("version", version);
+        card.put("description", "v1-" + agentName);
+        card.put("supportedInterfaces", List.of(agentInterface(agentName, "JSONRPC", protocolVersion),
+                agentInterface(agentName, "GRPC", protocolVersion)));
+        card.put("capabilities", agentCapabilities());
+        return JacksonUtils.toJson(card);
+    }
+    
+    protected void deleteAgentQuietly(String agentName, String version, String registrationType) throws Exception {
+        Query query = Query.newInstance().addParam("agentName", agentName)
+                .addParam("namespaceId", DEFAULT_NAMESPACE);
+        addIfNotBlank(query, "version", version);
+        addIfNotBlank(query, "registrationType", registrationType);
+        deleteQuietly(ADMIN_A2A_PATH, query);
+    }
+    
+    private String mcpServerSpecification(String mcpName, String version, String description) {
+        Map<String, Object> versionDetail = new LinkedHashMap<>();
+        versionDetail.put("version", version);
+        Map<String, Object> localServerConfig = new LinkedHashMap<>();
+        localServerConfig.put("command", "echo");
+        localServerConfig.put("args", Collections.singletonList("openapi-it"));
+        Map<String, Object> server = new LinkedHashMap<>();
+        server.put("name", mcpName);
+        server.put("protocol", "stdio");
+        server.put("description", description);
+        server.put("versionDetail", versionDetail);
+        server.put("localServerConfig", localServerConfig);
+        server.put("enabled", true);
+        return JacksonUtils.toJson(server);
+    }
+    
+    private String mcpToolSpecification(String toolName) {
+        Map<String, Object> textProperty = new LinkedHashMap<>();
+        textProperty.put("type", "string");
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("text", textProperty);
+        Map<String, Object> inputSchema = new LinkedHashMap<>();
+        inputSchema.put("type", "object");
+        inputSchema.put("properties", properties);
+        Map<String, Object> tool = new LinkedHashMap<>();
+        tool.put("name", toolName);
+        tool.put("description", "Echo text for OpenAPI IT");
+        tool.put("inputSchema", inputSchema);
+        Map<String, Object> spec = new LinkedHashMap<>();
+        spec.put("tools", Collections.singletonList(tool));
+        return JacksonUtils.toJson(spec);
+    }
+    
+    private String mcpResourceSpecification(String resourceName) {
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("name", resourceName);
+        resource.put("uri", "file:///tmp/" + resourceName + ".txt");
+        resource.put("description", "OpenAPI IT resource");
+        resource.put("mimeType", "text/plain");
+        Map<String, Object> spec = new LinkedHashMap<>();
+        spec.put("resources", Collections.singletonList(resource));
+        return JacksonUtils.toJson(spec);
+    }
+    
+    private Map<String, Object> agentInterface(String agentName, String protocolBinding, String protocolVersion) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("url", "https://example.com/" + agentName + "/" + protocolBinding.toLowerCase());
+        result.put("protocolBinding", protocolBinding);
+        result.put("protocolVersion", protocolVersion);
+        result.put("transport", protocolBinding);
+        return result;
+    }
+    
+    private Map<String, Object> agentCapabilities() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("streaming", true);
+        result.put("extendedAgentCard", true);
+        return result;
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/a2a/A2aAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/a2a/A2aAdminApiOpenApiITCase.java
@@ -17,23 +17,11 @@
 package com.alibaba.nacos.test.adminapi.ai.a2a;
 
 import com.alibaba.nacos.api.model.v2.ErrorCode;
-import com.alibaba.nacos.common.http.HttpRestResult;
-import com.alibaba.nacos.common.http.client.NacosRestTemplate;
-import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
-import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -44,45 +32,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Integration tests for A2A admin APIs ({@code /nacos/v3/admin/ai/a2a}).
  *
- * <p>These tests run against an already started standalone server (default
- * {@code 127.0.0.1:8848}) and assume auth is disabled in the local environment.
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: legacy and v1 agent cards can be registered, normalized, queried by version/latest,
+ *     updated to a new latest version, listed by blur search, and enumerated by version.</li>
+ *     <li>Boundary/validation: namespace defaults to public; register defaults registrationType to URL; update allows
+ *     omitted registrationType; invalid search, missing agentName, invalid registrationType, empty card, malformed
+ *     JSON, and incomplete legacy/v1 endpoint definitions are rejected with HTTP 400.</li>
+ *     <li>Exception/error handling: absent agents return a controlled not-found result and delete is tolerant of
+ *     absent resources.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
  */
-public class A2aAdminApiOpenApiITCase {
-    
-    private static final Logger LOGGER = LoggerFactory.getLogger(A2aAdminApiOpenApiITCase.class);
-    
-    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
-    
-    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
-    
-    private static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
-    
-    private static final String A2A_ADMIN_PATH = "/nacos/v3/admin/ai/a2a";
-    
-    private static final String A2A_ADMIN_LIST_PATH = A2A_ADMIN_PATH + "/list";
-    
-    private static final String A2A_ADMIN_VERSION_LIST_PATH = A2A_ADMIN_PATH + "/version/list";
-    
-    private static final String DEFAULT_NAMESPACE = "public";
+public class A2aAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
     
     private static final String REGISTRATION_TYPE_URL = "URL";
     
     private static final String SEARCH_BLUR = "blur";
-    
-    private CloseableHttpClient httpClient;
-    
-    private NacosRestTemplate nacosRestTemplate;
-    
-    @BeforeEach
-    public void setUp() throws Exception {
-        httpClient = HttpClientBuilder.create().build();
-        nacosRestTemplate = new NacosRestTemplate(LOGGER, new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
-    }
-    
-    @AfterEach
-    public void tearDown() throws Exception {
-        nacosRestTemplate.close();
-    }
     
     @Test
     public void testRegisterLegacyAgentCardAndGetAgentCardSuccess() throws Exception {
@@ -109,7 +76,7 @@ public class A2aAdminApiOpenApiITCase {
             assertEquals("JSONRPC", supportedInterfaces.get(0).get("protocolBinding").asText());
             assertEquals("1.0", supportedInterfaces.get(0).get("protocolVersion").asText());
         } finally {
-            deleteAgent(agentName, version, REGISTRATION_TYPE_URL);
+            deleteAgentQuietly(agentName, version, REGISTRATION_TYPE_URL);
         }
     }
     
@@ -143,7 +110,7 @@ public class A2aAdminApiOpenApiITCase {
                     "additionalInterfaces should be generated for v1 card");
             assertEquals("GRPC", additionalInterfaces.get(0).get("transport").asText());
         } finally {
-            deleteAgent(agentName, version, REGISTRATION_TYPE_URL);
+            deleteAgentQuietly(agentName, version, REGISTRATION_TYPE_URL);
         }
     }
     
@@ -153,7 +120,7 @@ public class A2aAdminApiOpenApiITCase {
         String v1 = "3.0.0";
         String v2 = "3.1.0";
         try {
-            JsonNode register = registerAgent(agentName, v1, REGISTRATION_TYPE_URL, buildV1AgentCard(agentName, v1, "1.0"));
+            JsonNode register = registerAgent(agentName, v1, null, buildV1AgentCard(agentName, v1, "1.0"));
             assertEquals(ErrorCode.SUCCESS.getCode(), register.get("code").asInt(), register.toString());
             
             JsonNode updateResult = updateAgentCard(agentName, v2, REGISTRATION_TYPE_URL,
@@ -175,11 +142,28 @@ public class A2aAdminApiOpenApiITCase {
             assertTrue(pageItems.isArray() && pageItems.size() >= 1);
             assertEquals(agentName, pageItems.get(0).get("name").asText());
         } finally {
-            deleteAgent(agentName, v1, REGISTRATION_TYPE_URL);
-            deleteAgent(agentName, v2, REGISTRATION_TYPE_URL);
+            deleteAgentQuietly(agentName, v1, REGISTRATION_TYPE_URL);
+            deleteAgentQuietly(agentName, v2, REGISTRATION_TYPE_URL);
         }
     }
     
+    @Test
+    public void testGetListAndVersionListValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(ADMIN_A2A_PATH, Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)),
+                400, ErrorCode.PARAMETER_MISSING, "name");
+        assertError(getRaw(ADMIN_A2A_LIST_PATH, Query.newInstance().addParam("search", "invalid")
+                .addParam("pageNo", "1").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+        assertError(getRaw(ADMIN_A2A_VERSION_LIST_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE)), 400, ErrorCode.PARAMETER_MISSING,
+                "name");
+
+        String absentAgent = "openapi-absent-" + UUID.randomUUID();
+        assertError(getRaw(ADMIN_A2A_PATH, Query.newInstance().addParam("agentName", absentAgent)
+                .addParam("namespaceId", DEFAULT_NAMESPACE)), 404, ErrorCode.AGENT_NOT_FOUND,
+                "Agent not found");
+    }
+
     @Test
     public void testRegisterInvalidAgentCardReturnsBadRequest() throws Exception {
         String agentName = "openapi-invalid-" + UUID.randomUUID();
@@ -238,103 +222,46 @@ public class A2aAdminApiOpenApiITCase {
     
     private JsonNode registerAgent(String agentName, String version, String registrationType, String agentCard)
             throws Exception {
-        String url = BASE_URL + A2A_ADMIN_PATH;
         Map<String, String> form = buildAgentCardForm(agentName, version, registrationType, agentCard);
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url, Header.EMPTY, form, String.class);
-        assertTrue(restResult.ok(), "register HTTP status should be 2xx, body=" + restResult.getData());
-        return JacksonUtils.toObj(restResult.getData());
+        if (null == registrationType) {
+            form.remove("registrationType");
+        }
+        return postFormOk(ADMIN_A2A_PATH, form);
     }
     
     private JsonNode updateAgentCard(String agentName, String version, String registrationType, String agentCard,
             boolean setAsLatest) throws Exception {
-        String url = BASE_URL + A2A_ADMIN_PATH;
         Map<String, String> form = buildAgentCardForm(agentName, version, registrationType, agentCard);
         form.put("setAsLatest", String.valueOf(setAsLatest));
-        HttpRestResult<String> restResult = nacosRestTemplate.putForm(url, Header.EMPTY, form, String.class);
-        assertTrue(restResult.ok(), "update HTTP status should be 2xx, body=" + restResult.getData());
-        return JacksonUtils.toObj(restResult.getData());
+        return putFormOk(ADMIN_A2A_PATH, form);
     }
     
     private JsonNode getAgentCard(String agentName, String version, String registrationType) throws Exception {
-        String url = BASE_URL + A2A_ADMIN_PATH;
         Query query = Query.newInstance().addParam("agentName", agentName).addParam("namespaceId", DEFAULT_NAMESPACE)
                 .addParam("registrationType", registrationType);
         if (null != version) {
             query.addParam("version", version);
         }
-        HttpRestResult<String> restResult = nacosRestTemplate.get(url, Header.EMPTY, query, String.class);
-        assertTrue(restResult.ok(), "get HTTP status should be 2xx, body=" + restResult.getData());
-        return JacksonUtils.toObj(restResult.getData());
+        return getJsonOk(ADMIN_A2A_PATH, query);
     }
     
     private JsonNode listAgentVersions(String agentName, String registrationType) throws Exception {
-        String url = BASE_URL + A2A_ADMIN_VERSION_LIST_PATH;
         Query query = Query.newInstance().addParam("agentName", agentName).addParam("namespaceId", DEFAULT_NAMESPACE)
                 .addParam("registrationType", registrationType);
-        HttpRestResult<String> restResult = nacosRestTemplate.get(url, Header.EMPTY, query, String.class);
-        assertTrue(restResult.ok(), "version list HTTP status should be 2xx, body=" + restResult.getData());
-        return JacksonUtils.toObj(restResult.getData());
+        return getJsonOk(ADMIN_A2A_VERSION_LIST_PATH, query);
     }
     
     private JsonNode listAgents(String agentName, String search, int pageNo, int pageSize) throws Exception {
-        String url = BASE_URL + A2A_ADMIN_LIST_PATH;
         Query query = Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE).addParam("agentName", agentName)
                 .addParam("search", search).addParam("pageNo", String.valueOf(pageNo))
                 .addParam("pageSize", String.valueOf(pageSize));
-        HttpRestResult<String> restResult = nacosRestTemplate.get(url, Header.EMPTY, query, String.class);
-        assertTrue(restResult.ok(), "list HTTP status should be 2xx, body=" + restResult.getData());
-        return JacksonUtils.toObj(restResult.getData());
-    }
-    
-    private void deleteAgent(String agentName, String version, String registrationType) throws Exception {
-        String url = BASE_URL + A2A_ADMIN_PATH;
-        Query query = Query.newInstance().addParam("agentName", agentName).addParam("namespaceId", DEFAULT_NAMESPACE)
-                .addParam("registrationType", registrationType);
-        if (null != version) {
-            query.addParam("version", version);
-        }
-        HttpRestResult<String> restResult = nacosRestTemplate.delete(url, Header.EMPTY, query, String.class);
-        if (!restResult.ok()) {
-            LOGGER.warn("delete agent non-OK: code={} body={}", restResult.getCode(), restResult.getData());
-        }
+        return getJsonOk(ADMIN_A2A_LIST_PATH, query);
     }
     
     private void assertBadRequestContains(Map<String, String> form, String expectedText) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(BASE_URL + A2A_ADMIN_PATH, Header.EMPTY, form,
-                String.class);
-        assertEquals(400, restResult.getCode(), "expect bad request, body=" + restResult.getData());
-        String message = String.valueOf(restResult.getMessage());
-        String body = String.valueOf(restResult.getData());
-        assertTrue(message.contains(expectedText) || body.contains(expectedText),
-                "expected message should contain `" + expectedText + "`, actual=" + body);
-    }
-    
-    private Map<String, String> buildAgentCardForm(String agentName, String version, String registrationType,
-            String agentCard) {
-        Map<String, String> form = new LinkedHashMap<>();
-        form.put("agentName", agentName);
-        form.put("version", version);
-        form.put("namespaceId", DEFAULT_NAMESPACE);
-        form.put("registrationType", registrationType);
-        form.put("agentCard", agentCard);
-        return form;
-    }
-    
-    private String buildLegacyAgentCard(String agentName, String version) {
-        return String.format("{\"name\":\"%s\",\"version\":\"%s\",\"description\":\"legacy-%s\","
-                        + "\"protocolVersion\":\"1.0\",\"preferredTransport\":\"JSONRPC\","
-                        + "\"url\":\"https://example.com/%s/jsonrpc\","
-                        + "\"additionalInterfaces\":[{\"url\":\"https://example.com/%s/grpc\",\"transport\":\"GRPC\"}],"
-                        + "\"capabilities\":{\"streaming\":true,\"extendedAgentCard\":true}}",
-                agentName, version, agentName, agentName, agentName);
-    }
-    
-    private String buildV1AgentCard(String agentName, String version, String protocolVersion) {
-        return String.format("{\"name\":\"%s\",\"version\":\"%s\",\"description\":\"v1-%s\","
-                        + "\"supportedInterfaces\":["
-                        + "{\"url\":\"https://example.com/%s/jsonrpc\",\"protocolBinding\":\"JSONRPC\",\"protocolVersion\":\"%s\"},"
-                        + "{\"url\":\"https://example.com/%s/grpc\",\"protocolBinding\":\"GRPC\",\"protocolVersion\":\"%s\"}"
-                        + "],\"capabilities\":{\"streaming\":true,\"extendedAgentCard\":true}}",
-                agentName, version, agentName, agentName, protocolVersion, agentName, protocolVersion);
+        HttpResponse response = postRaw(ADMIN_A2A_PATH, queryFrom(form));
+        assertEquals(400, response.code(), response.body());
+        assertTrue(response.body().contains(expectedText),
+                "expected message should contain `" + expectedText + "`, actual=" + response.body());
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/agentspec/AgentSpecAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/agentspec/AgentSpecAdminApiOpenApiITCase.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.ai.agentspec;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for AgentSpec admin OpenAPI {@code /nacos/v3/admin/ai/agentspecs}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: draft creation, draft update, force-publish, admin detail, version detail,
+ *     version metadata, list, labels, bizTags, scope, online/offline, and delete expose the expected AgentSpec
+ *     state.</li>
+ *     <li>Boundary/validation: namespace defaults to public; list supports accurate/blur and scope filters while
+ *     the shared {@code bizTag} request parameter is accepted but not applied by the AgentSpec service; required
+ *     agentSpecName, agentSpecCard, targetVersion, version, labels, scope, and positive pagination validation
+ *     follows the controller forms; draft forking, auto-create-by-update, and draft deletion are covered.</li>
+ *     <li>Exception/error handling: absent AgentSpecs and versions return controlled RESOURCE_NOT_FOUND bodies,
+ *     direct publish from draft and redraft from online return validation errors instead of HTTP 500, and invalid
+ *     search or scope parameters return HTTP 400.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class AgentSpecAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
+
+    @Test
+    public void testAgentSpecLifecycleGovernanceListAndDelete() throws Exception {
+        String agentSpecName = randomAiName("agentspec");
+        JsonNode draft = postFormOk(ADMIN_AGENT_SPEC_PATH + "/draft",
+                agentSpecDraftForm(agentSpecName, "1.0.0"));
+        assertEquals("1.0.0", draft.get("data").asText(), draft.toString());
+        addCleanup(() -> deleteAgentSpecQuietly(agentSpecName));
+
+        JsonNode updated = putFormOk(ADMIN_AGENT_SPEC_PATH + "/draft",
+                agentSpecUpdateForm(agentSpecName, "1.0.0", "AgentSpec v1",
+                        "scenario-v1", "soul v1"));
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        JsonNode draftDetail = getJsonOk(ADMIN_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "1.0.0")).get("data");
+        assertAgentSpecContent(draftDetail, agentSpecName, "1.0.0", "AgentSpec v1",
+                "scenario-v1", "soul v1");
+        assertAgentSpecVersionStatus(agentSpecName, "1.0.0", "draft");
+        assertAgentSpecMetaContent(getJsonOk(ADMIN_AGENT_SPEC_VERSION_META_PATH,
+                agentSpecVersionQuery(agentSpecName, "1.0.0")).get("data"), agentSpecName,
+                "1.0.0", "AgentSpec v1", "scenario-v1");
+
+        assertError(postRaw(ADMIN_AGENT_SPEC_PATH + "/publish",
+                queryFrom(agentSpecPublishForm(agentSpecName, "1.0.0"))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewing version can be published");
+        assertEquals("ok", postFormOk(ADMIN_AGENT_SPEC_PATH + "/force-publish",
+                agentSpecPublishForm(agentSpecName, "1.0.0")).get("data").asText());
+
+        JsonNode meta = getJsonOk(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)).get("data");
+        assertEquals(agentSpecName, meta.get("name").asText(), meta.toString());
+        assertEquals("AgentSpec v1", meta.get("description").asText(), meta.toString());
+        assertEquals("1.0.0", meta.get("labels").get("latest").asText(), meta.toString());
+        assertEquals(1, meta.get("onlineCnt").asInt(), meta.toString());
+        assertTrue(meta.get("enable").asBoolean(), meta.toString());
+        assertFalse(meta.get("scope").asText().isBlank(), meta.toString());
+        assertEquals("online", findAgentSpecVersionSummary(meta, "1.0.0").get("status").asText(),
+                meta.toString());
+
+        assertAgentSpecListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("agentSpecName", agentSpecName).addParam("search", "accurate")
+                .addParam("pageNo", "1").addParam("pageSize", "10"), agentSpecName);
+        assertAgentSpecListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("agentSpecName", agentSpecName.substring(0, 8)).addParam("search", "blur")
+                .addParam("pageNo", "1").addParam("pageSize", "1000"), agentSpecName);
+
+        assertEquals("ok", putFormOk(ADMIN_AGENT_SPEC_PATH + "/labels",
+                agentSpecLabelsForm(agentSpecName, "{\"stable\":\"1.0.0\"}")).get("data").asText());
+        assertEquals("ok", putFormOk(ADMIN_AGENT_SPEC_PATH + "/biz-tags",
+                agentSpecBizTagsForm(agentSpecName, "[\"openapi\",\"admin\"]")).get("data").asText());
+        assertEquals("ok", putFormOk(ADMIN_AGENT_SPEC_PATH + "/scope",
+                agentSpecScopeForm(agentSpecName, "PUBLIC")).get("data").asText());
+        assertEquals("PUBLIC", getJsonOk(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName))
+                .get("data").get("scope").asText());
+        assertEquals("ok", putFormOk(ADMIN_AGENT_SPEC_PATH + "/scope",
+                agentSpecScopeForm(agentSpecName, "PRIVATE")).get("data").asText());
+        JsonNode governed = getJsonOk(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)).get("data");
+        assertEquals("1.0.0", governed.get("labels").get("stable").asText(), governed.toString());
+        assertEquals("[\"openapi\",\"admin\"]", governed.get("bizTags").asText(), governed.toString());
+        assertEquals("PRIVATE", governed.get("scope").asText(), governed.toString());
+        assertAgentSpecListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("scope", "PRIVATE").addParam("agentSpecName", agentSpecName)
+                .addParam("search", "accurate"), agentSpecName);
+        assertAgentSpecListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("bizTag", "does-not-filter").addParam("agentSpecName", agentSpecName)
+                .addParam("search", "accurate"), agentSpecName);
+
+        assertEquals("ok", postFormOk(ADMIN_AGENT_SPEC_PATH + "/offline",
+                agentSpecOnlineForm(agentSpecName, "1.0.0", null)).get("data").asText());
+        assertAgentSpecVersionStatus(agentSpecName, "1.0.0", "offline");
+        assertEquals("ok", postFormOk(ADMIN_AGENT_SPEC_PATH + "/online",
+                agentSpecOnlineForm(agentSpecName, "1.0.0", null)).get("data").asText());
+        assertAgentSpecVersionStatus(agentSpecName, "1.0.0", "online");
+
+        assertEquals("ok", postFormOk(ADMIN_AGENT_SPEC_PATH + "/offline",
+                agentSpecOnlineForm(agentSpecName, null, "agentspec")).get("data").asText());
+        assertFalse(getJsonOk(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName))
+                .get("data").get("enable").asBoolean());
+        assertEquals("ok", postFormOk(ADMIN_AGENT_SPEC_PATH + "/online",
+                agentSpecOnlineForm(agentSpecName, null, "agentspec")).get("data").asText());
+        assertTrue(getJsonOk(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName))
+                .get("data").get("enable").asBoolean());
+
+        assertError(postRaw(ADMIN_AGENT_SPEC_PATH + "/redraft",
+                queryFrom(agentSpecPublishForm(agentSpecName, "1.0.0"))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewed version can be re-edited");
+
+        JsonNode delete = deleteJsonOk(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName));
+        assertEquals("ok", delete.get("data").asText(), delete.toString());
+        assertError(getRaw(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec not found");
+    }
+
+    @Test
+    public void testAgentSpecForkSubmitDeleteDraftAndUpdateAutoCreate() throws Exception {
+        String autoName = randomAiName("agentspec-auto");
+        assertEquals("ok", putFormOk(ADMIN_AGENT_SPEC_PATH + "/draft",
+                agentSpecUpdateForm(autoName, "0.0.1", "Auto AgentSpec", "auto-scenario",
+                        "auto soul")).get("data").asText());
+        addCleanup(() -> deleteAgentSpecQuietly(autoName));
+        assertAgentSpecVersionStatus(autoName, "0.0.1", "draft");
+        assertAgentSpecContent(getJsonOk(ADMIN_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(autoName, "0.0.1")).get("data"), autoName, "0.0.1",
+                "Auto AgentSpec", "auto-scenario", "auto soul");
+
+        String agentSpecName = randomAiName("agentspec-submit");
+        postFormOk(ADMIN_AGENT_SPEC_PATH + "/draft", agentSpecDraftForm(agentSpecName, "1.0.0"));
+        addCleanup(() -> deleteAgentSpecQuietly(agentSpecName));
+        putFormOk(ADMIN_AGENT_SPEC_PATH + "/draft",
+                agentSpecUpdateForm(agentSpecName, "1.0.0", "AgentSpec v1",
+                        "scenario-v1", "soul v1"));
+        postFormOk(ADMIN_AGENT_SPEC_PATH + "/force-publish",
+                agentSpecPublishForm(agentSpecName, "1.0.0"));
+
+        assertError(postRaw(ADMIN_AGENT_SPEC_PATH + "/draft",
+                queryFrom(agentSpecForkForm(agentSpecName, "1.0.0", "1.0.0"))), 409,
+                ErrorCode.RESOURCE_CONFLICT, "targetVersion already exists");
+
+        JsonNode forked = postFormOk(ADMIN_AGENT_SPEC_PATH + "/draft",
+                agentSpecForkForm(agentSpecName, "2.0.0", "1.0.0"));
+        assertEquals("2.0.0", forked.get("data").asText(), forked.toString());
+        assertAgentSpecVersionStatus(agentSpecName, "2.0.0", "draft");
+
+        JsonNode deleteDraft = deleteJsonOk(ADMIN_AGENT_SPEC_PATH + "/draft",
+                agentSpecQuery(agentSpecName));
+        assertEquals("ok", deleteDraft.get("data").asText(), deleteDraft.toString());
+        assertError(getRaw(ADMIN_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "2.0.0")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec version not found");
+
+        postFormOk(ADMIN_AGENT_SPEC_PATH + "/draft",
+                agentSpecForkForm(agentSpecName, "2.0.0", "1.0.0"));
+        putFormOk(ADMIN_AGENT_SPEC_PATH + "/draft",
+                agentSpecUpdateForm(agentSpecName, "2.0.0", "AgentSpec v2",
+                        "scenario-v2", "soul v2"));
+        JsonNode submit = postFormOk(ADMIN_AGENT_SPEC_PATH + "/submit",
+                agentSpecQueryForm(agentSpecName));
+        assertEquals("2.0.0", submit.get("data").asText(), submit.toString());
+        String submittedStatus = agentSpecVersionStatus(agentSpecName, "2.0.0");
+        assertTrue("online".equals(submittedStatus) || "reviewing".equals(submittedStatus),
+                submittedStatus);
+        if ("reviewing".equals(submittedStatus)) {
+            postFormOk(ADMIN_AGENT_SPEC_PATH + "/force-publish",
+                    agentSpecPublishForm(agentSpecName, "2.0.0"));
+        }
+        assertAgentSpecContent(getJsonOk(ADMIN_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "2.0.0")).get("data"), agentSpecName,
+                "2.0.0", "AgentSpec v2", "scenario-v2", "soul v2");
+    }
+
+    @Test
+    public void testAgentSpecValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(ADMIN_AGENT_SPEC_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "agentSpecName");
+        assertError(postRaw(ADMIN_AGENT_SPEC_PATH + "/draft",
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "agentSpecName");
+        assertError(putRaw(ADMIN_AGENT_SPEC_PATH + "/draft",
+                agentSpecQuery(randomAiName("missing-card"))), 400,
+                ErrorCode.PARAMETER_MISSING, "agentSpecCard");
+
+        Map<String, String> invalidVersion = agentSpecDraftForm(randomAiName("bad-version"),
+                "bad-version");
+        assertError(postRaw(ADMIN_AGENT_SPEC_PATH + "/draft", queryFrom(invalidVersion)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Invalid targetVersion format");
+        assertError(postRaw(ADMIN_AGENT_SPEC_PATH + "/force-publish",
+                queryFrom(agentSpecQueryForm(randomAiName("missing-version")))), 400,
+                ErrorCode.PARAMETER_MISSING, "version");
+        assertError(putRaw(ADMIN_AGENT_SPEC_PATH + "/labels",
+                agentSpecQuery(randomAiName("missing-labels"))), 400,
+                ErrorCode.PARAMETER_MISSING, "labels");
+        assertError(putRaw(ADMIN_AGENT_SPEC_PATH + "/scope",
+                agentSpecQuery(randomAiName("missing-scope"))), 400,
+                ErrorCode.PARAMETER_MISSING, "scope");
+        assertError(putRaw(ADMIN_AGENT_SPEC_PATH + "/scope",
+                queryFrom(agentSpecScopeForm(randomAiName("invalid-scope"), "TEAM"))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "PUBLIC or PRIVATE");
+        assertError(getRaw(ADMIN_AGENT_SPEC_LIST_PATH, Query.newInstance().addParam("search", "invalid")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+        assertError(getRaw(ADMIN_AGENT_SPEC_LIST_PATH, Query.newInstance().addParam("scope", "TEAM")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "scope");
+        assertError(getRaw(ADMIN_AGENT_SPEC_LIST_PATH, Query.newInstance().addParam("pageNo", "0")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+
+        String absentName = randomAiName("absent");
+        assertError(getRaw(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(absentName)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec not found");
+        assertError(getRaw(ADMIN_AGENT_SPEC_VERSION_PATH, agentSpecVersionQuery(absentName, "1.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec not found");
+        assertError(getRaw(ADMIN_AGENT_SPEC_VERSION_META_PATH,
+                agentSpecVersionQuery(absentName, "1.0.0")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec not found");
+    }
+
+    private void assertAgentSpecListContains(Query query, String agentSpecName) throws Exception {
+        JsonNode page = getJsonOk(ADMIN_AGENT_SPEC_LIST_PATH, query).get("data");
+        assertEmptyPageShape(page);
+        JsonNode found = findByName(page, "name", agentSpecName);
+        assertFalse(found.isMissingNode(), page.toString());
+        assertEquals(agentSpecName, found.get("name").asText(), found.toString());
+        assertNotNull(found.get("labels"), found.toString());
+    }
+
+    private void assertAgentSpecVersionStatus(String agentSpecName, String version, String status)
+            throws Exception {
+        assertEquals(status, agentSpecVersionStatus(agentSpecName, version));
+    }
+
+    private String agentSpecVersionStatus(String agentSpecName, String version) throws Exception {
+        JsonNode meta = getJsonOk(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)).get("data");
+        JsonNode versionSummary = findAgentSpecVersionSummary(meta, version);
+        assertFalse(versionSummary.isMissingNode(), meta.toString());
+        return versionSummary.get("status").asText();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/agentspec/AgentSpecUploadAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/agentspec/AgentSpecUploadAdminApiOpenApiITCase.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.ai.agentspec;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for AgentSpec admin upload OpenAPI {@code /nacos/v3/admin/ai/agentspecs/upload}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: single ZIP upload creates a draft from {@code manifest.json} and resources, overwrite
+ *     updates an existing editing draft, later uploads create the next draft version, and seed archives import
+ *     multiple AgentSpecs.</li>
+ *     <li>Boundary/validation: namespace defaults to public; upload-created versions use the service-managed
+ *     {@code 0.0.x} sequence; duplicate working drafts require overwrite; seed archive upload returns the imported
+ *     names summary.</li>
+ *     <li>Exception/error handling: empty files, malformed ZIP files, and archives without {@code manifest.json}
+ *     return controlled HTTP 400 Result bodies instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class AgentSpecUploadAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
+
+    @Test
+    public void testSingleAgentSpecUploadOverwriteAndVersionBump() throws Exception {
+        String agentSpecName = randomAiName("agentspec-upload");
+        Query uploadQuery = uploadQuery(false);
+        HttpResponse uploaded = postMultipartRaw(ADMIN_AGENT_SPEC_PATH + "/upload", uploadQuery,
+                "file", agentSpecName + ".zip", "application/zip",
+                buildAgentSpecZip(agentSpecName, "0.0.1", "Uploaded AgentSpec v1",
+                        "upload-v1", "uploaded soul"));
+        assertUploadSuccess(uploaded, agentSpecName);
+        addCleanup(() -> deleteAgentSpecQuietly(agentSpecName));
+        assertAgentSpecContent(getJsonOk(ADMIN_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "0.0.1")).get("data"), agentSpecName,
+                "0.0.1", "Uploaded AgentSpec v1", "upload-v1", "uploaded soul");
+
+        assertError(postMultipartRaw(ADMIN_AGENT_SPEC_PATH + "/upload", uploadQuery,
+                "file", agentSpecName + ".zip", "application/zip",
+                buildAgentSpecZip(agentSpecName, "0.0.1", "Duplicate AgentSpec",
+                        "duplicate", "duplicate soul")), 409,
+                ErrorCode.RESOURCE_CONFLICT, "working version");
+        HttpResponse overwritten = postMultipartRaw(ADMIN_AGENT_SPEC_PATH + "/upload",
+                uploadQuery(true), "file", agentSpecName + ".zip", "application/zip",
+                buildAgentSpecZip(agentSpecName, "0.0.1", "Overwritten AgentSpec",
+                        "overwrite", "overwritten soul"));
+        assertUploadSuccess(overwritten, agentSpecName);
+        assertAgentSpecContent(getJsonOk(ADMIN_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "0.0.1")).get("data"), agentSpecName,
+                "0.0.1", "Overwritten AgentSpec", "overwrite", "overwritten soul");
+
+        postFormOk(ADMIN_AGENT_SPEC_PATH + "/force-publish",
+                agentSpecPublishForm(agentSpecName, "0.0.1"));
+        HttpResponse nextUpload = postMultipartRaw(ADMIN_AGENT_SPEC_PATH + "/upload",
+                uploadQuery(false), "file", agentSpecName + ".zip", "application/zip",
+                buildAgentSpecZip(agentSpecName, "0.0.2", "Uploaded AgentSpec v2",
+                        "upload-v2", "uploaded soul v2"));
+        assertUploadSuccess(nextUpload, agentSpecName);
+        JsonNode meta = getJsonOk(ADMIN_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)).get("data");
+        assertEquals("0.0.2", meta.get("editingVersion").asText(), meta.toString());
+        assertAgentSpecContent(getJsonOk(ADMIN_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "0.0.2")).get("data"), agentSpecName,
+                "0.0.2", "Uploaded AgentSpec v2", "upload-v2", "uploaded soul v2");
+    }
+
+    @Test
+    public void testSeedArchiveUploadImportsMultipleAgentSpecs() throws Exception {
+        String firstName = randomAiName("seed-a");
+        String secondName = randomAiName("seed-b");
+        Map<String, String> specs = new LinkedHashMap<>();
+        specs.put(firstName, "seed-scenario-a");
+        specs.put(secondName, "seed-scenario-b");
+        HttpResponse uploaded = postMultipartRaw(ADMIN_AGENT_SPEC_PATH + "/upload", uploadQuery(false),
+                "file", "agentspec-seed.zip", "application/zip", buildAgentSpecSeedArchive(specs));
+        JsonNode root = assertUploadResult(uploaded);
+        String summary = root.get("data").asText();
+        assertTrue(summary.contains("Imported 2 agentspecs"), summary);
+        assertTrue(summary.contains(firstName), summary);
+        assertTrue(summary.contains(secondName), summary);
+        addCleanup(() -> deleteAgentSpecQuietly(firstName));
+        addCleanup(() -> deleteAgentSpecQuietly(secondName));
+
+        assertAgentSpecContent(getJsonOk(ADMIN_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(firstName, "0.0.1")).get("data"), firstName, "0.0.1",
+                "uploaded seed " + firstName, "seed-scenario-a", "seed soul for " + firstName);
+        assertAgentSpecContent(getJsonOk(ADMIN_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(secondName, "0.0.1")).get("data"), secondName, "0.0.1",
+                "uploaded seed " + secondName, "seed-scenario-b", "seed soul for " + secondName);
+    }
+
+    @Test
+    public void testAgentSpecUploadValidationErrors() throws Exception {
+        assertError(postMultipartRaw(ADMIN_AGENT_SPEC_PATH + "/upload", uploadQuery(false),
+                "file", "empty.zip", "application/zip", new byte[0]), 400,
+                ErrorCode.DATA_EMPTY, "File is required");
+        assertError(postMultipartRaw(ADMIN_AGENT_SPEC_PATH + "/upload", uploadQuery(false),
+                "file", "plain.zip", "application/zip", "not a zip".getBytes()), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Failed to read agentspec zip archive");
+        assertError(postMultipartRaw(ADMIN_AGENT_SPEC_PATH + "/upload", uploadQuery(false),
+                "file", "no-manifest.zip", "application/zip", buildZipWithoutAgentSpecManifest()),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "manifest.json file not found");
+    }
+
+    private Query uploadQuery(boolean overwrite) {
+        return Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("overwrite", String.valueOf(overwrite));
+    }
+
+    private void assertUploadSuccess(HttpResponse response, String agentSpecName) {
+        JsonNode root = assertUploadResult(response);
+        assertEquals(agentSpecName, root.get("data").asText(), root.toString());
+    }
+
+    private JsonNode assertUploadResult(HttpResponse response) {
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        return root;
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/importer/AiResourceImportAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/importer/AiResourceImportAdminApiOpenApiITCase.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.ai.importer;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for AI resource import admin OpenAPI {@code /nacos/v3/admin/ai/import}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: configured import sources are listed with sanitized source information and can be
+ *     filtered by {@code mcp}, {@code skill}, or an unsupported resource type without exposing runtime endpoint or
+ *     secret fields.</li>
+ *     <li>Boundary/validation: {@code resourceType}, {@code sourceId}, {@code selectedItems}, JSON
+ *     {@code selectedItems}, JSON {@code options}, and empty selected item lists are validated for search,
+ *     validate, and execute. {@code query}, {@code cursor}, {@code limit}, {@code overwriteExisting},
+ *     {@code skipInvalid}, and {@code validationToken} are accepted form fields; the IT avoids successful external
+ *     network search/import and verifies their local form boundary through controlled source errors.</li>
+ *     <li>Exception/error handling: unknown sources return RESOURCE_NOT_FOUND, unsupported source/resourceType
+ *     combinations return HTTP 400, and all malformed form requests return standard v3 Result error bodies instead
+ *     of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class AiResourceImportAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
+
+    private static final String SOURCE_MCP_OFFICIAL = "mcp-official";
+
+    private static final String SOURCE_SKILLS_SH = "skills-sh";
+
+    private static final String UNKNOWN_SOURCE = "openapi-it-unknown-source";
+
+    @Test
+    public void testListSourcesFiltersAndSanitizesSourceInfo() throws Exception {
+        JsonNode allSources = getJsonOk(ADMIN_IMPORT_SOURCES_PATH, importSourceQuery(null))
+                .get("data");
+        assertTrue(allSources.isArray(), allSources.toString());
+        assertImportSource(findImportSource(allSources, SOURCE_MCP_OFFICIAL), SOURCE_MCP_OFFICIAL,
+                "mcp-registry", IMPORT_RESOURCE_TYPE_MCP);
+        assertImportSource(findImportSource(allSources, SOURCE_SKILLS_SH), SOURCE_SKILLS_SH,
+                "skills-sh", IMPORT_RESOURCE_TYPE_SKILL);
+        assertSourcesDoNotExposeRuntimeFields(allSources);
+
+        JsonNode mcpSources = getJsonOk(ADMIN_IMPORT_SOURCES_PATH,
+                importSourceQuery(IMPORT_RESOURCE_TYPE_MCP)).get("data");
+        assertImportSource(findImportSource(mcpSources, SOURCE_MCP_OFFICIAL), SOURCE_MCP_OFFICIAL,
+                "mcp-registry", IMPORT_RESOURCE_TYPE_MCP);
+        assertTrue(findImportSource(mcpSources, SOURCE_SKILLS_SH).isMissingNode(),
+                mcpSources.toString());
+        assertEverySourceSupports(mcpSources, IMPORT_RESOURCE_TYPE_MCP);
+
+        JsonNode skillSources = getJsonOk(ADMIN_IMPORT_SOURCES_PATH,
+                importSourceQuery(IMPORT_RESOURCE_TYPE_SKILL)).get("data");
+        assertImportSource(findImportSource(skillSources, SOURCE_SKILLS_SH), SOURCE_SKILLS_SH,
+                "skills-sh", IMPORT_RESOURCE_TYPE_SKILL);
+        assertTrue(findImportSource(skillSources, SOURCE_MCP_OFFICIAL).isMissingNode(),
+                skillSources.toString());
+        assertEverySourceSupports(skillSources, IMPORT_RESOURCE_TYPE_SKILL);
+
+        JsonNode unsupportedSources = getJsonOk(ADMIN_IMPORT_SOURCES_PATH,
+                importSourceQuery("unsupported-resource-type")).get("data");
+        assertTrue(unsupportedSources.isArray(), unsupportedSources.toString());
+        assertEquals(0, unsupportedSources.size(), unsupportedSources.toString());
+    }
+
+    @Test
+    public void testSearchValidationAndSourceErrors() throws Exception {
+        assertError(postRaw(ADMIN_IMPORT_SEARCH_PATH,
+                queryFrom(importSearchForm(null, SOURCE_MCP_OFFICIAL, "nacos", 10, null))),
+                400, ErrorCode.PARAMETER_MISSING, "resourceType");
+        assertError(postRaw(ADMIN_IMPORT_SEARCH_PATH,
+                queryFrom(importSearchForm(IMPORT_RESOURCE_TYPE_MCP, null, "nacos", 10, null))),
+                400, ErrorCode.PARAMETER_MISSING, "sourceId");
+        assertError(postRaw(ADMIN_IMPORT_SEARCH_PATH,
+                queryFrom(importSearchForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL,
+                        "nacos", 10, "{"))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "options");
+
+        Map<String, String> unknownSource = importSearchForm(IMPORT_RESOURCE_TYPE_MCP,
+                UNKNOWN_SOURCE, "nacos", 0, importOptionsJson());
+        unknownSource.put("cursor", "next-page");
+        assertError(postRaw(ADMIN_IMPORT_SEARCH_PATH, queryFrom(unknownSource)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "source not found");
+
+        assertError(postRaw(ADMIN_IMPORT_SEARCH_PATH,
+                queryFrom(importSearchForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_MCP_OFFICIAL,
+                        "skill", 1, importOptionsJson()))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "does not support resource type");
+    }
+
+    @Test
+    public void testValidateSelectedItemsBoundariesAndSourceErrors() throws Exception {
+        String selectedItems = importSelectedItemsJson("external-skill", "openapi-skill",
+                "1.0.0");
+        assertError(postRaw(ADMIN_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(null, SOURCE_SKILLS_SH, selectedItems, null,
+                        false))), 400, ErrorCode.PARAMETER_MISSING, "resourceType");
+        assertError(postRaw(ADMIN_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, null, selectedItems,
+                        null, false))), 400, ErrorCode.PARAMETER_MISSING, "sourceId");
+        assertError(postRaw(ADMIN_IMPORT_VALIDATE_PATH,
+                queryFrom(importSourceForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_SKILLS_SH))),
+                400, ErrorCode.PARAMETER_MISSING, "selectedItems");
+        assertError(postRaw(ADMIN_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_SKILLS_SH, "{",
+                        null, false))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "selectedItems");
+        assertError(postRaw(ADMIN_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_SKILLS_SH,
+                        selectedItems, "{", false))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "options");
+        assertError(postRaw(ADMIN_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_SKILLS_SH, "[]",
+                        null, true))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "selected items must not be empty");
+        assertError(postRaw(ADMIN_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, UNKNOWN_SOURCE,
+                        selectedItems, importOptionsJson(), true))), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "source not found");
+        assertError(postRaw(ADMIN_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_SKILLS_SH,
+                        selectedItems, importOptionsJson(), false))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "does not support resource type");
+    }
+
+    @Test
+    public void testExecuteSelectedItemsBoundariesAndSourceErrors() throws Exception {
+        String selectedItems = importSelectedItemsJson("external-mcp", "openapi-mcp", "1.0.0");
+        assertError(postRaw(ADMIN_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(null, SOURCE_MCP_OFFICIAL, selectedItems, null,
+                        false, true))), 400, ErrorCode.PARAMETER_MISSING, "resourceType");
+        assertError(postRaw(ADMIN_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, null, selectedItems, null,
+                        false, true))), 400, ErrorCode.PARAMETER_MISSING, "sourceId");
+        assertError(postRaw(ADMIN_IMPORT_EXECUTE_PATH,
+                queryFrom(importSourceForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL))),
+                400, ErrorCode.PARAMETER_MISSING, "selectedItems");
+        assertError(postRaw(ADMIN_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL, "{",
+                        null, false, true))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "selectedItems");
+        assertError(postRaw(ADMIN_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL,
+                        selectedItems, "{", false, true))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "options");
+        assertError(postRaw(ADMIN_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL, "[]",
+                        null, true, true))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "selected items must not be empty");
+        assertError(postRaw(ADMIN_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, UNKNOWN_SOURCE,
+                        selectedItems, importOptionsJson(), true, false))), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "source not found");
+        assertError(postRaw(ADMIN_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_MCP_OFFICIAL,
+                        selectedItems, importOptionsJson(), false, true))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "does not support resource type");
+    }
+
+    private void assertImportSource(JsonNode source, String sourceId, String pluginName,
+            String resourceType) {
+        assertFalse(source.isMissingNode(), sourceId);
+        assertEquals(sourceId, source.get("sourceId").asText(), source.toString());
+        assertEquals(pluginName, source.get("pluginName").asText(), source.toString());
+        assertTrue(source.get("enabled").asBoolean(), source.toString());
+        assertResourceTypesContain(source, resourceType);
+        assertTrue(source.get("capabilities").isArray(), source.toString());
+        assertTrue(source.get("capabilities").toString().contains("search"), source.toString());
+        assertTrue(source.get("capabilities").toString().contains("validate"), source.toString());
+        assertTrue(source.get("capabilities").toString().contains("execute"), source.toString());
+    }
+
+    private void assertEverySourceSupports(JsonNode sources, String resourceType) {
+        for (JsonNode source : sources) {
+            assertResourceTypesContain(source, resourceType);
+        }
+    }
+
+    private void assertResourceTypesContain(JsonNode source, String resourceType) {
+        boolean found = false;
+        for (JsonNode each : source.get("resourceTypes")) {
+            if (resourceType.equals(each.asText())) {
+                found = true;
+            }
+        }
+        assertTrue(found, source.toString());
+    }
+
+    private void assertSourcesDoNotExposeRuntimeFields(JsonNode sources) {
+        for (JsonNode source : sources) {
+            assertFalse(source.has("endpoint"), source.toString());
+            assertFalse(source.has("authRef"), source.toString());
+            assertFalse(source.has("properties"), source.toString());
+        }
+    }
+
+    private JsonNode findImportSource(JsonNode sources, String sourceId) {
+        for (JsonNode source : sources) {
+            if (sourceId.equals(source.get("sourceId").asText())) {
+                return source;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/mcp/McpAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/mcp/McpAdminApiOpenApiITCase.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.ai.mcp;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Integration tests for MCP admin OpenAPI {@code /nacos/v3/admin/ai/mcp}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: create persists an MCP server with stdio server specification, tools, resources, and a
+ *     generated ID; detail can be queried by ID and by name; update adds a new latest version; list supports accurate
+ *     and blur name filters; delete removes the server.</li>
+ *     <li>Boundary/validation: omitted namespaceId defaults to public; detail/delete accept either mcpId or mcpName;
+ *     list defaults search to accurate; invalid search, missing identity, missing serverSpecification, missing
+ *     version, and invalid custom ID are rejected with HTTP 400.</li>
+ *     <li>Exception/error handling: duplicate create returns conflict, absent server returns the MCP not-found result
+ *     envelope, and malformed JSON is rejected as a controlled validation error instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class McpAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
+    
+    @Test
+    public void testCreateUpdateListGetAndDeleteMcpServer() throws Exception {
+        String mcpName = randomAiName("mcp");
+        String toolName = "tool_" + mcpName.replace('-', '_');
+        String resourceName = "resource_" + mcpName.replace('-', '_');
+        JsonNode created = postFormOk(ADMIN_MCP_PATH,
+                mcpServerForm(mcpName, "1.0.0", "initial MCP server", toolName, resourceName));
+        String mcpId = created.get("data").asText();
+        addCleanup(() -> deleteMcpServerQuietly(mcpName, mcpId));
+        
+        JsonNode detailById = getJsonOk(ADMIN_MCP_PATH, mcpIdentityQuery(null, mcpId, null)).get("data");
+        assertMcpDetail(detailById, mcpName, "1.0.0", "initial MCP server", toolName, resourceName);
+        assertEquals(mcpId, detailById.get("id").asText(), detailById.toString());
+        
+        JsonNode detailByName = getJsonOk(ADMIN_MCP_PATH, mcpIdentityQuery(mcpName, null, "1.0.0"))
+                .get("data");
+        assertMcpDetail(detailByName, mcpName, "1.0.0", "initial MCP server", toolName, resourceName);
+        
+        Map<String, String> updateForm = mcpServerForm(mcpName, "1.1.0", "updated MCP server",
+                toolName + "_v2", resourceName + "_v2");
+        JsonNode updated = putFormOk(ADMIN_MCP_PATH, updateForm);
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        
+        JsonNode latest = getJsonOk(ADMIN_MCP_PATH, mcpIdentityQuery(mcpName, null, null)).get("data");
+        assertMcpDetail(latest, mcpName, "1.1.0", "updated MCP server", toolName + "_v2",
+                resourceName + "_v2");
+        assertEquals(2, latest.get("allVersions").size(), latest.toString());
+        
+        JsonNode accurateList = getJsonOk(ADMIN_MCP_LIST_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("mcpName", mcpName)
+                .addParam("pageNo", "1").addParam("pageSize", "10")).get("data");
+        assertPageContains(accurateList, "name", mcpName);
+        
+        JsonNode blurList = getJsonOk(ADMIN_MCP_LIST_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("mcpName", mcpName.substring(0, 8))
+                .addParam("search", "blur").addParam("pageNo", "1").addParam("pageSize", "10")).get("data");
+        assertPageContains(blurList, "name", mcpName);
+        
+        deleteJsonOk(ADMIN_MCP_PATH, mcpIdentityQuery(null, mcpId, null));
+        assertMcpServerNotFoundEventually(mcpId);
+    }
+    
+    @Test
+    public void testCreateMcpServerValidationAndConflictErrors() throws Exception {
+        String mcpName = randomAiName("mcp-validation");
+        assertError(postRaw(ADMIN_MCP_PATH, Query.newInstance().addParam("mcpName", mcpName)), 400,
+                ErrorCode.PARAMETER_MISSING, "serverSpecification");
+        
+        assertError(postRaw(ADMIN_MCP_PATH, Query.newInstance().addParam("mcpName", mcpName)
+                .addParam("serverSpecification", "{")), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "Can't be parsed");
+        
+        Map<String, String> missingVersion = mcpServerForm(mcpName, "1.0.0", "missing version",
+                "tool_missing", "resource_missing");
+        missingVersion.put("serverSpecification", "{\"name\":\"" + mcpName + "\",\"protocol\":\"stdio\"}");
+        assertError(postRaw(ADMIN_MCP_PATH, queryFrom(missingVersion)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Version must be specified");
+        
+        Map<String, String> invalidId = mcpServerForm(mcpName, "1.0.0", "invalid id",
+                "tool_invalid_id", "resource_invalid_id");
+        invalidId.put("serverSpecification", "{\"id\":\"not-a-uuid\",\"name\":\"" + mcpName
+                + "\",\"protocol\":\"stdio\",\"version\":\"1.0.0\"}");
+        assertError(postRaw(ADMIN_MCP_PATH, queryFrom(invalidId)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "uuid pattern");
+        
+        JsonNode created = postFormOk(ADMIN_MCP_PATH,
+                mcpServerForm(mcpName, "1.0.0", "conflict source", "tool_conflict", "resource_conflict"));
+        String mcpId = created.get("data").asText();
+        addCleanup(() -> deleteMcpServerQuietly(mcpName, mcpId));
+        assertError(postRaw(ADMIN_MCP_PATH, queryFrom(mcpServerForm(mcpName, "1.0.1",
+                "conflict duplicate", "tool_conflict_2", "resource_conflict_2"))), 409,
+                ErrorCode.RESOURCE_CONFLICT, "has existed");
+    }
+    
+    @Test
+    public void testGetListAndDeleteMcpServerValidationErrors() throws Exception {
+        assertError(getRaw(ADMIN_MCP_PATH, Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "mcpId");
+        assertError(deleteRaw(ADMIN_MCP_PATH, Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)),
+                400, ErrorCode.PARAMETER_MISSING, "mcpId");
+        assertError(getRaw(ADMIN_MCP_LIST_PATH, Query.newInstance().addParam("search", "invalid")
+                .addParam("pageNo", "1").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+        assertError(getRaw(ADMIN_MCP_LIST_PATH, Query.newInstance().addParam("search", "accurate")
+                .addParam("pageNo", "0").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        
+        JsonNode emptyPage = getJsonOk(ADMIN_MCP_LIST_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("mcpName", randomAiName("absent-mcp"))
+                .addParam("pageNo", "1").addParam("pageSize", "10")).get("data");
+        assertEmptyPageShape(emptyPage);
+        assertFalse(emptyPage.get("pageItems").elements().hasNext(), emptyPage.toString());
+    }
+    
+    private void assertMcpServerNotFoundEventually(String mcpId) throws Exception {
+        HttpResponse lastResponse = null;
+        for (int i = 0; i < 10; i++) {
+            lastResponse = getRaw(ADMIN_MCP_PATH, mcpIdentityQuery(null, mcpId, null));
+            if (404 == lastResponse.code()) {
+                assertError(lastResponse, 404, ErrorCode.MCP_SERVER_NOT_FOUND, "not found");
+                return;
+            }
+            Thread.sleep(200L);
+        }
+        assertError(lastResponse, 404, ErrorCode.MCP_SERVER_NOT_FOUND, "not found");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/pipeline/PipelineAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/pipeline/PipelineAdminApiOpenApiITCase.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.ai.pipeline;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests for pipeline admin OpenAPI {@code /nacos/v3/admin/ai/pipelines}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: current and legacy list endpoints return the page contract for a resource type with
+ *     optional resourceName, namespaceId, and version filters.</li>
+ *     <li>Boundary/validation: resourceType is required for list; pageNo and pageSize are validated by PageForm; the
+ *     query-parameter detail endpoint requires pipelineId. The path-variable detail endpoint is kept as deprecated
+ *     compatibility and shares the not-found contract.</li>
+ *     <li>Exception/error handling: unknown pipeline IDs return HTTP 404 with a wrapped RESOURCE_NOT_FOUND body. A
+ *     successful detail query is not created here because pipeline rows require configured publish-pipeline plugins;
+ *     in the default standalone IT environment list may legitimately be empty.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class PipelineAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
+    
+    @Test
+    public void testListPipelinesCurrentAndLegacyReturnPageContract() throws Exception {
+        Query query = Query.newInstance().addParam("resourceType", "prompt")
+                .addParam("resourceName", randomAiName("pipeline-resource"))
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("version", "1.0.0")
+                .addParam("pageNo", "1").addParam("pageSize", "10");
+        
+        JsonNode currentPage = getJsonOk(ADMIN_PIPELINE_LIST_PATH, query).get("data");
+        assertEmptyPageShape(currentPage);
+        JsonNode legacyPage = getJsonOk(ADMIN_PIPELINE_PATH, query).get("data");
+        assertEquals(currentPage.get("totalCount").asInt(), legacyPage.get("totalCount").asInt(),
+                legacyPage.toString());
+        assertEmptyPageShape(legacyPage);
+    }
+    
+    @Test
+    public void testListPipelinesValidationErrors() throws Exception {
+        assertError(getRaw(ADMIN_PIPELINE_LIST_PATH, Query.newInstance().addParam("pageNo", "1")
+                .addParam("pageSize", "10")), 400, ErrorCode.PARAMETER_VALIDATE_ERROR, "resourceType");
+        assertError(getRaw(ADMIN_PIPELINE_LIST_PATH, Query.newInstance().addParam("resourceType", "prompt")
+                .addParam("pageNo", "0").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(ADMIN_PIPELINE_PATH, Query.newInstance().addParam("pageNo", "1")
+                .addParam("pageSize", "10")), 400, ErrorCode.PARAMETER_VALIDATE_ERROR, "resourceType");
+    }
+    
+    @Test
+    public void testPipelineDetailValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(ADMIN_PIPELINE_DETAIL_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pipelineId");
+        
+        String absentPipelineId = "pipeline-" + randomAiName("absent");
+        assertError(getRaw(ADMIN_PIPELINE_DETAIL_PATH,
+                Query.newInstance().addParam("pipelineId", absentPipelineId)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Pipeline execution not found");
+        assertError(getRaw(ADMIN_PIPELINE_PATH + "/" + absentPipelineId), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Pipeline execution not found");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/prompt/PromptAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/prompt/PromptAdminApiOpenApiITCase.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.ai.prompt;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for prompt admin OpenAPI {@code /nacos/v3/admin/ai/prompt}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: draft creation and update persist editable content; force-publish makes a version
+ *     online and latest; governance, version detail, version list, list, Markdown download, labels, description,
+ *     bizTags, online/offline, and delete expose the expected prompt state.</li>
+ *     <li>Boundary/validation: namespace defaults to public; list supports accurate/blur and bizTags filters while
+ *     clamping page arguments; promptKey, template or basedOnVersion, version, labels, and description are required
+ *     where controller forms require them; legacy version format is validated.</li>
+ *     <li>Exception/error handling: absent prompts and versions return controlled RESOURCE_NOT_FOUND bodies, direct
+ *     publish from draft and redraft from online return validation errors instead of HTTP 500, and invalid search
+ *     returns HTTP 400.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class PromptAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
+
+    @Test
+    public void testPromptLifecycleGovernanceListDownloadAndDelete() throws Exception {
+        String promptKey = randomPromptKey("prompt");
+        String draftTemplate = "Hello {{name}} from draft";
+        String updatedTemplate = "Hello {{name}} from updated draft";
+        JsonNode draft = postFormOk(ADMIN_PROMPT_PATH + "/draft",
+                promptDraftForm(promptKey, "1.0.0", draftTemplate, "initial description", "openapi,admin"));
+        assertEquals("1.0.0", draft.get("data").asText(), draft.toString());
+        addCleanup(() -> deletePromptQuietly(promptKey));
+
+        JsonNode updated = putFormOk(ADMIN_PROMPT_PATH + "/draft",
+                promptUpdateDraftForm(promptKey, updatedTemplate));
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        JsonNode draftDetail = getJsonOk(ADMIN_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data");
+        assertPromptVersion(draftDetail, promptKey, "1.0.0", "draft", updatedTemplate);
+
+        assertError(postRaw(ADMIN_PROMPT_PATH + "/publish", queryFrom(promptPublishForm(promptKey, "1.0.0"))),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewing version can be published");
+        JsonNode published = postFormOk(ADMIN_PROMPT_PATH + "/force-publish",
+                promptPublishForm(promptKey, "1.0.0"));
+        assertEquals("ok", published.get("data").asText(), published.toString());
+
+        JsonNode governance = getJsonOk(ADMIN_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey)).get("data");
+        assertEquals(promptKey, governance.get("promptKey").asText(), governance.toString());
+        assertEquals("1.0.0", governance.get("latestVersion").asText(), governance.toString());
+        assertEquals(1, governance.get("onlineCnt").asInt(), governance.toString());
+        assertEquals("1.0.0", governance.get("labels").get("latest").asText(), governance.toString());
+        assertEquals("initial description", governance.get("description").asText(), governance.toString());
+        assertEquals("openapi,admin", governance.get("bizTagsStr").asText(), governance.toString());
+
+        JsonNode onlineDetail = getJsonOk(ADMIN_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data");
+        assertPromptVersion(onlineDetail, promptKey, "1.0.0", "online", updatedTemplate);
+        assertNotNull(onlineDetail.get("md5").asText(), onlineDetail.toString());
+
+        assertPromptVersionPageContains(promptKey, "1.0.0", "online");
+        assertPromptListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("promptKey", promptKey).addParam("search", "accurate")
+                .addParam("pageNo", "1").addParam("pageSize", "10"), promptKey);
+        assertPromptListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("promptKey", promptKey.substring(0, 8)).addParam("search", "blur")
+                .addParam("bizTags", "openapi").addParam("pageNo", "0").addParam("pageSize", "1000"),
+                promptKey);
+
+        ByteResponse download = getRawBytes(ADMIN_PROMPT_VERSION_DOWNLOAD_PATH,
+                promptVersionQuery(promptKey, "1.0.0"));
+        assertEquals(200, download.code(), new String(download.body(), StandardCharsets.UTF_8));
+        assertTrue(download.contentDisposition().contains(promptKey + "_1.0.0.md"),
+                download.contentDisposition());
+        String markdown = new String(download.body(), StandardCharsets.UTF_8);
+        assertTrue(markdown.contains("promptKey: \"" + promptKey + "\""), markdown);
+        assertTrue(markdown.contains(updatedTemplate), markdown);
+
+        assertEquals("ok", putFormOk(ADMIN_PROMPT_PATH + "/labels",
+                promptLabelsForm(promptKey, "{\"stable\":\"1.0.0\"}")).get("data").asText());
+        assertEquals("ok", putFormOk(ADMIN_PROMPT_PATH + "/description",
+                promptDescriptionForm(promptKey, "updated description")).get("data").asText());
+        assertEquals("ok", putFormOk(ADMIN_PROMPT_PATH + "/biz-tags",
+                promptBizTagsForm(promptKey, "updated,openapi")).get("data").asText());
+        JsonNode updatedGovernance = getJsonOk(ADMIN_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey))
+                .get("data");
+        assertEquals("1.0.0", updatedGovernance.get("labels").get("stable").asText(),
+                updatedGovernance.toString());
+        assertEquals("1.0.0", updatedGovernance.get("labels").get("latest").asText(),
+                updatedGovernance.toString());
+        assertEquals("updated description", updatedGovernance.get("description").asText(),
+                updatedGovernance.toString());
+        assertEquals("updated,openapi", updatedGovernance.get("bizTagsStr").asText(),
+                updatedGovernance.toString());
+
+        assertEquals("ok", postFormOk(ADMIN_PROMPT_PATH + "/offline",
+                promptPublishForm(promptKey, "1.0.0")).get("data").asText());
+        assertPromptVersion(getJsonOk(ADMIN_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data"), promptKey, "1.0.0", "offline", updatedTemplate);
+        assertEquals("ok", postFormOk(ADMIN_PROMPT_PATH + "/online",
+                promptPublishForm(promptKey, "1.0.0")).get("data").asText());
+        assertPromptVersion(getJsonOk(ADMIN_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data"), promptKey, "1.0.0", "online", updatedTemplate);
+
+        assertError(postRaw(ADMIN_PROMPT_PATH + "/redraft", queryFrom(promptPublishForm(promptKey, "1.0.0"))),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewed version can be re-edited");
+
+        JsonNode delete = deleteJsonOk(ADMIN_PROMPT_PATH, promptQuery(promptKey));
+        assertTrue(delete.get("data").asBoolean(), delete.toString());
+        assertError(getRaw(ADMIN_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+    }
+
+    @Test
+    public void testPromptSubmitAndLegacyCompatibilityEndpoints() throws Exception {
+        String legacyPublishKey = randomPromptKey("legacy-publish");
+        Map<String, String> legacyPublish = promptQueryForm(legacyPublishKey);
+        legacyPublish.put("version", "1.0.0");
+        legacyPublish.put("template", "Legacy publish {{name}} template");
+        legacyPublish.put("variables", "[{\"name\":\"name\",\"defaultValue\":\"Nacos\",\"description\":\"target name\"}]");
+        legacyPublish.put("commitMsg", "openapi prompt admin legacy publish");
+        legacyPublish.put("description", "legacy publish desc");
+        legacyPublish.put("bizTags", "legacy-publish");
+        assertTrue(postFormOk(ADMIN_PROMPT_PATH, legacyPublish).get("data").asBoolean());
+        addCleanup(() -> deletePromptQuietly(legacyPublishKey));
+        JsonNode legacyVersion = getJsonOk(ADMIN_PROMPT_VERSION_PATH,
+                promptVersionQuery(legacyPublishKey, "1.0.0")).get("data");
+        assertTrue("online".equals(legacyVersion.get("status").asText())
+                || "reviewing".equals(legacyVersion.get("status").asText()), legacyVersion.toString());
+        if (!"online".equals(legacyVersion.get("status").asText())) {
+            postFormOk(ADMIN_PROMPT_PATH + "/force-publish",
+                    promptPublishForm(legacyPublishKey, "1.0.0"));
+        }
+        assertPromptRuntimeDetail(getJsonOk(ADMIN_PROMPT_PATH + "/detail",
+                promptVersionQuery(legacyPublishKey, "1.0.0")).get("data"), legacyPublishKey, "1.0.0",
+                "Legacy publish {{name}} template");
+
+        String promptKey = randomPromptKey("legacy");
+        postFormOk(ADMIN_PROMPT_PATH + "/draft",
+                promptDraftForm(promptKey, "1.0.0", "Legacy {{name}} template", "legacy desc", "legacy"));
+        addCleanup(() -> deletePromptQuietly(promptKey));
+
+        JsonNode submit = postFormOk(ADMIN_PROMPT_PATH + "/submit", promptQueryForm(promptKey));
+        assertEquals("1.0.0", submit.get("data").asText(), submit.toString());
+        JsonNode submitted = getJsonOk(ADMIN_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data");
+        assertTrue("online".equals(submitted.get("status").asText())
+                || "reviewing".equals(submitted.get("status").asText()), submitted.toString());
+        if (!"online".equals(submitted.get("status").asText())) {
+            postFormOk(ADMIN_PROMPT_PATH + "/force-publish", promptPublishForm(promptKey, "1.0.0"));
+        }
+
+        JsonNode metadata = getJsonOk(ADMIN_PROMPT_PATH + "/metadata", promptQuery(promptKey)).get("data");
+        assertEquals(promptKey, metadata.get("promptKey").asText(), metadata.toString());
+        JsonNode detail = getJsonOk(ADMIN_PROMPT_PATH + "/detail",
+                promptVersionQuery(promptKey, "1.0.0")).get("data");
+        assertPromptRuntimeDetail(detail, promptKey, "1.0.0", "Legacy {{name}} template");
+
+        Map<String, String> bindLabel = promptQueryForm(promptKey);
+        bindLabel.put("label", "legacy");
+        bindLabel.put("version", "1.0.0");
+        assertTrue(putFormOk(ADMIN_PROMPT_PATH + "/label", bindLabel).get("data").asBoolean());
+        assertEquals("1.0.0", getJsonOk(ADMIN_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey))
+                .get("data").get("labels").get("legacy").asText());
+
+        Map<String, String> metadataUpdate = promptQueryForm(promptKey);
+        metadataUpdate.put("description", "legacy metadata");
+        metadataUpdate.put("bizTags", "legacy,compat");
+        assertTrue(putFormOk(ADMIN_PROMPT_PATH + "/metadata", metadataUpdate).get("data").asBoolean());
+        JsonNode updated = getJsonOk(ADMIN_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey)).get("data");
+        assertEquals("legacy metadata", updated.get("description").asText(), updated.toString());
+        assertEquals("legacy,compat", updated.get("bizTagsStr").asText(), updated.toString());
+
+        Map<String, String> unbindLabel = promptQueryForm(promptKey);
+        unbindLabel.put("label", "legacy");
+        assertTrue(deleteJsonOk(ADMIN_PROMPT_PATH + "/label", queryFrom(unbindLabel)).get("data").asBoolean());
+    }
+
+    @Test
+    public void testPromptValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(ADMIN_PROMPT_GOVERNANCE_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "promptKey");
+        assertError(postRaw(ADMIN_PROMPT_PATH + "/draft",
+                queryFrom(promptQueryForm(randomPromptKey("missing-template")))), 400,
+                ErrorCode.PARAMETER_MISSING, "Either 'basedOnVersion' or 'template'");
+        assertError(putRaw(ADMIN_PROMPT_PATH + "/draft",
+                promptQuery(randomPromptKey("missing-template-update"))), 400,
+                ErrorCode.PARAMETER_MISSING, "template");
+        assertError(postRaw(ADMIN_PROMPT_PATH + "/force-publish",
+                queryFrom(promptQueryForm(randomPromptKey("missing-version")))), 400,
+                ErrorCode.PARAMETER_MISSING, "version");
+        assertError(putRaw(ADMIN_PROMPT_PATH + "/labels", promptQuery(randomPromptKey("missing-labels"))),
+                400, ErrorCode.PARAMETER_MISSING, "labels");
+        assertError(putRaw(ADMIN_PROMPT_PATH + "/description",
+                promptQuery(randomPromptKey("missing-description"))), 400,
+                ErrorCode.PARAMETER_MISSING, "description");
+        assertError(getRaw(ADMIN_PROMPT_LIST_PATH, Query.newInstance().addParam("search", "invalid")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+
+        String absentPrompt = randomPromptKey("absent");
+        assertError(getRaw(ADMIN_PROMPT_GOVERNANCE_PATH, promptQuery(absentPrompt)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+        assertError(getRaw(ADMIN_PROMPT_VERSION_PATH, promptVersionQuery(absentPrompt, "1.0.0")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+        assertError(getRaw(ADMIN_PROMPT_VERSION_DOWNLOAD_PATH, promptVersionQuery(absentPrompt, "1.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+
+        Map<String, String> legacyPublish = promptQueryForm(randomPromptKey("legacy-invalid-version"));
+        legacyPublish.put("version", "bad-version");
+        legacyPublish.put("template", "invalid legacy version");
+        assertError(postRaw(ADMIN_PROMPT_PATH, queryFrom(legacyPublish)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "major.minor.patch");
+    }
+
+    private void assertPromptVersionPageContains(String promptKey, String version, String status)
+            throws Exception {
+        JsonNode page = getJsonOk(ADMIN_PROMPT_VERSIONS_PATH, promptQuery(promptKey)
+                .addParam("pageNo", "1").addParam("pageSize", "10")).get("data");
+        assertEmptyPageShape(page);
+        for (JsonNode item : page.get("pageItems")) {
+            if (version.equals(item.get("version").asText())) {
+                assertEquals(status, item.get("status").asText(), item.toString());
+                return;
+            }
+        }
+        throw new AssertionError("Version " + version + " not found in " + page);
+    }
+
+    private void assertPromptListContains(Query query, String promptKey) throws Exception {
+        JsonNode page = getJsonOk(ADMIN_PROMPT_LIST_PATH, query).get("data");
+        assertEmptyPageShape(page);
+        JsonNode found = findByName(page, "promptKey", promptKey);
+        assertTrue(!found.isMissingNode(), page.toString());
+        assertEquals(promptKey, found.get("promptKey").asText(), found.toString());
+    }
+
+    private void assertPromptRuntimeDetail(JsonNode data, String promptKey, String version, String template) {
+        assertEquals(promptKey, data.get("promptKey").asText(), data.toString());
+        assertEquals(version, data.get("version").asText(), data.toString());
+        assertEquals(template, data.get("template").asText(), data.toString());
+        assertEquals("name", data.get("variables").get(0).get("name").asText(), data.toString());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/skill/SkillAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/skill/SkillAdminApiOpenApiITCase.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.ai.skill;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for skill admin OpenAPI {@code /nacos/v3/admin/ai/skills}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: draft creation and update persist editable skill content; force-publish makes a
+ *     version online and latest; admin detail, version detail, list, ZIP download, labels, bizTags, scope,
+ *     online/offline, and delete expose the expected skill state.</li>
+ *     <li>Boundary/validation: namespace defaults to public; list supports accurate/blur, scope, and bizTag
+ *     filters; skillName, skillCard, targetVersion, version, labels, scope, and positive pagination validation
+ *     follows the controller forms; draft forking and draft deletion are covered explicitly.</li>
+ *     <li>Exception/error handling: absent skills and versions return controlled RESOURCE_NOT_FOUND bodies, direct
+ *     publish from draft and redraft from online return validation errors instead of HTTP 500, and invalid search
+ *     or scope parameters return HTTP 400.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class SkillAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
+
+    @Test
+    public void testSkillLifecycleGovernanceListDownloadAndDelete() throws Exception {
+        String skillName = randomAiName("skill");
+        String draftBody = "Use the initial skill instructions.";
+        String updatedBody = "Use the updated skill instructions.";
+        JsonNode draft = postFormOk(ADMIN_SKILL_PATH + "/draft",
+                skillDraftForm(skillName, "1.0.0", draftBody, "guide draft"));
+        assertEquals("1.0.0", draft.get("data").asText(), draft.toString());
+        addCleanup(() -> deleteSkillQuietly(skillName));
+
+        JsonNode updated = putFormOk(ADMIN_SKILL_PATH + "/draft",
+                skillUpdateForm(skillName, updatedBody, "guide updated"));
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        JsonNode draftDetail = getJsonOk(ADMIN_SKILL_VERSION_PATH,
+                skillVersionQuery(skillName, "1.0.0")).get("data");
+        assertSkillContent(draftDetail, skillName, "1.0.0", updatedBody, "guide updated");
+        assertSkillVersionStatus(skillName, "1.0.0", "draft");
+
+        assertError(postRaw(ADMIN_SKILL_PATH + "/publish", queryFrom(skillPublishForm(skillName, "1.0.0"))),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewing version can be published");
+        JsonNode published = postFormOk(ADMIN_SKILL_PATH + "/force-publish",
+                skillPublishForm(skillName, "1.0.0"));
+        assertEquals("ok", published.get("data").asText(), published.toString());
+
+        JsonNode meta = getJsonOk(ADMIN_SKILL_PATH, skillQuery(skillName)).get("data");
+        assertEquals(skillName, meta.get("name").asText(), meta.toString());
+        assertEquals("1.0.0", meta.get("labels").get("latest").asText(), meta.toString());
+        assertEquals(1, meta.get("onlineCnt").asInt(), meta.toString());
+        assertTrue(meta.get("enable").asBoolean(), meta.toString());
+        assertFalse(meta.get("scope").asText().isBlank(), meta.toString());
+        assertEquals("online", findSkillVersionSummary(meta, "1.0.0").get("status").asText(),
+                meta.toString());
+
+        JsonNode onlineDetail = getJsonOk(ADMIN_SKILL_VERSION_PATH,
+                skillVersionQuery(skillName, "1.0.0")).get("data");
+        assertSkillContent(onlineDetail, skillName, "1.0.0", updatedBody, "guide updated");
+        assertSkillListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("skillName", skillName).addParam("search", "accurate")
+                .addParam("pageNo", "1").addParam("pageSize", "10"), skillName);
+        assertSkillListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("skillName", skillName.substring(0, 8)).addParam("search", "blur")
+                .addParam("pageNo", "1").addParam("pageSize", "1000"), skillName);
+
+        assertSkillZip(getRawBytes(ADMIN_SKILL_VERSION_DOWNLOAD_PATH,
+                skillVersionQuery(skillName, "1.0.0")), skillName, "1.0.0", updatedBody,
+                "guide updated");
+
+        assertEquals("ok", putFormOk(ADMIN_SKILL_PATH + "/labels",
+                skillLabelsForm(skillName, "{\"stable\":\"1.0.0\"}")).get("data").asText());
+        assertEquals("ok", putFormOk(ADMIN_SKILL_PATH + "/biz-tags",
+                skillBizTagsForm(skillName, "[\"openapi\",\"admin\"]")).get("data").asText());
+        assertEquals("ok", putFormOk(ADMIN_SKILL_PATH + "/scope",
+                skillScopeForm(skillName, "PUBLIC")).get("data").asText());
+        assertEquals("PUBLIC", getJsonOk(ADMIN_SKILL_PATH, skillQuery(skillName)).get("data")
+                .get("scope").asText());
+        assertEquals("ok", putFormOk(ADMIN_SKILL_PATH + "/scope",
+                skillScopeForm(skillName, "PRIVATE")).get("data").asText());
+        JsonNode governed = getJsonOk(ADMIN_SKILL_PATH, skillQuery(skillName)).get("data");
+        assertEquals("1.0.0", governed.get("labels").get("stable").asText(), governed.toString());
+        assertEquals("[\"openapi\",\"admin\"]", governed.get("bizTags").asText(), governed.toString());
+        assertEquals("PRIVATE", governed.get("scope").asText(), governed.toString());
+        assertSkillListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("scope", "PRIVATE").addParam("bizTag", "openapi")
+                .addParam("skillName", skillName).addParam("search", "accurate"), skillName);
+
+        assertEquals("ok", postFormOk(ADMIN_SKILL_PATH + "/offline",
+                skillOnlineForm(skillName, "1.0.0", null)).get("data").asText());
+        assertSkillVersionStatus(skillName, "1.0.0", "offline");
+        assertEquals("ok", postFormOk(ADMIN_SKILL_PATH + "/online",
+                skillOnlineForm(skillName, "1.0.0", null)).get("data").asText());
+        assertSkillVersionStatus(skillName, "1.0.0", "online");
+
+        assertEquals("ok", postFormOk(ADMIN_SKILL_PATH + "/offline",
+                skillOnlineForm(skillName, null, "skill")).get("data").asText());
+        assertFalse(getJsonOk(ADMIN_SKILL_PATH, skillQuery(skillName)).get("data").get("enable")
+                .asBoolean());
+        assertEquals("ok", postFormOk(ADMIN_SKILL_PATH + "/online",
+                skillOnlineForm(skillName, null, "skill")).get("data").asText());
+        assertTrue(getJsonOk(ADMIN_SKILL_PATH, skillQuery(skillName)).get("data").get("enable")
+                .asBoolean());
+
+        assertError(postRaw(ADMIN_SKILL_PATH + "/redraft", queryFrom(skillPublishForm(skillName, "1.0.0"))),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewed version can be re-edited");
+
+        JsonNode delete = deleteJsonOk(ADMIN_SKILL_PATH, skillQuery(skillName));
+        assertEquals("ok", delete.get("data").asText(), delete.toString());
+        assertError(getRaw(ADMIN_SKILL_PATH, skillQuery(skillName)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Skill not found");
+    }
+
+    @Test
+    public void testSkillForkSubmitAndDeleteDraft() throws Exception {
+        String skillName = randomAiName("skill-submit");
+        postFormOk(ADMIN_SKILL_PATH + "/draft",
+                skillDraftForm(skillName, "1.0.0", "Version one body.", "guide v1"));
+        addCleanup(() -> deleteSkillQuietly(skillName));
+        postFormOk(ADMIN_SKILL_PATH + "/force-publish", skillPublishForm(skillName, "1.0.0"));
+
+        assertError(postRaw(ADMIN_SKILL_PATH + "/draft",
+                queryFrom(skillForkForm(skillName, "1.0.0", "1.0.0"))), 409,
+                ErrorCode.RESOURCE_CONFLICT, "targetVersion already exists");
+
+        JsonNode forked = postFormOk(ADMIN_SKILL_PATH + "/draft",
+                skillForkForm(skillName, "2.0.0", "1.0.0"));
+        assertEquals("2.0.0", forked.get("data").asText(), forked.toString());
+        assertSkillVersionStatus(skillName, "2.0.0", "draft");
+
+        JsonNode deleteDraft = deleteJsonOk(ADMIN_SKILL_PATH + "/draft", skillQuery(skillName));
+        assertEquals("ok", deleteDraft.get("data").asText(), deleteDraft.toString());
+        assertError(getRaw(ADMIN_SKILL_VERSION_PATH, skillVersionQuery(skillName, "2.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Skill version not found");
+
+        postFormOk(ADMIN_SKILL_PATH + "/draft", skillForkForm(skillName, "2.0.0", "1.0.0"));
+        putFormOk(ADMIN_SKILL_PATH + "/draft",
+                skillUpdateForm(skillName, "Version two submitted body.", "guide v2"));
+        JsonNode submit = postFormOk(ADMIN_SKILL_PATH + "/submit", skillQueryForm(skillName));
+        assertEquals("2.0.0", submit.get("data").asText(), submit.toString());
+        String submittedStatus = skillVersionStatus(skillName, "2.0.0");
+        assertTrue("online".equals(submittedStatus) || "reviewing".equals(submittedStatus),
+                submittedStatus);
+        if ("reviewing".equals(submittedStatus)) {
+            postFormOk(ADMIN_SKILL_PATH + "/force-publish", skillPublishForm(skillName, "2.0.0"));
+        }
+        assertSkillContent(getJsonOk(ADMIN_SKILL_VERSION_PATH, skillVersionQuery(skillName, "2.0.0"))
+                .get("data"), skillName, "2.0.0", "Version two submitted body.", "guide v2");
+    }
+
+    @Test
+    public void testSkillValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(ADMIN_SKILL_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "skillName");
+        assertError(postRaw(ADMIN_SKILL_PATH + "/draft",
+                queryFrom(skillQueryForm(randomAiName("missing-card")))), 400,
+                ErrorCode.PARAMETER_MISSING, "skillCard");
+
+        String mismatchSkill = randomAiName("mismatch");
+        Map<String, String> mismatch = skillDraftForm(mismatchSkill, "1.0.0", "body", "guide");
+        mismatch.put("skillName", randomAiName("other"));
+        assertError(postRaw(ADMIN_SKILL_PATH + "/draft", queryFrom(mismatch)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "skillCard name must match skillName");
+
+        Map<String, String> invalidVersion = skillDraftForm(randomAiName("bad-version"),
+                "bad-version", "body", "guide");
+        assertError(postRaw(ADMIN_SKILL_PATH + "/draft", queryFrom(invalidVersion)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Invalid targetVersion format");
+        assertError(postRaw(ADMIN_SKILL_PATH + "/force-publish",
+                queryFrom(skillQueryForm(randomAiName("missing-version")))), 400,
+                ErrorCode.PARAMETER_MISSING, "version");
+        assertError(putRaw(ADMIN_SKILL_PATH + "/labels", skillQuery(randomAiName("missing-labels"))),
+                400, ErrorCode.PARAMETER_MISSING, "labels");
+        assertError(putRaw(ADMIN_SKILL_PATH + "/scope", skillQuery(randomAiName("missing-scope"))),
+                400, ErrorCode.PARAMETER_MISSING, "scope");
+        assertError(putRaw(ADMIN_SKILL_PATH + "/scope",
+                queryFrom(skillScopeForm(randomAiName("invalid-scope"), "TEAM"))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "PUBLIC or PRIVATE");
+        assertError(getRaw(ADMIN_SKILL_LIST_PATH, Query.newInstance().addParam("search", "invalid")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+        assertError(getRaw(ADMIN_SKILL_LIST_PATH, Query.newInstance().addParam("scope", "TEAM")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "scope");
+        assertError(getRaw(ADMIN_SKILL_LIST_PATH, Query.newInstance().addParam("pageNo", "0")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+
+        String absentSkill = randomAiName("absent");
+        assertError(getRaw(ADMIN_SKILL_PATH, skillQuery(absentSkill)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Skill not found");
+        assertError(getRaw(ADMIN_SKILL_VERSION_PATH, skillVersionQuery(absentSkill, "1.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Skill not found");
+        assertError(getRaw(ADMIN_SKILL_VERSION_DOWNLOAD_PATH, skillVersionQuery(absentSkill, "1.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Skill not found");
+    }
+
+    private void assertSkillListContains(Query query, String skillName) throws Exception {
+        JsonNode page = getJsonOk(ADMIN_SKILL_LIST_PATH, query).get("data");
+        assertEmptyPageShape(page);
+        JsonNode found = findByName(page, "name", skillName);
+        assertFalse(found.isMissingNode(), page.toString());
+        assertEquals(skillName, found.get("name").asText(), found.toString());
+        assertNotNull(found.get("labels"), found.toString());
+    }
+
+    private void assertSkillVersionStatus(String skillName, String version, String status)
+            throws Exception {
+        assertEquals(status, skillVersionStatus(skillName, version));
+    }
+
+    private String skillVersionStatus(String skillName, String version) throws Exception {
+        JsonNode meta = getJsonOk(ADMIN_SKILL_PATH, skillQuery(skillName)).get("data");
+        JsonNode versionSummary = findSkillVersionSummary(meta, version);
+        assertFalse(versionSummary.isMissingNode(), meta.toString());
+        return versionSummary.get("status").asText();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/skill/SkillUploadAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/skill/SkillUploadAdminApiOpenApiITCase.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.ai.skill;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for skill admin upload OpenAPI {@code /nacos/v3/admin/ai/skills/upload}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: single ZIP upload creates a draft from {@code SKILL.md} plus resource files, overwrite
+ *     updates an existing editing draft, and batch upload reports successful skill folders with persisted content.</li>
+ *     <li>Boundary/validation: namespace defaults to public; upload version resolves from SKILL.md before
+ *     targetVersion; duplicate working drafts require overwrite; batch upload keeps valid folders while reporting
+ *     invalid folders in {@code failed}.</li>
+ *     <li>Exception/error handling: empty and malformed ZIP files, invalid targetVersion, and archives without
+ *     {@code SKILL.md} return controlled HTTP 400 Result bodies instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class SkillUploadAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
+
+    @Test
+    public void testSingleSkillUploadOverwriteAndVersionBump() throws Exception {
+        String skillName = randomAiName("upload");
+        Query uploadQuery = uploadQuery(false, "9.9.9", "openapi upload");
+        HttpResponse uploaded = postMultipartRaw(ADMIN_SKILL_PATH + "/upload", uploadQuery,
+                "file", skillName + ".zip", "application/zip",
+                buildSkillZip(skillName, "1.0.0", "Uploaded body v1.", "uploaded guide"));
+        assertUploadSuccess(uploaded, skillName);
+        addCleanup(() -> deleteSkillQuietly(skillName));
+
+        JsonNode uploadedDetail = getJsonOk(ADMIN_SKILL_VERSION_PATH,
+                skillVersionQuery(skillName, "1.0.0")).get("data");
+        assertSkillContent(uploadedDetail, skillName, "1.0.0", "Uploaded body v1.",
+                "uploaded guide");
+
+        assertError(postMultipartRaw(ADMIN_SKILL_PATH + "/upload", uploadQuery,
+                "file", skillName + ".zip", "application/zip",
+                buildSkillZip(skillName, "1.0.0", "Duplicate body.", "duplicate guide")),
+                409, ErrorCode.RESOURCE_CONFLICT, "working version");
+        HttpResponse overwritten = postMultipartRaw(ADMIN_SKILL_PATH + "/upload",
+                uploadQuery(true, "9.9.9", "openapi overwrite"), "file", skillName + ".zip",
+                "application/zip",
+                buildSkillZip(skillName, "1.0.0", "Overwritten body.", "overwritten guide"));
+        assertUploadSuccess(overwritten, skillName);
+        assertSkillContent(getJsonOk(ADMIN_SKILL_VERSION_PATH, skillVersionQuery(skillName, "1.0.0"))
+                .get("data"), skillName, "1.0.0", "Overwritten body.", "overwritten guide");
+
+        postFormOk(ADMIN_SKILL_PATH + "/force-publish", skillPublishForm(skillName, "1.0.0"));
+        HttpResponse nextUpload = postMultipartRaw(ADMIN_SKILL_PATH + "/upload",
+                uploadQuery(false, "1.0.0", "openapi next draft"), "file", skillName + ".zip",
+                "application/zip",
+                buildSkillZip(skillName, null, "Uploaded body v2.", "uploaded guide v2"));
+        assertUploadSuccess(nextUpload, skillName);
+        JsonNode meta = getJsonOk(ADMIN_SKILL_PATH, skillQuery(skillName)).get("data");
+        assertEquals("1.0.1", meta.get("editingVersion").asText(), meta.toString());
+        assertSkillContent(getJsonOk(ADMIN_SKILL_VERSION_PATH, skillVersionQuery(skillName, "1.0.1"))
+                .get("data"), skillName, "1.0.1", "Uploaded body v2.", "uploaded guide v2");
+    }
+
+    @Test
+    public void testBatchSkillUploadSuccessAndPartialFailure() throws Exception {
+        String firstSkill = randomAiName("batch-a");
+        String secondSkill = randomAiName("batch-b");
+        Map<String, String> skills = new LinkedHashMap<>();
+        skills.put(firstSkill, "Batch body A.");
+        skills.put(secondSkill, "Batch body B.");
+        HttpResponse batch = postMultipartRaw(ADMIN_SKILL_PATH + "/upload/batch",
+                uploadQuery(false, null, null), "file", "skills.zip", "application/zip",
+                buildMultiSkillZip(skills));
+        JsonNode data = assertUploadResult(batch).get("data");
+        assertArrayContains(data.get("succeeded"), firstSkill);
+        assertArrayContains(data.get("succeeded"), secondSkill);
+        assertEquals(0, data.get("failed").size(), data.toString());
+        addCleanup(() -> deleteSkillQuietly(firstSkill));
+        addCleanup(() -> deleteSkillQuietly(secondSkill));
+        assertSkillContent(getJsonOk(ADMIN_SKILL_VERSION_PATH, skillVersionQuery(firstSkill, "1.0.0"))
+                .get("data"), firstSkill, "1.0.0", "Batch body A.", "guide for " + firstSkill);
+        assertSkillContent(getJsonOk(ADMIN_SKILL_VERSION_PATH, skillVersionQuery(secondSkill, "1.0.0"))
+                .get("data"), secondSkill, "1.0.0", "Batch body B.", "guide for " + secondSkill);
+
+        String validSkill = randomAiName("batch-valid");
+        HttpResponse partial = postMultipartRaw(ADMIN_SKILL_PATH + "/upload/batch",
+                uploadQuery(false, null, null), "file", "partial.zip", "application/zip",
+                buildPartiallyInvalidMultiSkillZip(validSkill, "Valid batch body."));
+        JsonNode partialData = assertUploadResult(partial).get("data");
+        assertArrayContains(partialData.get("succeeded"), validSkill);
+        assertEquals(1, partialData.get("failed").size(), partialData.toString());
+        assertEquals("invalid-skill", partialData.get("failed").get(0).get("name").asText(),
+                partialData.toString());
+        assertFalse(partialData.get("failed").get(0).get("reason").asText().isBlank(),
+                partialData.toString());
+        addCleanup(() -> deleteSkillQuietly(validSkill));
+    }
+
+    @Test
+    public void testSkillUploadValidationErrors() throws Exception {
+        String skillName = randomAiName("upload-invalid");
+        assertError(postMultipartRaw(ADMIN_SKILL_PATH + "/upload", uploadQuery(false, null, null),
+                "file", "empty.zip", "application/zip", new byte[0]), 400,
+                ErrorCode.DATA_EMPTY, "File is required");
+        assertError(postMultipartRaw(ADMIN_SKILL_PATH + "/upload", uploadQuery(false, null, null),
+                "file", "plain.zip", "application/zip", "not a zip".getBytes()), 400,
+                ErrorCode.PARSING_DATA_FAILED, "Failed to parse zip file");
+        assertError(postMultipartRaw(ADMIN_SKILL_PATH + "/upload",
+                uploadQuery(false, "bad-version", null), "file", "skill.zip", "application/zip",
+                buildSkillZip(skillName, null, "Body.", "Guide.")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Invalid version from targetVersion parameter");
+        assertError(postMultipartRaw(ADMIN_SKILL_PATH + "/upload/batch", uploadQuery(false, null, null),
+                "file", "plain.zip", "application/zip", "not a zip".getBytes()), 400,
+                ErrorCode.PARSING_DATA_FAILED, "Failed to parse zip file");
+    }
+
+    private Query uploadQuery(boolean overwrite, String targetVersion, String commitMsg) {
+        Query query = Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("overwrite", String.valueOf(overwrite));
+        addIfNotBlank(query, "targetVersion", targetVersion);
+        addIfNotBlank(query, "commitMsg", commitMsg);
+        return query;
+    }
+
+    private void assertUploadSuccess(HttpResponse response, String skillName) {
+        JsonNode root = assertUploadResult(response);
+        assertEquals(skillName, root.get("data").asText(), root.toString());
+    }
+
+    private JsonNode assertUploadResult(HttpResponse response) {
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        return root;
+    }
+
+    private void assertArrayContains(JsonNode array, String expected) {
+        for (JsonNode item : array) {
+            if (expected.equals(item.asText())) {
+                return;
+            }
+        }
+        throw new AssertionError("Expected " + expected + " in " + array);
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiBaseITCase.java
@@ -55,6 +55,8 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
 
     protected static final String ADMIN_CONFIG_GRAY_PATH = ADMIN_CONFIG_PATH + "/gray";
 
+    protected static final String ADMIN_CONFIG_IMPORT_PATH = ADMIN_CONFIG_PATH + "/import";
+
     protected static final String ADMIN_CONFIG_EXPORT_PATH = ADMIN_CONFIG_PATH + "/export";
 
     protected static final String ADMIN_CONFIG_CLONE_PATH = ADMIN_CONFIG_PATH + "/clone";
@@ -66,6 +68,12 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
     protected static final String ADMIN_HISTORY_CONFIGS_PATH = ADMIN_HISTORY_PATH + "/configs";
 
     protected static final String ADMIN_LISTENER_PATH = nacosPath(Constants.LISTENER_CONTROLLER_V3_ADMIN_PATH);
+
+    protected static final String ADMIN_METRICS_PATH = nacosPath(Constants.METRICS_CONTROLLER_V3_ADMIN_PATH);
+
+    protected static final String ADMIN_CAPACITY_PATH = nacosPath(Constants.CAPACITY_CONTROLLER_V3_ADMIN_PATH);
+
+    protected static final String ADMIN_OPS_PATH = nacosPath(Constants.OPS_CONTROLLER_V3_ADMIN_PATH);
 
     protected static final String DEFAULT_NAMESPACE = "public";
 

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiBaseITCase.java
@@ -39,32 +39,44 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author xiweng.yy
  */
 public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
-    
+
     protected static final String ADMIN_CONFIG_PATH = nacosPath(Constants.CONFIG_ADMIN_V3_PATH);
-    
+
     protected static final String ADMIN_CONFIG_LIST_PATH = ADMIN_CONFIG_PATH + "/list";
-    
+
+    protected static final String ADMIN_CONFIG_BATCH_PATH = ADMIN_CONFIG_PATH + "/batch";
+
+    protected static final String ADMIN_CONFIG_LISTENER_PATH = ADMIN_CONFIG_PATH + "/listener";
+
     protected static final String ADMIN_CONFIG_METADATA_PATH = ADMIN_CONFIG_PATH + "/metadata";
-    
+
+    protected static final String ADMIN_HISTORY_PATH = nacosPath(Constants.HISTORY_ADMIN_V3_PATH);
+
+    protected static final String ADMIN_HISTORY_LIST_PATH = ADMIN_HISTORY_PATH + "/list";
+
+    protected static final String ADMIN_HISTORY_CONFIGS_PATH = ADMIN_HISTORY_PATH + "/configs";
+
+    protected static final String ADMIN_LISTENER_PATH = nacosPath(Constants.LISTENER_CONTROLLER_V3_ADMIN_PATH);
+
     protected static final String DEFAULT_NAMESPACE = "public";
-    
+
     protected static final String TEST_GROUP = "openapi_it_group";
-    
+
     protected static final String DEFAULT_TYPE = ConfigType.getDefaultType().getType();
-    
+
     protected String randomDataId(String scenario) {
         return "openapi_it_admin_" + scenario + "_" + UUID.randomUUID();
     }
-    
+
     protected String randomGroupName(String scenario) {
         return TEST_GROUP + "_" + scenario + "_" + UUID.randomUUID();
     }
-    
+
     protected JsonNode publishConfig(String dataId, String groupName, String namespaceId, String content)
             throws Exception {
         return publishConfig(dataId, groupName, namespaceId, content, DEFAULT_TYPE, "", "");
     }
-    
+
     protected JsonNode publishConfig(String dataId, String groupName, String namespaceId, String content,
             String type, String description, String configTags) throws Exception {
         JsonNode root = postFormOk(ADMIN_CONFIG_PATH,
@@ -72,11 +84,11 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
         assertTrue(root.get("data").asBoolean(), root.toString());
         return root;
     }
-    
+
     protected JsonNode queryConfig(String dataId, String groupName, String namespaceId) throws Exception {
         return getJsonOk(ADMIN_CONFIG_PATH, configQuery(dataId, groupName, namespaceId));
     }
-    
+
     protected JsonNode updateConfigMetadata(String dataId, String groupName, String namespaceId,
             String description, String configTags) throws Exception {
         JsonNode root = putFormOk(ADMIN_CONFIG_METADATA_PATH,
@@ -84,17 +96,17 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
         assertTrue(root.get("data").asBoolean(), root.toString());
         return root;
     }
-    
+
     protected JsonNode deleteConfig(String dataId, String groupName, String namespaceId) throws Exception {
         JsonNode root = deleteJsonOk(ADMIN_CONFIG_PATH, configDeleteQuery(dataId, groupName, namespaceId));
         assertTrue(root.get("data").asBoolean(), root.toString());
         return root;
     }
-    
+
     protected void deleteConfigQuietly(String dataId, String groupName, String namespaceId) throws Exception {
         deleteQuietly(ADMIN_CONFIG_PATH, configDeleteQuery(dataId, groupName, namespaceId));
     }
-    
+
     protected Query configQuery(String dataId, String groupName, String namespaceId) {
         Query query = Query.newInstance();
         addIfNotBlank(query, "dataId", dataId);
@@ -102,7 +114,7 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
         addIfNotBlank(query, "namespaceId", namespaceId);
         return query;
     }
-    
+
     protected Query listQuery(String dataId, String groupName, String namespaceId, int pageNo, int pageSize) {
         Query query = configQuery(dataId, groupName, namespaceId);
         query.addParam("search", "blur");
@@ -110,7 +122,14 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
         query.addParam("pageSize", String.valueOf(pageSize));
         return query;
     }
-    
+
+    protected Query historyQuery(String dataId, String groupName, String namespaceId, int pageNo, int pageSize) {
+        Query query = configQuery(dataId, groupName, namespaceId);
+        query.addParam("pageNo", String.valueOf(pageNo));
+        query.addParam("pageSize", String.valueOf(pageSize));
+        return query;
+    }
+
     protected void assertConfigDetail(JsonNode data, String dataId, String groupName, String namespaceId,
             String content, String type) throws Exception {
         assertEquals(dataId, data.get("dataId").asText(), data.toString());
@@ -123,7 +142,7 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
         assertTrue(data.get("createTime").asLong() > 0L, data.toString());
         assertTrue(data.get("modifyTime").asLong() > 0L, data.toString());
     }
-    
+
     protected void assertConfigMetadata(JsonNode data, String description, String configTags) {
         assertEquals(description, data.get("desc").asText(), data.toString());
         if (configTags.isEmpty()) {
@@ -133,17 +152,34 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
             assertEquals(configTags, data.get("configTags").asText(), data.toString());
         }
     }
-    
+
     protected void assertPageContainsConfig(JsonNode page, String dataId, String groupName, String contentMd5) {
         JsonNode found = findConfig(page, dataId, groupName);
         assertFalse(found.isMissingNode(), page.toString());
         assertEquals(contentMd5, found.get("md5").asText(), found.toString());
     }
-    
+
     protected void assertPageNotContainsConfig(JsonNode page, String dataId, String groupName) {
         assertTrue(findConfig(page, dataId, groupName).isMissingNode(), page.toString());
     }
-    
+
+    protected void assertArrayContainsConfig(JsonNode items, String dataId, String groupName, String contentMd5) {
+        JsonNode found = findConfigInArray(items, dataId, groupName);
+        assertFalse(found.isMissingNode(), items.toString());
+        assertEquals(contentMd5, found.get("md5").asText(), found.toString());
+    }
+
+    protected JsonNode assertArrayContainsConfig(JsonNode items, String dataId, String groupName) {
+        JsonNode found = findConfigInArray(items, dataId, groupName);
+        assertFalse(found.isMissingNode(), items.toString());
+        return found;
+    }
+
+    protected void assertListenerInfo(JsonNode data, String queryType) {
+        assertEquals(queryType, data.get("queryType").asText(), data.toString());
+        assertTrue(data.get("listenersStatus").isObject(), data.toString());
+    }
+
     protected JsonNode findConfig(JsonNode page, String dataId, String groupName) {
         for (JsonNode item : page.get("pageItems")) {
             if (dataId.equals(item.get("dataId").asText())
@@ -153,17 +189,27 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
         }
         return MissingNode.getInstance();
     }
-    
+
+    protected JsonNode findConfigInArray(JsonNode items, String dataId, String groupName) {
+        for (JsonNode item : items) {
+            if (dataId.equals(item.get("dataId").asText())
+                    && groupName.equals(item.get("groupName").asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+
     protected static String md5(String content) throws Exception {
         return MD5Utils.md5Hex(content, StandardCharsets.UTF_8.name());
     }
-    
+
     private Query configDeleteQuery(String dataId, String groupName, String namespaceId) {
         Query query = configQuery(dataId, groupName, namespaceId);
         query.addParam("tag", "");
         return query;
     }
-    
+
     private static Map<String, String> buildPublishForm(String dataId, String groupName, String namespaceId,
             String content, String type, String description, String configTags) {
         Map<String, String> form = new LinkedHashMap<>();
@@ -184,7 +230,7 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
         form.put("schema", "");
         return form;
     }
-    
+
     private static Map<String, String> buildMetadataForm(String dataId, String groupName, String namespaceId,
             String description, String configTags) {
         Map<String, String> form = new LinkedHashMap<>();

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiBaseITCase.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.config.server.constant.Constants;
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shared helpers for config admin OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
+    
+    protected static final String ADMIN_CONFIG_PATH = nacosPath(Constants.CONFIG_ADMIN_V3_PATH);
+    
+    protected static final String ADMIN_CONFIG_LIST_PATH = ADMIN_CONFIG_PATH + "/list";
+    
+    protected static final String ADMIN_CONFIG_METADATA_PATH = ADMIN_CONFIG_PATH + "/metadata";
+    
+    protected static final String DEFAULT_NAMESPACE = "public";
+    
+    protected static final String TEST_GROUP = "openapi_it_group";
+    
+    protected static final String DEFAULT_TYPE = ConfigType.getDefaultType().getType();
+    
+    protected String randomDataId(String scenario) {
+        return "openapi_it_admin_" + scenario + "_" + UUID.randomUUID();
+    }
+    
+    protected String randomGroupName(String scenario) {
+        return TEST_GROUP + "_" + scenario + "_" + UUID.randomUUID();
+    }
+    
+    protected JsonNode publishConfig(String dataId, String groupName, String namespaceId, String content)
+            throws Exception {
+        return publishConfig(dataId, groupName, namespaceId, content, DEFAULT_TYPE, "", "");
+    }
+    
+    protected JsonNode publishConfig(String dataId, String groupName, String namespaceId, String content,
+            String type, String description, String configTags) throws Exception {
+        JsonNode root = postFormOk(ADMIN_CONFIG_PATH,
+                buildPublishForm(dataId, groupName, namespaceId, content, type, description, configTags));
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        return root;
+    }
+    
+    protected JsonNode queryConfig(String dataId, String groupName, String namespaceId) throws Exception {
+        return getJsonOk(ADMIN_CONFIG_PATH, configQuery(dataId, groupName, namespaceId));
+    }
+    
+    protected JsonNode updateConfigMetadata(String dataId, String groupName, String namespaceId,
+            String description, String configTags) throws Exception {
+        JsonNode root = putFormOk(ADMIN_CONFIG_METADATA_PATH,
+                buildMetadataForm(dataId, groupName, namespaceId, description, configTags));
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        return root;
+    }
+    
+    protected JsonNode deleteConfig(String dataId, String groupName, String namespaceId) throws Exception {
+        JsonNode root = deleteJsonOk(ADMIN_CONFIG_PATH, configDeleteQuery(dataId, groupName, namespaceId));
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        return root;
+    }
+    
+    protected void deleteConfigQuietly(String dataId, String groupName, String namespaceId) throws Exception {
+        deleteQuietly(ADMIN_CONFIG_PATH, configDeleteQuery(dataId, groupName, namespaceId));
+    }
+    
+    protected Query configQuery(String dataId, String groupName, String namespaceId) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "dataId", dataId);
+        addIfNotBlank(query, "groupName", groupName);
+        addIfNotBlank(query, "namespaceId", namespaceId);
+        return query;
+    }
+    
+    protected Query listQuery(String dataId, String groupName, String namespaceId, int pageNo, int pageSize) {
+        Query query = configQuery(dataId, groupName, namespaceId);
+        query.addParam("search", "blur");
+        query.addParam("pageNo", String.valueOf(pageNo));
+        query.addParam("pageSize", String.valueOf(pageSize));
+        return query;
+    }
+    
+    protected void assertConfigDetail(JsonNode data, String dataId, String groupName, String namespaceId,
+            String content, String type) throws Exception {
+        assertEquals(dataId, data.get("dataId").asText(), data.toString());
+        assertEquals(groupName, data.get("groupName").asText(), data.toString());
+        assertEquals(namespaceId, data.get("namespaceId").asText(), data.toString());
+        assertEquals(content, data.get("content").asText(), data.toString());
+        assertEquals(type, data.get("type").asText(), data.toString());
+        assertEquals(MD5Utils.md5Hex(content, StandardCharsets.UTF_8.name()), data.get("md5").asText(),
+                data.toString());
+        assertTrue(data.get("createTime").asLong() > 0L, data.toString());
+        assertTrue(data.get("modifyTime").asLong() > 0L, data.toString());
+    }
+    
+    protected void assertConfigMetadata(JsonNode data, String description, String configTags) {
+        assertEquals(description, data.get("desc").asText(), data.toString());
+        if (configTags.isEmpty()) {
+            assertTrue(data.get("configTags").isNull() || data.get("configTags").asText().isEmpty(),
+                    data.toString());
+        } else {
+            assertEquals(configTags, data.get("configTags").asText(), data.toString());
+        }
+    }
+    
+    protected void assertPageContainsConfig(JsonNode page, String dataId, String groupName, String contentMd5) {
+        JsonNode found = findConfig(page, dataId, groupName);
+        assertFalse(found.isMissingNode(), page.toString());
+        assertEquals(contentMd5, found.get("md5").asText(), found.toString());
+    }
+    
+    protected void assertPageNotContainsConfig(JsonNode page, String dataId, String groupName) {
+        assertTrue(findConfig(page, dataId, groupName).isMissingNode(), page.toString());
+    }
+    
+    protected JsonNode findConfig(JsonNode page, String dataId, String groupName) {
+        for (JsonNode item : page.get("pageItems")) {
+            if (dataId.equals(item.get("dataId").asText())
+                    && groupName.equals(item.get("groupName").asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+    
+    protected static String md5(String content) throws Exception {
+        return MD5Utils.md5Hex(content, StandardCharsets.UTF_8.name());
+    }
+    
+    private Query configDeleteQuery(String dataId, String groupName, String namespaceId) {
+        Query query = configQuery(dataId, groupName, namespaceId);
+        query.addParam("tag", "");
+        return query;
+    }
+    
+    private static Map<String, String> buildPublishForm(String dataId, String groupName, String namespaceId,
+            String content, String type, String description, String configTags) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("dataId", dataId);
+        form.put("groupName", groupName);
+        if (null != namespaceId) {
+            form.put("namespaceId", namespaceId);
+        }
+        form.put("content", content);
+        form.put("tag", "");
+        form.put("appName", "");
+        form.put("src_user", "");
+        form.put("configTags", configTags);
+        form.put("desc", description);
+        form.put("use", "");
+        form.put("effect", "");
+        form.put("type", type);
+        form.put("schema", "");
+        return form;
+    }
+    
+    private static Map<String, String> buildMetadataForm(String dataId, String groupName, String namespaceId,
+            String description, String configTags) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("dataId", dataId);
+        form.put("groupName", groupName);
+        if (null != namespaceId) {
+            form.put("namespaceId", namespaceId);
+        }
+        form.put("configTags", configTags);
+        form.put("desc", description);
+        return form;
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiBaseITCase.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.test.adminapi.config;
 
 import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.constant.Constants;
@@ -49,6 +50,14 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
     protected static final String ADMIN_CONFIG_LISTENER_PATH = ADMIN_CONFIG_PATH + "/listener";
 
     protected static final String ADMIN_CONFIG_METADATA_PATH = ADMIN_CONFIG_PATH + "/metadata";
+
+    protected static final String ADMIN_CONFIG_BETA_PATH = ADMIN_CONFIG_PATH + "/beta";
+
+    protected static final String ADMIN_CONFIG_GRAY_PATH = ADMIN_CONFIG_PATH + "/gray";
+
+    protected static final String ADMIN_CONFIG_EXPORT_PATH = ADMIN_CONFIG_PATH + "/export";
+
+    protected static final String ADMIN_CONFIG_CLONE_PATH = ADMIN_CONFIG_PATH + "/clone";
 
     protected static final String ADMIN_HISTORY_PATH = nacosPath(Constants.HISTORY_ADMIN_V3_PATH);
 
@@ -85,6 +94,28 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
         return root;
     }
 
+    protected JsonNode publishBetaConfig(String dataId, String groupName, String namespaceId, String content,
+            String betaIps) throws Exception {
+        Header header = Header.newInstance().addParam("betaIps", betaIps);
+        JsonNode root = postFormOk(ADMIN_CONFIG_PATH, header,
+                buildPublishForm(dataId, groupName, namespaceId, content, DEFAULT_TYPE, "", ""));
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        return root;
+    }
+
+    protected JsonNode publishGrayConfig(String dataId, String groupName, String namespaceId, String content,
+            String grayName, String grayRuleExp) throws Exception {
+        Map<String, String> form = buildPublishForm(dataId, groupName, namespaceId, content, DEFAULT_TYPE, "", "");
+        form.put("grayName", grayName);
+        form.put("grayType", "tagv2");
+        form.put("grayMatchRuleExp", grayRuleExp);
+        form.put("grayVersion", "1.0.0");
+        form.put("grayPriority", "1");
+        JsonNode root = postFormOk(ADMIN_CONFIG_GRAY_PATH, form);
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        return root;
+    }
+
     protected JsonNode queryConfig(String dataId, String groupName, String namespaceId) throws Exception {
         return getJsonOk(ADMIN_CONFIG_PATH, configQuery(dataId, groupName, namespaceId));
     }
@@ -105,6 +136,15 @@ public abstract class ConfigAdminApiBaseITCase extends OpenApiBaseITCase {
 
     protected void deleteConfigQuietly(String dataId, String groupName, String namespaceId) throws Exception {
         deleteQuietly(ADMIN_CONFIG_PATH, configDeleteQuery(dataId, groupName, namespaceId));
+    }
+
+    protected void deleteBetaQuietly(String dataId, String groupName, String namespaceId) throws Exception {
+        deleteQuietly(ADMIN_CONFIG_BETA_PATH, configQuery(dataId, groupName, namespaceId));
+    }
+
+    protected void deleteGrayQuietly(String dataId, String groupName, String namespaceId, String grayName)
+            throws Exception {
+        deleteQuietly(ADMIN_CONFIG_GRAY_PATH, configQuery(dataId, groupName, namespaceId).addParam("grayName", grayName));
     }
 
     protected Query configQuery(String dataId, String groupName, String namespaceId) {

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigAdminApiOpenApiITCase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for config admin OpenAPI {@code /nacos/v3/admin/cs/config}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: publish creates a config, republish updates its content, query returns the admin detail
+ *     model, metadata update changes description and config tags, and delete removes the config.</li>
+ *     <li>Boundary/validation: omitted namespaceId is stored as public, invalid config type is normalized to text,
+ *     {@code dataId}, {@code groupName}, and {@code content} are required, and the legacy {@code group} parameter does
+ *     not replace {@code groupName} for the v3 API.</li>
+ *     <li>Exception/error handling: absent configs return HTTP 404 with the v3 {@code Result} error envelope, and
+ *     invalid namespace values return HTTP 400 instead of leaking HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testPublishQueryUpdateMetadataAndDeleteConfig() throws Exception {
+        String dataId = randomDataId("crud");
+        String groupName = randomGroupName("crud");
+        String initialContent = "{\"name\":\"initial\"}";
+        String initialDescription = "initial config description";
+        String initialTags = "tag-a,tag-b";
+        publishConfig(dataId, groupName, "", initialContent, ConfigType.JSON.getType(), initialDescription,
+                initialTags);
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+        
+        JsonNode initialData = queryConfig(dataId, groupName, null).get("data");
+        assertConfigDetail(initialData, dataId, groupName, DEFAULT_NAMESPACE, initialContent,
+                ConfigType.JSON.getType());
+        assertConfigMetadata(initialData, initialDescription, initialTags);
+        
+        String updatedContent = "plain-content-" + dataId;
+        publishConfig(dataId, groupName, "", updatedContent, "not-a-real-type", "", "");
+        JsonNode updatedData = queryConfig(dataId, groupName, "").get("data");
+        assertConfigDetail(updatedData, dataId, groupName, DEFAULT_NAMESPACE, updatedContent, DEFAULT_TYPE);
+        
+        String metadataDescription = "metadata-updated-description";
+        String metadataTags = "tag-updated-a,tag-updated-b";
+        updateConfigMetadata(dataId, groupName, "", metadataDescription, metadataTags);
+        JsonNode metadataData = queryConfig(dataId, groupName, "").get("data");
+        assertConfigDetail(metadataData, dataId, groupName, DEFAULT_NAMESPACE, updatedContent, DEFAULT_TYPE);
+        assertConfigMetadata(metadataData, metadataDescription, metadataTags);
+        
+        deleteConfig(dataId, groupName, "");
+        assertError(getRaw(ADMIN_CONFIG_PATH, configQuery(dataId, groupName, "")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Config not exist");
+    }
+    
+    @Test
+    public void testPublishConfigRequiredParametersReturnBadRequest() throws Exception {
+        String dataId = randomDataId("required");
+        String groupName = randomGroupName("required");
+        assertError(postRaw(ADMIN_CONFIG_PATH, Query.newInstance().addParam("groupName", groupName)
+                .addParam("content", "content")), 400, ErrorCode.PARAMETER_MISSING, "dataId");
+        assertError(postRaw(ADMIN_CONFIG_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("content", "content")), 400, ErrorCode.PARAMETER_MISSING, "groupName");
+        assertError(postRaw(ADMIN_CONFIG_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("groupName", groupName)), 400, ErrorCode.PARAMETER_MISSING, "content");
+        assertError(postRaw(ADMIN_CONFIG_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("group", groupName).addParam("content", "content")), 400,
+                ErrorCode.PARAMETER_MISSING, "groupName");
+    }
+    
+    @Test
+    public void testQueryConfigNotFoundAndInvalidNamespaceReturnControlledErrors() throws Exception {
+        String absentDataId = randomDataId("absent");
+        String groupName = randomGroupName("absent");
+        assertError(getRaw(ADMIN_CONFIG_PATH, configQuery(absentDataId, groupName, "")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Config not exist");
+        
+        Query invalidNamespace = configQuery(absentDataId, groupName, "invalid namespace");
+        assertError(getRaw(ADMIN_CONFIG_PATH, invalidNamespace), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "namespaceId");
+    }
+    
+    @Test
+    public void testDeleteConfigRequiredParametersReturnBadRequest() throws Exception {
+        String dataId = randomDataId("delete-required");
+        String groupName = randomGroupName("delete-required");
+        assertError(deleteRaw(ADMIN_CONFIG_PATH, Query.newInstance().addParam("groupName", groupName)), 400,
+                ErrorCode.PARAMETER_MISSING, "dataId");
+        assertError(deleteRaw(ADMIN_CONFIG_PATH, Query.newInstance().addParam("dataId", dataId)), 400,
+                ErrorCode.PARAMETER_MISSING, "groupName");
+    }
+    
+    @Test
+    public void testMetadataUpdateRequiresExistingConfigIdentityFields() throws Exception {
+        String dataId = randomDataId("metadata-required");
+        String groupName = randomGroupName("metadata-required");
+        assertError(putRaw(ADMIN_CONFIG_METADATA_PATH, Query.newInstance().addParam("groupName", groupName)
+                .addParam("desc", "desc").addParam("configTags", "tag")), 400,
+                ErrorCode.PARAMETER_MISSING, "dataId");
+        assertError(putRaw(ADMIN_CONFIG_METADATA_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("desc", "desc").addParam("configTags", "tag")), 400,
+                ErrorCode.PARAMETER_MISSING, "groupName");
+        
+        publishConfig(dataId, groupName, "", "metadata-content");
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+        updateConfigMetadata(dataId, groupName, "", "", "");
+        JsonNode data = queryConfig(dataId, groupName, "").get("data");
+        assertConfigMetadata(data, "", "");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigBatchDeleteAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigBatchDeleteAdminApiOpenApiITCase.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for config admin batch delete OpenAPI {@code DELETE /nacos/v3/admin/cs/config/batch}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: comma-separated config ids delete multiple existing configs and each deleted config
+ *     becomes absent from the detail API.</li>
+ *     <li>Boundary/validation: non-existing ids are accepted and ignored, while {@code ids} is required.</li>
+ *     <li>Exception/error handling: missing {@code ids} returns HTTP 400 with the v3 {@code Result} error envelope
+ *     instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigBatchDeleteAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testBatchDeleteExistingConfigsAndIgnoreMissingId() throws Exception {
+        String firstDataId = randomDataId("batch-delete-a");
+        String secondDataId = randomDataId("batch-delete-b");
+        String groupName = randomGroupName("batch-delete");
+        publishConfig(firstDataId, groupName, "", "batch-delete-first");
+        addCleanup(() -> deleteConfigQuietly(firstDataId, groupName, ""));
+        publishConfig(secondDataId, groupName, "", "batch-delete-second");
+        addCleanup(() -> deleteConfigQuietly(secondDataId, groupName, ""));
+        
+        JsonNode first = queryConfig(firstDataId, groupName, "").get("data");
+        JsonNode second = queryConfig(secondDataId, groupName, "").get("data");
+        String ids = first.get("id").asText() + "," + second.get("id").asText() + ",999999999999";
+        
+        JsonNode root = deleteJsonOk(ADMIN_CONFIG_BATCH_PATH, Query.newInstance().addParam("ids", ids));
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        assertError(getRaw(ADMIN_CONFIG_PATH, configQuery(firstDataId, groupName, "")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Config not exist");
+        assertError(getRaw(ADMIN_CONFIG_PATH, configQuery(secondDataId, groupName, "")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Config not exist");
+    }
+    
+    @Test
+    public void testBatchDeleteIdsValidationReturnsBadRequest() throws Exception {
+        assertError(deleteRaw(ADMIN_CONFIG_BATCH_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "ids");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigBetaAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigBetaAdminApiOpenApiITCase.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for config beta admin OpenAPI {@code /nacos/v3/admin/cs/config/beta}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: a beta publish made through the config publish API can be queried from the beta API and
+ *     can be stopped, after which beta query returns not found.</li>
+ *     <li>Boundary/validation: omitted namespace uses public, beta rule is generated from {@code betaIps}, and
+ *     {@code dataId}/{@code groupName} are required.</li>
+ *     <li>Exception/error handling: absent beta configs return HTTP 404 with the v3 {@code Result} error envelope
+ *     instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigBetaAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testQueryAndStopBetaConfig() throws Exception {
+        String dataId = randomDataId("beta");
+        String groupName = randomGroupName("beta");
+        String content = "beta-content";
+        String betaIps = "127.0.0.1";
+        publishBetaConfig(dataId, groupName, "", content, betaIps);
+        addCleanup(() -> deleteBetaQuietly(dataId, groupName, ""));
+        
+        JsonNode beta = getJsonOk(ADMIN_CONFIG_BETA_PATH, configQuery(dataId, groupName, null)).get("data");
+        assertEquals(dataId, beta.get("dataId").asText(), beta.toString());
+        assertEquals(groupName, beta.get("groupName").asText(), beta.toString());
+        assertEquals(DEFAULT_NAMESPACE, beta.get("namespaceId").asText(), beta.toString());
+        assertEquals(content, beta.get("content").asText(), beta.toString());
+        assertEquals("beta", beta.get("grayName").asText(), beta.toString());
+        assertTrue(beta.get("grayRule").asText().contains(betaIps), beta.toString());
+        
+        JsonNode stopped = deleteJsonOk(ADMIN_CONFIG_BETA_PATH, configQuery(dataId, groupName, ""));
+        assertTrue(stopped.get("data").asBoolean(), stopped.toString());
+        assertError(getRaw(ADMIN_CONFIG_BETA_PATH, configQuery(dataId, groupName, "")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Config is not in beta");
+    }
+    
+    @Test
+    public void testBetaRequiredParametersAndAbsentConfigReturnControlledErrors() throws Exception {
+        String dataId = randomDataId("beta-required");
+        String groupName = randomGroupName("beta-required");
+        assertError(getRaw(ADMIN_CONFIG_BETA_PATH, Query.newInstance().addParam("groupName", groupName)),
+                400, ErrorCode.PARAMETER_MISSING, "dataId");
+        assertError(getRaw(ADMIN_CONFIG_BETA_PATH, Query.newInstance().addParam("dataId", dataId)),
+                400, ErrorCode.PARAMETER_MISSING, "groupName");
+        assertError(getRaw(ADMIN_CONFIG_BETA_PATH, configQuery(dataId, groupName, "")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Config is not in beta");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigCapacityAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigCapacityAdminApiOpenApiITCase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for config capacity admin OpenAPI {@code /nacos/v3/admin/cs/capacity}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: updating group capacity persists quota and size limits that can be queried through the
+ *     capacity detail API.</li>
+ *     <li>Boundary/validation: at least one of {@code groupName}/{@code namespaceId} is required, and at least one
+ *     capacity value is required for update. The success case uses an isolated random group; there is no public delete
+ *     endpoint for capacity rows.</li>
+ *     <li>Exception/error handling: missing identity or capacity values return HTTP 400 with the v3 {@code Result}
+ *     error envelope instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigCapacityAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testUpdateAndQueryGroupCapacity() throws Exception {
+        String groupName = randomGroupName("capacity");
+        JsonNode updated = postFormOk(ADMIN_CAPACITY_PATH, Query.newInstance().addParam("groupName", groupName)
+                .addParam("quota", "101").addParam("maxSize", "1024")
+                .addParam("maxAggrCount", "8").addParam("maxAggrSize", "512"));
+        assertTrue(updated.get("data").asBoolean(), updated.toString());
+        
+        JsonNode capacity = getJsonOk(ADMIN_CAPACITY_PATH,
+                Query.newInstance().addParam("groupName", groupName)).get("data");
+        assertEquals(101, capacity.get("quota").asInt(), capacity.toString());
+        assertEquals(1024, capacity.get("maxSize").asInt(), capacity.toString());
+        assertEquals(8, capacity.get("maxAggrCount").asInt(), capacity.toString());
+        assertEquals(512, capacity.get("maxAggrSize").asInt(), capacity.toString());
+    }
+    
+    @Test
+    public void testCapacityValidationReturnsBadRequest() throws Exception {
+        assertError(getRaw(ADMIN_CAPACITY_PATH), 400, ErrorCode.PARAMETER_MISSING,
+                "At least one of the parameters");
+        assertError(postRaw(ADMIN_CAPACITY_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "At least one of the parameters");
+        assertError(postRaw(ADMIN_CAPACITY_PATH, Query.newInstance().addParam("groupName",
+                randomGroupName("capacity-required"))), 400,
+                ErrorCode.PARAMETER_MISSING, "quota, maxSize, maxAggrCount, maxAggrSize");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigCloneAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigCloneAdminApiOpenApiITCase.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for config clone admin OpenAPI {@code POST /nacos/v3/admin/cs/config/clone}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: clone copies an existing config id to a target dataId/groupName in the target namespace
+ *     and the cloned config can be queried with the original content and type.</li>
+ *     <li>Boundary/validation: {@code namespaceId} is required, empty clone lists are rejected with
+ *     {@code NO_SELECTED_CONFIG}, and unknown source ids return {@code DATA_EMPTY} without creating data.</li>
+ *     <li>Exception/error handling: request-parameter errors return HTTP 400 and business failures keep the v3
+ *     {@code Result} envelope instead of leaking HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigCloneAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testCloneConfigToTargetIdentity() throws Exception {
+        String sourceDataId = randomDataId("clone-source");
+        String sourceGroup = randomGroupName("clone-source");
+        String targetDataId = randomDataId("clone-target");
+        String targetGroup = randomGroupName("clone-target");
+        String content = "clone-content";
+        publishConfig(sourceDataId, sourceGroup, "", content, ConfigType.JSON.getType(), "clone desc", "");
+        addCleanup(() -> deleteConfigQuietly(sourceDataId, sourceGroup, ""));
+        addCleanup(() -> deleteConfigQuietly(targetDataId, targetGroup, ""));
+        JsonNode source = queryConfig(sourceDataId, sourceGroup, "").get("data");
+        
+        String body = "[{\"configId\":" + source.get("id").asText() + ",\"targetDataId\":\""
+                + targetDataId + "\",\"targetGroupName\":\"" + targetGroup + "\"}]";
+        JsonNode root = postJsonOk(ADMIN_CONFIG_CLONE_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE).addParam("policy", "OVERWRITE"),
+                body);
+        assertTrue(root.get("data").get("succCount").asInt() >= 1, root.toString());
+        
+        JsonNode cloned = queryConfig(targetDataId, targetGroup, DEFAULT_NAMESPACE).get("data");
+        assertConfigDetail(cloned, targetDataId, targetGroup, DEFAULT_NAMESPACE, content, ConfigType.JSON.getType());
+    }
+    
+    @Test
+    public void testCloneValidationAndBusinessFailuresReturnResultEnvelope() throws Exception {
+        assertError(postJsonRaw(ADMIN_CONFIG_CLONE_PATH, Query.newInstance(), "[]"), 400,
+                ErrorCode.PARAMETER_MISSING, "namespaceId");
+        
+        HttpResponse emptyResponse = postJsonRaw(ADMIN_CONFIG_CLONE_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE), "[]");
+        assertEquals(200, emptyResponse.code(), emptyResponse.body());
+        JsonNode emptyRoot = JacksonUtils.toObj(emptyResponse.body());
+        assertFailureResult(emptyRoot, ErrorCode.NO_SELECTED_CONFIG, "succCount");
+        
+        HttpResponse absentSourceResponse = postJsonRaw(ADMIN_CONFIG_CLONE_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE),
+                "[{\"configId\":999999999999,\"targetDataId\":\"absent\",\"targetGroupName\":\"absent\"}]");
+        assertEquals(200, absentSourceResponse.code(), absentSourceResponse.body());
+        JsonNode absentSourceRoot = JacksonUtils.toObj(absentSourceResponse.body());
+        assertFailureResult(absentSourceRoot, ErrorCode.DATA_EMPTY, "succCount");
+    }
+    
+    private void assertFailureResult(JsonNode root, ErrorCode errorCode, String dataField) {
+        assertEquals(errorCode.getCode(), root.get("code").asInt(), root.toString());
+        assertEquals(errorCode.getMsg(), root.get("message").asText(), root.toString());
+        assertTrue(root.get("data").has(dataField), root.toString());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigExportAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigExportAdminApiOpenApiITCase.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.config.server.constant.Constants;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for config export admin OpenAPI {@code GET /nacos/v3/admin/cs/config/export}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: export by config id returns a downloadable zip containing the config content entry and
+ *     the metadata yaml entry.</li>
+ *     <li>Boundary/validation: exported config ids are serialized as query parameters, omitted namespace uses public,
+ *     and invalid namespace values are rejected when ids are present.</li>
+ *     <li>Exception/error handling: namespace validation returns HTTP 400 with a v3 {@code Result} body instead of
+ *     HTTP 500. Export without {@code ids} is not asserted because the current endpoint dereferences a null id list
+ *     before validation.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigExportAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testExportConfigByIdReturnsZipWithContentAndMetadata() throws Exception {
+        String dataId = randomDataId("export");
+        String groupName = randomGroupName("export");
+        String content = "export-content";
+        publishConfig(dataId, groupName, "", content, ConfigType.TEXT.getType(), "export desc", "");
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+        JsonNode config = queryConfig(dataId, groupName, "").get("data");
+        
+        ByteResponse response = getRawBytes(ADMIN_CONFIG_EXPORT_PATH,
+                Query.newInstance().addParam("ids", config.get("id").asText()));
+        assertEquals(200, response.code(), response.contentDisposition());
+        assertTrue(response.contentDisposition().startsWith("attachment;filename=nacos_config_export_"),
+                response.contentDisposition());
+        
+        Map<String, String> entries = unzip(response.body());
+        String configEntry = groupName + Constants.CONFIG_EXPORT_ITEM_FILE_SEPARATOR + dataId;
+        assertEquals(content, entries.get(configEntry), entries.toString());
+        String metadata = entries.get(Constants.CONFIG_EXPORT_METADATA_NEW);
+        assertTrue(metadata.contains("dataId: " + dataId), metadata);
+        assertTrue(metadata.contains("group: " + groupName), metadata);
+        assertTrue(metadata.contains("type: text"), metadata);
+    }
+    
+    @Test
+    public void testExportInvalidNamespaceReturnsBadRequest() throws Exception {
+        assertError(getRaw(ADMIN_CONFIG_EXPORT_PATH, Query.newInstance().addParam("ids", "1")
+                .addParam("namespaceId", "invalid namespace")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceId");
+    }
+    
+    private Map<String, String> unzip(byte[] body) throws Exception {
+        Map<String, String> result = new HashMap<>();
+        try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(body))) {
+            ZipEntry entry;
+            while (null != (entry = zipInputStream.getNextEntry())) {
+                result.put(entry.getName(), new String(zipInputStream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        }
+        return result;
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigGrayAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigGrayAdminApiOpenApiITCase.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for config gray admin OpenAPI {@code /nacos/v3/admin/cs/config/gray}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: publish gray creates a queryable gray config with content, md5, gray name, and serialized
+ *     tagv2 rule information.</li>
+ *     <li>Boundary/validation: omitted namespace uses public, tagv2 version {@code 1.0.0} is accepted, and
+ *     {@code grayName}, {@code grayRuleExp}, {@code grayVersion}, {@code dataId}, and {@code groupName} are
+ *     validated.</li>
+ *     <li>Exception/error handling: absent gray configs and required-parameter failures return controlled v3
+ *     {@code Result} errors. Successful delete is intentionally not asserted here because the current standalone
+ *     endpoint removes the row but reports a server error after persistence; cleanup tolerates that branch.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigGrayAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testPublishAndQueryGrayConfig() throws Exception {
+        String dataId = randomDataId("gray");
+        String groupName = randomGroupName("gray");
+        String content = "gray-content";
+        String grayName = "tagv2_openapi_it_gray";
+        String grayRuleExp = "region=hz";
+        publishGrayConfig(dataId, groupName, "", content, grayName, grayRuleExp);
+        addCleanup(() -> deleteGrayQuietly(dataId, groupName, "", grayName));
+        
+        JsonNode gray = getJsonOk(ADMIN_CONFIG_GRAY_PATH,
+                configQuery(dataId, groupName, null).addParam("grayName", grayName)).get("data");
+        assertEquals(dataId, gray.get("dataId").asText(), gray.toString());
+        assertEquals(groupName, gray.get("groupName").asText(), gray.toString());
+        assertEquals(DEFAULT_NAMESPACE, gray.get("namespaceId").asText(), gray.toString());
+        assertEquals(content, gray.get("content").asText(), gray.toString());
+        assertEquals(md5(content), gray.get("md5").asText(), gray.toString());
+        assertEquals(grayName, gray.get("grayName").asText(), gray.toString());
+        assertTrue(gray.get("grayRule").asText().contains("\"type\":\"tagv2\""), gray.toString());
+        assertTrue(gray.get("grayRule").asText().contains("\"version\":\"1.0.0\""), gray.toString());
+    }
+    
+    @Test
+    public void testGrayValidationAndAbsentConfigReturnControlledErrors() throws Exception {
+        String dataId = randomDataId("gray-required");
+        String groupName = randomGroupName("gray-required");
+        assertError(postRaw(ADMIN_CONFIG_GRAY_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("groupName", groupName).addParam("content", "content")
+                .addParam("grayRuleExp", "region=hz").addParam("grayVersion", "1.0.0")),
+                400, ErrorCode.PARAMETER_MISSING, "grayName");
+        assertError(postRaw(ADMIN_CONFIG_GRAY_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("groupName", groupName).addParam("content", "content")
+                .addParam("grayName", "tagv2_openapi_it_gray").addParam("grayVersion", "1.0.0")),
+                400, ErrorCode.PARAMETER_MISSING, "grayRuleExp");
+        assertError(postRaw(ADMIN_CONFIG_GRAY_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("groupName", groupName).addParam("content", "content")
+                .addParam("grayName", "invalid name").addParam("grayRuleExp", "region=hz")
+                .addParam("grayVersion", "1.0.0")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "grayName");
+        assertError(getRaw(ADMIN_CONFIG_GRAY_PATH, configQuery(dataId, groupName, "")
+                .addParam("grayName", "tagv2_openapi_it_absent")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Config gray version not found");
+        assertError(deleteRaw(ADMIN_CONFIG_GRAY_PATH, configQuery(dataId, groupName, "")),
+                400, ErrorCode.PARAMETER_MISSING, "grayName");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigHistoryAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigHistoryAdminApiOpenApiITCase.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for config history admin OpenAPIs under {@code /nacos/v3/admin/cs/history}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: publish and republish create history rows, history list is newest first, detail returns
+ *     the selected history content, previous returns the current config's latest historical content, and namespace
+ *     config listing exposes the current config identity.</li>
+ *     <li>Boundary/validation: page size larger than the controller cap is accepted, {@code pageNo}/{@code pageSize},
+ *     {@code dataId}, {@code groupName}, {@code nid}, and {@code namespaceId} are validated by their endpoints.</li>
+ *     <li>Exception/error handling: missing, absent, and identity-mismatched history queries return controlled v3
+ *     {@code Result} errors with HTTP 400 or 403 instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigHistoryAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testHistoryListDetailPreviousAndNamespaceConfigs() throws Exception {
+        String dataId = randomDataId("history");
+        String groupName = randomGroupName("history");
+        String firstContent = "history-first-content";
+        String secondContent = "history-second-content";
+        publishConfig(dataId, groupName, "", firstContent);
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+        publishConfig(dataId, groupName, "", secondContent);
+        
+        JsonNode currentConfig = queryConfig(dataId, groupName, "").get("data");
+        assertConfigDetail(currentConfig, dataId, groupName, DEFAULT_NAMESPACE, secondContent, DEFAULT_TYPE);
+        
+        JsonNode historyPage = getJsonOk(ADMIN_HISTORY_LIST_PATH,
+                historyQuery(dataId, groupName, "", 1, 1000)).get("data");
+        assertEquals(1, historyPage.get("pageNumber").asInt(), historyPage.toString());
+        assertEquals(2, historyPage.get("totalCount").asInt(), historyPage.toString());
+        assertEquals(2, historyPage.get("pageItems").size(), historyPage.toString());
+        JsonNode newestHistory = historyPage.get("pageItems").get(0);
+        JsonNode oldestHistory = historyPage.get("pageItems").get(1);
+        assertEquals(dataId, newestHistory.get("dataId").asText(), newestHistory.toString());
+        assertEquals(groupName, newestHistory.get("groupName").asText(), newestHistory.toString());
+        assertTrue(newestHistory.get("opType").asText().trim().startsWith("U"), newestHistory.toString());
+        assertTrue(oldestHistory.get("opType").asText().trim().startsWith("I"), oldestHistory.toString());
+        
+        Query detailQuery = configQuery(dataId, groupName, "")
+                .addParam("nid", newestHistory.get("id").asText());
+        JsonNode historyDetail = getJsonOk(ADMIN_HISTORY_PATH, detailQuery).get("data");
+        assertEquals(firstContent, historyDetail.get("content").asText(), historyDetail.toString());
+        assertEquals(md5(firstContent), historyDetail.get("md5").asText(), historyDetail.toString());
+        assertEquals("formal", historyDetail.get("publishType").asText(), historyDetail.toString());
+        
+        Query previousQuery = configQuery(dataId, groupName, "")
+                .addParam("id", currentConfig.get("id").asText());
+        JsonNode previous = getJsonOk(ADMIN_HISTORY_PATH + "/previous", previousQuery).get("data");
+        assertEquals(firstContent, previous.get("content").asText(), previous.toString());
+        assertEquals(newestHistory.get("id").asText(), previous.get("id").asText(), previous.toString());
+        
+        JsonNode namespaceConfigs = getJsonOk(ADMIN_HISTORY_CONFIGS_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)).get("data");
+        JsonNode namespaceConfig = assertArrayContainsConfig(namespaceConfigs, dataId, groupName);
+        assertEquals(DEFAULT_TYPE, namespaceConfig.get("type").asText(), namespaceConfig.toString());
+        
+        assertError(getRaw(ADMIN_HISTORY_PATH, configQuery("wrong-" + dataId, groupName, "")
+                .addParam("nid", newestHistory.get("id").asText())), 403,
+                ErrorCode.ACCESS_DENIED, "dataId");
+    }
+    
+    @Test
+    public void testHistoryValidationAndAbsentHistoryReturnControlledErrors() throws Exception {
+        String dataId = randomDataId("history-validation");
+        String groupName = randomGroupName("history-validation");
+        assertError(getRaw(ADMIN_HISTORY_LIST_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("pageNo", "1").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_MISSING, "groupName");
+        assertError(getRaw(ADMIN_HISTORY_LIST_PATH, historyQuery(dataId, groupName, "", 0, 10)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(ADMIN_HISTORY_LIST_PATH, historyQuery(dataId, groupName, "", 1, 0)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageSize");
+        
+        assertError(getRaw(ADMIN_HISTORY_PATH, configQuery(dataId, groupName, "")), 400,
+                ErrorCode.PARAMETER_MISSING, "nid");
+        assertError(getRaw(ADMIN_HISTORY_PATH, configQuery(dataId, groupName, "")
+                .addParam("nid", "999999999999")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Source must not be null");
+        
+        assertError(getRaw(ADMIN_HISTORY_CONFIGS_PATH), 400, ErrorCode.PARAMETER_MISSING,
+                "namespaceId");
+        assertError(getRaw(ADMIN_HISTORY_CONFIGS_PATH,
+                Query.newInstance().addParam("namespaceId", "invalid namespace")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceId");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigImportAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigImportAdminApiOpenApiITCase.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.config.server.constant.Constants;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for config import admin OpenAPI {@code POST /nacos/v3/admin/cs/config/import}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: a valid metadata zip imports and publishes a config that can be queried with content,
+ *     type, and description.</li>
+ *     <li>Boundary/validation: omitted namespace uses public, {@code ABORT} policy is accepted, missing file returns
+ *     {@code DATA_EMPTY}, and malformed metadata returns {@code METADATA_ILLEGAL} with an object data field.</li>
+ *     <li>Exception/error handling: business failures are returned in the v3 {@code Result} envelope instead of HTTP
+ *     500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigImportAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testImportConfigZipPublishesConfig() throws Exception {
+        String dataId = randomDataId("import");
+        String groupName = randomGroupName("import");
+        String content = "import-content";
+        String description = "import desc";
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+        
+        HttpResponse response = postMultipartRaw(ADMIN_CONFIG_IMPORT_PATH,
+                Query.newInstance().addParam("policy", "ABORT"), "file", "nacos-import.zip",
+                "application/zip", buildImportZip(dataId, groupName, content, description));
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        assertEquals(1, root.get("data").get("succCount").asInt(), root.toString());
+        
+        JsonNode imported = queryConfig(dataId, groupName, "").get("data");
+        assertConfigDetail(imported, dataId, groupName, DEFAULT_NAMESPACE, content, ConfigType.TEXT.getType());
+        assertEquals(description, imported.get("desc").asText(), imported.toString());
+    }
+    
+    @Test
+    public void testImportMissingFileAndBadMetadataReturnFailureResult() throws Exception {
+        HttpResponse missingFile = postRaw(ADMIN_CONFIG_IMPORT_PATH, Query.newInstance().addParam("policy", "ABORT"));
+        assertEquals(200, missingFile.code(), missingFile.body());
+        assertFailureResult(JacksonUtils.toObj(missingFile.body()), ErrorCode.DATA_EMPTY);
+        
+        HttpResponse badMetadata = postMultipartRaw(ADMIN_CONFIG_IMPORT_PATH,
+                Query.newInstance().addParam("policy", "ABORT"), "file", "bad-import.zip",
+                "application/zip", buildBadMetadataZip());
+        assertEquals(200, badMetadata.code(), badMetadata.body());
+        assertFailureResult(JacksonUtils.toObj(badMetadata.body()), ErrorCode.METADATA_ILLEGAL);
+    }
+    
+    private void assertFailureResult(JsonNode root, ErrorCode errorCode) {
+        assertEquals(errorCode.getCode(), root.get("code").asInt(), root.toString());
+        assertEquals(errorCode.getMsg(), root.get("message").asText(), root.toString());
+        assertTrue(root.get("data").isObject(), root.toString());
+    }
+    
+    private byte[] buildImportZip(String dataId, String groupName, String content, String description)
+            throws Exception {
+        String metadata = "metadata:\n"
+                + "- dataId: " + dataId + "\n"
+                + "  group: " + groupName + "\n"
+                + "  type: text\n"
+                + "  appName: ''\n"
+                + "  desc: " + description + "\n";
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+            writeEntry(zipOutputStream, Constants.CONFIG_EXPORT_METADATA_NEW, metadata);
+            writeEntry(zipOutputStream, groupName + Constants.CONFIG_EXPORT_ITEM_FILE_SEPARATOR + dataId, content);
+        }
+        return outputStream.toByteArray();
+    }
+    
+    private byte[] buildBadMetadataZip() throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+            writeEntry(zipOutputStream, Constants.CONFIG_EXPORT_METADATA_NEW, "metadata: []\n");
+        }
+        return outputStream.toByteArray();
+    }
+    
+    private void writeEntry(ZipOutputStream zipOutputStream, String name, String content) throws Exception {
+        zipOutputStream.putNextEntry(new ZipEntry(name));
+        zipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        zipOutputStream.closeEntry();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigListAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigListAdminApiOpenApiITCase.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests for config admin list OpenAPI {@code GET /nacos/v3/admin/cs/config/list}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: list returns published configs in the admin page model, supports {@code *}-based fuzzy
+ *     dataId search, advanced filters such as type and tags, and reports pagination fields correctly.</li>
+ *     <li>Boundary/validation: omitted namespaceId uses public; blank dataId is accepted for group-scoped listing;
+ *     no-match searches return a successful empty page; pageNo and pageSize must be positive.</li>
+ *     <li>Exception/error handling: pagination validation failures return HTTP 400 with the v3 {@code Result} error
+ *     envelope instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigListAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testListConfigsByFuzzyDataIdAdvancedFiltersAndPagination() throws Exception {
+        String prefix = randomDataId("list");
+        String groupName = randomGroupName("list");
+        String firstDataId = prefix + "_a";
+        String secondDataId = prefix + "_b";
+        String firstContent = "list-content-a";
+        String secondContent = "list-content-b";
+        String firstTags = "list-tag-a";
+        publishConfig(firstDataId, groupName, "", firstContent, ConfigType.JSON.getType(), "first", firstTags);
+        addCleanup(() -> deleteConfigQuietly(firstDataId, groupName, ""));
+        publishConfig(secondDataId, groupName, "", secondContent, ConfigType.YAML.getType(), "second",
+                "list-tag-b");
+        addCleanup(() -> deleteConfigQuietly(secondDataId, groupName, ""));
+        
+        String dataIdPattern = prefix + "*";
+        JsonNode allPage = list(dataIdPattern, groupName, 1, 10).get("data");
+        assertEquals(1, allPage.get("pageNumber").asInt(), allPage.toString());
+        assertEquals(2, allPage.get("totalCount").asInt(), allPage.toString());
+        assertPageContainsConfig(allPage, firstDataId, groupName, md5(firstContent));
+        assertPageContainsConfig(allPage, secondDataId, groupName, md5(secondContent));
+        
+        JsonNode paged = list(dataIdPattern, groupName, 1, 1).get("data");
+        assertEquals(1, paged.get("pageNumber").asInt(), paged.toString());
+        assertEquals(2, paged.get("totalCount").asInt(), paged.toString());
+        assertEquals(2, paged.get("pagesAvailable").asInt(), paged.toString());
+        assertEquals(1, paged.get("pageItems").size(), paged.toString());
+        
+        Query typeFilter = listQuery(dataIdPattern, groupName, "", 1, 10)
+                .addParam("type", ConfigType.JSON.getType());
+        JsonNode typePage = getJsonOk(ADMIN_CONFIG_LIST_PATH, typeFilter).get("data");
+        assertEquals(1, typePage.get("totalCount").asInt(), typePage.toString());
+        JsonNode first = findConfig(typePage, firstDataId, groupName);
+        assertEquals(ConfigType.JSON.getType(), first.get("type").asText(), first.toString());
+        assertPageNotContainsConfig(typePage, secondDataId, groupName);
+        
+        Query tagsFilter = listQuery(dataIdPattern, groupName, "", 1, 10).addParam("configTags", firstTags);
+        JsonNode tagsPage = getJsonOk(ADMIN_CONFIG_LIST_PATH, tagsFilter).get("data");
+        assertEquals(1, tagsPage.get("totalCount").asInt(), tagsPage.toString());
+        assertPageContainsConfig(tagsPage, firstDataId, groupName, md5(firstContent));
+        assertPageNotContainsConfig(tagsPage, secondDataId, groupName);
+    }
+    
+    @Test
+    public void testListConfigAllowsBlankDataIdAndNoMatchReturnsEmptyPage() throws Exception {
+        String dataId = randomDataId("blank-data");
+        String groupName = randomGroupName("blank-data");
+        String content = "blank-data-list-content";
+        publishConfig(dataId, groupName, "", content, ConfigType.TEXT.getType(), "blank data id", "");
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+        
+        JsonNode groupScoped = getJsonOk(ADMIN_CONFIG_LIST_PATH, listQuery("", groupName, null, 1, 10)).get("data");
+        assertEquals(1, groupScoped.get("pageNumber").asInt(), groupScoped.toString());
+        assertPageContainsConfig(groupScoped, dataId, groupName, md5(content));
+        
+        JsonNode noMatch = list("no-match-" + randomDataId("list") + "*", groupName, 1, 10).get("data");
+        assertEquals(1, noMatch.get("pageNumber").asInt(), noMatch.toString());
+        assertEquals(0, noMatch.get("totalCount").asInt(), noMatch.toString());
+        assertEquals(0, noMatch.get("pagesAvailable").asInt(), noMatch.toString());
+        assertEquals(0, noMatch.get("pageItems").size(), noMatch.toString());
+    }
+    
+    @Test
+    public void testListConfigInvalidPaginationReturnsBadRequest() throws Exception {
+        assertError(getRaw(ADMIN_CONFIG_LIST_PATH + "?search=blur&pageNo=0"), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(ADMIN_CONFIG_LIST_PATH + "?search=blur&pageSize=0"), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageSize");
+    }
+    
+    private JsonNode list(String dataId, String groupName, int pageNo, int pageSize) throws Exception {
+        return getJsonOk(ADMIN_CONFIG_LIST_PATH, listQuery(dataId, groupName, "", pageNo, pageSize));
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigListenerAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigListenerAdminApiOpenApiITCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests for config listener admin OpenAPIs.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: {@code /config/listener} returns config-scoped listener state and
+ *     {@code /listener} returns ip-scoped listener state with their documented {@code queryType} values.</li>
+ *     <li>Boundary/validation: omitted namespace uses public for config listener lookup, {@code aggregation=false},
+ *     {@code all=true}, and namespace filtering are accepted even when no listeners are registered.</li>
+ *     <li>Exception/error handling: required identity fields and required {@code ip} return HTTP 400 with the v3
+ *     {@code Result} error envelope instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigListenerAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testConfigListenerQueryReturnsConfigQueryType() throws Exception {
+        String dataId = randomDataId("listener");
+        String groupName = randomGroupName("listener");
+        publishConfig(dataId, groupName, "", "listener-content");
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+        
+        JsonNode defaultAggregation = getJsonOk(ADMIN_CONFIG_LISTENER_PATH,
+                configQuery(dataId, groupName, null)).get("data");
+        assertListenerInfo(defaultAggregation, "config");
+        assertEquals(0, defaultAggregation.get("listenersStatus").size(), defaultAggregation.toString());
+        
+        JsonNode noAggregation = getJsonOk(ADMIN_CONFIG_LISTENER_PATH,
+                configQuery(dataId, groupName, "").addParam("aggregation", "false")).get("data");
+        assertListenerInfo(noAggregation, "config");
+        assertEquals(0, noAggregation.get("listenersStatus").size(), noAggregation.toString());
+    }
+    
+    @Test
+    public void testIpListenerQueryAcceptsAllAndNamespaceFilter() throws Exception {
+        JsonNode defaultQuery = getJsonOk(ADMIN_LISTENER_PATH,
+                Query.newInstance().addParam("ip", "127.0.0.1")).get("data");
+        assertListenerInfo(defaultQuery, "ip");
+        
+        JsonNode allWithNamespace = getJsonOk(ADMIN_LISTENER_PATH,
+                Query.newInstance().addParam("ip", "127.0.0.1").addParam("all", "true")
+                        .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("aggregation", "false")).get("data");
+        assertListenerInfo(allWithNamespace, "ip");
+    }
+    
+    @Test
+    public void testListenerRequiredParametersReturnBadRequest() throws Exception {
+        String dataId = randomDataId("listener-required");
+        String groupName = randomGroupName("listener-required");
+        assertError(getRaw(ADMIN_CONFIG_LISTENER_PATH, Query.newInstance().addParam("groupName", groupName)),
+                400, ErrorCode.PARAMETER_MISSING, "dataId");
+        assertError(getRaw(ADMIN_CONFIG_LISTENER_PATH, Query.newInstance().addParam("dataId", dataId)),
+                400, ErrorCode.PARAMETER_MISSING, "groupName");
+        assertError(getRaw(ADMIN_LISTENER_PATH), 400, ErrorCode.PARAMETER_MISSING, "ip");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigMetricsAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigMetricsAdminApiOpenApiITCase.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for config metrics admin OpenAPIs under {@code /nacos/v3/admin/cs/metrics}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: local ip metrics returns a map and cluster metrics returns a map with
+ *     {@code complete} status for a dataId/groupName identity.</li>
+ *     <li>Boundary/validation: namespace is defaulted for valid calls, dataId/groupName are required by the runtime
+ *     parameter validator, and invalid namespace values are rejected.</li>
+ *     <li>Exception/error handling: missing required {@code ip}, missing config identity, and invalid namespace values
+ *     return HTTP 400 with the v3 {@code Result} error envelope instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigMetricsAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testLocalAndClusterMetricsReturnResultMaps() throws Exception {
+        Query metricQuery = Query.newInstance().addParam("ip", "127.0.0.1")
+                .addParam("dataId", randomDataId("metrics")).addParam("groupName", randomGroupName("metrics"));
+        JsonNode local = getJsonOk(ADMIN_METRICS_PATH + "/ip",
+                metricQuery).get("data");
+        assertTrue(local.isObject(), local.toString());
+        
+        JsonNode cluster = getJsonOk(ADMIN_METRICS_PATH + "/cluster",
+                metricQuery).get("data");
+        assertTrue(cluster.isObject(), cluster.toString());
+        assertTrue(cluster.has("complete"), cluster.toString());
+    }
+    
+    @Test
+    public void testMetricsValidationReturnsBadRequest() throws Exception {
+        assertError(getRaw(ADMIN_METRICS_PATH + "/ip"), 400, ErrorCode.PARAMETER_MISSING, "ip");
+        assertError(getRaw(ADMIN_METRICS_PATH + "/cluster"), 400, ErrorCode.PARAMETER_MISSING, "ip");
+        assertError(getRaw(ADMIN_METRICS_PATH + "/ip", Query.newInstance().addParam("ip", "127.0.0.1")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "dataId");
+        assertError(getRaw(ADMIN_METRICS_PATH + "/ip",
+                Query.newInstance().addParam("ip", "127.0.0.1").addParam("dataId", randomDataId("metrics-invalid"))
+                        .addParam("groupName", randomGroupName("metrics-invalid"))
+                        .addParam("namespaceId", "invalid namespace")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceId");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigOpsAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigOpsAdminApiOpenApiITCase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests for config ops admin OpenAPIs under {@code /nacos/v3/admin/cs/ops}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: local-cache dump trigger returns the v3 success envelope when the standalone server can
+ *     dump from store.</li>
+ *     <li>Boundary/validation: log level update requires both {@code logName} and {@code logLevel}, and Derby ops
+ *     requires {@code sql}. Derby import is intentionally not exercised because it mutates the embedded database from
+ *     an uploaded external dump.</li>
+ *     <li>Exception/error handling: missing required operation parameters return HTTP 400 with the v3 {@code Result}
+ *     error envelope instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigOpsAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
+    
+    @Test
+    public void testLocalCacheDumpReturnsSuccessEnvelope() throws Exception {
+        HttpResponse response = postRaw(ADMIN_OPS_PATH + "/localCache", Query.newInstance());
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        assertEquals("Local cache updated from store successfully!", root.get("data").asText(), root.toString());
+    }
+    
+    @Test
+    public void testOpsRequiredParametersReturnBadRequest() throws Exception {
+        assertError(putRaw(ADMIN_OPS_PATH + "/log", Query.newInstance().addParam("logLevel", "INFO")),
+                400, ErrorCode.PARAMETER_MISSING, "logName");
+        assertError(putRaw(ADMIN_OPS_PATH + "/log", Query.newInstance().addParam("logName", "config-server")),
+                400, ErrorCode.PARAMETER_MISSING, "logLevel");
+        assertError(getRaw(ADMIN_OPS_PATH + "/derby"), 400, ErrorCode.PARAMETER_MISSING, "sql");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreAdminApiBaseITCase.java
@@ -44,6 +44,9 @@ public abstract class CoreAdminApiBaseITCase extends OpenApiBaseITCase {
     protected static final String ADMIN_CORE_OPS_PATH =
             nacosPath(Commons.NACOS_ADMIN_CORE_CONTEXT_V3 + "/ops");
 
+    protected static final String ADMIN_CORE_STATE_PATH =
+            nacosPath(Commons.NACOS_ADMIN_CORE_CONTEXT_V3 + "/state");
+
     protected String randomNamespaceId(String scenario) {
         return "openapi_it_admin_" + scenario + "_" + UUID.randomUUID();
     }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreAdminApiBaseITCase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.core;
+
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.core.utils.Commons;
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
+
+import java.util.UUID;
+
+/**
+ * Shared helpers for core admin OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class CoreAdminApiBaseITCase extends OpenApiBaseITCase {
+
+    protected static final String ADMIN_CORE_NAMESPACE_PATH =
+            nacosPath(Commons.NACOS_ADMIN_CORE_CONTEXT_V3 + "/namespace");
+
+    protected static final String ADMIN_CORE_CLUSTER_PATH =
+            nacosPath(Commons.NACOS_ADMIN_CORE_CONTEXT_V3 + "/cluster");
+
+    protected static final String ADMIN_CORE_PLUGIN_PATH =
+            nacosPath(Commons.NACOS_ADMIN_CORE_CONTEXT_V3 + "/plugin");
+
+    protected static final String ADMIN_CORE_LOADER_PATH =
+            nacosPath(Commons.NACOS_ADMIN_CORE_CONTEXT_V3 + "/loader");
+
+    protected static final String ADMIN_CORE_OPS_PATH =
+            nacosPath(Commons.NACOS_ADMIN_CORE_CONTEXT_V3 + "/ops");
+
+    protected String randomNamespaceId(String scenario) {
+        return "openapi_it_admin_" + scenario + "_" + UUID.randomUUID();
+    }
+
+    protected Query namespaceQuery(String namespaceId, String namespaceName, String namespaceDesc) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "namespaceId", namespaceId);
+        addIfNotBlank(query, "namespaceName", namespaceName);
+        addIfNotBlank(query, "namespaceDesc", namespaceDesc);
+        return query;
+    }
+
+    protected void deleteNamespaceQuietly(String namespaceId) throws Exception {
+        deleteQuietly(ADMIN_CORE_NAMESPACE_PATH, Query.newInstance().addParam("namespaceId", namespaceId));
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreClusterAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreClusterAdminApiOpenApiITCase.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.core;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for core cluster admin OpenAPI {@code /nacos/v3/admin/core/cluster}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: self and node list expose current member state, and address/state filters preserve the
+ *     member view contract.</li>
+ *     <li>Boundary/validation: state filter is case-insensitive for legal values; illegal states, empty node-update
+ *     bodies, and missing lookup type are rejected.</li>
+ *     <li>Exception/error handling: topology mutation success paths are intentionally not executed because they alter
+ *     cluster membership; validation failures are verified to return controlled v3 error envelopes.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class CoreClusterAdminApiOpenApiITCase extends CoreAdminApiBaseITCase {
+
+    @Test
+    public void testSelfAndNodeListExposeCurrentMemberState() throws Exception {
+        JsonNode self = getJsonOk(ADMIN_CORE_CLUSTER_PATH + "/node/self", Query.newInstance()).get("data");
+        assertTrue(self.get("address").asText().contains(":"), self.toString());
+        assertTrue(self.get("state").asText().length() > 0, self.toString());
+
+        JsonNode allNodes = getJsonOk(ADMIN_CORE_CLUSTER_PATH + "/node/list", Query.newInstance()).get("data");
+        assertTrue(allNodes.size() >= 1, allNodes.toString());
+        assertFalse(findMember(allNodes, self.get("address").asText()).isMissingNode(), allNodes.toString());
+
+        JsonNode filteredByAddress = getJsonOk(ADMIN_CORE_CLUSTER_PATH + "/node/list",
+                Query.newInstance().addParam("address", self.get("address").asText())).get("data");
+        assertFalse(findMember(filteredByAddress, self.get("address").asText()).isMissingNode(),
+                filteredByAddress.toString());
+
+        JsonNode filteredByState = getJsonOk(ADMIN_CORE_CLUSTER_PATH + "/node/list",
+                Query.newInstance().addParam("state", self.get("state").asText().toLowerCase())).get("data");
+        assertFalse(findMember(filteredByState, self.get("address").asText()).isMissingNode(),
+                filteredByState.toString());
+    }
+
+    @Test
+    public void testClusterValidationReturnsBadRequest() throws Exception {
+        assertError(getRaw(ADMIN_CORE_CLUSTER_PATH + "/node/list",
+                Query.newInstance().addParam("state", "not-a-state")), 400,
+                ErrorCode.ILLEGAL_STATE, "not-a-state");
+        assertError(putJsonRaw(ADMIN_CORE_CLUSTER_PATH + "/node/list", Query.newInstance(), "[]"),
+                400, ErrorCode.PARAMETER_MISSING, "nodes");
+        assertError(putRaw(ADMIN_CORE_CLUSTER_PATH + "/lookup", Query.newInstance()),
+                400, ErrorCode.PARAMETER_MISSING, "type");
+    }
+
+    private JsonNode findMember(JsonNode members, String address) {
+        for (JsonNode each : members) {
+            if (address.equals(each.get("address").asText())) {
+                return each;
+            }
+        }
+        return com.fasterxml.jackson.databind.node.MissingNode.getInstance();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreOpsAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreOpsAdminApiOpenApiITCase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.core;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for core ops admin OpenAPI {@code /nacos/v3/admin/core/ops}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: id-generator diagnostics return a list shape, and runtime log-level update accepts a
+ *     valid JSON request.</li>
+ *     <li>Boundary/validation: raft maintenance requires {@code command}/{@code value}; log update requires
+ *     {@code logName}/{@code logLevel}. Raft success commands are intentionally not executed because they can affect CP
+ *     leadership, snapshots, or peers.</li>
+ *     <li>Exception/error handling: missing JSON-body fields return HTTP 400 with the v3 {@code Result} envelope.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class CoreOpsAdminApiOpenApiITCase extends CoreAdminApiBaseITCase {
+
+    @Test
+    public void testIdsAndLogUpdate() throws Exception {
+        JsonNode ids = getJsonOk(ADMIN_CORE_OPS_PATH + "/ids", Query.newInstance()).get("data");
+        assertTrue(ids.isArray(), ids.toString());
+        for (JsonNode each : ids) {
+            assertTrue(each.get("resource").asText().length() > 0, each.toString());
+            assertTrue(each.get("info").has("currentId"), each.toString());
+            assertTrue(each.get("info").has("workerId"), each.toString());
+        }
+
+        JsonNode logUpdate = putJsonOk(ADMIN_CORE_OPS_PATH + "/log", Query.newInstance(),
+                "{\"logName\":\"core\",\"logLevel\":\"INFO\"}");
+        assertEquals(0, logUpdate.get("code").asInt(), logUpdate.toString());
+    }
+
+    @Test
+    public void testCoreOpsValidationReturnsBadRequest() throws Exception {
+        assertError(postJsonRaw(ADMIN_CORE_OPS_PATH + "/raft", Query.newInstance(), "{}"),
+                400, ErrorCode.PARAMETER_MISSING, "Raft command");
+        assertError(postJsonRaw(ADMIN_CORE_OPS_PATH + "/raft", Query.newInstance(),
+                "{\"command\":\"doSnapshot\"}"), 400, ErrorCode.PARAMETER_MISSING,
+                "Raft command value");
+        assertError(putJsonRaw(ADMIN_CORE_OPS_PATH + "/log", Query.newInstance(), "{}"),
+                400, ErrorCode.PARAMETER_MISSING, "Log name");
+        assertError(putJsonRaw(ADMIN_CORE_OPS_PATH + "/log", Query.newInstance(),
+                "{\"logName\":\"core\"}"), 400, ErrorCode.PARAMETER_MISSING, "Log level");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreStateAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/CoreStateAdminApiOpenApiITCase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.core;
+
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for core state admin OpenAPI {@code /nacos/v3/admin/core/state}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: server state returns the deployed module-state map, liveness returns {@code ok}, and
+ *     readiness returns the standard v3 success envelope when the standalone server is ready.</li>
+ *     <li>Boundary/validation: the endpoints expose no required request parameters; an unexpected query parameter is
+ *     ignored by the state endpoint and must not change the response shape.</li>
+ *     <li>Exception/error handling: the readiness failure branch is not forced because it requires making the shared
+ *     standalone server unhealthy; this class verifies the healthy contract and Result shape for the deployed server.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class CoreStateAdminApiOpenApiITCase extends CoreAdminApiBaseITCase {
+
+    @Test
+    public void testServerStateLivenessAndReadiness() throws Exception {
+        JsonNode state = getJsonOk(ADMIN_CORE_STATE_PATH, Query.newInstance()).get("data");
+        assertTrue(state.isObject(), state.toString());
+        assertTrue(state.size() > 0, state.toString());
+
+        JsonNode stateWithUnexpectedQuery = getJsonOk(ADMIN_CORE_STATE_PATH,
+                Query.newInstance().addParam("unexpected", "ignored")).get("data");
+        assertTrue(stateWithUnexpectedQuery.isObject(), stateWithUnexpectedQuery.toString());
+
+        JsonNode liveness = getJsonOk(ADMIN_CORE_STATE_PATH + "/liveness", Query.newInstance());
+        assertEquals("ok", liveness.get("data").asText(), liveness.toString());
+
+        JsonNode readiness = getJsonOk(ADMIN_CORE_STATE_PATH + "/readiness", Query.newInstance());
+        assertEquals("ok", readiness.get("data").asText(), readiness.toString());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/NamespaceAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/NamespaceAdminApiOpenApiITCase.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.core;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Integration tests for core namespace admin OpenAPI {@code /nacos/v3/admin/core/namespace}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: create persists namespace metadata, detail/list/check expose the namespace, update
+ *     changes display metadata, and delete removes it.</li>
+ *     <li>Boundary/validation: explicit namespace ids are trimmed and limited to 128 characters; namespace names reject
+ *     reserved characters; {@code namespaceId} and {@code namespaceName} are required by the deployed form.</li>
+ *     <li>Exception/error handling: required-field and illegal namespace input return HTTP 400 with the v3
+ *     {@code Result} error envelope.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class NamespaceAdminApiOpenApiITCase extends CoreAdminApiBaseITCase {
+
+    @Test
+    public void testCreateDetailUpdateListCheckAndDeleteNamespace() throws Exception {
+        String namespaceId = randomNamespaceId("namespace");
+        postFormOk(ADMIN_CORE_NAMESPACE_PATH,
+                namespaceQuery(namespaceId, "openapi namespace", "created by openapi it"));
+        addCleanup(() -> deleteNamespaceQuietly(namespaceId));
+
+        JsonNode detail = getJsonOk(ADMIN_CORE_NAMESPACE_PATH,
+                Query.newInstance().addParam("namespaceId", namespaceId)).get("data");
+        assertEquals(namespaceId, detail.get("namespace").asText(), detail.toString());
+        assertEquals("openapi namespace", detail.get("namespaceShowName").asText(), detail.toString());
+        assertEquals("created by openapi it", detail.get("namespaceDesc").asText(), detail.toString());
+
+        JsonNode list = getJsonOk(ADMIN_CORE_NAMESPACE_PATH + "/list", Query.newInstance()).get("data");
+        assertFalse(findNamespace(list, namespaceId).isMissingNode(), list.toString());
+        JsonNode check = getJsonOk(ADMIN_CORE_NAMESPACE_PATH + "/check",
+                Query.newInstance().addParam("namespaceId", namespaceId)).get("data");
+        assertEquals(1, check.asInt(), check.toString());
+
+        JsonNode updated = putFormOk(ADMIN_CORE_NAMESPACE_PATH,
+                namespaceQuery(namespaceId, "openapi namespace updated", "updated by openapi it"));
+        assertEquals(true, updated.get("data").asBoolean(), updated.toString());
+        JsonNode updatedDetail = getJsonOk(ADMIN_CORE_NAMESPACE_PATH,
+                Query.newInstance().addParam("namespaceId", namespaceId)).get("data");
+        assertEquals("openapi namespace updated", updatedDetail.get("namespaceShowName").asText(),
+                updatedDetail.toString());
+        assertEquals("updated by openapi it", updatedDetail.get("namespaceDesc").asText(),
+                updatedDetail.toString());
+
+        JsonNode deleted = deleteJsonOk(ADMIN_CORE_NAMESPACE_PATH,
+                Query.newInstance().addParam("namespaceId", namespaceId));
+        assertEquals(true, deleted.get("data").asBoolean(), deleted.toString());
+        JsonNode checkAfterDelete = getJsonOk(ADMIN_CORE_NAMESPACE_PATH + "/check",
+                Query.newInstance().addParam("namespaceId", namespaceId)).get("data");
+        assertEquals(0, checkAfterDelete.asInt(), checkAfterDelete.toString());
+    }
+
+    @Test
+    public void testNamespaceValidationReturnsBadRequest() throws Exception {
+        assertError(postRaw(ADMIN_CORE_NAMESPACE_PATH,
+                Query.newInstance().addParam("namespaceName", "missing id")), 400,
+                ErrorCode.PARAMETER_MISSING, "namespaceId");
+        assertError(postRaw(ADMIN_CORE_NAMESPACE_PATH,
+                Query.newInstance().addParam("namespaceId", randomNamespaceId("missing-name"))),
+                400, ErrorCode.PARAMETER_MISSING, "namespaceName");
+        assertError(postRaw(ADMIN_CORE_NAMESPACE_PATH,
+                namespaceQuery(randomNamespaceId("bad-name"), "bad@name", "bad")), 400,
+                ErrorCode.ILLEGAL_NAMESPACE, "namespaceName");
+        assertError(postRaw(ADMIN_CORE_NAMESPACE_PATH,
+                namespaceQuery("n".repeat(129), "too long", "bad")), 400,
+                ErrorCode.ILLEGAL_NAMESPACE, "too long namespaceId");
+    }
+
+    private JsonNode findNamespace(JsonNode namespaces, String namespaceId) {
+        for (JsonNode each : namespaces) {
+            if (namespaceId.equals(each.get("namespace").asText())) {
+                return each;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/PluginAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/PluginAdminApiOpenApiITCase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.core;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for core plugin admin OpenAPI {@code /nacos/v3/admin/core/plugin}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: plugin list exposes discovered plugin inventory, pluginType filters narrow results, and
+ *     plugin detail returns the same identity plus mutable-state fields.</li>
+ *     <li>Boundary/validation: unknown pluginType filters return an empty list; missing plugin detail is reported as
+ *     not found.</li>
+ *     <li>Exception/error handling: plugin state/config mutation success paths are intentionally not executed because
+ *     they change runtime extension state; detail not-found is verified as a controlled RESOURCE_NOT_FOUND response.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class PluginAdminApiOpenApiITCase extends CoreAdminApiBaseITCase {
+
+    @Test
+    public void testListFilterAndDetailPluginInventory() throws Exception {
+        JsonNode plugins = getJsonOk(ADMIN_CORE_PLUGIN_PATH + "/list", Query.newInstance()).get("data");
+        assertTrue(plugins.size() > 0, plugins.toString());
+
+        JsonNode plugin = plugins.get(0);
+        assertTrue(plugin.get("pluginId").asText().contains(":"), plugin.toString());
+        assertTrue(plugin.get("pluginType").asText().length() > 0, plugin.toString());
+        assertTrue(plugin.get("pluginName").asText().length() > 0, plugin.toString());
+
+        JsonNode filtered = getJsonOk(ADMIN_CORE_PLUGIN_PATH + "/list",
+                Query.newInstance().addParam("pluginType", plugin.get("pluginType").asText())).get("data");
+        assertTrue(filtered.size() > 0, filtered.toString());
+        for (JsonNode each : filtered) {
+            assertEquals(plugin.get("pluginType").asText(), each.get("pluginType").asText(), each.toString());
+        }
+
+        JsonNode detail = getJsonOk(ADMIN_CORE_PLUGIN_PATH + "/detail",
+                Query.newInstance().addParam("pluginType", plugin.get("pluginType").asText())
+                        .addParam("pluginName", plugin.get("pluginName").asText())).get("data");
+        assertEquals(plugin.get("pluginId").asText(), detail.get("pluginId").asText(), detail.toString());
+        assertEquals(plugin.get("pluginType").asText(), detail.get("pluginType").asText(), detail.toString());
+        assertEquals(plugin.get("pluginName").asText(), detail.get("pluginName").asText(), detail.toString());
+        assertTrue(detail.has("enabled"), detail.toString());
+        assertTrue(detail.has("configurable"), detail.toString());
+
+        JsonNode unknownType = getJsonOk(ADMIN_CORE_PLUGIN_PATH + "/list",
+                Query.newInstance().addParam("pluginType", "not-a-plugin-type")).get("data");
+        assertEquals(0, unknownType.size(), unknownType.toString());
+    }
+
+    @Test
+    public void testPluginDetailNotFoundReturnsControlledError() throws Exception {
+        assertError(getRaw(ADMIN_CORE_PLUGIN_PATH + "/detail",
+                Query.newInstance().addParam("pluginType", "auth").addParam("pluginName", "missing-plugin")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "auth:missing-plugin");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/ServerLoaderAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/ServerLoaderAdminApiOpenApiITCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.core;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for core server-loader admin OpenAPI {@code /nacos/v3/admin/core/loader}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: current local connection map and cluster loader metrics return the v3 success envelope
+ *     and diagnostic shapes.</li>
+ *     <li>Boundary/validation: reload-by-count and reload-single-client require {@code count} and
+ *     {@code connectionId}; destructive connection rebalance success paths are intentionally not executed.</li>
+ *     <li>Exception/error handling: missing required parameters return controlled HTTP 400 errors instead of invoking
+ *     rebalance operations.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ServerLoaderAdminApiOpenApiITCase extends CoreAdminApiBaseITCase {
+
+    @Test
+    public void testCurrentClientsAndClusterMetrics() throws Exception {
+        JsonNode current = getJsonOk(ADMIN_CORE_LOADER_PATH + "/current", Query.newInstance()).get("data");
+        assertTrue(current.isObject(), current.toString());
+
+        JsonNode metrics = getJsonOk(ADMIN_CORE_LOADER_PATH + "/cluster", Query.newInstance()).get("data");
+        assertTrue(metrics.get("memberCount").asInt() >= 1, metrics.toString());
+        assertTrue(metrics.get("metricsCount").asInt() >= 0, metrics.toString());
+        assertTrue(metrics.get("total").asInt() >= 0, metrics.toString());
+        assertNotNull(metrics.get("detail"), metrics.toString());
+    }
+
+    @Test
+    public void testLoaderValidationReturnsBadRequest() throws Exception {
+        assertError(postRaw(ADMIN_CORE_LOADER_PATH + "/reloadCurrent", Query.newInstance()),
+                400, ErrorCode.PARAMETER_MISSING, "count");
+        assertError(postRaw(ADMIN_CORE_LOADER_PATH + "/reloadClient", Query.newInstance()),
+                400, ErrorCode.PARAMETER_MISSING, "connectionId");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/ClientAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/ClientAdminApiOpenApiITCase.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for naming client admin OpenAPI {@code /nacos/v3/admin/ns/client}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: an HTTP registered instance creates an ip:port client visible in client list/detail,
+ *     client publish list, service publisher list, empty subscribe lists, and distro responsible-server query.</li>
+ *     <li>Boundary/validation: service publisher/subscriber queries respect namespace/group isolation, omitted
+ *     namespace/group use public and DEFAULT_GROUP, optional ip/port filters narrow publisher results, and
+ *     {@code serviceName} is required for service-scoped queries.</li>
+ *     <li>Exception/error handling: missing clients return RESOURCE_NOT_FOUND with HTTP 404, and required-field
+ *     failures return HTTP 400 in the v3 {@code Result} envelope.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ClientAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
+
+    private static final String TEST_CLUSTER = "openapi-it-admin-client-cluster";
+
+    @Test
+    public void testClientDiagnosticsForRegisteredHttpInstance() throws Exception {
+        String serviceName = randomServiceName("client");
+        String groupName = randomGroupName("client");
+        String ip = "10.13.4.1";
+        int port = 19701;
+        String clientId = ip + ":" + port + "#true";
+
+        registerInstance(serviceName, groupName, DEFAULT_NAMESPACE, ip, port, TEST_CLUSTER,
+                "{\"scene\":\"client\"}", "1.0", "true", "true", "true");
+        addCleanup(() -> deleteServiceQuietly(serviceName, groupName, DEFAULT_NAMESPACE));
+        addCleanup(() -> deregisterInstanceQuietly(serviceName, groupName, DEFAULT_NAMESPACE, ip, port,
+                TEST_CLUSTER));
+
+        waitUntilInstanceVisible(serviceName, groupName, DEFAULT_NAMESPACE, TEST_CLUSTER, ip, port);
+        waitUntilClientVisible(clientId);
+
+        JsonNode detail = getJsonOk(ADMIN_CLIENT_PATH, Query.newInstance().addParam("clientId", clientId))
+                .get("data");
+        assertEquals(clientId, detail.get("clientId").asText(), detail.toString());
+        assertEquals("ipPort", detail.get("clientType").asText(), detail.toString());
+        assertTrue(detail.get("ephemeral").asBoolean(), detail.toString());
+
+        JsonNode publishedServices = getJsonOk(ADMIN_CLIENT_PATH + "/publish/list",
+                Query.newInstance().addParam("clientId", clientId)).get("data");
+        JsonNode publishedService = findClientService(publishedServices, serviceName, groupName);
+        assertFalse(publishedService.isMissingNode(), publishedServices.toString());
+        assertEquals(ip, publishedService.get("publisherInfo").get("ip").asText(), publishedService.toString());
+        assertEquals(port, publishedService.get("publisherInfo").get("port").asInt(), publishedService.toString());
+        assertEquals(TEST_CLUSTER, publishedService.get("publisherInfo").get("clusterName").asText(),
+                publishedService.toString());
+
+        JsonNode publishedClients = getJsonOk(ADMIN_CLIENT_PATH + "/service/publisher/list",
+                clientServiceQuery(serviceName, groupName, DEFAULT_NAMESPACE, ip, port)).get("data");
+        assertEquals(1, publishedClients.size(), publishedClients.toString());
+        assertEquals(clientId, publishedClients.get(0).get("clientId").asText(), publishedClients.toString());
+
+        JsonNode filteredOut = getJsonOk(ADMIN_CLIENT_PATH + "/service/publisher/list",
+                clientServiceQuery(serviceName, groupName, DEFAULT_NAMESPACE, ip, port + 1)).get("data");
+        assertEquals(0, filteredOut.size(), filteredOut.toString());
+        JsonNode defaultGroupPublishers = getJsonOk(ADMIN_CLIENT_PATH + "/service/publisher/list",
+                clientServiceQuery(serviceName, null, null, null, null)).get("data");
+        assertEquals(0, defaultGroupPublishers.size(), defaultGroupPublishers.toString());
+
+        JsonNode clientSubscribeList = getJsonOk(ADMIN_CLIENT_PATH + "/subscribe/list",
+                Query.newInstance().addParam("clientId", clientId)).get("data");
+        assertEquals(0, clientSubscribeList.size(), clientSubscribeList.toString());
+        JsonNode serviceSubscriberList = getJsonOk(ADMIN_CLIENT_PATH + "/service/subscriber/list",
+                clientServiceQuery(serviceName, groupName, DEFAULT_NAMESPACE, null, null)).get("data");
+        assertEquals(0, serviceSubscriberList.size(), serviceSubscriberList.toString());
+
+        JsonNode distro = getJsonOk(ADMIN_CLIENT_PATH + "/distro",
+                Query.newInstance().addParam("ip", ip).addParam("port", String.valueOf(port))).get("data");
+        assertTrue(distro.get("responsibleServer").asText().length() > 0, distro.toString());
+    }
+
+    @Test
+    public void testClientValidationAndNotFoundReturnControlledErrors() throws Exception {
+        assertError(getRaw(ADMIN_CLIENT_PATH, Query.newInstance().addParam("clientId", "missing-client")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "missing-client");
+        assertError(getRaw(ADMIN_CLIENT_PATH + "/publish/list",
+                Query.newInstance().addParam("clientId", "missing-client")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "missing-client");
+        assertError(getRaw(ADMIN_CLIENT_PATH + "/service/publisher/list", Query.newInstance()),
+                400, ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(getRaw(ADMIN_CLIENT_PATH + "/service/subscriber/list", Query.newInstance()),
+                400, ErrorCode.PARAMETER_MISSING, "serviceName");
+    }
+
+    private void waitUntilClientVisible(String clientId) throws Exception {
+        JsonNode clients = null;
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            clients = getJsonOk(ADMIN_CLIENT_PATH + "/list", Query.newInstance()).get("data");
+            for (JsonNode each : clients) {
+                if (clientId.equals(each.asText())) {
+                    return;
+                }
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected client to be visible, clientId=" + clientId + ", last clients="
+                + clients);
+    }
+
+    private JsonNode findClientService(JsonNode services, String serviceName, String groupName) {
+        for (JsonNode each : services) {
+            if (serviceName.equals(each.get("serviceName").asText())
+                    && groupName.equals(each.get("groupName").asText())) {
+                return each;
+            }
+        }
+        return com.fasterxml.jackson.databind.node.MissingNode.getInstance();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/ClusterAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/ClusterAdminApiOpenApiITCase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Integration tests for naming cluster admin OpenAPI {@code /nacos/v3/admin/ns/cluster}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: update persists cluster health-check port, checker type, instance-port policy, and
+ *     metadata, verified through service detail's cluster map after an instance has made the cluster visible in service
+ *     storage.</li>
+ *     <li>Boundary/validation: omitted namespace/group default to public and DEFAULT_GROUP; serviceName, clusterName,
+ *     checkPort, useInstancePort4Check, and healthChecker are required.</li>
+ *     <li>Exception/error handling: missing required fields and a non-existent owning service return controlled
+ *     failures instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ClusterAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
+    
+    private static final String TEST_CLUSTER = "openapi-it-admin-cluster";
+    
+    @Test
+    public void testUpdateClusterMetadataAndDefaultGroup() throws Exception {
+        String serviceName = randomServiceName("cluster");
+        String ip = "10.13.2.1";
+        int port = 19501;
+        
+        registerInstance(serviceName, null, null, ip, port, TEST_CLUSTER, "{\"scene\":\"cluster\"}",
+                "1.0", "true", "true", "true");
+        addCleanup(() -> deleteServiceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        addCleanup(() -> deregisterInstanceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port,
+                TEST_CLUSTER));
+        waitUntilInstanceVisible(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, ip, port);
+        
+        JsonNode root = putFormOk(ADMIN_CLUSTER_PATH, clusterQuery(serviceName, null, null, TEST_CLUSTER,
+                "18888", "false", "{\"type\":\"TCP\"}", "{\"zone\":\"hz\",\"owner\":\"it\"}"));
+        assertEquals("ok", root.get("data").asText(), root.toString());
+        
+        JsonNode cluster = waitUntilClusterMetadata(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER,
+                "zone", "hz");
+        assertEquals(TEST_CLUSTER, cluster.get("clusterName").asText(), cluster.toString());
+        assertEquals(18888, cluster.get("healthyCheckPort").asInt(), cluster.toString());
+        assertFalse(cluster.get("useInstancePortForCheck").asBoolean(), cluster.toString());
+        assertEquals("TCP", cluster.get("healthChecker").get("type").asText(), cluster.toString());
+        assertEquals("it", cluster.get("metadata").get("owner").asText(), cluster.toString());
+    }
+    
+    @Test
+    public void testClusterValidationReturnsBadRequest() throws Exception {
+        assertError(putRaw(ADMIN_CLUSTER_PATH, Query.newInstance().addParam("clusterName", TEST_CLUSTER)
+                .addParam("checkPort", "18889").addParam("useInstancePort4Check", "true")
+                .addParam("healthChecker", "{\"type\":\"TCP\"}")), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(putRaw(ADMIN_CLUSTER_PATH, clusterQuery(randomServiceName("missing-cluster"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, null, "18889", "true", "{\"type\":\"TCP\"}", null)),
+                400, ErrorCode.PARAMETER_MISSING, "clusterName");
+        assertError(putRaw(ADMIN_CLUSTER_PATH, clusterQuery(randomServiceName("missing-port"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, null, "true", "{\"type\":\"TCP\"}", null)),
+                400, ErrorCode.PARAMETER_MISSING, "checkPort");
+        assertError(putRaw(ADMIN_CLUSTER_PATH, clusterQuery(randomServiceName("missing-use-port"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, "18889", null, "{\"type\":\"TCP\"}", null)),
+                400, ErrorCode.PARAMETER_MISSING, "useInstancePort4Check");
+        assertError(putRaw(ADMIN_CLUSTER_PATH, clusterQuery(randomServiceName("missing-checker"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, "18889", "true", null, null)),
+                400, ErrorCode.PARAMETER_MISSING, "healthChecker");
+    }
+    
+    @Test
+    public void testUpdateClusterForMissingServiceReturnsControlledError() throws Exception {
+        assertError(putRaw(ADMIN_CLUSTER_PATH, clusterQuery(randomServiceName("missing-service"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, "18890", "true", "{\"type\":\"TCP\"}",
+                "{\"zone\":\"missing\"}")), 400, ErrorCode.SERVER_ERROR, "service not found");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/HealthAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/HealthAdminApiOpenApiITCase.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for naming health admin OpenAPI {@code /nacos/v3/admin/ns/health}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: checker discovery returns built-in checker types, and manual health update can change a
+ *     persistent instance when the owning cluster uses the NONE health checker.</li>
+ *     <li>Boundary/validation: omitted namespace/group/cluster default to public, DEFAULT_GROUP, and DEFAULT;
+ *     {@code healthy}, {@code serviceName}, {@code ip}, and {@code port} are required.</li>
+ *     <li>Exception/error handling: manual health update against a service without an eligible NONE checker returns a
+ *     controlled failure instead of silently changing ephemeral health state.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class HealthAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
+
+    private static final String TEST_CLUSTER = "openapi-it-admin-health-cluster";
+
+    @Test
+    public void testCheckersReturnBuiltInHealthCheckerTypes() throws Exception {
+        JsonNode data = getJsonOk(ADMIN_HEALTH_PATH + "/checkers", Query.newInstance()).get("data");
+        assertTrue(data.has("NONE"), data.toString());
+        assertTrue(data.has("TCP"), data.toString());
+        assertTrue(data.get("NONE").isObject(), data.toString());
+        assertTrue(data.get("TCP").isObject(), data.toString());
+    }
+
+    @Test
+    public void testUpdatePersistentInstanceHealthWhenClusterUsesNoneChecker() throws Exception {
+        String serviceName = randomServiceName("health");
+        String ip = "10.13.3.1";
+        int port = 19601;
+
+        createService(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, "{\"scene\":\"health\"}", "0.1");
+        addCleanup(() -> deleteServiceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        putFormOk(ADMIN_CLUSTER_PATH, clusterQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER,
+                "0", "true", "{\"type\":\"NONE\"}", "{\"health\":\"manual\"}"));
+        registerInstance(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port, TEST_CLUSTER,
+                "{\"scene\":\"health\"}", "1.0", "true", "true", "false");
+        addCleanup(() -> deregisterInstanceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port,
+                TEST_CLUSTER, "false"));
+
+        JsonNode registered = waitUntilInstanceVisible(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE,
+                TEST_CLUSTER, ip, port);
+        assertInstanceState(registered, 1.0D, true, true, false);
+
+        JsonNode updated = putFormOk(ADMIN_HEALTH_INSTANCE_PATH, healthQuery(serviceName, DEFAULT_GROUP,
+                DEFAULT_NAMESPACE, ip, port, TEST_CLUSTER, "false"));
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        JsonNode unhealthy = waitUntilInstanceHealthy(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE,
+                TEST_CLUSTER, ip, port, false);
+        assertInstanceState(unhealthy, 1.0D, false, true, false);
+
+        putFormOk(ADMIN_HEALTH_INSTANCE_PATH, healthQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip,
+                port, TEST_CLUSTER, "true"));
+        JsonNode healthy = waitUntilInstanceHealthy(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE,
+                TEST_CLUSTER, ip, port, true);
+        assertInstanceState(healthy, 1.0D, true, true, false);
+    }
+
+    @Test
+    public void testUpdateHealthValidationReturnsBadRequest() throws Exception {
+        assertError(putRaw(ADMIN_HEALTH_INSTANCE_PATH, instanceQuery(randomServiceName("missing-healthy"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, "10.13.3.2", 19602)), 400,
+                ErrorCode.PARAMETER_MISSING, "healthy");
+        assertError(putRaw(ADMIN_HEALTH_INSTANCE_PATH, Query.newInstance().addParam("healthy", "true")
+                .addParam("ip", "10.13.3.3").addParam("port", "19603")), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(putRaw(ADMIN_HEALTH_INSTANCE_PATH, Query.newInstance().addParam("healthy", "true")
+                .addParam("serviceName", randomServiceName("missing-ip")).addParam("port", "19604")),
+                400, ErrorCode.PARAMETER_MISSING, "ip");
+        assertError(putRaw(ADMIN_HEALTH_INSTANCE_PATH, Query.newInstance().addParam("healthy", "true")
+                .addParam("serviceName", randomServiceName("missing-port")).addParam("ip", "10.13.3.5")),
+                400, ErrorCode.PARAMETER_MISSING, "port");
+    }
+
+    @Test
+    public void testUpdateHealthWithoutManualCheckerReturnsControlledError() throws Exception {
+        String serviceName = randomServiceName("health-error");
+        String ip = "10.13.3.6";
+        int port = 19606;
+
+        registerInstance(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port, DEFAULT_CLUSTER,
+                "{\"scene\":\"health-error\"}", "1.0", "true", "true", "true");
+        addCleanup(() -> deleteServiceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        addCleanup(() -> deregisterInstanceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port));
+        waitUntilInstanceVisible(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, DEFAULT_CLUSTER, ip, port);
+
+        assertError(putRaw(ADMIN_HEALTH_INSTANCE_PATH, healthQuery(serviceName, DEFAULT_GROUP,
+                DEFAULT_NAMESPACE, ip, port, DEFAULT_CLUSTER, "false")), 400,
+                ErrorCode.SERVER_ERROR, "health check is still working");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/InstanceAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/InstanceAdminApiOpenApiITCase.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for naming instance admin OpenAPI {@code /nacos/v3/admin/ns/instance}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: register makes an instance visible through detail/list, full update and partial update
+ *     change operational metadata/weight/enabled fields, and delete removes the instance from the admin list.</li>
+ *     <li>Boundary/validation: omitted namespace/group/cluster default to public, DEFAULT_GROUP, and DEFAULT;
+ *     explicit group/cluster isolate list results; {@code healthyOnly} filters unhealthy instances; an absent cluster
+ *     filter returns a controlled 404; required {@code serviceName}, {@code ip}, and {@code port}, invalid weight, and
+ *     invalid cluster names are rejected.</li>
+ *     <li>Exception/error handling: querying a missing instance returns a controlled RESOURCE_NOT_FOUND envelope, and
+ *     registering an ephemeral instance into a persistent service is rejected instead of changing service type; the
+ *     current deployed contract wraps this runtime branch as SERVER_ERROR data with HTTP 400.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class InstanceAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
+    
+    private static final String TEST_CLUSTER = "openapi-it-admin-instance-cluster";
+    
+    @Test
+    public void testRegisterWithDefaultsDetailUpdatePartialUpdateAndDelete() throws Exception {
+        String serviceName = randomServiceName("instance");
+        String ip = "10.13.0.1";
+        int port = 19301;
+        
+        registerInstance(serviceName, null, null, ip, port, null, "{\"source\":\"admin-it\"}",
+                "2.5", "true", "true", "true");
+        addCleanup(() -> deleteServiceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        addCleanup(() -> deregisterInstanceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port));
+        
+        JsonNode registered = waitUntilInstanceVisible(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE,
+                DEFAULT_CLUSTER, ip, port);
+        assertInstance(registered, serviceName, DEFAULT_GROUP, ip, port, DEFAULT_CLUSTER, "source", "admin-it");
+        assertInstanceState(registered, 2.5D, true, true, true);
+        
+        JsonNode detail = getInstanceDetail(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port,
+                DEFAULT_CLUSTER);
+        assertInstance(detail, serviceName, DEFAULT_GROUP, ip, port, DEFAULT_CLUSTER, "source", "admin-it");
+        
+        updateInstance(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port, DEFAULT_CLUSTER,
+                "{\"source\":\"updated\",\"version\":\"full\"}", "3.5", null, "false", "true");
+        JsonNode updated = waitUntilInstanceMetadata(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE,
+                DEFAULT_CLUSTER, ip, port, "source", "updated");
+        assertInstance(updated, serviceName, DEFAULT_GROUP, ip, port, DEFAULT_CLUSTER, "source", "updated");
+        assertEquals("full", updated.get("metadata").get("version").asText(), updated.toString());
+        assertInstanceState(updated, 3.5D, true, false, true);
+        
+        partialUpdateInstance(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port, DEFAULT_CLUSTER,
+                "{\"source\":\"partial\"}", "4.5", "true");
+        JsonNode partialUpdated = waitUntilInstanceMetadata(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE,
+                DEFAULT_CLUSTER, ip, port, "source", "partial");
+        assertInstance(partialUpdated, serviceName, DEFAULT_GROUP, ip, port, DEFAULT_CLUSTER, "source",
+                "partial");
+        assertInstanceState(partialUpdated, 4.5D, true, true, true);
+        partialUpdated = waitUntilInstanceMetadataMissing(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE,
+                DEFAULT_CLUSTER, ip, port, "version");
+        assertInstanceState(partialUpdated, 4.5D, true, true, true);
+        
+        JsonNode deleted = deleteJsonOk(ADMIN_INSTANCE_PATH,
+                instanceQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port, DEFAULT_CLUSTER));
+        assertEquals("ok", deleted.get("data").asText(), deleted.toString());
+        waitUntilInstanceAbsent(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, DEFAULT_CLUSTER, ip, port);
+    }
+    
+    @Test
+    public void testListFiltersByClusterAndHealthyOnly() throws Exception {
+        String serviceName = randomServiceName("instance-list");
+        String groupName = randomGroupName("instance-list");
+        String healthyIp = "10.13.0.2";
+        String unhealthyIp = "10.13.0.3";
+        int healthyPort = 19302;
+        int unhealthyPort = 19303;
+        
+        registerInstance(serviceName, groupName, DEFAULT_NAMESPACE, healthyIp, healthyPort, TEST_CLUSTER,
+                "{\"role\":\"healthy\"}", "1.0", "true", "true", "true");
+        registerInstance(serviceName, groupName, DEFAULT_NAMESPACE, unhealthyIp, unhealthyPort, TEST_CLUSTER,
+                "{\"role\":\"unhealthy\"}", "1.0", "false", "true", "true");
+        addCleanup(() -> deleteServiceQuietly(serviceName, groupName, DEFAULT_NAMESPACE));
+        addCleanup(() -> deregisterInstanceQuietly(serviceName, groupName, DEFAULT_NAMESPACE, healthyIp,
+                healthyPort, TEST_CLUSTER));
+        addCleanup(() -> deregisterInstanceQuietly(serviceName, groupName, DEFAULT_NAMESPACE, unhealthyIp,
+                unhealthyPort, TEST_CLUSTER));
+        
+        waitUntilInstanceVisible(serviceName, groupName, DEFAULT_NAMESPACE, TEST_CLUSTER, healthyIp, healthyPort);
+        waitUntilInstanceVisible(serviceName, groupName, DEFAULT_NAMESPACE, TEST_CLUSTER, unhealthyIp,
+                unhealthyPort);
+        
+        JsonNode all = listInstances(serviceName, groupName, DEFAULT_NAMESPACE, TEST_CLUSTER, "false");
+        assertFalse(findInstance(all, healthyIp, healthyPort).isMissingNode(), all.toString());
+        assertFalse(findInstance(all, unhealthyIp, unhealthyPort).isMissingNode(), all.toString());
+        
+        JsonNode healthyOnly = listInstances(serviceName, groupName, DEFAULT_NAMESPACE, TEST_CLUSTER, "true");
+        assertFalse(findInstance(healthyOnly, healthyIp, healthyPort).isMissingNode(), healthyOnly.toString());
+        assertTrue(findInstance(healthyOnly, unhealthyIp, unhealthyPort).isMissingNode(), healthyOnly.toString());
+        
+        assertError(getRaw(ADMIN_INSTANCE_LIST_PATH, instanceListQuery(serviceName, groupName,
+                DEFAULT_NAMESPACE, "other-cluster", "false")), 404, ErrorCode.SERVER_ERROR,
+                "cluster other-cluster is not found");
+    }
+    
+    @Test
+    public void testInstanceValidationReturnsBadRequest() throws Exception {
+        assertError(postRaw(ADMIN_INSTANCE_PATH, Query.newInstance().addParam("ip", "10.13.0.4")
+                .addParam("port", "19304")), 400, ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(postRaw(ADMIN_INSTANCE_PATH, Query.newInstance().addParam("serviceName",
+                randomServiceName("missing-ip")).addParam("port", "19305")), 400,
+                ErrorCode.PARAMETER_MISSING, "ip");
+        assertError(postRaw(ADMIN_INSTANCE_PATH, Query.newInstance().addParam("serviceName",
+                randomServiceName("missing-port")).addParam("ip", "10.13.0.6")), 400,
+                ErrorCode.PARAMETER_MISSING, "port");
+        assertError(postRaw(ADMIN_INSTANCE_PATH, instanceQuery(randomServiceName("bad-weight"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, "10.13.0.7", 19307).addParam("weight", "10001")),
+                400, ErrorCode.WEIGHT_ERROR, "weights range");
+        assertError(postRaw(ADMIN_INSTANCE_PATH, instanceQuery(randomServiceName("bad-cluster"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, "10.13.0.8", 19308, "cluster1,cluster2")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "cluster");
+        assertError(getRaw(ADMIN_INSTANCE_LIST_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+    }
+    
+    @Test
+    public void testMissingAndMismatchedInstanceReturnControlledErrors() throws Exception {
+        String missingServiceName = randomServiceName("missing-instance");
+        assertError(getRaw(ADMIN_INSTANCE_PATH, instanceQuery(missingServiceName, DEFAULT_GROUP,
+                DEFAULT_NAMESPACE, "10.13.0.9", 19309)), 404, ErrorCode.RESOURCE_NOT_FOUND,
+                "no ips found");
+        
+        String persistentServiceName = randomServiceName("persistent-service");
+        createService(persistentServiceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, "{\"type\":\"persistent\"}",
+                "0.1");
+        addCleanup(() -> deleteServiceQuietly(persistentServiceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        assertError(postRaw(ADMIN_INSTANCE_PATH, instanceQuery(persistentServiceName, DEFAULT_GROUP,
+                DEFAULT_NAMESPACE, "10.13.0.10", 19310).addParam("ephemeral", "true")),
+                400, ErrorCode.SERVER_ERROR, "persistent service");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/InstanceMetadataAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/InstanceMetadataAdminApiOpenApiITCase.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for naming instance metadata batch admin OpenAPI
+ * {@code /nacos/v3/admin/ns/instance/metadata/batch}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: batch update overlays operational metadata on all matching instances, and batch delete
+ *     removes selected metadata keys from selected instances while leaving other instances untouched.</li>
+ *     <li>Boundary/validation: omitted {@code instances} means all instances of the service; an instance selector
+ *     without {@code clusterName} defaults to DEFAULT; {@code serviceName} and {@code metadata} are required. The
+ *     controller's malformed-JSON no-op branch is not covered here because the deployed HTTP parameter extractor
+ *     rejects malformed {@code instances} before the controller is invoked.</li>
+ *     <li>Exception/error handling: required-field failures return HTTP 400 with the v3 {@code Result} envelope, and
+ *     required-field failures return HTTP 400 with the v3 {@code Result} envelope.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class InstanceMetadataAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
+    
+    @Test
+    public void testBatchUpdateAndDeleteInstanceMetadata() throws Exception {
+        String serviceName = randomServiceName("instance-metadata");
+        String groupName = randomGroupName("instance-metadata");
+        String firstIp = "10.13.1.1";
+        String secondIp = "10.13.1.2";
+        int firstPort = 19401;
+        int secondPort = 19402;
+        
+        registerInstance(serviceName, groupName, DEFAULT_NAMESPACE, firstIp, firstPort,
+                "{\"role\":\"first\"}", "1.0");
+        registerInstance(serviceName, groupName, DEFAULT_NAMESPACE, secondIp, secondPort,
+                "{\"role\":\"second\"}", "1.0");
+        addCleanup(() -> deleteServiceQuietly(serviceName, groupName, DEFAULT_NAMESPACE));
+        addCleanup(() -> deregisterInstanceQuietly(serviceName, groupName, DEFAULT_NAMESPACE, firstIp,
+                firstPort));
+        addCleanup(() -> deregisterInstanceQuietly(serviceName, groupName, DEFAULT_NAMESPACE, secondIp,
+                secondPort));
+        
+        waitUntilInstanceVisible(serviceName, groupName, DEFAULT_NAMESPACE, DEFAULT_CLUSTER, firstIp,
+                firstPort);
+        waitUntilInstanceVisible(serviceName, groupName, DEFAULT_NAMESPACE, DEFAULT_CLUSTER, secondIp,
+                secondPort);
+        
+        JsonNode updated = putFormOk(ADMIN_INSTANCE_METADATA_BATCH_PATH,
+                metadataBatchQuery(serviceName, groupName, DEFAULT_NAMESPACE, "{\"batch\":\"added\"}",
+                        null, "ephemeral"));
+        assertEquals(2, updated.get("data").get("updated").size(), updated.toString());
+        assertTrue(updated.get("data").get("updated").toString().contains(firstIp), updated.toString());
+        assertTrue(updated.get("data").get("updated").toString().contains(secondIp), updated.toString());
+        
+        JsonNode firstWithBatch = waitUntilInstanceMetadata(serviceName, groupName, DEFAULT_NAMESPACE,
+                DEFAULT_CLUSTER, firstIp, firstPort, "batch", "added");
+        JsonNode secondWithBatch = waitUntilInstanceMetadata(serviceName, groupName, DEFAULT_NAMESPACE,
+                DEFAULT_CLUSTER, secondIp, secondPort, "batch", "added");
+        assertEquals("added", firstWithBatch.get("metadata").get("batch").asText(), firstWithBatch.toString());
+        assertEquals("added", secondWithBatch.get("metadata").get("batch").asText(), secondWithBatch.toString());
+        
+        String selectedInstance = "[{\"ip\":\"" + firstIp + "\",\"port\":" + firstPort + "}]";
+        JsonNode deleted = deleteJsonOk(ADMIN_INSTANCE_METADATA_BATCH_PATH,
+                metadataBatchQuery(serviceName, groupName, DEFAULT_NAMESPACE, "{\"batch\":\"\"}",
+                        selectedInstance, "ephemeral"));
+        assertEquals(1, deleted.get("data").get("updated").size(), deleted.toString());
+        assertTrue(deleted.get("data").get("updated").toString().contains(firstIp), deleted.toString());
+        
+        JsonNode firstAfterDelete = waitUntilInstanceMetadataMissing(serviceName, groupName, DEFAULT_NAMESPACE,
+                DEFAULT_CLUSTER, firstIp, firstPort, "batch");
+        JsonNode secondAfterDelete = waitUntilInstanceMetadata(serviceName, groupName, DEFAULT_NAMESPACE,
+                DEFAULT_CLUSTER, secondIp, secondPort, "batch", "added");
+        assertFalse(firstAfterDelete.get("metadata").has("batch"), firstAfterDelete.toString());
+        assertEquals("added", secondAfterDelete.get("metadata").get("batch").asText(),
+                secondAfterDelete.toString());
+    }
+    
+    @Test
+    public void testBatchMetadataValidationReturnsBadRequest() throws Exception {
+        assertError(putRaw(ADMIN_INSTANCE_METADATA_BATCH_PATH,
+                Query.newInstance().addParam("metadata", "{\"batch\":\"missing-service\"}")),
+                400, ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(putRaw(ADMIN_INSTANCE_METADATA_BATCH_PATH,
+                Query.newInstance().addParam("serviceName", randomServiceName("missing-metadata"))),
+                400, ErrorCode.PARAMETER_MISSING, "metadata");
+        assertError(deleteRaw(ADMIN_INSTANCE_METADATA_BATCH_PATH,
+                Query.newInstance().addParam("metadata", "{\"batch\":\"missing-service\"}")),
+                400, ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(deleteRaw(ADMIN_INSTANCE_METADATA_BATCH_PATH,
+                Query.newInstance().addParam("serviceName", randomServiceName("missing-metadata"))),
+                400, ErrorCode.PARAMETER_MISSING, "metadata");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/NamingAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/NamingAdminApiBaseITCase.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.naming;
+
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.naming.misc.UtilsAndCommons;
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shared helpers for naming admin OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
+    
+    protected static final String ADMIN_SERVICE_PATH = nacosPath(UtilsAndCommons.SERVICE_CONTROLLER_V3_ADMIN_PATH);
+    
+    protected static final String ADMIN_INSTANCE_PATH = nacosPath(UtilsAndCommons.INSTANCE_CONTROLLER_V3_ADMIN_PATH);
+    
+    protected static final String ADMIN_CLUSTER_PATH = nacosPath(UtilsAndCommons.CLUSTER_CONTROLLER_V3_ADMIN_PATH);
+    
+    protected static final String DEFAULT_NAMESPACE = "public";
+    
+    protected static final String DEFAULT_GROUP = "DEFAULT_GROUP";
+    
+    protected static final String DEFAULT_CLUSTER = "DEFAULT";
+    
+    protected String randomServiceName(String scenario) {
+        return "openapi_it_admin_" + scenario + "_" + UUID.randomUUID();
+    }
+    
+    protected String randomGroupName(String scenario) {
+        return "openapi_it_group_" + scenario + "_" + UUID.randomUUID();
+    }
+    
+    protected Query serviceQuery(String serviceName, String groupName, String namespaceId) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "serviceName", serviceName);
+        addIfNotBlank(query, "groupName", groupName);
+        addIfNotBlank(query, "namespaceId", namespaceId);
+        return query;
+    }
+    
+    protected Query serviceListQuery(String serviceName, String groupName, String namespaceId,
+            int pageNo, int pageSize) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "serviceNameParam", serviceName);
+        addIfNotBlank(query, "groupNameParam", groupName);
+        addIfNotBlank(query, "namespaceId", namespaceId);
+        query.addParam("pageNo", String.valueOf(pageNo));
+        query.addParam("pageSize", String.valueOf(pageSize));
+        return query;
+    }
+    
+    protected JsonNode createService(String serviceName, String groupName, String namespaceId,
+            String metadata, String protectThreshold) throws Exception {
+        JsonNode root = postFormOk(ADMIN_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId)
+                .addParam("metadata", metadata).addParam("protectThreshold", protectThreshold)
+                .addParam("ephemeral", "false"));
+        assertEquals("ok", root.get("data").asText(), root.toString());
+        return root;
+    }
+    
+    protected JsonNode updateService(String serviceName, String groupName, String namespaceId,
+            String metadata, String protectThreshold) throws Exception {
+        JsonNode root = putFormOk(ADMIN_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId)
+                .addParam("metadata", metadata).addParam("protectThreshold", protectThreshold));
+        assertEquals("ok", root.get("data").asText(), root.toString());
+        return root;
+    }
+    
+    protected void deleteServiceQuietly(String serviceName, String groupName, String namespaceId) throws Exception {
+        deleteQuietly(ADMIN_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId));
+    }
+    
+    protected void assertServiceDetail(JsonNode data, String serviceName, String groupName, String namespaceId,
+            String metadataKey, String metadataValue) {
+        assertEquals(serviceName, data.get("serviceName").asText(), data.toString());
+        assertEquals(groupName, data.get("groupName").asText(), data.toString());
+        assertEquals(namespaceId, data.get("namespaceId").asText(), data.toString());
+        assertEquals(metadataValue, data.get("metadata").get(metadataKey).asText(), data.toString());
+        assertFalse(data.get("ephemeral").asBoolean(), data.toString());
+    }
+    
+    protected JsonNode findService(JsonNode page, String serviceName, String groupName) {
+        for (JsonNode item : page.get("pageItems")) {
+            if (serviceName.equals(item.get("name").asText())
+                    && groupName.equals(item.get("groupName").asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+    
+    protected void assertServiceListed(JsonNode page, String serviceName, String groupName) {
+        JsonNode service = findService(page, serviceName, groupName);
+        assertFalse(service.isMissingNode(), page.toString());
+        assertTrue(service.get("clusterCount").asInt() >= 0, service.toString());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/NamingAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/NamingAdminApiBaseITCase.java
@@ -48,6 +48,14 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
 
     protected static final String ADMIN_CLUSTER_PATH = nacosPath(UtilsAndCommons.CLUSTER_CONTROLLER_V3_ADMIN_PATH);
 
+    protected static final String ADMIN_HEALTH_PATH = nacosPath(UtilsAndCommons.HEALTH_CONTROLLER_V3_ADMIN_PATH);
+
+    protected static final String ADMIN_HEALTH_INSTANCE_PATH = ADMIN_HEALTH_PATH + "/instance";
+
+    protected static final String ADMIN_CLIENT_PATH = nacosPath(UtilsAndCommons.CLIENT_CONTROLLER_V3_ADMIN_PATH);
+
+    protected static final String ADMIN_OPERATOR_PATH = nacosPath(UtilsAndCommons.OPERATOR_CONTROLLER_V3_ADMIN_PATH);
+
     protected static final String DEFAULT_NAMESPACE = "public";
 
     protected static final String DEFAULT_GROUP = "DEFAULT_GROUP";
@@ -119,6 +127,31 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         addIfNotBlank(query, "useInstancePort4Check", useInstancePort4Check);
         addIfNotBlank(query, "healthChecker", healthChecker);
         addIfNotBlank(query, "metadata", metadata);
+        return query;
+    }
+
+    protected Query healthQuery(String serviceName, String groupName, String namespaceId, String ip, int port,
+            String clusterName, String healthy) {
+        Query query = instanceQuery(serviceName, groupName, namespaceId, ip, port, clusterName);
+        addIfNotBlank(query, "healthy", healthy);
+        return query;
+    }
+
+    protected Query clientServiceQuery(String serviceName, String groupName, String namespaceId, String ip,
+            Integer port) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        addIfNotBlank(query, "ip", ip);
+        if (null != port) {
+            query.addParam("port", String.valueOf(port));
+        }
+        return query;
+    }
+
+    protected Query switchQuery(String entry, String value, String debug) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "entry", entry);
+        addIfNotBlank(query, "value", value);
+        addIfNotBlank(query, "debug", debug);
         return query;
     }
 
@@ -195,7 +228,14 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
 
     protected void deregisterInstanceQuietly(String serviceName, String groupName, String namespaceId, String ip,
             int port, String clusterName) throws Exception {
-        deleteQuietly(ADMIN_INSTANCE_PATH, instanceQuery(serviceName, groupName, namespaceId, ip, port, clusterName));
+        deregisterInstanceQuietly(serviceName, groupName, namespaceId, ip, port, clusterName, null);
+    }
+
+    protected void deregisterInstanceQuietly(String serviceName, String groupName, String namespaceId, String ip,
+            int port, String clusterName, String ephemeral) throws Exception {
+        Query query = instanceQuery(serviceName, groupName, namespaceId, ip, port, clusterName);
+        addIfNotBlank(query, "ephemeral", ephemeral);
+        deleteQuietly(ADMIN_INSTANCE_PATH, query);
     }
 
     protected void assertServiceDetail(JsonNode data, String serviceName, String groupName, String namespaceId,
@@ -302,6 +342,20 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         }
         throw new AssertionError("Expected instance metadata " + metadataKey + " to be missing, last instance="
                 + instance);
+    }
+
+    protected JsonNode waitUntilInstanceHealthy(String serviceName, String groupName, String namespaceId,
+            String clusterName, String ip, int port, boolean healthy) throws Exception {
+        JsonNode instance = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            instance = getInstanceDetail(serviceName, groupName, namespaceId, ip, port, clusterName);
+            if (healthy == instance.path("healthy").asBoolean(!healthy)) {
+                return instance;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected instance healthy=" + healthy + ", last instance=" + instance);
     }
 
     protected void assertInstance(JsonNode instance, String serviceName, String groupName, String ip, int port,

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/NamingAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/NamingAdminApiBaseITCase.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 
+import java.util.concurrent.TimeUnit;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,27 +35,33 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author xiweng.yy
  */
 public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
-    
+
     protected static final String ADMIN_SERVICE_PATH = nacosPath(UtilsAndCommons.SERVICE_CONTROLLER_V3_ADMIN_PATH);
-    
+
     protected static final String ADMIN_INSTANCE_PATH = nacosPath(UtilsAndCommons.INSTANCE_CONTROLLER_V3_ADMIN_PATH);
-    
+
+    protected static final String ADMIN_INSTANCE_LIST_PATH = ADMIN_INSTANCE_PATH + "/list";
+
+    protected static final String ADMIN_INSTANCE_PARTIAL_PATH = ADMIN_INSTANCE_PATH + "/partial";
+
+    protected static final String ADMIN_INSTANCE_METADATA_BATCH_PATH = ADMIN_INSTANCE_PATH + "/metadata/batch";
+
     protected static final String ADMIN_CLUSTER_PATH = nacosPath(UtilsAndCommons.CLUSTER_CONTROLLER_V3_ADMIN_PATH);
-    
+
     protected static final String DEFAULT_NAMESPACE = "public";
-    
+
     protected static final String DEFAULT_GROUP = "DEFAULT_GROUP";
-    
+
     protected static final String DEFAULT_CLUSTER = "DEFAULT";
-    
+
     protected String randomServiceName(String scenario) {
         return "openapi_it_admin_" + scenario + "_" + UUID.randomUUID();
     }
-    
+
     protected String randomGroupName(String scenario) {
         return "openapi_it_group_" + scenario + "_" + UUID.randomUUID();
     }
-    
+
     protected Query serviceQuery(String serviceName, String groupName, String namespaceId) {
         Query query = Query.newInstance();
         addIfNotBlank(query, "serviceName", serviceName);
@@ -62,7 +69,7 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         addIfNotBlank(query, "namespaceId", namespaceId);
         return query;
     }
-    
+
     protected Query serviceListQuery(String serviceName, String groupName, String namespaceId,
             int pageNo, int pageSize) {
         Query query = Query.newInstance();
@@ -73,7 +80,48 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         query.addParam("pageSize", String.valueOf(pageSize));
         return query;
     }
-    
+
+    protected Query instanceQuery(String serviceName, String groupName, String namespaceId, String ip, int port) {
+        return instanceQuery(serviceName, groupName, namespaceId, ip, port, null);
+    }
+
+    protected Query instanceQuery(String serviceName, String groupName, String namespaceId, String ip, int port,
+            String clusterName) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        addIfNotBlank(query, "ip", ip);
+        query.addParam("port", String.valueOf(port));
+        addIfNotBlank(query, "clusterName", clusterName);
+        return query;
+    }
+
+    protected Query instanceListQuery(String serviceName, String groupName, String namespaceId, String clusterName,
+            String healthyOnly) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        addIfNotBlank(query, "clusterName", clusterName);
+        addIfNotBlank(query, "healthyOnly", healthyOnly);
+        return query;
+    }
+
+    protected Query metadataBatchQuery(String serviceName, String groupName, String namespaceId, String metadata,
+            String instances, String consistencyType) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        addIfNotBlank(query, "metadata", metadata);
+        addIfNotBlank(query, "instances", instances);
+        addIfNotBlank(query, "consistencyType", consistencyType);
+        return query;
+    }
+
+    protected Query clusterQuery(String serviceName, String groupName, String namespaceId, String clusterName,
+            String checkPort, String useInstancePort4Check, String healthChecker, String metadata) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        addIfNotBlank(query, "clusterName", clusterName);
+        addIfNotBlank(query, "checkPort", checkPort);
+        addIfNotBlank(query, "useInstancePort4Check", useInstancePort4Check);
+        addIfNotBlank(query, "healthChecker", healthChecker);
+        addIfNotBlank(query, "metadata", metadata);
+        return query;
+    }
+
     protected JsonNode createService(String serviceName, String groupName, String namespaceId,
             String metadata, String protectThreshold) throws Exception {
         JsonNode root = postFormOk(ADMIN_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId)
@@ -82,7 +130,7 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         assertEquals("ok", root.get("data").asText(), root.toString());
         return root;
     }
-    
+
     protected JsonNode updateService(String serviceName, String groupName, String namespaceId,
             String metadata, String protectThreshold) throws Exception {
         JsonNode root = putFormOk(ADMIN_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId)
@@ -90,11 +138,66 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         assertEquals("ok", root.get("data").asText(), root.toString());
         return root;
     }
-    
+
     protected void deleteServiceQuietly(String serviceName, String groupName, String namespaceId) throws Exception {
         deleteQuietly(ADMIN_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId));
     }
-    
+
+    protected JsonNode registerInstance(String serviceName, String groupName, String namespaceId, String ip,
+            int port, String metadata, String weight) throws Exception {
+        return registerInstance(serviceName, groupName, namespaceId, ip, port, DEFAULT_CLUSTER, metadata,
+                weight, null, null, "true");
+    }
+
+    protected JsonNode registerInstance(String serviceName, String groupName, String namespaceId, String ip,
+            int port, String clusterName, String metadata, String weight, String healthy, String enabled,
+            String ephemeral) throws Exception {
+        Query query = instanceQuery(serviceName, groupName, namespaceId, ip, port, clusterName);
+        addIfNotBlank(query, "metadata", metadata);
+        addIfNotBlank(query, "weight", weight);
+        addIfNotBlank(query, "healthy", healthy);
+        addIfNotBlank(query, "enabled", enabled);
+        addIfNotBlank(query, "ephemeral", ephemeral);
+        JsonNode root = postFormOk(ADMIN_INSTANCE_PATH, query);
+        assertEquals("ok", root.get("data").asText(), root.toString());
+        return root;
+    }
+
+    protected JsonNode updateInstance(String serviceName, String groupName, String namespaceId, String ip,
+            int port, String clusterName, String metadata, String weight, String healthy, String enabled,
+            String ephemeral) throws Exception {
+        Query query = instanceQuery(serviceName, groupName, namespaceId, ip, port, clusterName);
+        addIfNotBlank(query, "metadata", metadata);
+        addIfNotBlank(query, "weight", weight);
+        addIfNotBlank(query, "healthy", healthy);
+        addIfNotBlank(query, "enabled", enabled);
+        addIfNotBlank(query, "ephemeral", ephemeral);
+        JsonNode root = putFormOk(ADMIN_INSTANCE_PATH, query);
+        assertEquals("ok", root.get("data").asText(), root.toString());
+        return root;
+    }
+
+    protected JsonNode partialUpdateInstance(String serviceName, String groupName, String namespaceId, String ip,
+            int port, String clusterName, String metadata, String weight, String enabled) throws Exception {
+        Query query = instanceQuery(serviceName, groupName, namespaceId, ip, port, clusterName);
+        addIfNotBlank(query, "metadata", metadata);
+        addIfNotBlank(query, "weight", weight);
+        addIfNotBlank(query, "enabled", enabled);
+        JsonNode root = putFormOk(ADMIN_INSTANCE_PARTIAL_PATH, query);
+        assertEquals("ok", root.get("data").asText(), root.toString());
+        return root;
+    }
+
+    protected void deregisterInstanceQuietly(String serviceName, String groupName, String namespaceId, String ip,
+            int port) throws Exception {
+        deregisterInstanceQuietly(serviceName, groupName, namespaceId, ip, port, DEFAULT_CLUSTER);
+    }
+
+    protected void deregisterInstanceQuietly(String serviceName, String groupName, String namespaceId, String ip,
+            int port, String clusterName) throws Exception {
+        deleteQuietly(ADMIN_INSTANCE_PATH, instanceQuery(serviceName, groupName, namespaceId, ip, port, clusterName));
+    }
+
     protected void assertServiceDetail(JsonNode data, String serviceName, String groupName, String namespaceId,
             String metadataKey, String metadataValue) {
         assertEquals(serviceName, data.get("serviceName").asText(), data.toString());
@@ -103,7 +206,7 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         assertEquals(metadataValue, data.get("metadata").get(metadataKey).asText(), data.toString());
         assertFalse(data.get("ephemeral").asBoolean(), data.toString());
     }
-    
+
     protected JsonNode findService(JsonNode page, String serviceName, String groupName) {
         for (JsonNode item : page.get("pageItems")) {
             if (serviceName.equals(item.get("name").asText())
@@ -113,10 +216,126 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         }
         return MissingNode.getInstance();
     }
-    
+
     protected void assertServiceListed(JsonNode page, String serviceName, String groupName) {
         JsonNode service = findService(page, serviceName, groupName);
         assertFalse(service.isMissingNode(), page.toString());
         assertTrue(service.get("clusterCount").asInt() >= 0, service.toString());
+    }
+
+    protected JsonNode getInstanceDetail(String serviceName, String groupName, String namespaceId, String ip,
+            int port, String clusterName) throws Exception {
+        return getJsonOk(ADMIN_INSTANCE_PATH, instanceQuery(serviceName, groupName, namespaceId, ip, port,
+                clusterName)).get("data");
+    }
+
+    protected JsonNode listInstances(String serviceName, String groupName, String namespaceId, String clusterName,
+            String healthyOnly) throws Exception {
+        return getJsonOk(ADMIN_INSTANCE_LIST_PATH, instanceListQuery(serviceName, groupName, namespaceId,
+                clusterName, healthyOnly)).get("data");
+    }
+
+    protected JsonNode findInstance(JsonNode instances, String ip, int port) {
+        for (JsonNode each : instances) {
+            if (ip.equals(each.get("ip").asText()) && port == each.get("port").asInt()) {
+                return each;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+
+    protected JsonNode waitUntilInstanceVisible(String serviceName, String groupName, String namespaceId,
+            String clusterName, String ip, int port) throws Exception {
+        JsonNode listed = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            listed = listInstances(serviceName, groupName, namespaceId, null, null);
+            JsonNode instance = findInstance(listed, ip, port);
+            if (!instance.isMissingNode()) {
+                return instance;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected registered instance to be visible, last result=" + listed);
+    }
+
+    protected void waitUntilInstanceAbsent(String serviceName, String groupName, String namespaceId,
+            String clusterName, String ip, int port) throws Exception {
+        JsonNode listed = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            listed = listInstances(serviceName, groupName, namespaceId, null, null);
+            if (findInstance(listed, ip, port).isMissingNode()) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected deregistered instance to be absent, last result=" + listed);
+    }
+
+    protected JsonNode waitUntilInstanceMetadata(String serviceName, String groupName, String namespaceId,
+            String clusterName, String ip, int port, String metadataKey, String expectedValue) throws Exception {
+        JsonNode instance = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            instance = getInstanceDetail(serviceName, groupName, namespaceId, ip, port, clusterName);
+            JsonNode metadata = instance.path("metadata");
+            if (expectedValue.equals(metadata.path(metadataKey).asText(null))) {
+                return instance;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected instance metadata " + metadataKey + "=" + expectedValue
+                + ", last instance=" + instance);
+    }
+
+    protected JsonNode waitUntilInstanceMetadataMissing(String serviceName, String groupName, String namespaceId,
+            String clusterName, String ip, int port, String metadataKey) throws Exception {
+        JsonNode instance = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            instance = getInstanceDetail(serviceName, groupName, namespaceId, ip, port, clusterName);
+            if (!instance.path("metadata").has(metadataKey)) {
+                return instance;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected instance metadata " + metadataKey + " to be missing, last instance="
+                + instance);
+    }
+
+    protected void assertInstance(JsonNode instance, String serviceName, String groupName, String ip, int port,
+            String clusterName, String metadataKey, String metadataValue) {
+        assertEquals(groupName + "@@" + serviceName, instance.get("serviceName").asText(), instance.toString());
+        assertEquals(ip, instance.get("ip").asText(), instance.toString());
+        assertEquals(port, instance.get("port").asInt(), instance.toString());
+        assertEquals(clusterName, instance.get("clusterName").asText(), instance.toString());
+        if (null != metadataKey) {
+            assertEquals(metadataValue, instance.get("metadata").get(metadataKey).asText(), instance.toString());
+        }
+    }
+
+    protected void assertInstanceState(JsonNode instance, double weight, boolean healthy, boolean enabled,
+            boolean ephemeral) {
+        assertEquals(weight, instance.get("weight").asDouble(), 0.0001D, instance.toString());
+        assertEquals(healthy, instance.get("healthy").asBoolean(), instance.toString());
+        assertEquals(enabled, instance.get("enabled").asBoolean(), instance.toString());
+        assertEquals(ephemeral, instance.get("ephemeral").asBoolean(), instance.toString());
+    }
+
+    protected JsonNode waitUntilClusterMetadata(String serviceName, String groupName, String namespaceId,
+            String clusterName, String metadataKey, String metadataValue) throws Exception {
+        JsonNode detail = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            detail = getJsonOk(ADMIN_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId)).get("data");
+            JsonNode cluster = detail.path("clusterMap").path(clusterName);
+            if (!cluster.isMissingNode()
+                    && metadataValue.equals(cluster.path("metadata").path(metadataKey).asText(null))) {
+                return cluster;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected cluster metadata to be visible, last service detail=" + detail);
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/OperatorAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/OperatorAdminApiOpenApiITCase.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for naming operator admin OpenAPI {@code /nacos/v3/admin/ns/ops}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: switches can be queried and updated with debug mode, metrics returns status-only and
+ *     full diagnostic shapes, and log-level update returns the standard success envelope.</li>
+ *     <li>Boundary/validation: metrics defaults to {@code onlyStatus=true}; {@code entry}/{@code value} are required
+ *     for switch updates; debug switch update is restored during cleanup.</li>
+ *     <li>Exception/error handling: invalid switch values are converted into a controlled SERVER_ERROR response rather
+ *     than an unwrapped exception.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class OperatorAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
+
+    private static final String SWITCHES_PATH = ADMIN_OPERATOR_PATH + "/switches";
+
+    private static final String METRICS_PATH = ADMIN_OPERATOR_PATH + "/metrics";
+
+    private static final String LOG_PATH = ADMIN_OPERATOR_PATH + "/log";
+
+    @Test
+    public void testSwitchesMetricsAndLogLevelOperations() throws Exception {
+        JsonNode switches = getJsonOk(SWITCHES_PATH, Query.newInstance()).get("data");
+        assertEquals("00-00---000-NACOS_SWITCH_DOMAIN-000---00-00", switches.get("name").asText(),
+                switches.toString());
+        assertTrue(switches.has("lightBeatEnabled"), switches.toString());
+        boolean originalLightBeatEnabled = switches.get("lightBeatEnabled").asBoolean();
+        addCleanup(() -> putFormOk(SWITCHES_PATH, switchQuery("lightBeatEnabled",
+                String.valueOf(originalLightBeatEnabled), "true")));
+
+        JsonNode switchUpdate = putFormOk(SWITCHES_PATH, switchQuery("lightBeatEnabled",
+                String.valueOf(!originalLightBeatEnabled), "true"));
+        assertEquals("ok", switchUpdate.get("data").asText(), switchUpdate.toString());
+        JsonNode updatedSwitches = getJsonOk(SWITCHES_PATH, Query.newInstance()).get("data");
+        assertEquals(!originalLightBeatEnabled, updatedSwitches.get("lightBeatEnabled").asBoolean(),
+                updatedSwitches.toString());
+
+        JsonNode defaultMetrics = getJsonOk(METRICS_PATH, Query.newInstance()).get("data");
+        assertTrue(defaultMetrics.get("status").asText().length() > 0, defaultMetrics.toString());
+        assertFalse(defaultMetrics.has("clientCount"), defaultMetrics.toString());
+
+        JsonNode fullMetrics = getJsonOk(METRICS_PATH,
+                Query.newInstance().addParam("onlyStatus", "false")).get("data");
+        assertTrue(fullMetrics.get("status").asText().length() > 0, fullMetrics.toString());
+        assertTrue(fullMetrics.get("clientCount").asInt() >= 0, fullMetrics.toString());
+        assertTrue(fullMetrics.get("serviceCount").asInt() >= 0, fullMetrics.toString());
+
+        JsonNode logUpdate = putFormOk(LOG_PATH, Query.newInstance().addParam("logName", "naming-main")
+                .addParam("logLevel", "INFO"));
+        assertEquals("ok", logUpdate.get("data").asText(), logUpdate.toString());
+    }
+
+    @Test
+    public void testOperatorValidationReturnsBadRequestAndControlledServerError() throws Exception {
+        assertError(putRaw(SWITCHES_PATH, Query.newInstance().addParam("value", "true")),
+                400, ErrorCode.PARAMETER_MISSING, "entry");
+        assertError(putRaw(SWITCHES_PATH, Query.newInstance().addParam("entry", "lightBeatEnabled")),
+                400, ErrorCode.PARAMETER_MISSING, "value");
+        assertError(putRaw(SWITCHES_PATH, switchQuery("distroThreshold", "-1", "true")),
+                500, ErrorCode.SERVER_ERROR, "distroThreshold");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/ServiceAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/ServiceAdminApiOpenApiITCase.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests for naming service admin OpenAPI {@code /nacos/v3/admin/ns/service}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: create persists a service, detail returns metadata/default namespace/group/ephemeral
+ *     fields, update changes service metadata, list can find the service by {@code serviceNameParam}/{@code
+ *     groupNameParam}, and delete removes it from the list.</li>
+ *     <li>Boundary/validation: omitted namespace and group default to public and DEFAULT_GROUP; service list requires
+ *     positive pagination values; {@code serviceName} is required for create/detail/update/delete.</li>
+ *     <li>Exception/error handling: missing required fields and invalid pagination return HTTP 400 with the v3
+ *     {@code Result} error envelope instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ServiceAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
+    
+    @Test
+    public void testCreateDetailUpdateListAndDeleteService() throws Exception {
+        String serviceName = randomServiceName("service");
+        createService(serviceName, "", null, "{\"env\":\"it\"}", "0.4");
+        addCleanup(() -> deleteServiceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        
+        JsonNode created = getJsonOk(ADMIN_SERVICE_PATH,
+                serviceQuery(serviceName, null, null)).get("data");
+        assertServiceDetail(created, serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, "env", "it");
+        assertEquals(0.4F, created.get("protectThreshold").floatValue(), 0.001F, created.toString());
+        
+        updateService(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, "{\"env\":\"updated\"}", "0.6");
+        JsonNode updated = getJsonOk(ADMIN_SERVICE_PATH,
+                serviceQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE)).get("data");
+        assertServiceDetail(updated, serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, "env", "updated");
+        assertEquals(0.6F, updated.get("protectThreshold").floatValue(), 0.001F, updated.toString());
+        
+        JsonNode listed = getJsonOk(ADMIN_SERVICE_PATH + "/list",
+                serviceListQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, 1, 10)).get("data");
+        assertEquals(1, listed.get("pageNumber").asInt(), listed.toString());
+        assertServiceListed(listed, serviceName, DEFAULT_GROUP);
+        
+        JsonNode deleted = deleteJsonOk(ADMIN_SERVICE_PATH,
+                serviceQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        assertEquals("ok", deleted.get("data").asText(), deleted.toString());
+        JsonNode afterDelete = getJsonOk(ADMIN_SERVICE_PATH + "/list",
+                serviceListQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, 1, 10)).get("data");
+        assertEquals(0, afterDelete.get("totalCount").asInt(), afterDelete.toString());
+    }
+    
+    @Test
+    public void testServiceValidationReturnsBadRequest() throws Exception {
+        assertError(postRaw(ADMIN_SERVICE_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(getRaw(ADMIN_SERVICE_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(putRaw(ADMIN_SERVICE_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(deleteRaw(ADMIN_SERVICE_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(getRaw(ADMIN_SERVICE_PATH + "/list",
+                serviceListQuery(randomServiceName("service-page"), DEFAULT_GROUP, DEFAULT_NAMESPACE, 0, 10)),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
@@ -16,9 +16,14 @@
 
 package com.alibaba.nacos.test.openapi;
 
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
+import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -35,7 +40,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Shared standalone-server OpenAPI integration test infrastructure.
@@ -116,6 +127,76 @@ public abstract class OpenApiBaseITCase {
         return executeRaw(new HttpDelete(url(path + "?" + query.toQueryUrl())));
     }
     
+    protected JsonNode getJsonOk(String path, Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.get(url(path), Header.EMPTY, query, String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
+                + restResult.getData() + ", message=" + restResult.getMessage());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+
+    protected JsonNode postFormOk(String path, Map<String, String> form) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), Header.EMPTY, form, String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
+                + restResult.getData() + ", message=" + restResult.getMessage());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+
+    protected JsonNode postFormOk(String path, Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), Header.EMPTY, query,
+                Collections.emptyMap(), String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
+                + restResult.getData() + ", message=" + restResult.getMessage());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+
+    protected JsonNode putFormOk(String path, Map<String, String> form) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.putForm(url(path), Header.EMPTY, form, String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
+                + restResult.getData() + ", message=" + restResult.getMessage());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+
+    protected JsonNode deleteJsonOk(String path, Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(path), Header.EMPTY, query, String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
+                + restResult.getData() + ", message=" + restResult.getMessage());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+
+    protected void deleteQuietly(String path, Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(path), Header.EMPTY, query, String.class);
+        if (!restResult.ok()) {
+            logger().warn("delete non-OK: path={} code={} body={}", path, restResult.getCode(), restResult.getData());
+        }
+    }
+
+    protected void assertSuccess(JsonNode root) {
+        assertNotNull(root);
+        assertEquals(ErrorCode.SUCCESS.getCode(), root.get("code").asInt(), root.toString());
+        assertEquals(ErrorCode.SUCCESS.getMsg(), root.get("message").asText(), root.toString());
+    }
+
+    protected void assertError(HttpResponse response, int expectedStatus, ErrorCode expectedCode, String expectedData)
+            throws Exception {
+        assertEquals(expectedStatus, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertNotNull(root, response.body());
+        assertEquals(expectedCode.getCode(), root.get("code").asInt(), response.body());
+        assertNotNull(root.get("message"), response.body());
+        assertNotNull(root.get("data"), response.body());
+        assertTrue(root.get("data").asText().contains(expectedData), response.body());
+    }
+
     protected HttpResponse executeRaw(ClassicHttpRequest request) throws Exception {
         HttpClientResponseHandler<HttpResponse> responseHandler = response -> {
             String body = null == response.getEntity() ? "" : EntityUtils.toString(response.getEntity());

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
@@ -178,6 +178,20 @@ public abstract class OpenApiBaseITCase {
         return executeRaw(post);
     }
 
+    protected JsonNode putJsonOk(String path, Query query, String json) throws Exception {
+        HttpResponse response = putJsonRaw(path, query, json);
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        return root;
+    }
+
+    protected HttpResponse putJsonRaw(String path, Query query, String json) throws Exception {
+        HttpPut put = new HttpPut(url(path + "?" + query.toQueryUrl()));
+        put.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+        return executeRaw(put);
+    }
+
     protected HttpResponse postMultipartRaw(String path, Query query, String fieldName, String fileName,
             String contentType, byte[] fileBytes) throws Exception {
         String boundary = "----nacos-openapi-it-" + System.nanoTime();

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
@@ -32,8 +32,10 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
@@ -137,7 +139,11 @@ public abstract class OpenApiBaseITCase {
     }
 
     protected JsonNode postFormOk(String path, Map<String, String> form) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), Header.EMPTY, form, String.class);
+        return postFormOk(path, Header.EMPTY, form);
+    }
+
+    protected JsonNode postFormOk(String path, Header header, Map<String, String> form) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), header, form, String.class);
         assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
                 + restResult.getData() + ", message=" + restResult.getMessage());
         JsonNode root = JacksonUtils.toObj(restResult.getData());
@@ -153,6 +159,20 @@ public abstract class OpenApiBaseITCase {
         JsonNode root = JacksonUtils.toObj(restResult.getData());
         assertSuccess(root);
         return root;
+    }
+
+    protected JsonNode postJsonOk(String path, Query query, String json) throws Exception {
+        HttpResponse response = postJsonRaw(path, query, json);
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        return root;
+    }
+
+    protected HttpResponse postJsonRaw(String path, Query query, String json) throws Exception {
+        HttpPost post = new HttpPost(url(path + "?" + query.toQueryUrl()));
+        post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+        return executeRaw(post);
     }
 
     protected JsonNode putFormOk(String path, Map<String, String> form) throws Exception {

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
@@ -203,6 +203,16 @@ public abstract class OpenApiBaseITCase {
         return root;
     }
 
+    protected JsonNode putFormOk(String path, Query query) throws Exception {
+        HttpRestResult<String> restResult = nacosRestTemplate.putForm(url(path), Header.EMPTY, query,
+                Collections.emptyMap(), String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
+                + restResult.getData() + ", message=" + restResult.getMessage());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        return root;
+    }
+
     protected JsonNode deleteJsonOk(String path, Query query) throws Exception {
         HttpRestResult<String> restResult = nacosRestTemplate.delete(url(path), Header.EMPTY, query, String.class);
         assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
@@ -34,6 +34,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.AfterEach;
@@ -41,6 +42,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
@@ -172,6 +175,22 @@ public abstract class OpenApiBaseITCase {
     protected HttpResponse postJsonRaw(String path, Query query, String json) throws Exception {
         HttpPost post = new HttpPost(url(path + "?" + query.toQueryUrl()));
         post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+        return executeRaw(post);
+    }
+
+    protected HttpResponse postMultipartRaw(String path, Query query, String fieldName, String fileName,
+            String contentType, byte[] fileBytes) throws Exception {
+        String boundary = "----nacos-openapi-it-" + System.nanoTime();
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        body.write(("--" + boundary + "\r\n").getBytes(StandardCharsets.UTF_8));
+        body.write(("Content-Disposition: form-data; name=\"" + fieldName + "\"; filename=\"" + fileName
+                + "\"\r\n").getBytes(StandardCharsets.UTF_8));
+        body.write(("Content-Type: " + contentType + "\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+        body.write(fileBytes);
+        body.write(("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
+        HttpPost post = new HttpPost(url(path + "?" + query.toQueryUrl()));
+        post.setEntity(new ByteArrayEntity(body.toByteArray(),
+                ContentType.parse("multipart/form-data; boundary=" + boundary)));
         return executeRaw(post);
     }
 

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AiOpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/client/ai/AiOpenApiBaseITCase.java
@@ -16,20 +16,7 @@
 
 package com.alibaba.nacos.test.openapi.client.ai;
 
-import com.alibaba.nacos.api.model.v2.ErrorCode;
-import com.alibaba.nacos.common.http.HttpRestResult;
-import com.alibaba.nacos.common.http.param.Header;
-import com.alibaba.nacos.common.http.param.Query;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
-import com.fasterxml.jackson.databind.JsonNode;
-
-import java.util.Collections;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Shared helpers for AI client OpenAPI integration tests.
@@ -39,62 +26,4 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public abstract class AiOpenApiBaseITCase extends OpenApiBaseITCase {
     
     protected static final String DEFAULT_NAMESPACE = "public";
-    
-    protected JsonNode postFormOk(String path, Map<String, String> form) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), Header.EMPTY, form, String.class);
-        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
-                + restResult.getData() + ", message=" + restResult.getMessage());
-        JsonNode root = JacksonUtils.toObj(restResult.getData());
-        assertSuccess(root);
-        return root;
-    }
-    
-    protected JsonNode postFormOk(String path, Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), Header.EMPTY, query,
-                Collections.emptyMap(), String.class);
-        assertTrue(restResult.ok(), "HTTP status should be 2xx, body=" + restResult.getData());
-        JsonNode root = JacksonUtils.toObj(restResult.getData());
-        assertSuccess(root);
-        return root;
-    }
-    
-    protected JsonNode putFormOk(String path, Map<String, String> form) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.putForm(url(path), Header.EMPTY, form, String.class);
-        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
-                + restResult.getData() + ", message=" + restResult.getMessage());
-        JsonNode root = JacksonUtils.toObj(restResult.getData());
-        assertSuccess(root);
-        return root;
-    }
-    
-    protected JsonNode getJsonOk(String path, Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.get(url(path), Header.EMPTY, query, String.class);
-        assertTrue(restResult.ok(), "HTTP status should be 2xx, body=" + restResult.getData());
-        JsonNode root = JacksonUtils.toObj(restResult.getData());
-        assertSuccess(root);
-        return root;
-    }
-    
-    protected void deleteQuietly(String path, Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(path), Header.EMPTY, query, String.class);
-        if (!restResult.ok()) {
-            logger().warn("delete non-OK: path={} code={} body={}", path, restResult.getCode(), restResult.getData());
-        }
-    }
-    
-    protected void assertSuccess(JsonNode root) {
-        assertNotNull(root);
-        assertEquals(ErrorCode.SUCCESS.getCode(), root.get("code").asInt(), root.toString());
-        assertEquals(ErrorCode.SUCCESS.getMsg(), root.get("message").asText(), root.toString());
-    }
-    
-    protected void assertError(HttpResponse response, int expectedStatus, ErrorCode expectedCode, String expectedData)
-            throws Exception {
-        assertEquals(expectedStatus, response.code(), response.body());
-        JsonNode root = JacksonUtils.toObj(response.body());
-        assertNotNull(root, response.body());
-        assertEquals(expectedCode.getCode(), root.get("code").asInt(), response.body());
-        assertNotNull(root.get("message").asText(), response.body());
-        assertTrue(root.get("data").asText().contains(expectedData), response.body());
-    }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add scenario-driven integration tests for Nacos v3 admin OpenAPI under `test/openapi-test`, following issue #14879 and the standalone-server test framework. The tests cover Config, Naming, Core, and AI admin APIs, and assert expected behavior, validation boundaries, controlled error responses, and response shapes.

## Brief changelog

- Add shared admin OpenAPI IT helpers for config, naming, core, and AI admin tests.
- Add admin IT cases for Config CRUD, list, history, listener, gray, beta, import, export, clone, capacity, metrics, and ops APIs.
- Add admin IT cases for Naming service, instance, metadata, cluster, health, operator, and client APIs.
- Add admin IT cases for Core namespace, cluster, plugin, loader, ops, and state APIs.
- Add admin IT cases for AI A2A, MCP, pipeline, prompt, skill, AgentSpec, and import APIs, including upload/import paths that are stable in standalone mode.

## Verifying this change

- [x] `mvn -pl test/openapi-test -DskipTests test-compile`
- [x] `mvn -pl test/openapi-test -Pintegration-test '-Dit.test=*AdminApiOpenApiITCase' test-compile failsafe:integration-test failsafe:verify` (96 tests)
- [x] `mvn -pl test/openapi-test spotless:check`
- [x] `git diff --check`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Add integration-test coverage in the test module.
* [ ] Run full package checks such as `mvn -B clean package apache-rat:check spotbugs:check -DskipTests`, `mvn clean install`, and full integration-test commands.