### PR TITLE
[ISSUE #14879] Add Java SDK integration test module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ This file provides guidance to AI coding agents (Claude Code, Cursor, GitHub Cop
   cases, and coverage registry in the same change set. If the functional path
   cannot be exercised in standalone IT, cover boundary/error scenarios and
   document the reason.
+- **Java SDK IT impact comes first**: Before adding, changing, deleting, or
+  deprecating any public Java SDK interface, factory, model, listener behavior,
+  lifecycle behavior, or exception mapping, AI agents MUST analyze and update
+  `test/java-sdk-test` coverage, including scenario documentation. If the
+  end-to-end success path is impractical, cover SDK parameter validation,
+  boundary behavior, and controlled exceptions.
 - **Disclose AI usage**: When a significant part of a commit is AI-generated, add a trailer to your commit message:
   ```
   Assisted-by: Claude Code
@@ -222,7 +228,8 @@ English:
   [Visibility Plugin Spec](./specs/en/auth/visibility-plugin-spec.md),
   [Default Auth Plugin Implementation Spec](./specs/en/auth/default-auth-plugin-spec.md)
 - Testing model:
-  [API Integration Test Spec](./specs/en/testing/api-integration-test-spec.md)
+  [API Integration Test Spec](./specs/en/testing/api-integration-test-spec.md),
+  [Java SDK Integration Test Spec](./specs/en/testing/java-sdk-integration-test-spec.md)
 
 Simplified Chinese:
 
@@ -298,7 +305,8 @@ Simplified Chinese:
   [可见性插件规范](./specs/zh-cn/auth/visibility-plugin-spec.md)，
   [默认鉴权插件实现规范](./specs/zh-cn/auth/default-auth-plugin-spec.md)
 - 测试模型：
-  [API 集成测试规范](./specs/zh-cn/testing/api-integration-test-spec.md)
+  [API 集成测试规范](./specs/zh-cn/testing/api-integration-test-spec.md)，
+  [Java SDK 集成测试规范](./specs/zh-cn/testing/java-sdk-integration-test-spec.md)
 
 This section is a quick implementation checklist for agents. If it conflicts
 with the specs, follow the specs and update this checklist.
@@ -370,6 +378,22 @@ For every HTTP API addition, modification, deletion, or deprecation, handle
    `*_API_TEST_SCENARIOS.md` document.
 5. If the functional success path is hard to exercise in standalone IT, at
    least cover boundary and error scenarios and document the uncovered path.
+
+### Java SDK Integration Tests
+
+For every Java SDK public contract change, handle `test/java-sdk-test` before
+the SDK change is considered complete:
+
+1. Read the public interface, implementation, request/response model, listener
+   path, lifecycle code, exception mapping, and matching SDK/client specs.
+2. Build or update the scenario matrix for factory/lifecycle behavior,
+   expected capability, boundary/validation behavior, listener/subscription
+   behavior, and exception handling.
+3. Add, update, or remove Java SDK IT cases for the changed SDK contract. Assert
+   SDK return values, callbacks, remote side effects, and typed exceptions.
+4. Update `test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md`.
+5. Keep SDK ITs as external-client tests against a standalone Nacos server; do
+   not start Spring or Nacos inside the test class.
 
 ### Controller Example
 

--- a/specs/en/README.md
+++ b/specs/en/README.md
@@ -72,6 +72,7 @@ extension mechanisms, and cross-cutting security rules.
 ## Testing Model
 
 - [API Integration Test Spec](testing/api-integration-test-spec.md)
+- [Java SDK Integration Test Spec](testing/java-sdk-integration-test-spec.md)
 
 Agent guidance files such as [AGENTS.md](../../AGENTS.md) should summarize these
 specs for local execution. The specs remain the rule source when API guidance is

--- a/specs/en/sdk/sdk-java-impl-spec.md
+++ b/specs/en/sdk/sdk-java-impl-spec.md
@@ -35,6 +35,12 @@ is defined by the [Client Runtime Specs](../client/README.md). The Java
 Maintainer SDK is the preferred Java entry point for management, UI, gateway,
 and operation scenarios.
 
+Java SDK behavior must be verified with scenario-oriented integration tests
+according to the
+[Java SDK Integration Test Spec](../testing/java-sdk-integration-test-spec.md)
+whenever public SDK interfaces, factories, models, listener behavior,
+lifecycle behavior, or exception mapping change.
+
 ## 2. Java Client SDK Factories and Lifecycle
 
 | Interface | Factory | Shutdown method |

--- a/specs/en/testing/java-sdk-integration-test-spec.md
+++ b/specs/en/testing/java-sdk-integration-test-spec.md
@@ -144,5 +144,11 @@ For Java SDK IT changes, run:
 - `mvn -pl test/java-sdk-test -DskipTests test-compile`
 
 When a standalone Nacos server is available, run the relevant Failsafe
-selection or `mvn -pl test/java-sdk-test -Pintegration-test -DskipTests=false
+selection or
+`mvn -pl test/java-sdk-test -Pjava-sdk-integration-test -DskipTests=false
 verify`.
+
+Java SDK ITs intentionally use the dedicated `java-sdk-integration-test` Maven
+profile. The generic `integration-test` profile is reserved for HTTP API IT
+workflows and must not accidentally run SDK tests that depend on SDK gRPC
+connection readiness or optional server abilities.

--- a/specs/en/testing/java-sdk-integration-test-spec.md
+++ b/specs/en/testing/java-sdk-integration-test-spec.md
@@ -1,0 +1,148 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Java SDK Integration Test Spec
+
+This spec defines the integration-test model for Nacos Java SDK public
+contracts. It complements the [API Integration Test Spec](api-integration-test-spec.md):
+HTTP API ITs verify deployed HTTP contracts, while Java SDK ITs verify the
+typed Java SDK behavior seen by applications.
+
+The goal is SDK scenario coverage. It is not line coverage or branch coverage.
+
+## 1. Scope
+
+The primary Java SDK IT location is `test/java-sdk-test`. Tests in this module
+assume a standalone Nacos server is already running and create real Java SDK
+clients as external applications.
+
+This spec applies when changing:
+
+- public interfaces such as `ConfigService`, `NamingService`, `AiService`,
+  `A2aService`, `LockService`, and their maintainer-client equivalents;
+- public factories such as `NacosFactory`, `ConfigFactory`, `NamingFactory`,
+  `AiFactory`, and `NacosLockFactory`;
+- public request, response, or domain models returned by SDK methods;
+- listener, subscription, local cache, redo, factory initialization, shutdown,
+  or exception mapping behavior;
+- SDK configuration keys and defaulting behavior.
+
+Unit tests remain necessary for isolated implementation branches, but they do
+not replace Java SDK ITs for externally visible SDK behavior.
+
+## 2. SDK Change Rule
+
+Before implementing a Java SDK contract addition, modification, deletion, or
+deprecation, the change owner must perform an SDK IT impact analysis:
+
+1. Identify the affected SDK interface, factory, model, or listener path.
+2. Read the public API, implementation, validators, transport mapping, response
+   assembly, exception mapping, lifecycle code, and matching SDK/client specs.
+3. Build a scenario matrix for factory/lifecycle behavior, expected capability,
+   boundary/validation behavior, listener or subscription behavior, and
+   exception/error handling.
+4. Add, update, or remove `test/java-sdk-test` cases in the same change set.
+5. Update `test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md`.
+
+If the full success path is not practical in standalone IT, the test must still
+cover SDK parameter validation, local boundary behavior, controlled exceptions,
+and any low-risk observable server interaction. The skipped path and reason
+must be documented.
+
+## 3. Required Scenario Groups
+
+Every Java SDK IT should cover these groups when observable.
+
+### 3.1 Factory And Lifecycle
+
+Verify that the SDK can be created through the public factory with realistic
+properties, honors server address and namespace defaults, and releases
+resources through the public shutdown method.
+
+### 3.2 Expected Capability
+
+Verify that SDK methods perform the promised remote or local behavior. Prefer
+publish-then-query, register-then-query, subscribe-then-callback,
+lock-then-unlock, release-then-load, and delete-then-absent flows.
+
+Assertions must check typed SDK return values, model fields, callbacks, and
+remote side effects instead of only checking that no exception was thrown.
+
+### 3.3 Boundary And Validation
+
+Cover required parameters, optional defaults, invalid enum or type values,
+namespace and group defaults, timeout behavior, malformed model objects,
+listener identity requirements, duplicate or idempotent calls, and missing
+resource behavior.
+
+### 3.4 Exception And Error Handling
+
+Verify that SDK-visible failures produce controlled `NacosException` or
+documented return values. Tests should catch regressions where invalid input,
+not-found resources, remote failures, or invalid lifecycle use become
+unexpected runtime exceptions.
+
+### 3.5 Listener And Subscription Behavior
+
+For listener APIs, verify initial query behavior when applicable, callback
+delivery for an observable change, unsubscribe/remove behavior, and cleanup.
+Use bounded waits and clear assertion messages.
+
+## 4. Test Organization
+
+Java SDK ITs should live under:
+
+- `com.alibaba.nacos.test.sdk.config`
+- `com.alibaba.nacos.test.sdk.naming`
+- `com.alibaba.nacos.test.sdk.ai`
+- `com.alibaba.nacos.test.sdk.lock`
+- `com.alibaba.nacos.test.sdk.maintainer.<domain>` when maintainer SDK ITs are
+  added
+
+Prefer one public SDK interface, or one tightly coupled API family, per test
+class. Shared client construction, cleanup, bounded waits, random resource
+names, and shutdown handling should live in a base class.
+
+## 5. Runtime Rules
+
+Java SDK ITs must:
+
+- use JUnit 5 and Failsafe;
+- avoid `@SpringBootTest`, `SpringExtension`, and starting Nacos inside tests;
+- read `nacos.host` and `nacos.port`, defaulting to `127.0.0.1:8848`;
+- create real SDK clients through public factories;
+- generate isolated resource names;
+- cleanup created config, naming, AI, or lock resources;
+- shut down every SDK instance even when assertions fail;
+- use bounded retries for asynchronous server effects.
+
+## 6. Scenario Documentation
+
+Each SDK IT class must include a compact `Scenario coverage` Javadoc section,
+or update `test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md` when the matrix is large.
+The documentation must say what is verified and why any branch is intentionally
+not covered.
+
+## 7. Validation
+
+For Java SDK IT changes, run:
+
+- `mvn -pl test/java-sdk-test spotless:check`
+- `mvn -pl test/java-sdk-test -DskipTests test-compile`
+
+When a standalone Nacos server is available, run the relevant Failsafe
+selection or `mvn -pl test/java-sdk-test -Pintegration-test -DskipTests=false
+verify`.

--- a/specs/zh-cn/README.md
+++ b/specs/zh-cn/README.md
@@ -71,6 +71,7 @@
 ## 测试模型
 
 - [API 集成测试规范](testing/api-integration-test-spec.md)
+- [Java SDK 集成测试规范](testing/java-sdk-integration-test-spec.md)
 
 [AGENTS.md](../../AGENTS.md) 等 Agent 指南文件应只摘要这些规范以便本地执行。
 当人、AI agent、模板或校验工具使用 API 指南时，规范仍然是规则来源。

--- a/specs/zh-cn/sdk/sdk-java-impl-spec.md
+++ b/specs/zh-cn/sdk/sdk-java-impl-spec.md
@@ -32,6 +32,10 @@ Java Client SDK 是现有运行时应用行为的基准。它的连接、server 
 本地缓存和 redo 行为由[客户端运行时规范](../client/README.md)定义。Java Maintainer SDK
 是管理、UI、网关和运维场景的推荐 Java 接入方式。
 
+当公开 SDK interface、factory、模型、监听行为、生命周期行为或异常映射发生
+变化时，必须按照[Java SDK 集成测试规范](../testing/java-sdk-integration-test-spec.md)
+使用场景化 IT 验证 Java SDK 行为。
+
 ## 2. Java Client SDK Factory 和生命周期
 
 | Interface | Factory | 生命周期关闭方法 |

--- a/specs/zh-cn/testing/java-sdk-integration-test-spec.md
+++ b/specs/zh-cn/testing/java-sdk-integration-test-spec.md
@@ -128,4 +128,9 @@ Java SDK IT 变更需要运行：
 - `mvn -pl test/java-sdk-test -DskipTests test-compile`
 
 当单机 Nacos 服务可用时，应运行相关 Failsafe 选择，或执行
-`mvn -pl test/java-sdk-test -Pintegration-test -DskipTests=false verify`。
+`mvn -pl test/java-sdk-test -Pjava-sdk-integration-test -DskipTests=false
+verify`。
+
+Java SDK IT 必须使用独立的 `java-sdk-integration-test` Maven profile。通用
+`integration-test` profile 保留给 HTTP API IT 工作流，不能意外运行依赖 SDK
+gRPC 连接就绪状态或可选服务端能力的 SDK 测试。

--- a/specs/zh-cn/testing/java-sdk-integration-test-spec.md
+++ b/specs/zh-cn/testing/java-sdk-integration-test-spec.md
@@ -1,0 +1,131 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Java SDK 集成测试规范
+
+本规范定义 Nacos Java SDK 公开契约的集成测试模型。它与
+[API 集成测试规范](api-integration-test-spec.md)互补：HTTP API IT 验证部署后
+的 HTTP 契约，Java SDK IT 验证应用侧看到的类型化 Java SDK 行为。
+
+Java SDK IT 的目标是 SDK 场景覆盖，不是行覆盖率或分支覆盖率。
+
+## 1. 范围
+
+Java SDK IT 的主要位置是 `test/java-sdk-test`。该模块假设单机 Nacos 服务已经
+启动，并以外部应用身份创建真实 Java SDK 客户端。
+
+本规范适用于以下变更：
+
+- `ConfigService`、`NamingService`、`AiService`、`A2aService`、
+  `LockService` 以及 maintainer-client 对应公开 interface；
+- `NacosFactory`、`ConfigFactory`、`NamingFactory`、`AiFactory`、
+  `NacosLockFactory` 等公开 factory；
+- SDK 方法返回的公开 request、response 或领域模型；
+- listener、subscription、本地缓存、redo、factory 初始化、shutdown 或异常映射；
+- SDK 配置项和默认值行为。
+
+单元测试仍然需要覆盖隔离实现分支，但不能替代对外可见 SDK 行为的 Java SDK IT。
+
+## 2. SDK 变更规则
+
+在实现 Java SDK 契约新增、修改、删除或废弃前，变更负责人必须完成 SDK IT
+影响分析：
+
+1. 识别受影响的 SDK interface、factory、模型或 listener 路径。
+2. 阅读公开 API、实现、校验器、传输映射、响应组装、异常映射、生命周期代码
+   和对应 SDK/client 规范。
+3. 形成场景矩阵，覆盖 factory/生命周期行为、预期功能、边界/校验行为、
+   listener 或 subscription 行为，以及异常/错误处理。
+4. 在同一个变更集中新增、更新或移除 `test/java-sdk-test` 用例。
+5. 更新 `test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md`。
+
+如果完整成功路径在单机 IT 中难以实际执行，测试仍必须覆盖 SDK 参数校验、
+本地边界行为、受控异常，以及低风险可观测的服务端交互。未覆盖路径和原因
+必须记录在文档中。
+
+## 3. 必须覆盖的场景组
+
+每个 Java SDK IT 都应覆盖以下可观测场景组。
+
+### 3.1 Factory 和生命周期
+
+验证 SDK 可以通过公开 factory 使用真实 properties 创建，能正确处理 server
+address 和 namespace 默认值，并能通过公开 shutdown 方法释放资源。
+
+### 3.2 预期功能
+
+验证 SDK 方法完成承诺的远程或本地行为。优先使用发布后查询、注册后查询、
+订阅后回调、加锁后解锁、发布后加载、删除后确认不存在等流程。
+
+断言必须检查类型化 SDK 返回值、模型字段、回调和远程副作用，不能只判断没有
+抛出异常。
+
+### 3.3 边界和校验
+
+覆盖必填参数、可选默认值、非法枚举或类型、namespace/group 默认值、超时行为、
+异常模型对象、listener 身份要求、重复或幂等调用，以及资源不存在行为。
+
+### 3.4 异常和错误处理
+
+验证 SDK 可见失败会产生受控 `NacosException` 或文档化返回值。测试应捕捉非法
+输入、资源不存在、远端失败或非法生命周期使用变成非预期运行时异常的回归。
+
+### 3.5 Listener 和订阅行为
+
+对于 listener API，应验证适用场景下的初始查询行为、可观测变更触发回调、
+unsubscribe/remove 行为和清理逻辑。等待必须有边界，并提供清晰断言信息。
+
+## 4. 测试组织
+
+Java SDK IT 应放在：
+
+- `com.alibaba.nacos.test.sdk.config`
+- `com.alibaba.nacos.test.sdk.naming`
+- `com.alibaba.nacos.test.sdk.ai`
+- `com.alibaba.nacos.test.sdk.lock`
+- 新增 maintainer SDK IT 时使用 `com.alibaba.nacos.test.sdk.maintainer.<domain>`
+
+建议一个公开 SDK interface 或一组强关联 API family 对应一个测试类。共享的客户端
+构造、清理、有界等待、随机资源名和 shutdown 逻辑应抽象到基础类。
+
+## 5. 运行规则
+
+Java SDK IT 必须：
+
+- 使用 JUnit 5 和 Failsafe；
+- 避免 `@SpringBootTest`、`SpringExtension`，也不要在测试类中启动 Nacos；
+- 读取 `nacos.host` 和 `nacos.port`，默认 `127.0.0.1:8848`；
+- 通过公开 factory 创建真实 SDK 客户端；
+- 生成隔离的资源名称；
+- 清理创建的 config、naming、AI 或 lock 资源；
+- 即使断言失败，也要关闭每个 SDK 实例；
+- 对异步服务端效果使用有界重试。
+
+## 6. 场景文档
+
+每个 SDK IT 类都必须包含简洁的 `Scenario coverage` Javadoc；当矩阵较大时，
+应更新 `test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md`。文档必须说明验证了什么，
+以及为什么有分支被有意跳过。
+
+## 7. 验证
+
+Java SDK IT 变更需要运行：
+
+- `mvn -pl test/java-sdk-test spotless:check`
+- `mvn -pl test/java-sdk-test -DskipTests test-compile`
+
+当单机 Nacos 服务可用时，应运行相关 Failsafe 选择，或执行
+`mvn -pl test/java-sdk-test -Pintegration-test -DskipTests=false verify`。

--- a/test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md
+++ b/test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md
@@ -25,6 +25,10 @@ The detailed scenario matrix lives in
 the current IT has representative coverage but must not be treated as complete
 SDK API scenario coverage.
 
+Java SDK ITs run only with the dedicated Maven profile
+`java-sdk-integration-test`. The generic `integration-test` profile belongs to
+HTTP API IT CI and should build this module without executing SDK IT cases.
+
 ## Client SDK
 
 | SDK interface | IT class | Status | Scenario coverage | Known gaps |

--- a/test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md
+++ b/test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md
@@ -1,0 +1,44 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Java SDK IT Coverage Registry
+
+This registry records which public Java SDK interfaces are covered by
+`test/java-sdk-test` integration tests and the scenario groups each class
+verifies.
+
+The detailed scenario matrix lives in
+[`JAVA_SDK_IT_SCENARIOS.md`](JAVA_SDK_IT_SCENARIOS.md). A `Partial` status means
+the current IT has representative coverage but must not be treated as complete
+SDK API scenario coverage.
+
+## Client SDK
+
+| SDK interface | IT class | Status | Scenario coverage | Known gaps |
+| --- | --- | --- | --- | --- |
+| `ConfigService` | `ConfigServiceJavaSdkITCase` | Partial | Verifies factory creation, publish/query/getConfigWithResult/CAS/remove lifecycle, missing-result shape, missing/idempotent removal, standalone `addListener`, listener removal behavior, client-side invalid parameter handling, invalid type handling, missing config behavior, and shutdown cleanup. | Config filter, fuzzy watch, invalid listener input, timeout behavior, and additional valid config types remain. |
+| `NamingService` | `NamingServiceJavaSdkITCase` | Partial | Verifies factory creation, explicit/default group registration, string and `Instance` overloads, batch register and partial batch deregister, query/select/list/deregister lifecycle, cluster and metadata behavior, disabled/zero-weight filtering, subscribe callback delivery, subscribe state, null listener no-op, unsubscribe-stop behavior, validation for blank service, null instance, invalid cluster, invalid heartbeat metadata, persistent batch member, mismatched group prefix, missing service empty result, no-healthy selection failure, and shutdown cleanup. | Duplicate and missing deregister behavior, IP/port boundaries, explicit unhealthy selection, selector/fuzzy watch, empty batch-list behavior, and remaining pagination boundaries remain. |
+| `AiService` / `A2aService` | `AiServiceJavaSdkITCase` | Partial | Verifies factory creation, MCP release/query/subscribe, MCP latest and duplicate-version behavior, MCP endpoint register/deregister with returned detail state, A2A agent card release/query/subscribe, A2A latest-version and service endpoint registration scenarios, current-value listener callbacks, missing-resource nullable subscribe/load shapes, missing skill download controlled exception, SDK validation for MCP/A2A/Prompt/Skill/AgentSpec required parameters, endpoint validation, batch endpoint version mismatch, and shutdown cleanup. | Direct MCP endpoint-spec release, all-version MCP endpoint behavior, A2A duplicate-version idempotency, A2A batch endpoint overwrite, functional Prompt/Skill/AgentSpec resource scenarios, and unsubscribe-stop callback behavior remain. |
+| `LockService` | `LockServiceJavaSdkITCase` | Covered | Verifies factory creation, distributed lock acquire/compete/release/reacquire lifecycle, repeated release boundary, expiration-based reacquire, unsupported lock type and missing key error mapping, null lock-instance SDK boundary, direct `remoteTryLock`/`remoteReleaseLock`, and shutdown cleanup. | No known public `LockService` scenario gap in the standalone Java SDK IT. |
+
+## Pending SDK Surfaces
+
+The following SDK surfaces are documented by
+`specs/*/testing/java-sdk-integration-test-spec.md` and should be added in
+later batches:
+
+- deprecated `NamingMaintainService`
+- maintainer-client SDK interfaces

--- a/test/java-sdk-test/JAVA_SDK_IT_SCENARIOS.md
+++ b/test/java-sdk-test/JAVA_SDK_IT_SCENARIOS.md
@@ -1,0 +1,105 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Java SDK IT Scenario Matrix
+
+This document records Java SDK integration-test scenario coverage. The goal is
+SDK API scenario coverage, not line coverage, branch coverage, or a small demo
+per service interface.
+
+## Status Legend
+
+| Status | Meaning |
+| --- | --- |
+| Covered | The current IT verifies the expected behavior and its important result shape. |
+| Partial | The current IT verifies representative behavior, but important public SDK scenarios remain. |
+| Pending | No IT currently verifies this public SDK scenario. |
+| Documented gap | The scenario is not practical in the standalone Java SDK IT yet; the reason must be recorded. |
+
+An SDK API is not complete while important method parameters, defaulting rules,
+return variants, lifecycle paths, listener behavior, or exception mappings are
+left as `Partial` or `Pending` without a documented reason.
+
+## ConfigService
+
+| Public SDK surface | Required scenarios | Current status | Current / missing coverage |
+| --- | --- | --- | --- |
+| Factory, server status, shutdown | Create via `ConfigFactory`, wait for `UP`, and close cleanly after each test. | Covered | `JavaSdkBaseITCase` creates and shuts down the client. |
+| `getConfig` | Existing config, missing config, invalid identity, default group behavior, and timeout path where practical. | Partial | Existing and missing config, blank dataId, invalid group, and default group are covered. Timeout remains. |
+| `getConfigWithResult` | Existing config returns content and md5; missing config returns the documented result shape. | Covered | Existing content/md5 and missing-result empty shape are covered. |
+| `publishConfig` overloads | Default type, explicit valid type, invalid type, empty or invalid content, group defaulting, and durable server state. | Partial | Default publish, explicit `TEXT`, invalid type, missing content, invalid group, and blank group are covered. Other valid types remain. |
+| `publishConfigCas` overloads | Bad md5 rejection, correct md5 update, missing config CAS, empty CAS md5, explicit type, and unchanged state after failed CAS. | Covered | Bad md5, correct md5, missing config CAS, empty CAS md5 as normal publish, explicit type, and unchanged state after failed CAS are covered. |
+| `removeConfig` | Existing config removal, missing config/idempotent behavior, invalid identity, and absence after removal. | Covered | Existing removal, missing/idempotent removal, invalid identity, and absence after removal are covered. |
+| `addListener`, `getConfigAndSignListener`, `removeListener` | Initial value, later update callback, standalone `addListener`, removal stops callbacks, invalid listener input. | Partial | `getConfigAndSignListener`, standalone `addListener`, update callback, and remove-listener stop behavior are covered. Invalid listener input remains. |
+| `addConfigFilter` | Filter registration effect or explicit standalone limitation. | Pending | No current scenario. Need decide whether a real filter can be observed through public SDK only. |
+| Fuzzy watch APIs | Fixed group pattern, dataId+group pattern, matched key return, event callback, cancel behavior, invalid pattern/listener. | Pending | No current scenario. |
+
+## NamingService
+
+| Public SDK surface | Required scenarios | Current status | Current / missing coverage |
+| --- | --- | --- | --- |
+| Factory, server status, shutdown | Create via `NamingFactory`, wait for `UP`, and close cleanly after each test. | Covered | `JavaSdkBaseITCase` creates and shuts down the client. |
+| `registerInstance` overloads | Default group, explicit group, cluster, `Instance` metadata, string overloads, duplicate registration, invalid IP/port/cluster/service, and persistent/ephemeral behavior where exposed. | Partial | Explicit group, default group, string overload, cluster, metadata, blank service, null instance, invalid cluster, invalid heartbeat metadata, persistent batch member, and mismatched group prefix are covered. Duplicate registration and IP/port boundaries remain. |
+| `batchRegisterInstance` / `batchDeregisterInstance` | Batch success, partial or invalid member validation, empty list, and cleanup after batch deregister. | Partial | Batch success, partial batch deregister, cleanup, and invalid persistent batch member are covered. Empty-list and null-list behavior remain. |
+| `deregisterInstance` overloads | Existing instance removal, missing instance/idempotent behavior, default group, cluster overload, and invalid identity. | Partial | Existing removal through `Instance` overload, default string overload removal, and cluster removal are covered. Missing-instance/idempotent behavior remains. |
+| `getAllInstances` overloads | Existing, missing service empty result, default group, explicit group, cluster filters, subscribe flag, and empty cluster list behavior. | Partial | Existing query, missing service, default group, explicit group, cluster filter, subscribe=false, and empty cluster list behavior are covered. subscribe=true/cache behavior remains. |
+| `selectInstances` overloads | Healthy-only filtering, unhealthy/disabled boundaries, cluster filters, subscribe flag, and missing-service empty result. | Partial | Healthy selection, disabled filtering, zero-weight filtering, cluster filters, subscribe=false, and missing-service empty result are covered. Explicit unhealthy selection remains. |
+| `selectOneHealthyInstance` overloads | Success, cluster selection, default group, subscribe flag, and controlled failure when no healthy instance exists. | Covered | Success, cluster/default-group/subscribe overloads, and missing/no-healthy `IllegalStateException` behavior are covered. |
+| `subscribe` / `unsubscribe` overloads | Initial and update event, cluster/selector filtering, removal stops callbacks, invalid listener, and `getSubscribeServices` state. | Partial | Basic grouped subscribe event, `getSubscribeServices`, null listener no-op, unsubscribe-stop behavior, and cleanup are covered. Cluster/selector listener overloads remain. |
+| Fuzzy watch APIs | Fixed group pattern, service+group pattern, matched service keys, event callback, cancel behavior, invalid pattern/listener. | Pending | No current scenario. |
+| `getServicesOfServer` overloads | Pagination, default group, explicit group, selector overload, empty pages, and invalid page boundary. | Partial | Default and explicit group pages containing registered services are covered. Empty pages, invalid page boundary, and selector scenarios remain. |
+
+## AiService And A2aService
+
+| Public SDK surface | Required scenarios | Current status | Current / missing coverage |
+| --- | --- | --- | --- |
+| Factory and shutdown | Create via `AiFactory` and close cleanly after each test. | Covered | `JavaSdkBaseITCase` creates and shuts down the client. |
+| MCP release/query | New MCP, new version, duplicate version idempotency, latest-version lookup, explicit-version lookup, tool/resource/endpoint variants, invalid specification, and missing MCP behavior. | Partial | New MCP with tool/resource specs, new version, duplicate version idempotency, latest-version lookup, explicit-version query, invalid specification, and missing MCP get behavior are covered. Direct endpoint-spec release variant remains. |
+| MCP endpoint register/deregister | Register all-version or versioned endpoint, verify returned detail/endpoint state, deregister own endpoint, invalid address/port/version, and missing MCP. | Partial | Versioned endpoint register/deregister, returned detail state, and invalid address/port are covered. All-version endpoint and missing MCP endpoint behavior remain. |
+| MCP subscribe/unsubscribe | Current-value callback, versioned/latest subscription, not-found nullable result, invalid listener, and unsubscribe stops callbacks. | Partial | Versioned current-value callback, missing nullable subscribe result, unsubscribe cleanup, and invalid listener are covered. Unsubscribe-stop callback behavior remains. |
+| A2A agent card release/query | New card, new version, duplicate version idempotency, `setAsLatest`, URL vs service registration type, default latest query, explicit version query, invalid card, and missing card behavior. | Partial | New card, new versions, default latest query, explicit version query, `setAsLatest`, URL and service registration type query, invalid card, and missing nullable subscribe behavior are covered. Duplicate-version idempotency remains. |
+| A2A endpoint register/deregister | Single endpoint, batch endpoint overwrite, transport/path/TLS boundaries, own-client deregister behavior, invalid endpoint, and missing agent. | Partial | Single endpoint register/deregister, service registration type query, invalid endpoint, empty batch, and mismatched endpoint versions are covered. Batch overwrite and missing agent remain. |
+| A2A subscribe/unsubscribe | Current-value callback, latest/versioned subscription, not-found nullable result, invalid listener, and unsubscribe stops callbacks. | Partial | Versioned current-value callback, missing nullable subscribe result, unsubscribe cleanup, and invalid listener are covered. Unsubscribe-stop callback behavior remains. |
+| Prompt APIs | Get by latest/version/label, subscribe/unsubscribe, missing prompt behavior, invalid key/label/listener, and label/version selection. | Partial | Missing prompt nullable subscribe, invalid key/label/listener, and unsubscribe cleanup are covered. Functional prompt resource scenarios and label/version selection remain. |
+| Skill APIs | Download by latest/version/label, subscribe/unsubscribe, missing skill behavior, invalid name/listener, and ZIP byte contract. | Partial | Missing skill nullable subscribe, missing download controlled exception, invalid name/listener, and unsubscribe cleanup are covered. Functional ZIP contract and version/label download remain. |
+| AgentSpec APIs | Load, subscribe/unsubscribe, missing AgentSpec behavior, invalid name/listener, and assembled resource contract. | Partial | Missing load and subscribe nullable shapes, invalid name/listener, and unsubscribe cleanup are covered. Functional assembled resource contract remains. |
+
+## LockService
+
+| Public SDK surface | Required scenarios | Current status | Current / missing coverage |
+| --- | --- | --- | --- |
+| Factory and shutdown | Create via `NacosLockFactory` and close cleanly after each test. | Covered | `JavaSdkBaseITCase` creates and shuts down the client. |
+| `lock` / `unLock` | Acquire, competing client rejection, release, reacquire, repeated release, invalid type, null or invalid fields, and expiration behavior. | Covered | Acquire/compete/release/reacquire/repeated release, unsupported type, missing key, null instance, and expiration are covered. |
+| `remoteTryLock` / `remoteReleaseLock` | Direct remote acquire/release path, repeated release, invalid input, and consistency with public `lock`/`unLock`. | Covered | Direct remote acquire/release, repeated acquire/release, and consistency with public lock behavior are covered. |
+
+## Later SDK Surfaces
+
+| Public SDK surface | Required scenarios | Current status | Notes |
+| --- | --- | --- | --- |
+| Deprecated `NamingMaintainService` | Create/query/update/delete service and update instance if the deprecated client can still be created in the standalone IT. | Pending | Listed separately because the API is deprecated after 3.3.0. |
+| Maintainer client SDK interfaces | Maintainer API behavior, authorization assumptions, validation, and controlled errors. | Pending | Needs a separate batch because it uses a different artifact and service model. |
+
+## Recommended Next Test Batches
+
+1. Config and Naming watcher expansion: config filter, invalid listener, selector
+   subscription, duplicate/missing deregister behavior, invalid IP/port, and
+   explicit unhealthy selection.
+2. AI functional expansion: direct MCP endpoint-spec release, all-version MCP
+   endpoints, A2A batch endpoint overwrite, duplicate A2A version behavior, and
+   functional Prompt/Skill/AgentSpec resource creation or explicit standalone
+   limitations.
+3. Fuzzy watch expansion for Config and Naming once the standalone server path
+   and event timing are proven stable.

--- a/test/java-sdk-test/JAVA_SDK_IT_SCENARIOS.md
+++ b/test/java-sdk-test/JAVA_SDK_IT_SCENARIOS.md
@@ -20,6 +20,11 @@ This document records Java SDK integration-test scenario coverage. The goal is
 SDK API scenario coverage, not line coverage, branch coverage, or a small demo
 per service interface.
 
+Run these scenarios with the dedicated Maven profile
+`java-sdk-integration-test` after a standalone Nacos server is ready. The
+generic `integration-test` profile is for HTTP API IT and must not be used to
+execute SDK IT cases implicitly.
+
 ## Status Legend
 
 | Status | Meaning |

--- a/test/java-sdk-test/pom.xml
+++ b/test/java-sdk-test/pom.xml
@@ -37,7 +37,7 @@
     
     <profiles>
         <profile>
-            <id>integration-test</id>
+            <id>java-sdk-integration-test</id>
             <build>
                 <plugins>
                     <plugin>

--- a/test/java-sdk-test/pom.xml
+++ b/test/java-sdk-test/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 1999-2026 Alibaba Group Holding Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.nacos</groupId>
+        <artifactId>nacos-test</artifactId>
+        <version>${revision}</version>
+    </parent>
+    
+    <artifactId>java-sdk-test</artifactId>
+    <name>nacos-java-sdk-test ${project.version}</name>
+    <url>https://nacos.io</url>
+    
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    
+    <profiles>
+        <profile>
+            <id>integration-test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven-failsafe-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <nacos.host>127.0.0.1</nacos.host>
+                                <nacos.port>8848</nacos.port>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/JavaSdkBaseITCase.java
+++ b/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/JavaSdkBaseITCase.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.sdk;
+
+import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.AiFactory;
+import com.alibaba.nacos.api.ai.AiService;
+import com.alibaba.nacos.api.config.ConfigFactory;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.lock.LockService;
+import com.alibaba.nacos.api.lock.NacosLockFactory;
+import com.alibaba.nacos.api.naming.NamingFactory;
+import com.alibaba.nacos.api.naming.NamingService;
+import org.junit.jupiter.api.AfterEach;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Shared standalone-server Java SDK integration test infrastructure.
+ *
+ * @author xiweng.yy
+ */
+public abstract class JavaSdkBaseITCase {
+    
+    protected static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
+    
+    protected static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
+    
+    protected static final String SERVER_ADDR = NACOS_HOST + ":" + NACOS_PORT;
+    
+    protected static final int DEFAULT_TIMEOUT_MS = 3000;
+    
+    private static final String SDK_STATUS_UP = "UP";
+    
+    private final Deque<CleanupAction> cleanupActions = new ArrayDeque<>();
+    
+    private final Deque<CleanupAction> shutdownActions = new ArrayDeque<>();
+    
+    @AfterEach
+    public void tearDownJavaSdkBase() throws Exception {
+        Exception failure = runActions(cleanupActions, null);
+        failure = runActions(shutdownActions, failure);
+        if (null != failure) {
+            throw failure;
+        }
+    }
+    
+    protected ConfigService createConfigService() throws Exception {
+        ConfigService service = ConfigFactory.createConfigService(sdkProperties());
+        shutdownActions.addFirst(service::shutDown);
+        waitUntil("config SDK client should connect to server",
+                () -> SDK_STATUS_UP.equals(service.getServerStatus()));
+        return service;
+    }
+    
+    protected NamingService createNamingService() throws Exception {
+        NamingService service = NamingFactory.createNamingService(sdkProperties());
+        shutdownActions.addFirst(service::shutDown);
+        waitUntil("naming SDK client should connect to server",
+                () -> SDK_STATUS_UP.equals(service.getServerStatus()));
+        return service;
+    }
+    
+    protected AiService createAiService() throws NacosException {
+        AiService service = AiFactory.createAiService(sdkProperties());
+        shutdownActions.addFirst(service::shutdown);
+        return service;
+    }
+    
+    protected LockService createLockService() throws NacosException {
+        LockService service = NacosLockFactory.createLockService(sdkProperties());
+        shutdownActions.addFirst(service::shutdown);
+        return service;
+    }
+    
+    protected Properties sdkProperties() {
+        Properties properties = new Properties();
+        properties.setProperty(PropertyKeyConst.SERVER_ADDR, SERVER_ADDR);
+        return properties;
+    }
+    
+    protected void addCleanup(CleanupAction cleanupAction) {
+        cleanupActions.addFirst(cleanupAction);
+    }
+    
+    protected String randomDataId(String scenario) {
+        return "java-sdk-it-" + scenario + "-" + randomSuffix() + ".data";
+    }
+    
+    protected String randomGroup(String scenario) {
+        return "JAVA_SDK_IT_" + scenario.toUpperCase(Locale.ROOT) + "_"
+                + randomSuffix().toUpperCase(Locale.ROOT);
+    }
+    
+    protected String randomServiceName(String scenario) {
+        return "java-sdk-it-" + scenario + "-" + randomSuffix();
+    }
+    
+    protected int randomPort() {
+        return 10000 + Math.abs(UUID.randomUUID().hashCode() % 30000);
+    }
+    
+    protected void waitUntil(String reason, CheckedCondition condition) throws Exception {
+        long deadline = System.currentTimeMillis() + 10000;
+        Throwable lastFailure = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                if (condition.evaluate()) {
+                    return;
+                }
+            } catch (Throwable throwable) {
+                lastFailure = throwable;
+            }
+            Thread.sleep(500);
+        }
+        if (null == lastFailure) {
+            fail(reason);
+        }
+        fail(reason + ", last failure: " + lastFailure.getMessage(), lastFailure);
+    }
+    
+    private String randomSuffix() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+    
+    private Exception runActions(Deque<CleanupAction> actions, Exception failure) {
+        Exception result = failure;
+        while (!actions.isEmpty()) {
+            try {
+                actions.removeFirst().run();
+            } catch (Exception exception) {
+                if (null == result && !isCleanupIgnorable(exception)) {
+                    result = exception;
+                } else if (null != result) {
+                    result.addSuppressed(exception);
+                }
+            }
+        }
+        return result;
+    }
+    
+    private boolean isCleanupIgnorable(Exception exception) {
+        if (!(exception instanceof NacosException)) {
+            return false;
+        }
+        NacosException nacosException = (NacosException) exception;
+        return NacosException.NOT_FOUND == nacosException.getErrCode()
+                || NacosException.RESOURCE_NOT_FOUND == nacosException.getErrCode();
+    }
+    
+    @FunctionalInterface
+    protected interface CleanupAction {
+        
+        void run() throws Exception;
+    }
+    
+    @FunctionalInterface
+    protected interface CheckedCondition {
+        
+        boolean evaluate() throws Exception;
+    }
+}

