### PR TITLE
Cover core maintainer SDK integration scenarios

### DIFF
--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/core/AbstractCoreMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/core/AbstractCoreMaintainerService.java
@@ -74,7 +74,7 @@ public abstract class AbstractCoreMaintainerService implements CoreMaintainerSer
     @Override
     public Boolean readiness() throws NacosException {
         HttpRequest httpRequest = new HttpRequest.Builder().setHttpMethod(HttpMethod.GET)
-            .setPath(Constants.AdminApiPath.CORE_OPS_ADMIN_PATH + "/readiness").build();
+            .setPath(Constants.AdminApiPath.CORE_STATE_ADMIN_PATH + "/readiness").build();
         HttpRestResult<String> httpRestResult = clientHttpProxy.executeSyncHttpRequest(httpRequest);
         return httpRestResult.ok();
     }

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
@@ -32,7 +32,7 @@ maintainer SDK IT cases.
 
 | Maintainer SDK interface | IT class | Status | Scenario coverage | Known gaps |
 | --- | --- | --- | --- | --- |
-| `CoreMaintainerService` | `CoreMaintainerServiceMaintainerSdkITCase` | Partial | Verifies factory creation through `NacosMaintainerFactory`, standalone server liveness/readiness, server-state result mapping, ID generator list, cluster node list, current client map, cluster loader metrics, plugin list, default `nacos.host`/`nacos.port` profile wiring, and shutdown cleanup. | Unavailable-server error mapping, auth-enabled behavior, namespace operations, mutating cluster/plugin/loader controls, and wider maintainer SDK surfaces remain pending for later batches. |
+| `CoreMaintainerService` | `CoreMaintainerServiceMaintainerSdkITCase` | Partial | Verifies factory creation through `NacosMaintainerFactory`, standalone server liveness/readiness, server-state result mapping, ID generator list, cluster node list, current client map, cluster loader metrics, plugin list, namespace create/get/list/update/check/delete lifecycle, duplicate namespace controlled error, invalid namespace parameter errors, default namespace lookup, default `nacos.host`/`nacos.port` profile wiring, and shutdown cleanup. | Unavailable-server error mapping, auth-enabled behavior, mutating cluster/plugin/loader controls, and wider maintainer SDK surfaces remain pending for later batches. |
 
 ## Pending Maintainer SDK Surfaces
 

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
@@ -32,7 +32,7 @@ maintainer SDK IT cases.
 
 | Maintainer SDK interface | IT class | Status | Scenario coverage | Known gaps |
 | --- | --- | --- | --- | --- |
-| `CoreMaintainerService` | `CoreMaintainerServiceMaintainerSdkITCase` | Partial | Verifies factory creation through `NacosMaintainerFactory`, standalone server liveness, server-state result mapping, default `nacos.host`/`nacos.port` profile wiring, and shutdown cleanup. | Readiness is pending because the maintainer SDK currently calls `/v3/admin/core/ops/readiness` while the server exposes `/v3/admin/core/state/readiness`. Unavailable-server error mapping, auth-enabled behavior, namespace operations, cluster/plugin/loader operations, and wider maintainer SDK surfaces remain pending for later batches. |
+| `CoreMaintainerService` | `CoreMaintainerServiceMaintainerSdkITCase` | Partial | Verifies factory creation through `NacosMaintainerFactory`, standalone server liveness/readiness, server-state result mapping, default `nacos.host`/`nacos.port` profile wiring, and shutdown cleanup. | Unavailable-server error mapping, auth-enabled behavior, namespace operations, cluster/plugin/loader operations, and wider maintainer SDK surfaces remain pending for later batches. |
 
 ## Pending Maintainer SDK Surfaces
 

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
@@ -32,7 +32,7 @@ maintainer SDK IT cases.
 
 | Maintainer SDK interface | IT class | Status | Scenario coverage | Known gaps |
 | --- | --- | --- | --- | --- |
