### PR TITLE
Add maintainer SDK integration test skeleton

### DIFF
--- a/.github/workflows/it-new.yml
+++ b/.github/workflows/it-new.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   integration-test:
-    name: OpenAPI and Java SDK Integration Test
+    name: OpenAPI, Java SDK and Maintainer SDK Integration Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -81,3 +81,6 @@ jobs:
 
       - name: Run Java SDK IT Tests
         run: mvn -pl test/java-sdk-test clean verify -Pjava-sdk-integration-test -DskipTests=false
+
+      - name: Run Maintainer SDK IT Tests
+        run: mvn -pl test/maintainer-sdk-test clean verify -Pmaintainer-sdk-integration-test -DskipTests=false

--- a/test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md
+++ b/test/java-sdk-test/JAVA_SDK_IT_COVERAGE.md
@@ -45,4 +45,5 @@ The following SDK surfaces are documented by
 later batches:
 
 - deprecated `NamingMaintainService`
-- maintainer-client SDK interfaces
+- maintainer-client SDK interfaces are tracked separately in
+  `test/maintainer-sdk-test`

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
@@ -1,0 +1,48 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Maintainer SDK IT Coverage Registry
+
+This registry records which public maintainer SDK interfaces are covered by
+`test/maintainer-sdk-test` integration tests and the scenario groups each class
+verifies.
+
+The detailed scenario matrix lives in
+[`MAINTAINER_SDK_IT_SCENARIOS.md`](MAINTAINER_SDK_IT_SCENARIOS.md). A `Partial`
+status means the current IT has representative coverage but must not be treated
+as complete maintainer SDK scenario coverage.
+
+Maintainer SDK ITs run only with the dedicated Maven profile
+`maintainer-sdk-integration-test`. The generic `integration-test` profile
+belongs to HTTP API IT CI and should build this module without executing
+maintainer SDK IT cases.
+
+| Maintainer SDK interface | IT class | Status | Scenario coverage | Known gaps |
+| --- | --- | --- | --- | --- |
+| `CoreMaintainerService` | `CoreMaintainerServiceMaintainerSdkITCase` | Partial | Verifies factory creation through `NacosMaintainerFactory`, standalone server liveness, server-state result mapping, default `nacos.host`/`nacos.port` profile wiring, and shutdown cleanup. | Readiness is pending because the maintainer SDK currently calls `/v3/admin/core/ops/readiness` while the server exposes `/v3/admin/core/state/readiness`. Unavailable-server error mapping, auth-enabled behavior, namespace operations, cluster/plugin/loader operations, and wider maintainer SDK surfaces remain pending for later batches. |
+
+## Pending Maintainer SDK Surfaces
+
+- `CoreMaintainerService` namespace, cluster, plugin, and loader operations
+- `ConfigMaintainerService`
+- `BetaConfigMaintainerService`
+- `ConfigHistoryMaintainerService`
+- `ConfigOpsMaintainerService`
+- `NamingMaintainerService`, `ServiceMaintainerService`,
+  `InstanceMaintainerService`, and `NamingClientMaintainerService`
+- `AiMaintainerService`, `McpMaintainerService`, `A2aMaintainerService`,
+  `PromptMaintainerService`, `SkillMaintainerService`,
+  `AgentSpecMaintainerService`, and `PipelineMaintainerService`

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
@@ -1,0 +1,40 @@
+<!--
+  Copyright 1999-2026 Alibaba Group Holding Ltd.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Maintainer SDK IT Scenarios
+
+Status legend: `Covered` means the important public contract is verified,
+`Partial` means representative behavior is verified but important scenarios
+remain, and `Pending` means no IT verifies that surface yet.
+
+| Public maintainer SDK surface | Required scenarios | Current status | Current/missing coverage |
+| --- | --- | --- | --- |
+| `CoreMaintainerService` server state and health probes | Factory creation, standalone server liveness, readiness, server state shape, unavailable-server error mapping, and auth-disabled/admin-surface assumptions. | Partial | Covers factory creation through `NacosMaintainerFactory`, real HTTP liveness, and server-state result mapping against standalone server. Readiness is pending because `ConfigMaintainerService.readiness()` currently targets `/v3/admin/core/ops/readiness` while the server exposes `/v3/admin/core/state/readiness`; unavailable-server and auth-enabled mappings remain pending. |
+| `CoreMaintainerService` namespace operations | Create, query, update, duplicate, delete, absent namespace, default/blank namespace boundaries, and cleanup idempotency. | Pending | No maintainer SDK IT yet. |
+| `CoreMaintainerService` cluster/plugin/loader operations | Read-only cluster/plugin/loader queries, controlled operation boundaries, and dangerous mutation exclusions for shared standalone CI. | Pending | No maintainer SDK IT yet. |
+| `ConfigMaintainerService` config lifecycle | Publish, query, list, metadata update, history query, delete, absent config, required parameter validation, and cleanup idempotency. | Pending | No maintainer SDK IT yet. |
+| `BetaConfigMaintainerService` | Publish/query/delete beta config, required beta IP validation, and normal config compatibility. | Pending | No maintainer SDK IT yet. |
+| `ConfigHistoryMaintainerService` | Config history list/detail/previous lookup across publish/update/delete lifecycle. | Pending | No maintainer SDK IT yet. |
+| `ConfigOpsMaintainerService` | Config listener/client/search diagnostics with stable setup and empty-result behavior. | Pending | No maintainer SDK IT yet. |
+| `NamingMaintainerService` and sub-services | Service/instance/cluster/client/health/ops admin workflows, defaulting, validation, idempotency, and cleanup. | Pending | No maintainer SDK IT yet. |
+| `AiMaintainerService` and delegate services | MCP, A2A, Prompt, Skill, AgentSpec, and Pipeline admin workflows, version behavior, validation, upload/download boundaries, and cleanup. | Pending | No maintainer SDK IT yet. |
+
+## Coverage Summary
+
+Current in-scope maintained surfaces: 9.
+
+- Strict coverage: 0 / 9 = 0.0%
+- Effective coverage: (0 + 1 * 0.5) / 9 = 5.6%