--- a/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/ai/AiServiceJavaSdkITCase.java
+++ b/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/ai/AiServiceJavaSdkITCase.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.sdk.ai;
+
+import com.alibaba.nacos.api.ai.AiService;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosAgentCardListener;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosAgentSpecListener;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosMcpServerListener;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosPromptListener;
+import com.alibaba.nacos.api.ai.listener.AbstractNacosSkillListener;
+import com.alibaba.nacos.api.ai.listener.NacosAgentCardEvent;
+import com.alibaba.nacos.api.ai.listener.NacosAgentSpecEvent;
+import com.alibaba.nacos.api.ai.listener.NacosMcpServerEvent;
+import com.alibaba.nacos.api.ai.listener.NacosPromptEvent;
+import com.alibaba.nacos.api.ai.listener.NacosSkillEvent;
+import com.alibaba.nacos.api.ai.model.NacosAiConfigKeyCodec;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCapabilities;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCard;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCardDetailInfo;
+import com.alibaba.nacos.api.ai.model.a2a.AgentEndpoint;
+import com.alibaba.nacos.api.ai.model.a2a.AgentInterface;
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
+import com.alibaba.nacos.api.ai.model.mcp.McpEndpointInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpResourceSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerBasicInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
+import com.alibaba.nacos.api.ai.model.mcp.McpTool;
+import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
+import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.test.sdk.JavaSdkBaseITCase;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for Java SDK {@link AiService} and inherited A2A APIs.
+ *
+ * <p>The full scenario matrix and remaining gaps are recorded in
+ * {@code test/java-sdk-test/JAVA_SDK_IT_SCENARIOS.md}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: release/query MCP server and A2A agent card through the
+ *     public Java SDK factory, including current-value subscription callbacks, latest-version
+ *     lookup, duplicate release behavior, and endpoint registration APIs.</li>
+ *     <li>Boundary/validation: missing MCP, A2A, Prompt, Skill, AgentSpec, endpoint, and
+ *     listener parameters throw controlled {@link NacosException} values; missing subscribed
+ *     resources return nullable SDK shapes where the SDK defines them.</li>
+ *     <li>Error handling: unsupported registration data, mismatched endpoint versions, missing
+ *     labels, and missing downloadable resources are rejected by SDK validation or controlled
+ *     SDK exceptions before becoming uncontrolled remote failures.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class AiServiceJavaSdkITCase extends JavaSdkBaseITCase {
+    
+    private static final String A2A_AGENT_GROUP = "agent";
+    
+    private static final String A2A_AGENT_VERSION_GROUP = "agent-version";
+    
+    private static final String MCP_SERVER_GROUP = "mcp-server";
+    
+    private static final String MCP_SERVER_VERSIONS_GROUP = "mcp-server-versions";
+    
+    private static final String MCP_SERVER_TOOL_GROUP = "mcp-tools";
+    
+    private static final String MCP_SERVER_RESOURCE_GROUP = "mcp-resources";
+    
+    private static final String LOCALHOST = "127.0.0.1";
+    
+    @Test
+    public void testReleaseQueryAndSubscribeMcpServer() throws Exception {
+        AiService aiService = createAiService();
+        ConfigService configService = createConfigService();
+        String mcpName = randomServiceName("mcp");
+        String version = "1.0.0";
+        
+        String mcpId = aiService.releaseMcpServer(buildMcpServer(mcpName, version),
+                buildMcpToolSpecification(mcpName), buildMcpResourceSpecification(mcpName));
+        addCleanup(() -> cleanupMcpServer(configService, mcpId, version));
+        
+        McpServerDetailInfo detail = aiService.getMcpServer(mcpName, version);
+        assertEquals(mcpId, detail.getId(), detail.toString());
+        assertEquals(mcpName, detail.getName(), detail.toString());
+        assertEquals(version, detail.getVersionDetail().getVersion(), detail.toString());
+        assertNotNull(detail.getToolSpec(), detail.toString());
+        assertNotNull(detail.getResourceSpec(), detail.toString());
+        
+        AtomicReference<McpServerDetailInfo> callback = new AtomicReference<>();
+        AbstractNacosMcpServerListener listener = new AbstractNacosMcpServerListener() {
+            @Override
+            public void onEvent(NacosMcpServerEvent event) {
+                callback.set(event.getMcpServerDetailInfo());
+            }
+        };
+        addCleanup(() -> aiService.unsubscribeMcpServer(mcpName, version, listener));
+        McpServerDetailInfo subscribed = aiService.subscribeMcpServer(mcpName, version, listener);
+        assertEquals(mcpId, subscribed.getId(), subscribed.toString());
+        assertNotNull(callback.get(), "subscribe should invoke listener with current MCP detail");
+        assertEquals(mcpId, callback.get().getId(), callback.get().toString());
+    }
+    
+    @Test
+    public void testMcpServerLatestDuplicateAndEndpointScenarios() throws Exception {
+        AiService aiService = createAiService();
+        ConfigService configService = createConfigService();
+        String mcpName = randomServiceName("mcp-version");
+        String firstVersion = "1.0.0";
+        String secondVersion = "2.0.0";
+        int endpointPort = randomPort();
+        
+        String mcpId = aiService.releaseMcpServer(buildMcpServer(mcpName, firstVersion),
+                buildMcpToolSpecification(mcpName), buildMcpResourceSpecification(mcpName));
+        addCleanup(() -> cleanupMcpServer(configService, mcpId, firstVersion));
+        assertEquals(mcpId, aiService.releaseMcpServer(buildMcpServer(mcpName, firstVersion),
+                buildMcpToolSpecification(mcpName), buildMcpResourceSpecification(mcpName)));
+        
+        String secondReleaseId = aiService.releaseMcpServer(buildMcpServer(mcpName, secondVersion),
+                buildMcpToolSpecification(mcpName), buildMcpResourceSpecification(mcpName));
+        addCleanup(() -> cleanupMcpServer(configService, mcpId, secondVersion));
+        assertEquals(mcpId, secondReleaseId);
+        
+        McpServerDetailInfo latest = aiService.getMcpServer(mcpName);
+        assertEquals(secondVersion, latest.getVersionDetail().getVersion(), latest.toString());
+        assertTrue(containsMcpVersion(latest, firstVersion), latest.toString());
+        assertTrue(containsMcpVersion(latest, secondVersion), latest.toString());
+        
+        addCleanup(() -> aiService.deregisterMcpServerEndpoint(mcpName, LOCALHOST, endpointPort));
+        aiService.registerMcpServerEndpoint(mcpName, LOCALHOST, endpointPort, secondVersion);
+        waitUntil("registered MCP endpoint should appear in queried detail",
+                () -> containsMcpEndpoint(aiService.getMcpServer(mcpName, secondVersion),
+                        endpointPort));
+        
+        aiService.deregisterMcpServerEndpoint(mcpName, LOCALHOST, endpointPort);
+        waitUntil("deregistered MCP endpoint should disappear from queried detail",
+                () -> !containsMcpEndpoint(aiService.getMcpServer(mcpName, secondVersion),
+                        endpointPort));
+    }
+    
+    @Test
+    public void testMissingMcpSubscriptionReturnsNullableShape() throws Exception {
+        AiService aiService = createAiService();
+        String missingName = randomServiceName("missing-mcp");
+        AbstractNacosMcpServerListener listener = new AbstractNacosMcpServerListener() {
+            @Override
+            public void onEvent(NacosMcpServerEvent event) {
+            }
+        };
+        addCleanup(() -> aiService.unsubscribeMcpServer(missingName, listener));
+        
+        assertNull(aiService.subscribeMcpServer(missingName, listener));
+        NacosException missing = assertThrows(NacosException.class,
+                () -> aiService.getMcpServer(missingName));
+        assertEquals(NacosException.NOT_FOUND, missing.getErrCode(), missing.toString());
+    }
+    
+    @Test
+    public void testReleaseQueryAndSubscribeAgentCard() throws Exception {
+        AiService aiService = createAiService();
+        ConfigService configService = createConfigService();
+        String agentName = randomServiceName("agent");
+        String version = "1.0.0";
+        
+        aiService.releaseAgentCard(buildAgentCard(agentName, version),
+                AiConstants.A2a.A2A_ENDPOINT_TYPE_URL, true);
+        addCleanup(() -> cleanupAgentCard(configService, agentName, version));
+        
+        AgentCardDetailInfo detail = aiService.getAgentCard(agentName, version,
+                AiConstants.A2a.A2A_ENDPOINT_TYPE_URL);
+        assertEquals(agentName, detail.getName(), detail.toString());
+        assertEquals(version, detail.getVersion(), detail.toString());
+        assertEquals(AiConstants.A2a.A2A_ENDPOINT_TYPE_URL, detail.getRegistrationType(),
+                detail.toString());
+        assertTrue(detail.isLatestVersion(), detail.toString());
+        
+        AtomicReference<AgentCardDetailInfo> callback = new AtomicReference<>();
+        AbstractNacosAgentCardListener listener = new AbstractNacosAgentCardListener() {
+            @Override
+            public void onEvent(NacosAgentCardEvent event) {
+                callback.set(event.getAgentCard());
+            }
+        };
+        addCleanup(() -> aiService.unsubscribeAgentCard(agentName, version, listener));
+        AgentCardDetailInfo subscribed = aiService.subscribeAgentCard(agentName, version, listener);
+        assertEquals(agentName, subscribed.getName(), subscribed.toString());
+        assertNotNull(callback.get(), "subscribe should invoke listener with current agent card");
+        assertEquals(agentName, callback.get().getName(), callback.get().toString());
+    }
+    
+    @Test
+    public void testAgentCardLatestVersionAndEndpointScenarios() throws Exception {
+        AiService aiService = createAiService();
+        ConfigService configService = createConfigService();
+        String agentName = randomServiceName("agent-version");
+        String firstVersion = "1.0.0";
+        String secondVersion = "2.0.0";
+        String thirdVersion = "3.0.0";
+        
+        aiService.releaseAgentCard(buildAgentCard(agentName, firstVersion),
+                AiConstants.A2a.A2A_ENDPOINT_TYPE_URL, true);
+        addCleanup(() -> cleanupAgentCard(configService, agentName, firstVersion));
+        aiService.releaseAgentCard(buildAgentCard(agentName, secondVersion),
+                AiConstants.A2a.A2A_ENDPOINT_TYPE_URL, false);
+        addCleanup(() -> cleanupAgentCard(configService, agentName, secondVersion));
+        assertEquals(firstVersion, aiService.getAgentCard(agentName).getVersion());
+        assertEquals(secondVersion, aiService.getAgentCard(agentName, secondVersion).getVersion());
+        assertTrue(!aiService.getAgentCard(agentName, secondVersion).isLatestVersion(),
+                aiService.getAgentCard(agentName, secondVersion).toString());
+        
+        aiService.releaseAgentCard(buildAgentCard(agentName, thirdVersion),
+                AiConstants.A2a.A2A_ENDPOINT_TYPE_URL, true);
+        addCleanup(() -> cleanupAgentCard(configService, agentName, thirdVersion));
+        assertEquals(thirdVersion, aiService.getAgentCard(agentName).getVersion());
+        
+        AgentEndpoint endpoint = buildAgentEndpoint(thirdVersion);
+        addCleanup(() -> aiService.deregisterAgentEndpoint(agentName, endpoint));
+        aiService.registerAgentEndpoint(agentName, endpoint);
+        AgentCardDetailInfo serviceDetail = aiService.getAgentCard(agentName, thirdVersion,
+                AiConstants.A2a.A2A_ENDPOINT_TYPE_SERVICE);
+        assertEquals(agentName, serviceDetail.getName(), serviceDetail.toString());
+        assertEquals(AiConstants.A2a.A2A_ENDPOINT_TYPE_SERVICE,
+                serviceDetail.getRegistrationType(), serviceDetail.toString());
+        aiService.deregisterAgentEndpoint(agentName, endpoint);
+    }
+    
+    @Test
+    public void testMissingAiSubscriptionResourcesReturnNullableShapes() throws Exception {
+        AiService aiService = createAiService();
+        String agentName = randomServiceName("missing-agent");
+        String promptKey = randomServiceName("missing-prompt");
+        String skillName = randomServiceName("missing-skill");
+        String agentSpecName = randomServiceName("missing-agentspec");
+        AbstractNacosAgentCardListener agentCardListener = new AbstractNacosAgentCardListener() {
+            @Override
+            public void onEvent(NacosAgentCardEvent event) {
+            }
+        };
+        AbstractNacosPromptListener promptListener = new AbstractNacosPromptListener() {
+            @Override
+            public void onEvent(NacosPromptEvent event) {
+            }
+        };
+        AbstractNacosSkillListener skillListener = new AbstractNacosSkillListener() {
+            @Override
+            public void onEvent(NacosSkillEvent event) {
+            }
+        };
+        AbstractNacosAgentSpecListener agentSpecListener = new AbstractNacosAgentSpecListener() {
+            @Override
+            public void onEvent(NacosAgentSpecEvent event) {
+            }
+        };
+        addCleanup(() -> aiService.unsubscribeAgentCard(agentName, agentCardListener));
+        addCleanup(() -> aiService.unsubscribePrompt(promptKey, null, null, promptListener));
+        addCleanup(() -> aiService.unsubscribeSkill(skillName, null, null, skillListener));
+        addCleanup(() -> aiService.unsubscribeAgentSpec(agentSpecName, agentSpecListener));
+        
+        assertNull(aiService.subscribeAgentCard(agentName, agentCardListener));
+        assertNull(aiService.subscribePrompt(promptKey, null, null, promptListener));
+        assertNull(aiService.subscribeSkill(skillName, null, null, skillListener));
+        AgentSpec agentSpec = aiService.loadAgentSpec(agentSpecName);
+        assertNull(agentSpec);
+        assertNull(aiService.subscribeAgentSpec(agentSpecName, agentSpecListener));
+        assertThrows(NacosException.class, () -> aiService.downloadSkillZip(skillName));
+    }
+    
+    @Test
+    public void testInvalidAiParametersThrowNacosException() throws Exception {
+        AiService aiService = createAiService();
+        String name = randomServiceName("invalid-ai");
+        
+        assertInvalidParam(() -> aiService.getMcpServer(""));
+        assertInvalidParam(() -> aiService.releaseMcpServer(null, new McpToolSpecification()));
+        assertInvalidParam(() -> aiService.releaseMcpServer(new McpServerBasicInfo(),
+                new McpToolSpecification()));
+        assertInvalidParam(() -> aiService.subscribeMcpServer(name, null));
+        
+        assertInvalidParam(() -> aiService.getAgentCard(""));
+        assertInvalidParam(() -> aiService.releaseAgentCard(null));
+        assertInvalidParam(() -> aiService.releaseAgentCard(buildInvalidAgentCard(name)));
+        assertInvalidParam(() -> aiService.registerAgentEndpoint("", buildAgentEndpoint()));
+        assertInvalidParam(() -> aiService.registerAgentEndpoint(name, new AgentEndpoint()));
+        assertInvalidParam(() -> aiService.subscribeAgentCard(name, null));
+        assertInvalidParam(() -> aiService.registerAgentEndpoint(name, Collections.emptyList()));
+        assertInvalidParam(() -> aiService.registerAgentEndpoint(name,
+                Arrays.asList(buildAgentEndpoint("1.0.0"), buildAgentEndpoint("2.0.0"))));
+        assertInvalidParam(() -> aiService.registerMcpServerEndpoint(name, "", randomPort()));
+        assertInvalidParam(() -> aiService.registerMcpServerEndpoint(name, LOCALHOST, -1));
+        
+        assertInvalidParam(() -> aiService.getPrompt(""));
+        assertInvalidParam(() -> aiService.getPromptByLabel(name, ""));
+        assertInvalidParam(() -> aiService.subscribePrompt(name, null, null, null));
+        
+        assertInvalidParam(() -> aiService.downloadSkillZip(""));
+        assertInvalidParam(() -> aiService.subscribeSkill(name, null, null, null));
+        
+        assertInvalidParam(() -> aiService.loadAgentSpec(""));
+        assertInvalidParam(() -> aiService.subscribeAgentSpec(name, null));
+    }
+    
+    private void assertInvalidParam(CheckedRunnable runnable) {
+        NacosException exception = assertThrows(NacosException.class, runnable::run);
+        assertEquals(NacosException.INVALID_PARAM, exception.getErrCode(), exception.toString());
+    }
+    
+    private McpServerBasicInfo buildMcpServer(String mcpName, String version) {
+        McpServerBasicInfo result = new McpServerBasicInfo();
+        result.setName(mcpName);
+        result.setProtocol(AiConstants.Mcp.MCP_PROTOCOL_STDIO);
+        result.setDescription("Java SDK IT MCP server");
+        result.setVersion(version);
+        ServerVersionDetail versionDetail = new ServerVersionDetail();
+        versionDetail.setVersion(version);
+        result.setVersionDetail(versionDetail);
+        return result;
+    }
+    
+    private McpToolSpecification buildMcpToolSpecification(String mcpName) {
+        McpTool tool = new McpTool();
+        tool.setName("tool_" + mcpName.replace('-', '_'));
+        tool.setDescription("Echo text for Java SDK IT");
+        tool.setInputSchema(Collections.singletonMap("type", "object"));
+        McpToolSpecification result = new McpToolSpecification();
+        result.setTools(Collections.singletonList(tool));
+        return result;
+    }
+    
+    private McpResourceSpecification buildMcpResourceSpecification(String mcpName) {
+        LinkedHashMap<String, Object> resource = new LinkedHashMap<>();
+        resource.put("name", "resource_" + mcpName.replace('-', '_'));
+        resource.put("uri", "file:///tmp/" + mcpName + ".txt");
+        resource.put("description", "Java SDK IT resource");
+        resource.put("mimeType", "text/plain");
+        McpResourceSpecification result = new McpResourceSpecification();
+        result.setResources(Collections.singletonList(resource));
+        return result;
+    }
+    
+    private AgentCard buildAgentCard(String agentName, String version) {
+        AgentInterface jsonRpc = new AgentInterface();
+        jsonRpc.setUrl("https://example.com/" + agentName + "/jsonrpc");
+        jsonRpc.setProtocolBinding(AiConstants.A2a.A2A_ENDPOINT_DEFAULT_TRANSPORT);
+        jsonRpc.setProtocolVersion("1.0");
+        
+        AgentCapabilities capabilities = new AgentCapabilities();
+        capabilities.setStreaming(true);
+        capabilities.setExtendedAgentCard(true);
+        
+        AgentCard result = new AgentCard();
+        result.setName(agentName);
+        result.setVersion(version);
+        result.setDescription("Java SDK IT agent");
+        result.setSupportedInterfaces(Collections.singletonList(jsonRpc));
+        result.setCapabilities(capabilities);
+        return result;
+    }
+    
+    private AgentCard buildInvalidAgentCard(String agentName) {
+        AgentCard result = new AgentCard();
+        result.setName(agentName);
+        result.setVersion("1.0.0");
+        return result;
+    }
+    
+    private AgentEndpoint buildAgentEndpoint() {
+        return buildAgentEndpoint("1.0.0");
+    }
+    
+    private AgentEndpoint buildAgentEndpoint(String version) {
+        AgentEndpoint result = new AgentEndpoint();
+        result.setVersion(version);
+        result.setAddress(LOCALHOST);
+        result.setPort(randomPort());
+        result.setTransport(AiConstants.A2a.A2A_ENDPOINT_DEFAULT_TRANSPORT);
+        result.setPath("/a2a");
+        return result;
+    }
+    
+    private boolean containsMcpVersion(McpServerDetailInfo detail, String version) {
+        List<ServerVersionDetail> versions = detail.getAllVersions();
+        return null != versions && versions.stream()
+                .anyMatch(each -> version.equals(each.getVersion()));
+    }
+    
+    private boolean containsMcpEndpoint(McpServerDetailInfo detail, int port) {
+        List<McpEndpointInfo> endpoints = detail.getBackendEndpoints();
+        return null != endpoints && endpoints.stream()
+                .anyMatch(endpoint -> LOCALHOST.equals(endpoint.getAddress())
+                        && port == endpoint.getPort());
+    }
+    
+    private void cleanupMcpServer(ConfigService configService, String mcpId, String version)
+            throws NacosException {
+        configService.removeConfig(mcpId + "-" + version + "-mcp-server.json", MCP_SERVER_GROUP);
+        configService.removeConfig(mcpId + "-mcp-versions.json", MCP_SERVER_VERSIONS_GROUP);
+        configService.removeConfig(mcpId + "-" + version + "-mcp-tools.json",
+                MCP_SERVER_TOOL_GROUP);
+        configService.removeConfig(mcpId + "-" + version + "-mcp-resources.json",
+                MCP_SERVER_RESOURCE_GROUP);
+    }
+    
+    private void cleanupAgentCard(ConfigService configService, String agentName, String version)
+            throws NacosException {
+        String encodedName = NacosAiConfigKeyCodec.encodeSegment(agentName);
+        configService.removeConfig(encodedName + "-" + version, A2A_AGENT_VERSION_GROUP);
+        configService.removeConfig(encodedName, A2A_AGENT_GROUP);
+    }
+    
+    @FunctionalInterface
+    private interface CheckedRunnable {
+        
+        void run() throws Exception;
+    }
+}

