### PR TITLE
Add AI registry unit coverage

### DIFF
--- a/ai-registry-adaptor/pom.xml
+++ b/ai-registry-adaptor/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>nacos-ai</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test-autoconfigure</artifactId>
             <scope>test</scope>

--- a/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/controller/SkillsRegistryController.java
+++ b/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/controller/SkillsRegistryController.java
@@ -216,9 +216,6 @@ public class SkillsRegistryController {
         if (StringUtils.isBlank(extracted)) {
             return extracted;
         }
-        while (extracted.startsWith("/")) {
-            extracted = extracted.substring(1);
-        }
-        return extracted;
+        return extracted.replaceFirst("^/+", "");
     }
 }

--- a/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/service/NacosSkillsRegistryService.java
+++ b/ai-registry-adaptor/src/main/java/com/alibaba/nacos/airegistry/service/NacosSkillsRegistryService.java
@@ -33,13 +33,13 @@ import com.alibaba.nacos.airegistry.model.skills.SkillsSearchResponse;
 import com.alibaba.nacos.airegistry.model.skills.WellKnownSkillEntry;
 import com.alibaba.nacos.airegistry.model.skills.WellKnownSkillsIndex;
 import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -425,18 +425,7 @@ public class NacosSkillsRegistryService {
     }
     
     private String sha256Digest(byte[] bytes) throws NacosException {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(bytes);
-            StringBuilder result = new StringBuilder(DIGEST_SHA256_PREFIX);
-            for (byte each : hash) {
-                result.append(String.format("%02x", each & 0xff));
-            }
-            return result.toString();
-        } catch (Exception e) {
-            throw new NacosException(NacosException.SERVER_ERROR,
-                "Failed to calculate skill well-known digest: " + e.getMessage(), e);
-        }
+        return DIGEST_SHA256_PREFIX + DigestUtils.sha256Hex(bytes);
     }
     
     private long safeDownloadCount(SkillSummary summary) {

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/NacosAiRegistryTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/NacosAiRegistryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.airegistry;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.boot.SpringApplication;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Unit tests for {@link NacosAiRegistry}.
+ *
+ * @author nacos
+ */
+class NacosAiRegistryTest {
+    
+    @Test
+    void testConstruct() {
+        assertNotNull(new NacosAiRegistry());
+    }
+    
+    @Test
+    void testMainDelegatesToSpringApplication() {
+        String[] args = {"--server.port=0"};
+        try (MockedStatic<SpringApplication> springApplication = Mockito
+            .mockStatic(SpringApplication.class)) {
+            NacosAiRegistry.main(args);
+            springApplication.verify(() -> SpringApplication.run(NacosAiRegistry.class, args));
+        }
+    }
+}

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/config/AiRegistryPackageExcludeFilterTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/config/AiRegistryPackageExcludeFilterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.airegistry.config;
+
+import com.alibaba.nacos.airegistry.NacosAiRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AiRegistryPackageExcludeFilterTest {
+    
+    @Test
+    void testGetResponsiblePackagePrefix() {
+        AiRegistryPackageExcludeFilter filter = new AiRegistryPackageExcludeFilter();
+        
+        assertEquals(NacosAiRegistry.class.getPackage().getName(),
+            filter.getResponsiblePackagePrefix());
+    }
+    
+    @Test
+    void testIsExcludedAlwaysReturnsTrue() {
+        AiRegistryPackageExcludeFilter filter = new AiRegistryPackageExcludeFilter();
+        
+        assertTrue(filter.isExcluded("com.alibaba.nacos.airegistry.NacosAiRegistry",
+            Collections.emptySet()));
+        assertTrue(filter.isExcluded(null, null));
+    }
+}

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/config/HttpPathConfigurationTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/config/HttpPathConfigurationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.airegistry.config;
+
+import org.apache.catalina.connector.Connector;
+import org.apache.tomcat.util.buf.EncodedSolidusHandling;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class HttpPathConfigurationTest {
+    
+    @Test
+    void testConnectorCustomizerAllowsEncodedSolidus() {
+        HttpPathConfiguration configuration = new HttpPathConfiguration();
+        TomcatConnectorCustomizer customizer = configuration.connectorCustomizer();
+        Connector connector = new Connector();
+        
+        customizer.customize(connector);
+        
+        assertEquals(EncodedSolidusHandling.PASS_THROUGH.getValue(),
+            connector.getEncodedSolidusHandling());
+    }
+    
+    @Test
+    void testWebSecurityCustomizerCreated() {
+        HttpPathConfiguration configuration = new HttpPathConfiguration();
+        WebSecurityCustomizer customizer = configuration.webSecurityCustomizer();
+        
+        assertNotNull(customizer);
+        WebSecurity webSecurity = mock(WebSecurity.class);
+        customizer.customize(webSecurity);
+        verify(webSecurity).httpFirewall(any(StrictHttpFirewall.class));
+    }
+}

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/controller/SkillsRegistryControllerTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/controller/SkillsRegistryControllerTest.java
@@ -33,13 +33,17 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.HandlerMapping;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -161,6 +165,17 @@ class SkillsRegistryControllerTest {
     }
     
     @Test
+    void testGetSkillMarkdownNotFound() throws Exception {
+        when(nacosSkillsRegistryService.getSkillFileContent("public", "missing-skill", "SKILL.md"))
+            .thenReturn(null);
+        
+        mockMvc.perform(
+            MockMvcRequestBuilders
+                .get("/registry/public/.well-known/agent-skills/missing-skill/SKILL.md"))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
     void testGetSkillArchive() throws Exception {
         when(nacosSkillsRegistryService.getSkillArchiveContent("public", "demo-skill"))
             .thenReturn("zip".getBytes());
@@ -174,6 +189,17 @@ class SkillsRegistryControllerTest {
             .getContentAsByteArray();
         
         assertEquals("zip", new String(content, StandardCharsets.UTF_8));
+    }
+    
+    @Test
+    void testGetSkillArchiveNotFound() throws Exception {
+        when(nacosSkillsRegistryService.getSkillArchiveContent("public", "missing-skill"))
+            .thenReturn(null);
+        
+        mockMvc.perform(
+            MockMvcRequestBuilders
+                .get("/registry/public/.well-known/agent-skills/missing-skill.zip"))
+            .andExpect(status().isNotFound());
     }
     
     @Test
@@ -203,5 +229,28 @@ class SkillsRegistryControllerTest {
             MockMvcRequestBuilders
                 .get("/registry/public/.well-known/agent-skills/demo-skill/docs/missing.md"))
             .andExpect(status().isNotFound());
+    }
+    
+    @Test
+    void testExtractFilePathBoundaryCases() throws Exception {
+        Method extractFilePath =
+            SkillsRegistryController.class.getDeclaredMethod("extractFilePath",
+                HttpServletRequest.class);
+        extractFilePath.setAccessible(true);
+        
+        HttpServletRequest blankRequest = mock(HttpServletRequest.class);
+        when(blankRequest.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE))
+            .thenReturn("/registry/public/.well-known/skills/demo-skill/");
+        when(blankRequest.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
+            .thenReturn("/registry/{namespaceId}/.well-known/skills/{skillName}/**");
+        assertEquals("", extractFilePath.invoke(skillsRegistryController, blankRequest));
+        
+        HttpServletRequest slashRequest = mock(HttpServletRequest.class);
+        when(slashRequest.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE))
+            .thenReturn("/docs/guide.md");
+        when(slashRequest.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
+            .thenReturn("/**");
+        assertEquals("docs/guide.md", extractFilePath.invoke(skillsRegistryController,
+            slashRequest));
     }
 }

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/form/AiRegistryFormTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/form/AiRegistryFormTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.airegistry.form;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AiRegistryFormTest {
+    
+    @Test
+    void testListServerFormValidateAcceptsValidSearchMode() {
+        ListServerForm form = new ListServerForm();
+        form.setOffset(1);
+        form.setLimit(Constants.MAX_LIST_SIZE);
+        form.setNamespaceId("public");
+        form.setServerName("server");
+        form.setSearchMode(Constants.MCP_LIST_SEARCH_BLUR);
+        
+        assertDoesNotThrow(form::validate);
+        assertEquals(1, form.getOffset());
+        assertEquals(Constants.MAX_LIST_SIZE, form.getLimit());
+        assertEquals("public", form.getNamespaceId());
+        assertEquals("server", form.getServerName());
+        assertEquals(Constants.MCP_LIST_SEARCH_BLUR, form.getSearchMode());
+    }
+    
+    @Test
+    void testListServerFormValidateRejectsNegativeOffset() {
+        ListServerForm form = new ListServerForm();
+        form.setOffset(-1);
+        
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testListServerFormValidateRejectsLimitTooLarge() {
+        ListServerForm form = new ListServerForm();
+        form.setLimit(Constants.MAX_LIST_SIZE + 1);
+        
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testListServerFormValidateRejectsUnknownSearchMode() {
+        ListServerForm form = new ListServerForm();
+        form.setSearchMode("unknown");
+        
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testListServersOfficialFormResolveOffsetDefaultsToZero() throws Exception {
+        ListServersOfficialForm form = new ListServersOfficialForm();
+        
+        assertEquals(0, form.resolveOffset());
+        form.validate();
+        assertEquals(ListServersOfficialForm.DEFAULT_LIMIT, form.getLimit());
+    }
+    
+    @Test
+    void testListServersOfficialFormValidateRejectsNegativeLimit() {
+        ListServersOfficialForm form = new ListServersOfficialForm();
+        form.setLimit(-1);
+        
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testListServersOfficialFormValidateRejectsLimitTooLarge() {
+        ListServersOfficialForm form = new ListServersOfficialForm();
+        form.setLimit(ListServersOfficialForm.MAX_LIMIT + 1);
+        
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testListServersOfficialFormResolveOffsetRejectsNegativeCursor() {
+        ListServersOfficialForm form = new ListServersOfficialForm();
+        form.setCursor("-1");
+        
+        assertThrows(NacosApiException.class, form::resolveOffset);
+    }
+    
+    @Test
+    void testListServersOfficialFormResolveOffsetRejectsInvalidCursor() {
+        ListServersOfficialForm form = new ListServersOfficialForm();
+        form.setCursor("abc");
+        
+        assertThrows(NacosApiException.class, form::resolveOffset);
+    }
+    
+    @Test
+    void testListServersOfficialFormGetterAndSetter() throws Exception {
+        ListServersOfficialForm form = new ListServersOfficialForm();
+        form.setCursor("7");
+        form.setLimit(null);
+        form.setSearch("redis");
+        form.setUpdatedSince("2026-06-01T00:00:00Z");
+        
+        form.validate();
+        
+        assertEquals(7, form.resolveOffset());
+        assertEquals(ListServersOfficialForm.DEFAULT_LIMIT, form.getLimit());
+        assertEquals("redis", form.getSearch());
+        assertEquals("2026-06-01T00:00:00Z", form.getUpdatedSince());
+    }
+    
+    @Test
+    void testListServersNacosFormGetterAndSetter() {
+        ListServersNacosForm form = new ListServersNacosForm();
+        form.setNamespaceId("namespace");
+        
+        assertEquals("namespace", form.getNamespaceId());
+    }
+    
+    @Test
+    void testGetServerFormValidateAndNamespace() {
+        GetServerForm form = new GetServerForm();
+        form.setNamespaceId("namespace");
+        
+        assertDoesNotThrow(form::validate);
+        assertEquals("namespace", form.getNamespaceId());
+    }
+    
+    @Test
+    void testSkillsSearchFormValidateRequiresNamespaceId() {
+        SkillsSearchForm form = new SkillsSearchForm();
+        
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testSkillsSearchFormValidateDefaultsAndCapsLimit() throws Exception {
+        SkillsSearchForm form = new SkillsSearchForm();
+        form.setNamespaceId("namespace");
+        form.setQ("deploy");
+        form.setLimit(100);
+        
+        form.validate();
+        
+        assertEquals("namespace", form.getNamespaceId());
+        assertEquals("deploy", form.getQ());
+        assertEquals(10, form.getLimit());
+        
+        form.setLimit(0);
+        form.validate();
+        assertEquals(10, form.getLimit());
+    }
+    
+    @Test
+    void testSkillsFileQueryFormValidateRequiresFields() {
+        SkillsFileQueryForm form = new SkillsFileQueryForm();
+        
+        assertThrows(NacosApiException.class, form::validate);
+        
+        form.setNamespaceId("namespace");
+        assertThrows(NacosApiException.class, form::validate);
+        
+        form.setSkillName("skill");
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testSkillsFileQueryFormValidateRejectsUnsafeFilePath() {
+        SkillsFileQueryForm form = new SkillsFileQueryForm();
+        form.setNamespaceId("namespace");
+        form.setSkillName("skill");
+        form.setFilePath("../README.md");
+        
+        assertThrows(NacosApiException.class, form::validate);
+        
+        form.setFilePath("/README.md");
+        assertThrows(NacosApiException.class, form::validate);
+        
+        form.setFilePath("\\README.md");
+        assertThrows(NacosApiException.class, form::validate);
+    }
+    
+    @Test
+    void testSkillsFileQueryFormValidateAcceptsRelativeFilePath() {
+        SkillsFileQueryForm form = new SkillsFileQueryForm();
+        form.setNamespaceId("namespace");
+        form.setSkillName("skill");
+        form.setFilePath("docs/README.md");
+        
+        assertDoesNotThrow(form::validate);
+        assertEquals("namespace", form.getNamespaceId());
+        assertEquals("skill", form.getSkillName());
+        assertEquals("docs/README.md", form.getFilePath());
+    }
+}

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/model/skills/SkillsModelTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/model/skills/SkillsModelTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.airegistry.model.skills;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SkillsModelTest {
+    
+    @Test
+    void testSkillsSearchItemGetterAndSetter() {
+        SkillsSearchItem item = new SkillsSearchItem();
+        item.setId("skill-id");
+        item.setName("deploy");
+        item.setInstalls(10L);
+        item.setSource("skills-sh");
+        
+        assertEquals("skill-id", item.getId());
+        assertEquals("deploy", item.getName());
+        assertEquals(10L, item.getInstalls());
+        assertEquals("skills-sh", item.getSource());
+    }
+    
+    @Test
+    void testSkillsSearchResponseGetterAndSetter() {
+        SkillsSearchItem item = new SkillsSearchItem();
+        SkillsSearchResponse response = new SkillsSearchResponse();
+        response.setSkills(Collections.singletonList(item));
+        
+        assertEquals(Collections.singletonList(item), response.getSkills());
+    }
+    
+    @Test
+    void testWellKnownSkillEntryGetterAndSetter() {
+        WellKnownSkillEntry entry = new WellKnownSkillEntry();
+        entry.setName("deploy");
+        entry.setType("skill");
+        entry.setDescription("Deploy app");
+        entry.setUrl("https://example.com/skill");
+        entry.setDigest("sha256:123");
+        entry.setVersion("1.0.0");
+        entry.setFiles(Collections.singletonList("SKILL.md"));
+        
+        assertEquals("deploy", entry.getName());
+        assertEquals("skill", entry.getType());
+        assertEquals("Deploy app", entry.getDescription());
+        assertEquals("https://example.com/skill", entry.getUrl());
+        assertEquals("sha256:123", entry.getDigest());
+        assertEquals("1.0.0", entry.getVersion());
+        assertEquals(Collections.singletonList("SKILL.md"), entry.getFiles());
+    }
+    
+    @Test
+    void testWellKnownSkillsIndexGetterAndSetter() {
+        WellKnownSkillEntry entry = new WellKnownSkillEntry();
+        WellKnownSkillsIndex index = new WellKnownSkillsIndex();
+        index.setSchema("https://schemas.example.com/skills.json");
+        index.setSkills(Collections.singletonList(entry));
+        
+        assertEquals("https://schemas.example.com/skills.json", index.getSchema());
+        assertEquals(Collections.singletonList(entry), index.getSkills());
+    }
+}

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/service/NacosAiRegistryServiceTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/service/NacosAiRegistryServiceTest.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.registry.McpRegistryServerList;
+import com.alibaba.nacos.api.ai.model.mcp.registry.Remote;
 import com.alibaba.nacos.api.ai.model.mcp.registry.ServerResponse;
 import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
 import com.alibaba.nacos.api.exception.NacosException;
@@ -42,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -49,6 +51,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -226,9 +229,46 @@ class NacosAiRegistryServiceTest {
     }
     
     @Test
+    void listMcpServersSkipsEmptyNamespaceAndFailedDetail() throws NacosException {
+        ListServerForm listServerForm = new ListServerForm();
+        listServerForm.setOffset(0);
+        listServerForm.setLimit(2);
+        listServerForm.setNamespaceId(RANDOM_NAMESPACE_ID);
+        Page<McpServerBasicInfo> countPage = new Page<>();
+        countPage.setTotalCount(0);
+        countPage.setPageItems(new LinkedList<>());
+        when(mcpServerOperationService.listMcpServerWithPage(eq(RANDOM_NAMESPACE_ID),
+            Mockito.any(), Mockito.any(), eq(1), eq(1))).thenReturn(countPage);
+        assertTrue(mcpRegistryService.listMcpServers(listServerForm).getServers().isEmpty());
+        
+        McpServerBasicInfo basicInfo = mockMcpServerBasicInfo(0, RANDOM_NAMESPACE_ID);
+        Page<McpServerBasicInfo> dataPage = new Page<>();
+        dataPage.setTotalCount(1);
+        dataPage.setPageItems(List.of(basicInfo));
+        when(mcpServerOperationService.listMcpServerWithPage(eq(RANDOM_NAMESPACE_ID),
+            Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt()))
+            .thenReturn(dataPage);
+        when(mcpServerOperationService.getMcpServerDetail(RANDOM_NAMESPACE_ID, null,
+            basicInfo.getName(), null))
+            .thenThrow(new NacosException(NacosException.SERVER_ERROR, "boom"));
+        
+        assertTrue(mcpRegistryService.listMcpServers(listServerForm).getServers().isEmpty());
+    }
+    
+    @Test
     void getServerNotFound() throws NacosException {
         String serverName = "nonExistentServer";
+        when(mcpServerOperationService.getMcpServerDetail(null, null, serverName, null))
+            .thenThrow(new NacosException(NacosException.NOT_FOUND, "not found"));
         assertNull(mcpRegistryService.getServer(serverName, null, null));
+    }
+    
+    @Test
+    void getServerRethrowsUnexpectedException() throws NacosException {
+        when(mcpServerOperationService.getMcpServerDetail(null, null, "boom", null))
+            .thenThrow(new NacosException(NacosException.SERVER_ERROR, "boom"));
+        
+        assertThrows(NacosException.class, () -> mcpRegistryService.getServer("boom", null, null));
     }
     
     @Test
@@ -287,6 +327,109 @@ class NacosAiRegistryServiceTest {
             mockMcpServerDetailInfo(id, RANDOM_NAMESPACE_ID, false, true));
         when(mcpServerIndex.getMcpServerById(eq(id))).thenReturn(new McpServerIndexData());
         assertNotNull(mcpRegistryService.getTools(id, null));
+    }
+    
+    @Test
+    void getServerVersionsReturnsSortedVersionsAndMetadata() throws NacosException {
+        McpServerDetailInfo latest =
+            mockMcpServerDetailInfo("id", RANDOM_NAMESPACE_ID, true, false);
+        ServerVersionDetail v2 = new ServerVersionDetail();
+        v2.setVersion("2.0.0");
+        v2.setRelease_date("2025-06-11T02:29:17Z");
+        ServerVersionDetail v1 = new ServerVersionDetail();
+        v1.setVersion("1.0.0");
+        v1.setRelease_date("2025-06-10T02:29:17Z");
+        latest.setAllVersions(new LinkedList<>(List.of(v2, v1)));
+        when(mcpServerOperationService.getMcpServerDetail(RANDOM_NAMESPACE_ID, null,
+            "mockMcpServer", null)).thenReturn(latest);
+        when(mcpServerOperationService.getMcpServerDetail(RANDOM_NAMESPACE_ID, null,
+            "mockMcpServer", "1.0.0"))
+            .thenReturn(mockMcpServerDetailInfo("id", RANDOM_NAMESPACE_ID, true, false));
+        McpServerDetailInfo version2 =
+            mockMcpServerDetailInfo("id", RANDOM_NAMESPACE_ID, true, false);
+        version2.getVersionDetail().setVersion("2.0.0");
+        when(mcpServerOperationService.getMcpServerDetail(RANDOM_NAMESPACE_ID, null,
+            "mockMcpServer", "2.0.0")).thenReturn(version2);
+        
+        McpRegistryServerList result =
+            mcpRegistryService.getServerVersions(RANDOM_NAMESPACE_ID, "mockMcpServer");
+        
+        assertEquals(2, result.getServers().size());
+        assertEquals(2, result.getMetadata().getCount());
+        assertEquals("1.0.0", result.getServers().get(0).getServer().getVersion());
+        assertEquals("2.0.0", result.getServers().get(1).getServer().getVersion());
+    }
+    
+    @Test
+    void getServerVersionsHandlesErrors() throws NacosException {
+        when(mcpServerOperationService.getMcpServerDetail(RANDOM_NAMESPACE_ID, null, "missing",
+            null))
+            .thenThrow(new NacosException(NacosException.NOT_FOUND, "not found"));
+        assertNull(mcpRegistryService.getServerVersions(RANDOM_NAMESPACE_ID, "missing"));
+        
+        when(mcpServerOperationService.getMcpServerDetail(RANDOM_NAMESPACE_ID, null, "boom", null))
+            .thenThrow(new NacosException(NacosException.SERVER_ERROR, "boom"));
+        assertThrows(NacosException.class,
+            () -> mcpRegistryService.getServerVersions(RANDOM_NAMESPACE_ID, "boom"));
+        
+        McpServerDetailInfo latest =
+            mockMcpServerDetailInfo("id", RANDOM_NAMESPACE_ID, false, false);
+        ServerVersionDetail v1 = new ServerVersionDetail();
+        v1.setVersion("1.0.0");
+        latest.setAllVersions(new LinkedList<>(List.of(v1)));
+        when(mcpServerOperationService.getMcpServerDetail(RANDOM_NAMESPACE_ID, null,
+            "inner-boom", null)).thenReturn(latest);
+        when(mcpServerOperationService.getMcpServerDetail(RANDOM_NAMESPACE_ID, null,
+            "inner-boom", "1.0.0"))
+            .thenThrow(new NacosException(NacosException.SERVER_ERROR, "inner boom"));
+        assertThrows(RuntimeException.class,
+            () -> mcpRegistryService.getServerVersions(RANDOM_NAMESPACE_ID, "inner-boom"));
+    }
+    
+    @Test
+    void privateEndpointHelpersCoverProtocolBranches() throws Exception {
+        Method pickEndpoints = NacosMcpRegistryService.class.getDeclaredMethod("pickEndpoints",
+            List.class, List.class);
+        pickEndpoints.setAccessible(true);
+        List<McpEndpointInfo> frontend =
+            List.of(buildEndpoint("https", "example.com", 443, "/mcp"));
+        List<McpEndpointInfo> backend = List.of(buildEndpoint("http", "127.0.0.1", 8080, "/api"));
+        assertEquals(frontend, pickEndpoints.invoke(mcpRegistryService, frontend, backend));
+        
+        Method toRemotes =
+            NacosMcpRegistryService.class.getDeclaredMethod("toRemotes", List.class, String.class);
+        toRemotes.setAccessible(true);
+        assertNull(toRemotes.invoke(mcpRegistryService, List.of(), "sse"));
+        @SuppressWarnings("unchecked")
+        List<Remote> remotes =
+            (List<Remote>) toRemotes.invoke(mcpRegistryService, frontend, "streamable");
+        assertEquals("https://example.com/mcp", remotes.get(0).getUrl());
+        
+        Method buildUrl =
+            NacosMcpRegistryService.class.getDeclaredMethod("buildUrl", McpEndpointInfo.class);
+        buildUrl.setAccessible(true);
+        assertEquals("http://example.com/mcp",
+            buildUrl.invoke(mcpRegistryService, buildEndpoint("http", "example.com", 80, "/mcp")));
+        
+        Method buildRemotes =
+            NacosMcpRegistryService.class.getDeclaredMethod("buildRemotes",
+                McpServerDetailInfo.class);
+        buildRemotes.setAccessible(true);
+        McpServerDetailInfo streamable = mockMcpServerDetailInfo("id", RANDOM_NAMESPACE_ID, false,
+            false);
+        streamable.setFrontProtocol(AiConstants.Mcp.MCP_PROTOCOL_STREAMABLE);
+        streamable.setFrontendEndpoints(frontend);
+        @SuppressWarnings("unchecked")
+        List<Remote> streamableRemotes =
+            (List<Remote>) buildRemotes.invoke(mcpRegistryService, streamable);
+        assertEquals(AiConstants.Mcp.OFFICIAL_TRANSPORT_STREAMABLE,
+            streamableRemotes.get(0).getType());
+        
+        McpServerDetailInfo unknownProtocol =
+            mockMcpServerDetailInfo("id", RANDOM_NAMESPACE_ID, false, false);
+        unknownProtocol.setFrontProtocol("unknown");
+        unknownProtocol.setFrontendEndpoints(frontend);
+        assertNull(buildRemotes.invoke(mcpRegistryService, unknownProtocol));
     }
     
     private void mockMultipleNamespace() {
@@ -391,6 +534,15 @@ class NacosAiRegistryServiceTest {
         if (withTools) {
             result.setToolSpec(new McpToolSpecification());
         }
+        return result;
+    }
+    
+    private McpEndpointInfo buildEndpoint(String protocol, String address, int port, String path) {
+        McpEndpointInfo result = new McpEndpointInfo();
+        result.setProtocol(protocol);
+        result.setAddress(address);
+        result.setPort(port);
+        result.setPath(path);
         return result;
     }
 }

--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/service/NacosSkillsRegistryServiceTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/service/NacosSkillsRegistryServiceTest.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.ai.service.skills.SkillOperationService;
 import com.alibaba.nacos.api.ai.model.skills.Skill;
 import com.alibaba.nacos.api.ai.model.skills.SkillResource;
 import com.alibaba.nacos.api.ai.model.skills.SkillSummary;
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.airegistry.model.skills.SkillsSearchResponse;
 import com.alibaba.nacos.airegistry.model.skills.WellKnownSkillsIndex;
@@ -34,8 +35,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for {@link NacosSkillsRegistryService}.
@@ -163,6 +168,26 @@ class NacosSkillsRegistryServiceTest {
     }
     
     @Test
+    void testSearchSortsTiedDownloadCountByName() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        page.setPageItems(List.of(buildSummary("z-skill", 5L), buildSummary("a-skill", 5L)));
+        when(skillOperationService.listSkills(eq("public"), eq("tie"), eq(SEARCH_BLUR),
+            eq("download_count"), eq(1), eq(100))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "a-skill")).thenReturn(buildManifest("v1"));
+        when(skillIndexManifestService.query("public", "z-skill")).thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "a-skill", "v1"))
+            .thenReturn(buildSimpleSkill("a-skill"));
+        when(skillOperationService.getSkillVersionDetail("public", "z-skill", "v1"))
+            .thenReturn(buildSimpleSkill("z-skill"));
+        
+        SkillsSearchResponse result = service.search("public", "tie", 10, "source");
+        
+        assertEquals("a-skill", result.getSkills().get(0).getName());
+        assertEquals("z-skill", result.getSkills().get(1).getName());
+    }
+    
+    @Test
     void testGetSkillFileContent() throws Exception {
         Page<SkillSummary> page = new Page<>();
         page.setPagesAvailable(1);
@@ -201,6 +226,260 @@ class NacosSkillsRegistryServiceTest {
         assertZipEntryContains(zipBytes, "SKILL.md", "name: demo-skill");
         assertZipEntryContains(zipBytes, "docs/guide.md", "guide");
         verify(skillOperationService).downloadSkillVersion("public", "demo-skill", "v1");
+    }
+    
+    @Test
+    void testSearchStopsAtLimitAndDefaultsDownloadCount() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(2);
+        page.setPageItems(List.of(buildSummary("first", null), buildSummary("second", 2L)));
+        when(skillOperationService.listSkills(eq("public"), eq("q"), eq(SEARCH_BLUR),
+            eq("download_count"), eq(1), eq(100))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "first")).thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "first", "v1")).thenReturn(
+            buildSimpleSkill("first"));
+        
+        SkillsSearchResponse result = service.search("public", "q", 1, "source");
+        
+        assertEquals(1, result.getSkills().size());
+        assertEquals(0L, result.getSkills().get(0).getInstalls());
+    }
+    
+    @Test
+    void testBuildIndexStopsOnEmptyPageAndSkipsIneligibleSummaries() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        SkillSummary disabled = buildSummary("disabled", 1L);
+        disabled.setEnable(false);
+        SkillSummary privateSkill = buildSummary("private", 1L);
+        privateSkill.setScope("private");
+        SkillSummary offline = buildSummary("offline", 1L);
+        offline.setOnlineCnt(0);
+        SkillSummary blank = buildSummary("", 1L);
+        page.setPageItems(Arrays.asList(null, disabled, privateSkill, offline, blank));
+        when(skillOperationService.listSkills(eq("public"), eq((String) null), eq(SEARCH_BLUR),
+            eq("download_count"), eq(1), eq(100))).thenReturn(page);
+        
+        assertTrue(service.buildAgentSkillsIndex("public").getSkills().isEmpty());
+        
+        Page<SkillSummary> emptyPage = new Page<>();
+        emptyPage.setPagesAvailable(1);
+        emptyPage.setPageItems(List.of());
+        when(skillOperationService.listSkills(eq("public"), eq("empty"), eq(SEARCH_BLUR),
+            eq("download_count"), eq(1), eq(100))).thenReturn(emptyPage);
+        assertTrue(service.search("public", "empty", 10, "source").getSkills().isEmpty());
+    }
+    
+    @Test
+    void testLoadSkillReturnsNullForMissingManifestVersionAndDeniedDetail() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        page.setPageItems(List.of(buildSummary("missing-version", 1L),
+            buildSummary("denied", 1L), buildSummary("empty-skill", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq((String) null), eq(SEARCH_BLUR),
+            eq("download_count"), eq(1), eq(100))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "missing-version"))
+            .thenReturn(new SkillIndexManifest());
+        when(skillIndexManifestService.query("public", "denied")).thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "denied", "v1"))
+            .thenThrow(new NacosException(NacosException.NO_RIGHT, "denied"));
+        when(skillIndexManifestService.query("public", "empty-skill"))
+            .thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "empty-skill", "v1"))
+            .thenReturn(new Skill());
+        
+        assertTrue(service.buildAgentSkillsIndex("public").getSkills().isEmpty());
+    }
+    
+    @Test
+    void testLoadSkillRethrowsUnexpectedDetailException() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        page.setPageItems(List.of(buildSummary("boom", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq((String) null), eq(SEARCH_BLUR),
+            eq("download_count"), eq(1), eq(100))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "boom")).thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "boom", "v1"))
+            .thenThrow(new NacosException(NacosException.SERVER_ERROR, "boom"));
+        
+        assertThrows(NacosException.class, () -> service.buildAgentSkillsIndex("public"));
+    }
+    
+    @Test
+    void testGetSkillFileContentNullCases() throws Exception {
+        Page<SkillSummary> empty = new Page<>();
+        empty.setPageItems(List.of());
+        when(skillOperationService.listSkills(eq("public"), eq("missing"), eq(SEARCH_ACCURATE),
+            eq("download_count"), eq(1), eq(1))).thenReturn(empty);
+        assertNull(service.getSkillFileContent("public", "missing", "SKILL.md"));
+        
+        Page<SkillSummary> page = new Page<>();
+        page.setPageItems(List.of(buildSummary("no-resource", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq("no-resource"), eq(SEARCH_ACCURATE),
+            eq("download_count"), eq(1), eq(1))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "no-resource"))
+            .thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "no-resource", "v1"))
+            .thenReturn(buildSimpleSkill("no-resource"));
+        assertNull(service.getSkillFileContent("public", "no-resource", "docs/guide.md"));
+        
+        Page<SkillSummary> nullEntryPage = new Page<>();
+        nullEntryPage.setPageItems(List.of(buildSummary("null-entry", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq("null-entry"), eq(SEARCH_ACCURATE),
+            eq("download_count"), eq(1), eq(1))).thenReturn(nullEntryPage);
+        when(skillIndexManifestService.query("public", "null-entry"))
+            .thenReturn(buildManifest("v1"));
+        Skill nullEntry = buildSimpleSkill("null-entry");
+        Map<String, SkillResource> resources = new HashMap<>();
+        resources.put("null", null);
+        nullEntry.setResource(resources);
+        when(skillOperationService.getSkillVersionDetail("public", "null-entry", "v1"))
+            .thenReturn(nullEntry);
+        assertNull(service.getSkillFileContent("public", "null-entry", "docs/guide.md"));
+    }
+    
+    @Test
+    void testBuildFilesSkipsNullAndBlankResourcesAndRejectsBinaryExtension() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPagesAvailable(1);
+        page.setPageItems(List.of(buildSummary("mixed", 1L), buildSummary("font", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq((String) null), eq(SEARCH_BLUR),
+            eq("download_count"), eq(1), eq(100))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "mixed")).thenReturn(buildManifest("v1"));
+        when(skillIndexManifestService.query("public", "font")).thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "mixed", "v1"))
+            .thenReturn(buildMixedResourceSkill("mixed"));
+        when(skillOperationService.getSkillVersionDetail("public", "font", "v1"))
+            .thenReturn(buildExtensionBinarySkill("font"));
+        
+        WellKnownSkillsIndex result = service.buildLegacySkillsIndex("public");
+        
+        assertEquals(1, result.getSkills().size());
+        assertEquals(List.of("SKILL.md", "guide.md"), result.getSkills().get(0).getFiles());
+    }
+    
+    @Test
+    void testLoadSkillNullAndIneligibleCases() throws Exception {
+        Page<SkillSummary> nullPage = null;
+        when(skillOperationService.listSkills(eq("public"), eq("null-page"), eq(SEARCH_ACCURATE),
+            eq("download_count"), eq(1), eq(1))).thenReturn(nullPage);
+        assertNull(service.getSkillFileContent("public", "null-page", "SKILL.md"));
+        
+        Page<SkillSummary> disabledPage = new Page<>();
+        SkillSummary disabled = buildSummary("disabled", 1L);
+        disabled.setEnable(false);
+        disabledPage.setPageItems(List.of(disabled));
+        when(skillOperationService.listSkills(eq("public"), eq("disabled"), eq(SEARCH_ACCURATE),
+            eq("download_count"), eq(1), eq(1))).thenReturn(disabledPage);
+        assertNull(service.getSkillArchiveContent("public", "disabled"));
+        
+        Page<SkillSummary> noDescriptionPage = new Page<>();
+        noDescriptionPage.setPageItems(List.of(buildSummary("no-description", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq("no-description"),
+            eq(SEARCH_ACCURATE), eq("download_count"), eq(1), eq(1)))
+            .thenReturn(noDescriptionPage);
+        when(skillIndexManifestService.query("public", "no-description"))
+            .thenReturn(buildManifest("v1"));
+        Skill noDescription = buildSimpleSkill("no-description");
+        noDescription.setDescription(" ");
+        when(skillOperationService.downloadSkillVersion("public", "no-description", "v1"))
+            .thenReturn(noDescription);
+        assertNull(service.getSkillArchiveContent("public", "no-description"));
+    }
+    
+    @Test
+    void testBuildIndexSkipsNullExportableAndMultiplePages() throws Exception {
+        Page<SkillSummary> firstPage = new Page<>();
+        firstPage.setPagesAvailable(2);
+        firstPage.setPageItems(List.of(buildSummary("not-found", 1L)));
+        Page<SkillSummary> secondPage = new Page<>();
+        secondPage.setPagesAvailable(2);
+        secondPage.setPageItems(List.of(buildSummary("second-page", 2L)));
+        when(skillOperationService.listSkills(eq("public"), eq((String) null), eq(SEARCH_BLUR),
+            eq("download_count"), eq(1), eq(100))).thenReturn(firstPage);
+        when(skillOperationService.listSkills(eq("public"), eq((String) null), eq(SEARCH_BLUR),
+            eq("download_count"), eq(2), eq(100))).thenReturn(secondPage);
+        when(skillIndexManifestService.query("public", "not-found"))
+            .thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "not-found", "v1"))
+            .thenThrow(new NacosException(NacosException.NOT_FOUND, "not found"));
+        when(skillIndexManifestService.query("public", "second-page"))
+            .thenReturn(buildManifest("v1"));
+        when(skillOperationService.getSkillVersionDetail("public", "second-page", "v1"))
+            .thenReturn(buildSimpleSkill("second-page"));
+        
+        WellKnownSkillsIndex result = service.buildAgentSkillsIndex("public");
+        
+        assertEquals(1, result.getSkills().size());
+        assertEquals("second-page", result.getSkills().get(0).getName());
+    }
+    
+    @Test
+    void testArchiveCreationFailureForUnsafeResourcePath() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPageItems(List.of(buildSummary("unsafe", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq("unsafe"), eq(SEARCH_ACCURATE),
+            eq("download_count"), eq(1), eq(1))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "unsafe"))
+            .thenReturn(buildManifest("v1"));
+        when(skillOperationService.downloadSkillVersion("public", "unsafe", "v1"))
+            .thenReturn(buildUnsafeResourceSkill("unsafe"));
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.getSkillArchiveContent("public", "unsafe"));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+    }
+    
+    @Test
+    void testArchiveWritesEmptyResourceForNullContent() throws Exception {
+        Page<SkillSummary> page = new Page<>();
+        page.setPageItems(List.of(buildSummary("empty-file", 1L)));
+        when(skillOperationService.listSkills(eq("public"), eq("empty-file"), eq(SEARCH_ACCURATE),
+            eq("download_count"), eq(1), eq(1))).thenReturn(page);
+        when(skillIndexManifestService.query("public", "empty-file"))
+            .thenReturn(buildManifest("v1"));
+        when(skillOperationService.downloadSkillVersion("public", "empty-file", "v1"))
+            .thenReturn(buildMixedResourceSkill("empty-file"));
+        
+        byte[] zipBytes = service.getSkillArchiveContent("public", "empty-file");
+        
+        assertZipEntryContains(zipBytes, "guide.md", "");
+    }
+    
+    @Test
+    void testPrivateResourceHelpers() throws Exception {
+        Method isBinaryResource =
+            NacosSkillsRegistryService.class.getDeclaredMethod("isBinaryResource",
+                SkillResource.class);
+        isBinaryResource.setAccessible(true);
+        SkillResource noExtension = new SkillResource();
+        noExtension.setName("README");
+        assertEquals(false, isBinaryResource.invoke(service, noExtension));
+        SkillResource blankName = new SkillResource();
+        blankName.setName(" ");
+        assertEquals(false, isBinaryResource.invoke(service, blankName));
+        SkillResource trailingDot = new SkillResource();
+        trailingDot.setName("README.");
+        assertEquals(false, isBinaryResource.invoke(service, trailingDot));
+        
+        Method buildRelativePath =
+            NacosSkillsRegistryService.class.getDeclaredMethod("buildRelativePath",
+                SkillResource.class);
+        buildRelativePath.setAccessible(true);
+        SkillResource rootFile = new SkillResource();
+        rootFile.setName("guide.md");
+        assertEquals("guide.md", buildRelativePath.invoke(service, rootFile));
+        
+        Method encodePath =
+            NacosSkillsRegistryService.class.getDeclaredMethod("encodePath", String.class);
+        encodePath.setAccessible(true);
+        assertEquals("docs/a%20b.md", encodePath.invoke(service, "docs/a b.md"));
+        
+        Method buildFiles =
+            NacosSkillsRegistryService.class.getDeclaredMethod("buildFiles", Skill.class);
+        buildFiles.setAccessible(true);
+        assertEquals(List.of("SKILL.md"), buildFiles.invoke(service, buildEmptyResourceSkill()));
     }
     
     private SkillSummary buildSummary(String name, Long downloadCount) {
@@ -257,6 +536,44 @@ class NacosSkillsRegistryServiceTest {
         metadata.put("encoding", "base64");
         binary.setMetadata(metadata);
         result.setResource(Map.of("assets::logo.png", binary));
+        return result;
+    }
+    
+    private Skill buildMixedResourceSkill(String name) {
+        Skill result = buildSimpleSkill(name);
+        SkillResource blankName = new SkillResource();
+        blankName.setName(" ");
+        SkillResource guide = new SkillResource();
+        guide.setName("guide.md");
+        guide.setContent(null);
+        result.setResource(new HashMap<>());
+        result.getResource().put("null", null);
+        result.getResource().put("blank", blankName);
+        result.getResource().put("guide", guide);
+        return result;
+    }
+    
+    private Skill buildExtensionBinarySkill(String name) {
+        Skill result = buildSimpleSkill(name);
+        SkillResource binary = new SkillResource();
+        binary.setName("font.ttf");
+        binary.setContent("font");
+        result.setResource(Map.of("font", binary));
+        return result;
+    }
+    
+    private Skill buildEmptyResourceSkill() {
+        Skill result = buildSimpleSkill("empty-resource");
+        result.setResource(Collections.emptyMap());
+        return result;
+    }
+    
+    private Skill buildUnsafeResourceSkill(String name) {
+        Skill result = buildSimpleSkill(name);
+        SkillResource unsafe = new SkillResource();
+        unsafe.setName("../evil.md");
+        unsafe.setContent("evil");
+        result.setResource(Map.of("unsafe", unsafe));
         return result;
     }
     

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportService.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/main/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportService.java
@@ -378,10 +378,7 @@ public class SkillWellKnownImportService implements AiResourceImportService {
         if (format == ArchiveFormat.ZIP) {
             return artifact.getBody();
         }
-        if (format == ArchiveFormat.TAR || format == ArchiveFormat.TAR_GZ) {
-            return convertTarToZip(artifact.getBody(), format == ArchiveFormat.TAR_GZ);
-        }
-        throw invalid("Unsupported Skill well-known archive format: " + artifact.getUrl());
+        return convertTarToZip(artifact.getBody(), format == ArchiveFormat.TAR_GZ);
     }
     
     private byte[] convertTarToZip(byte[] bytes, boolean gzip) throws Exception {

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportServiceBuilderTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/DefaultAiResourceImportServiceBuilderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.ai.importer.defaultimpl;
+
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.mcp.McpRegistryImportService;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.mcp.McpRegistryImportServiceBuilder;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.skill.SkillWellKnownImportService;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.skill.SkillWellKnownImportServiceBuilder;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.skill.SkillsShImportService;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.skill.SkillsShImportServiceBuilder;
+import com.alibaba.nacos.plugin.ai.importer.spi.AiResourceImportService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class DefaultAiResourceImportServiceBuilderTest {
+    
+    @Test
+    void testMcpRegistryImportServiceBuilder() {
+        McpRegistryImportServiceBuilder builder = new McpRegistryImportServiceBuilder();
+        
+        AiResourceImportService service = builder.build(new Properties());
+        
+        assertEquals(McpRegistryImportServiceBuilder.IMPORTER_TYPE, builder.importerType());
+        assertInstanceOf(McpRegistryImportService.class, service);
+    }
+    
+    @Test
+    void testSkillsShImportServiceBuilder() {
+        SkillsShImportServiceBuilder builder = new SkillsShImportServiceBuilder();
+        
+        AiResourceImportService service = builder.build(new Properties());
+        
+        assertEquals(SkillsShImportServiceBuilder.IMPORTER_TYPE, builder.importerType());
+        assertInstanceOf(SkillsShImportService.class, service);
+    }
+    
+    @Test
+    void testSkillWellKnownImportServiceBuilder() {
+        SkillWellKnownImportServiceBuilder builder = new SkillWellKnownImportServiceBuilder();
+        
+        AiResourceImportService service = builder.build(new Properties());
+        
+        assertEquals(SkillWellKnownImportServiceBuilder.IMPORTER_TYPE, builder.importerType());
+        assertInstanceOf(SkillWellKnownImportService.class, service);
+    }
+}

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/DefaultImportHttpClientTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/DefaultImportHttpClientTest.java
@@ -26,19 +26,33 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLParameters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -57,7 +71,7 @@ class DefaultImportHttpClientTest {
     @BeforeEach
     void setUp() throws Exception {
         lenient().when(httpClient.send(any(HttpRequest.class),
-            any(HttpResponse.BodyHandler.class))).thenReturn(response(200, "ok"));
+            anyBodyHandler())).thenReturn(response(200, "ok"));
     }
     
     @Test
@@ -93,13 +107,159 @@ class DefaultImportHttpClientTest {
     }
     
     @Test
+    void testAllowsHttpWhenCamelPropertyOptIn() throws Exception {
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        AiResourceImportSource source = source(1024);
+        source.setProperties(Collections.singletonMap(
+            DefaultImportHttpClient.PROPERTY_ALLOW_HTTP_CAMEL, "true"));
+        
+        ImportHttpResponse response =
+            client.get(source, "http://registry.example.com/index.json", 3, "application/json");
+        
+        assertEquals(200, response.getStatusCode());
+        assertEquals("ok", new String(response.getBody(), StandardCharsets.UTF_8));
+        org.mockito.Mockito.verify(httpClient).send(argThat(
+            request -> request.timeout().orElseThrow().getSeconds() == 3
+                && request.headers().firstValue("Accept").orElse("").equals("application/json")),
+            anyBodyHandler());
+    }
+    
+    @Test
     void testRejectsOversizedResponse() throws Exception {
         lenient().when(httpClient.send(any(HttpRequest.class),
-            any(HttpResponse.BodyHandler.class))).thenReturn(response(200, "toolong"));
+            anyBodyHandler())).thenReturn(response(200, "toolong"));
         DefaultImportHttpClient client = newClient("93.184.216.34");
         
         assertThrows(NacosException.class,
             () -> client.get(source(2), "https://registry.example.com/index.json", "*/*"));