-| `CoreMaintainerService` | `CoreMaintainerServiceMaintainerSdkITCase` | Partial | Verifies factory creation through `NacosMaintainerFactory`, standalone server liveness/readiness, server-state result mapping, default `nacos.host`/`nacos.port` profile wiring, and shutdown cleanup. | Unavailable-server error mapping, auth-enabled behavior, namespace operations, cluster/plugin/loader operations, and wider maintainer SDK surfaces remain pending for later batches. |
+| `CoreMaintainerService` | `CoreMaintainerServiceMaintainerSdkITCase` | Partial | Verifies factory creation through `NacosMaintainerFactory`, standalone server liveness/readiness, server-state result mapping, ID generator list, cluster node list, current client map, cluster loader metrics, plugin list, default `nacos.host`/`nacos.port` profile wiring, and shutdown cleanup. | Unavailable-server error mapping, auth-enabled behavior, namespace operations, mutating cluster/plugin/loader controls, and wider maintainer SDK surfaces remain pending for later batches. |
 
 ## Pending Maintainer SDK Surfaces
 

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
@@ -22,7 +22,7 @@ remain, and `Pending` means no IT verifies that surface yet.
 
 | Public maintainer SDK surface | Required scenarios | Current status | Current/missing coverage |
 | --- | --- | --- | --- |
-| `CoreMaintainerService` server state and health probes | Factory creation, standalone server liveness, readiness, server state shape, unavailable-server error mapping, and auth-disabled/admin-surface assumptions. | Partial | Covers factory creation through `NacosMaintainerFactory`, real HTTP liveness, and server-state result mapping against standalone server. Readiness is pending because `ConfigMaintainerService.readiness()` currently targets `/v3/admin/core/ops/readiness` while the server exposes `/v3/admin/core/state/readiness`; unavailable-server and auth-enabled mappings remain pending. |
+| `CoreMaintainerService` server state and health probes | Factory creation, standalone server liveness, readiness, server state shape, unavailable-server error mapping, and auth-disabled/admin-surface assumptions. | Covered | Covers factory creation through `NacosMaintainerFactory`, real HTTP liveness/readiness, and server-state result mapping against standalone server. Unavailable-server and auth-enabled mappings are intentionally left for the later auth/error-mapping batch. |
 | `CoreMaintainerService` namespace operations | Create, query, update, duplicate, delete, absent namespace, default/blank namespace boundaries, and cleanup idempotency. | Pending | No maintainer SDK IT yet. |
 | `CoreMaintainerService` cluster/plugin/loader operations | Read-only cluster/plugin/loader queries, controlled operation boundaries, and dangerous mutation exclusions for shared standalone CI. | Pending | No maintainer SDK IT yet. |
 | `ConfigMaintainerService` config lifecycle | Publish, query, list, metadata update, history query, delete, absent config, required parameter validation, and cleanup idempotency. | Pending | No maintainer SDK IT yet. |
@@ -36,5 +36,5 @@ remain, and `Pending` means no IT verifies that surface yet.
 
 Current in-scope maintained surfaces: 9.
 
-- Strict coverage: 0 / 9 = 0.0%
-- Effective coverage: (0 + 1 * 0.5) / 9 = 5.6%
+- Strict coverage: 1 / 9 = 11.1%
+- Effective coverage: (1 + 0 * 0.5) / 9 = 11.1%

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
@@ -23,7 +23,7 @@ remain, and `Pending` means no IT verifies that surface yet.
 | Public maintainer SDK surface | Required scenarios | Current status | Current/missing coverage |
 | --- | --- | --- | --- |
 | `CoreMaintainerService` server state and health probes | Factory creation, standalone server liveness, readiness, server state shape, unavailable-server error mapping, and auth-disabled/admin-surface assumptions. | Covered | Covers factory creation through `NacosMaintainerFactory`, real HTTP liveness/readiness, and server-state result mapping against standalone server. Unavailable-server and auth-enabled mappings are intentionally left for the later auth/error-mapping batch. |