--- a/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/config/ConfigServiceJavaSdkITCase.java
+++ b/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/config/ConfigServiceJavaSdkITCase.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.sdk.config;
+
+import com.alibaba.nacos.api.config.ConfigQueryResult;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.config.ConfigType;
+import com.alibaba.nacos.api.config.listener.Listener;
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.test.sdk.JavaSdkBaseITCase;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for Java SDK {@link ConfigService}.
+ *
+ * <p>The full scenario matrix and remaining gaps are recorded in
+ * {@code test/java-sdk-test/JAVA_SDK_IT_SCENARIOS.md}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: publish, query, query-with-result, CAS update, and remove config
+ *     through the public Java SDK factory; standalone listener registration receives later
+ *     changes.</li>
+ *     <li>Boundary/validation: blank group uses the default group, missing config returns
+ *     {@code null}, missing query result has an empty result shape, bad CAS md5 is rejected,
+ *     empty CAS md5 behaves as normal publish, missing removal is idempotent, and missing
+ *     identity/content fields throw {@link NacosException}.</li>
+ *     <li>Error handling: invalid config type is mapped to a failed SDK publish result and does
+ *     not create data.</li>
+ *     <li>Listener/error handling: {@code getConfigAndSignListener} returns the current value,
+ *     delivers later updates, standalone listener receives updates, listener removal stops later
+ *     callbacks, and listener cleanup plus SDK shutdown are safe.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class ConfigServiceJavaSdkITCase extends JavaSdkBaseITCase {
+    
+    @Test
+    public void testPublishQueryCasAndRemoveConfig() throws Exception {
+        ConfigService configService = createConfigService();
+        String dataId = randomDataId("lifecycle");
+        String group = randomGroup("config");
+        String firstContent = "sdk.config.first=true";
+        String secondContent = "sdk.config.second=true";
+        addCleanup(() -> configService.removeConfig(dataId, group));
+        
+        assertTrue(configService.publishConfig(dataId, group, firstContent, ConfigType.TEXT.getType()));
+        assertEquals(firstContent, configService.getConfig(dataId, group, DEFAULT_TIMEOUT_MS));
+        ConfigQueryResult queryResult = configService.getConfigWithResult(dataId, group, DEFAULT_TIMEOUT_MS);
+        assertEquals(firstContent, queryResult.getContent());
+        assertNotNull(queryResult.getMd5(), queryResult.toString());
+        
+        assertFalse(configService.publishConfigCas(dataId, group, "bad-cas-content", "bad-md5",
+                ConfigType.TEXT.getType()));
+        assertEquals(firstContent, configService.getConfig(dataId, group, DEFAULT_TIMEOUT_MS));
+        assertTrue(configService.publishConfigCas(dataId, group, secondContent, queryResult.getMd5(),
+                ConfigType.TEXT.getType()));
+        assertEquals(secondContent, configService.getConfig(dataId, group, DEFAULT_TIMEOUT_MS));
+        
+        assertTrue(configService.removeConfig(dataId, group));
+        waitUntil("removed config should be absent", () -> null == configService.getConfig(dataId, group,
+                DEFAULT_TIMEOUT_MS));
+        assertNull(configService.getConfig(dataId, group, DEFAULT_TIMEOUT_MS));
+    }
+    
+    @Test
+    public void testMissingConfigResultAndRemoveAreEmptyAndIdempotent() throws Exception {
+        ConfigService configService = createConfigService();
+        String dataId = randomDataId("missing-result");
+        String group = randomGroup("config");
+        
+        assertNull(configService.getConfig(dataId, group, DEFAULT_TIMEOUT_MS));
+        ConfigQueryResult queryResult = configService.getConfigWithResult(dataId, group,
+                DEFAULT_TIMEOUT_MS);
+        assertNotNull(queryResult, "missing config should still return a result object");
+        assertNull(queryResult.getContent(), queryResult.toString());
+        assertNull(queryResult.getMd5(), queryResult.toString());
+        assertNull(queryResult.getConfigType(), queryResult.toString());
+        
+        assertTrue(configService.removeConfig(dataId, group),
+                "server-side remove of an absent config is idempotent");
+        assertNull(configService.getConfig(dataId, group, DEFAULT_TIMEOUT_MS));
+    }
+    
+    @Test
+    public void testCasBoundaryForMissingAndEmptyMd5() throws Exception {
+        ConfigService configService = createConfigService();
+        String missingDataId = randomDataId("missing-cas");
+        String emptyMd5DataId = randomDataId("empty-cas");
+        String group = randomGroup("config");
+        addCleanup(() -> configService.removeConfig(missingDataId, group));
+        addCleanup(() -> configService.removeConfig(emptyMd5DataId, group));
+        
+        assertFalse(configService.publishConfigCas(missingDataId, group, "missing.cas",
+                "missing-md5", ConfigType.TEXT.getType()));
+        assertNull(configService.getConfig(missingDataId, group, DEFAULT_TIMEOUT_MS));
+        
+        assertTrue(configService.publishConfigCas(emptyMd5DataId, group, "empty.md5.cas", "",
+                ConfigType.TEXT.getType()));
+        assertEquals("empty.md5.cas", configService.getConfig(emptyMd5DataId, group,
+                DEFAULT_TIMEOUT_MS));
+    }
+    
+    @Test
+    public void testGetConfigAndSignListenerReceivesUpdates() throws Exception {
+        ConfigService configService = createConfigService();
+        String dataId = randomDataId("listener");
+        String group = randomGroup("config");
+        String firstContent = "sdk.listener.first=true";
+        String secondContent = "sdk.listener.second=true";
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<String> received = new AtomicReference<>();
+        Listener listener = new Listener() {
+            @Override
+            public Executor getExecutor() {
+                return null;
+            }
+            
+            @Override
+            public void receiveConfigInfo(String configInfo) {
+                if (secondContent.equals(configInfo)) {
+                    received.set(configInfo);
+                    latch.countDown();
+                }
+            }
+        };
+        addCleanup(() -> configService.removeListener(dataId, group, listener));
+        addCleanup(() -> configService.removeConfig(dataId, group));
+        
+        assertTrue(configService.publishConfig(dataId, group, firstContent));
+        assertEquals(firstContent, configService.getConfigAndSignListener(dataId, group, DEFAULT_TIMEOUT_MS,
+                listener));
+        assertTrue(configService.publishConfig(dataId, group, secondContent));
+        
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "listener should receive updated config");
+        assertEquals(secondContent, received.get());
+    }
+    
+    @Test
+    public void testAddListenerReceivesPublishedUpdate() throws Exception {
+        ConfigService configService = createConfigService();
+        String dataId = randomDataId("add-listener");
+        String group = randomGroup("config");
+        String content = "sdk.listener.add=true";
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<String> received = new AtomicReference<>();
+        Listener listener = listenerForContent(content, latch, received);
+        addCleanup(() -> configService.removeListener(dataId, group, listener));
+        addCleanup(() -> configService.removeConfig(dataId, group));
+        
+        configService.addListener(dataId, group, listener);
+        assertTrue(configService.publishConfig(dataId, group, content));
+        
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "standalone listener should receive update");
+        assertEquals(content, received.get());
+    }
+    
+    @Test
+    public void testRemoveListenerStopsLaterCallbacks() throws Exception {
+        ConfigService configService = createConfigService();
+        String dataId = randomDataId("remove-listener");
+        String group = randomGroup("config");
+        String firstContent = "sdk.listener.before-remove=true";
+        String secondContent = "sdk.listener.after-remove=true";
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<String> received = new AtomicReference<>();
+        Listener listener = listenerForContent(secondContent, latch, received);
+        addCleanup(() -> configService.removeListener(dataId, group, listener));
+        addCleanup(() -> configService.removeConfig(dataId, group));
+        
+        assertTrue(configService.publishConfig(dataId, group, firstContent));
+        configService.addListener(dataId, group, listener);
+        configService.removeListener(dataId, group, listener);
+        assertTrue(configService.publishConfig(dataId, group, secondContent));
+        
+        assertFalse(latch.await(2, TimeUnit.SECONDS),
+                "removed listener should not receive later update");
+        assertNull(received.get());
+        assertEquals(secondContent, configService.getConfig(dataId, group, DEFAULT_TIMEOUT_MS));
+    }
+    
+    @Test
+    public void testConfigValidationAndDefaultGroupBoundary() throws Exception {
+        ConfigService configService = createConfigService();
+        String group = randomGroup("invalid");
+        String defaultGroupDataId = randomDataId("default-group");
+        String invalidTypeDataId = randomDataId("invalid-type");
+        addCleanup(() -> configService.removeConfig(defaultGroupDataId, Constants.DEFAULT_GROUP));
+        addCleanup(() -> configService.removeConfig(invalidTypeDataId, group));
+        
+        NacosException missingDataId = assertThrows(NacosException.class,
+                () -> configService.getConfig("", group, DEFAULT_TIMEOUT_MS));
+        assertEquals(NacosException.CLIENT_INVALID_PARAM, missingDataId.getErrCode(), missingDataId.toString());
+        
+        NacosException missingContent = assertThrows(NacosException.class,
+                () -> configService.publishConfig(randomDataId("invalid"), group, ""));
+        assertEquals(NacosException.CLIENT_INVALID_PARAM, missingContent.getErrCode(), missingContent.toString());
+        
+        NacosException invalidGroup = assertThrows(NacosException.class,
+                () -> configService.getConfig(randomDataId("invalid"), "bad/group", DEFAULT_TIMEOUT_MS));
+        assertEquals(NacosException.CLIENT_INVALID_PARAM, invalidGroup.getErrCode(), invalidGroup.toString());
+        
+        assertTrue(configService.publishConfig(defaultGroupDataId, "", "default.group.boundary"));
+        assertEquals("default.group.boundary", configService.getConfig(defaultGroupDataId,
+                Constants.DEFAULT_GROUP, DEFAULT_TIMEOUT_MS));
+        
+        assertFalse(configService.publishConfig(invalidTypeDataId, group, "content", "bad-type"));
+        assertNull(configService.getConfig(invalidTypeDataId, group, DEFAULT_TIMEOUT_MS));
+    }
+    
+    private Listener listenerForContent(String expectedContent, CountDownLatch latch,
+            AtomicReference<String> received) {
+        return new Listener() {
+            @Override
+            public Executor getExecutor() {
+                return null;
+            }
+            
+            @Override
+            public void receiveConfigInfo(String configInfo) {
+                if (expectedContent.equals(configInfo)) {
+                    received.set(configInfo);
+                    latch.countDown();
+                }
+            }
+        };
+    }
+}

