### PR TITLE
Add naming maintainer residual IT coverage

### DIFF
--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImpl.java
@@ -210,8 +210,10 @@ public class NacosNamingMaintainerServiceImpl extends AbstractCoreMaintainerServ
             .setPath(Constants.AdminApiPath.NAMING_SERVICE_ADMIN_PATH + "/selector/types").build();
         HttpRestResult<String> httpRestResult =
             getClientHttpProxy().executeSyncHttpRequest(httpRequest);
-        return JacksonUtils.toObj(httpRestResult.getData(), new TypeReference<List<String>>() {
-        });
+        Result<List<String>> result =
+            JacksonUtils.toObj(httpRestResult.getData(), new TypeReference<Result<List<String>>>() {
+            });
+        return result.getData();
     }
     
     @Override
@@ -483,9 +485,11 @@ public class NacosNamingMaintainerServiceImpl extends AbstractCoreMaintainerServ
             .setPath(Constants.AdminApiPath.NAMING_HEALTH_ADMIN_PATH + "/checkers").build();
         HttpRestResult<String> httpRestResult =
             getClientHttpProxy().executeSyncHttpRequest(httpRequest);
-        return JacksonUtils.toObj(httpRestResult.getData(),
-            new TypeReference<Map<String, AbstractHealthChecker>>() {
+        Result<Map<String, AbstractHealthChecker>> result = JacksonUtils.toObj(
+            httpRestResult.getData(),
+            new TypeReference<Result<Map<String, AbstractHealthChecker>>>() {
             });
+        return result.getData();
     }
     
     @Override
@@ -511,8 +515,10 @@ public class NacosNamingMaintainerServiceImpl extends AbstractCoreMaintainerServ
             .setPath(Constants.AdminApiPath.NAMING_CLIENT_ADMIN_PATH + "/list").build();
         HttpRestResult<String> httpRestResult =
             getClientHttpProxy().executeSyncHttpRequest(httpRequest);
-        return JacksonUtils.toObj(httpRestResult.getData(), new TypeReference<List<String>>() {
-        });
+        Result<List<String>> result =
+            JacksonUtils.toObj(httpRestResult.getData(), new TypeReference<Result<List<String>>>() {
+            });
+        return result.getData();
     }
     
     @Override

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImplTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/naming/NacosNamingMaintainerServiceImplTest.java
@@ -255,7 +255,8 @@ public class NacosNamingMaintainerServiceImplTest {
         // Arrange
         List<String> expectedList = Arrays.asList("type1", "type2");
         HttpRestResult<String> mockHttpRestResult = new HttpRestResult<>();
-        mockHttpRestResult.setData(new ObjectMapper().writeValueAsString(expectedList));
+        mockHttpRestResult.setData(
+            new ObjectMapper().writeValueAsString(Result.success(expectedList)));
         
         when(clientHttpProxy.executeSyncHttpRequest(any())).thenReturn(mockHttpRestResult);
         
@@ -264,6 +265,7 @@ public class NacosNamingMaintainerServiceImplTest {
         
         // Assert
         assertNotNull(result);
+        assertEquals(expectedList, result);
         verify(clientHttpProxy, times(1)).executeSyncHttpRequest(any());
     }
     
@@ -652,7 +654,8 @@ public class NacosNamingMaintainerServiceImplTest {
         // Arrange
         Map<String, AbstractHealthChecker> expectedCheckers = new HashMap<>();
         HttpRestResult<String> mockHttpRestResult = new HttpRestResult<>();
-        mockHttpRestResult.setData(new ObjectMapper().writeValueAsString(expectedCheckers));
+        mockHttpRestResult.setData(
+            new ObjectMapper().writeValueAsString(Result.success(expectedCheckers)));
         
         when(clientHttpProxy.executeSyncHttpRequest(any())).thenReturn(mockHttpRestResult);
         
@@ -699,7 +702,8 @@ public class NacosNamingMaintainerServiceImplTest {
         // Arrange
         List<String> expectedList = Arrays.asList("client1", "client2");
         HttpRestResult<String> mockHttpRestResult = new HttpRestResult<>();
-        mockHttpRestResult.setData(new ObjectMapper().writeValueAsString(expectedList));
+        mockHttpRestResult.setData(
+            new ObjectMapper().writeValueAsString(Result.success(expectedList)));
         
         when(clientHttpProxy.executeSyncHttpRequest(any())).thenReturn(mockHttpRestResult);
         
@@ -708,6 +712,7 @@ public class NacosNamingMaintainerServiceImplTest {
         
         // Assert
         assertNotNull(result);
+        assertEquals(expectedList, result);
         verify(clientHttpProxy, times(1)).executeSyncHttpRequest(any());
     }
     

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_COVERAGE.md
@@ -34,7 +34,7 @@ maintainer SDK IT cases.
 | --- | --- | --- | --- | --- |
 | `CoreMaintainerService` | `CoreMaintainerServiceMaintainerSdkITCase` | Partial | Verifies factory creation through `NacosMaintainerFactory`, standalone server liveness/readiness, server-state result mapping, ID generator list, cluster node list, current client map, cluster loader metrics, plugin list, namespace create/get/list/update/check/delete lifecycle, duplicate namespace controlled error, invalid namespace parameter errors, default namespace lookup, default `nacos.host`/`nacos.port` profile wiring, and shutdown cleanup. | Unavailable-server error mapping, auth-enabled behavior, mutating cluster/plugin/loader controls, and wider maintainer SDK surfaces remain pending for later batches. |
 | `ConfigMaintainerService` / `ConfigHistoryMaintainerService` / `BetaConfigMaintainerService` / `ConfigOpsMaintainerService` | `ConfigMaintainerServiceMaintainerSdkITCase` | Partial | Verifies publish/get/list/search/update-metadata/update/delete lifecycle, namespace config list, delete by storage ID, missing config controlled exception, invalid publish parameters, config history list/detail/previous queries across updates, beta publish/query/stop and missing beta IP validation, config listener diagnostics by config and IP, local-cache dump command, config log-level command, default host/port wiring, and cleanup. | Clone/import/export and auth-enabled behavior remain pending for later batches. |
-| `NamingMaintainerService` / `ServiceMaintainerService` / `InstanceMaintainerService` | `NamingMaintainerServiceMaintainerSdkITCase` | Partial | Verifies persistent service create/get/update/list/remove lifecycle, missing service controlled exception, invalid service parameter validation, persistent instance register/list/detail/update/partial-update/batch-metadata-update/batch-metadata-delete/deregister lifecycle, invalid instance parameter validation, subscriber diagnostics, naming metrics/log operations, default host/port wiring, and cleanup. | Cluster health, health-checker queries, selector types, naming client diagnostics, and auth-enabled behavior remain pending for later batches. |
+| `NamingMaintainerService` / `ServiceMaintainerService` / `InstanceMaintainerService` | `NamingMaintainerServiceMaintainerSdkITCase` | Covered | Verifies persistent service create/get/update/list/detail-list/remove lifecycle, missing service controlled exception, invalid service parameter validation, persistent instance register/list/detail/update/partial-update/batch-metadata-update/batch-metadata-delete/deregister lifecycle, invalid instance parameter validation, selector type and health-checker queries, cluster health-checker metadata update, manual persistent instance health status update, naming client list/detail/publisher/subscriber diagnostics, subscriber diagnostics, naming metrics/log operations, default host/port wiring, and cleanup. | Auth-enabled behavior is intentionally deferred because maintainer SDK IT currently runs against auth-disabled standalone Nacos. |
 
 ## Pending Maintainer SDK Surfaces
 
@@ -43,8 +43,6 @@ maintainer SDK IT cases.
 - `BetaConfigMaintainerService`
 - `ConfigHistoryMaintainerService`
 - `ConfigOpsMaintainerService`
-- `NamingMaintainerService` cluster, health-checker, selector, and client
-  diagnostics operations
 - `AiMaintainerService`, `McpMaintainerService`, `A2aMaintainerService`,
   `PromptMaintainerService`, `SkillMaintainerService`,
   `AgentSpecMaintainerService`, and `PipelineMaintainerService`

--- a/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
+++ b/test/maintainer-sdk-test/MAINTAINER_SDK_IT_SCENARIOS.md
@@ -29,12 +29,12 @@ remain, and `Pending` means no IT verifies that surface yet.
 | `BetaConfigMaintainerService` | Publish/query/delete beta config, required beta IP validation, and normal config compatibility. | Covered | Covers required beta IP validation, beta publish/query/stop lifecycle, beta content assertion, and missing-after-stop controlled exception. |
 | `ConfigHistoryMaintainerService` | Config history list/detail/previous lookup across publish/update/delete lifecycle. | Partial | Covers history list/detail/previous lookup after publish and update. Delete-history behavior remains pending to avoid coupling this batch to delete trace timing. |
 | `ConfigOpsMaintainerService` | Config listener/client/search diagnostics with stable setup and empty-result behavior. | Covered | Covers config listener diagnostics by dataId/group/namespace, IP listener diagnostics, local-cache dump command, and config log-level command. |
-| `NamingMaintainerService` and sub-services | Service/instance/cluster/client/health/ops admin workflows, defaulting, validation, idempotency, and cleanup. | Partial | Covers persistent service create/get/update/list/remove lifecycle, missing service controlled exception, invalid service parameter validation, persistent instance register/list/detail/update/partial-update/batch-metadata-update/batch-metadata-delete/deregister lifecycle, invalid instance parameter validation, subscriber diagnostics, naming metrics/log operations, and cleanup. Cluster health, health-checker queries, selector types, naming client diagnostics, and auth-enabled behavior remain pending. |
+| `NamingMaintainerService` and sub-services | Service/instance/cluster/client/health/ops admin workflows, defaulting, validation, idempotency, and cleanup. | Covered | Covers persistent service create/get/update/list/detail-list/remove lifecycle, missing service controlled exception, invalid service parameter validation, persistent instance register/list/detail/update/partial-update/batch-metadata-update/batch-metadata-delete/deregister lifecycle, invalid instance parameter validation, selector type and health-checker queries, cluster health-checker metadata update, manual persistent instance health status update, naming client list/detail/publisher/subscriber diagnostics, subscriber diagnostics, naming metrics/log operations, and cleanup. Auth-enabled behavior is intentionally deferred because standalone maintainer SDK IT does not enable auth. |
 | `AiMaintainerService` and delegate services | MCP, A2A, Prompt, Skill, AgentSpec, and Pipeline admin workflows, version behavior, validation, upload/download boundaries, and cleanup. | Pending | No maintainer SDK IT yet. |
 
 ## Coverage Summary
 
 Current in-scope maintained surfaces: 9.
 
-- Strict coverage: 4 / 9 = 44.4%
-- Effective coverage: (4 + 3 * 0.5) / 9 = 61.1%
+- Strict coverage: 5 / 9 = 55.6%
+- Effective coverage: (5 + 3 * 0.5) / 9 = 72.2%

--- a/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/MaintainerSdkBaseITCase.java
+++ b/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/MaintainerSdkBaseITCase.java
@@ -142,8 +142,10 @@ public abstract class MaintainerSdkBaseITCase {
             return false;
         }
         NacosException nacosException = (NacosException) exception;
+        String message = String.valueOf(nacosException.getMessage()).toLowerCase(Locale.ROOT);
         return NacosException.NOT_FOUND == nacosException.getErrCode()
-                || NacosException.RESOURCE_NOT_FOUND == nacosException.getErrCode();
+                || NacosException.RESOURCE_NOT_FOUND == nacosException.getErrCode()
+                || message.contains("not found") || message.contains("not exist");
     }
     
     @FunctionalInterface

--- a/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/naming/NamingMaintainerServiceMaintainerSdkITCase.java
+++ b/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/naming/NamingMaintainerServiceMaintainerSdkITCase.java
@@ -21,6 +21,12 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.Service;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.AbstractHealthChecker;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClientPublisherInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClientServiceInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClientSubscriberInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClientSummaryInfo;
+import com.alibaba.nacos.api.naming.pojo.maintainer.ClusterInfo;
 import com.alibaba.nacos.api.naming.pojo.maintainer.InstanceMetadataBatchResult;
 import com.alibaba.nacos.api.naming.pojo.maintainer.MetricsInfo;
 import com.alibaba.nacos.api.naming.pojo.maintainer.ServiceDetailInfo;
@@ -52,6 +58,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *     <li>Expected capability: maintainer SDK can register, query, update,
  *     partially update, batch update metadata, and deregister persistent
  *     instances.</li>
+ *     <li>Expected capability: maintainer SDK can query selector types,
+ *     health checkers, service detail pages, cluster metadata, manual
+ *     persistent instance health, and naming client diagnostics.</li>
  *     <li>Boundary/validation: missing service and invalid service/instance
  *     required parameters fail with controlled SDK exceptions.</li>
  * </ul>
@@ -71,6 +80,7 @@ class NamingMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase
                 () -> maintainerService.getServiceDetail(namespaceId, groupName, serviceName));
         assertNotNull(maintainerService.createService(namespaceId, groupName, serviceName, false,
                 0.3F));
+        addCleanup(() -> maintainerService.removeService(namespaceId, groupName, serviceName));
         
         ServiceDetailInfo detail =
                 maintainerService.getServiceDetail(namespaceId, groupName, serviceName);
@@ -95,6 +105,10 @@ class NamingMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase
                 maintainerService.listServices(namespaceId, groupName, serviceName, false, 1, 10);
         assertContainsService(services, groupName, serviceName);
         
+        Page<ServiceDetailInfo> detailedServices =
+                maintainerService.listServicesWithDetail(namespaceId, groupName, serviceName, 1, 10);
+        assertContainsServiceDetail(detailedServices, groupName, serviceName);
+        
         assertNotNull(maintainerService.removeService(namespaceId, groupName, serviceName));
         assertThrows(NacosException.class,
                 () -> maintainerService.getServiceDetail(namespaceId, groupName, serviceName));
@@ -114,6 +128,7 @@ class NamingMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase
         assertNotNull(maintainerService.createService(service));
         addCleanup(() -> maintainerService.removeService(service));
         assertNotNull(maintainerService.registerInstance(service, instance));
+        addCleanup(() -> maintainerService.deregisterInstance(service, instance));
         
         Instance detail = maintainerService.getInstanceDetail(service, instance);
         assertInstance(detail, ip, port, true, true);
@@ -168,6 +183,55 @@ class NamingMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase
     }
     
     @Test
