### PR TITLE
chore(ci): upgrade mvnd to 1.0.6 and fetch checksums from GitHub API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Set up Maven Daemon
         shell: bash
         env:
-          MVND_VERSION: '1.0.5'
+          MVND_VERSION: '1.0.6'
+          # The download speed from downloads.apache.org and archive.apache.org can sometimes be very slow.
           # MVND_BASE_URL: 'https://downloads.apache.org/maven/mvnd'
           # MVND_BASE_URL: 'https://archive.apache.org/dist/maven/mvnd'
           # GitHub releases do not have a .sha256 file.
@@ -52,20 +53,16 @@ jobs:
             *)     echo "Unsupported arch: ${{ runner.arch }}"; exit 1 ;;
           esac
           MVND_DIR="maven-mvnd-${MVND_VERSION}-${MVND_OS}-${MVND_ARCH}"
-          MVND_URL="${MVND_BASE_URL}/${MVND_VERSION}/${MVND_DIR}.zip"
+          MVND_ZIP="${MVND_DIR}.zip"
+          MVND_URL="${MVND_BASE_URL}/${MVND_VERSION}/${MVND_ZIP}"
           echo "Downloading mvnd ${MVND_VERSION} for ${MVND_OS}/${MVND_ARCH}..."
           echo "Download URL: $MVND_URL"
           curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused "$MVND_URL" -o "$RUNNER_TEMP/mvnd.zip"
           # echo "Checksum URL: ${MVND_URL}.sha256"
           # curl -fsSL --retry 3 --retry-delay 5 --retry-connrefused "${MVND_URL}.sha256" -o "$RUNNER_TEMP/mvnd.zip.sha256"
-          case "${MVND_OS}-${MVND_ARCH}" in
-            linux-amd64)     EXPECTED='4a8d83bbf7757a1132c4116cfeea69aaa93b341b8253344ff42b33001f281830' ;;
-            linux-aarch64)   EXPECTED='5f68558d8950d4020eecd19e10fae40a4fcb4db00ebd359dad39b4bb52b9efa0' ;;
-            darwin-amd64)    EXPECTED='95e12908f24fd018ee41e5d31fe43a86340877e9b937651732e310b250411de3' ;;
-            darwin-aarch64)  EXPECTED='bd98f847478de20158242f6cce6d9bc6cb6e3e9ba7b932237f0122f52a8de5a3' ;;
-            windows-amd64)   EXPECTED='15cd4716bbb0ff96d2b66607262f6145a772dcfd10b24ab18c8338d1e1f4da8e' ;;
-            *)               echo "Unsupported combination: ${MVND_OS}-${MVND_ARCH}"; exit 1 ;;
-          esac
+          RELEASE_API="https://api.github.com/repos/apache/maven-mvnd/releases/tags/${MVND_VERSION}"
+          echo "Fetching expected checksum from GitHub API..."                                                                                                           
+          EXPECTED=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "$RELEASE_API" | jq -r --arg name "$MVND_ZIP" '.assets[] | select(.name == $name) | .digest' | sed 's/^sha256://')
           echo "Verifying download..."
           # EXPECTED=$(cut -d' ' -f1 "$RUNNER_TEMP/mvnd.zip.sha256")
           ACTUAL=$(sha256sum "$RUNNER_TEMP/mvnd.zip" | cut -d' ' -f1 | tr -d '\\')


### PR DESCRIPTION
Replace hardcoded SHA256 digests with dynamic lookup via GitHub Releases API, which simplifies version bumps and avoids stale checksums.

https://github.com/alibaba/nacos/issues/15283

## What is the purpose of the change

Upgrade mvnd from 1.0.5 to 1.0.6 in the CI workflow, and improve the checksum verification mechanism by fetching SHA256 digests dynamically from the GitHub Releases API instead of hardcoding them per platform.

## Brief changelog

- Bump `MVND_VERSION` from `1.0.5` to `1.0.6`
- Replace hardcoded per-platform SHA256 checksums with dynamic lookup via `https://api.github.com/repos/apache/maven-mvnd/releases/tags/${MVND_VERSION}`
- Extract `MVND_ZIP` variable for reuse in download URL and API query
- Use `GITHUB_TOKEN` to authenticate against the GitHub API (avoids rate limiting)

## Verifying this change

Verified by the CI workflow passing on the PR branch.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