--- a/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/lock/LockServiceJavaSdkITCase.java
+++ b/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/lock/LockServiceJavaSdkITCase.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.sdk.lock;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.lock.LockService;
+import com.alibaba.nacos.api.lock.common.LockConstants;
+import com.alibaba.nacos.api.lock.model.LockInstance;
+import com.alibaba.nacos.test.sdk.JavaSdkBaseITCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for Java SDK {@link LockService}.
+ *
+ * <p>The full scenario matrix and remaining gaps are recorded in
+ * {@code test/java-sdk-test/JAVA_SDK_IT_SCENARIOS.md}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: acquire and release a distributed Nacos mutex lock through the
+ *     public Java SDK factory and through direct remote methods.</li>
+ *     <li>Boundary/validation: a second SDK client cannot acquire the same held lock, release
+ *     clears the lock, released or expired keys can be acquired again, repeated release returns
+ *     false, and null lock instances fail at the SDK boundary.</li>
+ *     <li>Error handling: unsupported lock type is returned as a controlled
+ *     {@link NacosException} instead of an uncontrolled client runtime failure; missing lock key
+ *     is also mapped to a controlled server error.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class LockServiceJavaSdkITCase extends JavaSdkBaseITCase {
+    
+    @Test
+    public void testAcquireCompeteReleaseAndReacquireLock() throws Exception {
+        LockService owner = createLockService();
+        LockService contender = createLockService();
+        LockInstance lock = newLockInstance("lifecycle", LockConstants.NACOS_LOCK_TYPE);
+        addCleanup(() -> owner.unLock(lock));
+        addCleanup(() -> contender.unLock(lock));
+        
+        assertTrue(owner.lock(lock));
+        assertFalse(contender.lock(lock));
+        assertTrue(owner.unLock(lock));
+        assertTrue(contender.lock(lock));
+        assertTrue(contender.unLock(lock));
+        assertFalse(owner.unLock(lock));
+    }
+    
+    @Test
+    public void testDirectRemoteTryLockAndReleaseLock() throws Exception {
+        LockService lockService = createLockService();
+        LockInstance lock = newLockInstance("remote", LockConstants.NACOS_LOCK_TYPE);
+        addCleanup(() -> lockService.remoteReleaseLock(lock));
+        
+        assertTrue(lockService.remoteTryLock(lock));
+        assertFalse(lockService.remoteTryLock(lock));
+        assertTrue(lockService.remoteReleaseLock(lock));
+        assertFalse(lockService.remoteReleaseLock(lock));
+    }
+    
+    @Test
+    public void testExpiredLockCanBeAcquiredByAnotherClient() throws Exception {
+        LockService owner = createLockService();
+        LockService contender = createLockService();
+        LockInstance lock = new LockInstance("java-sdk-it-lock-expire-"
+                + randomServiceName("lock"), 500L, LockConstants.NACOS_LOCK_TYPE);
+        addCleanup(() -> owner.unLock(lock));
+        addCleanup(() -> contender.unLock(lock));
+        
+        assertTrue(owner.lock(lock));
+        assertFalse(contender.lock(lock));
+        waitUntil("expired lock should be acquirable by another client",
+                () -> contender.lock(lock));
+        assertTrue(contender.unLock(lock));
+    }
+    
+    @Test
+    public void testInvalidLockInputThrowsControlledException() throws Exception {
+        LockService lockService = createLockService();
+        LockInstance unsupported = newLockInstance("unsupported-type", "UNKNOWN_LOCK_TYPE");
+        LockInstance missingKey = new LockInstance(null, 30000L, LockConstants.NACOS_LOCK_TYPE);
+        
+        assertThrows(NacosException.class, () -> lockService.lock(unsupported));
+        assertThrows(NacosException.class, () -> lockService.lock(missingKey));
+        assertThrows(NullPointerException.class, () -> lockService.lock(null));
+    }
+    
+    private LockInstance newLockInstance(String scenario, String lockType) {
+        return new LockInstance("java-sdk-it-lock-" + scenario + "-" + randomServiceName("lock"),
+                30000L, lockType);
+    }
+}

