### PR TITLE
[ISSUE #14879] Add console OpenAPI IT coverage

### DIFF
--- a/test/openapi-test/ADMIN_API_TEST_SCENARIOS.md
+++ b/test/openapi-test/ADMIN_API_TEST_SCENARIOS.md
@@ -1,0 +1,80 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Admin API IT Scenario Index
+
+This document records which admin API operations are covered by the
+standalone-server IT classes under
+`src/test/java/com/alibaba/nacos/test/adminapi`.
+
+Source API surface: admin swagger at `https://nacos.io/swagger/admin/zh/api.json`.
+The branch-level coverage target is API scenario coverage: expected capability,
+boundary/validation behavior, and controlled exception/error handling.
+
+## Config
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `ConfigAdminApiOpenApiITCase` | `GET,POST,PUT,DELETE /v3/admin/cs/config` | Publishes, republishes, queries, updates metadata, and deletes config; covers public namespace defaulting, type normalization, required identity/content fields, absent config 404, duplicate/update semantics, and malformed metadata errors. |
+| `ConfigListAdminApiOpenApiITCase` | `GET /v3/admin/cs/config/list` | Lists published configs through admin page model with fuzzy and accurate filters; covers type and tag filters, blank dataId group-scoped listing, public namespace defaulting, pagination validation, empty pages, and wrapped error bodies. |
+| `ConfigBatchDeleteAdminApiOpenApiITCase` | `DELETE /v3/admin/cs/config/batch` | Deletes multiple configs by comma-separated ids and verifies absence; covers non-existing ids being ignored, required `ids`, and HTTP 400 v3 Result validation errors. |
+| `ConfigBetaAdminApiOpenApiITCase` | `GET,DELETE /v3/admin/cs/config/beta` | Queries and deletes beta config created via publish API; covers public namespace defaulting, beta rule generated from `betaIps`, required fields, absent beta 404, and v3 error envelope. |
+| `ConfigGrayAdminApiOpenApiITCase` | `GET,POST,PUT,DELETE /v3/admin/cs/config/gray` | Publishes, queries, updates, and deletes gray config with gray metadata; covers public namespace defaulting, tagv2 version acceptance, grayName/rule requirements, absent gray config, and parameter validation errors. |
+| `ConfigImportAdminApiOpenApiITCase` | `POST /v3/admin/cs/config/import` | Imports a metadata ZIP and verifies the imported config can be queried; covers public namespace defaulting, `ABORT` policy, missing file, malformed metadata ZIP, and business failures in v3 Result form. |
+| `ConfigExportAdminApiOpenApiITCase` | `GET /v3/admin/cs/config/export` | Exports config by ids and namespace as downloadable ZIP containing config entries and metadata; covers public namespace defaulting, query serialization, invalid namespace, absent ids, and non-JSON download/error response variants. |
+| `ConfigCloneAdminApiOpenApiITCase` | `POST /v3/admin/cs/config/clone` | Clones existing configs to target dataId/group/namespace and verifies queried target content; covers required namespace, empty clone list rejection, malformed clone payload, business failures, and v3 error bodies. |
+| `ConfigHistoryAdminApiOpenApiITCase` | `GET /v3/admin/cs/history`<br>`GET /v3/admin/cs/history/list`<br>`GET /v3/admin/cs/history/previous`<br>`GET /v3/admin/cs/history/configs` | Publishes/republishes config and verifies history list, detail, previous, and configs history queries; covers large page size, required paging and identity fields, absent/mismatched history, and controlled errors. |
+| `ConfigListenerAdminApiOpenApiITCase` | `GET /v3/admin/cs/config/listener`<br>`GET /v3/admin/cs/listener` | Queries config-scoped and IP-scoped listener state; covers public namespace defaulting, `aggregation=false`, required dataId/group/ip, and HTTP 400 validation envelopes. |
+| `ConfigCapacityAdminApiOpenApiITCase` | `GET,POST /v3/admin/cs/capacity` | Updates and queries group/namespace capacity limits; covers identity requirements, at-least-one capacity field, and validation error envelopes. There is no public delete endpoint for capacity rows. |
+| `ConfigMetricsAdminApiOpenApiITCase` | `GET /v3/admin/cs/metrics` | Queries config metrics and verifies JSON object shape; covers parameter-free request behavior and success response contract. |
+| `ConfigOpsAdminApiOpenApiITCase` | `POST /v3/admin/cs/ops/localCache`<br>`PUT /v3/admin/cs/ops/log`<br>`GET /v3/admin/cs/ops/derby`<br>`POST /v3/admin/cs/ops/derby/import` | Triggers local-cache dump success and verifies ops validation; covers log update required params, Derby query required `sql`, Derby import disabled/non-embedded controlled failure, and intentionally avoids successful DB import because it mutates embedded storage. |
+
+## Naming
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `ServiceAdminApiOpenApiITCase` | `GET,PUT,POST,DELETE /v3/admin/ns/service`<br>`GET /v3/admin/ns/service/list`<br>`GET /v3/admin/ns/service/selector/types`<br>`GET /v3/admin/ns/service/subscribers` | Creates, queries, updates, lists, and deletes persistent services; verifies selector types, subscriber empty page shape, public/default group defaults, required serviceName, pagination validation, and v3 errors. |
+| `InstanceAdminApiOpenApiITCase` | `GET,PUT,POST,DELETE /v3/admin/ns/instance`<br>`GET /v3/admin/ns/instance/list`<br>`PUT /v3/admin/ns/instance/partial` | Registers, queries, lists, updates, partially updates, and deletes instances; covers defaults, healthy/enabled/ephemeral/weight behavior, required fields, invalid values, missing instance, and persistent-service conflicts. |
+| `InstanceMetadataAdminApiOpenApiITCase` | `PUT,DELETE /v3/admin/ns/instance/metadata/batch` | Batch-updates and batch-deletes instance metadata and verifies applied/removed metadata; covers omitted instance selector meaning all instances, explicit selector isolation, required fields, malformed selector, and empty target behavior. |
+| `ClusterAdminApiOpenApiITCase` | `PUT /v3/admin/ns/cluster` | Updates cluster health check config and verifies service cluster metadata; covers defaults, required service/cluster/checker/check port fields, missing service, and validation errors. |
+| `HealthAdminApiOpenApiITCase` | `GET /v3/admin/ns/health/checkers`<br>`PUT /v3/admin/ns/health/instance` | Lists health checker types and manually updates instance health where eligible; covers defaults, required fields, missing checker/service branches, and controlled SERVER_ERROR/v3 errors. |
+| `ClientAdminApiOpenApiITCase` | `GET /v3/admin/ns/client/list`<br>`GET /v3/admin/ns/client`<br>`GET /v3/admin/ns/client/publishers`<br>`GET /v3/admin/ns/client/subscribers`<br>`GET /v3/admin/ns/client/distro` | Verifies HTTP registered instance creates a visible client; covers detail, publish/subscriber lists, distro info, namespace/group isolation, required service fields, missing client 404, and empty list shapes. |
+| `OperatorAdminApiOpenApiITCase` | `GET,PUT /v3/admin/ns/ops/switches`<br>`GET /v3/admin/ns/ops/metrics`<br>`PUT /v3/admin/ns/ops/log` | Queries and updates naming switches, queries metrics, and updates naming log level; covers metrics defaulting, required switch fields, invalid values, and controlled SERVER_ERROR/v3 errors. |
+
+## Core
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `NamespaceAdminApiOpenApiITCase` | `GET,PUT,POST,DELETE /v3/admin/core/namespace`<br>`GET /v3/admin/core/namespace/exist`<br>`GET /v3/admin/core/namespace/list` | Creates, queries, lists, checks, updates, and deletes namespace metadata; covers id trimming/length, namespace name validation, duplicate/missing fields, post-delete checks, and HTTP 400 errors. |
+| `CoreClusterAdminApiOpenApiITCase` | `GET /v3/admin/core/cluster/self`<br>`GET /v3/admin/core/cluster/nodes`<br>`PUT /v3/admin/core/cluster/node`<br>`POST /v3/admin/core/cluster/lookup` | Queries self node and node list with address/state filters; covers case-insensitive legal state, illegal state validation, empty node update body, lookup required fields, and intentionally avoids topology mutation success paths. |
+| `ServerLoaderAdminApiOpenApiITCase` | `GET /v3/admin/core/loader/current`<br>`GET /v3/admin/core/loader/cluster`<br>`POST /v3/admin/core/loader/reloadCurrent`<br>`POST /v3/admin/core/loader/reloadClient`<br>`POST /v3/admin/core/loader/smartReloadCluster` | Queries current connections and cluster loader metrics; covers required count/connectionId, numeric loaderFactor validation for smart reload, and intentionally avoids successful rebalance operations. |
+| `PluginAdminApiOpenApiITCase` | `GET /v3/admin/core/plugin`<br>`GET /v3/admin/core/plugin/list`<br>`GET /v3/admin/core/plugin/detail`<br>`PUT /v3/admin/core/plugin/status`<br>`GET,PUT /v3/admin/core/plugin/config` | Lists plugins, filters by pluginType, and queries detail; covers unknown type empty list, missing plugin 404, status/config required params, and intentionally avoids mutating plugin runtime state. |
+| `CoreOpsAdminApiOpenApiITCase` | `GET /v3/admin/core/ops/ids`<br>`POST /v3/admin/core/ops/raft`<br>`PUT /v3/admin/core/ops/log` | Queries id-generator diagnostics and updates runtime log level; covers raft command/value requirements, log body requirements, and JSON body validation errors. |
+| `CoreStateAdminApiOpenApiITCase` | `GET /v3/admin/core/state`<br>`GET /v3/admin/core/state/liveness`<br>`GET /v3/admin/core/state/readiness` | Queries server state, liveness, and readiness; covers parameter-free behavior, unexpected query tolerance, and documents that readiness failure is not forced because it mutates shared server state. |
+
+## AI Registry
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `A2aAdminApiOpenApiITCase` | `GET,PUT,POST,DELETE /v3/admin/ai/a2a`<br>`GET /v3/admin/ai/a2a/list`<br>`GET /v3/admin/ai/a2a/version/list` | Registers legacy and v1 agent cards, normalizes interfaces, queries by version/latest, updates latest, lists, enumerates versions, and deletes; covers defaults, invalid search/type/card JSON, missing identity, absent agent, and tolerant delete. |
+| `McpAdminApiOpenApiITCase` | `GET,PUT,POST,DELETE /v3/admin/ai/mcp`<br>`GET /v3/admin/ai/mcp/list` | Creates MCP server with stdio spec/tools/resources, queries by id/name/latest, updates version, lists accurate/blur, and deletes; covers identity alternatives, invalid search/custom id/JSON, duplicate conflict, not-found, and empty pages. |
+| `PipelineAdminApiOpenApiITCase` | `GET /v3/admin/ai/pipelines`<br>`GET /v3/admin/ai/pipelines/list`<br>`GET /v3/admin/ai/pipelines/detail`<br>`GET /v3/admin/ai/pipelines/{pipelineId}` | Lists current and legacy pipeline page contracts and queries pipeline detail; covers required resourceType, pagination validation, unknown pipeline 404, and unavailable external resource behavior. |
+| `AiResourceImportAdminApiOpenApiITCase` | `GET /v3/admin/ai/import/sources`<br>`POST /v3/admin/ai/import/search`<br>`POST /v3/admin/ai/import/validate`<br>`POST /v3/admin/ai/import/execute` | Lists sanitized import sources and runs search/validate/execute flows with fake source data; covers required fields, JSON option parsing, overwrite/skipInvalid flags, unsupported resource/source types, token mismatch, and import result errors. |
+| `PromptAdminApiOpenApiITCase` | `DELETE /v3/admin/ai/prompt`<br>`GET /v3/admin/ai/prompt/list`<br>`GET /v3/admin/ai/prompt/versions`<br>`GET /v3/admin/ai/prompt/governance`<br>`GET /v3/admin/ai/prompt/version`<br>`GET /v3/admin/ai/prompt/version/download`<br>`POST,PUT,DELETE /v3/admin/ai/prompt/draft`<br>`POST /v3/admin/ai/prompt/submit`<br>`POST /v3/admin/ai/prompt/publish`<br>`POST /v3/admin/ai/prompt/force-publish`<br>`POST /v3/admin/ai/prompt/redraft`<br>`POST /v3/admin/ai/prompt/online`<br>`POST /v3/admin/ai/prompt/offline`<br>`PUT /v3/admin/ai/prompt/labels`<br>`PUT /v3/admin/ai/prompt/description`<br>`PUT /v3/admin/ai/prompt/biz-tags` | Exercises prompt draft create/update/delete, submit, force-publish, governance, versions, list, metadata, labels, bizTags, online/offline, download, legacy compatibility, and delete; covers defaults, search filters, version format, missing params, absent resources, and controlled workflow errors. |
+| `SkillAdminApiOpenApiITCase` | `GET,DELETE /v3/admin/ai/skills`<br>`GET /v3/admin/ai/skills/list`<br>`GET /v3/admin/ai/skills/version`<br>`GET /v3/admin/ai/skills/version/download`<br>`POST,PUT,DELETE /v3/admin/ai/skills/draft`<br>`POST /v3/admin/ai/skills/submit`<br>`POST /v3/admin/ai/skills/publish`<br>`POST /v3/admin/ai/skills/force-publish`<br>`POST /v3/admin/ai/skills/redraft`<br>`POST /v3/admin/ai/skills/online`<br>`POST /v3/admin/ai/skills/offline`<br>`PUT /v3/admin/ai/skills/labels`<br>`PUT /v3/admin/ai/skills/biz-tags`<br>`PUT /v3/admin/ai/skills/scope` | Exercises skill draft/create/update/delete/fork, submit, force-publish, metadata, labels, bizTags, scope, online/offline, download, list, and delete; covers defaults, search/scope/bizTag filters, version and `SKILL.md` mismatch validation, absent resources, and controlled workflow errors. |
+| `SkillUploadAdminApiOpenApiITCase` | `POST /v3/admin/ai/skills/upload`<br>`POST /v3/admin/ai/skills/upload/batch` | Uploads single and batch skill ZIPs, validates generated drafts/resources, overwrite behavior, next version generation, and partial batch handling; covers empty/malformed ZIP, invalid targetVersion, missing `SKILL.md`, and upload error envelopes. |
+| `AgentSpecAdminApiOpenApiITCase` | `GET,DELETE /v3/admin/ai/agentspecs`<br>`GET /v3/admin/ai/agentspecs/list`<br>`GET /v3/admin/ai/agentspecs/version`<br>`GET /v3/admin/ai/agentspecs/version/meta`<br>`POST,PUT,DELETE /v3/admin/ai/agentspecs/draft`<br>`POST /v3/admin/ai/agentspecs/submit`<br>`POST /v3/admin/ai/agentspecs/publish`<br>`POST /v3/admin/ai/agentspecs/force-publish`<br>`POST /v3/admin/ai/agentspecs/redraft`<br>`POST /v3/admin/ai/agentspecs/online`<br>`POST /v3/admin/ai/agentspecs/offline`<br>`PUT /v3/admin/ai/agentspecs/labels`<br>`PUT /v3/admin/ai/agentspecs/biz-tags`<br>`PUT /v3/admin/ai/agentspecs/scope` | Exercises AgentSpec draft/create/update/delete/fork, force-publish, metadata, version/meta, labels, bizTags, scope, online/offline, list, and delete; covers defaults, search/scope filters, version validation, absent resources, and controlled workflow errors. |
+| `AgentSpecUploadAdminApiOpenApiITCase` | `POST /v3/admin/ai/agentspecs/upload` | Uploads single and batch AgentSpec ZIPs, validates manifest/resources, overwrite behavior, next version generation, and partial batch handling; covers empty/malformed ZIP, missing manifest, invalid targetVersion, and upload error envelopes. |

--- a/test/openapi-test/API_TEST_COVERAGE.md
+++ b/test/openapi-test/API_TEST_COVERAGE.md
@@ -1,0 +1,42 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# OpenAPI IT Coverage Registry
+
+This registry records which Nacos HTTP APIs are covered by
+`test/openapi-test` integration tests and where to find the scenario matrix for
+each API surface. It is meant for maintainers and agents to quickly locate
+coverage before adding or debugging an IT.
+
+## Maintenance Rules
+
+- Update the matching scenario document whenever an OpenAPI/AdminAPI/ConsoleAPI
+  IT class is added, removed, or gains meaningful scenario coverage.
+- Keep the class Javadoc `Scenario coverage` section or the scenario document
+  as the source of truth for what a class verifies.
+- Record API scenario coverage, not line or branch coverage. Each row should
+  identify expected capability, boundary/validation, and exception/error
+  handling coverage when those scenario groups are practical.
+- If an exposed success path is intentionally not executed because it mutates
+  risky runtime or storage state, record the reason in the scenario cell.
+
+## Coverage Documents
+
+| API surface | Scenario document | Test package |
+| --- | --- | --- |
+| Client OpenAPI | [CLIENT_API_TEST_SCENARIOS.md](CLIENT_API_TEST_SCENARIOS.md) | `src/test/java/com/alibaba/nacos/test/openapi/client` |
+| Admin API | [ADMIN_API_TEST_SCENARIOS.md](ADMIN_API_TEST_SCENARIOS.md) | `src/test/java/com/alibaba/nacos/test/adminapi` |
+| Console API | [CONSOLE_API_TEST_SCENARIOS.md](CONSOLE_API_TEST_SCENARIOS.md) | `src/test/java/com/alibaba/nacos/test/consoleapi` |

--- a/test/openapi-test/CLIENT_API_TEST_SCENARIOS.md
+++ b/test/openapi-test/CLIENT_API_TEST_SCENARIOS.md
@@ -1,0 +1,49 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Client API IT Scenario Index
+
+This document records which client OpenAPI operations are covered by the
+standalone-server IT classes under
+`src/test/java/com/alibaba/nacos/test/openapi/client`.
+
+Source API surface: Nacos client OpenAPI swagger and production controllers
+for `/v3/client/**`. The branch-level coverage target is API scenario coverage:
+expected capability, boundary/validation behavior, and controlled
+exception/error handling.
+
+## Config
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `ConfigOpenApiITCase` | `GET /v3/client/cs/config` | Queries config published by admin API with content, md5, lastModified, contentType, and beta fields; verifies public namespace defaulting, wrong namespace not-found, required `dataId`/`groupName`, legacy `group` rejection, invalid namespace, and wrapped not-found/error bodies. |
+
+## Naming
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `InstanceRegisterOpenApiITCase` | `POST /v3/client/ns/instance` | Registers instances and verifies visibility through list; covers namespace/group/cluster/healthy/weight/enabled defaults, explicit group/cluster behavior, required service/ip/port validation, invalid weight/cluster, and duplicate or service-state errors. |
+| `InstanceListOpenApiITCase` | `GET /v3/client/ns/instance/list` | Lists enabled registered instances with metadata and health fields; covers namespace/group/cluster defaults, healthy-only and enabled filtering, empty-result behavior, required `serviceName`, malformed or unknown parameters, and not-found style results. |
+| `InstanceDeregisterOpenApiITCase` | `DELETE /v3/client/ns/instance` | Deregisters an existing instance and verifies absence from list; covers default and explicit group/cluster values, idempotent missing-instance behavior, required service/ip/port validation, and malformed port handling. |
+
+## AI Registry
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `PromptClientOpenApiITCase` | `GET /v3/client/ai/prompt` | Queries online prompts by latest, explicit version, and label; verifies namespace defaulting, version-over-label priority, md5 conditional HTTP 304, missing promptKey/version resolution, absent prompt, unknown version, and offline/not-online errors. |
+| `SkillClientOpenApiITCase` | `GET /v3/client/ai/skills` | Downloads online skills as ZIP by latest, version, and label with resource entries; covers namespace defaulting, version-over-label priority, missing skillName, absent skill, unknown version/label, and controlled not-found JSON for download failures. |
+| `AgentSpecClientOpenApiITCase` | `GET /v3/client/ai/agentspecs` | Queries online AgentSpecs by latest, version, and label with manifest/resource content; covers namespace defaulting, label/version resolution, missing agentSpecName, absent AgentSpec, unknown version, and controlled not-found errors. |
+| `AgentSpecSearchClientOpenApiITCase` | `GET /v3/client/ai/agentspecs/search` | Searches enabled AgentSpecs with online versions and keyword filters; covers optional keyword, namespace defaulting, page defaults and validation, empty page success, and invalid pagination errors. |

--- a/test/openapi-test/CONSOLE_API_TEST_SCENARIOS.md
+++ b/test/openapi-test/CONSOLE_API_TEST_SCENARIOS.md
@@ -1,0 +1,83 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Console API IT Scenario Index
+
+This document records which console API operations are covered by the
+standalone-server IT classes under
+`src/test/java/com/alibaba/nacos/test/consoleapi`.
+
+Source API surface: console swagger at `https://nacos.io/swagger/console/zh/api.json`.
+The branch-level coverage target is API scenario coverage: expected capability,
+boundary/validation behavior, and controlled exception/error handling.
+
+## Core, Health, Plugin, And Server
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `HealthConsoleApiOpenApiITCase` | `GET /v3/console/health/liveness`<br>`GET /v3/console/health/readiness` | Verifies health endpoints return wrapped success bodies with `ok`; validates the console port/base path contract. These APIs have no request parameters, so boundary coverage is limited to response contract shape. |
+| `NamespaceConsoleApiOpenApiITCase` | `GET,PUT,POST,DELETE /v3/console/core/namespace`<br>`GET /v3/console/core/namespace/exist`<br>`GET /v3/console/core/namespace/list` | Creates, queries, updates, lists, checks existence, and deletes a namespace; validates missing required fields, invalid or overlong namespace IDs/names, duplicate create, and absent namespace behavior. |
+| `ClusterConsoleApiOpenApiITCase` | `GET /v3/console/core/cluster/nodes` | Verifies standalone cluster node list shape, node identity fields, and wrapped response contract. The endpoint has no request parameters in the swagger surface. |
+| `ServerStateConsoleApiOpenApiITCase` | `GET /v3/console/server/state`<br>`GET /v3/console/server/announcement`<br>`GET /v3/console/server/guide` | Verifies server state exposes expected state keys and announcement/guide endpoints return controlled wrapped data in the default standalone environment. These APIs do not mutate state. |
+| `PluginConsoleApiOpenApiITCase` | `GET /v3/console/plugin`<br>`GET /v3/console/plugin/list`<br>`GET /v3/console/plugin/availability`<br>`GET /v3/console/plugin/config`<br>`PUT /v3/console/plugin/config`<br>`PUT /v3/console/plugin/status` | Verifies plugin list/status/config/availability response shapes, built-in plugin visibility, config/status update validation, and controlled errors for missing or unknown plugin identifiers. |
+
+## Config
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `ConfigConsoleApiOpenApiITCase` | `GET,POST,DELETE /v3/console/cs/config` | Publishes, queries, updates, and deletes config; verifies content, md5, type, description, config tags, namespace/group defaults, missing required fields, invalid type, and absent config behavior. |
+| `ConfigListConsoleApiOpenApiITCase` | `GET /v3/console/cs/config/list`<br>`GET /v3/console/cs/config/searchDetail` | Verifies list/search pagination shape, accurate and blur search behavior, dataId/group/content filters, empty pages, page validation, and required search parameters. |
+| `ConfigListenerConsoleApiOpenApiITCase` | `GET /v3/console/cs/config/listener`<br>`GET /v3/console/cs/config/listener/ip` | Verifies listener status response shape for config and IP scoped queries, missing dataId/group validation, query type fields, and controlled empty listener state. |
+| `ConfigHistoryConsoleApiOpenApiITCase` | `GET /v3/console/cs/history`<br>`GET /v3/console/cs/history/list`<br>`GET /v3/console/cs/history/previous`<br>`GET /v3/console/cs/history/configs` | Publishes versioned config changes and verifies history list/detail/previous/config snapshots; validates missing identifiers, pagination, and absent history/config behavior. |
+| `ConfigBetaConsoleApiOpenApiITCase` | `GET,DELETE /v3/console/cs/config/beta` | Publishes beta config through console headers, queries and deletes beta content, and verifies missing/absent beta responses stay wrapped and non-500. |
+| `ConfigBatchDeleteConsoleApiOpenApiITCase` | `DELETE /v3/console/cs/config/batchDelete` | Creates multiple configs, deletes them through the batch API, verifies absence, and validates missing/empty IDs and malformed batch input. |
+| `ConfigExportConsoleApiOpenApiITCase` | `GET /v3/console/cs/config/export2` | Exports existing config data, verifies file response and exported content, and validates empty export, missing namespace/group filters, and controlled bad request cases. |
+| `ConfigImportConsoleApiOpenApiITCase` | `POST /v3/console/cs/config/import` | Imports zipped config payloads, verifies persisted imported data, overwrite behavior, malformed archive handling, and import result structure for success and failure cases. |
+| `ConfigCloneConsoleApiOpenApiITCase` | `POST /v3/console/cs/config/clone` | Clones config to target dataId/group/namespace, verifies target content and metadata, and validates missing clone source/target fields and absent source config behavior. |
+
+## Naming
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `ServiceConsoleApiOpenApiITCase` | `GET,PUT,POST,DELETE /v3/console/ns/service`<br>`GET /v3/console/ns/service/list`<br>`GET /v3/console/ns/service/selector/types`<br>`GET /v3/console/ns/service/subscribers` | Creates, queries, updates, lists, and deletes services; verifies selector type list, empty subscriber page shape, namespace/group defaults, duplicate create, invalid service/group/page fields, and absent service errors. |
+| `ServiceClusterConsoleApiOpenApiITCase` | `PUT /v3/console/ns/service/cluster` | Creates service cluster metadata, verifies cluster-specific service detail/list behavior, updates health checker/protect threshold style fields, and validates missing service/cluster fields plus absent service behavior. |
+| `InstanceConsoleApiOpenApiITCase` | `PUT,DELETE /v3/console/ns/instance`<br>`GET /v3/console/ns/instance/list` | Registers setup service/instance, updates instance metadata/weight/enabled fields, lists instance state, deletes the instance, and validates missing IP/port/service, invalid port/weight, absent service, and controlled not-found behavior. |
+
+## AI Registry And Copilot
+
+| IT class | Covered API operations | Scenario coverage |
+| --- | --- | --- |
+| `A2aConsoleApiOpenApiITCase` | `GET,PUT,POST,DELETE /v3/console/ai/a2a`<br>`GET /v3/console/ai/a2a/list`<br>`GET /v3/console/ai/a2a/version/list` | Registers legacy and v1 AgentCards, verifies normalized fields and latest/version queries, updates a new version, lists by accurate/blur search, deletes resources, and validates missing names, bad search, invalid registration type, malformed JSON, incomplete endpoint definitions, and absent agents. |
+| `McpConsoleApiOpenApiITCase` | `GET,PUT,POST,DELETE /v3/console/ai/mcp`<br>`GET /v3/console/ai/mcp/list`<br>`GET /v3/console/ai/mcp/importToolsFromMcp`<br>`POST /v3/console/ai/mcp/import/validate`<br>`POST /v3/console/ai/mcp/import/execute` | Creates, queries, updates, lists, and deletes MCP servers; verifies generated ID, latest/allVersions, tool spec, accurate/blur list, duplicate conflict, missing identity/spec/version, invalid ID, malformed JSON, absent server, unsupported tool import transport, and import request validation. Console currently accepts `resourceSpecification` but does not persist it because the controller does not parse resources; the IT records that observable behavior. |
+| `PromptConsoleApiOpenApiITCase` | `DELETE /v3/console/ai/prompt`<br>`GET /v3/console/ai/prompt/list`<br>`GET /v3/console/ai/prompt/versions`<br>`GET /v3/console/ai/prompt/governance`<br>`GET /v3/console/ai/prompt/version`<br>`GET /v3/console/ai/prompt/version/download`<br>`POST,PUT,DELETE /v3/console/ai/prompt/draft`<br>`POST /v3/console/ai/prompt/submit`<br>`POST /v3/console/ai/prompt/publish`<br>`POST /v3/console/ai/prompt/force-publish`<br>`POST /v3/console/ai/prompt/redraft`<br>`POST /v3/console/ai/prompt/online`<br>`POST /v3/console/ai/prompt/offline`<br>`PUT /v3/console/ai/prompt/labels`<br>`PUT /v3/console/ai/prompt/description`<br>`PUT /v3/console/ai/prompt/biz-tags` | Verifies prompt draft/update/delete, submit, force publish, version detail, governance metadata, version list, list filters, Markdown download, labels/description/bizTags, online/offline, delete, and absent resource/version errors. Validates missing promptKey/template/version/labels/description, invalid search, publish/redraft state errors, and controlled non-500 failures. Runtime-only legacy prompt endpoints are intentionally not covered because they are not exposed by the console controller. |
+| `SkillConsoleApiOpenApiITCase` | `GET,DELETE /v3/console/ai/skills`<br>`GET /v3/console/ai/skills/list`<br>`GET /v3/console/ai/skills/version`<br>`GET /v3/console/ai/skills/version/download`<br>`POST,PUT,DELETE /v3/console/ai/skills/draft`<br>`POST /v3/console/ai/skills/submit`<br>`POST /v3/console/ai/skills/publish`<br>`POST /v3/console/ai/skills/force-publish`<br>`POST /v3/console/ai/skills/redraft`<br>`POST /v3/console/ai/skills/online`<br>`POST /v3/console/ai/skills/offline`<br>`PUT /v3/console/ai/skills/labels`<br>`PUT /v3/console/ai/skills/biz-tags`<br>`PUT /v3/console/ai/skills/scope` | Verifies skill draft/update/fork/delete, submit, force publish, detail, version detail, list filters, ZIP download, labels, bizTags, PUBLIC/PRIVATE scope, version-level and skill-level online/offline, delete, and absent resource/version errors. Validates missing skillName/skillCard/targetVersion/version/labels/scope, name mismatch, invalid version/search/scope/page, and invalid lifecycle transitions. |
+| `SkillUploadConsoleApiOpenApiITCase` | `POST /v3/console/ai/skills/upload`<br>`POST /v3/console/ai/skills/upload/batch` | Verifies single ZIP upload from `SKILL.md` plus resources, overwrite of an editing draft, next draft version after publish, batch upload success, partial batch failure reporting, duplicate working draft conflict, empty/malformed ZIP, invalid targetVersion, and archive parsing failures. |
+| `AgentSpecConsoleApiOpenApiITCase` | `GET,DELETE /v3/console/ai/agentspecs`<br>`GET /v3/console/ai/agentspecs/list`<br>`GET /v3/console/ai/agentspecs/version`<br>`POST,PUT,DELETE /v3/console/ai/agentspecs/draft`<br>`POST /v3/console/ai/agentspecs/submit`<br>`POST /v3/console/ai/agentspecs/publish`<br>`POST /v3/console/ai/agentspecs/force-publish`<br>`POST /v3/console/ai/agentspecs/redraft`<br>`POST /v3/console/ai/agentspecs/online`<br>`POST /v3/console/ai/agentspecs/offline`<br>`PUT /v3/console/ai/agentspecs/labels`<br>`PUT /v3/console/ai/agentspecs/biz-tags`<br>`PUT /v3/console/ai/agentspecs/scope` | Verifies AgentSpec draft/update/auto-create/fork/delete, submit, force publish, detail, version detail, list filters, labels, bizTags, scope, version-level and resource-level online/offline, delete, and absent resource/version errors. Validates missing agentSpecName/agentSpecCard/targetVersion/version/labels/scope, invalid version/search/scope/page, and invalid lifecycle transitions. The shared `bizTag` filter is accepted but not applied by the AgentSpec service; the IT records that behavior. |
+| `AgentSpecUploadConsoleApiOpenApiITCase` | `POST /v3/console/ai/agentspecs/upload` | Verifies single AgentSpec ZIP upload from `manifest.json` plus resources, overwrite of an editing draft, next draft version after publish, seed archives importing multiple AgentSpecs, empty file, malformed ZIP, and missing manifest errors. |
+| `AiResourceImportConsoleApiOpenApiITCase` | `GET /v3/console/ai/import/sources`<br>`POST /v3/console/ai/import/search`<br>`POST /v3/console/ai/import/validate`<br>`POST /v3/console/ai/import/execute` | Verifies configured import source list, resourceType filters, sanitized source info, unsupported resource type empty result, missing resourceType/sourceId/selectedItems, malformed JSON options/selectedItems, empty selected items, unknown source not-found, unsupported source/resourceType combinations, and controlled error bodies without performing external network import. |
+| `PipelineConsoleApiOpenApiITCase` | `GET /v3/console/ai/pipelines`<br>`GET /v3/console/ai/pipelines/list`<br>`GET /v3/console/ai/pipelines/detail`<br>`GET /v3/console/ai/pipelines/{pipelineId}` | Verifies current and legacy list page contracts for resourceType/resourceName/namespaceId/version filters, required resourceType, page validation, required pipelineId, and absent pipeline not-found errors. Successful detail creation is not covered in the default standalone IT environment because pipeline rows require configured publish-pipeline plugins. |
+| `CopilotConsoleApiOpenApiITCase` | `GET,POST /v3/console/copilot/config`<br>`POST /v3/console/copilot/skill/optimize`<br>`POST /v3/console/copilot/skill/generate`<br>`POST /v3/console/copilot/prompt/optimize`<br>`POST /v3/console/copilot/prompt/debug` | Verifies config save/read for API key, model, studio URL, and studio project; records that non-editable config fields are accepted but ignored by the save path. Verifies malformed JSON config error and SSE validation error events for empty bodies and missing required skill/background/prompt/userInput fields without invoking an external LLM provider. |
+
+## Validation Snapshot
+
+The console API IT set was validated with:
+
+- `mvn -pl test/openapi-test spotless:apply`
+- `mvn -pl test/openapi-test spotless:check`
+- `mvn -pl test/openapi-test -DskipTests test-compile`
+- `mvn -pl test/openapi-test -Pintegration-test -DskipTests=false -Dit.test='*ConsoleApiOpenApiITCase' verify`
+
+The full console IT verification ran 75 tests with no failures.

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ConsoleApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ConsoleApiBaseITCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi;
+
+import com.alibaba.nacos.test.openapi.OpenApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shared helpers for console OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class ConsoleApiBaseITCase extends OpenApiBaseITCase {
+
+    protected static final String DEFAULT_NAMESPACE = "public";
+
+    protected static final String DEFAULT_GROUP = "DEFAULT_GROUP";
+
+    protected static final String DEFAULT_CLUSTER = "DEFAULT";
+
+    protected static final String NACOS_CONSOLE_PORT = System.getProperty("nacos.console.port", "8080");
+
+    protected static final String CONSOLE_BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_CONSOLE_PORT;
+
+    protected static final String CONSOLE_BASE_PATH = "/v3/console";
+
+    @Override
+    protected String baseUrl() {
+        return CONSOLE_BASE_URL;
+    }
+
+    protected String randomConsoleName(String scenario) {
+        return "openapi_it_console_" + scenario + "_" + UUID.randomUUID();
+    }
+
+    protected void assertPageShape(JsonNode page) {
+        assertNotNull(page.get("pageNumber"), page.toString());
+        assertNotNull(page.get("pagesAvailable"), page.toString());
+        assertNotNull(page.get("totalCount"), page.toString());
+        assertTrue(page.get("pageNumber").asInt() >= 1, page.toString());
+        assertTrue(page.get("pagesAvailable").asInt() >= 0, page.toString());
+        assertTrue(page.get("totalCount").asInt() >= 0, page.toString());
+        assertTrue(page.get("pageItems").isArray(), page.toString());
+    }
+
+    protected void assertArrayContainsText(JsonNode array, String expected) {
+        for (JsonNode item : array) {
+            if (expected.equals(item.asText())) {
+                return;
+            }
+        }
+        throw new AssertionError("Expected array to contain " + expected + ", actual=" + array);
+    }
+
+    protected JsonNode findByTextField(JsonNode array, String fieldName, String expected) {
+        for (JsonNode item : array) {
+            if (expected.equals(item.path(fieldName).asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/AiConsoleApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/AiConsoleApiBaseITCase.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.copilot.constant.CopilotConstants;
+import com.alibaba.nacos.test.adminapi.ai.AiAdminApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shared helpers for AI console OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class AiConsoleApiBaseITCase extends AiAdminApiBaseITCase {
+
+    protected static final String NACOS_CONSOLE_PORT = System.getProperty("nacos.console.port", "8080");
+
+    protected static final String CONSOLE_BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_CONSOLE_PORT;
+
+    protected static final String CONSOLE_A2A_PATH = Constants.A2A.CONSOLE_PATH;
+
+    protected static final String CONSOLE_A2A_LIST_PATH = CONSOLE_A2A_PATH + "/list";
+
+    protected static final String CONSOLE_A2A_VERSION_LIST_PATH = CONSOLE_A2A_PATH + "/version/list";
+
+    protected static final String CONSOLE_MCP_PATH = Constants.MCP_CONSOLE_PATH;
+
+    protected static final String CONSOLE_MCP_LIST_PATH = CONSOLE_MCP_PATH + "/list";
+
+    protected static final String CONSOLE_MCP_IMPORT_TOOLS_PATH = CONSOLE_MCP_PATH + "/importToolsFromMcp";
+
+    protected static final String CONSOLE_MCP_IMPORT_VALIDATE_PATH = CONSOLE_MCP_PATH + "/import/validate";
+
+    protected static final String CONSOLE_MCP_IMPORT_EXECUTE_PATH = CONSOLE_MCP_PATH + "/import/execute";
+
+    protected static final String CONSOLE_PIPELINE_PATH = Constants.Pipeline.CONSOLE_PATH;
+
+    protected static final String CONSOLE_PIPELINE_LIST_PATH =
+            CONSOLE_PIPELINE_PATH + Constants.Pipeline.LIST_SUBPATH;
+
+    protected static final String CONSOLE_PIPELINE_DETAIL_PATH =
+            CONSOLE_PIPELINE_PATH + Constants.Pipeline.DETAIL_SUBPATH;
+
+    protected static final String CONSOLE_PROMPT_PATH = Constants.Prompt.CONSOLE_PATH;
+
+    protected static final String CONSOLE_PROMPT_LIST_PATH = CONSOLE_PROMPT_PATH + "/list";
+
+    protected static final String CONSOLE_PROMPT_VERSIONS_PATH = CONSOLE_PROMPT_PATH + "/versions";
+
+    protected static final String CONSOLE_PROMPT_GOVERNANCE_PATH = CONSOLE_PROMPT_PATH + "/governance";
+
+    protected static final String CONSOLE_PROMPT_VERSION_PATH = CONSOLE_PROMPT_PATH + "/version";
+
+    protected static final String CONSOLE_PROMPT_VERSION_DOWNLOAD_PATH =
+            CONSOLE_PROMPT_PATH + "/version/download";
+
+    protected static final String CONSOLE_SKILL_PATH = Constants.Skills.CONSOLE_PATH;
+
+    protected static final String CONSOLE_SKILL_LIST_PATH = CONSOLE_SKILL_PATH + "/list";
+
+    protected static final String CONSOLE_SKILL_VERSION_PATH = CONSOLE_SKILL_PATH + "/version";
+
+    protected static final String CONSOLE_SKILL_VERSION_DOWNLOAD_PATH =
+            CONSOLE_SKILL_PATH + "/version/download";
+
+    protected static final String CONSOLE_AGENT_SPEC_PATH = Constants.AgentSpecs.CONSOLE_PATH;
+
+    protected static final String CONSOLE_AGENT_SPEC_LIST_PATH = CONSOLE_AGENT_SPEC_PATH + "/list";
+
+    protected static final String CONSOLE_AGENT_SPEC_VERSION_PATH =
+            CONSOLE_AGENT_SPEC_PATH + "/version";
+
+    protected static final String CONSOLE_IMPORT_PATH = Constants.AI_RESOURCE_IMPORT_CONSOLE_PATH;
+
+    protected static final String CONSOLE_IMPORT_SOURCES_PATH = CONSOLE_IMPORT_PATH + "/sources";
+
+    protected static final String CONSOLE_IMPORT_SEARCH_PATH = CONSOLE_IMPORT_PATH + "/search";
+
+    protected static final String CONSOLE_IMPORT_VALIDATE_PATH = CONSOLE_IMPORT_PATH + "/validate";
+
+    protected static final String CONSOLE_IMPORT_EXECUTE_PATH = CONSOLE_IMPORT_PATH + "/execute";
+
+    protected static final String CONSOLE_COPILOT_PATH = CopilotConstants.COPILOT_CONSOLE_PATH;
+
+    protected static final String CONSOLE_COPILOT_CONFIG_PATH = CONSOLE_COPILOT_PATH + "/config";
+
+    @Override
+    protected String baseUrl() {
+        return CONSOLE_BASE_URL;
+    }
+
+    @Override
+    protected void deleteMcpServerQuietly(String mcpName, String mcpId) throws Exception {
+        deleteQuietly(CONSOLE_MCP_PATH, mcpIdentityQuery(mcpName, mcpId, null));
+    }
+
+    @Override
+    protected void assertMcpDetail(JsonNode data, String mcpName, String version, String description,
+            String toolName, String resourceName) {
+        assertEquals(DEFAULT_NAMESPACE, data.get("namespaceId").asText(), data.toString());
+        assertEquals(mcpName, data.get("name").asText(), data.toString());
+        assertEquals(version, data.get("version").asText(), data.toString());
+        assertEquals(description, data.get("description").asText(), data.toString());
+        assertEquals("stdio", data.get("protocol").asText(), data.toString());
+        assertEquals(version, data.get("versionDetail").get("version").asText(), data.toString());
+        assertEquals(toolName, data.get("toolSpec").get("tools").get(0).get("name").asText(),
+                data.toString());
+        assertTrue(data.path("resourceSpec").isNull() || data.path("resourceSpec").isMissingNode(),
+                "Console MCP API currently accepts but does not persist resourceSpecification: "
+                        + resourceName + ", actual=" + data);
+    }
+
+    @Override
+    protected void deleteAgentQuietly(String agentName, String version, String registrationType)
+            throws Exception {
+        Query query = Query.newInstance().addParam("agentName", agentName)
+                .addParam("namespaceId", DEFAULT_NAMESPACE);
+        addIfNotBlank(query, "version", version);
+        addIfNotBlank(query, "registrationType", registrationType);
+        deleteQuietly(CONSOLE_A2A_PATH, query);
+    }
+
+    @Override
+    protected void deletePromptQuietly(String promptKey) throws Exception {
+        deleteQuietly(CONSOLE_PROMPT_PATH, promptQuery(promptKey));
+    }
+
+    @Override
+    protected void deleteSkillQuietly(String skillName) throws Exception {
+        deleteQuietly(CONSOLE_SKILL_PATH, skillQuery(skillName));
+    }
+
+    @Override
+    protected void deleteAgentSpecQuietly(String agentSpecName) throws Exception {
+        deleteQuietly(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName));
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/a2a/A2aConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/a2a/A2aConsoleApiOpenApiITCase.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.a2a;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for A2A console APIs ({@code /v3/console/ai/a2a}).
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: legacy and v1 agent cards can be registered, normalized, queried by version/latest,
+ *     updated to a new latest version, listed by blur search, and enumerated by version.</li>
+ *     <li>Boundary/validation: namespace defaults to public; register defaults registrationType to URL; update allows
+ *     omitted registrationType; invalid search, missing agentName, invalid registrationType, empty card, malformed
+ *     JSON, and incomplete legacy/v1 endpoint definitions are rejected with HTTP 400.</li>
+ *     <li>Exception/error handling: absent agents return a controlled not-found result and delete is tolerant of
+ *     absent resources.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class A2aConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+    
+    private static final String REGISTRATION_TYPE_URL = "URL";
+    
+    private static final String SEARCH_BLUR = "blur";
+    
+    @Test
+    public void testRegisterLegacyAgentCardAndGetAgentCardSuccess() throws Exception {
+        String agentName = "openapi-legacy-" + UUID.randomUUID();
+        String version = "1.2.0";
+        String legacyAgentCard = buildLegacyAgentCard(agentName, version);
+        try {
+            JsonNode register = registerAgent(agentName, version, REGISTRATION_TYPE_URL, legacyAgentCard);
+            assertEquals(ErrorCode.SUCCESS.getCode(), register.get("code").asInt(), register.toString());
+            assertEquals("ok", register.get("data").asText());
+            
+            JsonNode queryResult = getAgentCard(agentName, version, REGISTRATION_TYPE_URL);
+            assertEquals(ErrorCode.SUCCESS.getCode(), queryResult.get("code").asInt(), queryResult.toString());
+            JsonNode data = queryResult.get("data");
+            assertNotNull(data);
+            assertEquals(agentName, data.get("name").asText());
+            assertEquals(version, data.get("version").asText());
+            assertEquals("JSONRPC", data.get("preferredTransport").asText());
+            assertEquals("1.0", data.get("protocolVersion").asText());
+            JsonNode supportedInterfaces = data.get("supportedInterfaces");
+            assertTrue(null != supportedInterfaces && supportedInterfaces.isArray() && supportedInterfaces.size() >= 1,
+                    "supportedInterfaces should be generated for legacy card");
+            assertEquals("https://example.com/" + agentName + "/jsonrpc", supportedInterfaces.get(0).get("url").asText());
+            assertEquals("JSONRPC", supportedInterfaces.get(0).get("protocolBinding").asText());
+            assertEquals("1.0", supportedInterfaces.get(0).get("protocolVersion").asText());
+        } finally {
+            deleteAgentQuietly(agentName, version, REGISTRATION_TYPE_URL);
+        }
+    }
+    
+    @Test
+    public void testRegisterV1AgentCardAndGetAgentCardSuccess() throws Exception {
+        String agentName = "openapi-v1-" + UUID.randomUUID();
+        String version = "2.0.0";
+        String v1AgentCard = buildV1AgentCard(agentName, version, "1.0");
+        try {
+            JsonNode register = registerAgent(agentName, version, REGISTRATION_TYPE_URL, v1AgentCard);
+            assertEquals(ErrorCode.SUCCESS.getCode(), register.get("code").asInt(), register.toString());
+            assertEquals("ok", register.get("data").asText());
+            
+            JsonNode queryResult = getAgentCard(agentName, version, REGISTRATION_TYPE_URL);
+            assertEquals(ErrorCode.SUCCESS.getCode(), queryResult.get("code").asInt(), queryResult.toString());
+            JsonNode data = queryResult.get("data");
+            assertNotNull(data);
+            assertEquals(agentName, data.get("name").asText());
+            assertEquals(version, data.get("version").asText());
+            JsonNode supportedInterfaces = data.get("supportedInterfaces");
+            assertEquals(2, supportedInterfaces.size());
+            assertEquals("1.0", supportedInterfaces.get(0).get("protocolVersion").asText());
+            assertEquals("JSONRPC", supportedInterfaces.get(0).get("protocolBinding").asText());
+            assertEquals("https://example.com/" + agentName + "/jsonrpc", supportedInterfaces.get(0).get("url").asText());
+            // Legacy mirror fields should also be available for compatibility.
+            assertEquals("1.0", data.get("protocolVersion").asText());
+            assertEquals("JSONRPC", data.get("preferredTransport").asText());
+            assertEquals("https://example.com/" + agentName + "/jsonrpc", data.get("url").asText());
+            JsonNode additionalInterfaces = data.get("additionalInterfaces");
+            assertTrue(null != additionalInterfaces && additionalInterfaces.isArray() && additionalInterfaces.size() >= 1,
+                    "additionalInterfaces should be generated for v1 card");
+            assertEquals("GRPC", additionalInterfaces.get(0).get("transport").asText());
+        } finally {
+            deleteAgentQuietly(agentName, version, REGISTRATION_TYPE_URL);
+        }
+    }
+    
+    @Test
+    public void testUpdateAgentCardAndListApisSuccess() throws Exception {
+        String agentName = "openapi-update-" + UUID.randomUUID();
+        String v1 = "3.0.0";
+        String v2 = "3.1.0";
+        try {
+            JsonNode register = registerAgent(agentName, v1, null, buildV1AgentCard(agentName, v1, "1.0"));
+            assertEquals(ErrorCode.SUCCESS.getCode(), register.get("code").asInt(), register.toString());
+            
+            JsonNode updateResult = updateAgentCard(agentName, v2, REGISTRATION_TYPE_URL,
+                    buildV1AgentCard(agentName, v2, "1.0"), true);
+            assertEquals(ErrorCode.SUCCESS.getCode(), updateResult.get("code").asInt(), updateResult.toString());
+            assertEquals("ok", updateResult.get("data").asText());
+            
+            JsonNode latest = getAgentCard(agentName, null, REGISTRATION_TYPE_URL);
+            assertEquals(ErrorCode.SUCCESS.getCode(), latest.get("code").asInt(), latest.toString());
+            assertEquals(v2, latest.get("data").get("version").asText());
+            
+            JsonNode versionList = listAgentVersions(agentName, REGISTRATION_TYPE_URL);
+            assertEquals(ErrorCode.SUCCESS.getCode(), versionList.get("code").asInt(), versionList.toString());
+            assertTrue(versionList.get("data").isArray() && versionList.get("data").size() >= 2);
+            
+            JsonNode listResult = listAgents(agentName, SEARCH_BLUR, 1, 10);
+            assertEquals(ErrorCode.SUCCESS.getCode(), listResult.get("code").asInt(), listResult.toString());
+            JsonNode pageItems = listResult.get("data").get("pageItems");
+            assertTrue(pageItems.isArray() && pageItems.size() >= 1);
+            assertEquals(agentName, pageItems.get(0).get("name").asText());
+        } finally {
+            deleteAgentQuietly(agentName, v1, REGISTRATION_TYPE_URL);
+            deleteAgentQuietly(agentName, v2, REGISTRATION_TYPE_URL);
+        }
+    }
+    
+    @Test
+    public void testGetListAndVersionListValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(CONSOLE_A2A_PATH, Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)),
+                400, ErrorCode.PARAMETER_MISSING, "name");
+        assertError(getRaw(CONSOLE_A2A_LIST_PATH, Query.newInstance().addParam("search", "invalid")
+                .addParam("pageNo", "1").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+        assertError(getRaw(CONSOLE_A2A_VERSION_LIST_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE)), 400, ErrorCode.PARAMETER_MISSING,
+                "name");
+
+        String absentAgent = "openapi-absent-" + UUID.randomUUID();
+        assertError(getRaw(CONSOLE_A2A_PATH, Query.newInstance().addParam("agentName", absentAgent)
+                .addParam("namespaceId", DEFAULT_NAMESPACE)), 404, ErrorCode.AGENT_NOT_FOUND,
+                "Agent not found");
+    }
+
+    @Test
+    public void testRegisterInvalidAgentCardReturnsBadRequest() throws Exception {
+        String agentName = "openapi-invalid-" + UUID.randomUUID();
+        String version = "1.0.0";
+        Map<String, String> form = buildAgentCardForm(agentName, version, REGISTRATION_TYPE_URL,
+                "{\"name\":\"" + agentName + "\",\"version\":\"" + version + "\"}");
+        assertBadRequestContains(form, "agentCard.supportedInterfaces");
+    }
+    
+    @Test
+    public void testRegisterLegacyAgentCardMissingProtocolVersionReturnsBadRequest() throws Exception {
+        String agentName = "openapi-legacy-missing-" + UUID.randomUUID();
+        String version = "1.0.1";
+        String invalidLegacy = String.format("{\"name\":\"%s\",\"version\":\"%s\","
+                        + "\"preferredTransport\":\"JSONRPC\",\"url\":\"https://example.com/%s/jsonrpc\"}",
+                agentName, version, agentName);
+        Map<String, String> form = buildAgentCardForm(agentName, version, REGISTRATION_TYPE_URL, invalidLegacy);
+        assertBadRequestContains(form, "agentCard.supportedInterfaces");
+    }
+    
+    @Test
+    public void testRegisterV1AgentCardMissingProtocolVersionReturnsBadRequest() throws Exception {
+        String agentName = "openapi-v1-missing-pv-" + UUID.randomUUID();
+        String version = "1.0.2";
+        String invalidV1 = String.format("{\"name\":\"%s\",\"version\":\"%s\","
+                        + "\"supportedInterfaces\":[{\"url\":\"https://example.com/%s/jsonrpc\","
+                        + "\"protocolBinding\":\"JSONRPC\"}]}", agentName, version, agentName);
+        Map<String, String> form = buildAgentCardForm(agentName, version, REGISTRATION_TYPE_URL, invalidV1);
+        assertBadRequestContains(form, "agentCard.supportedInterfaces");
+    }
+    
+    @Test
+    public void testRegisterInvalidRegistrationTypeReturnsBadRequest() throws Exception {
+        String agentName = "openapi-invalid-reg-" + UUID.randomUUID();
+        String version = "1.0.3";
+        Map<String, String> form = buildAgentCardForm(agentName, version, "INVALID",
+                buildV1AgentCard(agentName, version, "1.0"));
+        assertBadRequestContains(form, "registrationType");
+    }
+    
+    @Test
+    public void testRegisterMalformedAgentCardJsonReturnsBadRequest() throws Exception {
+        String agentName = "openapi-invalid-json-" + UUID.randomUUID();
+        String version = "1.0.4";
+        Map<String, String> form = buildAgentCardForm(agentName, version, REGISTRATION_TYPE_URL, "{");
+        assertBadRequestContains(form, "Can't be parsed");
+    }
+    
+    @Test
+    public void testRegisterEmptyAgentCardReturnsBadRequest() throws Exception {
+        String agentName = "openapi-empty-card-" + UUID.randomUUID();
+        String version = "1.0.5";
+        Map<String, String> form = buildAgentCardForm(agentName, version, REGISTRATION_TYPE_URL, "");
+        assertBadRequestContains(form, "agentCard");
+    }
+    
+    private JsonNode registerAgent(String agentName, String version, String registrationType, String agentCard)
+            throws Exception {
+        Map<String, String> form = buildAgentCardForm(agentName, version, registrationType, agentCard);
+        if (null == registrationType) {
+            form.remove("registrationType");
+        }
+        return postFormOk(CONSOLE_A2A_PATH, form);
+    }
+    
+    private JsonNode updateAgentCard(String agentName, String version, String registrationType, String agentCard,
+            boolean setAsLatest) throws Exception {
+        Map<String, String> form = buildAgentCardForm(agentName, version, registrationType, agentCard);
+        form.put("setAsLatest", String.valueOf(setAsLatest));
+        return putFormOk(CONSOLE_A2A_PATH, form);
+    }
+    
+    private JsonNode getAgentCard(String agentName, String version, String registrationType) throws Exception {
+        Query query = Query.newInstance().addParam("agentName", agentName).addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("registrationType", registrationType);
+        if (null != version) {
+            query.addParam("version", version);
+        }
+        return getJsonOk(CONSOLE_A2A_PATH, query);
+    }
+    
+    private JsonNode listAgentVersions(String agentName, String registrationType) throws Exception {
+        Query query = Query.newInstance().addParam("agentName", agentName).addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("registrationType", registrationType);
+        return getJsonOk(CONSOLE_A2A_VERSION_LIST_PATH, query);
+    }
+    
+    private JsonNode listAgents(String agentName, String search, int pageNo, int pageSize) throws Exception {
+        Query query = Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE).addParam("agentName", agentName)
+                .addParam("search", search).addParam("pageNo", String.valueOf(pageNo))
+                .addParam("pageSize", String.valueOf(pageSize));
+        return getJsonOk(CONSOLE_A2A_LIST_PATH, query);
+    }
+    
+    private void assertBadRequestContains(Map<String, String> form, String expectedText) throws Exception {
+        HttpResponse response = postRaw(CONSOLE_A2A_PATH, queryFrom(form));
+        assertEquals(400, response.code(), response.body());
+        assertTrue(response.body().contains(expectedText),
+                "expected message should contain `" + expectedText + "`, actual=" + response.body());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/agentspec/AgentSpecConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/agentspec/AgentSpecConsoleApiOpenApiITCase.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.agentspec;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for AgentSpec console OpenAPI {@code /v3/console/ai/agentspecs}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: draft creation, draft update, force-publish, console detail, version detail, list,
+ *     labels, bizTags, scope, online/offline, and delete expose the expected AgentSpec state.</li>
+ *     <li>Boundary/validation: namespace defaults to public; list supports accurate/blur and scope filters while
+ *     the shared {@code bizTag} request parameter is accepted but not applied by the AgentSpec service; required
+ *     agentSpecName, agentSpecCard, targetVersion, version, labels, scope, and positive pagination validation
+ *     follows the controller forms; draft forking, auto-create-by-update, and draft deletion are covered.</li>
+ *     <li>Exception/error handling: absent AgentSpecs and versions return controlled RESOURCE_NOT_FOUND bodies,
+ *     direct publish from draft and redraft from online return validation errors instead of HTTP 500, and invalid
+ *     search or scope parameters return HTTP 400.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class AgentSpecConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+
+    @Test
+    public void testAgentSpecLifecycleGovernanceListAndDelete() throws Exception {
+        String agentSpecName = randomAiName("agentspec");
+        JsonNode draft = postFormOk(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                agentSpecDraftForm(agentSpecName, "1.0.0"));
+        assertEquals("1.0.0", draft.get("data").asText(), draft.toString());
+        addCleanup(() -> deleteAgentSpecQuietly(agentSpecName));
+
+        JsonNode updated = putFormOk(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                agentSpecUpdateForm(agentSpecName, "1.0.0", "AgentSpec v1",
+                        "scenario-v1", "soul v1"));
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        JsonNode draftDetail = getJsonOk(CONSOLE_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "1.0.0")).get("data");
+        assertAgentSpecContent(draftDetail, agentSpecName, "1.0.0", "AgentSpec v1",
+                "scenario-v1", "soul v1");
+        assertAgentSpecVersionStatus(agentSpecName, "1.0.0", "draft");
+
+        assertError(postRaw(CONSOLE_AGENT_SPEC_PATH + "/publish",
+                queryFrom(agentSpecPublishForm(agentSpecName, "1.0.0"))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewing version can be published");
+        assertEquals("ok", postFormOk(CONSOLE_AGENT_SPEC_PATH + "/force-publish",
+                agentSpecPublishForm(agentSpecName, "1.0.0")).get("data").asText());
+
+        JsonNode meta = getJsonOk(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)).get("data");
+        assertEquals(agentSpecName, meta.get("name").asText(), meta.toString());
+        assertEquals("AgentSpec v1", meta.get("description").asText(), meta.toString());
+        assertEquals("1.0.0", meta.get("labels").get("latest").asText(), meta.toString());
+        assertEquals(1, meta.get("onlineCnt").asInt(), meta.toString());
+        assertTrue(meta.get("enable").asBoolean(), meta.toString());
+        assertFalse(meta.get("scope").asText().isBlank(), meta.toString());
+        assertEquals("online", findAgentSpecVersionSummary(meta, "1.0.0").get("status").asText(),
+                meta.toString());
+
+        assertAgentSpecListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("agentSpecName", agentSpecName).addParam("search", "accurate")
+                .addParam("pageNo", "1").addParam("pageSize", "10"), agentSpecName);
+        assertAgentSpecListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("agentSpecName", agentSpecName.substring(0, 8)).addParam("search", "blur")
+                .addParam("pageNo", "1").addParam("pageSize", "1000"), agentSpecName);
+
+        assertEquals("ok", putFormOk(CONSOLE_AGENT_SPEC_PATH + "/labels",
+                agentSpecLabelsForm(agentSpecName, "{\"stable\":\"1.0.0\"}")).get("data").asText());
+        assertEquals("ok", putFormOk(CONSOLE_AGENT_SPEC_PATH + "/biz-tags",
+                agentSpecBizTagsForm(agentSpecName, "[\"openapi\",\"console\"]")).get("data").asText());
+        assertEquals("ok", putFormOk(CONSOLE_AGENT_SPEC_PATH + "/scope",
+                agentSpecScopeForm(agentSpecName, "PUBLIC")).get("data").asText());
+        assertEquals("PUBLIC", getJsonOk(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName))
+                .get("data").get("scope").asText());
+        assertEquals("ok", putFormOk(CONSOLE_AGENT_SPEC_PATH + "/scope",
+                agentSpecScopeForm(agentSpecName, "PRIVATE")).get("data").asText());
+        JsonNode governed = getJsonOk(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)).get("data");
+        assertEquals("1.0.0", governed.get("labels").get("stable").asText(), governed.toString());
+        assertEquals("[\"openapi\",\"console\"]", governed.get("bizTags").asText(), governed.toString());
+        assertEquals("PRIVATE", governed.get("scope").asText(), governed.toString());
+        assertAgentSpecListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("scope", "PRIVATE").addParam("agentSpecName", agentSpecName)
+                .addParam("search", "accurate"), agentSpecName);
+        assertAgentSpecListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("bizTag", "does-not-filter").addParam("agentSpecName", agentSpecName)
+                .addParam("search", "accurate"), agentSpecName);
+
+        assertEquals("ok", postFormOk(CONSOLE_AGENT_SPEC_PATH + "/offline",
+                agentSpecOnlineForm(agentSpecName, "1.0.0", null)).get("data").asText());
+        assertAgentSpecVersionStatus(agentSpecName, "1.0.0", "offline");
+        assertEquals("ok", postFormOk(CONSOLE_AGENT_SPEC_PATH + "/online",
+                agentSpecOnlineForm(agentSpecName, "1.0.0", null)).get("data").asText());
+        assertAgentSpecVersionStatus(agentSpecName, "1.0.0", "online");
+
+        assertEquals("ok", postFormOk(CONSOLE_AGENT_SPEC_PATH + "/offline",
+                agentSpecOnlineForm(agentSpecName, null, "agentspec")).get("data").asText());
+        assertFalse(getJsonOk(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName))
+                .get("data").get("enable").asBoolean());
+        assertEquals("ok", postFormOk(CONSOLE_AGENT_SPEC_PATH + "/online",
+                agentSpecOnlineForm(agentSpecName, null, "agentspec")).get("data").asText());
+        assertTrue(getJsonOk(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName))
+                .get("data").get("enable").asBoolean());
+
+        assertError(postRaw(CONSOLE_AGENT_SPEC_PATH + "/redraft",
+                queryFrom(agentSpecPublishForm(agentSpecName, "1.0.0"))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewed version can be re-edited");
+
+        JsonNode delete = deleteJsonOk(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName));
+        assertEquals("ok", delete.get("data").asText(), delete.toString());
+        assertError(getRaw(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec not found");
+    }
+
+    @Test
+    public void testAgentSpecForkSubmitDeleteDraftAndUpdateAutoCreate() throws Exception {
+        String autoName = randomAiName("agentspec-auto");
+        assertEquals("ok", putFormOk(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                agentSpecUpdateForm(autoName, "0.0.1", "Auto AgentSpec", "auto-scenario",
+                        "auto soul")).get("data").asText());
+        addCleanup(() -> deleteAgentSpecQuietly(autoName));
+        assertAgentSpecVersionStatus(autoName, "0.0.1", "draft");
+        assertAgentSpecContent(getJsonOk(CONSOLE_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(autoName, "0.0.1")).get("data"), autoName, "0.0.1",
+                "Auto AgentSpec", "auto-scenario", "auto soul");
+
+        String agentSpecName = randomAiName("agentspec-submit");
+        postFormOk(CONSOLE_AGENT_SPEC_PATH + "/draft", agentSpecDraftForm(agentSpecName, "1.0.0"));
+        addCleanup(() -> deleteAgentSpecQuietly(agentSpecName));
+        putFormOk(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                agentSpecUpdateForm(agentSpecName, "1.0.0", "AgentSpec v1",
+                        "scenario-v1", "soul v1"));
+        postFormOk(CONSOLE_AGENT_SPEC_PATH + "/force-publish",
+                agentSpecPublishForm(agentSpecName, "1.0.0"));
+
+        assertError(postRaw(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                queryFrom(agentSpecForkForm(agentSpecName, "1.0.0", "1.0.0"))), 409,
+                ErrorCode.RESOURCE_CONFLICT, "targetVersion already exists");
+
+        JsonNode forked = postFormOk(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                agentSpecForkForm(agentSpecName, "2.0.0", "1.0.0"));
+        assertEquals("2.0.0", forked.get("data").asText(), forked.toString());
+        assertAgentSpecVersionStatus(agentSpecName, "2.0.0", "draft");
+
+        JsonNode deleteDraft = deleteJsonOk(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                agentSpecQuery(agentSpecName));
+        assertEquals("ok", deleteDraft.get("data").asText(), deleteDraft.toString());
+        assertError(getRaw(CONSOLE_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "2.0.0")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec version not found");
+
+        postFormOk(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                agentSpecForkForm(agentSpecName, "2.0.0", "1.0.0"));
+        putFormOk(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                agentSpecUpdateForm(agentSpecName, "2.0.0", "AgentSpec v2",
+                        "scenario-v2", "soul v2"));
+        JsonNode submit = postFormOk(CONSOLE_AGENT_SPEC_PATH + "/submit",
+                agentSpecQueryForm(agentSpecName));
+        assertEquals("2.0.0", submit.get("data").asText(), submit.toString());
+        String submittedStatus = agentSpecVersionStatus(agentSpecName, "2.0.0");
+        assertTrue("online".equals(submittedStatus) || "reviewing".equals(submittedStatus),
+                submittedStatus);
+        if ("reviewing".equals(submittedStatus)) {
+            postFormOk(CONSOLE_AGENT_SPEC_PATH + "/force-publish",
+                    agentSpecPublishForm(agentSpecName, "2.0.0"));
+        }
+        assertAgentSpecContent(getJsonOk(CONSOLE_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "2.0.0")).get("data"), agentSpecName,
+                "2.0.0", "AgentSpec v2", "scenario-v2", "soul v2");
+    }
+
+    @Test
+    public void testAgentSpecValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(CONSOLE_AGENT_SPEC_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "agentSpecName");
+        assertError(postRaw(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "agentSpecName");
+        assertError(putRaw(CONSOLE_AGENT_SPEC_PATH + "/draft",
+                agentSpecQuery(randomAiName("missing-card"))), 400,
+                ErrorCode.PARAMETER_MISSING, "agentSpecCard");
+
+        Map<String, String> invalidVersion = agentSpecDraftForm(randomAiName("bad-version"),
+                "bad-version");
+        assertError(postRaw(CONSOLE_AGENT_SPEC_PATH + "/draft", queryFrom(invalidVersion)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Invalid targetVersion format");
+        assertError(postRaw(CONSOLE_AGENT_SPEC_PATH + "/force-publish",
+                queryFrom(agentSpecQueryForm(randomAiName("missing-version")))), 400,
+                ErrorCode.PARAMETER_MISSING, "version");
+        assertError(putRaw(CONSOLE_AGENT_SPEC_PATH + "/labels",
+                agentSpecQuery(randomAiName("missing-labels"))), 400,
+                ErrorCode.PARAMETER_MISSING, "labels");
+        assertError(putRaw(CONSOLE_AGENT_SPEC_PATH + "/scope",
+                agentSpecQuery(randomAiName("missing-scope"))), 400,
+                ErrorCode.PARAMETER_MISSING, "scope");
+        assertError(putRaw(CONSOLE_AGENT_SPEC_PATH + "/scope",
+                queryFrom(agentSpecScopeForm(randomAiName("invalid-scope"), "TEAM"))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "PUBLIC or PRIVATE");
+        assertError(getRaw(CONSOLE_AGENT_SPEC_LIST_PATH, Query.newInstance().addParam("search", "invalid")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+        assertError(getRaw(CONSOLE_AGENT_SPEC_LIST_PATH, Query.newInstance().addParam("scope", "TEAM")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "scope");
+        assertError(getRaw(CONSOLE_AGENT_SPEC_LIST_PATH, Query.newInstance().addParam("pageNo", "0")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+
+        String absentName = randomAiName("absent");
+        assertError(getRaw(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(absentName)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec not found");
+        assertError(getRaw(CONSOLE_AGENT_SPEC_VERSION_PATH, agentSpecVersionQuery(absentName, "1.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "AgentSpec not found");
+    }
+
+    private void assertAgentSpecListContains(Query query, String agentSpecName) throws Exception {
+        JsonNode page = getJsonOk(CONSOLE_AGENT_SPEC_LIST_PATH, query).get("data");
+        assertEmptyPageShape(page);
+        JsonNode found = findByName(page, "name", agentSpecName);
+        assertFalse(found.isMissingNode(), page.toString());
+        assertEquals(agentSpecName, found.get("name").asText(), found.toString());
+        assertNotNull(found.get("labels"), found.toString());
+    }
+
+    private void assertAgentSpecVersionStatus(String agentSpecName, String version, String status)
+            throws Exception {
+        assertEquals(status, agentSpecVersionStatus(agentSpecName, version));
+    }
+
+    private String agentSpecVersionStatus(String agentSpecName, String version) throws Exception {
+        JsonNode meta = getJsonOk(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)).get("data");
+        JsonNode versionSummary = findAgentSpecVersionSummary(meta, version);
+        assertFalse(versionSummary.isMissingNode(), meta.toString());
+        return versionSummary.get("status").asText();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/agentspec/AgentSpecUploadConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/agentspec/AgentSpecUploadConsoleApiOpenApiITCase.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.agentspec;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for AgentSpec console upload OpenAPI {@code /v3/console/ai/agentspecs/upload}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: single ZIP upload creates a draft from {@code manifest.json} and resources, overwrite
+ *     updates an existing editing draft, later uploads create the next draft version, and seed archives import
+ *     multiple AgentSpecs.</li>
+ *     <li>Boundary/validation: namespace defaults to public; upload-created versions use the service-managed
+ *     {@code 0.0.x} sequence; duplicate working drafts require overwrite; seed archive upload returns the imported
+ *     names summary.</li>
+ *     <li>Exception/error handling: empty files, malformed ZIP files, and archives without {@code manifest.json}
+ *     return controlled HTTP 400 Result bodies instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class AgentSpecUploadConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+
+    @Test
+    public void testSingleAgentSpecUploadOverwriteAndVersionBump() throws Exception {
+        String agentSpecName = randomAiName("agentspec-upload");
+        Query uploadQuery = uploadQuery(false);
+        HttpResponse uploaded = postMultipartRaw(CONSOLE_AGENT_SPEC_PATH + "/upload", uploadQuery,
+                "file", agentSpecName + ".zip", "application/zip",
+                buildAgentSpecZip(agentSpecName, "0.0.1", "Uploaded AgentSpec v1",
+                        "upload-v1", "uploaded soul"));
+        assertUploadSuccess(uploaded, agentSpecName);
+        addCleanup(() -> deleteAgentSpecQuietly(agentSpecName));
+        assertAgentSpecContent(getJsonOk(CONSOLE_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "0.0.1")).get("data"), agentSpecName,
+                "0.0.1", "Uploaded AgentSpec v1", "upload-v1", "uploaded soul");
+
+        assertError(postMultipartRaw(CONSOLE_AGENT_SPEC_PATH + "/upload", uploadQuery,
+                "file", agentSpecName + ".zip", "application/zip",
+                buildAgentSpecZip(agentSpecName, "0.0.1", "Duplicate AgentSpec",
+                        "duplicate", "duplicate soul")), 409,
+                ErrorCode.RESOURCE_CONFLICT, "working version");
+        HttpResponse overwritten = postMultipartRaw(CONSOLE_AGENT_SPEC_PATH + "/upload",
+                uploadQuery(true), "file", agentSpecName + ".zip", "application/zip",
+                buildAgentSpecZip(agentSpecName, "0.0.1", "Overwritten AgentSpec",
+                        "overwrite", "overwritten soul"));
+        assertUploadSuccess(overwritten, agentSpecName);
+        assertAgentSpecContent(getJsonOk(CONSOLE_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "0.0.1")).get("data"), agentSpecName,
+                "0.0.1", "Overwritten AgentSpec", "overwrite", "overwritten soul");
+
+        postFormOk(CONSOLE_AGENT_SPEC_PATH + "/force-publish",
+                agentSpecPublishForm(agentSpecName, "0.0.1"));
+        HttpResponse nextUpload = postMultipartRaw(CONSOLE_AGENT_SPEC_PATH + "/upload",
+                uploadQuery(false), "file", agentSpecName + ".zip", "application/zip",
+                buildAgentSpecZip(agentSpecName, "0.0.2", "Uploaded AgentSpec v2",
+                        "upload-v2", "uploaded soul v2"));
+        assertUploadSuccess(nextUpload, agentSpecName);
+        JsonNode meta = getJsonOk(CONSOLE_AGENT_SPEC_PATH, agentSpecQuery(agentSpecName)).get("data");
+        assertEquals("0.0.2", meta.get("editingVersion").asText(), meta.toString());
+        assertAgentSpecContent(getJsonOk(CONSOLE_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(agentSpecName, "0.0.2")).get("data"), agentSpecName,
+                "0.0.2", "Uploaded AgentSpec v2", "upload-v2", "uploaded soul v2");
+    }
+
+    @Test
+    public void testSeedArchiveUploadImportsMultipleAgentSpecs() throws Exception {
+        String firstName = randomAiName("seed-a");
+        String secondName = randomAiName("seed-b");
+        Map<String, String> specs = new LinkedHashMap<>();
+        specs.put(firstName, "seed-scenario-a");
+        specs.put(secondName, "seed-scenario-b");
+        HttpResponse uploaded = postMultipartRaw(CONSOLE_AGENT_SPEC_PATH + "/upload", uploadQuery(false),
+                "file", "agentspec-seed.zip", "application/zip", buildAgentSpecSeedArchive(specs));
+        JsonNode root = assertUploadResult(uploaded);
+        String summary = root.get("data").asText();
+        assertTrue(summary.contains("Imported 2 agentspecs"), summary);
+        assertTrue(summary.contains(firstName), summary);
+        assertTrue(summary.contains(secondName), summary);
+        addCleanup(() -> deleteAgentSpecQuietly(firstName));
+        addCleanup(() -> deleteAgentSpecQuietly(secondName));
+
+        assertAgentSpecContent(getJsonOk(CONSOLE_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(firstName, "0.0.1")).get("data"), firstName, "0.0.1",
+                "uploaded seed " + firstName, "seed-scenario-a", "seed soul for " + firstName);
+        assertAgentSpecContent(getJsonOk(CONSOLE_AGENT_SPEC_VERSION_PATH,
+                agentSpecVersionQuery(secondName, "0.0.1")).get("data"), secondName, "0.0.1",
+                "uploaded seed " + secondName, "seed-scenario-b", "seed soul for " + secondName);
+    }
+
+    @Test
+    public void testAgentSpecUploadValidationErrors() throws Exception {
+        assertError(postMultipartRaw(CONSOLE_AGENT_SPEC_PATH + "/upload", uploadQuery(false),
+                "file", "empty.zip", "application/zip", new byte[0]), 400,
+                ErrorCode.DATA_EMPTY, "File is required");
+        assertError(postMultipartRaw(CONSOLE_AGENT_SPEC_PATH + "/upload", uploadQuery(false),
+                "file", "plain.zip", "application/zip", "not a zip".getBytes()), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Failed to read agentspec zip archive");
+        assertError(postMultipartRaw(CONSOLE_AGENT_SPEC_PATH + "/upload", uploadQuery(false),
+                "file", "no-manifest.zip", "application/zip", buildZipWithoutAgentSpecManifest()),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "manifest.json file not found");
+    }
+
+    private Query uploadQuery(boolean overwrite) {
+        return Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("overwrite", String.valueOf(overwrite));
+    }
+
+    private void assertUploadSuccess(HttpResponse response, String agentSpecName) {
+        JsonNode root = assertUploadResult(response);
+        assertEquals(agentSpecName, root.get("data").asText(), root.toString());
+    }
+
+    private JsonNode assertUploadResult(HttpResponse response) {
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        return root;
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/copilot/CopilotConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/copilot/CopilotConsoleApiOpenApiITCase.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.copilot;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for Copilot console OpenAPI {@code /v3/console/copilot}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: console config save persists the visible API key, model, studio URL, and studio
+ *     project fields; a subsequent read returns the configuration shape used by the controller.</li>
+ *     <li>Boundary/validation: SSE skill/prompt generation, optimization, and debug endpoints accept empty request
+ *     bodies as a controlled error event and validate required JSON fields before invoking any LLM provider; config
+ *     fields outside the four editable fields are accepted but ignored by the save path.</li>
+ *     <li>Exception/error handling: malformed config bodies return HTTP 400, and Copilot SSE validation failures
+ *     complete with an {@code error} event instead of surfacing an HTTP 500 or hanging stream.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class CopilotConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+
+    private static final String CONFIG_PATH = "/v3/console/cs/config";
+
+    private static final String COPILOT_CONFIG_DATA_ID = "copilot-config.json";
+
+    private static final String COPILOT_CONFIG_GROUP = "nacos-copilot";
+
+    @Test
+    public void testCopilotConfigSaveAndGetSuccess() throws Exception {
+        addCleanup(() -> deleteQuietly(CONFIG_PATH, Query.newInstance()
+                .addParam("dataId", COPILOT_CONFIG_DATA_ID)
+                .addParam("groupName", COPILOT_CONFIG_GROUP)
+                .addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("tag", "")));
+
+        String configJson = "{\"apiKey\":\"openapi-it-key\",\"model\":\"openapi-it-model\","
+                + "\"studioUrl\":\"http://127.0.0.1/studio\","
+                + "\"studioProject\":\"openapi-it-project\",\"enabled\":false}";
+        JsonNode saved = postJsonOk(CONSOLE_COPILOT_CONFIG_PATH, Query.EMPTY, configJson);
+        assertTrue(saved.get("data").asBoolean(), saved.toString());
+
+        JsonNode data = getJsonOk(CONSOLE_COPILOT_CONFIG_PATH, Query.EMPTY).get("data");
+        assertEquals("openapi-it-key", data.get("apiKey").asText(), data.toString());
+        assertEquals("openapi-it-model", data.get("model").asText(), data.toString());
+        assertEquals("http://127.0.0.1/studio", data.get("studioUrl").asText(), data.toString());
+        assertEquals("openapi-it-project", data.get("studioProject").asText(), data.toString());
+        assertTrue(data.get("enabled").asBoolean(), data.toString());
+        assertEquals(DEFAULT_NAMESPACE, data.get("defaultNamespace").asText(), data.toString());
+    }
+
+    @Test
+    public void testCopilotConfigMalformedJsonReturnsBadRequest() throws Exception {
+        assertError(postJsonRaw(CONSOLE_COPILOT_CONFIG_PATH, Query.EMPTY, "{"), 400,
+                ErrorCode.PARAMETER_MISSING, "JSON parse error");
+    }
+
+    @Test
+    public void testCopilotSseValidationErrorEvents() throws Exception {
+        assertSseErrorEvent(postRaw(CONSOLE_COPILOT_PATH + "/skill/optimize", Query.EMPTY),
+                "\"done\":true");
+        assertSseErrorEvent(postJsonRaw(CONSOLE_COPILOT_PATH + "/skill/optimize", Query.EMPTY,
+                "{}"), "Skill is required");
+        assertSseErrorEvent(postRaw(CONSOLE_COPILOT_PATH + "/skill/generate", Query.EMPTY),
+                "\"done\":true");
+        assertSseErrorEvent(postJsonRaw(CONSOLE_COPILOT_PATH + "/skill/generate", Query.EMPTY,
+                "{}"), "Background information is required");
+        assertSseErrorEvent(postRaw(CONSOLE_COPILOT_PATH + "/prompt/optimize", Query.EMPTY),
+                "\"done\":true");
+        assertSseErrorEvent(postJsonRaw(CONSOLE_COPILOT_PATH + "/prompt/optimize", Query.EMPTY,
+                "{}"), "Prompt is required");
+        assertSseErrorEvent(postRaw(CONSOLE_COPILOT_PATH + "/prompt/debug", Query.EMPTY),
+                "\"done\":true");
+        assertSseErrorEvent(postJsonRaw(CONSOLE_COPILOT_PATH + "/prompt/debug", Query.EMPTY,
+                "{\"prompt\":\"debug prompt\"}"), "\"done\":true");
+    }
+
+    private void assertSseErrorEvent(HttpResponse response, String expectedFragment) {
+        assertEquals(200, response.code(), response.body());
+        assertTrue(response.body().contains("event:error"), response.body());
+        assertTrue(response.body().contains(expectedFragment), response.body());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/importer/AiResourceImportConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/importer/AiResourceImportConsoleApiOpenApiITCase.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.importer;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for AI resource import console OpenAPI {@code /v3/console/ai/import}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: configured import sources are listed with sanitized source information and can be
+ *     filtered by {@code mcp}, {@code skill}, or an unsupported resource type without exposing runtime endpoint or
+ *     secret fields.</li>
+ *     <li>Boundary/validation: {@code resourceType}, {@code sourceId}, {@code selectedItems}, JSON
+ *     {@code selectedItems}, JSON {@code options}, and empty selected item lists are validated for search,
+ *     validate, and execute. {@code query}, {@code cursor}, {@code limit}, {@code overwriteExisting},
+ *     {@code skipInvalid}, and {@code validationToken} are accepted form fields; the IT avoids successful external
+ *     network search/import and verifies their local form boundary through controlled source errors.</li>
+ *     <li>Exception/error handling: unknown sources return RESOURCE_NOT_FOUND, unsupported source/resourceType
+ *     combinations return HTTP 400, and all malformed form requests return standard v3 Result error bodies instead
+ *     of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class AiResourceImportConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+
+    private static final String SOURCE_MCP_OFFICIAL = "mcp-official";
+
+    private static final String SOURCE_SKILLS_SH = "skills-sh";
+
+    private static final String UNKNOWN_SOURCE = "openapi-it-unknown-source";
+
+    @Test
+    public void testListSourcesFiltersAndSanitizesSourceInfo() throws Exception {
+        JsonNode allSources = getJsonOk(CONSOLE_IMPORT_SOURCES_PATH, importSourceQuery(null))
+                .get("data");
+        assertTrue(allSources.isArray(), allSources.toString());
+        assertImportSource(findImportSource(allSources, SOURCE_MCP_OFFICIAL), SOURCE_MCP_OFFICIAL,
+                "mcp-registry", IMPORT_RESOURCE_TYPE_MCP);
+        assertImportSource(findImportSource(allSources, SOURCE_SKILLS_SH), SOURCE_SKILLS_SH,
+                "skills-sh", IMPORT_RESOURCE_TYPE_SKILL);
+        assertSourcesDoNotExposeRuntimeFields(allSources);
+
+        JsonNode mcpSources = getJsonOk(CONSOLE_IMPORT_SOURCES_PATH,
+                importSourceQuery(IMPORT_RESOURCE_TYPE_MCP)).get("data");
+        assertImportSource(findImportSource(mcpSources, SOURCE_MCP_OFFICIAL), SOURCE_MCP_OFFICIAL,
+                "mcp-registry", IMPORT_RESOURCE_TYPE_MCP);
+        assertTrue(findImportSource(mcpSources, SOURCE_SKILLS_SH).isMissingNode(),
+                mcpSources.toString());
+        assertEverySourceSupports(mcpSources, IMPORT_RESOURCE_TYPE_MCP);
+
+        JsonNode skillSources = getJsonOk(CONSOLE_IMPORT_SOURCES_PATH,
+                importSourceQuery(IMPORT_RESOURCE_TYPE_SKILL)).get("data");
+        assertImportSource(findImportSource(skillSources, SOURCE_SKILLS_SH), SOURCE_SKILLS_SH,
+                "skills-sh", IMPORT_RESOURCE_TYPE_SKILL);
+        assertTrue(findImportSource(skillSources, SOURCE_MCP_OFFICIAL).isMissingNode(),
+                skillSources.toString());
+        assertEverySourceSupports(skillSources, IMPORT_RESOURCE_TYPE_SKILL);
+
+        JsonNode unsupportedSources = getJsonOk(CONSOLE_IMPORT_SOURCES_PATH,
+                importSourceQuery("unsupported-resource-type")).get("data");
+        assertTrue(unsupportedSources.isArray(), unsupportedSources.toString());
+        assertEquals(0, unsupportedSources.size(), unsupportedSources.toString());
+    }
+
+    @Test
+    public void testSearchValidationAndSourceErrors() throws Exception {
+        assertError(postRaw(CONSOLE_IMPORT_SEARCH_PATH,
+                queryFrom(importSearchForm(null, SOURCE_MCP_OFFICIAL, "nacos", 10, null))),
+                400, ErrorCode.PARAMETER_MISSING, "resourceType");
+        assertError(postRaw(CONSOLE_IMPORT_SEARCH_PATH,
+                queryFrom(importSearchForm(IMPORT_RESOURCE_TYPE_MCP, null, "nacos", 10, null))),
+                400, ErrorCode.PARAMETER_MISSING, "sourceId");
+        assertError(postRaw(CONSOLE_IMPORT_SEARCH_PATH,
+                queryFrom(importSearchForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL,
+                        "nacos", 10, "{"))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "options");
+
+        Map<String, String> unknownSource = importSearchForm(IMPORT_RESOURCE_TYPE_MCP,
+                UNKNOWN_SOURCE, "nacos", 0, importOptionsJson());
+        unknownSource.put("cursor", "next-page");
+        assertError(postRaw(CONSOLE_IMPORT_SEARCH_PATH, queryFrom(unknownSource)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "source not found");
+
+        assertError(postRaw(CONSOLE_IMPORT_SEARCH_PATH,
+                queryFrom(importSearchForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_MCP_OFFICIAL,
+                        "skill", 1, importOptionsJson()))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "does not support resource type");
+    }
+
+    @Test
+    public void testValidateSelectedItemsBoundariesAndSourceErrors() throws Exception {
+        String selectedItems = importSelectedItemsJson("external-skill", "openapi-skill",
+                "1.0.0");
+        assertError(postRaw(CONSOLE_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(null, SOURCE_SKILLS_SH, selectedItems, null,
+                        false))), 400, ErrorCode.PARAMETER_MISSING, "resourceType");
+        assertError(postRaw(CONSOLE_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, null, selectedItems,
+                        null, false))), 400, ErrorCode.PARAMETER_MISSING, "sourceId");
+        assertError(postRaw(CONSOLE_IMPORT_VALIDATE_PATH,
+                queryFrom(importSourceForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_SKILLS_SH))),
+                400, ErrorCode.PARAMETER_MISSING, "selectedItems");
+        assertError(postRaw(CONSOLE_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_SKILLS_SH, "{",
+                        null, false))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "selectedItems");
+        assertError(postRaw(CONSOLE_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_SKILLS_SH,
+                        selectedItems, "{", false))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "options");
+        assertError(postRaw(CONSOLE_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_SKILLS_SH, "[]",
+                        null, true))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "selected items must not be empty");
+        assertError(postRaw(CONSOLE_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_SKILL, UNKNOWN_SOURCE,
+                        selectedItems, importOptionsJson(), true))), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "source not found");
+        assertError(postRaw(CONSOLE_IMPORT_VALIDATE_PATH,
+                queryFrom(importValidateForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_SKILLS_SH,
+                        selectedItems, importOptionsJson(), false))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "does not support resource type");
+    }
+
+    @Test
+    public void testExecuteSelectedItemsBoundariesAndSourceErrors() throws Exception {
+        String selectedItems = importSelectedItemsJson("external-mcp", "openapi-mcp", "1.0.0");
+        assertError(postRaw(CONSOLE_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(null, SOURCE_MCP_OFFICIAL, selectedItems, null,
+                        false, true))), 400, ErrorCode.PARAMETER_MISSING, "resourceType");
+        assertError(postRaw(CONSOLE_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, null, selectedItems, null,
+                        false, true))), 400, ErrorCode.PARAMETER_MISSING, "sourceId");
+        assertError(postRaw(CONSOLE_IMPORT_EXECUTE_PATH,
+                queryFrom(importSourceForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL))),
+                400, ErrorCode.PARAMETER_MISSING, "selectedItems");
+        assertError(postRaw(CONSOLE_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL, "{",
+                        null, false, true))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "selectedItems");
+        assertError(postRaw(CONSOLE_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL,
+                        selectedItems, "{", false, true))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "options");
+        assertError(postRaw(CONSOLE_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, SOURCE_MCP_OFFICIAL, "[]",
+                        null, true, true))), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "selected items must not be empty");
+        assertError(postRaw(CONSOLE_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_MCP, UNKNOWN_SOURCE,
+                        selectedItems, importOptionsJson(), true, false))), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "source not found");
+        assertError(postRaw(CONSOLE_IMPORT_EXECUTE_PATH,
+                queryFrom(importExecuteForm(IMPORT_RESOURCE_TYPE_SKILL, SOURCE_MCP_OFFICIAL,
+                        selectedItems, importOptionsJson(), false, true))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "does not support resource type");
+    }
+
+    private void assertImportSource(JsonNode source, String sourceId, String pluginName,
+            String resourceType) {
+        assertFalse(source.isMissingNode(), sourceId);
+        assertEquals(sourceId, source.get("sourceId").asText(), source.toString());
+        assertEquals(pluginName, source.get("pluginName").asText(), source.toString());
+        assertTrue(source.get("enabled").asBoolean(), source.toString());
+        assertResourceTypesContain(source, resourceType);
+        assertTrue(source.get("capabilities").isArray(), source.toString());
+        assertTrue(source.get("capabilities").toString().contains("search"), source.toString());
+        assertTrue(source.get("capabilities").toString().contains("validate"), source.toString());
+        assertTrue(source.get("capabilities").toString().contains("execute"), source.toString());
+    }
+
+    private void assertEverySourceSupports(JsonNode sources, String resourceType) {
+        for (JsonNode source : sources) {
+            assertResourceTypesContain(source, resourceType);
+        }
+    }
+
+    private void assertResourceTypesContain(JsonNode source, String resourceType) {
+        boolean found = false;
+        for (JsonNode each : source.get("resourceTypes")) {
+            if (resourceType.equals(each.asText())) {
+                found = true;
+            }
+        }
+        assertTrue(found, source.toString());
+    }
+
+    private void assertSourcesDoNotExposeRuntimeFields(JsonNode sources) {
+        for (JsonNode source : sources) {
+            assertFalse(source.has("endpoint"), source.toString());
+            assertFalse(source.has("authRef"), source.toString());
+            assertFalse(source.has("properties"), source.toString());
+        }
+    }
+
+    private JsonNode findImportSource(JsonNode sources, String sourceId) {
+        for (JsonNode source : sources) {
+            if (sourceId.equals(source.get("sourceId").asText())) {
+                return source;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/mcp/McpConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/mcp/McpConsoleApiOpenApiITCase.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.mcp;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for MCP console OpenAPI {@code /v3/console/ai/mcp}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: create persists an MCP server with stdio server specification, tools, and a generated
+ *     ID; detail can be queried by ID and by name; update adds a new latest version; list supports accurate and blur
+ *     name filters; delete removes the server.</li>
+ *     <li>Boundary/validation: omitted namespaceId defaults to public; detail/delete accept either mcpId or mcpName;
+ *     list defaults search to accurate; invalid search, missing identity, missing serverSpecification, missing
+ *     version, invalid custom ID, and import request field omissions are rejected with HTTP 400. Console currently
+ *     accepts {@code resourceSpecification} but does not persist it because the controller does not parse resources.
+ *     </li>
+ *     <li>Exception/error handling: duplicate create returns conflict, absent server returns the MCP not-found result
+ *     envelope, malformed JSON is rejected as a controlled validation error, and unsupported MCP tool import
+ *     transports return a wrapped failure instead of an unhandled exception.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class McpConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+    
+    @Test
+    public void testCreateUpdateListGetAndDeleteMcpServer() throws Exception {
+        String mcpName = randomAiName("mcp");
+        String toolName = "tool_" + mcpName.replace('-', '_');
+        String resourceName = "resource_" + mcpName.replace('-', '_');
+        JsonNode created = postFormOk(CONSOLE_MCP_PATH,
+                mcpServerForm(mcpName, "1.0.0", "initial MCP server", toolName, resourceName));
+        String mcpId = created.get("data").asText();
+        addCleanup(() -> deleteMcpServerQuietly(mcpName, mcpId));
+        
+        JsonNode detailById = getJsonOk(CONSOLE_MCP_PATH, mcpIdentityQuery(null, mcpId, null)).get("data");
+        assertMcpDetail(detailById, mcpName, "1.0.0", "initial MCP server", toolName, resourceName);
+        assertEquals(mcpId, detailById.get("id").asText(), detailById.toString());
+        
+        JsonNode detailByName = getJsonOk(CONSOLE_MCP_PATH, mcpIdentityQuery(mcpName, null, "1.0.0"))
+                .get("data");
+        assertMcpDetail(detailByName, mcpName, "1.0.0", "initial MCP server", toolName, resourceName);
+        
+        Map<String, String> updateForm = mcpServerForm(mcpName, "1.1.0", "updated MCP server",
+                toolName + "_v2", resourceName + "_v2");
+        JsonNode updated = putFormOk(CONSOLE_MCP_PATH, updateForm);
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        
+        JsonNode latest = getJsonOk(CONSOLE_MCP_PATH, mcpIdentityQuery(mcpName, null, null)).get("data");
+        assertMcpDetail(latest, mcpName, "1.1.0", "updated MCP server", toolName + "_v2",
+                resourceName + "_v2");
+        assertEquals(2, latest.get("allVersions").size(), latest.toString());
+        
+        JsonNode accurateList = getJsonOk(CONSOLE_MCP_LIST_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("mcpName", mcpName)
+                .addParam("pageNo", "1").addParam("pageSize", "10")).get("data");
+        assertPageContains(accurateList, "name", mcpName);
+        
+        JsonNode blurList = getJsonOk(CONSOLE_MCP_LIST_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("mcpName", mcpName.substring(0, 8))
+                .addParam("search", "blur").addParam("pageNo", "1").addParam("pageSize", "10")).get("data");
+        assertPageContains(blurList, "name", mcpName);
+        
+        deleteJsonOk(CONSOLE_MCP_PATH, mcpIdentityQuery(null, mcpId, null));
+        assertMcpServerNotFoundEventually(mcpId);
+    }
+    
+    @Test
+    public void testCreateMcpServerValidationAndConflictErrors() throws Exception {
+        String mcpName = randomAiName("mcp-validation");
+        assertError(postRaw(CONSOLE_MCP_PATH, Query.newInstance().addParam("mcpName", mcpName)), 400,
+                ErrorCode.PARAMETER_MISSING, "serverSpecification");
+        
+        assertError(postRaw(CONSOLE_MCP_PATH, Query.newInstance().addParam("mcpName", mcpName)
+                .addParam("serverSpecification", "{")), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "Can't be parsed");
+        
+        Map<String, String> missingVersion = mcpServerForm(mcpName, "1.0.0", "missing version",
+                "tool_missing", "resource_missing");
+        missingVersion.put("serverSpecification", "{\"name\":\"" + mcpName + "\",\"protocol\":\"stdio\"}");
+        assertError(postRaw(CONSOLE_MCP_PATH, queryFrom(missingVersion)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Version must be specified");
+        
+        Map<String, String> invalidId = mcpServerForm(mcpName, "1.0.0", "invalid id",
+                "tool_invalid_id", "resource_invalid_id");
+        invalidId.put("serverSpecification", "{\"id\":\"not-a-uuid\",\"name\":\"" + mcpName
+                + "\",\"protocol\":\"stdio\",\"version\":\"1.0.0\"}");
+        assertError(postRaw(CONSOLE_MCP_PATH, queryFrom(invalidId)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "uuid pattern");
+        
+        JsonNode created = postFormOk(CONSOLE_MCP_PATH,
+                mcpServerForm(mcpName, "1.0.0", "conflict source", "tool_conflict", "resource_conflict"));
+        String mcpId = created.get("data").asText();
+        addCleanup(() -> deleteMcpServerQuietly(mcpName, mcpId));
+        assertError(postRaw(CONSOLE_MCP_PATH, queryFrom(mcpServerForm(mcpName, "1.0.1",
+                "conflict duplicate", "tool_conflict_2", "resource_conflict_2"))), 409,
+                ErrorCode.RESOURCE_CONFLICT, "has existed");
+    }
+    
+    @Test
+    public void testGetListAndDeleteMcpServerValidationErrors() throws Exception {
+        assertError(getRaw(CONSOLE_MCP_PATH, Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "mcpId");
+        assertError(deleteRaw(CONSOLE_MCP_PATH, Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)),
+                400, ErrorCode.PARAMETER_MISSING, "mcpId");
+        assertError(getRaw(CONSOLE_MCP_LIST_PATH, Query.newInstance().addParam("search", "invalid")
+                .addParam("pageNo", "1").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+        assertError(getRaw(CONSOLE_MCP_LIST_PATH, Query.newInstance().addParam("search", "accurate")
+                .addParam("pageNo", "0").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        
+        JsonNode emptyPage = getJsonOk(CONSOLE_MCP_LIST_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("mcpName", randomAiName("absent-mcp"))
+                .addParam("pageNo", "1").addParam("pageSize", "10")).get("data");
+        assertEmptyPageShape(emptyPage);
+        assertFalse(emptyPage.get("pageItems").elements().hasNext(), emptyPage.toString());
+    }
+
+    @Test
+    public void testImportToolsAndImportRequestValidationErrors() throws Exception {
+        HttpResponse unsupportedTransport = getRaw(CONSOLE_MCP_IMPORT_TOOLS_PATH, Query.newInstance()
+                .addParam("transportType", "stdio").addParam("baseUrl", "http://127.0.0.1:1")
+                .addParam("endpoint", "/mcp"));
+        assertEquals(200, unsupportedTransport.code(), unsupportedTransport.body());
+        JsonNode root = JacksonUtils.toObj(unsupportedTransport.body());
+        assertEquals(ErrorCode.SERVER_ERROR.getCode(), root.get("code").asInt(),
+                unsupportedTransport.body());
+        assertTrue(root.get("message").asText().contains("Unsupported transport type"),
+                unsupportedTransport.body());
+
+        assertError(postRaw(CONSOLE_MCP_IMPORT_VALIDATE_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("data", "{}")), 400,
+                ErrorCode.PARAMETER_MISSING, "importType");
+        assertError(postRaw(CONSOLE_MCP_IMPORT_VALIDATE_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("importType", "json")), 400,
+                ErrorCode.PARAMETER_MISSING, "data");
+        assertError(postRaw(CONSOLE_MCP_IMPORT_VALIDATE_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("importType", "invalid")
+                .addParam("data", "{}")), 400, ErrorCode.PARAMETER_VALIDATE_ERROR,
+                "json, url, file");
+
+        assertError(postRaw(CONSOLE_MCP_IMPORT_EXECUTE_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("data", "{}")
+                .addParam("skipInvalid", "true")), 400, ErrorCode.PARAMETER_MISSING,
+                "importType");
+        assertError(postRaw(CONSOLE_MCP_IMPORT_EXECUTE_PATH, Query.newInstance()
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("importType", "invalid")
+                .addParam("data", "{}").addParam("overrideExisting", "true")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "json, url, file");
+    }
+    
+    private void assertMcpServerNotFoundEventually(String mcpId) throws Exception {
+        HttpResponse lastResponse = null;
+        for (int i = 0; i < 10; i++) {
+            lastResponse = getRaw(CONSOLE_MCP_PATH, mcpIdentityQuery(null, mcpId, null));
+            if (404 == lastResponse.code()) {
+                assertError(lastResponse, 404, ErrorCode.MCP_SERVER_NOT_FOUND, "not found");
+                return;
+            }
+            Thread.sleep(200L);
+        }
+        assertError(lastResponse, 404, ErrorCode.MCP_SERVER_NOT_FOUND, "not found");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/pipeline/PipelineConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/pipeline/PipelineConsoleApiOpenApiITCase.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.pipeline;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests for pipeline console OpenAPI {@code /v3/console/ai/pipelines}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: current and legacy list endpoints return the page contract for a resource type with
+ *     optional resourceName, namespaceId, and version filters.</li>
+ *     <li>Boundary/validation: resourceType is required for list; pageNo and pageSize are validated by PageForm; the
+ *     query-parameter detail endpoint requires pipelineId. The path-variable detail endpoint is kept as deprecated
+ *     compatibility and shares the not-found contract.</li>
+ *     <li>Exception/error handling: unknown pipeline IDs return HTTP 404 with a wrapped RESOURCE_NOT_FOUND body. A
+ *     successful detail query is not created here because pipeline rows require configured publish-pipeline plugins;
+ *     in the default standalone IT environment list may legitimately be empty.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class PipelineConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+    
+    @Test
+    public void testListPipelinesCurrentAndLegacyReturnPageContract() throws Exception {
+        Query query = Query.newInstance().addParam("resourceType", "prompt")
+                .addParam("resourceName", randomAiName("pipeline-resource"))
+                .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("version", "1.0.0")
+                .addParam("pageNo", "1").addParam("pageSize", "10");
+        
+        JsonNode currentPage = getJsonOk(CONSOLE_PIPELINE_LIST_PATH, query).get("data");
+        assertEmptyPageShape(currentPage);
+        JsonNode legacyPage = getJsonOk(CONSOLE_PIPELINE_PATH, query).get("data");
+        assertEquals(currentPage.get("totalCount").asInt(), legacyPage.get("totalCount").asInt(),
+                legacyPage.toString());
+        assertEmptyPageShape(legacyPage);
+    }
+    
+    @Test
+    public void testListPipelinesValidationErrors() throws Exception {
+        assertError(getRaw(CONSOLE_PIPELINE_LIST_PATH, Query.newInstance().addParam("pageNo", "1")
+                .addParam("pageSize", "10")), 400, ErrorCode.PARAMETER_VALIDATE_ERROR, "resourceType");
+        assertError(getRaw(CONSOLE_PIPELINE_LIST_PATH, Query.newInstance().addParam("resourceType", "prompt")
+                .addParam("pageNo", "0").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(CONSOLE_PIPELINE_PATH, Query.newInstance().addParam("pageNo", "1")
+                .addParam("pageSize", "10")), 400, ErrorCode.PARAMETER_VALIDATE_ERROR, "resourceType");
+    }
+    
+    @Test
+    public void testPipelineDetailValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(CONSOLE_PIPELINE_DETAIL_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pipelineId");
+        
+        String absentPipelineId = "pipeline-" + randomAiName("absent");
+        assertError(getRaw(CONSOLE_PIPELINE_DETAIL_PATH,
+                Query.newInstance().addParam("pipelineId", absentPipelineId)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Pipeline execution not found");
+        assertError(getRaw(CONSOLE_PIPELINE_PATH + "/" + absentPipelineId), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Pipeline execution not found");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/prompt/PromptConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/prompt/PromptConsoleApiOpenApiITCase.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.prompt;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for prompt console OpenAPI {@code /v3/console/ai/prompt}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: draft creation and update persist editable content; draft delete removes only the
+ *     editing version while retaining prompt governance metadata; force-publish makes a version online and latest;
+ *     governance, version detail, version list, list, Markdown download, labels, description, bizTags,
+ *     online/offline, and delete expose the expected prompt state.</li>
+ *     <li>Boundary/validation: namespace defaults to public; list supports accurate/blur and bizTags filters while
+ *     clamping page arguments; promptKey, template or basedOnVersion, version, labels, and description are required
+ *     where controller forms require them. Runtime-only legacy endpoints are intentionally not covered because they
+ *     are not exposed by the console controller.</li>
+ *     <li>Exception/error handling: absent prompts and versions return controlled RESOURCE_NOT_FOUND bodies, direct
+ *     publish from draft and redraft from online return validation errors instead of HTTP 500, and invalid search
+ *     returns HTTP 400.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class PromptConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+
+    @Test
+    public void testPromptLifecycleGovernanceListDownloadAndDelete() throws Exception {
+        String promptKey = randomPromptKey("prompt");
+        String draftTemplate = "Hello {{name}} from draft";
+        String updatedTemplate = "Hello {{name}} from updated draft";
+        JsonNode draft = postFormOk(CONSOLE_PROMPT_PATH + "/draft",
+                promptDraftForm(promptKey, "1.0.0", draftTemplate, "initial description", "openapi,console"));
+        assertEquals("1.0.0", draft.get("data").asText(), draft.toString());
+        addCleanup(() -> deletePromptQuietly(promptKey));
+
+        JsonNode updated = putFormOk(CONSOLE_PROMPT_PATH + "/draft",
+                promptUpdateDraftForm(promptKey, updatedTemplate));
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        JsonNode draftDetail = getJsonOk(CONSOLE_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data");
+        assertPromptVersion(draftDetail, promptKey, "1.0.0", "draft", updatedTemplate);
+
+        assertError(postRaw(CONSOLE_PROMPT_PATH + "/publish", queryFrom(promptPublishForm(promptKey, "1.0.0"))),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewing version can be published");
+        JsonNode published = postFormOk(CONSOLE_PROMPT_PATH + "/force-publish",
+                promptPublishForm(promptKey, "1.0.0"));
+        assertEquals("ok", published.get("data").asText(), published.toString());
+
+        JsonNode governance = getJsonOk(CONSOLE_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey)).get("data");
+        assertEquals(promptKey, governance.get("promptKey").asText(), governance.toString());
+        assertEquals("1.0.0", governance.get("latestVersion").asText(), governance.toString());
+        assertEquals(1, governance.get("onlineCnt").asInt(), governance.toString());
+        assertEquals("1.0.0", governance.get("labels").get("latest").asText(), governance.toString());
+        assertEquals("initial description", governance.get("description").asText(), governance.toString());
+        assertEquals("openapi,console", governance.get("bizTagsStr").asText(), governance.toString());
+
+        JsonNode onlineDetail = getJsonOk(CONSOLE_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data");
+        assertPromptVersion(onlineDetail, promptKey, "1.0.0", "online", updatedTemplate);
+        assertNotNull(onlineDetail.get("md5").asText(), onlineDetail.toString());
+
+        assertPromptVersionPageContains(promptKey, "1.0.0", "online");
+        assertPromptListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("promptKey", promptKey).addParam("search", "accurate")
+                .addParam("pageNo", "1").addParam("pageSize", "10"), promptKey);
+        assertPromptListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("promptKey", promptKey.substring(0, 8)).addParam("search", "blur")
+                .addParam("bizTags", "openapi").addParam("pageNo", "0").addParam("pageSize", "1000"),
+                promptKey);
+
+        ByteResponse download = getRawBytes(CONSOLE_PROMPT_VERSION_DOWNLOAD_PATH,
+                promptVersionQuery(promptKey, "1.0.0"));
+        assertEquals(200, download.code(), new String(download.body(), StandardCharsets.UTF_8));
+        assertTrue(download.contentDisposition().contains(promptKey + "_1.0.0.md"),
+                download.contentDisposition());
+        String markdown = new String(download.body(), StandardCharsets.UTF_8);
+        assertTrue(markdown.contains("promptKey: \"" + promptKey + "\""), markdown);
+        assertTrue(markdown.contains(updatedTemplate), markdown);
+
+        assertEquals("ok", putFormOk(CONSOLE_PROMPT_PATH + "/labels",
+                promptLabelsForm(promptKey, "{\"stable\":\"1.0.0\"}")).get("data").asText());
+        assertEquals("ok", putFormOk(CONSOLE_PROMPT_PATH + "/description",
+                promptDescriptionForm(promptKey, "updated description")).get("data").asText());
+        assertEquals("ok", putFormOk(CONSOLE_PROMPT_PATH + "/biz-tags",
+                promptBizTagsForm(promptKey, "updated,openapi")).get("data").asText());
+        JsonNode updatedGovernance = getJsonOk(CONSOLE_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey))
+                .get("data");
+        assertEquals("1.0.0", updatedGovernance.get("labels").get("stable").asText(),
+                updatedGovernance.toString());
+        assertEquals("1.0.0", updatedGovernance.get("labels").get("latest").asText(),
+                updatedGovernance.toString());
+        assertEquals("updated description", updatedGovernance.get("description").asText(),
+                updatedGovernance.toString());
+        assertEquals("updated,openapi", updatedGovernance.get("bizTagsStr").asText(),
+                updatedGovernance.toString());
+
+        assertEquals("ok", postFormOk(CONSOLE_PROMPT_PATH + "/offline",
+                promptPublishForm(promptKey, "1.0.0")).get("data").asText());
+        assertPromptVersion(getJsonOk(CONSOLE_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data"), promptKey, "1.0.0", "offline", updatedTemplate);
+        assertEquals("ok", postFormOk(CONSOLE_PROMPT_PATH + "/online",
+                promptPublishForm(promptKey, "1.0.0")).get("data").asText());
+        assertPromptVersion(getJsonOk(CONSOLE_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data"), promptKey, "1.0.0", "online", updatedTemplate);
+
+        assertError(postRaw(CONSOLE_PROMPT_PATH + "/redraft", queryFrom(promptPublishForm(promptKey, "1.0.0"))),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewed version can be re-edited");
+
+        JsonNode delete = deleteJsonOk(CONSOLE_PROMPT_PATH, promptQuery(promptKey));
+        assertTrue(delete.get("data").asBoolean(), delete.toString());
+        assertError(getRaw(CONSOLE_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+    }
+
+    @Test
+    public void testPromptDeleteDraftRemovesEditingVersionOnly() throws Exception {
+        String promptKey = randomPromptKey("delete-draft");
+        postFormOk(CONSOLE_PROMPT_PATH + "/draft",
+                promptDraftForm(promptKey, "1.0.0", "Draft to delete {{name}}", "delete draft desc",
+                        "delete-draft"));
+        addCleanup(() -> deletePromptQuietly(promptKey));
+        assertPromptVersion(getJsonOk(CONSOLE_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data"), promptKey, "1.0.0", "draft", "Draft to delete {{name}}");
+
+        JsonNode deleted = deleteJsonOk(CONSOLE_PROMPT_PATH + "/draft", promptQuery(promptKey));
+        assertEquals("ok", deleted.get("data").asText(), deleted.toString());
+
+        JsonNode governance = getJsonOk(CONSOLE_PROMPT_GOVERNANCE_PATH, promptQuery(promptKey))
+                .get("data");
+        assertEquals(promptKey, governance.get("promptKey").asText(), governance.toString());
+        assertTrue(governance.path("editingVersion").isNull()
+                || governance.path("editingVersion").isMissingNode(), governance.toString());
+        assertEquals(0, governance.get("versions").size(), governance.toString());
+        assertError(getRaw(CONSOLE_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Prompt version not found");
+    }
+
+    @Test
+    public void testPromptSubmitDraftSuccess() throws Exception {
+        String promptKey = randomPromptKey("submit");
+        postFormOk(CONSOLE_PROMPT_PATH + "/draft",
+                promptDraftForm(promptKey, "1.0.0", "Submit {{name}} template", "submit desc", "submit"));
+        addCleanup(() -> deletePromptQuietly(promptKey));
+
+        JsonNode submit = postFormOk(CONSOLE_PROMPT_PATH + "/submit", promptQueryForm(promptKey));
+        assertEquals("1.0.0", submit.get("data").asText(), submit.toString());
+        JsonNode submitted = getJsonOk(CONSOLE_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data");
+        assertTrue("online".equals(submitted.get("status").asText())
+                || "reviewing".equals(submitted.get("status").asText()), submitted.toString());
+        if (!"online".equals(submitted.get("status").asText())) {
+            postFormOk(CONSOLE_PROMPT_PATH + "/force-publish", promptPublishForm(promptKey, "1.0.0"));
+        }
+        assertPromptVersion(getJsonOk(CONSOLE_PROMPT_VERSION_PATH, promptVersionQuery(promptKey, "1.0.0"))
+                .get("data"), promptKey, "1.0.0", "online", "Submit {{name}} template");
+    }
+
+    @Test
+    public void testPromptValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(CONSOLE_PROMPT_GOVERNANCE_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "promptKey");
+        assertError(postRaw(CONSOLE_PROMPT_PATH + "/draft",
+                queryFrom(promptQueryForm(randomPromptKey("missing-template")))), 400,
+                ErrorCode.PARAMETER_MISSING, "Either 'basedOnVersion' or 'template'");
+        assertError(putRaw(CONSOLE_PROMPT_PATH + "/draft",
+                promptQuery(randomPromptKey("missing-template-update"))), 400,
+                ErrorCode.PARAMETER_MISSING, "template");
+        assertError(deleteRaw(CONSOLE_PROMPT_PATH + "/draft",
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "promptKey");
+        assertError(postRaw(CONSOLE_PROMPT_PATH + "/force-publish",
+                queryFrom(promptQueryForm(randomPromptKey("missing-version")))), 400,
+                ErrorCode.PARAMETER_MISSING, "version");
+        assertError(putRaw(CONSOLE_PROMPT_PATH + "/labels", promptQuery(randomPromptKey("missing-labels"))),
+                400, ErrorCode.PARAMETER_MISSING, "labels");
+        assertError(putRaw(CONSOLE_PROMPT_PATH + "/description",
+                promptQuery(randomPromptKey("missing-description"))), 400,
+                ErrorCode.PARAMETER_MISSING, "description");
+        assertError(getRaw(CONSOLE_PROMPT_LIST_PATH, Query.newInstance().addParam("search", "invalid")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+
+        String absentPrompt = randomPromptKey("absent");
+        assertError(getRaw(CONSOLE_PROMPT_GOVERNANCE_PATH, promptQuery(absentPrompt)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+        assertError(getRaw(CONSOLE_PROMPT_VERSION_PATH, promptVersionQuery(absentPrompt, "1.0.0")), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+        assertError(getRaw(CONSOLE_PROMPT_VERSION_DOWNLOAD_PATH, promptVersionQuery(absentPrompt, "1.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Prompt not found");
+        assertError(deleteRaw(CONSOLE_PROMPT_PATH + "/draft", promptQuery(absentPrompt)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "not found");
+    }
+
+    private void assertPromptVersionPageContains(String promptKey, String version, String status)
+            throws Exception {
+        JsonNode page = getJsonOk(CONSOLE_PROMPT_VERSIONS_PATH, promptQuery(promptKey)
+                .addParam("pageNo", "1").addParam("pageSize", "10")).get("data");
+        assertEmptyPageShape(page);
+        for (JsonNode item : page.get("pageItems")) {
+            if (version.equals(item.get("version").asText())) {
+                assertEquals(status, item.get("status").asText(), item.toString());
+                return;
+            }
+        }
+        throw new AssertionError("Version " + version + " not found in " + page);
+    }
+
+    private void assertPromptListContains(Query query, String promptKey) throws Exception {
+        JsonNode page = getJsonOk(CONSOLE_PROMPT_LIST_PATH, query).get("data");
+        assertEmptyPageShape(page);
+        JsonNode found = findByName(page, "promptKey", promptKey);
+        assertTrue(!found.isMissingNode(), page.toString());
+        assertEquals(promptKey, found.get("promptKey").asText(), found.toString());
+    }
+
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/skill/SkillConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/skill/SkillConsoleApiOpenApiITCase.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.skill;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for skill console OpenAPI {@code /v3/console/ai/skills}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: draft creation and update persist editable skill content; force-publish makes a
+ *     version online and latest; console detail, version detail, list, ZIP download, labels, bizTags, scope,
+ *     online/offline, and delete expose the expected skill state.</li>
+ *     <li>Boundary/validation: namespace defaults to public; list supports accurate/blur, scope, and bizTag
+ *     filters; skillName, skillCard, targetVersion, version, labels, scope, and positive pagination validation
+ *     follows the controller forms; draft forking and draft deletion are covered explicitly.</li>
+ *     <li>Exception/error handling: absent skills and versions return controlled RESOURCE_NOT_FOUND bodies, direct
+ *     publish from draft and redraft from online return validation errors instead of HTTP 500, and invalid search
+ *     or scope parameters return HTTP 400.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class SkillConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+
+    @Test
+    public void testSkillLifecycleGovernanceListDownloadAndDelete() throws Exception {
+        String skillName = randomAiName("skill");
+        String draftBody = "Use the initial skill instructions.";
+        String updatedBody = "Use the updated skill instructions.";
+        JsonNode draft = postFormOk(CONSOLE_SKILL_PATH + "/draft",
+                skillDraftForm(skillName, "1.0.0", draftBody, "guide draft"));
+        assertEquals("1.0.0", draft.get("data").asText(), draft.toString());
+        addCleanup(() -> deleteSkillQuietly(skillName));
+
+        JsonNode updated = putFormOk(CONSOLE_SKILL_PATH + "/draft",
+                skillUpdateForm(skillName, updatedBody, "guide updated"));
+        assertEquals("ok", updated.get("data").asText(), updated.toString());
+        JsonNode draftDetail = getJsonOk(CONSOLE_SKILL_VERSION_PATH,
+                skillVersionQuery(skillName, "1.0.0")).get("data");
+        assertSkillContent(draftDetail, skillName, "1.0.0", updatedBody, "guide updated");
+        assertSkillVersionStatus(skillName, "1.0.0", "draft");
+
+        assertError(postRaw(CONSOLE_SKILL_PATH + "/publish", queryFrom(skillPublishForm(skillName, "1.0.0"))),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewing version can be published");
+        JsonNode published = postFormOk(CONSOLE_SKILL_PATH + "/force-publish",
+                skillPublishForm(skillName, "1.0.0"));
+        assertEquals("ok", published.get("data").asText(), published.toString());
+
+        JsonNode meta = getJsonOk(CONSOLE_SKILL_PATH, skillQuery(skillName)).get("data");
+        assertEquals(skillName, meta.get("name").asText(), meta.toString());
+        assertEquals("1.0.0", meta.get("labels").get("latest").asText(), meta.toString());
+        assertEquals(1, meta.get("onlineCnt").asInt(), meta.toString());
+        assertTrue(meta.get("enable").asBoolean(), meta.toString());
+        assertFalse(meta.get("scope").asText().isBlank(), meta.toString());
+        assertEquals("online", findSkillVersionSummary(meta, "1.0.0").get("status").asText(),
+                meta.toString());
+
+        JsonNode onlineDetail = getJsonOk(CONSOLE_SKILL_VERSION_PATH,
+                skillVersionQuery(skillName, "1.0.0")).get("data");
+        assertSkillContent(onlineDetail, skillName, "1.0.0", updatedBody, "guide updated");
+        assertSkillListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("skillName", skillName).addParam("search", "accurate")
+                .addParam("pageNo", "1").addParam("pageSize", "10"), skillName);
+        assertSkillListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("skillName", skillName.substring(0, 8)).addParam("search", "blur")
+                .addParam("pageNo", "1").addParam("pageSize", "1000"), skillName);
+
+        assertSkillZip(getRawBytes(CONSOLE_SKILL_VERSION_DOWNLOAD_PATH,
+                skillVersionQuery(skillName, "1.0.0")), skillName, "1.0.0", updatedBody,
+                "guide updated");
+
+        assertEquals("ok", putFormOk(CONSOLE_SKILL_PATH + "/labels",
+                skillLabelsForm(skillName, "{\"stable\":\"1.0.0\"}")).get("data").asText());
+        assertEquals("ok", putFormOk(CONSOLE_SKILL_PATH + "/biz-tags",
+                skillBizTagsForm(skillName, "[\"openapi\",\"console\"]")).get("data").asText());
+        assertEquals("ok", putFormOk(CONSOLE_SKILL_PATH + "/scope",
+                skillScopeForm(skillName, "PUBLIC")).get("data").asText());
+        assertEquals("PUBLIC", getJsonOk(CONSOLE_SKILL_PATH, skillQuery(skillName)).get("data")
+                .get("scope").asText());
+        assertEquals("ok", putFormOk(CONSOLE_SKILL_PATH + "/scope",
+                skillScopeForm(skillName, "PRIVATE")).get("data").asText());
+        JsonNode governed = getJsonOk(CONSOLE_SKILL_PATH, skillQuery(skillName)).get("data");
+        assertEquals("1.0.0", governed.get("labels").get("stable").asText(), governed.toString());
+        assertEquals("[\"openapi\",\"console\"]", governed.get("bizTags").asText(), governed.toString());
+        assertEquals("PRIVATE", governed.get("scope").asText(), governed.toString());
+        assertSkillListContains(Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("scope", "PRIVATE").addParam("bizTag", "openapi")
+                .addParam("skillName", skillName).addParam("search", "accurate"), skillName);
+
+        assertEquals("ok", postFormOk(CONSOLE_SKILL_PATH + "/offline",
+                skillOnlineForm(skillName, "1.0.0", null)).get("data").asText());
+        assertSkillVersionStatus(skillName, "1.0.0", "offline");
+        assertEquals("ok", postFormOk(CONSOLE_SKILL_PATH + "/online",
+                skillOnlineForm(skillName, "1.0.0", null)).get("data").asText());
+        assertSkillVersionStatus(skillName, "1.0.0", "online");
+
+        assertEquals("ok", postFormOk(CONSOLE_SKILL_PATH + "/offline",
+                skillOnlineForm(skillName, null, "skill")).get("data").asText());
+        assertFalse(getJsonOk(CONSOLE_SKILL_PATH, skillQuery(skillName)).get("data").get("enable")
+                .asBoolean());
+        assertEquals("ok", postFormOk(CONSOLE_SKILL_PATH + "/online",
+                skillOnlineForm(skillName, null, "skill")).get("data").asText());
+        assertTrue(getJsonOk(CONSOLE_SKILL_PATH, skillQuery(skillName)).get("data").get("enable")
+                .asBoolean());
+
+        assertError(postRaw(CONSOLE_SKILL_PATH + "/redraft", queryFrom(skillPublishForm(skillName, "1.0.0"))),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "Only reviewed version can be re-edited");
+
+        JsonNode delete = deleteJsonOk(CONSOLE_SKILL_PATH, skillQuery(skillName));
+        assertEquals("ok", delete.get("data").asText(), delete.toString());
+        assertError(getRaw(CONSOLE_SKILL_PATH, skillQuery(skillName)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Skill not found");
+    }
+
+    @Test
+    public void testSkillForkSubmitAndDeleteDraft() throws Exception {
+        String skillName = randomAiName("skill-submit");
+        postFormOk(CONSOLE_SKILL_PATH + "/draft",
+                skillDraftForm(skillName, "1.0.0", "Version one body.", "guide v1"));
+        addCleanup(() -> deleteSkillQuietly(skillName));
+        postFormOk(CONSOLE_SKILL_PATH + "/force-publish", skillPublishForm(skillName, "1.0.0"));
+
+        assertError(postRaw(CONSOLE_SKILL_PATH + "/draft",
+                queryFrom(skillForkForm(skillName, "1.0.0", "1.0.0"))), 409,
+                ErrorCode.RESOURCE_CONFLICT, "targetVersion already exists");
+
+        JsonNode forked = postFormOk(CONSOLE_SKILL_PATH + "/draft",
+                skillForkForm(skillName, "2.0.0", "1.0.0"));
+        assertEquals("2.0.0", forked.get("data").asText(), forked.toString());
+        assertSkillVersionStatus(skillName, "2.0.0", "draft");
+
+        JsonNode deleteDraft = deleteJsonOk(CONSOLE_SKILL_PATH + "/draft", skillQuery(skillName));
+        assertEquals("ok", deleteDraft.get("data").asText(), deleteDraft.toString());
+        assertError(getRaw(CONSOLE_SKILL_VERSION_PATH, skillVersionQuery(skillName, "2.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Skill version not found");
+
+        postFormOk(CONSOLE_SKILL_PATH + "/draft", skillForkForm(skillName, "2.0.0", "1.0.0"));
+        putFormOk(CONSOLE_SKILL_PATH + "/draft",
+                skillUpdateForm(skillName, "Version two submitted body.", "guide v2"));
+        JsonNode submit = postFormOk(CONSOLE_SKILL_PATH + "/submit", skillQueryForm(skillName));
+        assertEquals("2.0.0", submit.get("data").asText(), submit.toString());
+        String submittedStatus = skillVersionStatus(skillName, "2.0.0");
+        assertTrue("online".equals(submittedStatus) || "reviewing".equals(submittedStatus),
+                submittedStatus);
+        if ("reviewing".equals(submittedStatus)) {
+            postFormOk(CONSOLE_SKILL_PATH + "/force-publish", skillPublishForm(skillName, "2.0.0"));
+        }
+        assertSkillContent(getJsonOk(CONSOLE_SKILL_VERSION_PATH, skillVersionQuery(skillName, "2.0.0"))
+                .get("data"), skillName, "2.0.0", "Version two submitted body.", "guide v2");
+    }
+
+    @Test
+    public void testSkillValidationAndNotFoundErrors() throws Exception {
+        assertError(getRaw(CONSOLE_SKILL_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)), 400,
+                ErrorCode.PARAMETER_MISSING, "skillName");
+        assertError(postRaw(CONSOLE_SKILL_PATH + "/draft",
+                queryFrom(skillQueryForm(randomAiName("missing-card")))), 400,
+                ErrorCode.PARAMETER_MISSING, "skillCard");
+
+        String mismatchSkill = randomAiName("mismatch");
+        Map<String, String> mismatch = skillDraftForm(mismatchSkill, "1.0.0", "body", "guide");
+        mismatch.put("skillName", randomAiName("other"));
+        assertError(postRaw(CONSOLE_SKILL_PATH + "/draft", queryFrom(mismatch)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "skillCard name must match skillName");
+
+        Map<String, String> invalidVersion = skillDraftForm(randomAiName("bad-version"),
+                "bad-version", "body", "guide");
+        assertError(postRaw(CONSOLE_SKILL_PATH + "/draft", queryFrom(invalidVersion)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Invalid targetVersion format");
+        assertError(postRaw(CONSOLE_SKILL_PATH + "/force-publish",
+                queryFrom(skillQueryForm(randomAiName("missing-version")))), 400,
+                ErrorCode.PARAMETER_MISSING, "version");
+        assertError(putRaw(CONSOLE_SKILL_PATH + "/labels", skillQuery(randomAiName("missing-labels"))),
+                400, ErrorCode.PARAMETER_MISSING, "labels");
+        assertError(putRaw(CONSOLE_SKILL_PATH + "/scope", skillQuery(randomAiName("missing-scope"))),
+                400, ErrorCode.PARAMETER_MISSING, "scope");
+        assertError(putRaw(CONSOLE_SKILL_PATH + "/scope",
+                queryFrom(skillScopeForm(randomAiName("invalid-scope"), "TEAM"))), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "PUBLIC or PRIVATE");
+        assertError(getRaw(CONSOLE_SKILL_LIST_PATH, Query.newInstance().addParam("search", "invalid")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "search");
+        assertError(getRaw(CONSOLE_SKILL_LIST_PATH, Query.newInstance().addParam("scope", "TEAM")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "scope");
+        assertError(getRaw(CONSOLE_SKILL_LIST_PATH, Query.newInstance().addParam("pageNo", "0")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+
+        String absentSkill = randomAiName("absent");
+        assertError(getRaw(CONSOLE_SKILL_PATH, skillQuery(absentSkill)), 404,
+                ErrorCode.RESOURCE_NOT_FOUND, "Skill not found");
+        assertError(getRaw(CONSOLE_SKILL_VERSION_PATH, skillVersionQuery(absentSkill, "1.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Skill not found");
+        assertError(getRaw(CONSOLE_SKILL_VERSION_DOWNLOAD_PATH, skillVersionQuery(absentSkill, "1.0.0")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "Skill not found");
+    }
+
+    private void assertSkillListContains(Query query, String skillName) throws Exception {
+        JsonNode page = getJsonOk(CONSOLE_SKILL_LIST_PATH, query).get("data");
+        assertEmptyPageShape(page);
+        JsonNode found = findByName(page, "name", skillName);
+        assertFalse(found.isMissingNode(), page.toString());
+        assertEquals(skillName, found.get("name").asText(), found.toString());
+        assertNotNull(found.get("labels"), found.toString());
+    }
+
+    private void assertSkillVersionStatus(String skillName, String version, String status)
+            throws Exception {
+        assertEquals(status, skillVersionStatus(skillName, version));
+    }
+
+    private String skillVersionStatus(String skillName, String version) throws Exception {
+        JsonNode meta = getJsonOk(CONSOLE_SKILL_PATH, skillQuery(skillName)).get("data");
+        JsonNode versionSummary = findSkillVersionSummary(meta, version);
+        assertFalse(versionSummary.isMissingNode(), meta.toString());
+        return versionSummary.get("status").asText();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/skill/SkillUploadConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/ai/skill/SkillUploadConsoleApiOpenApiITCase.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.ai.skill;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.test.consoleapi.ai.AiConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for skill console upload OpenAPI {@code /v3/console/ai/skills/upload}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: single ZIP upload creates a draft from {@code SKILL.md} plus resource files, overwrite
+ *     updates an existing editing draft, and batch upload reports successful skill folders with persisted content.</li>
+ *     <li>Boundary/validation: namespace defaults to public; upload version resolves from SKILL.md before
+ *     targetVersion; duplicate working drafts require overwrite; batch upload keeps valid folders while reporting
+ *     invalid folders in {@code failed}.</li>
+ *     <li>Exception/error handling: empty and malformed ZIP files, invalid targetVersion, and archives without
+ *     {@code SKILL.md} return controlled HTTP 400 Result bodies instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class SkillUploadConsoleApiOpenApiITCase extends AiConsoleApiBaseITCase {
+
+    @Test
+    public void testSingleSkillUploadOverwriteAndVersionBump() throws Exception {
+        String skillName = randomAiName("upload");
+        Query uploadQuery = uploadQuery(false, "9.9.9", "openapi upload");
+        HttpResponse uploaded = postMultipartRaw(CONSOLE_SKILL_PATH + "/upload", uploadQuery,
+                "file", skillName + ".zip", "application/zip",
+                buildSkillZip(skillName, "1.0.0", "Uploaded body v1.", "uploaded guide"));
+        assertUploadSuccess(uploaded, skillName);
+        addCleanup(() -> deleteSkillQuietly(skillName));
+
+        JsonNode uploadedDetail = getJsonOk(CONSOLE_SKILL_VERSION_PATH,
+                skillVersionQuery(skillName, "1.0.0")).get("data");
+        assertSkillContent(uploadedDetail, skillName, "1.0.0", "Uploaded body v1.",
+                "uploaded guide");
+
+        assertError(postMultipartRaw(CONSOLE_SKILL_PATH + "/upload", uploadQuery,
+                "file", skillName + ".zip", "application/zip",
+                buildSkillZip(skillName, "1.0.0", "Duplicate body.", "duplicate guide")),
+                409, ErrorCode.RESOURCE_CONFLICT, "working version");
+        HttpResponse overwritten = postMultipartRaw(CONSOLE_SKILL_PATH + "/upload",
+                uploadQuery(true, "9.9.9", "openapi overwrite"), "file", skillName + ".zip",
+                "application/zip",
+                buildSkillZip(skillName, "1.0.0", "Overwritten body.", "overwritten guide"));
+        assertUploadSuccess(overwritten, skillName);
+        assertSkillContent(getJsonOk(CONSOLE_SKILL_VERSION_PATH, skillVersionQuery(skillName, "1.0.0"))
+                .get("data"), skillName, "1.0.0", "Overwritten body.", "overwritten guide");
+
+        postFormOk(CONSOLE_SKILL_PATH + "/force-publish", skillPublishForm(skillName, "1.0.0"));
+        HttpResponse nextUpload = postMultipartRaw(CONSOLE_SKILL_PATH + "/upload",
+                uploadQuery(false, "1.0.0", "openapi next draft"), "file", skillName + ".zip",
+                "application/zip",
+                buildSkillZip(skillName, null, "Uploaded body v2.", "uploaded guide v2"));
+        assertUploadSuccess(nextUpload, skillName);
+        JsonNode meta = getJsonOk(CONSOLE_SKILL_PATH, skillQuery(skillName)).get("data");
+        assertEquals("1.0.1", meta.get("editingVersion").asText(), meta.toString());
+        assertSkillContent(getJsonOk(CONSOLE_SKILL_VERSION_PATH, skillVersionQuery(skillName, "1.0.1"))
+                .get("data"), skillName, "1.0.1", "Uploaded body v2.", "uploaded guide v2");
+    }
+
+    @Test
+    public void testBatchSkillUploadSuccessAndPartialFailure() throws Exception {
+        String firstSkill = randomAiName("batch-a");
+        String secondSkill = randomAiName("batch-b");
+        Map<String, String> skills = new LinkedHashMap<>();
+        skills.put(firstSkill, "Batch body A.");
+        skills.put(secondSkill, "Batch body B.");
+        HttpResponse batch = postMultipartRaw(CONSOLE_SKILL_PATH + "/upload/batch",
+                uploadQuery(false, null, null), "file", "skills.zip", "application/zip",
+                buildMultiSkillZip(skills));
+        JsonNode data = assertUploadResult(batch).get("data");
+        assertArrayContains(data.get("succeeded"), firstSkill);
+        assertArrayContains(data.get("succeeded"), secondSkill);
+        assertEquals(0, data.get("failed").size(), data.toString());
+        addCleanup(() -> deleteSkillQuietly(firstSkill));
+        addCleanup(() -> deleteSkillQuietly(secondSkill));
+        assertSkillContent(getJsonOk(CONSOLE_SKILL_VERSION_PATH, skillVersionQuery(firstSkill, "1.0.0"))
+                .get("data"), firstSkill, "1.0.0", "Batch body A.", "guide for " + firstSkill);
+        assertSkillContent(getJsonOk(CONSOLE_SKILL_VERSION_PATH, skillVersionQuery(secondSkill, "1.0.0"))
+                .get("data"), secondSkill, "1.0.0", "Batch body B.", "guide for " + secondSkill);
+
+        String validSkill = randomAiName("batch-valid");
+        HttpResponse partial = postMultipartRaw(CONSOLE_SKILL_PATH + "/upload/batch",
+                uploadQuery(false, null, null), "file", "partial.zip", "application/zip",
+                buildPartiallyInvalidMultiSkillZip(validSkill, "Valid batch body."));
+        JsonNode partialData = assertUploadResult(partial).get("data");
+        assertArrayContains(partialData.get("succeeded"), validSkill);
+        assertEquals(1, partialData.get("failed").size(), partialData.toString());
+        assertEquals("invalid-skill", partialData.get("failed").get(0).get("name").asText(),
+                partialData.toString());
+        assertFalse(partialData.get("failed").get(0).get("reason").asText().isBlank(),
+                partialData.toString());
+        addCleanup(() -> deleteSkillQuietly(validSkill));
+    }
+
+    @Test
+    public void testSkillUploadValidationErrors() throws Exception {
+        String skillName = randomAiName("upload-invalid");
+        assertError(postMultipartRaw(CONSOLE_SKILL_PATH + "/upload", uploadQuery(false, null, null),
+                "file", "empty.zip", "application/zip", new byte[0]), 400,
+                ErrorCode.DATA_EMPTY, "File is required");
+        assertError(postMultipartRaw(CONSOLE_SKILL_PATH + "/upload", uploadQuery(false, null, null),
+                "file", "plain.zip", "application/zip", "not a zip".getBytes()), 400,
+                ErrorCode.PARSING_DATA_FAILED, "Failed to parse zip file");
+        assertError(postMultipartRaw(CONSOLE_SKILL_PATH + "/upload",
+                uploadQuery(false, "bad-version", null), "file", "skill.zip", "application/zip",
+                buildSkillZip(skillName, null, "Body.", "Guide.")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Invalid version from targetVersion parameter");
+        assertError(postMultipartRaw(CONSOLE_SKILL_PATH + "/upload/batch", uploadQuery(false, null, null),
+                "file", "plain.zip", "application/zip", "not a zip".getBytes()), 400,
+                ErrorCode.PARSING_DATA_FAILED, "Failed to parse zip file");
+    }
+
+    private Query uploadQuery(boolean overwrite, String targetVersion, String commitMsg) {
+        Query query = Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)
+                .addParam("overwrite", String.valueOf(overwrite));
+        addIfNotBlank(query, "targetVersion", targetVersion);
+        addIfNotBlank(query, "commitMsg", commitMsg);
+        return query;
+    }
+
+    private void assertUploadSuccess(HttpResponse response, String skillName) {
+        JsonNode root = assertUploadResult(response);
+        assertEquals(skillName, root.get("data").asText(), root.toString());
+    }
+
+    private JsonNode assertUploadResult(HttpResponse response) {
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        return root;
+    }
+
+    private void assertArrayContains(JsonNode array, String expected) {
+        for (JsonNode item : array) {
+            if (expected.equals(item.asText())) {
+                return;
+            }
+        }
+        throw new AssertionError("Expected " + expected + " in " + array);
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigBatchDeleteConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigBatchDeleteConsoleApiOpenApiITCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console config batch delete OpenAPI
+ * {@code DELETE /nacos/v3/console/cs/config/batchDelete}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: config ids delete multiple existing configs and each deleted config becomes absent from
+ *     the detail API.</li>
+ *     <li>Boundary/validation: non-existing ids are accepted and ignored, while {@code ids} is required.</li>
+ *     <li>Exception/error handling: missing {@code ids} returns HTTP 400 with the v3 {@code Result} envelope instead
+ *     of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigBatchDeleteConsoleApiOpenApiITCase extends ConfigConsoleApiBaseITCase {
+
+    @Test
+    public void testBatchDeleteExistingConfigsAndIgnoreMissingId() throws Exception {
+        String firstDataId = randomDataId("batch-delete-a");
+        String secondDataId = randomDataId("batch-delete-b");
+        String groupName = randomGroupName("batch-delete");
+        publishConfig(firstDataId, groupName, "", "console-batch-delete-first");
+        addCleanup(() -> deleteConfigQuietly(firstDataId, groupName, ""));
+        publishConfig(secondDataId, groupName, "", "console-batch-delete-second");
+        addCleanup(() -> deleteConfigQuietly(secondDataId, groupName, ""));
+
+        JsonNode first = queryConfig(firstDataId, groupName, "").get("data");
+        JsonNode second = queryConfig(secondDataId, groupName, "").get("data");
+        String ids = first.get("id").asText() + "," + second.get("id").asText() + ",999999999999";
+
+        JsonNode root = deleteJsonOk(CONSOLE_CONFIG_BATCH_DELETE_PATH, Query.newInstance().addParam("ids", ids));
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        assertSuccessDataNull(getRaw(CONSOLE_CONFIG_PATH, configQuery(firstDataId, groupName, "")));
+        assertSuccessDataNull(getRaw(CONSOLE_CONFIG_PATH, configQuery(secondDataId, groupName, "")));
+    }
+
+    @Test
+    public void testBatchDeleteIdsValidationReturnsBadRequest() throws Exception {
+        assertError(deleteRaw(CONSOLE_CONFIG_BATCH_DELETE_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "ids");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigBetaConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigBetaConsoleApiOpenApiITCase.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console config beta OpenAPI {@code /nacos/v3/console/cs/config/beta}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: beta publish through the config API can be queried from beta API and can be stopped,
+ *     after which beta query returns not found.</li>
+ *     <li>Boundary/validation: omitted namespace uses public, beta rule is generated from {@code betaIps}, and
+ *     {@code dataId}/{@code groupName} are required.</li>
+ *     <li>Exception/error handling: absent console beta queries return HTTP 200 with success and {@code data=null}
+ *     instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigBetaConsoleApiOpenApiITCase extends ConfigConsoleApiBaseITCase {
+
+    @Test
+    public void testQueryAndStopBetaConfig() throws Exception {
+        String dataId = randomDataId("beta");
+        String groupName = randomGroupName("beta");
+        String content = "console-beta-content";
+        String betaIps = "127.0.0.1";
+        publishBetaConfig(dataId, groupName, "", content, betaIps);
+        addCleanup(() -> deleteBetaQuietly(dataId, groupName, ""));
+
+        JsonNode beta = getJsonOk(CONSOLE_CONFIG_BETA_PATH, configQuery(dataId, groupName, null)).get("data");
+        assertEquals(dataId, beta.get("dataId").asText(), beta.toString());
+        assertEquals(groupName, beta.get("groupName").asText(), beta.toString());
+        assertEquals(DEFAULT_NAMESPACE, beta.get("namespaceId").asText(), beta.toString());
+        assertEquals(content, beta.get("content").asText(), beta.toString());
+        assertEquals("beta", beta.get("grayName").asText(), beta.toString());
+        assertTrue(beta.get("grayRule").asText().contains(betaIps), beta.toString());
+
+        JsonNode stopped = deleteJsonOk(CONSOLE_CONFIG_BETA_PATH, configQuery(dataId, groupName, ""));
+        assertTrue(stopped.get("data").asBoolean(), stopped.toString());
+        assertSuccessDataNull(getRaw(CONSOLE_CONFIG_BETA_PATH, configQuery(dataId, groupName, "")));
+    }
+
+    @Test
+    public void testBetaRequiredParametersAndAbsentConfigReturnControlledErrors() throws Exception {
+        String dataId = randomDataId("beta-required");
+        String groupName = randomGroupName("beta-required");
+        assertError(getRaw(CONSOLE_CONFIG_BETA_PATH, Query.newInstance().addParam("groupName", groupName)),
+                400, ErrorCode.PARAMETER_MISSING, "dataId");
+        assertError(getRaw(CONSOLE_CONFIG_BETA_PATH, Query.newInstance().addParam("dataId", dataId)),
+                400, ErrorCode.PARAMETER_MISSING, "groupName");
+        assertSuccessDataNull(getRaw(CONSOLE_CONFIG_BETA_PATH, configQuery(dataId, groupName, "")));
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigCloneConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigCloneConsoleApiOpenApiITCase.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console config clone OpenAPI {@code POST /nacos/v3/console/cs/config/clone}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: clone copies an existing {@code cfgId} to target {@code dataId}/{@code group} in
+ *     {@code targetNamespaceId}; the cloned config can be queried with original content and type.</li>
+ *     <li>Boundary/validation: {@code targetNamespaceId} is required, empty clone lists are rejected with
+ *     {@code NO_SELECTED_CONFIG}, and unknown source ids return {@code DATA_EMPTY} without creating data.</li>
+ *     <li>Exception/error handling: request-parameter errors return HTTP 400 and business failures keep the v3
+ *     {@code Result} envelope instead of leaking HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigCloneConsoleApiOpenApiITCase extends ConfigConsoleApiBaseITCase {
+
+    @Test
+    public void testCloneConfigToTargetIdentity() throws Exception {
+        String sourceDataId = randomDataId("clone-source");
+        String sourceGroup = randomGroupName("clone-source");
+        String targetDataId = randomDataId("clone-target");
+        String targetGroup = randomGroupName("clone-target");
+        String content = "console-clone-content";
+        publishConfig(sourceDataId, sourceGroup, "", content, ConfigType.JSON.getType(), "clone desc", "");
+        addCleanup(() -> deleteConfigQuietly(sourceDataId, sourceGroup, ""));
+        addCleanup(() -> deleteConfigQuietly(targetDataId, targetGroup, ""));
+        JsonNode source = queryConfig(sourceDataId, sourceGroup, "").get("data");
+
+        String body = "[{\"cfgId\":" + source.get("id").asText() + ",\"dataId\":\""
+                + targetDataId + "\",\"group\":\"" + targetGroup + "\"}]";
+        JsonNode root = postJsonOk(CONSOLE_CONFIG_CLONE_PATH,
+                Query.newInstance().addParam("targetNamespaceId", DEFAULT_NAMESPACE).addParam("policy",
+                        "OVERWRITE"),
+                body);
+        assertTrue(root.get("data").get("succCount").asInt() >= 1, root.toString());
+
+        JsonNode cloned = queryConfig(targetDataId, targetGroup, DEFAULT_NAMESPACE).get("data");
+        assertConfigDetail(cloned, targetDataId, targetGroup, DEFAULT_NAMESPACE, content, ConfigType.JSON.getType());
+    }
+
+    @Test
+    public void testCloneValidationAndBusinessFailuresReturnResultEnvelope() throws Exception {
+        assertError(postJsonRaw(CONSOLE_CONFIG_CLONE_PATH, Query.newInstance(), "[]"), 400,
+                ErrorCode.PARAMETER_MISSING, "targetNamespaceId");
+
+        HttpResponse emptyResponse = postJsonRaw(CONSOLE_CONFIG_CLONE_PATH,
+                Query.newInstance().addParam("targetNamespaceId", DEFAULT_NAMESPACE), "[]");
+        assertEquals(200, emptyResponse.code(), emptyResponse.body());
+        JsonNode emptyRoot = JacksonUtils.toObj(emptyResponse.body());
+        assertFailureResult(emptyRoot, ErrorCode.NO_SELECTED_CONFIG, "succCount");
+
+        HttpResponse absentSourceResponse = postJsonRaw(CONSOLE_CONFIG_CLONE_PATH,
+                Query.newInstance().addParam("targetNamespaceId", DEFAULT_NAMESPACE),
+                "[{\"cfgId\":999999999999,\"dataId\":\"absent\",\"group\":\"absent\"}]");
+        assertEquals(200, absentSourceResponse.code(), absentSourceResponse.body());
+        JsonNode absentSourceRoot = JacksonUtils.toObj(absentSourceResponse.body());
+        assertFailureResult(absentSourceRoot, ErrorCode.DATA_EMPTY, "succCount");
+    }
+
+    private void assertFailureResult(JsonNode root, ErrorCode errorCode, String dataField) {
+        assertEquals(errorCode.getCode(), root.get("code").asInt(), root.toString());
+        assertEquals(errorCode.getMsg(), root.get("message").asText(), root.toString());
+        assertTrue(root.get("data").has(dataField), root.toString());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigConsoleApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigConsoleApiBaseITCase.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.test.consoleapi.ConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shared helpers for config console OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class ConfigConsoleApiBaseITCase extends ConsoleApiBaseITCase {
+
+    protected static final String CONSOLE_CONFIG_PATH = CONSOLE_BASE_PATH + "/cs/config";
+
+    protected static final String CONSOLE_CONFIG_LIST_PATH = CONSOLE_CONFIG_PATH + "/list";
+
+    protected static final String CONSOLE_CONFIG_SEARCH_DETAIL_PATH = CONSOLE_CONFIG_PATH + "/searchDetail";
+
+    protected static final String CONSOLE_CONFIG_LISTENER_PATH = CONSOLE_CONFIG_PATH + "/listener";
+
+    protected static final String CONSOLE_CONFIG_LISTENER_IP_PATH = CONSOLE_CONFIG_PATH + "/listener/ip";
+
+    protected static final String CONSOLE_CONFIG_IMPORT_PATH = CONSOLE_CONFIG_PATH + "/import";
+
+    protected static final String CONSOLE_CONFIG_EXPORT_PATH = CONSOLE_CONFIG_PATH + "/export2";
+
+    protected static final String CONSOLE_CONFIG_CLONE_PATH = CONSOLE_CONFIG_PATH + "/clone";
+
+    protected static final String CONSOLE_CONFIG_BETA_PATH = CONSOLE_CONFIG_PATH + "/beta";
+
+    protected static final String CONSOLE_CONFIG_BATCH_DELETE_PATH = CONSOLE_CONFIG_PATH + "/batchDelete";
+
+    protected static final String CONSOLE_HISTORY_PATH = CONSOLE_BASE_PATH + "/cs/history";
+
+    protected static final String CONSOLE_HISTORY_LIST_PATH = CONSOLE_HISTORY_PATH + "/list";
+
+    protected static final String CONSOLE_HISTORY_PREVIOUS_PATH = CONSOLE_HISTORY_PATH + "/previous";
+
+    protected static final String CONSOLE_HISTORY_CONFIGS_PATH = CONSOLE_HISTORY_PATH + "/configs";
+
+    protected static final String DEFAULT_TYPE = ConfigType.getDefaultType().getType();
+
+    protected String randomDataId(String scenario) {
+        return randomConsoleName("config_" + scenario);
+    }
+
+    protected String randomGroupName(String scenario) {
+        return randomConsoleName("group_" + scenario);
+    }
+
+    protected JsonNode publishConfig(String dataId, String groupName, String namespaceId, String content)
+            throws Exception {
+        return publishConfig(dataId, groupName, namespaceId, content, DEFAULT_TYPE, "", "");
+    }
+
+    protected JsonNode publishConfig(String dataId, String groupName, String namespaceId, String content,
+            String type, String description, String configTags) throws Exception {
+        JsonNode root = postFormOk(CONSOLE_CONFIG_PATH,
+                buildPublishForm(dataId, groupName, namespaceId, content, type, description, configTags));
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        return root;
+    }
+
+    protected JsonNode publishBetaConfig(String dataId, String groupName, String namespaceId, String content,
+            String betaIps) throws Exception {
+        Header header = Header.newInstance().addParam("betaIps", betaIps);
+        JsonNode root = postFormOk(CONSOLE_CONFIG_PATH, header,
+                buildPublishForm(dataId, groupName, namespaceId, content, DEFAULT_TYPE, "", ""));
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        return root;
+    }
+
+    protected JsonNode queryConfig(String dataId, String groupName, String namespaceId) throws Exception {
+        return getJsonOk(CONSOLE_CONFIG_PATH, configQuery(dataId, groupName, namespaceId));
+    }
+
+    protected JsonNode deleteConfig(String dataId, String groupName, String namespaceId) throws Exception {
+        JsonNode root = deleteJsonOk(CONSOLE_CONFIG_PATH, configDeleteQuery(dataId, groupName, namespaceId));
+        assertTrue(root.get("data").asBoolean(), root.toString());
+        return root;
+    }
+
+    protected void deleteConfigQuietly(String dataId, String groupName, String namespaceId) throws Exception {
+        deleteQuietly(CONSOLE_CONFIG_PATH, configDeleteQuery(dataId, groupName, namespaceId));
+    }
+
+    protected void deleteBetaQuietly(String dataId, String groupName, String namespaceId) throws Exception {
+        deleteQuietly(CONSOLE_CONFIG_BETA_PATH, configQuery(dataId, groupName, namespaceId));
+    }
+
+    protected Query configQuery(String dataId, String groupName, String namespaceId) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "dataId", dataId);
+        addIfNotBlank(query, "groupName", groupName);
+        addIfNotBlank(query, "namespaceId", namespaceId);
+        return query;
+    }
+
+    protected Query listQuery(String dataId, String groupName, String namespaceId, int pageNo, int pageSize) {
+        Query query = configQuery(dataId, groupName, namespaceId);
+        query.addParam("search", "blur");
+        query.addParam("pageNo", String.valueOf(pageNo));
+        query.addParam("pageSize", String.valueOf(pageSize));
+        return query;
+    }
+
+    protected Query historyQuery(String dataId, String groupName, String namespaceId, int pageNo, int pageSize) {
+        Query query = configQuery(dataId, groupName, namespaceId);
+        query.addParam("pageNo", String.valueOf(pageNo));
+        query.addParam("pageSize", String.valueOf(pageSize));
+        return query;
+    }
+
+    protected void assertConfigDetail(JsonNode data, String dataId, String groupName, String namespaceId,
+            String content, String type) throws Exception {
+        assertEquals(dataId, data.get("dataId").asText(), data.toString());
+        assertEquals(groupName, data.get("groupName").asText(), data.toString());
+        assertEquals(namespaceId, data.get("namespaceId").asText(), data.toString());
+        assertEquals(content, data.get("content").asText(), data.toString());
+        assertEquals(type, data.get("type").asText(), data.toString());
+        assertEquals(md5(content), data.get("md5").asText(), data.toString());
+        assertTrue(data.get("createTime").asLong() > 0L, data.toString());
+        assertTrue(data.get("modifyTime").asLong() > 0L, data.toString());
+    }
+
+    protected void assertConfigMetadata(JsonNode data, String description, String configTags) {
+        assertEquals(description, data.get("desc").asText(), data.toString());
+        if (configTags.isEmpty()) {
+            assertTrue(data.get("configTags").isNull() || data.get("configTags").asText().isEmpty(),
+                    data.toString());
+        } else {
+            assertEquals(configTags, data.get("configTags").asText(), data.toString());
+        }
+    }
+
+    protected void assertPageContainsConfig(JsonNode page, String dataId, String groupName, String contentMd5) {
+        JsonNode found = findConfig(page, dataId, groupName);
+        assertFalse(found.isMissingNode(), page.toString());
+        assertEquals(contentMd5, found.get("md5").asText(), found.toString());
+    }
+
+    protected void assertPageNotContainsConfig(JsonNode page, String dataId, String groupName) {
+        assertTrue(findConfig(page, dataId, groupName).isMissingNode(), page.toString());
+    }
+
+    protected JsonNode assertArrayContainsConfig(JsonNode items, String dataId, String groupName) {
+        JsonNode found = findConfigInArray(items, dataId, groupName);
+        assertFalse(found.isMissingNode(), items.toString());
+        return found;
+    }
+
+    protected void assertListenerInfo(JsonNode data, String queryType) {
+        assertEquals(queryType, data.get("queryType").asText(), data.toString());
+        assertTrue(data.get("listenersStatus").isObject(), data.toString());
+    }
+
+    protected void assertSuccessDataNull(HttpResponse response) throws Exception {
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        assertTrue(root.get("data").isNull(), root.toString());
+    }
+
+    protected JsonNode findConfig(JsonNode page, String dataId, String groupName) {
+        for (JsonNode item : page.get("pageItems")) {
+            if (dataId.equals(item.get("dataId").asText())
+                    && groupName.equals(item.get("groupName").asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+
+    protected JsonNode findConfigInArray(JsonNode items, String dataId, String groupName) {
+        for (JsonNode item : items) {
+            if (dataId.equals(item.get("dataId").asText())
+                    && groupName.equals(item.get("groupName").asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+
+    protected static String md5(String content) throws Exception {
+        return MD5Utils.md5Hex(content, StandardCharsets.UTF_8.name());
+    }
+
+    private Query configDeleteQuery(String dataId, String groupName, String namespaceId) {
+        Query query = configQuery(dataId, groupName, namespaceId);
+        query.addParam("tag", "");
+        return query;
+    }
+
+    private static Map<String, String> buildPublishForm(String dataId, String groupName, String namespaceId,
+            String content, String type, String description, String configTags) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("dataId", dataId);
+        form.put("groupName", groupName);
+        if (null != namespaceId) {
+            form.put("namespaceId", namespaceId);
+        }
+        form.put("content", content);
+        form.put("tag", "");
+        form.put("appName", "");
+        form.put("src_user", "");
+        form.put("configTags", configTags);
+        form.put("desc", description);
+        form.put("use", "");
+        form.put("effect", "");
+        form.put("type", type);
+        form.put("schema", "");
+        return form;
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigConsoleApiOpenApiITCase.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for console config OpenAPI {@code /nacos/v3/console/cs/config}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: publish creates a config, republish updates content, query returns the console detail
+ *     model, and delete removes the config.</li>
+ *     <li>Boundary/validation: omitted namespaceId is stored as public, invalid config type is normalized to text,
+ *     {@code dataId}, {@code groupName}, and {@code content} are required, and legacy {@code group} does not replace
+ *     {@code groupName} for the v3 console API.</li>
+ *     <li>Exception/error handling: absent console config queries return HTTP 200 with success and {@code data=null},
+ *     while invalid namespace values return HTTP 400 rather than HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigConsoleApiOpenApiITCase extends ConfigConsoleApiBaseITCase {
+
+    @Test
+    public void testPublishQueryRepublishAndDeleteConfig() throws Exception {
+        String dataId = randomDataId("crud");
+        String groupName = randomGroupName("crud");
+        String initialContent = "{\"name\":\"initial\"}";
+        String description = "console config description";
+        String tags = "console-tag-a,console-tag-b";
+        publishConfig(dataId, groupName, "", initialContent, ConfigType.JSON.getType(), description, tags);
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+
+        JsonNode initialData = queryConfig(dataId, groupName, null).get("data");
+        assertConfigDetail(initialData, dataId, groupName, DEFAULT_NAMESPACE, initialContent,
+                ConfigType.JSON.getType());
+        assertConfigMetadata(initialData, description, tags);
+
+        String updatedContent = "plain-console-content-" + dataId;
+        publishConfig(dataId, groupName, "", updatedContent, "not-a-real-type", "", "");
+        JsonNode updatedData = queryConfig(dataId, groupName, "").get("data");
+        assertConfigDetail(updatedData, dataId, groupName, DEFAULT_NAMESPACE, updatedContent, DEFAULT_TYPE);
+
+        deleteConfig(dataId, groupName, "");
+        assertSuccessDataNull(getRaw(CONSOLE_CONFIG_PATH, configQuery(dataId, groupName, "")));
+    }
+
+    @Test
+    public void testPublishConfigRequiredParametersReturnBadRequest() throws Exception {
+        String dataId = randomDataId("required");
+        String groupName = randomGroupName("required");
+        assertError(postRaw(CONSOLE_CONFIG_PATH, Query.newInstance().addParam("groupName", groupName)
+                .addParam("content", "content")), 400, ErrorCode.PARAMETER_MISSING, "dataId");
+        assertError(postRaw(CONSOLE_CONFIG_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("content", "content")), 400, ErrorCode.PARAMETER_MISSING, "groupName");
+        assertError(postRaw(CONSOLE_CONFIG_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("groupName", groupName)), 400, ErrorCode.PARAMETER_MISSING, "content");
+        assertError(postRaw(CONSOLE_CONFIG_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("group", groupName).addParam("content", "content")), 400,
+                ErrorCode.PARAMETER_MISSING, "groupName");
+    }
+
+    @Test
+    public void testQueryDeleteNotFoundAndInvalidNamespaceReturnControlledErrors() throws Exception {
+        String dataId = randomDataId("absent");
+        String groupName = randomGroupName("absent");
+        assertSuccessDataNull(getRaw(CONSOLE_CONFIG_PATH, configQuery(dataId, groupName, "")));
+        assertError(getRaw(CONSOLE_CONFIG_PATH, configQuery(dataId, groupName, "invalid namespace")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceId");
+        assertError(deleteRaw(CONSOLE_CONFIG_PATH, Query.newInstance().addParam("groupName", groupName)),
+                400, ErrorCode.PARAMETER_MISSING, "dataId");
+        assertError(deleteRaw(CONSOLE_CONFIG_PATH, Query.newInstance().addParam("dataId", dataId)),
+                400, ErrorCode.PARAMETER_MISSING, "groupName");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigExportConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigExportConsoleApiOpenApiITCase.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.config.server.constant.Constants;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console config export OpenAPI {@code GET /nacos/v3/console/cs/config/export2}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: export by config id returns a downloadable zip containing the config content entry and
+ *     metadata yaml entry.</li>
+ *     <li>Boundary/validation: exported config ids are serialized as query parameters, omitted namespace uses public,
+ *     and invalid namespace values are rejected when ids are present.</li>
+ *     <li>Exception/error handling: namespace validation returns HTTP 400 with a v3 {@code Result} body instead of
+ *     HTTP 500. Export without {@code ids} is not asserted because the current endpoint dereferences a null id list
+ *     before validation.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigExportConsoleApiOpenApiITCase extends ConfigConsoleApiBaseITCase {
+
+    @Test
+    public void testExportConfigByIdReturnsZipWithContentAndMetadata() throws Exception {
+        String dataId = randomDataId("export");
+        String groupName = randomGroupName("export");
+        String content = "console-export-content";
+        publishConfig(dataId, groupName, "", content, ConfigType.TEXT.getType(), "console export desc", "");
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+        JsonNode config = queryConfig(dataId, groupName, "").get("data");
+
+        ByteResponse response = getRawBytes(CONSOLE_CONFIG_EXPORT_PATH,
+                Query.newInstance().addParam("ids", config.get("id").asText()));
+        assertEquals(200, response.code(), response.contentDisposition());
+        assertTrue(response.contentDisposition().startsWith("attachment;filename=nacos_config_export_"),
+                response.contentDisposition());
+
+        Map<String, String> entries = unzip(response.body());
+        String configEntry = groupName + Constants.CONFIG_EXPORT_ITEM_FILE_SEPARATOR + dataId;
+        assertEquals(content, entries.get(configEntry), entries.toString());
+        String metadata = entries.get(Constants.CONFIG_EXPORT_METADATA_NEW);
+        assertTrue(metadata.contains("dataId: " + dataId), metadata);
+        assertTrue(metadata.contains("group: " + groupName), metadata);
+        assertTrue(metadata.contains("type: text"), metadata);
+    }
+
+    @Test
+    public void testExportInvalidNamespaceReturnsBadRequest() throws Exception {
+        assertError(getRaw(CONSOLE_CONFIG_EXPORT_PATH, Query.newInstance().addParam("ids", "1")
+                .addParam("namespaceId", "invalid namespace")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceId");
+    }
+
+    private Map<String, String> unzip(byte[] body) throws Exception {
+        Map<String, String> result = new HashMap<>();
+        try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(body))) {
+            ZipEntry entry;
+            while (null != (entry = zipInputStream.getNextEntry())) {
+                result.put(entry.getName(), new String(zipInputStream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        }
+        return result;
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigHistoryConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigHistoryConsoleApiOpenApiITCase.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console config history OpenAPIs under {@code /nacos/v3/console/cs/history}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: publish and republish create history rows, history list is newest first, detail returns
+ *     selected historical content, previous returns current config's latest historical content, and namespace config
+ *     listing exposes the current config identity.</li>
+ *     <li>Boundary/validation: page size larger than the controller cap is accepted, {@code pageNo}/{@code pageSize},
+ *     {@code dataId}, {@code groupName}, {@code nid}, and {@code namespaceId} are validated.</li>
+ *     <li>Exception/error handling: missing, absent, and identity-mismatched history queries return controlled v3
+ *     {@code Result} errors with HTTP 400 or 403 instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigHistoryConsoleApiOpenApiITCase extends ConfigConsoleApiBaseITCase {
+
+    @Test
+    public void testHistoryListDetailPreviousAndNamespaceConfigs() throws Exception {
+        String dataId = randomDataId("history");
+        String groupName = randomGroupName("history");
+        String firstContent = "console-history-first";
+        String secondContent = "console-history-second";
+        publishConfig(dataId, groupName, "", firstContent);
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+        publishConfig(dataId, groupName, "", secondContent);
+
+        JsonNode currentConfig = queryConfig(dataId, groupName, "").get("data");
+        assertConfigDetail(currentConfig, dataId, groupName, DEFAULT_NAMESPACE, secondContent, DEFAULT_TYPE);
+
+        JsonNode historyPage = getJsonOk(CONSOLE_HISTORY_LIST_PATH,
+                historyQuery(dataId, groupName, "", 1, 1000)).get("data");
+        assertEquals(1, historyPage.get("pageNumber").asInt(), historyPage.toString());
+        assertEquals(2, historyPage.get("totalCount").asInt(), historyPage.toString());
+        assertEquals(2, historyPage.get("pageItems").size(), historyPage.toString());
+        JsonNode newestHistory = historyPage.get("pageItems").get(0);
+        JsonNode oldestHistory = historyPage.get("pageItems").get(1);
+        assertEquals(dataId, newestHistory.get("dataId").asText(), newestHistory.toString());
+        assertEquals(groupName, newestHistory.get("groupName").asText(), newestHistory.toString());
+        assertTrue(newestHistory.get("opType").asText().trim().startsWith("U"), newestHistory.toString());
+        assertTrue(oldestHistory.get("opType").asText().trim().startsWith("I"), oldestHistory.toString());
+
+        JsonNode historyDetail = getJsonOk(CONSOLE_HISTORY_PATH,
+                configQuery(dataId, groupName, "").addParam("nid", newestHistory.get("id").asText()))
+                .get("data");
+        assertEquals(firstContent, historyDetail.get("content").asText(), historyDetail.toString());
+        assertEquals(md5(firstContent), historyDetail.get("md5").asText(), historyDetail.toString());
+
+        JsonNode previous = getJsonOk(CONSOLE_HISTORY_PREVIOUS_PATH,
+                configQuery(dataId, groupName, "").addParam("id", currentConfig.get("id").asText()))
+                .get("data");
+        assertEquals(firstContent, previous.get("content").asText(), previous.toString());
+        assertEquals(newestHistory.get("id").asText(), previous.get("id").asText(), previous.toString());
+
+        JsonNode namespaceConfigs = getJsonOk(CONSOLE_HISTORY_CONFIGS_PATH,
+                Query.newInstance().addParam("namespaceId", DEFAULT_NAMESPACE)).get("data");
+        JsonNode namespaceConfig = assertArrayContainsConfig(namespaceConfigs, dataId, groupName);
+        assertEquals(DEFAULT_TYPE, namespaceConfig.get("type").asText(), namespaceConfig.toString());
+
+        assertError(getRaw(CONSOLE_HISTORY_PATH, configQuery("wrong-" + dataId, groupName, "")
+                .addParam("nid", newestHistory.get("id").asText())), 403,
+                ErrorCode.ACCESS_DENIED, "dataId");
+    }
+
+    @Test
+    public void testHistoryValidationAndAbsentHistoryReturnControlledErrors() throws Exception {
+        String dataId = randomDataId("history-validation");
+        String groupName = randomGroupName("history-validation");
+        assertError(getRaw(CONSOLE_HISTORY_LIST_PATH, Query.newInstance().addParam("dataId", dataId)
+                .addParam("pageNo", "1").addParam("pageSize", "10")), 400,
+                ErrorCode.PARAMETER_MISSING, "groupName");
+        assertError(getRaw(CONSOLE_HISTORY_LIST_PATH, historyQuery(dataId, groupName, "", 0, 10)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(CONSOLE_HISTORY_LIST_PATH, historyQuery(dataId, groupName, "", 1, 0)), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageSize");
+        assertError(getRaw(CONSOLE_HISTORY_PATH, configQuery(dataId, groupName, "")), 400,
+                ErrorCode.PARAMETER_MISSING, "nid");
+        assertError(getRaw(CONSOLE_HISTORY_PATH, configQuery(dataId, groupName, "")
+                .addParam("nid", "999999999999")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "Source must not be null");
+        assertError(getRaw(CONSOLE_HISTORY_CONFIGS_PATH), 400, ErrorCode.PARAMETER_MISSING,
+                "namespaceId");
+        assertError(getRaw(CONSOLE_HISTORY_CONFIGS_PATH,
+                Query.newInstance().addParam("namespaceId", "invalid namespace")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceId");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigImportConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigImportConsoleApiOpenApiITCase.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.config.server.constant.Constants;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console config import OpenAPI {@code POST /nacos/v3/console/cs/config/import}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: a valid metadata zip imports and publishes a config that can be queried with content,
+ *     type, and description.</li>
+ *     <li>Boundary/validation: omitted namespace uses public, {@code ABORT} policy is accepted, missing file returns
+ *     {@code DATA_EMPTY}, and malformed metadata returns {@code METADATA_ILLEGAL} with an object data field.</li>
+ *     <li>Exception/error handling: import business failures are returned in the v3 {@code Result} envelope instead
+ *     of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigImportConsoleApiOpenApiITCase extends ConfigConsoleApiBaseITCase {
+
+    @Test
+    public void testImportConfigZipPublishesConfig() throws Exception {
+        String dataId = randomDataId("import");
+        String groupName = randomGroupName("import");
+        String content = "console-import-content";
+        String description = "console import desc";
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+
+        HttpResponse response = postMultipartRaw(CONSOLE_CONFIG_IMPORT_PATH,
+                Query.newInstance().addParam("policy", "ABORT"), "file", "nacos-import.zip",
+                "application/zip", buildImportZip(dataId, groupName, content, description));
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertSuccess(root);
+        assertEquals(1, root.get("data").get("succCount").asInt(), root.toString());
+
+        JsonNode imported = queryConfig(dataId, groupName, "").get("data");
+        assertConfigDetail(imported, dataId, groupName, DEFAULT_NAMESPACE, content, ConfigType.TEXT.getType());
+        assertEquals(description, imported.get("desc").asText(), imported.toString());
+    }
+
+    @Test
+    public void testImportMissingFileAndBadMetadataReturnFailureResult() throws Exception {
+        HttpResponse missingFile = postRaw(CONSOLE_CONFIG_IMPORT_PATH,
+                Query.newInstance().addParam("policy", "ABORT"));
+        assertEquals(200, missingFile.code(), missingFile.body());
+        assertFailureResult(JacksonUtils.toObj(missingFile.body()), ErrorCode.DATA_EMPTY);
+
+        HttpResponse badMetadata = postMultipartRaw(CONSOLE_CONFIG_IMPORT_PATH,
+                Query.newInstance().addParam("policy", "ABORT"), "file", "bad-import.zip",
+                "application/zip", buildBadMetadataZip());
+        assertEquals(200, badMetadata.code(), badMetadata.body());
+        assertFailureResult(JacksonUtils.toObj(badMetadata.body()), ErrorCode.METADATA_ILLEGAL);
+    }
+
+    private void assertFailureResult(JsonNode root, ErrorCode errorCode) {
+        assertEquals(errorCode.getCode(), root.get("code").asInt(), root.toString());
+        assertEquals(errorCode.getMsg(), root.get("message").asText(), root.toString());
+        assertTrue(root.get("data").isObject(), root.toString());
+    }
+
+    private byte[] buildImportZip(String dataId, String groupName, String content, String description)
+            throws Exception {
+        String metadata = "metadata:\n"
+                + "- dataId: " + dataId + "\n"
+                + "  group: " + groupName + "\n"
+                + "  type: text\n"
+                + "  appName: ''\n"
+                + "  desc: " + description + "\n";
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+            writeEntry(zipOutputStream, Constants.CONFIG_EXPORT_METADATA_NEW, metadata);
+            writeEntry(zipOutputStream, groupName + Constants.CONFIG_EXPORT_ITEM_FILE_SEPARATOR + dataId, content);
+        }
+        return outputStream.toByteArray();
+    }
+
+    private byte[] buildBadMetadataZip() throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
+            writeEntry(zipOutputStream, Constants.CONFIG_EXPORT_METADATA_NEW, "metadata: []\n");
+        }
+        return outputStream.toByteArray();
+    }
+
+    private void writeEntry(ZipOutputStream zipOutputStream, String name, String content) throws Exception {
+        zipOutputStream.putNextEntry(new ZipEntry(name));
+        zipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        zipOutputStream.closeEntry();
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigListConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigListConsoleApiOpenApiITCase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests for console config list/search OpenAPIs.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: list returns published configs in the console page model, supports fuzzy dataId search,
+ *     advanced filters such as type/tags, exact content search via {@code searchDetail}, and pagination fields.</li>
+ *     <li>Boundary/validation: omitted namespaceId uses public, blank dataId is accepted for group-scoped listing,
+ *     no-match searches return a successful empty page, and pageNo/pageSize must be positive.</li>
+ *     <li>Exception/error handling: pagination validation failures return HTTP 400 with the v3 {@code Result} envelope
+ *     instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigListConsoleApiOpenApiITCase extends ConfigConsoleApiBaseITCase {
+
+    @Test
+    public void testListConfigsByFuzzyDataIdAdvancedFiltersAndContentSearch() throws Exception {
+        String prefix = randomDataId("list");
+        String groupName = randomGroupName("list");
+        String firstDataId = prefix + "_a";
+        String secondDataId = prefix + "_b";
+        String firstContent = "console-list-content-alpha";
+        String secondContent = "console-list-content-beta";
+        String firstTags = "console-list-tag-a";
+        publishConfig(firstDataId, groupName, "", firstContent, ConfigType.JSON.getType(), "first", firstTags);
+        addCleanup(() -> deleteConfigQuietly(firstDataId, groupName, ""));
+        publishConfig(secondDataId, groupName, "", secondContent, ConfigType.YAML.getType(), "second",
+                "console-list-tag-b");
+        addCleanup(() -> deleteConfigQuietly(secondDataId, groupName, ""));
+
+        String dataIdPattern = prefix + "*";
+        JsonNode allPage = getJsonOk(CONSOLE_CONFIG_LIST_PATH, listQuery(dataIdPattern, groupName, "", 1, 10))
+                .get("data");
+        assertEquals(1, allPage.get("pageNumber").asInt(), allPage.toString());
+        assertEquals(2, allPage.get("totalCount").asInt(), allPage.toString());
+        assertPageContainsConfig(allPage, firstDataId, groupName, md5(firstContent));
+        assertPageContainsConfig(allPage, secondDataId, groupName, md5(secondContent));
+
+        JsonNode paged = getJsonOk(CONSOLE_CONFIG_LIST_PATH, listQuery(dataIdPattern, groupName, "", 1, 1))
+                .get("data");
+        assertEquals(1, paged.get("pageNumber").asInt(), paged.toString());
+        assertEquals(2, paged.get("totalCount").asInt(), paged.toString());
+        assertEquals(2, paged.get("pagesAvailable").asInt(), paged.toString());
+        assertEquals(1, paged.get("pageItems").size(), paged.toString());
+
+        JsonNode typePage = getJsonOk(CONSOLE_CONFIG_LIST_PATH,
+                listQuery(dataIdPattern, groupName, "", 1, 10).addParam("type", ConfigType.JSON.getType()))
+                .get("data");
+        assertEquals(1, typePage.get("totalCount").asInt(), typePage.toString());
+        assertEquals(ConfigType.JSON.getType(), findConfig(typePage, firstDataId, groupName).get("type").asText(),
+                typePage.toString());
+        assertPageNotContainsConfig(typePage, secondDataId, groupName);
+
+        JsonNode tagsPage = getJsonOk(CONSOLE_CONFIG_LIST_PATH,
+                listQuery(dataIdPattern, groupName, "", 1, 10).addParam("configTags", firstTags)).get("data");
+        assertEquals(1, tagsPage.get("totalCount").asInt(), tagsPage.toString());
+        assertPageContainsConfig(tagsPage, firstDataId, groupName, md5(firstContent));
+
+        JsonNode contentPage = getJsonOk(CONSOLE_CONFIG_SEARCH_DETAIL_PATH,
+                listQuery(firstDataId, groupName, "", 1, 10).addParam("configDetail", firstContent)
+                        .addParam("search", "accurate")).get("data");
+        assertEquals(1, contentPage.get("totalCount").asInt(), contentPage.toString());
+        assertPageContainsConfig(contentPage, firstDataId, groupName, md5(firstContent));
+        assertPageNotContainsConfig(contentPage, secondDataId, groupName);
+
+        JsonNode partialContent = getJsonOk(CONSOLE_CONFIG_SEARCH_DETAIL_PATH,
+                listQuery(dataIdPattern, groupName, "", 1, 10).addParam("configDetail", "alpha")
+                        .addParam("search", "blur")).get("data");
+        assertEquals(0, partialContent.get("totalCount").asInt(), partialContent.toString());
+    }
+
+    @Test
+    public void testListAllowsBlankDataIdAndNoMatchReturnsEmptyPage() throws Exception {
+        String dataId = randomDataId("blank-data");
+        String groupName = randomGroupName("blank-data");
+        String content = "blank-data-list-content";
+        publishConfig(dataId, groupName, "", content, ConfigType.TEXT.getType(), "blank data id", "");
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+
+        JsonNode groupScoped = getJsonOk(CONSOLE_CONFIG_LIST_PATH, listQuery("", groupName, null, 1, 10))
+                .get("data");
+        assertEquals(1, groupScoped.get("pageNumber").asInt(), groupScoped.toString());
+        assertPageContainsConfig(groupScoped, dataId, groupName, md5(content));
+
+        JsonNode noMatch = getJsonOk(CONSOLE_CONFIG_LIST_PATH,
+                listQuery("no-match-" + randomDataId("list") + "*", groupName, "", 1, 10)).get("data");
+        assertEquals(1, noMatch.get("pageNumber").asInt(), noMatch.toString());
+        assertEquals(0, noMatch.get("totalCount").asInt(), noMatch.toString());
+        assertEquals(0, noMatch.get("pagesAvailable").asInt(), noMatch.toString());
+        assertEquals(0, noMatch.get("pageItems").size(), noMatch.toString());
+    }
+
+    @Test
+    public void testListAndSearchInvalidPaginationReturnBadRequest() throws Exception {
+        assertError(getRaw(CONSOLE_CONFIG_LIST_PATH + "?search=blur&pageNo=0"), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(CONSOLE_CONFIG_LIST_PATH + "?search=blur&pageSize=0"), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageSize");
+        assertError(getRaw(CONSOLE_CONFIG_SEARCH_DETAIL_PATH + "?search=blur&pageNo=0"), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigListenerConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/config/ConfigListenerConsoleApiOpenApiITCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.config;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests for console config listener OpenAPIs.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: {@code /config/listener} returns config-scoped listener state and
+ *     {@code /config/listener/ip} returns ip-scoped listener state with documented {@code queryType} values.</li>
+ *     <li>Boundary/validation: omitted namespace uses public for config listener lookup, {@code aggregation=false},
+ *     {@code all=true}, and namespace filtering are accepted when no listeners are registered.</li>
+ *     <li>Exception/error handling: required identity fields and required {@code ip} return HTTP 400 with the v3
+ *     {@code Result} error envelope instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigListenerConsoleApiOpenApiITCase extends ConfigConsoleApiBaseITCase {
+
+    @Test
+    public void testConfigListenerQueryReturnsConfigQueryType() throws Exception {
+        String dataId = randomDataId("listener");
+        String groupName = randomGroupName("listener");
+        publishConfig(dataId, groupName, "", "listener-content");
+        addCleanup(() -> deleteConfigQuietly(dataId, groupName, ""));
+
+        JsonNode defaultAggregation = getJsonOk(CONSOLE_CONFIG_LISTENER_PATH,
+                configQuery(dataId, groupName, null)).get("data");
+        assertListenerInfo(defaultAggregation, "config");
+        assertEquals(0, defaultAggregation.get("listenersStatus").size(), defaultAggregation.toString());
+
+        JsonNode noAggregation = getJsonOk(CONSOLE_CONFIG_LISTENER_PATH,
+                configQuery(dataId, groupName, "").addParam("aggregation", "false")).get("data");
+        assertListenerInfo(noAggregation, "config");
+        assertEquals(0, noAggregation.get("listenersStatus").size(), noAggregation.toString());
+    }
+
+    @Test
+    public void testIpListenerQueryAcceptsAllAndNamespaceFilter() throws Exception {
+        JsonNode defaultQuery = getJsonOk(CONSOLE_CONFIG_LISTENER_IP_PATH,
+                Query.newInstance().addParam("ip", "127.0.0.1")).get("data");
+        assertListenerInfo(defaultQuery, "ip");
+
+        JsonNode allWithNamespace = getJsonOk(CONSOLE_CONFIG_LISTENER_IP_PATH,
+                Query.newInstance().addParam("ip", "127.0.0.1").addParam("all", "true")
+                        .addParam("namespaceId", DEFAULT_NAMESPACE).addParam("aggregation", "false")).get("data");
+        assertListenerInfo(allWithNamespace, "ip");
+    }
+
+    @Test
+    public void testListenerRequiredParametersReturnBadRequest() throws Exception {
+        String dataId = randomDataId("listener-required");
+        String groupName = randomGroupName("listener-required");
+        assertError(getRaw(CONSOLE_CONFIG_LISTENER_PATH, Query.newInstance().addParam("groupName", groupName)),
+                400, ErrorCode.PARAMETER_MISSING, "dataId");
+        assertError(getRaw(CONSOLE_CONFIG_LISTENER_PATH, Query.newInstance().addParam("dataId", dataId)),
+                400, ErrorCode.PARAMETER_MISSING, "groupName");
+        assertError(getRaw(CONSOLE_CONFIG_LISTENER_IP_PATH), 400, ErrorCode.PARAMETER_MISSING, "ip");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/ClusterConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/ClusterConsoleApiOpenApiITCase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.core;
+
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console cluster OpenAPI {@code GET /nacos/v3/console/core/cluster/nodes}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: node list exposes current Nacos members and their address/state metadata.</li>
+ *     <li>Boundary/validation: omitted keyword returns the full member view; keyword filtering accepts address
+ *     fragments and unknown keywords return a successful empty collection.</li>
+ *     <li>Exception/error handling: this read-only endpoint has no controller-level required parameters or mutation
+ *     branch; the test verifies that filtering returns a controlled success envelope rather than HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ClusterConsoleApiOpenApiITCase extends CoreConsoleApiBaseITCase {
+
+    @Test
+    public void testNodeListAndKeywordFiltering() throws Exception {
+        JsonNode nodes = getJsonOk(CONSOLE_CLUSTER_NODES_PATH, Query.newInstance()).get("data");
+        assertTrue(nodes.isArray(), nodes.toString());
+        assertTrue(nodes.size() >= 1, nodes.toString());
+
+        JsonNode firstNode = nodes.get(0);
+        String address = firstNode.get("address").asText();
+        assertTrue(address.contains(":"), firstNode.toString());
+        assertTrue(firstNode.get("state").asText().length() > 0, firstNode.toString());
+
+        JsonNode filtered = getJsonOk(CONSOLE_CLUSTER_NODES_PATH,
+                Query.newInstance().addParam("keyword", address.substring(0, address.indexOf(':'))))
+                .get("data");
+        assertFalse(findByTextField(filtered, "address", address).isMissingNode(), filtered.toString());
+
+        JsonNode noMatch = getJsonOk(CONSOLE_CLUSTER_NODES_PATH,
+                Query.newInstance().addParam("keyword", "no-such-node-" + randomConsoleName("cluster")))
+                .get("data");
+        assertEquals(0, noMatch.size(), noMatch.toString());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/CoreConsoleApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/CoreConsoleApiBaseITCase.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.core;
+
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.test.consoleapi.ConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Shared helpers for core console OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class CoreConsoleApiBaseITCase extends ConsoleApiBaseITCase {
+
+    protected static final String CONSOLE_NAMESPACE_PATH = CONSOLE_BASE_PATH + "/core/namespace";
+
+    protected static final String CONSOLE_NAMESPACE_LIST_PATH = CONSOLE_NAMESPACE_PATH + "/list";
+
+    protected static final String CONSOLE_NAMESPACE_EXIST_PATH = CONSOLE_NAMESPACE_PATH + "/exist";
+
+    protected static final String CONSOLE_CLUSTER_PATH = CONSOLE_BASE_PATH + "/core/cluster";
+
+    protected static final String CONSOLE_CLUSTER_NODES_PATH = CONSOLE_CLUSTER_PATH + "/nodes";
+
+    protected static final String CONSOLE_PLUGIN_PATH = CONSOLE_BASE_PATH + "/plugin";
+
+    protected static final String CONSOLE_PLUGIN_LIST_PATH = CONSOLE_PLUGIN_PATH + "/list";
+
+    protected static final String CONSOLE_PLUGIN_AVAILABILITY_PATH = CONSOLE_PLUGIN_PATH + "/availability";
+
+    protected static final String CONSOLE_SERVER_PATH = CONSOLE_BASE_PATH + "/server";
+
+    protected static final String CONSOLE_HEALTH_PATH = CONSOLE_BASE_PATH + "/health";
+
+    protected String randomNamespaceId(String scenario) {
+        return "oit_ns_" + scenario + "_" + java.util.UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    protected Query namespaceCreateQuery(String namespaceId, String namespaceName, String namespaceDesc) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "customNamespaceId", namespaceId);
+        addIfNotBlank(query, "namespaceName", namespaceName);
+        addIfNotBlank(query, "namespaceDesc", namespaceDesc);
+        return query;
+    }
+
+    protected Query namespaceUpdateQuery(String namespaceId, String namespaceName, String namespaceDesc) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "namespaceId", namespaceId);
+        addIfNotBlank(query, "namespaceName", namespaceName);
+        addIfNotBlank(query, "namespaceDesc", namespaceDesc);
+        return query;
+    }
+
+    protected void deleteNamespaceQuietly(String namespaceId) throws Exception {
+        deleteQuietly(CONSOLE_NAMESPACE_PATH, Query.newInstance().addParam("namespaceId", namespaceId));
+    }
+
+    protected JsonNode findNamespace(JsonNode namespaces, String namespaceId) {
+        JsonNode namespace = findByTextField(namespaces, "namespace", namespaceId);
+        if (!namespace.isMissingNode()) {
+            return namespace;
+        }
+        return MissingNode.getInstance();
+    }
+
+    protected void assertNamespaceListed(JsonNode namespaces, String namespaceId) {
+        assertFalse(findNamespace(namespaces, namespaceId).isMissingNode(), namespaces.toString());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/HealthConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/HealthConsoleApiOpenApiITCase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.core;
+
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration tests for console health OpenAPIs under {@code /nacos/v3/console/health}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: liveness and readiness expose the console health state through v3 {@code Result}
+ *     bodies when the standalone server is healthy.</li>
+ *     <li>Boundary/validation: both APIs accept no required parameters; unexpected query parameters are ignored by
+ *     liveness and must not change the response envelope.</li>
+ *     <li>Exception/error handling: the readiness failure branch is not forced because it requires making the shared
+ *     standalone server unhealthy; this class verifies that the healthy deployed contract is HTTP 200 and not a raw
+ *     body or HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class HealthConsoleApiOpenApiITCase extends CoreConsoleApiBaseITCase {
+
+    @Test
+    public void testLivenessAndReadinessReturnHealthyResult() throws Exception {
+        JsonNode liveness = getJsonOk(CONSOLE_HEALTH_PATH + "/liveness",
+                Query.newInstance().addParam("unexpected", "ignored"));
+        assertEquals("ok", liveness.get("data").asText(), liveness.toString());
+
+        JsonNode readiness = getJsonOk(CONSOLE_HEALTH_PATH + "/readiness", Query.newInstance());
+        assertEquals("ok", readiness.get("data").asText(), readiness.toString());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/NamespaceConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/NamespaceConsoleApiOpenApiITCase.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.core;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console namespace OpenAPIs under {@code /nacos/v3/console/core/namespace}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: create persists namespace metadata, detail/list/exist expose it, update changes
+ *     display metadata, and delete removes it.</li>
+ *     <li>Boundary/validation: {@code customNamespaceId} is accepted for explicit creation, blank
+ *     {@code customNamespaceId} in exist returns false, namespace id/name are required where the form requires them,
+ *     and namespace name/id domain validation is enforced.</li>
+ *     <li>Exception/error handling: required-field and illegal namespace input return HTTP 400 with the v3
+ *     {@code Result} error envelope rather than HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class NamespaceConsoleApiOpenApiITCase extends CoreConsoleApiBaseITCase {
+
+    @Test
+    public void testCreateDetailUpdateListExistAndDeleteNamespace() throws Exception {
+        String namespaceId = randomNamespaceId("crud");
+        JsonNode created = postFormOk(CONSOLE_NAMESPACE_PATH,
+                namespaceCreateQuery(namespaceId, "console namespace", "created by console it"));
+        assertTrue(created.get("data").asBoolean(), created.toString());
+        addCleanup(() -> deleteNamespaceQuietly(namespaceId));
+
+        JsonNode detail = getJsonOk(CONSOLE_NAMESPACE_PATH,
+                Query.newInstance().addParam("namespaceId", namespaceId)).get("data");
+        assertEquals(namespaceId, detail.get("namespace").asText(), detail.toString());
+        assertEquals("console namespace", detail.get("namespaceShowName").asText(), detail.toString());
+        assertEquals("created by console it", detail.get("namespaceDesc").asText(), detail.toString());
+
+        JsonNode list = getJsonOk(CONSOLE_NAMESPACE_LIST_PATH, Query.newInstance()).get("data");
+        assertNamespaceListed(list, namespaceId);
+
+        JsonNode exists = getJsonOk(CONSOLE_NAMESPACE_EXIST_PATH,
+                Query.newInstance().addParam("customNamespaceId", namespaceId)).get("data");
+        assertTrue(exists.asBoolean(), exists.toString());
+
+        JsonNode updated = putFormOk(CONSOLE_NAMESPACE_PATH,
+                namespaceUpdateQuery(namespaceId, "console namespace updated", "updated by console it"));
+        assertTrue(updated.get("data").asBoolean(), updated.toString());
+
+        JsonNode updatedDetail = getJsonOk(CONSOLE_NAMESPACE_PATH,
+                Query.newInstance().addParam("namespaceId", namespaceId)).get("data");
+        assertEquals("console namespace updated", updatedDetail.get("namespaceShowName").asText(),
+                updatedDetail.toString());
+        assertEquals("updated by console it", updatedDetail.get("namespaceDesc").asText(),
+                updatedDetail.toString());
+
+        JsonNode blankExists = getJsonOk(CONSOLE_NAMESPACE_EXIST_PATH,
+                Query.newInstance().addParam("customNamespaceId", "")).get("data");
+        assertFalse(blankExists.asBoolean(), blankExists.toString());
+
+        JsonNode deleted = deleteJsonOk(CONSOLE_NAMESPACE_PATH,
+                Query.newInstance().addParam("namespaceId", namespaceId));
+        assertTrue(deleted.get("data").asBoolean(), deleted.toString());
+
+        JsonNode existsAfterDelete = getJsonOk(CONSOLE_NAMESPACE_EXIST_PATH,
+                Query.newInstance().addParam("customNamespaceId", namespaceId)).get("data");
+        assertFalse(existsAfterDelete.asBoolean(), existsAfterDelete.toString());
+    }
+
+    @Test
+    public void testNamespaceValidationReturnsBadRequest() throws Exception {
+        assertError(postRaw(CONSOLE_NAMESPACE_PATH,
+                Query.newInstance().addParam("customNamespaceId", randomNamespaceId("missing-name"))),
+                400, ErrorCode.PARAMETER_MISSING, "namespaceName");
+        assertError(putRaw(CONSOLE_NAMESPACE_PATH,
+                namespaceUpdateQuery(randomNamespaceId("missing-name"), null, "desc")),
+                400, ErrorCode.PARAMETER_MISSING, "namespaceName");
+        assertError(putRaw(CONSOLE_NAMESPACE_PATH,
+                namespaceUpdateQuery(null, "missing id", "desc")), 400,
+                ErrorCode.PARAMETER_MISSING, "namespaceId");
+        assertError(postRaw(CONSOLE_NAMESPACE_PATH,
+                namespaceCreateQuery(randomNamespaceId("bad-name"), "bad@name", "bad")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "namespaceShowName");
+        assertError(postRaw(CONSOLE_NAMESPACE_PATH,
+                namespaceCreateQuery("n".repeat(129), "too long", "bad")), 400,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, "length should not exceed 64");
+        assertError(getRaw(CONSOLE_NAMESPACE_PATH), 400, ErrorCode.PARAMETER_MISSING, "namespaceId");
+        assertError(getRaw(CONSOLE_NAMESPACE_EXIST_PATH), 400, ErrorCode.PARAMETER_MISSING,
+                "customNamespaceId");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/PluginConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/PluginConsoleApiOpenApiITCase.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.core;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console plugin OpenAPIs under {@code /nacos/v3/console/plugin}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: list exposes discovered plugin inventory, pluginType filtering narrows results, detail
+ *     returns identity and mutable-state fields, and availability returns the cluster-node availability map.</li>
+ *     <li>Boundary/validation: unknown pluginType list filter returns an empty list; detail/status/config/availability
+ *     require plugin identity parameters; config mutation requires a configuration map.</li>
+ *     <li>Exception/error handling: plugin state/config success mutations are intentionally not executed because they
+ *     change runtime extension state; missing plugin detail and validation errors are verified as controlled v3
+ *     envelopes.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class PluginConsoleApiOpenApiITCase extends CoreConsoleApiBaseITCase {
+
+    @Test
+    public void testListFilterDetailAndAvailability() throws Exception {
+        JsonNode plugins = getJsonOk(CONSOLE_PLUGIN_LIST_PATH, Query.newInstance()).get("data");
+        assertTrue(plugins.size() > 0, plugins.toString());
+
+        JsonNode plugin = plugins.get(0);
+        String pluginType = plugin.get("pluginType").asText();
+        String pluginName = plugin.get("pluginName").asText();
+        assertTrue(plugin.get("pluginId").asText().contains(":"), plugin.toString());
+        assertTrue(pluginType.length() > 0, plugin.toString());
+        assertTrue(pluginName.length() > 0, plugin.toString());
+
+        JsonNode filtered = getJsonOk(CONSOLE_PLUGIN_LIST_PATH,
+                Query.newInstance().addParam("pluginType", pluginType)).get("data");
+        assertTrue(filtered.size() > 0, filtered.toString());
+        for (JsonNode each : filtered) {
+            assertEquals(pluginType, each.get("pluginType").asText(), each.toString());
+        }
+
+        JsonNode detail = getJsonOk(CONSOLE_PLUGIN_PATH,
+                Query.newInstance().addParam("pluginType", pluginType).addParam("pluginName", pluginName))
+                .get("data");
+        assertEquals(plugin.get("pluginId").asText(), detail.get("pluginId").asText(), detail.toString());
+        assertEquals(pluginType, detail.get("pluginType").asText(), detail.toString());
+        assertEquals(pluginName, detail.get("pluginName").asText(), detail.toString());
+        assertTrue(detail.has("enabled"), detail.toString());
+        assertTrue(detail.has("configurable"), detail.toString());
+
+        JsonNode availability = getJsonOk(CONSOLE_PLUGIN_AVAILABILITY_PATH,
+                Query.newInstance().addParam("pluginType", pluginType).addParam("pluginName", pluginName))
+                .get("data");
+        assertTrue(availability.isObject(), availability.toString());
+
+        JsonNode unknownType = getJsonOk(CONSOLE_PLUGIN_LIST_PATH,
+                Query.newInstance().addParam("pluginType", "not-a-plugin-type")).get("data");
+        assertEquals(0, unknownType.size(), unknownType.toString());
+    }
+
+    @Test
+    public void testPluginValidationAndNotFoundReturnControlledErrors() throws Exception {
+        assertError(getRaw(CONSOLE_PLUGIN_PATH,
+                Query.newInstance().addParam("pluginType", "auth").addParam("pluginName", "missing-plugin")),
+                404, ErrorCode.RESOURCE_NOT_FOUND, "auth:missing-plugin");
+        assertError(getRaw(CONSOLE_PLUGIN_PATH,
+                Query.newInstance().addParam("pluginType", "auth")), 400,
+                ErrorCode.PARAMETER_MISSING, "pluginName");
+        assertError(getRaw(CONSOLE_PLUGIN_AVAILABILITY_PATH,
+                Query.newInstance().addParam("pluginName", "missing-plugin")), 400,
+                ErrorCode.PARAMETER_MISSING, "pluginType");
+        assertError(putRaw(CONSOLE_PLUGIN_PATH + "/status",
+                Query.newInstance().addParam("pluginType", "auth").addParam("enabled", "true")),
+                400, ErrorCode.PARAMETER_MISSING, "pluginName");
+        assertError(putRaw(CONSOLE_PLUGIN_PATH + "/config",
+                Query.newInstance().addParam("pluginType", "auth").addParam("pluginName", "missing-plugin")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "configuration");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/ServerStateConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/core/ServerStateConsoleApiOpenApiITCase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.core;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console server OpenAPIs under {@code /nacos/v3/console/server}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: state returns the console server state map, guide returns the configured guide text,
+ *     and announcement returns the language-specific announcement in the v3 {@code Result} envelope.</li>
+ *     <li>Boundary/validation: omitted announcement language defaults to zh-CN, en-US is accepted, and unexpected
+ *     query parameters on the state endpoint are ignored without changing the map response contract.</li>
+ *     <li>Exception/error handling: unsupported announcement language returns a controlled failure result instead of
+ *     HTTP 500; state intentionally does not use the {@code Result} wrapper because the controller returns a raw map.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ServerStateConsoleApiOpenApiITCase extends CoreConsoleApiBaseITCase {
+
+    @Test
+    public void testServerStateGuideAndAnnouncement() throws Exception {
+        HttpResponse stateResponse = getRaw(CONSOLE_SERVER_PATH + "/state?unexpected=ignored");
+        assertEquals(200, stateResponse.code(), stateResponse.body());
+        JsonNode state = JacksonUtils.toObj(stateResponse.body());
+        assertTrue(state.isObject(), state.toString());
+        assertTrue(state.size() > 0, state.toString());
+
+        JsonNode guide = getJsonOk(CONSOLE_SERVER_PATH + "/guide", Query.newInstance());
+        assertTrue(guide.get("data").isTextual(), guide.toString());
+
+        JsonNode defaultAnnouncement = getJsonOk(CONSOLE_SERVER_PATH + "/announcement",
+                Query.newInstance());
+        assertTrue(defaultAnnouncement.get("data").isTextual(), defaultAnnouncement.toString());
+
+        JsonNode enAnnouncement = getJsonOk(CONSOLE_SERVER_PATH + "/announcement",
+                Query.newInstance().addParam("language", "en-US"));
+        assertTrue(enAnnouncement.get("data").isTextual(), enAnnouncement.toString());
+    }
+
+    @Test
+    public void testUnsupportedAnnouncementLanguageReturnsFailureResult() throws Exception {
+        HttpResponse response = getRaw(CONSOLE_SERVER_PATH + "/announcement?language=fr-FR");
+        assertEquals(200, response.code(), response.body());
+        JsonNode root = JacksonUtils.toObj(response.body());
+        assertEquals(ErrorCode.SERVER_ERROR.getCode(), root.get("code").asInt(), response.body());
+        assertTrue(root.get("message").asText().contains("Unsupported language"), response.body());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/naming/InstanceConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/naming/InstanceConsoleApiOpenApiITCase.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console naming instance OpenAPI {@code /nacos/v3/console/ns/instance}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: list returns persistent instances in the console page model, update changes metadata,
+ *     weight and enabled state, accepts the healthy parameter while leaving persistent health server-controlled, and
+ *     delete removes the persistent instance. The instance setup uses admin register API because console exposes no
+ *     register endpoint.</li>
+ *     <li>Boundary/validation: omitted namespace/group default through setup, pageNo/pageSize must be positive,
+ *     required {@code serviceName}/{@code ip}/{@code port} are enforced, invalid weight is rejected, and console
+ *     delete rejects {@code ephemeral=true}. The custom cluster filter is intentionally not used before cluster
+ *     metadata exists because the console list API reports such filters as a controlled 404.</li>
+ *     <li>Exception/error handling: invalid filters and delete/update validation return HTTP 400 with the v3
+ *     {@code Result} envelope instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class InstanceConsoleApiOpenApiITCase extends NamingConsoleApiBaseITCase {
+
+    private static final String TEST_CLUSTER = "openapi-it-console-instance-cluster";
+
+    @Test
+    public void testListUpdateAndDeletePersistentInstance() throws Exception {
+        String serviceName = randomServiceName("instance");
+        String ip = "10.23.0.1";
+        int port = 20301;
+
+        registerPersistentInstanceForSetup(serviceName, null, null, ip, port, TEST_CLUSTER,
+                "{\"source\":\"console-it\"}", "2.5", "true", "true");
+        addCleanup(() -> deleteServiceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        addCleanup(() -> removePersistentInstanceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port,
+                TEST_CLUSTER));
+
+        JsonNode listed = waitUntilInstanceVisible(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER,
+                ip, port);
+        assertInstance(listed, serviceName, DEFAULT_GROUP, ip, port, TEST_CLUSTER, "source", "console-it");
+        assertInstanceState(listed, 2.5D, true, true, false);
+
+        JsonNode page = listInstances(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, null, 1, 1);
+        assertPageShape(page);
+        assertEquals(1, page.get("pageItems").size(), page.toString());
+        assertFalse(findInstance(page, ip, port).isMissingNode(), page.toString());
+
+        JsonNode update = putFormOk(CONSOLE_INSTANCE_PATH,
+                instanceQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port, TEST_CLUSTER)
+                        .addParam("metadata", "{\"source\":\"updated\",\"version\":\"console\"}")
+                        .addParam("weight", "3.5").addParam("healthy", "false")
+                        .addParam("enabled", "false").addParam("ephemeral", "false"));
+        assertEquals("ok", update.get("data").asText(), update.toString());
+
+        JsonNode updated = waitUntilInstanceMetadata(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER,
+                ip, port, "source", "updated");
+        assertInstance(updated, serviceName, DEFAULT_GROUP, ip, port, TEST_CLUSTER, "source", "updated");
+        assertEquals("console", updated.get("metadata").get("version").asText(), updated.toString());
+        assertInstanceState(updated, 3.5D, true, false, false);
+
+        JsonNode deleted = deleteJsonOk(CONSOLE_INSTANCE_PATH,
+                instanceQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port, TEST_CLUSTER));
+        assertEquals("ok", deleted.get("data").asText(), deleted.toString());
+        waitUntilInstanceAbsent(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, ip, port);
+    }
+
+    @Test
+    public void testInstanceValidationReturnsBadRequest() throws Exception {
+        assertError(getRaw(CONSOLE_INSTANCE_LIST_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(getRaw(CONSOLE_INSTANCE_LIST_PATH,
+                instanceListQuery(randomServiceName("page"), DEFAULT_GROUP, DEFAULT_NAMESPACE,
+                        TEST_CLUSTER, 0, 10)), 400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(putRaw(CONSOLE_INSTANCE_PATH, Query.newInstance().addParam("ip", "10.23.0.2")
+                .addParam("port", "20302")), 400, ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(putRaw(CONSOLE_INSTANCE_PATH, Query.newInstance().addParam("serviceName",
+                randomServiceName("missing-ip")).addParam("port", "20303")), 400,
+                ErrorCode.PARAMETER_MISSING, "ip");
+        assertError(putRaw(CONSOLE_INSTANCE_PATH, Query.newInstance().addParam("serviceName",
+                randomServiceName("missing-port")).addParam("ip", "10.23.0.4")), 400,
+                ErrorCode.PARAMETER_MISSING, "port");
+        assertError(putRaw(CONSOLE_INSTANCE_PATH, instanceQuery(randomServiceName("bad-weight"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, "10.23.0.5", 20305).addParam("weight", "10001")),
+                400, ErrorCode.WEIGHT_ERROR, "weights range");
+        assertError(deleteRaw(CONSOLE_INSTANCE_PATH, instanceQuery(randomServiceName("delete-ephemeral"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, "10.23.0.6", 20306).addParam("ephemeral", "true")),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "persistent instances");
+        assertError(deleteRaw(CONSOLE_INSTANCE_PATH, Query.newInstance().addParam("serviceName",
+                randomServiceName("delete-missing-ip")).addParam("port", "20307")),
+                400, ErrorCode.PARAMETER_MISSING, "ip");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/naming/NamingConsoleApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/naming/NamingConsoleApiBaseITCase.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.naming;
+
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.test.consoleapi.ConsoleApiBaseITCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shared helpers for naming console OpenAPI integration tests.
+ *
+ * @author xiweng.yy
+ */
+public abstract class NamingConsoleApiBaseITCase extends ConsoleApiBaseITCase {
+
+    protected static final String CONSOLE_SERVICE_PATH = CONSOLE_BASE_PATH + "/ns/service";
+
+    protected static final String CONSOLE_SERVICE_LIST_PATH = CONSOLE_SERVICE_PATH + "/list";
+
+    protected static final String CONSOLE_SERVICE_SUBSCRIBERS_PATH = CONSOLE_SERVICE_PATH + "/subscribers";
+
+    protected static final String CONSOLE_SERVICE_SELECTOR_TYPES_PATH = CONSOLE_SERVICE_PATH + "/selector/types";
+
+    protected static final String CONSOLE_SERVICE_CLUSTER_PATH = CONSOLE_SERVICE_PATH + "/cluster";
+
+    protected static final String CONSOLE_INSTANCE_PATH = CONSOLE_BASE_PATH + "/ns/instance";
+
+    protected static final String CONSOLE_INSTANCE_LIST_PATH = CONSOLE_INSTANCE_PATH + "/list";
+
+    protected static final String ADMIN_INSTANCE_PATH = nacosPath("/v3/admin/ns/instance");
+
+    protected String randomServiceName(String scenario) {
+        return randomConsoleName("service_" + scenario);
+    }
+
+    protected String randomGroupName(String scenario) {
+        return randomConsoleName("group_" + scenario);
+    }
+
+    protected Query serviceQuery(String serviceName, String groupName, String namespaceId) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "serviceName", serviceName);
+        addIfNotBlank(query, "groupName", groupName);
+        addIfNotBlank(query, "namespaceId", namespaceId);
+        return query;
+    }
+
+    protected Query serviceListQuery(String serviceName, String groupName, String namespaceId,
+            int pageNo, int pageSize) {
+        Query query = Query.newInstance();
+        addIfNotBlank(query, "serviceNameParam", serviceName);
+        addIfNotBlank(query, "groupNameParam", groupName);
+        addIfNotBlank(query, "namespaceId", namespaceId);
+        query.addParam("pageNo", String.valueOf(pageNo));
+        query.addParam("pageSize", String.valueOf(pageSize));
+        return query;
+    }
+
+    protected Query subscribersQuery(String serviceName, String groupName, String namespaceId,
+            int pageNo, int pageSize, String aggregation) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        query.addParam("pageNo", String.valueOf(pageNo));
+        query.addParam("pageSize", String.valueOf(pageSize));
+        addIfNotBlank(query, "aggregation", aggregation);
+        return query;
+    }
+
+    protected Query instanceQuery(String serviceName, String groupName, String namespaceId, String ip, int port) {
+        return instanceQuery(serviceName, groupName, namespaceId, ip, port, null);
+    }
+
+    protected Query instanceQuery(String serviceName, String groupName, String namespaceId, String ip, int port,
+            String clusterName) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        addIfNotBlank(query, "ip", ip);
+        query.addParam("port", String.valueOf(port));
+        addIfNotBlank(query, "clusterName", clusterName);
+        return query;
+    }
+
+    protected Query instanceListQuery(String serviceName, String groupName, String namespaceId, String clusterName,
+            int pageNo, int pageSize) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        addIfNotBlank(query, "clusterName", clusterName);
+        query.addParam("pageNo", String.valueOf(pageNo));
+        query.addParam("pageSize", String.valueOf(pageSize));
+        return query;
+    }
+
+    protected Query clusterQuery(String serviceName, String groupName, String namespaceId, String clusterName,
+            String checkPort, String useInstancePort4Check, String healthChecker, String metadata) {
+        Query query = serviceQuery(serviceName, groupName, namespaceId);
+        addIfNotBlank(query, "clusterName", clusterName);
+        addIfNotBlank(query, "checkPort", checkPort);
+        addIfNotBlank(query, "useInstancePort4Check", useInstancePort4Check);
+        addIfNotBlank(query, "healthChecker", healthChecker);
+        addIfNotBlank(query, "metadata", metadata);
+        return query;
+    }
+
+    protected JsonNode createService(String serviceName, String groupName, String namespaceId,
+            String metadata, String protectThreshold) throws Exception {
+        JsonNode root = postFormOk(CONSOLE_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId)
+                .addParam("metadata", metadata).addParam("protectThreshold", protectThreshold)
+                .addParam("ephemeral", "false"));
+        assertEquals("ok", root.get("data").asText(), root.toString());
+        return root;
+    }
+
+    protected JsonNode updateService(String serviceName, String groupName, String namespaceId,
+            String metadata, String protectThreshold) throws Exception {
+        JsonNode root = putFormOk(CONSOLE_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId)
+                .addParam("metadata", metadata).addParam("protectThreshold", protectThreshold));
+        assertEquals("ok", root.get("data").asText(), root.toString());
+        return root;
+    }
+
+    protected void deleteServiceQuietly(String serviceName, String groupName, String namespaceId) throws Exception {
+        deleteQuietly(CONSOLE_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId));
+    }
+
+    protected JsonNode registerPersistentInstanceForSetup(String serviceName, String groupName, String namespaceId,
+            String ip, int port, String clusterName, String metadata, String weight, String healthy,
+            String enabled) throws Exception {
+        Query query = instanceQuery(serviceName, groupName, namespaceId, ip, port, clusterName);
+        addIfNotBlank(query, "metadata", metadata);
+        addIfNotBlank(query, "weight", weight);
+        addIfNotBlank(query, "healthy", healthy);
+        addIfNotBlank(query, "enabled", enabled);
+        query.addParam("ephemeral", "false");
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(ADMIN_INSTANCE_PATH), Header.EMPTY,
+                query, Collections.emptyMap(), String.class);
+        assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
+                + restResult.getData() + ", message=" + restResult.getMessage());
+        JsonNode root = JacksonUtils.toObj(restResult.getData());
+        assertSuccess(root);
+        assertEquals("ok", root.get("data").asText(), root.toString());
+        return root;
+    }
+
+    protected void removePersistentInstanceQuietly(String serviceName, String groupName, String namespaceId,
+            String ip, int port, String clusterName) throws Exception {
+        Query query = instanceQuery(serviceName, groupName, namespaceId, ip, port, clusterName);
+        query.addParam("ephemeral", "false");
+        deleteQuietly(CONSOLE_INSTANCE_PATH, query);
+    }
+
+    protected JsonNode listInstances(String serviceName, String groupName, String namespaceId, String clusterName,
+            int pageNo, int pageSize) throws Exception {
+        return getJsonOk(CONSOLE_INSTANCE_LIST_PATH, instanceListQuery(serviceName, groupName, namespaceId,
+                clusterName, pageNo, pageSize)).get("data");
+    }
+
+    protected JsonNode waitUntilInstanceVisible(String serviceName, String groupName, String namespaceId,
+            String clusterName, String ip, int port) throws Exception {
+        JsonNode page = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            page = listInstances(serviceName, groupName, namespaceId, null, 1, 10);
+            JsonNode instance = findInstance(page, ip, port);
+            if (!instance.isMissingNode()) {
+                return instance;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected instance to be visible, last page=" + page);
+    }
+
+    protected void waitUntilInstanceAbsent(String serviceName, String groupName, String namespaceId,
+            String clusterName, String ip, int port) throws Exception {
+        JsonNode page = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            page = listInstances(serviceName, groupName, namespaceId, null, 1, 10);
+            if (findInstance(page, ip, port).isMissingNode()) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected instance to be absent, last page=" + page);
+    }
+
+    protected JsonNode waitUntilInstanceMetadata(String serviceName, String groupName, String namespaceId,
+            String clusterName, String ip, int port, String metadataKey, String expectedValue) throws Exception {
+        JsonNode instance = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            instance = findInstance(listInstances(serviceName, groupName, namespaceId, null, 1, 10),
+                    ip, port);
+            if (!instance.isMissingNode()
+                    && expectedValue.equals(instance.path("metadata").path(metadataKey).asText(null))) {
+                return instance;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected instance metadata " + metadataKey + "=" + expectedValue
+                + ", last instance=" + instance);
+    }
+
+    protected JsonNode waitUntilClusterMetadata(String serviceName, String groupName, String namespaceId,
+            String clusterName, String metadataKey, String metadataValue) throws Exception {
+        JsonNode detail = MissingNode.getInstance();
+        int retryTime = 20;
+        while (retryTime-- > 0) {
+            detail = getJsonOk(CONSOLE_SERVICE_PATH, serviceQuery(serviceName, groupName, namespaceId))
+                    .get("data");
+            JsonNode cluster = detail.path("clusterMap").path(clusterName);
+            if (!cluster.isMissingNode()
+                    && metadataValue.equals(cluster.path("metadata").path(metadataKey).asText(null))) {
+                return cluster;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        throw new AssertionError("Expected cluster metadata to be visible, last service detail=" + detail);
+    }
+
+    protected void assertServiceDetail(JsonNode data, String serviceName, String groupName, String namespaceId,
+            String metadataKey, String metadataValue) {
+        assertEquals(serviceName, data.get("serviceName").asText(), data.toString());
+        assertEquals(groupName, data.get("groupName").asText(), data.toString());
+        assertEquals(namespaceId, data.get("namespaceId").asText(), data.toString());
+        assertEquals(metadataValue, data.get("metadata").get(metadataKey).asText(), data.toString());
+        assertFalse(data.get("ephemeral").asBoolean(), data.toString());
+    }
+
+    protected JsonNode findService(JsonNode page, String serviceName, String groupName) {
+        for (JsonNode item : page.get("pageItems")) {
+            if (serviceName.equals(item.get("name").asText())
+                    && groupName.equals(item.get("groupName").asText())) {
+                return item;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+
+    protected void assertServiceListed(JsonNode page, String serviceName, String groupName) {
+        JsonNode service = findService(page, serviceName, groupName);
+        assertFalse(service.isMissingNode(), page.toString());
+        assertTrue(service.get("clusterCount").asInt() >= 0, service.toString());
+    }
+
+    protected JsonNode findInstance(JsonNode page, String ip, int port) {
+        for (JsonNode each : page.get("pageItems")) {
+            if (ip.equals(each.get("ip").asText()) && port == each.get("port").asInt()) {
+                return each;
+            }
+        }
+        return MissingNode.getInstance();
+    }
+
+    protected void assertInstance(JsonNode instance, String serviceName, String groupName, String ip, int port,
+            String clusterName, String metadataKey, String metadataValue) {
+        assertEquals(groupName + "@@" + serviceName, instance.get("serviceName").asText(), instance.toString());
+        assertEquals(ip, instance.get("ip").asText(), instance.toString());
+        assertEquals(port, instance.get("port").asInt(), instance.toString());
+        assertEquals(clusterName, instance.get("clusterName").asText(), instance.toString());
+        if (null != metadataKey) {
+            assertEquals(metadataValue, instance.get("metadata").get(metadataKey).asText(), instance.toString());
+        }
+    }
+
+    protected void assertInstanceState(JsonNode instance, double weight, boolean healthy, boolean enabled,
+            boolean ephemeral) {
+        assertEquals(weight, instance.get("weight").asDouble(), 0.0001D, instance.toString());
+        assertEquals(healthy, instance.get("healthy").asBoolean(), instance.toString());
+        assertEquals(enabled, instance.get("enabled").asBoolean(), instance.toString());
+        assertEquals(ephemeral, instance.get("ephemeral").asBoolean(), instance.toString());
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/naming/ServiceClusterConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/naming/ServiceClusterConsoleApiOpenApiITCase.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Integration tests for console naming service cluster OpenAPI
+ * {@code PUT /nacos/v3/console/ns/service/cluster}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: update persists cluster health-check port, checker type, instance-port policy, and
+ *     metadata, verified through service detail's cluster map after an instance makes the cluster visible.</li>
+ *     <li>Boundary/validation: omitted namespace/group default to public and DEFAULT_GROUP; serviceName, clusterName,
+ *     checkPort, useInstancePort4Check, and healthChecker are required.</li>
+ *     <li>Exception/error handling: missing required fields and a non-existent owning service return controlled
+ *     failures instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ServiceClusterConsoleApiOpenApiITCase extends NamingConsoleApiBaseITCase {
+
+    private static final String TEST_CLUSTER = "openapi-it-console-cluster";
+
+    @Test
+    public void testUpdateClusterMetadataAndDefaultGroup() throws Exception {
+        String serviceName = randomServiceName("cluster");
+        String ip = "10.23.2.1";
+        int port = 20501;
+
+        registerPersistentInstanceForSetup(serviceName, null, null, ip, port, TEST_CLUSTER,
+                "{\"scene\":\"cluster\"}", "1.0", "true", "true");
+        addCleanup(() -> deleteServiceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        addCleanup(() -> removePersistentInstanceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, ip, port,
+                TEST_CLUSTER));
+        waitUntilInstanceVisible(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, ip, port);
+
+        JsonNode root = putFormOk(CONSOLE_SERVICE_CLUSTER_PATH, clusterQuery(serviceName, null, null,
+                TEST_CLUSTER, "18888", "false", "{\"type\":\"TCP\"}", "{\"zone\":\"hz\",\"owner\":\"it\"}"));
+        assertEquals("ok", root.get("data").asText(), root.toString());
+
+        JsonNode cluster = waitUntilClusterMetadata(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER,
+                "zone", "hz");
+        assertEquals(TEST_CLUSTER, cluster.get("clusterName").asText(), cluster.toString());
+        assertEquals(18888, cluster.get("healthyCheckPort").asInt(), cluster.toString());
+        assertFalse(cluster.get("useInstancePortForCheck").asBoolean(), cluster.toString());
+        assertEquals("TCP", cluster.get("healthChecker").get("type").asText(), cluster.toString());
+        assertEquals("it", cluster.get("metadata").get("owner").asText(), cluster.toString());
+    }
+
+    @Test
+    public void testClusterValidationAndMissingServiceReturnControlledErrors() throws Exception {
+        assertError(putRaw(CONSOLE_SERVICE_CLUSTER_PATH, Query.newInstance().addParam("clusterName", TEST_CLUSTER)
+                .addParam("checkPort", "18889").addParam("useInstancePort4Check", "true")
+                .addParam("healthChecker", "{\"type\":\"TCP\"}")), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(putRaw(CONSOLE_SERVICE_CLUSTER_PATH, clusterQuery(randomServiceName("missing-cluster"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, null, "18889", "true", "{\"type\":\"TCP\"}", null)),
+                400, ErrorCode.PARAMETER_MISSING, "clusterName");
+        assertError(putRaw(CONSOLE_SERVICE_CLUSTER_PATH, clusterQuery(randomServiceName("missing-port"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, null, "true", "{\"type\":\"TCP\"}", null)),
+                400, ErrorCode.PARAMETER_MISSING, "checkPort");
+        assertError(putRaw(CONSOLE_SERVICE_CLUSTER_PATH, clusterQuery(randomServiceName("missing-use-port"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, "18889", null, "{\"type\":\"TCP\"}", null)),
+                400, ErrorCode.PARAMETER_MISSING, "useInstancePort4Check");
+        assertError(putRaw(CONSOLE_SERVICE_CLUSTER_PATH, clusterQuery(randomServiceName("missing-checker"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, "18889", "true", null, null)),
+                400, ErrorCode.PARAMETER_MISSING, "healthChecker");
+        assertError(putRaw(CONSOLE_SERVICE_CLUSTER_PATH, clusterQuery(randomServiceName("missing-service"),
+                DEFAULT_GROUP, DEFAULT_NAMESPACE, TEST_CLUSTER, "18890", "true", "{\"type\":\"TCP\"}",
+                "{\"zone\":\"missing\"}")), 400, ErrorCode.SERVER_ERROR, "service not found");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/naming/ServiceConsoleApiOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/consoleapi/naming/ServiceConsoleApiOpenApiITCase.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.consoleapi.naming;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.param.Query;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for console naming service OpenAPI {@code /nacos/v3/console/ns/service}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: create persists a service, detail returns metadata/default namespace/group/ephemeral
+ *     fields, update changes service metadata, list can find the service, selector-types exposes the built-in
+ *     {@code none} selector, subscribers returns the expected empty page shape, and delete removes the service.</li>
+ *     <li>Boundary/validation: omitted namespace and group default to public and DEFAULT_GROUP; list/subscriber
+ *     pagination requires positive values; {@code serviceName} is required for service identity APIs.</li>
+ *     <li>Exception/error handling: missing required fields and invalid pagination return HTTP 400 with the v3
+ *     {@code Result} envelope instead of HTTP 500.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ServiceConsoleApiOpenApiITCase extends NamingConsoleApiBaseITCase {
+
+    @Test
+    public void testCreateDetailUpdateListSubscribersSelectorAndDeleteService() throws Exception {
+        String serviceName = randomServiceName("service");
+        createService(serviceName, "", null, "{\"env\":\"console-it\"}", "0.4");
+        addCleanup(() -> deleteServiceQuietly(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+
+        JsonNode selectorTypes = getJsonOk(CONSOLE_SERVICE_SELECTOR_TYPES_PATH, Query.newInstance())
+                .get("data");
+        assertTrue(selectorTypes.isArray(), selectorTypes.toString());
+        assertArrayContainsText(selectorTypes, "none");
+
+        JsonNode created = getJsonOk(CONSOLE_SERVICE_PATH, serviceQuery(serviceName, null, null))
+                .get("data");
+        assertServiceDetail(created, serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, "env", "console-it");
+        assertEquals(0.4F, created.get("protectThreshold").floatValue(), 0.001F, created.toString());
+
+        updateService(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, "{\"env\":\"updated\"}", "0.6");
+        JsonNode updated = getJsonOk(CONSOLE_SERVICE_PATH,
+                serviceQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE)).get("data");
+        assertServiceDetail(updated, serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, "env", "updated");
+        assertEquals(0.6F, updated.get("protectThreshold").floatValue(), 0.001F, updated.toString());
+
+        JsonNode subscribers = getJsonOk(CONSOLE_SERVICE_SUBSCRIBERS_PATH,
+                subscribersQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, 1, 10, "false"))
+                .get("data");
+        assertPageShape(subscribers);
+        assertEquals(0, subscribers.get("totalCount").asInt(), subscribers.toString());
+
+        JsonNode listed = getJsonOk(CONSOLE_SERVICE_LIST_PATH,
+                serviceListQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, 1, 10)).get("data");
+        assertEquals(1, listed.get("pageNumber").asInt(), listed.toString());
+        assertServiceListed(listed, serviceName, DEFAULT_GROUP);
+
+        JsonNode deleted = deleteJsonOk(CONSOLE_SERVICE_PATH,
+                serviceQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE));
+        assertEquals("ok", deleted.get("data").asText(), deleted.toString());
+        JsonNode afterDelete = getJsonOk(CONSOLE_SERVICE_LIST_PATH,
+                serviceListQuery(serviceName, DEFAULT_GROUP, DEFAULT_NAMESPACE, 1, 10)).get("data");
+        assertEquals(0, afterDelete.get("totalCount").asInt(), afterDelete.toString());
+    }
+
+    @Test
+    public void testServiceValidationReturnsBadRequest() throws Exception {
+        assertError(postRaw(CONSOLE_SERVICE_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(getRaw(CONSOLE_SERVICE_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(putRaw(CONSOLE_SERVICE_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(deleteRaw(CONSOLE_SERVICE_PATH, Query.newInstance()), 400,
+                ErrorCode.PARAMETER_MISSING, "serviceName");
+        assertError(getRaw(CONSOLE_SERVICE_LIST_PATH,
+                serviceListQuery(randomServiceName("service-page"), DEFAULT_GROUP, DEFAULT_NAMESPACE, 0, 10)),
+                400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(CONSOLE_SERVICE_SUBSCRIBERS_PATH,
+                subscribersQuery(randomServiceName("subscriber-page"), DEFAULT_GROUP, DEFAULT_NAMESPACE, 0, 10,
+                        "false")), 400, ErrorCode.PARAMETER_VALIDATE_ERROR, "pageNo");
+        assertError(getRaw(CONSOLE_SERVICE_SUBSCRIBERS_PATH,
+                Query.newInstance().addParam("pageNo", "1").addParam("pageSize", "10")),
+                400, ErrorCode.PARAMETER_MISSING, "serviceName");
+    }
+}

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/OpenApiBaseITCase.java
@@ -107,9 +107,17 @@ public abstract class OpenApiBaseITCase {
     protected static String url(String path) {
         return BASE_URL + path;
     }
+
+    protected String baseUrl() {
+        return BASE_URL;
+    }
+
+    protected String requestUrl(String path) {
+        return baseUrl() + path;
+    }
     
     protected HttpResponse getRaw(String pathAndQuery) throws Exception {
-        return executeRaw(new HttpGet(url(pathAndQuery)));
+        return executeRaw(new HttpGet(requestUrl(pathAndQuery)));
     }
     
     protected HttpResponse getRaw(String path, Query query) throws Exception {
@@ -117,23 +125,23 @@ public abstract class OpenApiBaseITCase {
     }
     
     protected ByteResponse getRawBytes(String path, Query query) throws Exception {
-        return executeRawBytes(new HttpGet(url(path + "?" + query.toQueryUrl())));
+        return executeRawBytes(new HttpGet(requestUrl(path + "?" + query.toQueryUrl())));
     }
     
     protected HttpResponse postRaw(String path, Query query) throws Exception {
-        return executeRaw(new HttpPost(url(path + "?" + query.toQueryUrl())));
+        return executeRaw(new HttpPost(requestUrl(path + "?" + query.toQueryUrl())));
     }
     
     protected HttpResponse putRaw(String path, Query query) throws Exception {
-        return executeRaw(new HttpPut(url(path + "?" + query.toQueryUrl())));
+        return executeRaw(new HttpPut(requestUrl(path + "?" + query.toQueryUrl())));
     }
     
     protected HttpResponse deleteRaw(String path, Query query) throws Exception {
-        return executeRaw(new HttpDelete(url(path + "?" + query.toQueryUrl())));
+        return executeRaw(new HttpDelete(requestUrl(path + "?" + query.toQueryUrl())));
     }
     
     protected JsonNode getJsonOk(String path, Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.get(url(path), Header.EMPTY, query, String.class);
+        HttpRestResult<String> restResult = nacosRestTemplate.get(requestUrl(path), Header.EMPTY, query, String.class);
         assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
                 + restResult.getData() + ", message=" + restResult.getMessage());
         JsonNode root = JacksonUtils.toObj(restResult.getData());
@@ -146,7 +154,7 @@ public abstract class OpenApiBaseITCase {
     }
 
     protected JsonNode postFormOk(String path, Header header, Map<String, String> form) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), header, form, String.class);
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(requestUrl(path), header, form, String.class);
         assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
                 + restResult.getData() + ", message=" + restResult.getMessage());
         JsonNode root = JacksonUtils.toObj(restResult.getData());
@@ -155,7 +163,7 @@ public abstract class OpenApiBaseITCase {
     }
 
     protected JsonNode postFormOk(String path, Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.postForm(url(path), Header.EMPTY, query,
+        HttpRestResult<String> restResult = nacosRestTemplate.postForm(requestUrl(path), Header.EMPTY, query,
                 Collections.emptyMap(), String.class);
         assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
                 + restResult.getData() + ", message=" + restResult.getMessage());
@@ -173,7 +181,7 @@ public abstract class OpenApiBaseITCase {
     }
 
     protected HttpResponse postJsonRaw(String path, Query query, String json) throws Exception {
-        HttpPost post = new HttpPost(url(path + "?" + query.toQueryUrl()));
+        HttpPost post = new HttpPost(requestUrl(path + "?" + query.toQueryUrl()));
         post.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
         return executeRaw(post);
     }
@@ -187,7 +195,7 @@ public abstract class OpenApiBaseITCase {
     }
 
     protected HttpResponse putJsonRaw(String path, Query query, String json) throws Exception {
-        HttpPut put = new HttpPut(url(path + "?" + query.toQueryUrl()));
+        HttpPut put = new HttpPut(requestUrl(path + "?" + query.toQueryUrl()));
         put.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
         return executeRaw(put);
     }
@@ -202,14 +210,15 @@ public abstract class OpenApiBaseITCase {
         body.write(("Content-Type: " + contentType + "\r\n\r\n").getBytes(StandardCharsets.UTF_8));
         body.write(fileBytes);
         body.write(("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
-        HttpPost post = new HttpPost(url(path + "?" + query.toQueryUrl()));
+        HttpPost post = new HttpPost(requestUrl(path + "?" + query.toQueryUrl()));
         post.setEntity(new ByteArrayEntity(body.toByteArray(),
                 ContentType.parse("multipart/form-data; boundary=" + boundary)));
         return executeRaw(post);
     }
 
     protected JsonNode putFormOk(String path, Map<String, String> form) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.putForm(url(path), Header.EMPTY, form, String.class);
+        HttpRestResult<String> restResult = nacosRestTemplate.putForm(requestUrl(path), Header.EMPTY, form,
+                String.class);
         assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
                 + restResult.getData() + ", message=" + restResult.getMessage());
         JsonNode root = JacksonUtils.toObj(restResult.getData());
@@ -218,7 +227,7 @@ public abstract class OpenApiBaseITCase {
     }
 
     protected JsonNode putFormOk(String path, Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.putForm(url(path), Header.EMPTY, query,
+        HttpRestResult<String> restResult = nacosRestTemplate.putForm(requestUrl(path), Header.EMPTY, query,
                 Collections.emptyMap(), String.class);
         assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
                 + restResult.getData() + ", message=" + restResult.getMessage());
@@ -228,7 +237,8 @@ public abstract class OpenApiBaseITCase {
     }
 
     protected JsonNode deleteJsonOk(String path, Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(path), Header.EMPTY, query, String.class);
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(requestUrl(path), Header.EMPTY, query,
+                String.class);
         assertTrue(restResult.ok(), "HTTP status should be 2xx, code=" + restResult.getCode() + ", body="
                 + restResult.getData() + ", message=" + restResult.getMessage());
         JsonNode root = JacksonUtils.toObj(restResult.getData());
@@ -237,7 +247,8 @@ public abstract class OpenApiBaseITCase {
     }
 
     protected void deleteQuietly(String path, Query query) throws Exception {
-        HttpRestResult<String> restResult = nacosRestTemplate.delete(url(path), Header.EMPTY, query, String.class);
+        HttpRestResult<String> restResult = nacosRestTemplate.delete(requestUrl(path), Header.EMPTY, query,
+                String.class);
         if (!restResult.ok()) {
             logger().warn("delete non-OK: path={} code={} body={}", path, restResult.getCode(), restResult.getData());
         }


### PR DESCRIPTION

## What is the purpose of the change

Add scenario-oriented console OpenAPI integration tests under `test/openapi-test` for the standalone-server IT framework from issue #14879. The coverage follows the same standard used by the client and admin API ITs: expected capability, boundary/validation behavior, exception/error handling, and response contract checks.

## Brief changelog

- Add console core, config, and naming OpenAPI IT cases.
- Add console AI registry and Copilot OpenAPI IT cases.
- Reuse shared console IT base helpers for request construction, `NacosRestTemplate` lifecycle, cleanup, and assertions.
- Restore `API_TEST_COVERAGE.md` and split detailed coverage indexes into Client, Admin, and Console scenario documents.

## Verifying this change

- `mvn -pl test/openapi-test spotless:apply`
- `mvn -pl test/openapi-test spotless:check`
- `mvn -pl test/openapi-test apache-rat:check`
- `mvn -pl test/openapi-test -DskipTests test-compile`
- `mvn -pl test/openapi-test -Pintegration-test -DskipTests=false -Dit.test='*ConsoleApiOpenApiITCase' verify` (75 tests, no failures)

Checklist:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary integration tests to verify the change.
* [ ] Run the full pre-submission command set.