--- a/test/maintainer-sdk-test/pom.xml
+++ b/test/maintainer-sdk-test/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 1999-2026 Alibaba Group Holding Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alibaba.nacos</groupId>
+        <artifactId>nacos-test</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>maintainer-sdk-test</artifactId>
+    <name>nacos-maintainer-sdk-test ${project.version}</name>
+    <url>https://nacos.io</url>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>nacos-maintainer-client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>maintainer-sdk-integration-test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven-failsafe-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <nacos.host>127.0.0.1</nacos.host>
+                                <nacos.port>8848</nacos.port>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/MaintainerSdkBaseITCase.java
+++ b/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/MaintainerSdkBaseITCase.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.maintainer;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.maintainer.client.NacosMaintainerFactory;
+import com.alibaba.nacos.maintainer.client.config.ConfigMaintainerService;
+import org.junit.jupiter.api.AfterEach;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Properties;
+import java.util.UUID;
+
+/**
+ * Shared standalone-server maintainer SDK integration test infrastructure.
+ *
+ * @author xiweng.yy
+ */
+public abstract class MaintainerSdkBaseITCase {
+    
+    protected static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
+    
+    protected static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
+    
+    protected static final String SERVER_ADDR = NACOS_HOST + ":" + NACOS_PORT;
+    
+    private final Deque<CleanupAction> cleanupActions = new ArrayDeque<>();
+    
+    private final Deque<CleanupAction> shutdownActions = new ArrayDeque<>();
+    
+    @AfterEach
+    public void tearDownMaintainerSdkBase() throws Exception {
+        Exception failure = runActions(cleanupActions, null);
+        failure = runActions(shutdownActions, failure);
+        if (null != failure) {
+            throw failure;
+        }
+    }
+    
+    protected ConfigMaintainerService createConfigMaintainerService() throws NacosException {
+        ConfigMaintainerService service =
+                NacosMaintainerFactory.createConfigMaintainerService(maintainerProperties());
+        shutdownActions.addFirst(service::shutdown);
+        return service;
+    }
+    
+    protected Properties maintainerProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("serverAddr", SERVER_ADDR);
+        return properties;
+    }
+    
+    protected void addCleanup(CleanupAction cleanupAction) {
+        cleanupActions.addFirst(cleanupAction);
+    }
+    
+    protected String randomMaintainerName(String scenario) {
+        return "maintainer-sdk-it-" + scenario + "-" + randomSuffix();
+    }
+    
+    private String randomSuffix() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+    
+    private Exception runActions(Deque<CleanupAction> actions, Exception failure) {
+        Exception result = failure;
+        while (!actions.isEmpty()) {
+            try {
+                actions.removeFirst().run();
+            } catch (Exception exception) {
+                if (null == result && !isCleanupIgnorable(exception)) {
+                    result = exception;
+                } else if (null != result) {
+                    result.addSuppressed(exception);
+                }
+            }
+        }
+        return result;
+    }
+    
+    private boolean isCleanupIgnorable(Exception exception) {
+        if (!(exception instanceof NacosException)) {
+            return false;
+        }
+        NacosException nacosException = (NacosException) exception;
+        return NacosException.NOT_FOUND == nacosException.getErrCode()
+                || NacosException.RESOURCE_NOT_FOUND == nacosException.getErrCode();
+    }
+    
+    @FunctionalInterface
+    protected interface CleanupAction {
+        
+        void run() throws Exception;
+    }
+}

--- a/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/core/CoreMaintainerServiceMaintainerSdkITCase.java
+++ b/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/core/CoreMaintainerServiceMaintainerSdkITCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.maintainer.core;
+
+import com.alibaba.nacos.maintainer.client.config.ConfigMaintainerService;
+import com.alibaba.nacos.maintainer.client.core.CoreMaintainerService;
+import com.alibaba.nacos.test.maintainer.MaintainerSdkBaseITCase;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for {@link CoreMaintainerService}.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: maintainer SDK factory can create a client and
+ *     query liveness/server-state through a running standalone Nacos server.</li>
+ *     <li>Boundary/validation: profile wiring resolves the default
+ *     {@code nacos.host}/{@code nacos.port} server address.</li>
+ *     <li>Error handling: detailed readiness and unavailable-server mappings
+ *     are documented as pending scenarios for later batches.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+class CoreMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase {
+    
+    @Test
+    void shouldQueryStandaloneServerState() throws Exception {
+        ConfigMaintainerService maintainerService = createConfigMaintainerService();
+        
+        assertTrue(maintainerService.liveness());
+        Map<String, String> serverState = maintainerService.getServerState();
+        assertNotNull(serverState);
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -33,5 +33,6 @@
     <modules>
         <module>openapi-test</module>
         <module>java-sdk-test</module>
+        <module>maintainer-sdk-test</module>
     </modules>
 </project>


### PR DESCRIPTION
## Summary
- add a dedicated test/maintainer-sdk-test module for maintainer SDK integration tests
- add a first CoreMaintainerService smoke IT against a standalone Nacos server
- wire the maintainer SDK IT profile into the integration-test workflow and document the scenario matrix

## Verification
- mvn -pl test/maintainer-sdk-test spotless:check
- mvn -pl test/maintainer-sdk-test -am -DskipTests test-compile
- mvn -pl test/maintainer-sdk-test verify -Pmaintainer-sdk-integration-test -DskipTests=false