+    void shouldManageClusterAndInstanceHealth() throws Exception {
+        NamingMaintainerService maintainerService = createNamingMaintainerService();
+        String namespaceId = Constants.DEFAULT_NAMESPACE_ID;
+        String groupName = randomGroup("naming");
+        String serviceName = randomMaintainerName("cluster");
+        String ip = "127.0.0.1";
+        int port = randomPort();
+        Service service = service(namespaceId, groupName, serviceName, false);
+        Instance instance = instance(ip, port, false);
+        
+        assertNotNull(maintainerService.createService(service));
+        addCleanup(() -> maintainerService.removeService(service));
+        assertNotNull(maintainerService.registerInstance(service, instance));
+        addCleanup(() -> maintainerService.deregisterInstance(service, instance));
+        
+        ClusterInfo cluster = new ClusterInfo();
+        cluster.setClusterName(Constants.DEFAULT_CLUSTER_NAME);
+        cluster.setHealthChecker(new AbstractHealthChecker.None());
+        cluster.setHealthyCheckPort(port);
+        cluster.setUseInstancePortForCheck(true);
+        cluster.setMetadata(Collections.singletonMap("scenario", "cluster-health"));
+        assertEquals("ok", maintainerService.updateCluster(service, cluster));
+        
+        waitUntil("cluster metadata should be visible", () -> {
+            ServiceDetailInfo detail = maintainerService.getServiceDetail(service);
+            ClusterInfo updatedCluster =
+                    detail.getClusterMap().get(Constants.DEFAULT_CLUSTER_NAME);
+            return null != updatedCluster
+                    && null != updatedCluster.getHealthChecker()
+                    && AbstractHealthChecker.None.TYPE.equals(
+                            updatedCluster.getHealthChecker().getType())
+                    && null != updatedCluster.getMetadata()
+                    && "cluster-health".equals(updatedCluster.getMetadata().get("scenario"));
+        });
+        
+        Instance unhealthy = instance(ip, port, false);
+        unhealthy.setHealthy(false);
+        assertEquals("ok", maintainerService.updateInstanceHealthStatus(service, unhealthy));
+        waitUntil("manual unhealthy status should be visible",
+                () -> !maintainerService.getInstanceDetail(service, instance).isHealthy());
+        
+        Instance healthy = instance(ip, port, false);
+        healthy.setHealthy(true);
+        assertEquals("ok", maintainerService.updateInstanceHealthStatus(service, healthy));
+        waitUntil("manual healthy status should be visible",
+                () -> maintainerService.getInstanceDetail(service, instance).isHealthy());
+    }
+    
+    @Test
     void shouldRejectInvalidNamingParameters() throws Exception {
         NamingMaintainerService maintainerService = createNamingMaintainerService();
         String groupName = randomGroup("naming");
@@ -183,6 +247,72 @@ class NamingMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase
         Instance invalidPort = instance("127.0.0.1", 70000, false);
         assertThrows(NacosException.class, () -> maintainerService.registerInstance(service,
                 invalidPort));
+    }
+    
+    @Test
+    void shouldQueryNamingStaticDiagnostics() throws Exception {
+        NamingMaintainerService maintainerService = createNamingMaintainerService();
+        
+        List<String> selectorTypes = maintainerService.listSelectorTypes();
+        assertNotNull(selectorTypes);
+        assertTrue(selectorTypes.contains("none"));
+        
+        Map<String, AbstractHealthChecker> healthCheckers =
+                maintainerService.getHealthCheckers();
+        assertNotNull(healthCheckers);
+        assertTrue(healthCheckers.containsKey(AbstractHealthChecker.None.TYPE));
+    }
+    
+    @Test
+    void shouldQueryNamingClientDiagnostics() throws Exception {
+        NamingMaintainerService maintainerService = createNamingMaintainerService();
+        String namespaceId = Constants.DEFAULT_NAMESPACE_ID;
+        String groupName = randomGroup("naming");
+        String serviceName = randomMaintainerName("client-diagnostics");
+        String ip = "127.0.0.1";
+        int port = randomPort();
+        Service service = service(namespaceId, groupName, serviceName, false);
+        Instance instance = instance(ip, port, false);
+        
+        assertNotNull(maintainerService.createService(service));
+        addCleanup(() -> maintainerService.removeService(service));
+        assertNotNull(maintainerService.registerInstance(service, instance));
+        addCleanup(() -> maintainerService.deregisterInstance(service, instance));
+        waitUntil("published client should be visible", () -> maintainerService
+                .getPublishedClientList(namespaceId, groupName, serviceName, ip, port).stream()
+                .anyMatch(publisher -> ip.equals(publisher.getIp())
+                        && port == publisher.getPort()));
+        
+        List<ClientPublisherInfo> publishers =
+                maintainerService.getPublishedClientList(namespaceId, groupName, serviceName, ip,
+                        port);
+        assertTrue(publishers.stream().anyMatch(publisher -> ip.equals(publisher.getIp())
+                && port == publisher.getPort()));
+        
+        List<ClientSubscriberInfo> subscribers =
+                maintainerService.getSubscribeClientList(namespaceId, groupName, serviceName, ip,
+                        port);
+        assertNotNull(subscribers);
+        
+        List<String> clientIds = maintainerService.getClientList();
+        assertNotNull(clientIds);
+        String clientId = publishers.stream().map(ClientPublisherInfo::getClientId)
+                .filter(value -> null != value).findFirst().orElseThrow();
+        assertTrue(clientIds.contains(clientId));
+        
+        ClientSummaryInfo clientDetail = maintainerService.getClientDetail(clientId);
+        assertEquals(clientId, clientDetail.getClientId());
+        
+        List<ClientServiceInfo> publishedServices =
+                maintainerService.getPublishedServiceList(clientId);
+        assertTrue(publishedServices.stream()
+                .anyMatch(each -> namespaceId.equals(each.getNamespaceId())
+                        && groupName.equals(each.getGroupName())
+                        && serviceName.equals(each.getServiceName())));
+        
+        List<ClientServiceInfo> subscribeServices =
+                maintainerService.getSubscribeServiceList(clientId);
+        assertNotNull(subscribeServices);
     }
     
     @Test