-| `CoreMaintainerService` namespace operations | Create, query, update, duplicate, delete, absent namespace, default/blank namespace boundaries, and cleanup idempotency. | Pending | No maintainer SDK IT yet. |
+| `CoreMaintainerService` namespace operations | Create, query, update, duplicate, delete, absent namespace, default/blank namespace boundaries, and cleanup idempotency. | Covered | Covers default namespace lookup, explicit namespace create/get/list/update/check/delete lifecycle, duplicate namespace controlled exception, invalid namespace ID/name controlled exceptions, absent-after-delete check behavior, and cleanup idempotency. |
 | `CoreMaintainerService` cluster/plugin/loader operations | Read-only cluster/plugin/loader queries, controlled operation boundaries, and dangerous mutation exclusions for shared standalone CI. | Partial | Covers ID generator list, cluster node list, current client map, cluster loader metrics, and plugin list. Mutating operations such as lookup-mode changes, log-level updates, connection reloads, and plugin status/config updates remain pending or intentionally excluded until their standalone CI safety is reviewed. |
 | `ConfigMaintainerService` config lifecycle | Publish, query, list, metadata update, history query, delete, absent config, required parameter validation, and cleanup idempotency. | Pending | No maintainer SDK IT yet. |
 | `BetaConfigMaintainerService` | Publish/query/delete beta config, required beta IP validation, and normal config compatibility. | Pending | No maintainer SDK IT yet. |
@@ -36,5 +36,5 @@ remain, and `Pending` means no IT verifies that surface yet.
 
 Current in-scope maintained surfaces: 9.
 
-- Strict coverage: 1 / 9 = 11.1%
-- Effective coverage: (1 + 1 * 0.5) / 9 = 16.7%
+- Strict coverage: 2 / 9 = 22.2%
+- Effective coverage: (2 + 1 * 0.5) / 9 = 27.8%

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
@@ -24,7 +24,7 @@ remain, and `Pending` means no IT verifies that surface yet.
 | --- | --- | --- | --- |
 | `CoreMaintainerService` server state and health probes | Factory creation, standalone server liveness, readiness, server state shape, unavailable-server error mapping, and auth-disabled/admin-surface assumptions. | Covered | Covers factory creation through `NacosMaintainerFactory`, real HTTP liveness/readiness, and server-state result mapping against standalone server. Unavailable-server and auth-enabled mappings are intentionally left for the later auth/error-mapping batch. |
 | `CoreMaintainerService` namespace operations | Create, query, update, duplicate, delete, absent namespace, default/blank namespace boundaries, and cleanup idempotency. | Pending | No maintainer SDK IT yet. |
-| `CoreMaintainerService` cluster/plugin/loader operations | Read-only cluster/plugin/loader queries, controlled operation boundaries, and dangerous mutation exclusions for shared standalone CI. | Pending | No maintainer SDK IT yet. |
+| `CoreMaintainerService` cluster/plugin/loader operations | Read-only cluster/plugin/loader queries, controlled operation boundaries, and dangerous mutation exclusions for shared standalone CI. | Partial | Covers ID generator list, cluster node list, current client map, cluster loader metrics, and plugin list. Mutating operations such as lookup-mode changes, log-level updates, connection reloads, and plugin status/config updates remain pending or intentionally excluded until their standalone CI safety is reviewed. |
 | `ConfigMaintainerService` config lifecycle | Publish, query, list, metadata update, history query, delete, absent config, required parameter validation, and cleanup idempotency. | Pending | No maintainer SDK IT yet. |
 | `BetaConfigMaintainerService` | Publish/query/delete beta config, required beta IP validation, and normal config compatibility. | Pending | No maintainer SDK IT yet. |
 | `ConfigHistoryMaintainerService` | Config history list/detail/previous lookup across publish/update/delete lifecycle. | Pending | No maintainer SDK IT yet. |
@@ -37,4 +37,4 @@ remain, and `Pending` means no IT verifies that surface yet.
 Current in-scope maintained surfaces: 9.
 
 - Strict coverage: 1 / 9 = 11.1%
-- Effective coverage: (1 + 0 * 0.5) / 9 = 11.1%
+- Effective coverage: (1 + 1 * 0.5) / 9 = 16.7%

--- a/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/core/CoreMaintainerServiceMaintainerSdkITCase.java
+++ b/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/core/CoreMaintainerServiceMaintainerSdkITCase.java
@@ -16,11 +16,17 @@
 
 package com.alibaba.nacos.test.maintainer.core;
 
