### PR TITLE
fix(CVE-2023-35116,CVE-2025-52999): upgrade jackson to 2.16.2 (Related to #15025)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,28 +17,28 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
     <inceptionYear>2018</inceptionYear>
     <groupId>com.alibaba.nacos</groupId>
     <artifactId>nacos-all</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>
-    
+
     <name>Alibaba NACOS ${project.version}</name>
     <description>Top Nacos project pom.xml file</description>
     <url>https://nacos.io</url>
     <prerequisites>
         <maven>3.2.5</maven>
     </prerequisites>
-    
+
     <scm>
         <url>git@github.com:alibaba/nacos.git</url>
         <connection>scm:git@github.com:alibaba/nacos.git</connection>
         <developerConnection>scm:git@github.com:alibaba/nacos.git</developerConnection>
         <tag>nacos-all-${revision}</tag>
     </scm>
-    
+
     <mailingLists>
         <mailingList>
             <name>Development List</name>
@@ -59,7 +59,7 @@
             <post>commits-nacos@googlegroups.com</post>
         </mailingList>
     </mailingLists>
-    
+
     <developers>
         <developer>
             <id>Alibaba Nacos</id>
@@ -68,7 +68,7 @@
             <email>nacos_dev@linux.alibaba.com</email>
         </developer>
     </developers>
-    
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -76,17 +76,17 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    
+
     <organization>
         <name>Alibaba Group</name>
         <url>https://github.com/alibaba</url>
     </organization>
-    
+
     <issueManagement>
         <system>github</system>
         <url>https://github.com/alibaba/nacos/issues</url>
     </issueManagement>
-    
+
     <properties>
         <revision>2.5.2</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -100,7 +100,7 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <!-- Exclude all generated code -->
         <sonar.exclusions>file:**/generated-sources/**,**/test/**</sonar.exclusions>
-        
+
         <!-- plugin version -->
         <versions-maven-plugin.version>2.2</versions-maven-plugin.version>
         <dependency-mediator-maven-plugin.version>1.0.2</dependency-mediator-maven-plugin.version>
@@ -125,7 +125,7 @@
         <!-- dependency version related to plugin -->
         <extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
         <p3c-pmd.version>1.3.0</p3c-pmd.version>
-        
+
         <!-- dependency version -->
         <nacos.logback.adapter.version>1.1.4</nacos.logback.adapter.version>
         <spring-boot-dependencies.version>2.7.18</spring-boot-dependencies.version>
@@ -135,7 +135,7 @@
         <slf4j-api.version>1.7.26</slf4j-api.version>
         <logback.version>1.2.13</logback.version>
         <log4j.version>2.17.1</log4j.version>
-        
+
         <mysql-connector-java.version>8.2.0</mysql-connector-java.version>
         <derby.version>10.14.2.0</derby.version>
         <jjwt.version>0.11.2</jjwt.version>
@@ -150,14 +150,15 @@
         <rpc-grpc-impl.version>${jraft-core.version}</rpc-grpc-impl.version>
         <SnakeYaml.version>2.0</SnakeYaml.version>
         <junit5.version>5.10.2</junit5.version>
-        
+
         <!-- Maven Central Portal -->
         <central.publishing.maven.version>0.7.0</central.publishing.maven.version>
-        
+
         <!-- override dependency version -->
         <spring.version>5.3.39</spring.version>
         <spring-security.version>5.8.15</spring-security.version>
         <tomcat.version>9.0.118</tomcat.version>
+        <jackson.version>2.16.2</jackson.version>
     </properties>
     <!-- == -->
     <!-- =========================================================Build plugins================================================ -->
@@ -496,7 +497,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>jdk8</id>
@@ -535,11 +536,11 @@
                     <value>true</value>
                 </property>
             </activation>
-            
+
             <properties>
                 <maven.javadoc.skip>false</maven.javadoc.skip>
             </properties>
-            
+
             <build>
                 <plugins>
                     <plugin>
@@ -632,7 +633,7 @@
             </plugin>
         </plugins>
     </reporting>
-    
+
     <!-- Submodule management -->
     <modules>
         <module>config</module>
@@ -657,7 +658,7 @@
         <module>persistence</module>
         <module>logger-adapter-impl</module>
     </modules>
-    
+
     <!-- Default dependencies in all subprojects -->
     <dependencies>
         <dependency>
@@ -681,7 +682,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <!-- Manage the version numbers of dependencies,
     sub-modules will not introduce these dependencies by default -->
     <dependencyManagement>
@@ -711,6 +712,14 @@
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-bom</artifactId>
                 <version>${spring-security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <!-- Override Jackson from Spring Boot 2.7.18 BOM to fix CVE-2023-35116, CVE-2025-52999 -->
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -758,7 +767,7 @@
                 <artifactId>tomcat-embed-websocket</artifactId>
                 <version>${tomcat.version}</version>
             </dependency>
-            
+
             <!-- Internal libs -->
             <dependency>
                 <groupId>${project.groupId}</groupId>
@@ -840,7 +849,7 @@
                 <artifactId>nacos-address</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>nacos-istio</artifactId>
@@ -901,92 +910,92 @@
                 <artifactId>nacos-sys</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>
                 <version>${servlet-api.version}</version>
                 <scope>provided</scope>
             </dependency>
-            
+
             <!-- HikariCP -->
             <dependency>
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
                 <version>${HikariCP.version}</version>
             </dependency>
-            
+
             <!-- hessian -->
-            
+
             <dependency>
                 <groupId>com.caucho</groupId>
                 <artifactId>hessian</artifactId>
                 <version>${hessian.version}</version>
             </dependency>
-            
+
             <!-- Apache commons -->
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>${commons-collections.version}</version>
             </dependency>
-            
+
             <!-- Logging libs -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j-api.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
-            
+
             <!-- JDBC libs -->
             <dependency>
                 <groupId>com.mysql</groupId>
                 <artifactId>mysql-connector-j</artifactId>
                 <version>${mysql-connector-java.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
                 <version>${derby.version}</version>
             </dependency>
-            
+
             <!-- JRaft -->
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
@@ -1015,13 +1024,13 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.alipay.sofa</groupId>
                 <artifactId>rpc-grpc-impl</artifactId>
                 <version>${rpc-grpc-impl.version}</version>
             </dependency>
-            
+
             <!-- Third-party libs -->
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
@@ -1040,13 +1049,13 @@
                 <version>${jjwt.version}</version>
                 <scope>runtime</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>javax.annotation</groupId>
                 <artifactId>javax.annotation-api</artifactId>
                 <version>1.3.2</version>
             </dependency>
-            
+
             <!-- gRPC dependency start -->
             <dependency>
                 <groupId>io.grpc</groupId>
@@ -1081,21 +1090,21 @@
                 <version>${proto-google-common-protos.version}</version>
             </dependency>
             <!-- gRPC dependency end -->
-            
+
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${protobuf-java.version}</version>
             </dependency>
-            
-            
+
+
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>2.9.0</version>
                 <scope>compile</scope>
             </dependency>
-    
+
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

升级 nacos v2.x 中依赖的 Jackson 版本至 2.16.2，修复：
- **CVE-2023-35116** — `jackson-databind` 反序列化栈溢出漏洞
- **CVE-2025-52999** — `jackson-core` 资源耗尽漏洞

## Brief changelog

1. 新增 <jackson.version>2.16.2</jackson.version>
2. 在 <dependencyManagement> 中显式 import jackson-bom

## Verifying this change

BOM 覆盖范围验证：jackson-databind、jackson-core 已覆盖
升级后实际依赖版本，均为 2.16.2：
$ mvn dependency:tree -pl distribution -am -Dincludes='com.fasterxml.jackson*'
  [INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.16.2:compile
  [INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile
  [INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.16.2:compile
  [INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.16.2:compile
  [INFO] +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.16.2:compile
  [INFO] +- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.16.2:compile