--- a/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/naming/NamingServiceJavaSdkITCase.java
+++ b/test/java-sdk-test/src/test/java/com/alibaba/nacos/test/sdk/naming/NamingServiceJavaSdkITCase.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.sdk.naming;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.alibaba.nacos.api.naming.PreservedMetadataKeys;
+import com.alibaba.nacos.api.naming.listener.Event;
+import com.alibaba.nacos.api.naming.listener.EventListener;
+import com.alibaba.nacos.api.naming.listener.NamingEvent;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.ListView;
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.test.sdk.JavaSdkBaseITCase;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for Java SDK {@link NamingService}.
+ *
+ * <p>The full scenario matrix and remaining gaps are recorded in
+ * {@code test/java-sdk-test/JAVA_SDK_IT_SCENARIOS.md}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: register, query, select, list, and deregister instances
+ *     through the public Java SDK factory; default-group overloads and batch registration are
+ *     exercised.</li>
+ *     <li>Boundary/validation: explicit/default group and cluster are honored, missing service
+ *     is empty, disabled or zero-weight instances are filtered from healthy selection, blank
+ *     service name is rejected by the grouped-name utility, and null instance, invalid cluster,
+ *     invalid heartbeat metadata, persistent batch instance, plus mismatched group-prefix inputs
+ *     throw controlled SDK exceptions.</li>
+ *     <li>Listener/error handling: subscribe receives an instance change event, subscribe state
+ *     is visible, null listener subscribe is a no-op, unsubscribe stops later callbacks, and
+ *     deregister cleanup plus SDK shutdown are safe.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class NamingServiceJavaSdkITCase extends JavaSdkBaseITCase {
+    
+    private static final String TEST_IP = "127.0.0.1";
+    
+    @Test
+    public void testRegisterQuerySelectListAndDeregisterInstance() throws Exception {
+        NamingService namingService = createNamingService();
+        String serviceName = randomServiceName("lifecycle");
+        String groupName = randomGroup("naming");
+        String clusterName = "sdk-cluster";
+        int port = randomPort();
+        Instance instance = buildInstance(port, clusterName);
+        addCleanup(() -> namingService.deregisterInstance(serviceName, groupName, instance));
+        
+        namingService.registerInstance(serviceName, groupName, instance);
+        waitUntil("registered instance should be queryable",
+                () -> containsInstance(namingService.getAllInstances(serviceName, groupName, false), port));
+        
+        List<Instance> allInstances = namingService.getAllInstances(serviceName, groupName,
+                Collections.singletonList(clusterName), false);
+        Instance queried = findInstance(allInstances, port);
+        assertEquals(clusterName, queried.getClusterName());
+        assertEquals("java-sdk-test", queried.getMetadata().get("source"));
+        assertTrue(queried.isHealthy(), queried.toString());
+        assertTrue(queried.isEnabled(), queried.toString());
+        
+        assertTrue(containsInstance(namingService.selectInstances(serviceName, groupName, true, false), port));
+        assertEquals(port, namingService.selectOneHealthyInstance(serviceName, groupName, false).getPort());
+        ListView<String> services = namingService.getServicesOfServer(1, 20, groupName);
+        assertTrue(services.getData().contains(serviceName), services.toString());
+        
+        namingService.deregisterInstance(serviceName, groupName, instance);
+        waitUntil("deregistered instance should be absent",
+                () -> !containsInstance(namingService.getAllInstances(serviceName, groupName, false), port));
+        assertFalse(containsInstance(namingService.getAllInstances(serviceName, groupName, false), port));
+    }
+    
+    @Test
+    public void testDefaultGroupStringOverloadsRegisterAndDeregisterInstance() throws Exception {
+        NamingService namingService = createNamingService();
+        String serviceName = randomServiceName("default-group");
+        int port = randomPort();
+        addCleanup(() -> namingService.deregisterInstance(serviceName, TEST_IP, port));
+        
+        namingService.registerInstance(serviceName, TEST_IP, port);
+        waitUntil("default group instance should be queryable",
+                () -> containsInstance(namingService.getAllInstances(serviceName, false), port));
+        
+        assertTrue(containsInstance(namingService.getAllInstances(serviceName, false), port));
+        assertEquals(port, namingService.selectOneHealthyInstance(serviceName, false).getPort());
+        assertTrue(namingService.getServicesOfServer(1, 100).getData().contains(serviceName));
+        
+        namingService.deregisterInstance(serviceName, TEST_IP, port);
+        waitUntil("default group instance should be absent",
+                () -> !containsInstance(namingService.getAllInstances(serviceName, false), port));
+    }
+    
+    @Test
+    public void testBatchRegisterAndPartialBatchDeregisterInstance() throws Exception {
+        NamingService namingService = createNamingService();
+        String serviceName = randomServiceName("batch");
+        String groupName = randomGroup("naming");
+        Instance first = buildInstance(randomPort(), Constants.DEFAULT_CLUSTER_NAME);
+        Instance second = buildInstance(randomPort(), Constants.DEFAULT_CLUSTER_NAME);
+        List<Instance> instances = Arrays.asList(first, second);
+        addCleanup(() -> cleanupBatchInstances(namingService, serviceName, groupName, instances));
+        
+        namingService.batchRegisterInstance(serviceName, groupName, instances);
+        waitUntil("batch registered instances should be queryable",
+                () -> containsInstance(namingService.getAllInstances(serviceName, groupName, false),
+                        first.getPort()) && containsInstance(namingService.getAllInstances(serviceName,
+                        groupName, false), second.getPort()));
+        
+        assertTrue(containsInstance(namingService.getAllInstances(serviceName, groupName, false),
+                first.getPort()));
+        assertTrue(containsInstance(namingService.getAllInstances(serviceName, groupName, false),
+                second.getPort()));
+        
+        namingService.batchDeregisterInstance(serviceName, groupName, Collections.singletonList(first));
+        waitUntil("partial batch deregister should remove only the selected instance", () -> {
+            List<Instance> current = namingService.getAllInstances(serviceName, groupName, false);
+            return !containsInstance(current, first.getPort())
+                    && containsInstance(current, second.getPort());
+        });
+    }
+    
+    @Test
+    public void testHealthySelectionFiltersDisabledAndZeroWeightInstances() throws Exception {
+        NamingService namingService = createNamingService();
+        String serviceName = randomServiceName("selection");
+        String groupName = randomGroup("naming");
+        Instance healthy = buildInstance(randomPort(), Constants.DEFAULT_CLUSTER_NAME);
+        Instance disabled = buildInstance(randomPort(), Constants.DEFAULT_CLUSTER_NAME);
+        disabled.setEnabled(false);
+        Instance zeroWeight = buildInstance(randomPort(), Constants.DEFAULT_CLUSTER_NAME);
+        zeroWeight.setWeight(0D);
+        List<Instance> instances = Arrays.asList(healthy, disabled, zeroWeight);
+        for (Instance instance : instances) {
+            addCleanup(() -> namingService.deregisterInstance(serviceName, groupName, instance));
+        }
+        
+        for (Instance instance : instances) {
+            namingService.registerInstance(serviceName, groupName, instance);
+        }
+        waitUntil("all registered instances should be queryable",
+                () -> containsInstance(namingService.getAllInstances(serviceName, groupName, false),
+                        healthy.getPort()) && containsInstance(namingService.getAllInstances(serviceName,
+                        groupName, false), disabled.getPort()) && containsInstance(namingService
+                        .getAllInstances(serviceName, groupName, false), zeroWeight.getPort()));
+        
+        List<Instance> selected = namingService.selectInstances(serviceName, groupName, true, false);
+        assertTrue(containsInstance(selected, healthy.getPort()), selected.toString());
+        assertFalse(containsInstance(selected, disabled.getPort()), selected.toString());
+        assertFalse(containsInstance(selected, zeroWeight.getPort()), selected.toString());
+    }
+    
+    @Test
+    public void testSubscribeReceivesInstanceChangeEvent() throws Exception {
+        NamingService namingService = createNamingService();
+        String serviceName = randomServiceName("subscribe");
+        String groupName = randomGroup("naming");
+        int port = randomPort();
+        Instance instance = buildInstance(port, Constants.DEFAULT_CLUSTER_NAME);
+        CountDownLatch latch = new CountDownLatch(1);
+        EventListener listener = event -> {
+            if (eventContainsInstance(event, port)) {
+                latch.countDown();
+            }
+        };
+        addCleanup(() -> namingService.unsubscribe(serviceName, groupName, listener));
+        addCleanup(() -> namingService.deregisterInstance(serviceName, groupName, instance));
+        
+        namingService.subscribe(serviceName, groupName, listener);
+        namingService.registerInstance(serviceName, groupName, instance);
+        
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "listener should receive registered instance event");
+        assertTrue(containsSubscribedService(namingService.getSubscribeServices(), serviceName,
+                groupName), namingService.getSubscribeServices().toString());
+    }
+    
+    @Test
+    public void testUnsubscribeStopsLaterInstanceChangeEvents() throws Exception {
+        NamingService namingService = createNamingService();
+        String serviceName = randomServiceName("unsubscribe");
+        String groupName = randomGroup("naming");
+        int port = randomPort();
+        Instance instance = buildInstance(port, Constants.DEFAULT_CLUSTER_NAME);
+        CountDownLatch latch = new CountDownLatch(1);
+        EventListener listener = event -> {
+            if (eventContainsInstance(event, port)) {
+                latch.countDown();
+            }
+        };
+        addCleanup(() -> namingService.unsubscribe(serviceName, groupName, listener));
+        addCleanup(() -> namingService.deregisterInstance(serviceName, groupName, instance));
+        
+        namingService.subscribe(serviceName, groupName, listener);
+        namingService.unsubscribe(serviceName, groupName, listener);
+        namingService.registerInstance(serviceName, groupName, instance);
+        
+        assertFalse(latch.await(2, TimeUnit.SECONDS),
+                "unsubscribed listener should not receive later instance event");
+    }
+    
+    @Test
+    public void testInvalidNamingParametersThrowNacosException() throws Exception {
+        NamingService namingService = createNamingService();
+        String serviceName = randomServiceName("invalid");
+        Instance invalidCluster = buildInstance(randomPort(), "bad_cluster");
+        Instance mismatchedGroup = buildInstance(randomPort(), Constants.DEFAULT_CLUSTER_NAME);
+        mismatchedGroup.setServiceName("OTHER_GROUP@@" + serviceName);
+        Instance invalidHeartbeat = buildInstance(randomPort(), Constants.DEFAULT_CLUSTER_NAME);
+        invalidHeartbeat.addMetadata(PreservedMetadataKeys.HEART_BEAT_INTERVAL, "2000");
+        invalidHeartbeat.addMetadata(PreservedMetadataKeys.HEART_BEAT_TIMEOUT, "1000");
+        Instance persistentBatchInstance = buildInstance(randomPort(), Constants.DEFAULT_CLUSTER_NAME);
+        persistentBatchInstance.setEphemeral(false);
+        
+        assertThrows(IllegalArgumentException.class,
+                () -> namingService.registerInstance("", Constants.DEFAULT_GROUP, buildInstance(randomPort(),
+                        Constants.DEFAULT_CLUSTER_NAME)));
+        
+        NacosException nullInstance = assertThrows(NacosException.class,
+                () -> namingService.registerInstance(serviceName, Constants.DEFAULT_GROUP, null));
+        assertEquals(NacosException.INVALID_PARAM, nullInstance.getErrCode(), nullInstance.toString());
+        
+        NacosException badCluster = assertThrows(NacosException.class,
+                () -> namingService.registerInstance(serviceName, Constants.DEFAULT_GROUP, invalidCluster));
+        assertEquals(NacosException.INVALID_PARAM, badCluster.getErrCode(), badCluster.toString());
+        
+        NacosException wrongGroup = assertThrows(NacosException.class,
+                () -> namingService.registerInstance(serviceName, Constants.DEFAULT_GROUP, mismatchedGroup));
+        assertEquals(NacosException.CLIENT_INVALID_PARAM, wrongGroup.getErrCode(), wrongGroup.toString());
+        
+        NacosException badHeartbeat = assertThrows(NacosException.class,
+                () -> namingService.registerInstance(serviceName, Constants.DEFAULT_GROUP, invalidHeartbeat));
+        assertEquals(NacosException.INVALID_PARAM, badHeartbeat.getErrCode(), badHeartbeat.toString());
+        
+        NacosException badBatchInstance = assertThrows(NacosException.class,
+                () -> namingService.batchRegisterInstance(serviceName, Constants.DEFAULT_GROUP,
+                        Collections.singletonList(persistentBatchInstance)));
+        assertEquals(NacosException.INVALID_PARAM, badBatchInstance.getErrCode(), badBatchInstance.toString());
+        
+        assertTrue(namingService.getAllInstances(randomServiceName("missing"), Constants.DEFAULT_GROUP, false)
+                .isEmpty());
+        assertTrue(namingService.selectInstances(randomServiceName("missing"), Constants.DEFAULT_GROUP,
+                true, false).isEmpty());
+        assertThrows(IllegalStateException.class,
+                () -> namingService.selectOneHealthyInstance(randomServiceName("missing"),
+                        Constants.DEFAULT_GROUP, false));
+        namingService.subscribe(serviceName, Constants.DEFAULT_GROUP, (EventListener) null);
+        namingService.unsubscribe(serviceName, Constants.DEFAULT_GROUP, (EventListener) null);
+    }
+    
+    private Instance buildInstance(int port, String clusterName) {
+        Instance instance = new Instance();
+        instance.setIp(TEST_IP);
+        instance.setPort(port);
+        instance.setClusterName(clusterName);
+        instance.setWeight(2.0D);
+        instance.setHealthy(true);
+        instance.setEnabled(true);
+        instance.addMetadata("source", "java-sdk-test");
+        return instance;
+    }
+    
+    private boolean eventContainsInstance(Event event, int port) {
+        if (!(event instanceof NamingEvent)) {
+            return false;
+        }
+        return containsInstance(((NamingEvent) event).getInstances(), port);
+    }
+    
+    private boolean containsInstance(List<Instance> instances, int port) {
+        return instances.stream().anyMatch(instance -> TEST_IP.equals(instance.getIp()) && port == instance.getPort());
+    }
+    
+    private Instance findInstance(List<Instance> instances, int port) {
+        return instances.stream().filter(instance -> TEST_IP.equals(instance.getIp()) && port == instance.getPort())
+                .findFirst().orElseThrow(() -> new AssertionError("instance not found, port=" + port + ", data="
+                        + instances));
+    }
+    
+    private boolean containsSubscribedService(List<ServiceInfo> services, String serviceName,
+            String groupName) {
+        return services.stream().anyMatch(service -> serviceName.equals(service.getName())
+                && groupName.equals(service.getGroupName()));
+    }
+    
+    private void cleanupBatchInstances(NamingService namingService, String serviceName,
+            String groupName, List<Instance> instances) throws NacosException {
+        try {
+            namingService.batchDeregisterInstance(serviceName, groupName, instances);
+        } catch (NacosException ignored) {
+            for (Instance instance : instances) {
+                try {
+                    namingService.deregisterInstance(serviceName, groupName, instance);
+                } catch (NacosException ignoredAgain) {
+                    // cleanup should tolerate resources that were not registered or were already removed
+                }
+            }
+        }
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -35,6 +35,7 @@
         <module>naming-test</module>
         <module>core-test</module>
         <module>openapi-test</module>
+        <module>java-sdk-test</module>
     </modules>
     
     <dependencies>


### PR DESCRIPTION
## Motivation

Follow issue #14879 and extend the API integration-test approach to Java SDK coverage. The new module records SDK scenario coverage and validates public Java SDK behavior through the standalone IT framework.

## Changes

- Add Java SDK integration-test specs in English and Chinese.
- Add `test/java-sdk-test` as a standalone Java SDK IT module.
- Add shared SDK IT infrastructure and scenario coverage registry/matrix.
- Add Config, Naming, AI/A2A, and Lock Java SDK IT cases covering functional, boundary, listener/subscription, lifecycle, and error scenarios.
- Update AGENTS guidance so SDK API changes handle Java SDK IT impact first.

## Validation

- `mvn -pl test/java-sdk-test spotless:check`
- `mvn -pl test/java-sdk-test -DskipTests test-compile`
- `mvn -pl test/java-sdk-test apache-rat:check`
- `git diff --check`

Full integration verify was not marked as locally passed because the local standalone environment could not bring the SDK gRPC connection on `127.0.0.1:9848` to `UP`.

Assisted-by: Claude Code
