### PR TITLE
[ISSUE #14879] Complete remaining admin OpenAPI IT gaps

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpsControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpsControllerV3.java
@@ -218,17 +218,22 @@ public class ConfigOpsControllerV3 {
     private DeferredResult<Result<String>> convertToResult(
         DeferredResult<RestResult<String>> restResult) {
         DeferredResult<Result<String>> wrappedResponse = new DeferredResult<>();
-        restResult.onCompletion(() -> {
-            if (restResult.getResult() != null) {
-                RestResult<String> originalResult = (RestResult<String>) restResult.getResult();
-                Result<String> newResult =
-                    new Result<>(originalResult.getCode(), originalResult.getMessage(),
-                        originalResult.getData());
-                
-                wrappedResponse.setResult(newResult);
-            }
-        });
+        restResult.onCompletion(() -> copyRestResult(restResult, wrappedResponse));
+        copyRestResult(restResult, wrappedResponse);
         
         return wrappedResponse;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private void copyRestResult(DeferredResult<RestResult<String>> restResult,
+        DeferredResult<Result<String>> wrappedResponse) {
+        if (wrappedResponse.hasResult() || restResult.getResult() == null) {
+            return;
+        }
+        RestResult<String> originalResult = (RestResult<String>) restResult.getResult();
+        Result<String> newResult =
+            new Result<>(originalResult.getCode(), originalResult.getMessage(),
+                originalResult.getData());
+        wrappedResponse.setResult(newResult);
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpsControllerV3Test.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/ConfigOpsControllerV3Test.java
@@ -392,6 +392,20 @@ class ConfigOpsControllerV3Test {
     }
     
     @Test
+    @SuppressWarnings("unchecked")
+    void testConvertToResultCopiesPreCompletedRestResult() {
+        DeferredResult<RestResult<String>> restResult = new DeferredResult<>();
+        restResult.setResult(RestResultUtils.failed("pre-set failure"));
+        
+        DeferredResult<Result<String>> wrappedResult =
+            ReflectionTestUtils.invokeMethod(configOpsControllerV3, "convertToResult", restResult);
+        
+        Result<String> result = (Result<String>) wrappedResult.getResult();
+        assertEquals(500, result.getCode());
+        assertEquals("pre-set failure", result.getMessage());
+    }
+    
+    @Test
     void testConvertToResultIgnoresNullRestResult() {
         DeferredResult<RestResult<String>> restResult = new DeferredResult<>();
         DeferredResult<Result<String>> wrappedResult =

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/prompt/PromptAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/ai/prompt/PromptAdminApiOpenApiITCase.java
@@ -34,9 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Scenario coverage:
  * <ul>
- *     <li>Expected capability: draft creation and update persist editable content; force-publish makes a version
- *     online and latest; governance, version detail, version list, list, Markdown download, labels, description,
- *     bizTags, online/offline, and delete expose the expected prompt state.</li>
+ *     <li>Expected capability: draft creation and update persist editable content; draft delete removes only the
+ *     editing version while retaining prompt governance metadata; force-publish makes a version online and latest;
+ *     governance, version detail, version list, list, Markdown download, labels, description, bizTags,
+ *     online/offline, and delete expose the expected prompt state.</li>
  *     <li>Boundary/validation: namespace defaults to public; list supports accurate/blur and bizTags filters while
  *     clamping page arguments; promptKey, template or basedOnVersion, version, labels, and description are required
  *     where controller forms require them; legacy version format is validated.</li>
@@ -139,6 +140,29 @@ public class PromptAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
     }
 
     @Test
+    public void testPromptDeleteDraftRemovesEditingVersionOnly() throws Exception {
+        String promptKey = randomPromptKey("delete-draft");
+        postFormOk(ADMIN_PROMPT_PATH + "/draft",
+                promptDraftForm(promptKey, "1.0.0", "Draft to delete {{name}}", "delete draft desc",
+                        "delete-draft"));
+        addCleanup(() -> deletePromptQuietly(promptKey));
+        assertPromptVersion(getJsonOk(ADMIN_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data"), promptKey, "1.0.0", "draft", "Draft to delete {{name}}");
+
+        JsonNode deleted = deleteJsonOk(ADMIN_PROMPT_PATH + "/draft", promptQuery(promptKey));
+        assertEquals("ok", deleted.get("data").asText(), deleted.toString());
+
+        JsonNode governance = getJsonOk(ADMIN_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey))
+                .get("data");
+        assertEquals(promptKey, governance.get("promptKey").asText(), governance.toString());
+        assertTrue(governance.path("editingVersion").isNull()
+                || governance.path("editingVersion").isMissingNode(), governance.toString());
+        assertEquals(0, governance.get("versions").size(), governance.toString());
+        assertError(getRaw(ADMIN_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Prompt version not found");
+    }
+
+    @Test
     public void testPromptSubmitAndLegacyCompatibilityEndpoints() throws Exception {
         String legacyPublishKey = randomPromptKey("legacy-publish");
         Map<String, String> legacyPublish = promptQueryForm(legacyPublishKey);
@@ -214,6 +238,9 @@ public class PromptAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
         assertError(putRaw(ADMIN_PROMPT_PATH + "/draft",
                 promptQuery(randomPromptKey("missing-template-update"))), 400,
                 ErrorCode.PARAMETER_MISSING, "template");
+        assertError(deleteRaw(ADMIN_PROMPT_PATH + "/draft",
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "promptKey");
         assertError(postRaw(ADMIN_PROMPT_PATH + "/force-publish",
                 queryFrom(promptQueryForm(randomPromptKey("missing-version")))), 400,
                 ErrorCode.PARAMETER_MISSING, "version");
@@ -232,6 +259,8 @@ public class PromptAdminApiOpenApiITCase extends AiAdminApiBaseITCase {
                 ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
         assertError(getRaw(ADMIN_PROMPT_VERSION_DOWNLOAD_PATH, promptVersionQuery(absentPrompt, "1.0.0")),
                 404, ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+        assertError(deleteRaw(ADMIN_PROMPT_PATH + "/draft", promptQuery(absentPrompt)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "not found");
 
         Map<String, String> legacyPublish = promptQueryForm(randomPromptKey("legacy-invalid-version"));
         legacyPublish.put("version", "bad-version");

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigOpsAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/config/ConfigOpsAdminApiOpenApiITCase.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration tests for config ops admin OpenAPIs under {@code /nacos/v3/admin/cs/ops}.
@@ -31,11 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <ul>
  *     <li>Expected capability: local-cache dump trigger returns the v3 success envelope when the standalone server can
  *     dump from store.</li>
- *     <li>Boundary/validation: log level update requires both {@code logName} and {@code logLevel}, and Derby ops
- *     requires {@code sql}. Derby import is intentionally not exercised because it mutates the embedded database from
- *     an uploaded external dump.</li>
+ *     <li>Boundary/validation: log level update requires both {@code logName} and {@code logLevel}; Derby query
+ *     requires {@code sql}; Derby import is invoked with a multipart file but its success path is intentionally not
+ *     exercised because it mutates the embedded database from an uploaded external dump.</li>
  *     <li>Exception/error handling: missing required operation parameters return HTTP 400 with the v3 {@code Result}
- *     error envelope instead of HTTP 500.</li>
+ *     error envelope instead of HTTP 500, and disabled or non-embedded Derby import returns a controlled
+ *     {@code Result} failure body instead of importing data.</li>
  * </ul>
  *
  * @author xiweng.yy
@@ -58,5 +60,13 @@ public class ConfigOpsAdminApiOpenApiITCase extends ConfigAdminApiBaseITCase {
         assertError(putRaw(ADMIN_OPS_PATH + "/log", Query.newInstance().addParam("logName", "config-server")),
                 400, ErrorCode.PARAMETER_MISSING, "logLevel");
         assertError(getRaw(ADMIN_OPS_PATH + "/derby"), 400, ErrorCode.PARAMETER_MISSING, "sql");
+
+        HttpResponse importResponse = postMultipartRaw(ADMIN_OPS_PATH + "/derby/import", Query.newInstance(),
+                "file", "derby-import.sql", "text/plain", new byte[0]);
+        assertEquals(200, importResponse.code(), importResponse.body());
+        JsonNode importResult = JacksonUtils.toObj(importResponse.body());
+        assertTrue(importResult.get("code").asInt() != ErrorCode.SUCCESS.getCode(), importResult.toString());
+        assertTrue(importResult.get("message").asText().contains("Derby ops is disabled")
+                || importResult.get("message").asText().contains("embedded storage mode"), importResult.toString());
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/PluginAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/PluginAdminApiOpenApiITCase.java
@@ -31,10 +31,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <ul>
  *     <li>Expected capability: plugin list exposes discovered plugin inventory, pluginType filters narrow results, and
  *     plugin detail returns the same identity plus mutable-state fields.</li>
- *     <li>Boundary/validation: unknown pluginType filters return an empty list; missing plugin detail is reported as
- *     not found.</li>
+ *     <li>Boundary/validation: unknown pluginType filters return an empty list; status update requires
+ *     {@code pluginName}; config update requires {@code config}; missing plugin detail is reported as not found.</li>
  *     <li>Exception/error handling: plugin state/config mutation success paths are intentionally not executed because
- *     they change runtime extension state; detail not-found is verified as a controlled RESOURCE_NOT_FOUND response.</li>
+ *     they change runtime extension state; required-parameter and detail not-found failures are verified as controlled
+ *     v3 error envelopes.</li>
  * </ul>
  *
  * @author xiweng.yy
@@ -77,5 +78,15 @@ public class PluginAdminApiOpenApiITCase extends CoreAdminApiBaseITCase {
         assertError(getRaw(ADMIN_CORE_PLUGIN_PATH + "/detail",
                 Query.newInstance().addParam("pluginType", "auth").addParam("pluginName", "missing-plugin")),
                 404, ErrorCode.RESOURCE_NOT_FOUND, "auth:missing-plugin");
+    }
+
+    @Test
+    public void testPluginMutationValidationReturnsBadRequest() throws Exception {
+        assertError(putRaw(ADMIN_CORE_PLUGIN_PATH + "/status",
+                Query.newInstance().addParam("pluginType", "auth").addParam("enabled", "true")),
+                400, ErrorCode.PARAMETER_MISSING, "pluginName");
+        assertError(putRaw(ADMIN_CORE_PLUGIN_PATH + "/config",
+                Query.newInstance().addParam("pluginType", "auth").addParam("pluginName", "missing-plugin")),
+                400, ErrorCode.PARAMETER_MISSING, "config");
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/ServerLoaderAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/core/ServerLoaderAdminApiOpenApiITCase.java
@@ -32,7 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *     <li>Expected capability: current local connection map and cluster loader metrics return the v3 success envelope
  *     and diagnostic shapes.</li>
  *     <li>Boundary/validation: reload-by-count and reload-single-client require {@code count} and
- *     {@code connectionId}; destructive connection rebalance success paths are intentionally not executed.</li>
+ *     {@code connectionId}; smart cluster reload requires a numeric {@code loaderFactor}; destructive connection
+ *     rebalance success paths are intentionally not executed.</li>
  *     <li>Exception/error handling: missing required parameters return controlled HTTP 400 errors instead of invoking
  *     rebalance operations.</li>
  * </ul>
@@ -59,5 +60,8 @@ public class ServerLoaderAdminApiOpenApiITCase extends CoreAdminApiBaseITCase {
                 400, ErrorCode.PARAMETER_MISSING, "count");
         assertError(postRaw(ADMIN_CORE_LOADER_PATH + "/reloadClient", Query.newInstance()),
                 400, ErrorCode.PARAMETER_MISSING, "connectionId");
+        assertError(postRaw(ADMIN_CORE_LOADER_PATH + "/smartReloadCluster",
+                Query.newInstance().addParam("loaderFactor", "not-a-number")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "not-a-number");
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/NamingAdminApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/NamingAdminApiBaseITCase.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -37,6 +38,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
 
     protected static final String ADMIN_SERVICE_PATH = nacosPath(UtilsAndCommons.SERVICE_CONTROLLER_V3_ADMIN_PATH);
+
+    protected static final String ADMIN_SERVICE_LIST_PATH = ADMIN_SERVICE_PATH + "/list";
+
+    protected static final String ADMIN_SERVICE_SUBSCRIBERS_PATH = ADMIN_SERVICE_PATH + "/subscribers";
+
+    protected static final String ADMIN_SERVICE_SELECTOR_TYPES_PATH = ADMIN_SERVICE_PATH + "/selector/types";
 
     protected static final String ADMIN_INSTANCE_PATH = nacosPath(UtilsAndCommons.INSTANCE_CONTROLLER_V3_ADMIN_PATH);
 
@@ -86,6 +93,15 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         addIfNotBlank(query, "namespaceId", namespaceId);
         query.addParam("pageNo", String.valueOf(pageNo));
         query.addParam("pageSize", String.valueOf(pageSize));
+        return query;
+    }
+
+    protected Query subscribersQuery(String serviceName, String groupName, String namespaceId,
+            int pageNo, int pageSize, String aggregation) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        query.addParam("pageNo", String.valueOf(pageNo));
+        query.addParam("pageSize", String.valueOf(pageSize));
+        addIfNotBlank(query, "aggregation", aggregation);
         return query;
     }
 
@@ -261,6 +277,16 @@ public abstract class NamingAdminApiBaseITCase extends OpenApiBaseITCase {
         JsonNode service = findService(page, serviceName, groupName);
         assertFalse(service.isMissingNode(), page.toString());
         assertTrue(service.get("clusterCount").asInt() >= 0, service.toString());
+    }
+
+    protected void assertNamingPageShape(JsonNode page) {
+        assertNotNull(page.get("pageNumber"), page.toString());
+        assertNotNull(page.get("pagesAvailable"), page.toString());
+        assertNotNull(page.get("totalCount"), page.toString());
+        assertTrue(page.get("pageNumber").asInt() >= 1, page.toString());
+        assertTrue(page.get("pagesAvailable").asInt() >= 0, page.toString());
+        assertTrue(page.get("totalCount").asInt() >= 0, page.toString());
+        assertTrue(page.get("pageItems").isArray(), page.toString());
     }
 
     protected JsonNode getInstanceDetail(String serviceName, String groupName, String namespaceId, String ip,

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/ServiceAdminApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/naming/ServiceAdminApiOpenApiITCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration tests for naming service admin OpenAPI {@code /nacos/v3/admin/ns/service}.
@@ -30,9 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <ul>
  *     <li>Expected capability: create persists a service, detail returns metadata/default namespace/group/ephemeral
  *     fields, update changes service metadata, list can find the service by {@code serviceNameParam}/{@code
- *     groupNameParam}, and delete removes it from the list.</li>
+ *     groupNameParam}, selector-types exposes the built-in {@code none} selector, subscribers returns the
+ *     expected empty page shape for a service without subscribers, and delete removes the service from the list.</li>
  *     <li>Boundary/validation: omitted namespace and group default to public and DEFAULT_GROUP; service list requires
- *     positive pagination values; {@code serviceName} is required for create/detail/update/delete.</li>
+ *     positive pagination values; {@code serviceName} is required for create/detail/update/delete/subscribers.</li>
  *     <li>Exception/error handling: missing required fields and invalid pagination return HTTP 400 with the v3
  *     {@code Result} error envelope instead of HTTP 500.</li>
  * </ul>
@@ -46,6 +48,11 @@ public class ServiceAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
         String serviceName = randomServiceName("service");
         createService(serviceName, "", null, "{\"env\":\"it\"}", "0.4");
         addCleanup(() -> deleteServiceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+
+        JsonNode selectorTypes = getJsonOk(ADMIN_SERVICE_SELECTOR_TYPES_PATH, Query.newInstance())
+                .get("data");
+        assertTrue(selectorTypes.isArray(), selectorTypes.toString());
+        assertArrayContainsText(selectorTypes, "none");
         
         JsonNode created = getJsonOk(ADMIN_SERVICE_PATH,
                 serviceQuery(serviceName, null, null)).get("data");
@@ -58,7 +65,14 @@ public class ServiceAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
         assertServiceDetail(updated, serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, "env", "updated");
         assertEquals(0.6F, updated.get("protectThreshold").floatValue(), 0.001F, updated.toString());
         
-        JsonNode listed = getJsonOk(ADMIN_SERVICE_PATH + "/list",
+        JsonNode subscribers = getJsonOk(ADMIN_SERVICE_SUBSCRIBERS_PATH,
+                subscribersQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, 1, 10, "false"))
+                .get("data");
+        assertNamingPageShape(subscribers);
+        assertEquals(1, subscribers.get("pageNumber").asInt(), subscribers.toString());
+        assertEquals(0, subscribers.get("totalCount").asInt(), subscribers.toString());
+
+        JsonNode listed = getJsonOk(ADMIN_SERVICE_LIST_PATH,
                 serviceListQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, 1, 10)).get("data");
         assertEquals(1, listed.get("pageNumber").asInt(), listed.toString());
         assertServiceListed(listed, serviceName, DEFAULT_GROUP);
@@ -66,7 +80,7 @@ public class ServiceAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
         JsonNode deleted = deleteJsonOk(ADMIN_SERVICE_PATH,
                 serviceQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
         assertEquals("ok", deleted.get("data").asText(), deleted.toString());
-        JsonNode afterDelete = getJsonOk(ADMIN_SERVICE_PATH + "/list",
+        JsonNode afterDelete = getJsonOk(ADMIN_SERVICE_LIST_PATH,
                 serviceListQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, 1, 10)).get("data");
         assertEquals(0, afterDelete.get("totalCount").asInt(), afterDelete.toString());
     }
@@ -81,8 +95,23 @@ public class ServiceAdminApiOpenApiITCase extends NamingAdminApiBaseITCase {
                 ErrorCode.PARAMETER_MISSING, "serviceName");
         assertError(deleteRaw(ADMIN_SERVICE_PATH, Query.newInstance()), 400,
                 ErrorCode.PARAMETER_MISSING, "serviceName");
-        assertError(getRaw(ADMIN_SERVICE_PATH + "/list",
+        assertError(getRaw(ADMIN_SERVICE_LIST_PATH,
                 serviceListQuery(randomServiceName("service-page"), DEFAULT_GROUP, DEFAULT_NAMESPACE, 0, 10)),
                 400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(ADMIN_SERVICE_SUBSCRIBERS_PATH,
+                subscribersQuery(randomServiceName("subscriber-page"), DEFAULT_GROUP, DEFAULT_NAMESPACE, 0, 10,
+                        "false")), 400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(ADMIN_SERVICE_SUBSCRIBERS_PATH,
+                Query.newInstance().addParam("pageNo", "1").addParam("pageSize", "10")),
+                400, ErrorCode.PARAMETER_MISSING, "serviceName");
+    }
+
+    private void assertArrayContainsText(JsonNode array, String expected) {
+        for (JsonNode item : array) {
+            if (expected.equals(item.asText())) {
+                return;
+            }
+        }
+        throw new AssertionError("Expected array to contain " + expected + ", actual=" + array);
     }
 }


### PR DESCRIPTION
## Summary
- Cover the remaining admin swagger operation gaps with scenario-oriented IT assertions for service selector types/subscribers, prompt draft deletion, plugin mutations, loader smart reload validation, and config Derby import safety.
- Add naming test helpers for subscriber pagination and shared service subpaths.
- Fix Derby import DeferredResult conversion when a disabled/non-embedded branch completes before wrapping, and add a regression unit test.

## Tests
- mvn -pl config,test/openapi-test spotless:check
- mvn -pl config,test/openapi-test -DskipTests test-compile
- mvn -pl config -Dtest=ConfigOpsControllerV3Test test
- mvn -pl test/openapi-test -Pintegration-test -DskipTests=false -Dit.test=ServiceAdminApiOpenApiITCase,PromptAdminApiOpenApiITCase,PluginAdminApiOpenApiITCase,ServerLoaderAdminApiOpenApiITCase verify

Note: ConfigOpsAdminApiOpenApiITCase includes the Derby import safety IT, but the local 8848 service is an existing OrbStack server that does not include this branch's server-side DeferredResult fix. The production fix is covered by ConfigOpsControllerV3Test and should be exercised by CI with a freshly built standalone server.