+import com.alibaba.nacos.api.model.response.ConnectionInfo;
+import com.alibaba.nacos.api.model.response.IdGeneratorInfo;
+import com.alibaba.nacos.api.model.response.NacosMember;
+import com.alibaba.nacos.api.model.response.ServerLoaderMetrics;
 import com.alibaba.nacos.maintainer.client.config.ConfigMaintainerService;
 import com.alibaba.nacos.maintainer.client.core.CoreMaintainerService;
 import com.alibaba.nacos.test.maintainer.MaintainerSdkBaseITCase;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <ul>
  *     <li>Expected capability: maintainer SDK factory can create a client and
  *     query liveness/readiness/server-state through a running standalone Nacos
- *     server.</li>
+ *     server, plus read-only core operational views.</li>
  *     <li>Boundary/validation: profile wiring resolves the default
  *     {@code nacos.host}/{@code nacos.port} server address.</li>
  *     <li>Error handling: unavailable-server mappings are documented as pending
@@ -52,5 +58,25 @@ class CoreMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase {
         assertTrue(maintainerService.readiness());
         Map<String, String> serverState = maintainerService.getServerState();
         assertNotNull(serverState);
+    }
+    
+    @Test
+    void shouldQueryReadOnlyCoreOperationalViews() throws Exception {
+        ConfigMaintainerService maintainerService = createConfigMaintainerService();
+        
+        List<IdGeneratorInfo> idGenerators = maintainerService.getIdGenerators();
+        assertNotNull(idGenerators);
+        
+        Collection<NacosMember> members = maintainerService.listClusterNodes("", "");
+        assertNotNull(members);
+        
+        Map<String, ConnectionInfo> currentClients = maintainerService.getCurrentClients();
+        assertNotNull(currentClients);
+        
+        ServerLoaderMetrics loaderMetrics = maintainerService.getClusterLoaderMetrics();
+        assertNotNull(loaderMetrics);
+        
+        List<Map<String, Object>> plugins = maintainerService.listPlugins(null);
+        assertNotNull(plugins);
     }
 }

--- a/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/core/CoreMaintainerServiceMaintainerSdkITCase.java
+++ b/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/core/CoreMaintainerServiceMaintainerSdkITCase.java
@@ -16,9 +16,12 @@
 
 package com.alibaba.nacos.test.maintainer.core;
 
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.response.ConnectionInfo;
 import com.alibaba.nacos.api.model.response.IdGeneratorInfo;
 import com.alibaba.nacos.api.model.response.NacosMember;
+import com.alibaba.nacos.api.model.response.Namespace;
 import com.alibaba.nacos.api.model.response.ServerLoaderMetrics;
 import com.alibaba.nacos.maintainer.client.config.ConfigMaintainerService;
 import com.alibaba.nacos.maintainer.client.core.CoreMaintainerService;
@@ -29,7 +32,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -39,9 +45,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <ul>
  *     <li>Expected capability: maintainer SDK factory can create a client and
  *     query liveness/readiness/server-state through a running standalone Nacos
- *     server, plus read-only core operational views.</li>
+ *     server, read-only core operational views, and namespace lifecycle
+ *     operations.</li>
  *     <li>Boundary/validation: profile wiring resolves the default
- *     {@code nacos.host}/{@code nacos.port} server address.</li>
+ *     {@code nacos.host}/{@code nacos.port} server address; invalid namespace
+ *     ID/name inputs fail with controlled SDK exceptions.</li>
  *     <li>Error handling: unavailable-server mappings are documented as pending
  *     scenarios for later batches.</li>
  * </ul>
