### PR TITLE
[ISSUE #15305] Fix legacy Admin API compatibility spec

### DIFF
--- a/specs/en/http-api/v3-api-surface.md
+++ b/specs/en/http-api/v3-api-surface.md
@@ -104,9 +104,16 @@ Implemented Open API surface:
 
 ## 5. Admin API Implemented Behavior
 
-Admin APIs are operator-oriented and default to `ApiType.ADMIN_API`. Existing docs
-state that v3 Admin API is not compatible with v1/v2 Admin API, and that v1/v2
-Admin API compatibility requires `nacos.core.auth.admin.enabled=true`.
+Admin APIs are operator-oriented and default to `ApiType.ADMIN_API`. The standard
+Nacos 3.x Admin API uses the `/v3/admin/*` path. v1/v2 Admin APIs have been
+removed from the current Nacos main distribution, and new integrations should
+migrate to the v3 Admin API. If v1/v2 Admin APIs are still required during
+migration, use the
+[nacos-api-legacy-adapter](https://github.com/nacos-group/nacos-api-legacy-adapter)
+approach and follow the
+[Compatibility And Deprecation Spec](../design/compatibility-deprecation-spec.md).
+`nacos.core.auth.admin.enabled` only controls whether Admin API authentication is
+enabled; it is not a legacy Admin API compatibility switch.
 
 Current modules:
 

--- a/specs/zh-cn/http-api/v3-api-surface.md
+++ b/specs/zh-cn/http-api/v3-api-surface.md
@@ -102,9 +102,14 @@ V3 HTTP 行为当前由以下代码位置定义：
 
 ## 5. Admin API 已实现行为
 
-Admin API 面向运维人员，默认使用 `ApiType.ADMIN_API`。现有文档说明 v3
-Admin API 不兼容 v1/v2 Admin API；如果必须使用 v1/v2 Admin API 兼容能力，
-需要设置 `nacos.core.auth.admin.enabled=true`。
+Admin API 面向运维人员，默认使用 `ApiType.ADMIN_API`。Nacos 3.x 标准
+Admin API 使用 `/v3/admin/*` 路径。v1/v2 Admin API 已从当前 Nacos 主
+发行包中移除，新接入应迁移到 v3 Admin API；如果迁移期仍需使用 v1/v2
+Admin API，应参考
+[nacos-api-legacy-adapter](https://github.com/nacos-group/nacos-api-legacy-adapter)
+方案和[兼容与废弃策略规范](../design/compatibility-deprecation-spec.md)。
+`nacos.core.auth.admin.enabled` 仅表示是否启用 Admin API 鉴权，不是旧
+Admin API 兼容开关。
 
 当前模块：
 


### PR DESCRIPTION
## Summary
- clarify that Nacos 3.x standard Admin APIs use /v3/admin/*
- state that v1/v2 Admin APIs are removed from the current main distribution
- point migration-period users to nacos-api-legacy-adapter and compatibility/deprecation specs
- keep nacos.core.auth.admin.enabled scoped to Admin API authentication only

## Testing
- Not run; documentation-only change.