### PR TITLE
[ISSUE #15322] Sync logback adapter packagingData configuration

### DIFF
--- a/logger-adapter-impl/logback-adapter-12/src/main/resources/nacos-logback12.xml
+++ b/logger-adapter-impl/logback-adapter-12/src/main/resources/nacos-logback12.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<configuration debug="false" scan="false"  packagingData="true">
+<configuration debug="false" scan="false"  packagingData="${nacos.logback.packagingData:-false}">
     <nacosClientProperty scope="context" name="logPath" source="JM.LOG.PATH" defaultValue="${user.home}/logs"/>
     <nacosClientProperty scope="context" name="logRetainCount" source="JM.LOG.RETAIN.COUNT" defaultValue="7"/>
     <nacosClientProperty scope="context" name="logFileSize" source="JM.LOG.FILE.SIZE" defaultValue="10MB"/>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <extra-enforcer-rules.version>1.9.0</extra-enforcer-rules.version>
         
         <!-- dependency version -->
-        <nacos.logback.adapter.version>1.1.4</nacos.logback.adapter.version>
+        <nacos.logback.adapter.version>1.1.5</nacos.logback.adapter.version>
         <spring-boot-dependencies.version>3.5.14</spring-boot-dependencies.version>
         <commons-io.version>2.14.0</commons-io.version>
         <commons-collections.version>3.2.2</commons-collections.version>


### PR DESCRIPTION
## Summary
- Sync logback-adapter-12 packagingData default behavior with nacos-group/logback-adapter#17
- Make packagingData configurable through nacos.logback.packagingData with default false
- Upgrade external logback-adapter dependency version to 1.1.5

## Tests
- mvn -pl logger-adapter-impl/logback-adapter-12 -am spotless:check test
- git diff --check