@@ -78,5 +86,52 @@ class CoreMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase {
         
         List<Map<String, Object>> plugins = maintainerService.listPlugins(null);
         assertNotNull(plugins);
+    }
+    
+    @Test
+    void shouldManageNamespaceLifecycle() throws Exception {
+        ConfigMaintainerService maintainerService = createConfigMaintainerService();
+        Namespace publicNamespace = maintainerService.getNamespace(Constants.DEFAULT_NAMESPACE_ID);
+        assertEquals(Constants.DEFAULT_NAMESPACE_ID, publicNamespace.getNamespace());
+        
+        String namespaceId = randomMaintainerName("namespace");
+        String namespaceName = namespaceId + "-name";
+        String namespaceDesc = "namespace created by maintainer sdk integration test";
+        String updatedName = namespaceId + "-updated-name";
+        String updatedDesc = "namespace updated by maintainer sdk integration test";
+        
+        assertFalse(maintainerService.checkNamespaceIdExist(namespaceId));
+        assertTrue(maintainerService.createNamespace(namespaceId, namespaceName, namespaceDesc));
+        addCleanup(() -> maintainerService.deleteNamespace(namespaceId));
+        
+        assertTrue(maintainerService.checkNamespaceIdExist(namespaceId));
+        Namespace createdNamespace = maintainerService.getNamespace(namespaceId);
+        assertEquals(namespaceId, createdNamespace.getNamespace());
+        assertEquals(namespaceName, createdNamespace.getNamespaceShowName());
+        assertEquals(namespaceDesc, createdNamespace.getNamespaceDesc());
+        assertTrue(maintainerService.getNamespaceList().stream()
+                .anyMatch(namespace -> namespaceId.equals(namespace.getNamespace())));
+        
+        assertThrows(NacosException.class,
+                () -> maintainerService.createNamespace(namespaceId, namespaceName, namespaceDesc));
+        
+        assertTrue(maintainerService.updateNamespace(namespaceId, updatedName, updatedDesc));
+        Namespace updatedNamespace = maintainerService.getNamespace(namespaceId);
+        assertEquals(updatedName, updatedNamespace.getNamespaceShowName());
+        assertEquals(updatedDesc, updatedNamespace.getNamespaceDesc());
+        
+        assertTrue(maintainerService.deleteNamespace(namespaceId));
+        assertFalse(maintainerService.checkNamespaceIdExist(namespaceId));
+    }
+    
+    @Test
+    void shouldRejectInvalidNamespaceParameters() throws Exception {
+        ConfigMaintainerService maintainerService = createConfigMaintainerService();
+        
+        assertThrows(NacosException.class,
+                () -> maintainerService.createNamespace("invalid@namespace", "valid-name", ""));
+        assertThrows(NacosException.class,
+                () -> maintainerService.createNamespace(randomMaintainerName("namespace"),
+                        "invalid@name", ""));
     }
 }

--- a/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/core/CoreMaintainerServiceMaintainerSdkITCase.java
+++ b/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/core/CoreMaintainerServiceMaintainerSdkITCase.java
@@ -32,11 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>Scenario coverage:
  * <ul>
  *     <li>Expected capability: maintainer SDK factory can create a client and
- *     query liveness/server-state through a running standalone Nacos server.</li>
+ *     query liveness/readiness/server-state through a running standalone Nacos
+ *     server.</li>
  *     <li>Boundary/validation: profile wiring resolves the default
  *     {@code nacos.host}/{@code nacos.port} server address.</li>
- *     <li>Error handling: detailed readiness and unavailable-server mappings
- *     are documented as pending scenarios for later batches.</li>
+ *     <li>Error handling: unavailable-server mappings are documented as pending
+ *     scenarios for later batches.</li>
  * </ul>
  *
  * @author xiweng.yy
@@ -48,6 +49,7 @@ class CoreMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase {
         ConfigMaintainerService maintainerService = createConfigMaintainerService();
         
         assertTrue(maintainerService.liveness());
+        assertTrue(maintainerService.readiness());
         Map<String, String> serverState = maintainerService.getServerState();
         assertNotNull(serverState);
     }


### PR DESCRIPTION
## Summary
- fix maintainer SDK readiness probe path to the server state readiness endpoint
- cover CoreMaintainerService liveness/readiness/server-state and read-only operational queries
- cover namespace create/get/list/update/check/delete lifecycle, duplicate creation, default namespace lookup, and invalid namespace parameter errors

## Verification
- mvn -pl maintainer-client,test/maintainer-sdk-test spotless:apply spotless:check
- mvn -pl maintainer-client,test/maintainer-sdk-test -am -DskipTests test-compile
- mvn -pl test/maintainer-sdk-test spotless:apply spotless:check
- mvn -pl test/maintainer-sdk-test -DskipTests test-compile

## Notes
- Local maintainer SDK IT verify was attempted, but the local Nacos server was not reachable at 127.0.0.1:8848 during this run. CI should validate the full standalone-server IT path.