### PR TITLE
[ISSUE #15032] Fix TCP health-check channel leak and member IP prefix match

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
@@ -36,7 +36,6 @@ import com.alibaba.nacos.common.notify.listener.Subscriber;
 import com.alibaba.nacos.common.utils.ConcurrentHashSet;
 import com.alibaba.nacos.common.utils.ExceptionUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
-import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.utils.VersionUtils;
 import com.alibaba.nacos.core.ability.ServerAbilityInitializer;
 import com.alibaba.nacos.core.ability.ServerAbilityInitializerHolder;
@@ -293,9 +292,12 @@ public class ServerMemberManager implements NacosMemberManager {
             return true;
         }
         
-        // If only IP information is passed in, a fuzzy match is required
-        for (Map.Entry<String, Member> entry : serverList.entrySet()) {
-            if (StringUtils.contains(entry.getKey(), address)) {
+        // If only the IP is passed in (without port), match members by IP exactly.
+        // Comparing the member IP avoids IPv4 prefix collisions (e.g. "192.168.1.10"
+        // wrongly matching "192.168.1.100:8848") as well as IPv6 parsing pitfalls from
+        // naive ":" splitting (e.g. "[::1]:8848").
+        for (Member member : serverList.values()) {
+            if (address.equals(member.getIp())) {
                 result = true;
                 break;
             }

--- a/core/src/test/java/com/alibaba/nacos/core/cluster/ServerMemberManagerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/cluster/ServerMemberManagerTest.java
@@ -164,6 +164,39 @@ class ServerMemberManagerTest {
     }
     
     @Test
+    void testHasMemberShouldNotMatchIpPrefixOrSubstring() {
+        // serverList contains the member "1.1.1.1:8848".
+        assertTrue(serverMemberManager.hasMember("1.1.1.1"));
+        assertTrue(serverMemberManager.hasMember("1.1.1.1:8848"));
+        // None of the following are members; the previous substring match wrongly
+        // returned true for all of them.
+        assertFalse(serverMemberManager.hasMember("1.1.1"));
+        assertFalse(serverMemberManager.hasMember("1.1.1.1:88"));
+        assertFalse(serverMemberManager.hasMember("8848"));
+    }
+    
+    @Test
+    void testHasMemberIpv4PrefixCollision() {
+        Member member =
+            Member.builder().ip("192.168.1.100").port(8848).state(NodeState.UP).build();
+        assertTrue(serverMemberManager.memberJoin(Collections.singletonList(member)));
+        assertTrue(serverMemberManager.hasMember("192.168.1.100"));
+        assertTrue(serverMemberManager.hasMember("192.168.1.100:8848"));
+        // "192.168.1.10" is a prefix of the member IP but is not a member itself.
+        assertFalse(serverMemberManager.hasMember("192.168.1.10"));
+    }
+    
+    @Test
+    void testHasMemberIpv6() {
+        Member member = Member.builder().ip("[::1]").port(8848).state(NodeState.UP).build();
+        assertTrue(serverMemberManager.memberJoin(Collections.singletonList(member)));
+        // IPv6 lookups must work and must not be broken by naive ":" splitting.
+        assertTrue(serverMemberManager.hasMember(member.getIp()));
+        assertTrue(serverMemberManager.hasMember(member.getAddress()));
+        assertFalse(serverMemberManager.hasMember("[::2]"));
+    }
+    
+    @Test
     void testMemberLeave() {
         Member member = Member.builder().ip("1.1.3.3").port(8848).state(NodeState.DOWN).build();
         boolean joinResult = serverMemberManager.memberJoin(Collections.singletonList(member));

--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/TcpHealthCheckProcessor.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/TcpHealthCheckProcessor.java
@@ -188,6 +188,17 @@ public class TcpHealthCheckProcessor implements HealthCheckProcessorV2, Runnable
                     beat.finishCheck(true, false,
                         System.currentTimeMillis() - beat.getTask().getStartTime(),
                         "tcp:ok+");
+                    // Connections are not reused (keep-alive disabled), so close the
+                    // channel as soon as the check succeeds to avoid leaking the FD.
+                    // Closing failures must not flip the already-successful result, so
+                    // they are swallowed here instead of falling into the catch below.
+                    try {
+                        key.cancel();
+                        channel.close();
+                    } catch (Exception ignore) {
+                        // ignore close failure
+                    }
+                    return;
                 }
                 
                 if (key.isValid() && key.isReadable()) {
@@ -206,6 +217,15 @@ public class TcpHealthCheckProcessor implements HealthCheckProcessorV2, Runnable
                 // unable to connect, possibly port not opened
                 beat.finishCheck(false, true, switchDomain.getTcpHealthParams().getMax(),
                     "tcp:unable2connect:" + e.getMessage());
+                // finishCheck() already removed this beat from keyMap, so the next round
+                // can no longer close this channel; close it here to avoid leaking the FD
+                // on the common connection-refused failure path.
+                try {
+                    key.cancel();
+                    channel.close();
+                } catch (Exception ignore) {
+                    // ignore close failure
+                }
             } catch (Exception e) {
                 beat.finishCheck(false, false, switchDomain.getTcpHealthParams().getMax(),
                     "tcp:error:" + e.getMessage());

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/TcpHealthCheckProcessorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/TcpHealthCheckProcessorTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.v2.processor;
+
+import com.alibaba.nacos.naming.core.v2.metadata.ClusterMetadata;
+import com.alibaba.nacos.naming.core.v2.pojo.HealthCheckInstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.healthcheck.v2.HealthCheckTaskV2;
+import com.alibaba.nacos.naming.misc.SwitchDomain;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Constructor;
+import java.net.InetSocketAddress;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for {@link TcpHealthCheckProcessor} that the SocketChannel is closed on both the
+ * successful connect path and the connection-refused path, preventing file descriptor leaks.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TcpHealthCheckProcessorTest {
+    
+    @Mock
+    private HealthCheckCommonV2 healthCheckCommon;
+    
+    @Mock
+    private SwitchDomain switchDomain;
+    
+    @Mock
+    private SwitchDomain.TcpHealthParams healthParams;
+    
+    @Mock
+    private HealthCheckTaskV2 task;
+    
+    @Mock
+    private Service service;
+    
+    @Mock
+    private ClusterMetadata metadata;
+    
+    @Mock
+    private HealthCheckInstancePublishInfo instance;
+    
+    private TcpHealthCheckProcessor processor;
+    
+    private Selector selector;
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        EnvUtil.setEnvironment(new MockEnvironment());
+        when(switchDomain.getTcpHealthParams()).thenReturn(healthParams);
+        when(healthParams.getMax()).thenReturn(5000);
+        when(task.getStartTime()).thenReturn(System.currentTimeMillis());
+        when(service.getNameSpaceGroupedServiceName()).thenReturn("group@@service");
+        when(instance.getCluster()).thenReturn("cluster");
+        when(instance.getIp()).thenReturn("127.0.0.1");
+        when(instance.getPort()).thenReturn(8848);
+        processor = new TcpHealthCheckProcessor(healthCheckCommon, switchDomain);
+        selector = Selector.open();
+    }
+    
+    @AfterEach
+    void tearDown() throws Exception {
+        if (selector != null && selector.isOpen()) {
+            selector.close();
+        }
+    }
+    
+    @Test
+    void testChannelClosedOnSuccessfulConnect() throws Exception {
+        ServerSocketChannel server = ServerSocketChannel.open();
+        try {
+            server.socket().bind(new InetSocketAddress("127.0.0.1", 0));
+            int port = server.socket().getLocalPort();
+            SocketChannel channel = openAndConnect(port);
+            SelectionKey key = registerAndAwaitConnectable(channel);
+            
+            runPostProcessor(key);
+            
+            assertFalse(channel.isOpen(),
+                "channel should be closed after a successful TCP health check");
+        } finally {
+            server.close();
+        }
+    }
+    
+    @Test
+    void testChannelClosedOnConnectionRefused() throws Exception {
+        int refusedPort = findRefusedPort();
+        SocketChannel channel = openAndConnect(refusedPort);
+        SelectionKey key = registerAndAwaitConnectable(channel);
+        
+        runPostProcessor(key);
+        
+        assertFalse(channel.isOpen(),
+            "channel should be closed after a connection-refused TCP health check");
+    }
+    
+    private SocketChannel openAndConnect(int port) throws Exception {
+        SocketChannel channel = SocketChannel.open();
+        channel.configureBlocking(false);
+        channel.connect(new InetSocketAddress("127.0.0.1", port));
+        return channel;
+    }
+    
+    private SelectionKey registerAndAwaitConnectable(SocketChannel channel) throws Exception {
+        SelectionKey key =
+            channel.register(selector, SelectionKey.OP_CONNECT | SelectionKey.OP_READ);
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            selector.select(200);
+            if (key.isConnectable()) {
+                return key;
+            }
+        }
+        throw new IllegalStateException("channel did not become connectable in time");
+    }
+    
+    private void runPostProcessor(SelectionKey key) throws Exception {
+        key.attach(newBeat());
+        TcpHealthCheckProcessor.PostProcessor postProcessor = processor.new PostProcessor(key);
+        postProcessor.run();
+    }
+    
+    private Object newBeat() throws Exception {
+        Class<?> beatClass = Class.forName(
+            "com.alibaba.nacos.naming.healthcheck.v2.processor.TcpHealthCheckProcessor$Beat");
+        Constructor<?> constructor = beatClass.getDeclaredConstructor(TcpHealthCheckProcessor.class,
+            HealthCheckTaskV2.class, Service.class, ClusterMetadata.class,
+            HealthCheckInstancePublishInfo.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(processor, task, service, metadata, instance);
+    }
+    
+    private int findRefusedPort() throws Exception {
+        ServerSocketChannel tmp = ServerSocketChannel.open();
+        tmp.socket().bind(new InetSocketAddress("127.0.0.1", 0));
+        int port = tmp.socket().getLocalPort();
+        tmp.close();
+        return port;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes #15032. This supersedes the previously closed #14951 and addresses the review feedback left there.

Two cluster bugs are fixed:

**Bug 1 — `ServerMemberManager.hasMember(String)` matches IP by substring.**
The IP-only fallback used `StringUtils.contains(memberKey, address)`, so an IP like `192.168.1.10` wrongly matched a member `192.168.1.100:8848`, producing false-positive membership and split-brain alerts. The fix compares the member IP exactly (`address.equals(member.getIp())`), which is also IPv6-safe because it never splits on `:` (the previous review noted `split(":")[0]` would break `[::1]:8848`).

**Bug 2 — `TcpHealthCheckProcessor` (v2) leaks SocketChannels.**
In `PostProcessor.run()` neither the successful connect path nor the `ConnectException` (connection-refused) path closed the channel. On the failure path `finishCheck()` removes the beat from `keyMap`, so the next round can no longer close the orphaned channel — leaking a file descriptor on every connection-refused health check, which is a very common failure case. The fix cancels the key and closes the channel on both paths, swallowing close failures so they cannot flip an already-successful result.

## Brief changelog

- `ServerMemberManager.hasMember`: exact, IPv6-safe member-IP comparison; remove the now-unused `StringUtils` import.
- `TcpHealthCheckProcessor`: close the channel / cancel the key on the successful connect path and the `ConnectException` path.
- Tests:
  - `ServerMemberManagerTest`: prefix/substring collision regression + IPv6 lookup.
  - new `TcpHealthCheckProcessorTest`: channel is closed on successful connect and on connection-refused, using real loopback sockets and a real `Selector`.

## Verifying this change

- `ServerMemberManagerTest`: 38 tests pass. Reverting the `hasMember` fix makes the prefix/substring tests fail (`expected false but was true`).
- `TcpHealthCheckProcessorTest`: 2 tests pass. Reverting the success-path close makes the success test fail (channel still open).
- `mvn -pl core,naming spotless:check` passes.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (#15032).
* [x] Format the pull request title like `[ISSUE #123] Fix ...`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction.
* [x] Run basic checks (`spotless:check`) and unit tests for the affected modules.