+    }
+    
+    @Test
+    void testRejectsBlankUrl() {
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        
+        assertThrows(NacosException.class, () -> client.get(source(1024), " ", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testRejectsRelativeUrl() {
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        
+        assertThrows(NacosException.class, () -> client.get(source(1024), "/index.json", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testRejectsMalformedUrl() {
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        
+        assertThrows(NacosException.class,
+            () -> client.get(source(1024), "https://[bad", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testRejectsUnsupportedScheme() {
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        
+        assertThrows(NacosException.class,
+            () -> client.get(source(1024), "ftp://registry.example.com/index.json", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testRejectsHttpWhenSourceIsNull() {
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        
+        assertThrows(NacosException.class,
+            () -> client.get(null, "http://registry.example.com/index.json", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testRejectsMissingHost() {
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        
+        assertThrows(NacosException.class,
+            () -> client.get(source(1024), "https:///index.json", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testRejectsLocalhostWithoutResolvingDns() {
+        DefaultImportHttpClient client = new DefaultImportHttpClient(httpClient, host -> {
+            throw new AssertionError("localhost should be rejected before DNS lookup");
+        });
+        
+        assertThrows(NacosException.class,
+            () -> client.get(source(1024), "https://api.localhost/index.json", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testRejectsUnknownHost() {
+        DefaultImportHttpClient client = new DefaultImportHttpClient(httpClient, host -> {
+            throw new UnknownHostException(host);
+        });
+        
+        assertThrows(NacosException.class,
+            () -> client.get(source(1024), "https://registry.example.com/index.json", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testRejectsEmptyDnsResult() {
+        DefaultImportHttpClient client =
+            new DefaultImportHttpClient(httpClient, host -> new InetAddress[0]);
+        
+        assertThrows(NacosException.class,
+            () -> client.get(source(1024), "https://registry.example.com/index.json", "*/*"));
+        verifyNoInteractions(httpClient);
+    }
+    
+    @Test
+    void testUsesDefaultMaxResponseBytesWhenSourceNull() throws Exception {
+        DefaultImportHttpClient client = newClient("93.184.216.34");
+        
+        ImportHttpResponse response =
+            client.get(null, "https://registry.example.com/index.json", null);
+        
+        assertEquals(200, response.getStatusCode());
+        assertEquals("ok", new String(response.getBody(), StandardCharsets.UTF_8));
+    }
+    
+    @Test
+    void testLimitedBodyHandlerReadsChunks() throws Exception {
+        DefaultImportHttpClient client =
+            new DefaultImportHttpClient(new BodyHandlerHttpClient("ok", false),
+                host -> new InetAddress[] {InetAddress.getByName("93.184.216.34")});
+        
+        ImportHttpResponse response =
+            client.get(source(1024), "https://registry.example.com/index.json", "*/*");
+        
+        assertEquals(200, response.getStatusCode());
+        assertEquals("ok", new String(response.getBody(), StandardCharsets.UTF_8));
+    }
+    
+    @Test
+    void testLimitedBodyHandlerRejectsOversizedChunks() {
+        DefaultImportHttpClient client =
+            new DefaultImportHttpClient(new BodyHandlerHttpClient("toolong", false),
+                host -> new InetAddress[] {InetAddress.getByName("93.184.216.34")});
+        
+        assertThrows(Exception.class,
+            () -> client.get(source(2), "https://registry.example.com/index.json", "*/*"));
+    }
+    
+    @Test
+    void testLimitedBodyHandlerIgnoresChunksAfterError() {
+        DefaultImportHttpClient client =
+            new DefaultImportHttpClient(new BodyHandlerHttpClient("ok", true),
+                host -> new InetAddress[] {InetAddress.getByName("93.184.216.34")});
+        
+        assertThrows(Exception.class,
+            () -> client.get(source(1024), "https://registry.example.com/index.json", "*/*"));
     }
     
     private DefaultImportHttpClient newClient(String address) {
@@ -113,10 +273,19 @@ class DefaultImportHttpClientTest {
         return source;
     }
     
+    private HttpResponse.BodyHandler<byte[]> anyBodyHandler() {
+        return any();
+    }
+    
     private HttpResponse<byte[]> response(int status, String body) {
         Map<String, java.util.List<String>> headers = new HashMap<>(1);
         headers.put("Content-Type", Collections.singletonList("application/json"));
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        return response(status, bytes, headers);
+    }
+    
+    private HttpResponse<byte[]> response(int status, byte[] bytes,
+        Map<String, java.util.List<String>> headers) {
         return new HttpResponse<>() {
             
             @Override
@@ -159,5 +328,124 @@ class DefaultImportHttpClientTest {
                 return HttpClient.Version.HTTP_1_1;
             }
         };
+    }
+    
+    private class BodyHandlerHttpClient extends HttpClient {
+        
+        private final String body;
+        
+        private final boolean completeWithError;
+        
+        BodyHandlerHttpClient(String body, boolean completeWithError) {
+            this.body = body;
+            this.completeWithError = completeWithError;
+        }
+        
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return Optional.empty();
+        }
+        
+        @Override
+        public Optional<Duration> connectTimeout() {
+            return Optional.empty();
+        }
+        
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+        
+        @Override
+        public Optional<ProxySelector> proxy() {
+            return Optional.empty();
+        }
+        
+        @Override
+        public SSLContext sslContext() {
+            return null;
+        }
+        
+        @Override
+        public SSLParameters sslParameters() {
+            return null;
+        }
+        
+        @Override
+        public Optional<Authenticator> authenticator() {
+            return Optional.empty();
+        }
+        
+        @Override
+        public Version version() {
+            return Version.HTTP_1_1;
+        }
+        
+        @Override
+        public Optional<Executor> executor() {
+            return Optional.empty();
+        }
+        
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> HttpResponse<T> send(HttpRequest request,
+            HttpResponse.BodyHandler<T> responseBodyHandler) throws java.io.IOException,
+            InterruptedException {
+            HttpResponse.BodySubscriber<T> subscriber = responseBodyHandler.apply(
+                new HttpResponse.ResponseInfo() {
+                    
+                    @Override
+                    public int statusCode() {
+                        return 200;
+                    }
+                    
+                    @Override
+                    public HttpHeaders headers() {
+                        return HttpHeaders.of(Collections.emptyMap(), (key, value) -> true);
+                    }
+                    
+                    @Override
+                    public Version version() {
+                        return Version.HTTP_1_1;
+                    }
+                });
+            subscriber.onSubscribe(new Flow.Subscription() {
+                
+                @Override
+                public void request(long n) {
+                }
+                
+                @Override
+                public void cancel() {
+                }
+            });
+            if (completeWithError) {
+                subscriber.onError(new IllegalStateException("failed"));
+                subscriber.onNext(Collections.singletonList(ByteBuffer.wrap(new byte[] {'x'})));
+            } else {
+                byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+                List<ByteBuffer> chunks = Arrays.asList(ByteBuffer.wrap(bytes, 0, 1),
+                    ByteBuffer.wrap(bytes, 1, bytes.length - 1));
+                subscriber.onNext(chunks);
+                subscriber.onComplete();
+            }
+            T responseBody = subscriber.getBody().toCompletableFuture().join();
+            Map<String, java.util.List<String>> headers = new HashMap<>(1);
+            headers.put("Content-Type", Collections.singletonList("application/json"));
+            return (HttpResponse<T>) response(200, (byte[]) responseBody, headers);
+        }
+        
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request,
+            HttpResponse.BodyHandler<T> responseBodyHandler) {
+            return CompletableFuture.failedFuture(new UnsupportedOperationException());
+        }
+        
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request,
+            HttpResponse.BodyHandler<T> responseBodyHandler,
+            HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+            return CompletableFuture.failedFuture(new UnsupportedOperationException());
+        }
     }
 }

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/ImportHttpResponseTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/http/ImportHttpResponseTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.ai.importer.defaultimpl.http;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpHeaders;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImportHttpResponseTest {
+    
+    @Test
+    void testSuccessResponseGetter() {
+        byte[] body = "ok".getBytes(StandardCharsets.UTF_8);
+        ImportHttpResponse response =
+            new ImportHttpResponse("https://example.com", 200, headers("application/json"), body);
+        
+        assertTrue(response.isSuccess());
+        assertEquals("https://example.com", response.getUrl());
+        assertEquals(200, response.getStatusCode());
+        assertEquals("ok", new String(response.getBody(), StandardCharsets.UTF_8));
+        assertEquals("application/json", response.getContentType());
+    }
+    
+    @Test
+    void testNonSuccessAndNullBody() {
+        ImportHttpResponse response =
+            new ImportHttpResponse("https://example.com", 500, headers(null), null);
+        
+        assertFalse(response.isSuccess());
+        assertEquals(0, response.getBody().length);
+        assertEquals("", response.getContentType());
+    }
+    
+    private HttpHeaders headers(String contentType) {
+        if (contentType == null) {
+            return HttpHeaders.of(Collections.emptyMap(), (key, value) -> true);
+        }
+        Map<String, java.util.List<String>> headers = new HashMap<>(1);
+        headers.put("Content-Type", Collections.singletonList(contentType));
+        return HttpHeaders.of(headers, (key, value) -> true);
+    }
+}

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryClientTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryClientTest.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.ai.importer.defaultimpl.mcp;
+
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.model.mcp.registry.McpRegistryServerDetail;
+import com.alibaba.nacos.api.ai.model.mcp.registry.Remote;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.DefaultImportHttpClient;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.ImportHttpResponse;
+import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.http.HttpHeaders;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpRegistryClientTest {
+    
+    private static final String ENDPOINT = "https://registry.example.com/v0/servers";
+    
+    @Mock
+    private DefaultImportHttpClient httpClient;
+    
+    private McpRegistryClient client;
+    
+    @BeforeEach
+    void setUp() {
+        client = new McpRegistryClient(httpClient);
+    }
+    
+    @Test
+    void testFetchOfficialRegistryPageBuildsQueryAndAdaptsServers() throws Exception {
+        when(httpClient.get(any(AiResourceImportSource.class),
+            eq(ENDPOINT + "?cursor=cursor-1&limit=3&search=redis+cache"), eq(20),
+            eq("application/json"))).thenReturn(response(200, registryPageJson()));
+        
+        McpRegistryClient.Page page = client.fetchOfficialRegistryPage(source(), "cursor-1", 3,
+            "redis cache");
+        
+        assertEquals("next-1", page.getNextCursor());
+        assertEquals(3, page.getServers().size());
+        assertEquals("io.nacos/stdio", page.getServers().get(0).getName());
+        assertEquals(AiConstants.Mcp.MCP_PROTOCOL_STDIO, page.getServers().get(0).getProtocol());
+        assertEquals("1.0.0", page.getServers().get(0).getVersionDetail().getVersion());
+        assertEquals("2026-06-01T00:00:00Z",
+            page.getServers().get(0).getVersionDetail().getRelease_date());
+        assertEquals(Boolean.TRUE, page.getServers().get(0).getVersionDetail().getIs_latest());
+        assertEquals("active", page.getServers().get(0).getStatus());
+        assertEquals(AiConstants.Mcp.MCP_PROTOCOL_SSE, page.getServers().get(1).getProtocol());
+        assertEquals("example.com:8443", page.getServers().get(1).getRemoteServerConfig()
+            .getFrontEndpointConfigList().get(0).getEndpointData());
+        assertEquals("/sse", page.getServers().get(1).getRemoteServerConfig().getExportPath());
+        assertEquals(AiConstants.Mcp.MCP_PROTOCOL_STREAMABLE,
+            page.getServers().get(2).getProtocol());
+        assertEquals("example.org:80", page.getServers().get(2).getRemoteServerConfig()
+            .getFrontEndpointConfigList().get(0).getEndpointData());
+        assertEquals("/", page.getServers().get(2).getRemoteServerConfig().getExportPath());
+    }
+    
+    @Test
+    void testFetchOfficialRegistryPageSupportsExistingQueryAndEmptyList() throws Exception {
+        String endpoint = ENDPOINT + "?sort=name";
+        AiResourceImportSource source = source();
+        source.setEndpoint(endpoint);
+        when(httpClient.get(any(AiResourceImportSource.class), eq(endpoint + "&limit=30"),
+            eq(20), eq("application/json"))).thenReturn(response(200, "{}"));
+        
+        McpRegistryClient.Page page =
+            client.fetchOfficialRegistryPage(source, null, 30, null);
+        
+        assertEquals(0, page.getServers().size());
+        assertNull(page.getNextCursor());
+    }
+    
+    @Test
+    void testFetchOfficialRegistryPageRejectsMissingEndpoint() {
+        AiResourceImportSource source = source();
+        source.setEndpoint(" ");
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> client.fetchOfficialRegistryPage(source, null, null, null));
+        assertThrows(IllegalArgumentException.class,
+            () -> client.fetchOfficialRegistryPage(null, null, null, null));
+    }
+    
+    @Test
+    void testFetchOfficialRegistryPageRejectsHttpError() throws Exception {
+        when(httpClient.get(any(AiResourceImportSource.class), eq(ENDPOINT), eq(20),
+            eq("application/json"))).thenReturn(response(500, "{}"));
+        
+        assertThrows(IllegalStateException.class,
+            () -> client.fetchOfficialRegistryPage(source(), null, null, null));
+    }
+    
+    @Test
+    void testFetchOfficialRegistryPageRejectsInvalidJson() throws Exception {
+        when(httpClient.get(any(AiResourceImportSource.class), eq(ENDPOINT), eq(20),
+            eq("application/json"))).thenReturn(response(200, "{"));
+        
+        assertThrows(IllegalStateException.class,
+            () -> client.fetchOfficialRegistryPage(source(), null, null, null));
+    }
+    
+    @Test
+    void testFetchOfficialRegistryServerFindsByName() throws Exception {
+        when(httpClient.get(any(AiResourceImportSource.class),
+            eq(ENDPOINT + "?limit=30&search=io.nacos%2Fstdio"), eq(20),
+            eq("application/json"))).thenReturn(response(200, registryPageJson()));
+        
+        assertEquals("io.nacos/stdio",
+            client.fetchOfficialRegistryServer(source(), "io.nacos/stdio", 0).getName());
+    }
+    
+    @Test
+    void testFetchOfficialRegistryServerRejectsBlankOrMissingServer() throws Exception {
+        assertThrows(IllegalArgumentException.class,
+            () -> client.fetchOfficialRegistryServer(source(), " ", 30));
+        when(httpClient.get(any(AiResourceImportSource.class), eq(ENDPOINT + "?limit=1&search=x"),
+            eq(20), eq("application/json"))).thenReturn(response(200, registryPageJson()));
+        
+        assertThrows(IllegalStateException.class,
+            () -> client.fetchOfficialRegistryServer(source(), "x", 1));
+    }
+    
+    @Test
+    void testFetchOfficialRegistryPageRejectsMissingRemoteUrl() throws Exception {
+        when(httpClient.get(any(AiResourceImportSource.class), eq(ENDPOINT), eq(20),
+            eq("application/json"))).thenReturn(response(200, invalidRemotePageJson()));
+        
+        assertThrows(IllegalStateException.class,
+            () -> client.fetchOfficialRegistryPage(source(), null, null, null));
+    }
+    
+    @Test
+    void testConstructorWithHttpClientAndNullServerEntry() throws Exception {
+        assertThrows(Exception.class,
+            () -> new McpRegistryClient(new HttpClient() {
+                
+                @Override
+                public java.util.Optional<java.net.CookieHandler> cookieHandler() {
+                    return java.util.Optional.empty();
+                }
+                
+                @Override
+                public java.util.Optional<java.time.Duration> connectTimeout() {
+                    return java.util.Optional.empty();
+                }
+                
+                @Override
+                public Redirect followRedirects() {
+                    return Redirect.NEVER;
+                }
+                
+                @Override
+                public java.util.Optional<java.net.ProxySelector> proxy() {
+                    return java.util.Optional.empty();
+                }
+                
+                @Override
+                public javax.net.ssl.SSLContext sslContext() {
+                    return null;
+                }
+                
+                @Override
+                public javax.net.ssl.SSLParameters sslParameters() {
+                    return null;
+                }
+                
+                @Override
+                public java.util.Optional<java.net.Authenticator> authenticator() {
+                    return java.util.Optional.empty();
+                }
+                
+                @Override
+                public Version version() {
+                    return Version.HTTP_1_1;
+                }
+                
+                @Override
+                public java.util.Optional<java.util.concurrent.Executor> executor() {
+                    return java.util.Optional.empty();
+                }
+                
+                @Override
+                public <T> java.net.http.HttpResponse<T> send(java.net.http.HttpRequest request,
+                    java.net.http.HttpResponse.BodyHandler<T> responseBodyHandler) {
+                    throw new UnsupportedOperationException();
+                }
+                
+                @Override
+                public <T> java.util.concurrent.CompletableFuture<java.net.http.HttpResponse<T>> sendAsync(
+                    java.net.http.HttpRequest request,
+                    java.net.http.HttpResponse.BodyHandler<T> responseBodyHandler) {
+                    return java.util.concurrent.CompletableFuture.failedFuture(
+                        new UnsupportedOperationException());
+                }
+                
+                @Override
+                public <T> java.util.concurrent.CompletableFuture<java.net.http.HttpResponse<T>> sendAsync(
+                    java.net.http.HttpRequest request,
+                    java.net.http.HttpResponse.BodyHandler<T> responseBodyHandler,
+                    java.net.http.HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+                    return java.util.concurrent.CompletableFuture.failedFuture(
+                        new UnsupportedOperationException());
+                }
+            }).fetchOfficialRegistryPage(source(), null, null, null));
+        
+        when(httpClient.get(any(AiResourceImportSource.class), eq(ENDPOINT), eq(20),
+            eq("application/json"))).thenReturn(response(200, "{\"servers\":[{\"server\":null}]}"));
+        assertThrows(IllegalStateException.class,
+            () -> client.fetchOfficialRegistryPage(source(), null, null, null));
+    }
+    
+    @Test
+    void testAdaptOfficialMcpServerCatchesRemoteConfigFailure() throws Exception {
+        Remote remote = Mockito.mock(Remote.class);
+        when(remote.getUrl()).thenReturn("https://example.com/sse");
+        when(remote.getType()).thenReturn("sse");
+        when(remote.getHeaders()).thenThrow(
+            new IllegalStateException("bad type"));
+        McpRegistryServerDetail detail = new McpRegistryServerDetail();
+        detail.setName("io.nacos/bad-remote");
+        detail.setRemotes(Arrays.asList(remote));
+        Method method = McpRegistryClient.class.getDeclaredMethod("adaptOfficialMcpServer",
+            McpRegistryServerDetail.class);
+        method.setAccessible(true);
+        
+        assertThrows(Exception.class, () -> method.invoke(client, detail));
+    }
+    
+    private AiResourceImportSource source() {
+        AiResourceImportSource source = new AiResourceImportSource();
+        source.setEndpoint(ENDPOINT);
+        return source;
+    }
+    
+    private ImportHttpResponse response(int status, String body) {
+        return new ImportHttpResponse("https://registry.example.com/v0/servers", status,
+            HttpHeaders.of(Collections.emptyMap(), (key, value) -> true),
+            body.getBytes(StandardCharsets.UTF_8));
+    }
+    
+    private String registryPageJson() {
+        Map<String, Object> root = new HashMap<>();
+        root.put("servers", java.util.Arrays.asList(stdioServer(), sseServer(), streamServer()));
+        root.put("metadata", Collections.singletonMap("nextCursor", "next-1"));
+        return JacksonUtils.toJson(root);
+    }
+    
+    private Map<String, Object> stdioServer() {
+        Map<String, Object> detail = new HashMap<>();
+        detail.put("name", "io.nacos/stdio");
+        detail.put("description", "stdio server");
+        detail.put("repository", Collections.singletonMap("url", "https://github.com/nacos/stdio"));
+        detail.put("version", "1.0.0");
+        detail.put("packages", Collections.singletonList(Collections.singletonMap("registry_name",
+            "npm")));
+        return serverResponse(detail, "2026-06-01T00:00:00Z", "active");
+    }
+    
+    private Map<String, Object> sseServer() {
+        Map<String, Object> remote = new HashMap<>();
+        remote.put("type", "sse");
+        remote.put("url", "https://example.com:8443/sse");
+        remote.put("headers", Collections.singletonList(Collections.singletonMap("name", "token")));
+        Map<String, Object> detail = new HashMap<>();
+        detail.put("name", "io.nacos/sse");
+        detail.put("description", "sse server");
+        detail.put("version", "2.0.0");
+        detail.put("remotes", Collections.singletonList(remote));
+        return serverResponse(detail, "2026-06-02T00:00:00Z", null);
+    }
+    
+    private Map<String, Object> streamServer() {
+        Map<String, Object> remote = new HashMap<>();
+        remote.put("type", "STREAMABLE-HTTP");
+        remote.put("url", "http://example.org");
+        Map<String, Object> detail = new HashMap<>();
+        detail.put("name", "io.nacos/stream");
+        detail.put("id", "server-stream");
+        detail.put("description", "stream server");
+        detail.put("remotes", Collections.singletonList(remote));
+        return serverResponse(detail, null, null);
+    }
+    
+    private Map<String, Object> serverResponse(Map<String, Object> detail, String publishedAt,
+        String status) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("server", detail);
+        if (publishedAt != null || status != null) {
+            Map<String, Object> official = new HashMap<>();
+            official.put("publishedAt", publishedAt);
+            official.put("status", status);
+            response.put("_meta",
+                Collections.singletonMap("io.modelcontextprotocol.registry/official", official));
+        }
+        return response;
+    }
+    
+    private String invalidRemotePageJson() {
+        Map<String, Object> remote = new HashMap<>();
+        remote.put("type", "sse");
+        remote.put("url", null);
+        Map<String, Object> detail = new HashMap<>();
+        detail.put("name", "io.nacos/bad");
+        detail.put("remotes", Collections.singletonList(remote));
+        return JacksonUtils.toJson(Collections.singletonMap("servers",
+            Collections.singletonList(serverResponse(detail, null, null))));
+    }
+}

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryImportServiceTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/mcp/McpRegistryImportServiceTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.plugin.ai.importer.defaultimpl.mcp;
 
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.registry.Repository;
 import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.common.utils.JacksonUtils;
@@ -41,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.reset;
 
 /**
  * Unit tests for {@link McpRegistryImportService}.
@@ -105,6 +107,57 @@ class McpRegistryImportServiceTest {
         context.getSource().setEndpoint(null);
         
         assertThrows(NacosException.class, () -> importService.search(context));
+    }
+    
+    @Test
+    void testSearchWrapsClientFailureAndHandlesEmptyPage() throws Exception {
+        when(client.fetchOfficialRegistryPage(any(AiResourceImportSource.class), any(), any(),
+            any())).thenThrow(new IllegalStateException("boom"));
+        assertThrows(NacosException.class, () -> importService.search(newContext()));
+        
+        reset(client);
+        McpRegistryImportService emptyService = new McpRegistryImportService(client);
+        when(client.fetchOfficialRegistryPage(any(AiResourceImportSource.class), eq("cursor-1"),
+            eq(20), eq("redis"))).thenReturn(new McpRegistryClient.Page(null, null));
+        AiResourceImportCandidatePage result = emptyService.search(newContext());
+        assertEquals(0, result.getItems().size());
+    }
+    
+    @Test
+    void testFetchRejectsInvalidItemAndWrapsClientFailure() throws Exception {
+        assertThrows(NacosException.class, () -> importService.fetch(newFetchContext(), null));
+        assertThrows(NacosException.class,
+            () -> importService.fetch(newFetchContext(), new AiResourceImportItem()));
+        
+        AiResourceImportItem item = new AiResourceImportItem();
+        item.setName("io.nacos/test-server");
+        when(client.fetchOfficialRegistryServer(any(AiResourceImportSource.class),
+            eq("io.nacos/test-server"), eq(30))).thenThrow(new IllegalStateException("boom"));
+        assertThrows(NacosException.class, () -> importService.fetch(newFetchContext(), item));
+    }
+    
+    @Test
+    void testFetchUsesContextLimitAndFallbackVersionMetadata() throws Exception {
+        McpServerDetailInfo server = newMcpServer();
+        server.setVersion("2.0.0");
+        server.setVersionDetail(null);
+        server.setStatus("active");
+        Repository repository = new Repository();
+        repository.setUrl("https://github.com/nacos/test-server");
+        server.setRepository(repository);
+        when(client.fetchOfficialRegistryServer(any(AiResourceImportSource.class),
+            eq("io.nacos/test-server"), eq(7))).thenReturn(server);
+        AiResourceImportContext context = newFetchContext();
+        context.setLimit(7);
+        AiResourceImportItem item = new AiResourceImportItem();
+        item.setName("io.nacos/test-server");
+        
+        AiResourceImportArtifact result = importService.fetch(context, item);
+        
+        assertEquals("2.0.0", result.getVersion());
+        assertEquals("active", result.getSourceMetadata().get("status"));
+        assertEquals("https://github.com/nacos/test-server",
+            result.getSourceMetadata().get("repository"));
     }
     
     @Test

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportServiceTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillWellKnownImportServiceTest.java
@@ -24,14 +24,17 @@ import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
 import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.DefaultImportHttpClient;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.ImportHttpResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -43,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.LinkedHashMap;
 import java.util.zip.ZipInputStream;
 import javax.net.ssl.SSLSession;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -55,7 +59,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link SkillWellKnownImportService}.
@@ -162,6 +168,249 @@ class SkillWellKnownImportServiceTest {
     }
     
     @Test
+    void testSearchHandlesCursorAndUnsupportedEntries() throws Exception {
+        SkillWellKnownImportService service = serviceWithResponses(
+            responseMap("https://registry.example.com/.well-known/agent-skills/index.json",
+                importResponse(200, "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":[null,"
+                    + "{\"name\":\"\"},"
+                    + "{\"name\":\"unsupported\",\"type\":\"unknown\"},"
+                    + "{\"name\":\"matched\",\"description\":\"Matched skill\",\"type\":\"skill-md\","
+                    + "\"url\":\"matched/SKILL.md\",\"digest\":\"sha256:abc\"}]}")));
+        AiResourceImportContext context = newContext("https://registry.example.com");
+        context.setQuery("matched");
+        context.setCursor("abc");
+        context.setLimit(1);
+        
+        AiResourceImportCandidatePage result = service.search(context);
+        
+        assertEquals(1, result.getItems().size());
+        assertEquals("matched", result.getItems().get(0).getExternalId());
+        
+        context.setCursor("0");
+        assertEquals(1, service.search(context).getItems().size());
+    }
+    
+    @Test
+    void testSearchReturnsEmptyForEmptyIndexAndWrapsFailures() throws Exception {
+        SkillWellKnownImportService emptyService = serviceWithResponses(
+            responseMap("https://registry.example.com/.well-known/agent-skills/index.json",
+                importResponse(200, "{\"skills\":[]}")));
+        assertTrue(emptyService.search(newContext("https://registry.example.com")).getItems()
+            .isEmpty());
+        
+        SkillWellKnownImportService nullIndexService = serviceWithResponses(
+            responseMap("https://registry.example.com/.well-known/agent-skills/index.json",
+                importResponse(200, "null")));
+        assertThrows(NacosException.class,
+            () -> nullIndexService.search(newContext("https://registry.example.com")));
+        
+        SkillWellKnownImportService badSchemaService = serviceWithResponses(
+            responseMap("https://registry.example.com/.well-known/agent-skills/index.json",
+                importResponse(200,
+                    "{\"$schema\":\"https://example.com/unsupported\",\"skills\":[]}")));
+        assertThrows(NacosException.class,
+            () -> badSchemaService.search(newContext("https://registry.example.com")));
+        
+        DefaultImportHttpClient client = Mockito.mock(DefaultImportHttpClient.class);
+        when(client.get(any(AiResourceImportSource.class), any(String.class), eq(20), eq("*/*")))
+            .thenThrow(new IllegalStateException("boom"));
+        assertThrows(NacosException.class,
+            () -> new SkillWellKnownImportService(client).search(
+                newContext("https://registry.example.com")));
+        
+        SkillWellKnownImportService allFailService = serviceWithResponses(responseMap(
+            "https://registry.example.com/.well-known/agent-skills/index.json",
+            importResponse(404, ""),
+            "https://registry.example.com/.well-known/skills/index.json",
+            importResponse(404, "")));
+        assertThrows(NacosException.class,
+            () -> allFailService.search(newContext("https://registry.example.com")));
+    }
+    
+    @Test
+    void testFetchRejectsInvalidItemsAndEndpoint() {
+        assertThrows(NacosException.class, () -> importService.fetch(newContext(), null));
+        assertThrows(NacosException.class, () -> importService.fetch(newContext(), item(" ")));
+        
+        AiResourceImportContext context = newContext(" ");
+        assertThrows(NacosException.class, () -> importService.search(context));
+    }
+    
+    @Test
+    void testFetchVersion020RejectsBlankUrlAndUnsupportedType() throws Exception {
+        SkillWellKnownImportService blankUrlService = serviceWithResponses(
+            responseMap("https://registry.example.com/.well-known/agent-skills/index.json",
+                importResponse(200, "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
+                    + "{\"name\":\"blank-url\",\"type\":\"skill-md\","
+                    + "\"digest\":\"sha256:abc\"}]}")));
+        assertThrows(NacosException.class,
+            () -> blankUrlService.fetch(newContext("https://registry.example.com"),
+                item("blank-url")));
+        
+        byte[] markdown = skillMarkdown("unknown-type").getBytes(StandardCharsets.UTF_8);
+        SkillWellKnownImportService unsupportedTypeService = serviceWithResponses(responseMap(
+            "https://registry.example.com/.well-known/agent-skills/index.json",
+            importResponse(200, "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
+                + "{\"name\":\"unknown-type\",\"type\":\"unknown\","
+                + "\"url\":\"unknown-type/SKILL.md\","
+                + "\"digest\":\"sha256:" + sha256Hex(markdown) + "\"}]}"),
+            "https://registry.example.com/.well-known/agent-skills/unknown-type/SKILL.md",
+            importResponse(200, markdown, "text/markdown")));
+        assertThrows(NacosException.class,
+            () -> unsupportedTypeService.fetch(newContext("https://registry.example.com"),
+                item("unknown-type")));
+    }
+    
+    @Test
+    void testFetchVersion020RejectsArtifactHttpErrorAndDigest() throws Exception {
+        SkillWellKnownImportService httpErrorService = serviceWithResponses(responseMap(
+            "https://registry.example.com/.well-known/agent-skills/index.json",
+            importResponse(200, "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
+                + "{\"name\":\"md-skill\",\"type\":\"skill-md\","
+                + "\"url\":\"md-skill/SKILL.md\",\"digest\":\"sha256:abc\"}]}"),
+            "https://registry.example.com/.well-known/agent-skills/md-skill/SKILL.md",
+            importResponse(500, "", "text/markdown")));
+        assertThrows(NacosException.class,
+            () -> httpErrorService.fetch(newContext("https://registry.example.com"),
+                item("md-skill")));
+        
+        SkillWellKnownImportService blankDigestService = serviceWithResponses(responseMap(
+            "https://registry.example.com/.well-known/agent-skills/index.json",
+            importResponse(200, "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
+                + "{\"name\":\"md-skill\",\"type\":\"skill-md\","
+                + "\"url\":\"md-skill/SKILL.md\"}]}"),
+            "https://registry.example.com/.well-known/agent-skills/md-skill/SKILL.md",
+            importResponse(200, skillMarkdown("md-skill").getBytes(StandardCharsets.UTF_8),
+                "text/markdown")));
+        assertThrows(NacosException.class,
+            () -> blankDigestService.fetch(newContext("https://registry.example.com"),
+                item("md-skill")));
+        
+        SkillWellKnownImportService invalidDigestService = serviceWithResponses(responseMap(
+            "https://registry.example.com/.well-known/agent-skills/index.json",
+            importResponse(200, "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
+                + "{\"name\":\"md-skill\",\"type\":\"skill-md\","
+                + "\"url\":\"md-skill/SKILL.md\",\"digest\":\"md5:abc\"}]}"),
+            "https://registry.example.com/.well-known/agent-skills/md-skill/SKILL.md",
+            importResponse(200, skillMarkdown("md-skill").getBytes(StandardCharsets.UTF_8),
+                "text/markdown")));
+        assertThrows(NacosException.class,
+            () -> invalidDigestService.fetch(newContext("https://registry.example.com"),
+                item("md-skill")));
+    }
+    
+    @Test
+    void testFetchVersion020ZipAndTarArchives() throws Exception {
+        byte[] zip = zipBytes("zip-skill/SKILL.md", skillMarkdown("zip-skill"));
+        byte[] tar = tarSkillArchive();
+        SkillWellKnownImportService service = serviceWithResponses(responseMap(
+            "https://registry.example.com/.well-known/agent-skills/index.json",
+            importResponse(200, "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
+                + "{\"name\":\"zip-skill\",\"type\":\"archive\",\"url\":\"zip-skill.zip\","
+                + "\"digest\":\"sha256:" + sha256Hex(zip) + "\"},"
+                + "{\"name\":\"tar-skill\",\"type\":\"archive\",\"url\":\"tar-skill.tar\","
+                + "\"digest\":\"sha256:" + sha256Hex(tar) + "\"}]}"),
+            "https://registry.example.com/.well-known/agent-skills/zip-skill.zip",
+            importResponse(200, zip, "application/zip"),
+            "https://registry.example.com/.well-known/agent-skills/tar-skill.tar",
+            importResponse(200, tar, "application/x-tar")));
+        
+        assertZipEntryContains(service.fetch(newContext("https://registry.example.com"),
+            item("zip-skill")).getPayload(), "zip-skill/SKILL.md", "name: zip-skill");
+        assertZipEntryContains(service.fetch(newContext("https://registry.example.com"),
+            item("tar-skill")).getPayload(), "tar-skill/SKILL.md", "name: tar-skill");
+    }
+    
+    @Test
+    void testFetchVersion020RejectsUnsupportedArchiveAndOversizedArtifact() throws Exception {
+        byte[] bytes = skillMarkdown("archive-skill").getBytes(StandardCharsets.UTF_8);
+        SkillWellKnownImportService service = serviceWithResponses(responseMap(
+            "https://registry.example.com/.well-known/agent-skills/index.json",
+            importResponse(200, "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
+                + "{\"name\":\"archive-skill\",\"type\":\"archive\",\"url\":\"archive-skill.bin\","
+                + "\"digest\":\"sha256:" + sha256Hex(bytes) + "\"}]}"),
+            "https://registry.example.com/.well-known/agent-skills/archive-skill.bin",
+            importResponse(200, bytes, "application/octet-stream")));
+        assertThrows(NacosException.class,
+            () -> service.fetch(newContext("https://registry.example.com"),
+                item("archive-skill")));
+        
+        AiResourceImportContext smallContext = newContext("https://registry.example.com");
+        smallContext.getSource().setMaxArtifactSize(1);
+        assertThrows(NacosException.class,
+            () -> service.fetch(smallContext, item("archive-skill")));
+    }
+    
+    @Test
+    void testArchiveConversionBoundaryBranches() throws Exception {
+        Method convert = SkillWellKnownImportService.class.getDeclaredMethod("convertTarToZip",
+            byte[].class, boolean.class);
+        convert.setAccessible(true);
+        byte[] zip = (byte[]) convert.invoke(importService, tarWithDirectoryAndDuplicate(), false);
+        assertZipEntryContains(zip, "archive-skill/SKILL.md", "name: archive-skill");
+        
+        assertThrows(Exception.class, () -> convert.invoke(importService, tarWithManyEntries(),
+            false));
+        assertThrows(Exception.class, () -> convert.invoke(importService, tarWithLargeEntry(),
+            false));
+        byte[] blankNameZip = (byte[]) convert.invoke(importService, tarWithBlankEntryName(),
+            false);
+        assertEquals(0, countZipEntries(blankNameZip));
+        
+        Method normalize = SkillWellKnownImportService.class.getDeclaredMethod(
+            "normalizeArchiveEntryName", String.class);
+        normalize.setAccessible(true);
+        assertNull(normalize.invoke(importService, " "));
+    }
+    
+    @Test
+    void testFetchVersion010DefaultFilesAndEndpointVariants() throws Exception {
+        SkillWellKnownImportService service = serviceWithResponses(responseMap(
+            "https://registry.example.com/.well-known/skills/index.json",
+            importResponse(200, "{\"skills\":[{\"name\":\"default-file\"}]}"),
+            "https://registry.example.com/.well-known/skills/default-file/SKILL.md",
+            importResponse(200, skillMarkdown("default-file"), "text/markdown")));
+        assertZipEntryContains(service.fetch(
+            newContext("https://registry.example.com/.well-known/skills/"), item("default-file"))
+            .getPayload(), "default-file/SKILL.md", "name: default-file");
+        
+        SkillWellKnownImportService byHttpClient = new SkillWellKnownImportService(httpClient);
+        assertEquals(SkillWellKnownImportServiceBuilder.IMPORTER_TYPE,
+            byHttpClient.importerType());
+        
+        SkillWellKnownImportService indexFileService = serviceWithResponses(responseMap(
+            "https://registry.example.com/index.json",
+            importResponse(200, "{\"skills\":[{\"name\":\"index-file\"}]}"),
+            "https://registry.example.com/index-file/SKILL.md",
+            importResponse(200, skillMarkdown("index-file"), "text/markdown")));
+        assertZipEntryContains(indexFileService.fetch(
+            newContext("https://registry.example.com/index.json"), item("index-file"))
+            .getPayload(), "index-file/SKILL.md", "name: index-file");
+        
+        Method trim = SkillWellKnownImportService.class.getDeclaredMethod("trimTrailingSlash",
+            String.class);
+        trim.setAccessible(true);
+        assertThrows(Exception.class, () -> trim.invoke(importService, " "));
+        
+        Method base = SkillWellKnownImportService.class.getDeclaredMethod("wellKnownBase",
+            String.class);
+        base.setAccessible(true);
+        assertEquals("https://registry.example.com/custom",
+            base.invoke(importService, "https://registry.example.com/custom-index.json"));
+        assertEquals("https://registry.example.com/plain",
+            base.invoke(importService, "https://registry.example.com/plain"));
+        
+        SkillWellKnownImportService missingFileService = serviceWithResponses(responseMap(
+            "https://registry.example.com/.well-known/agent-skills/index.json",
+            importResponse(200, "{\"skills\":[{\"name\":\"missing-file\"}]}"),
+            "https://registry.example.com/.well-known/agent-skills/missing-file/SKILL.md",
+            importResponse(404, "", "text/markdown")));
+        assertThrows(NacosException.class,
+            () -> missingFileService.fetch(newContext("https://registry.example.com"),
+                item("missing-file")));
+    }
+    
+    @Test
     void testFetchRejectsMissingSkill() {
         assertThrows(NacosException.class,
             () -> importService.fetch(newContext(), item("missing-skill")));
@@ -225,11 +474,11 @@ class SkillWellKnownImportServiceTest {
         return "{\"$schema\":\"" + SCHEMA_0_2 + "\",\"skills\":["
             + "{\"name\":\"md-skill\",\"type\":\"skill-md\","
             + "\"description\":\"Markdown skill\","
-            + "\"url\":\"md-skill/SKILL.md\","
+            + "\"url\":\"md-skill/SKILL.md\",\"version\":\"1.0.0\","
             + "\"digest\":\"sha256:" + sha256Hex(markdown) + "\"},"
             + "{\"name\":\"archive-skill\",\"type\":\"archive\","
             + "\"description\":\"Archive skill\","
-            + "\"url\":\"archive-skill.tar.gz\","
+            + "\"url\":\"archive-skill.tar.gz\",\"version\":\"1.0.0\","
             + "\"digest\":\"sha256:" + sha256Hex(archive) + "\"}"
             + "]}";
     }
@@ -351,6 +600,55 @@ class SkillWellKnownImportServiceTest {
         };
     }
     
+    private Map<String, ImportHttpResponse> responseMap(Object... keyValues) {
+        Map<String, ImportHttpResponse> result = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            result.put((String) keyValues[i], (ImportHttpResponse) keyValues[i + 1]);
+        }
+        return result;
+    }
+    
+    private SkillWellKnownImportService serviceWithResponses(
+        Map<String, ImportHttpResponse> responses) throws Exception {
+        DefaultImportHttpClient client = Mockito.mock(DefaultImportHttpClient.class);
+        when(client.get(any(AiResourceImportSource.class), any(String.class), eq(20), eq("*/*")))
+            .thenAnswer(invocation -> {
+                String url = invocation.getArgument(1);
+                ImportHttpResponse response = responses.get(url);
+                if (response == null) {
+                    return importResponse(404, "", "text/plain");
+                }
+                return response;
+            });
+        return new SkillWellKnownImportService(client);
+    }
+    
+    private ImportHttpResponse importResponse(int status, byte[] bytes, String contentType) {
+        Map<String, java.util.List<String>> headers = new HashMap<>(1);
+        headers.put("Content-Type", Collections.singletonList(contentType));
+        return new ImportHttpResponse("https://registry.example.com/artifact", status,
+            HttpHeaders.of(headers, (key, value) -> true), bytes);
+    }
+    
+    private ImportHttpResponse importResponse(int status, String body) {
+        return importResponse(status, body.getBytes(StandardCharsets.UTF_8), "application/json");
+    }
+    
+    private ImportHttpResponse importResponse(int status, String body, String contentType) {
+        return importResponse(status, body.getBytes(StandardCharsets.UTF_8), contentType);
+    }
+    
+    private byte[] zipBytes(String name, String content) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (java.util.zip.ZipOutputStream zip =
+            new java.util.zip.ZipOutputStream(output, StandardCharsets.UTF_8)) {
+            zip.putNextEntry(new java.util.zip.ZipEntry(name));
+            zip.write(content.getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+        return output.toByteArray();
+    }
+    
     private byte[] tarGzSkillArchive() throws Exception {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         try (GzipCompressorOutputStream gzip = new GzipCompressorOutputStream(output);
@@ -359,6 +657,58 @@ class SkillWellKnownImportServiceTest {
                 skillMarkdown("archive-skill").getBytes(StandardCharsets.UTF_8));
             addTarEntry(tar, "archive-skill/docs/guide.md",
                 "# Guide".getBytes(StandardCharsets.UTF_8));
+        }
+        return output.toByteArray();
+    }
+    
+    private byte[] tarSkillArchive() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(output)) {
+            addTarEntry(tar, "./tar-skill/SKILL.md",
+                skillMarkdown("tar-skill").getBytes(StandardCharsets.UTF_8));
+        }
+        return output.toByteArray();
+    }
+    
+    private byte[] tarWithDirectoryAndDuplicate() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(output)) {
+            TarArchiveEntry directory = new TarArchiveEntry("archive-skill/docs/");
+            directory.setSize(0);
+            tar.putArchiveEntry(directory);
+            tar.closeArchiveEntry();
+            addTarEntry(tar, "./archive-skill/SKILL.md",
+                skillMarkdown("archive-skill").getBytes(StandardCharsets.UTF_8));
+            addTarEntry(tar, "archive-skill/SKILL.md",
+                "duplicate".getBytes(StandardCharsets.UTF_8));
+        }
+        return output.toByteArray();
+    }
+    
+    private byte[] tarWithManyEntries() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(output)) {
+            for (int i = 0; i < 501; i++) {
+                addTarEntry(tar, "archive-skill/file-" + i + ".txt",
+                    "x".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        return output.toByteArray();
+    }
+    
+    private byte[] tarWithLargeEntry() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(output)) {
+            byte[] bytes = new byte[50 * 1024 * 1024 + 1];
+            addTarEntry(tar, "archive-skill/large.bin", bytes);
+        }
+        return output.toByteArray();
+    }
+    
+    private byte[] tarWithBlankEntryName() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(output)) {
+            addTarEntry(tar, "./\t", new byte[0]);
         }
         return output.toByteArray();
     }
@@ -399,5 +749,16 @@ class SkillWellKnownImportServiceTest {
             }
         }
         throw new AssertionError("Zip entry not found: " + entryName);
+    }
+    
+    private int countZipEntries(byte[] zipBytes) throws Exception {
+        int count = 0;
+        try (ZipInputStream zip = new ZipInputStream(new ByteArrayInputStream(zipBytes),
+            StandardCharsets.UTF_8)) {
+            while (zip.getNextEntry() != null) {
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillsShImportServiceTest.java
+++ b/plugin-default-impl/nacos-default-ai-importer-plugin/src/test/java/com/alibaba/nacos/plugin/ai/importer/defaultimpl/skill/SkillsShImportServiceTest.java
@@ -24,14 +24,17 @@ import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportItem;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportPayloadKind;
 import com.alibaba.nacos.plugin.ai.importer.model.AiResourceImportSource;
 import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.DefaultImportHttpClient;
+import com.alibaba.nacos.plugin.ai.importer.defaultimpl.http.ImportHttpResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -51,8 +54,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link SkillsShImportService}.
@@ -162,6 +167,147 @@ class SkillsShImportServiceTest {
         assertEquals("PDF Skill", result.getName());
         assertEquals("openai/skills/pdf", result.getExternalId());
         assertZipEntryContains(result.getPayload(), "pdf/SKILL.md", "name: pdf");
+    }
+    
+    @Test
+    void testSearchReturnsEmptyWhenResponseHasNoSkills() throws Exception {
+        SkillsShImportService service = serviceWithResponse(200, "{}");
+        
+        AiResourceImportCandidatePage result = service.search(newContext());
+        
+        assertTrue(result.getItems().isEmpty());
+    }
+    
+    @Test
+    void testSearchSkipsInvalidItemsAndStopsAtLimit() throws Exception {
+        SkillsShImportService service = serviceWithResponse(200, "{\"skills\":[null,"
+            + "{\"id\":\"\"},"
+            + "{\"id\":\"owner/repo/one\",\"skillId\":\"one\",\"source\":\"owner/repo\"},"
+            + "{\"id\":\"owner/repo/two\",\"skillId\":\"two\",\"source\":\"\"}]}");
+        AiResourceImportContext context = newContext();
+        context.setLimit(2);
+        
+        AiResourceImportCandidatePage result = service.search(context);
+        
+        assertEquals(2, result.getItems().size());
+        assertEquals("owner/repo/one", result.getItems().get(0).getExternalId());
+    }
+    
+    @Test
+    void testSearchRejectsHttpError() throws Exception {
+        SkillsShImportService service = serviceWithResponse(500, "{}");
+        
+        assertThrows(NacosException.class, () -> service.search(newContext()));
+    }
+    
+    @Test
+    void testSearchWrapsHttpClientFailure() throws Exception {
+        DefaultImportHttpClient client = Mockito.mock(DefaultImportHttpClient.class);
+        when(client.get(any(AiResourceImportSource.class), any(String.class), eq(20),
+            eq("application/json"))).thenThrow(new IllegalStateException("boom"));
+        
+        assertThrows(NacosException.class,
+            () -> new SkillsShImportService(client).search(newContext()));
+    }
+    
+    @Test
+    void testFetchRejectsHttpErrorAndWrapsClientFailure() throws Exception {
+        SkillsShImportService service = serviceWithResponse(500, "{}");
+        assertThrows(NacosException.class,
+            () -> service.fetch(newContext(), item("owner/repo/one")));
+        
+        DefaultImportHttpClient client = Mockito.mock(DefaultImportHttpClient.class);
+        when(client.get(any(AiResourceImportSource.class), any(String.class), eq(20),
+            eq("application/json"))).thenThrow(new IllegalStateException("boom"));
+        assertThrows(NacosException.class,
+            () -> new SkillsShImportService(client).fetch(newContext(), item("owner/repo/one")));
+    }
+    
+    @Test
+    void testFetchRejectsInvalidItems() {
+        assertThrows(NacosException.class, () -> importService.fetch(newContext(), null));
+        assertThrows(NacosException.class,
+            () -> importService.fetch(newContext(), item("missing")));
+        assertThrows(NacosException.class,
+            () -> importService.fetch(newContext(), item("bad-source/repo/skill")));
+        assertThrows(NacosException.class,
+            () -> importService.fetch(newContext(), item("owner/repo/../skill")));
+        assertThrows(NacosException.class,
+            () -> importService.fetch(newContext(), item("owner/repo/.hidden")));
+        assertThrows(NacosException.class,
+            () -> importService.fetch(newContext(), item("owner/repo/path\\")));
+        
+        AiResourceImportItem metadataItem = new AiResourceImportItem();
+        metadataItem.setExternalId("owner/repo/skill");
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("repositorySource", "invalid");
+        metadata.put("skillId", "skill");
+        metadataItem.setMetadata(metadata);
+        assertThrows(NacosException.class,
+            () -> importService.fetch(newContext(), metadataItem));
+    }
+    
+    @Test
+    void testFetchRejectsInvalidDownloadResponse() throws Exception {
+        assertThrows(NacosException.class,
+            () -> serviceWithResponse(200, "{}").fetch(newContext(), item("owner/repo/one")));
+        assertThrows(NacosException.class,
+            () -> serviceWithResponse(200, "{\"files\":[{\"path\":\" \",\"contents\":\"x\"}]}")
+                .fetch(newContext(), item("owner/repo/one")));
+    }
+    
+    @Test
+    void testFetchRejectsFileCountAndSizeLimit() throws Exception {
+        AiResourceImportContext countContext = newContext();
+        countContext.getSource().setMaxItemCount(1);
+        String tooManyFiles = "{\"files\":[{\"path\":\"SKILL.md\",\"contents\":\"x\"},"
+            + "{\"path\":\"README.md\",\"contents\":\"y\"}]}";
+        assertThrows(NacosException.class,
+            () -> serviceWithResponse(200, tooManyFiles).fetch(countContext,
+                item("owner/repo/one")));
+        
+        AiResourceImportContext sizeContext = newContext();
+        sizeContext.getSource().setMaxArtifactSize(1);
+        assertThrows(NacosException.class,
+            () -> serviceWithResponse(200, downloadJson()).fetch(sizeContext,
+                item("owner/repo/one")));
+    }
+    
+    @Test
+    void testFetchNormalizesAndSkipsDuplicateFiles() throws Exception {
+        String json = "{\"files\":["
+            + "{\"path\":\"./SKILL.md\",\"contents\":\"name: one\"},"
+            + "{\"path\":\"SKILL.md\",\"contents\":\"duplicate\"}"
+            + "]}";
+        
+        AiResourceImportArtifact result =
+            serviceWithResponse(200, json).fetch(newContext(), item("owner/repo/one"));
+        
+        assertZipEntryContains(result.getPayload(), "one/SKILL.md", "name: one");
+    }
+    
+    @Test
+    void testEndpointVariantsAndConstructor() throws Exception {
+        SkillsShImportService byHttpClient = new SkillsShImportService(httpClient);
+        assertEquals(SkillsShImportServiceBuilder.IMPORTER_TYPE, byHttpClient.importerType());
+        
+        AiResourceImportContext searchEndpoint = newContext();
+        searchEndpoint.getSource().setEndpoint(ENDPOINT + "/api/search/");
+        assertEquals(1, importService.search(searchEndpoint).getItems().size());
+        
+        AiResourceImportContext downloadEndpoint = newContext();
+        downloadEndpoint.getSource().setEndpoint(ENDPOINT + "/api/download/");
+        assertZipEntryContains(importService.fetch(downloadEndpoint, item("openai/skills/pdf"))
+            .getPayload(), "pdf/SKILL.md", "name: pdf");
+        
+        AiResourceImportContext blankEndpoint = newContext();
+        blankEndpoint.getSource().setEndpoint(" ");
+        assertThrows(NacosException.class, () -> importService.search(blankEndpoint));
+        
+        Method method = SkillsShImportService.class.getDeclaredMethod("trimTrailingSlash",
+            String.class);
+        method.setAccessible(true);
+        assertThrows(Exception.class, () -> method.invoke(importService, " "));
     }
     
     @Test
@@ -295,6 +441,19 @@ class SkillsShImportServiceTest {
                 return HttpClient.Version.HTTP_1_1;
             }
         };
+    }
+    
+    private SkillsShImportService serviceWithResponse(int status, String body) throws Exception {
+        DefaultImportHttpClient client = Mockito.mock(DefaultImportHttpClient.class);
+        when(client.get(any(AiResourceImportSource.class), any(String.class), eq(20),
+            eq("application/json"))).thenReturn(importResponse(status, body));
+        return new SkillsShImportService(client);
+    }
+    
+    private ImportHttpResponse importResponse(int status, String body) {
+        return new ImportHttpResponse("https://skills.sh/api/search", status,
+            HttpHeaders.of(Collections.emptyMap(), (key, value) -> true),
+            body.getBytes(StandardCharsets.UTF_8));
     }
     
     private void assertZipEntryContains(byte[] zipBytes, String entryName, String expected)


### PR DESCRIPTION
## Summary
- Add unit tests for ai-registry-adaptor to reach 100% JaCoCo line coverage
- Add unit tests for nacos-default-ai-importer-plugin to reach 100% JaCoCo line coverage
- Simplify unreachable defensive paths used by the well-known skills export flow

## Validation
- mvn spotless:apply -pl ai-registry-adaptor,plugin-default-impl/nacos-default-ai-importer-plugin
- mvn spotless:check -pl ai-registry-adaptor,plugin-default-impl/nacos-default-ai-importer-plugin
- mvn test -pl ai-registry-adaptor,plugin-default-impl/nacos-default-ai-importer-plugin