### PR TITLE
[ISSUE #15275] Copy pg-upgrade-null-tenant-id.sql to distribution/conf

### DIFF
--- a/plugin-default-impl/nacos-default-plugin-all/pom.xml
+++ b/plugin-default-impl/nacos-default-plugin-all/pom.xml
@@ -126,6 +126,8 @@
                                       tofile="${project.basedir}/../../distribution/conf/pg-schema.sql" overwrite="true"/>
                                 <copy file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-grant-nacos-readwrite.sql"
                                       tofile="${project.basedir}/../../distribution/conf/pg-grant-nacos-readwrite.sql" overwrite="true"/>
+                                <copy file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-upgrade-null-tenant-id.sql"
+                                      tofile="${project.basedir}/../../distribution/conf/pg-upgrade-null-tenant-id.sql" overwrite="true"/>
                                 <copy file="${project.basedir}/../nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/resources/META-INF/oracle-schema.sql"
                                       tofile="${project.basedir}/../../distribution/conf/oracle-schema.sql" overwrite="true"/>
                             </target>


### PR DESCRIPTION
## What is the purpose of the change

Fix the Docker image upgrade crash when migrating Nacos 3.2.1 → 3.2.2 with PostgreSQL. The `pg-upgrade-null-tenant-id.sql` migration script (introduced in #15150) was missing from the container filesystem because it wasn't copied to `distribution/conf` during the Maven build, unlike other schema SQL files.

## Brief changelog

- Copy `pg-upgrade-null-tenant-id.sql` to `distribution/conf` in the `copy-db-schema-sql-to-distribution-conf` Maven execution

## Verifying this change

After `mvn package`, `distribution/conf/pg-upgrade-null-tenant-id.sql` exists and matches the content of the source file at `plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/resources/META-INF/pg-upgrade-null-tenant-id.sql`.