@@ -244,6 +374,14 @@ class NamingMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase
         assertNotNull(page);
         assertTrue(page.getPageItems().stream()
                 .anyMatch(service -> serviceName.equals(service.getName())
+                        && groupName.equals(service.getGroupName())));
+    }
+    
+    private void assertContainsServiceDetail(Page<ServiceDetailInfo> page, String groupName,
+            String serviceName) {
+        assertNotNull(page);
+        assertTrue(page.getPageItems().stream()
+                .anyMatch(service -> serviceName.equals(service.getServiceName())
                         && groupName.equals(service.getGroupName())));
     }
     


### PR DESCRIPTION
### Summary
- Fix naming maintainer client parsing for selector types, health checkers, and client list Result responses
- Add maintainer SDK Naming residual IT coverage for service detail list, cluster health, static diagnostics, and client diagnostics
- Update maintainer SDK coverage docs

### Validation
- mvn -pl maintainer-client,test/maintainer-sdk-test spotless:check
- mvn -pl maintainer-client -Dtest=NacosNamingMaintainerServiceImplTest test
- mvn -pl test/maintainer-sdk-test -Pmaintainer-sdk-integration-test -DskipTests=false -Dit.test=NamingMaintainerServiceMaintainerSdkITCase verify
- mvn -pl test/maintainer-sdk-test -Pmaintainer-sdk-integration-test -DskipTests=false verify