### PR TITLE
[ISSUE #15321] Feat:Update the disk cache by refreshing asynchronously

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/DiskCache.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/DiskCache.java
@@ -52,6 +52,10 @@ public class DiskCache {
      * @param dir directory
      */
     public static void write(ServiceInfo dom, String dir) {
+        writeWithResult(dom, dir);
+    }
+    
+    static boolean writeWithResult(ServiceInfo dom, String dir) {
         
         try {
             makeSureCacheDirExists(dir);
@@ -72,9 +76,10 @@ public class DiskCache {
             //Use the concurrent API to ensure the consistency.
             ConcurrentDiskUtil.writeFileContent(file, keyContentBuffer.toString(),
                 Charset.defaultCharset().toString());
-            
+            return true;
         } catch (Throwable e) {
             NAMING_LOGGER.error("[NA] failed to write cache for dom:" + dom.getName(), e);
+            return false;
         }
     }
     

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefreshEvent.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefreshEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.naming.cache;
+
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+
+/**
+ * Event for async service info disk cache refresh.
+ *
+ * @author Zhengcy05
+ */
+public class ServiceInfoDiskCacheRefreshEvent {
+    
+    private final String serviceKey;
+    
+    private final ServiceInfo serviceInfo;
+    
+    private final String cacheDir;
+    
+    /**
+     * Create a disk cache refresh event.
+     *
+     * @param serviceKey service key without clusters
+     * @param serviceInfo latest service info snapshot
+     * @param cacheDir disk cache directory
+     */
+    public ServiceInfoDiskCacheRefreshEvent(String serviceKey, ServiceInfo serviceInfo,
+        String cacheDir) {
+        this.serviceKey = serviceKey;
+        this.serviceInfo = serviceInfo;
+        this.cacheDir = cacheDir;
+    }
+    
+    /**
+     * Get service key.
+     *
+     * @return service key
+     */
+    public String getServiceKey() {
+        return serviceKey;
+    }
+    
+    /**
+     * Get service info snapshot.
+     *
+     * @return service info snapshot
+     */
+    public ServiceInfo getServiceInfo() {
+        return serviceInfo;
+    }
+    
+    /**
+     * Get disk cache directory.
+     *
+     * @return disk cache directory
+     */
+    public String getCacheDir() {
+        return cacheDir;
+    }
+}

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefresher.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefresher.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.naming.cache;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.common.executor.NameThreadFactory;
+import com.alibaba.nacos.common.lifecycle.Closeable;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static com.alibaba.nacos.client.utils.LogUtils.NAMING_LOGGER;
+
+/**
+ * Async refresher for service info disk cache.
+ *
+ * @author Zhengcy05
+ */
+public class ServiceInfoDiskCacheRefresher implements Closeable {
+    
+    static final long DEFAULT_FLUSH_INTERVAL_MILLISECONDS = 100L;
+    
+    static final long DEFAULT_SHUTDOWN_TIMEOUT_MILLISECONDS = 3000L;
+    
+    private static final String REFRESHER_THREAD_NAME =
+        "com.alibaba.nacos.client.naming.disk.cache.refresher";
+    
+    private final ConcurrentMap<String, ServiceInfoDiskCacheRefreshEvent> pendingEvents;
+    
+    private final ScheduledThreadPoolExecutor refreshExecutor;
+    
+    private final DiskCacheWriter diskCacheWriter;
+    
+    private final long shutdownTimeoutMilliseconds;
+    
+    /**
+     * Create a disk cache refresher with default flush and shutdown settings.
+     */
+    public ServiceInfoDiskCacheRefresher() {
+        this(DEFAULT_FLUSH_INTERVAL_MILLISECONDS, DEFAULT_SHUTDOWN_TIMEOUT_MILLISECONDS,
+            DiskCache::writeWithResult);
+    }
+    
+    /**
+     * Create a disk cache refresher for tests or custom runtime settings.
+     * This constructor keeps the production constructor simple while allowing deterministic tests.
+     *
+     * @param flushIntervalMilliseconds flush interval in milliseconds
+     * @param shutdownTimeoutMilliseconds shutdown wait timeout in milliseconds
+     * @param diskCacheWriter writer used to persist disk cache
+     */
+    ServiceInfoDiskCacheRefresher(long flushIntervalMilliseconds, long shutdownTimeoutMilliseconds,
+        DiskCacheWriter diskCacheWriter) {
+        this.pendingEvents = new ConcurrentHashMap<>(16);
+        this.refreshExecutor = new ScheduledThreadPoolExecutor(1,
+            new NameThreadFactory(REFRESHER_THREAD_NAME));
+        this.diskCacheWriter = diskCacheWriter;
+        this.shutdownTimeoutMilliseconds = shutdownTimeoutMilliseconds;
+        this.refreshExecutor.scheduleWithFixedDelay(this::safeFlushPendingEvents,
+            flushIntervalMilliseconds, flushIntervalMilliseconds, TimeUnit.MILLISECONDS);
+    }
+    
+    /**
+     * Publish a refresh event and keep only the latest snapshot for the service key.
+     *
+     * @param event refresh event
+     */
+    public void publishEvent(ServiceInfoDiskCacheRefreshEvent event) {
+        pendingEvents.put(event.getServiceKey(), event);
+    }
+    
+    /**
+     * Flush pending refresh events immediately.
+     */
+    void flushNow() {
+        safeFlushPendingEvents();
+    }
+    
+    /**
+     * Get pending refresh event size.
+     *
+     * @return pending refresh event size
+     */
+    int pendingEventSize() {
+        return pendingEvents.size();
+    }
+    
+    /**
+     * Check whether refresher executor has been shutdown.
+     *
+     * @return {@code true} if shutdown, otherwise {@code false}
+     */
+    boolean isShutdown() {
+        return refreshExecutor.isShutdown();
+    }
+    
+    private void safeFlushPendingEvents() {
+        try {
+            flushPendingEvents();
+        } catch (Throwable e) {
+            NAMING_LOGGER.error("[NA] failed to flush service info disk cache refresh event", e);
+        }
+    }
+    
+    private void flushPendingEvents() {
+        for (String serviceKey : pendingEvents.keySet()) {
+            ServiceInfoDiskCacheRefreshEvent event = pendingEvents.get(serviceKey);
+            if (null == event) {
+                continue;
+            }
+            boolean writeResult =
+                diskCacheWriter.write(event.getServiceInfo(), event.getCacheDir());
+            if (writeResult) {
+                pendingEvents.remove(serviceKey, event);
+            }
+        }
+    }
+    
+    /**
+     * Shutdown refresher after flushing pending events.
+     *
+     * @throws NacosException if interrupted during shutdown
+     */
+    @Override
+    public void shutdown() throws NacosException {
+        flushPendingEvents();
+        refreshExecutor.shutdown();
+        try {
+            if (!refreshExecutor.awaitTermination(shutdownTimeoutMilliseconds,
+                TimeUnit.MILLISECONDS)) {
+                NAMING_LOGGER.warn("[NA] timeout while waiting service info disk cache refresher "
+                    + "to shutdown, pending event size: {}", pendingEvents.size());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new NacosException(NacosException.CLIENT_DISCONNECT,
+                "Interrupted while shutting down service info disk cache refresher", e);
+        }
+        flushPendingEvents();
+    }
+    
+    @FunctionalInterface
+    interface DiskCacheWriter {
+        
+        /**
+         * Write service info to disk cache.
+         *
+         * @param serviceInfo service info
+         * @param cacheDir cache dir
+         * @return {@code true} if write success, otherwise {@code false}
+         */
+        boolean write(ServiceInfo serviceInfo, String cacheDir);
+    }
+}

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
@@ -52,13 +52,15 @@ public class ServiceInfoHolder implements Closeable {
     private final boolean pushEmptyProtection;
     
     private final InstancesDiffer instancesDiffer;
-    
+
+    private final ServiceInfoDiskCacheRefresher serviceInfoDiskCacheRefresher;
+
     private String cacheDir;
     
     private String notifierEventScope;
     
     private boolean enableClientMetrics = true;
-    
+
     public ServiceInfoHolder(String namespace, String notifierEventScope,
         NacosClientProperties properties) {
         cacheDir = CacheDirUtil.initCacheDir(namespace, properties);
@@ -69,6 +71,7 @@ public class ServiceInfoHolder implements Closeable {
             this.serviceInfoMap = new ConcurrentHashMap<>(16);
         }
         this.failoverReactor = new FailoverReactor(this, notifierEventScope);
+        this.serviceInfoDiskCacheRefresher = new ServiceInfoDiskCacheRefresher();
         this.pushEmptyProtection = isPushEmptyProtect(properties);
         this.notifierEventScope = notifierEventScope;
         this.enableClientMetrics = Boolean.parseBoolean(
@@ -164,9 +167,20 @@ public class ServiceInfoHolder implements Closeable {
                         serviceInfo.getGroupName(),
                         serviceInfo.getClusters(), serviceInfo.getHosts(), diff));
             }
-            DiskCache.write(serviceInfo, cacheDir);
+            publishDiskCacheRefreshEvent(serviceKey, serviceInfo);
         }
         return serviceInfo;
+    }
+    
+    /**
+     * Publish a disk cache refresh event for async persistence.
+     *
+     * @param serviceKey service key without clusters
+     * @param serviceInfo latest service info snapshot
+     */
+    private void publishDiskCacheRefreshEvent(String serviceKey, ServiceInfo serviceInfo) {
+        serviceInfoDiskCacheRefresher.publishEvent(
+            new ServiceInfoDiskCacheRefreshEvent(serviceKey, serviceInfo, cacheDir));
     }
     
     private boolean isEmptyOrErrorPush(ServiceInfo serviceInfo) {
@@ -195,6 +209,7 @@ public class ServiceInfoHolder implements Closeable {
         String className = this.getClass().getName();
         NAMING_LOGGER.info("{} do shutdown begin", className);
         failoverReactor.shutdown();
+        serviceInfoDiskCacheRefresher.shutdown();
         NAMING_LOGGER.info("{} do shutdown stop", className);
     }
 }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
@@ -52,15 +52,15 @@ public class ServiceInfoHolder implements Closeable {
     private final boolean pushEmptyProtection;
     
     private final InstancesDiffer instancesDiffer;
-
+    
     private final ServiceInfoDiskCacheRefresher serviceInfoDiskCacheRefresher;
-
+    
     private String cacheDir;
     
     private String notifierEventScope;
     
     private boolean enableClientMetrics = true;
-
+    
     public ServiceInfoHolder(String namespace, String notifierEventScope,
         NacosClientProperties properties) {
         cacheDir = CacheDirUtil.initCacheDir(namespace, properties);

--- a/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefresherTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefresherTest.java
@@ -208,7 +208,6 @@ class ServiceInfoDiskCacheRefresherTest {
             }
         });
         assertTrue(taskStarted.await(1, TimeUnit.SECONDS));
-        
         try {
             refresher.shutdown();
             assertTrue(refresher.isShutdown());
@@ -221,6 +220,18 @@ class ServiceInfoDiskCacheRefresherTest {
     @Test
     void testShutdownWhenInterruptedThrowException() throws Exception {
         ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> true);
+        CountDownLatch taskStarted = new CountDownLatch(1);
+        CountDownLatch releaseTask = new CountDownLatch(1);
+        ScheduledThreadPoolExecutor refreshExecutor = getRefreshExecutor(refresher);
+        refreshExecutor.execute(() -> {
+            taskStarted.countDown();
+            try {
+                releaseTask.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertTrue(taskStarted.await(1, TimeUnit.SECONDS));
         try {
             Thread.currentThread().interrupt();
             assertThrows(com.alibaba.nacos.api.exception.NacosException.class, refresher::shutdown);
@@ -228,9 +239,8 @@ class ServiceInfoDiskCacheRefresherTest {
             assertTrue(refresher.isShutdown());
         } finally {
             Thread.interrupted();
-            if (!refresher.isShutdown()) {
-                refresher.shutdown();
-            }
+            releaseTask.countDown();
+            refreshExecutor.awaitTermination(1, TimeUnit.SECONDS);
         }
     }
     

--- a/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefresherTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefresherTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.naming.cache;
+
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceInfoDiskCacheRefresherTest {
+    
+    @Test
+    void testPublishEventOnlyWriteLatestSnapshot() throws Exception {
+        AtomicInteger writeCount = new AtomicInteger();
+        Map<String, ServiceInfo> writtenData = new ConcurrentHashMap<>();
+        ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> {
+            writeCount.incrementAndGet();
+            writtenData.put(serviceInfo.getKeyWithoutClusters(), serviceInfo);
+            return true;
+        });
+        try {
+            ServiceInfo first = createServiceInfo("a@@b@@c", "1.1.1.1", 1);
+            ServiceInfo second = createServiceInfo("a@@b@@c", "1.1.1.2", 2);
+            refresher.publishEvent(
+                new ServiceInfoDiskCacheRefreshEvent(first.getKeyWithoutClusters(), first,
+                    "cache"));
+            refresher
+                .publishEvent(new ServiceInfoDiskCacheRefreshEvent(second.getKeyWithoutClusters(),
+                    second, "cache"));
+            
+            refresher.flushNow();
+            
+            assertEquals(1, writeCount.get());
+            assertEquals("1.1.1.2", writtenData.get("a@@b").getHosts().get(0).getIp());
+            assertEquals(0, refresher.pendingEventSize());
+        } finally {
+            refresher.shutdown();
+        }
+    }
+    
+    @Test
+    void testFlushDifferentServiceKeys() throws Exception {
+        AtomicInteger writeCount = new AtomicInteger();
+        ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> {
+            writeCount.incrementAndGet();
+            return true;
+        });
+        try {
+            ServiceInfo first = createServiceInfo("a@@b@@c", "1.1.1.1", 1);
+            ServiceInfo second = createServiceInfo("d@@e@@f", "1.1.1.2", 2);
+            refresher.publishEvent(
+                new ServiceInfoDiskCacheRefreshEvent(first.getKeyWithoutClusters(), first,
+                    "cache"));
+            refresher
+                .publishEvent(new ServiceInfoDiskCacheRefreshEvent(second.getKeyWithoutClusters(),
+                    second, "cache"));
+            
+            refresher.flushNow();
+            
+            assertEquals(2, writeCount.get());
+            assertEquals(0, refresher.pendingEventSize());
+        } finally {
+            refresher.shutdown();
+        }
+    }
+    
+    @Test
+    void testFlushFailedEventRetry() throws Exception {
+        AtomicBoolean firstFailure = new AtomicBoolean(true);
+        AtomicInteger successWriteCount = new AtomicInteger();
+        ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> {
+            if ("a@@b".equals(serviceInfo.getKeyWithoutClusters())
+                && firstFailure.getAndSet(false)) {
+                return false;
+            }
+            successWriteCount.incrementAndGet();
+            return true;
+        });
+        try {
+            ServiceInfo failed = createServiceInfo("a@@b@@c", "1.1.1.1", 1);
+            ServiceInfo success = createServiceInfo("d@@e@@f", "1.1.1.2", 2);
+            refresher
+                .publishEvent(new ServiceInfoDiskCacheRefreshEvent(failed.getKeyWithoutClusters(),
+                    failed, "cache"));
+            refresher
+                .publishEvent(new ServiceInfoDiskCacheRefreshEvent(success.getKeyWithoutClusters(),
+                    success, "cache"));
+            
+            refresher.flushNow();
+            assertEquals(1, refresher.pendingEventSize());
+            assertEquals(1, successWriteCount.get());
+            
+            refresher.flushNow();
+            assertEquals(0, refresher.pendingEventSize());
+            assertEquals(2, successWriteCount.get());
+        } finally {
+            refresher.shutdown();
+        }
+    }
+    
+    @Test
+    void testShutdownFlushPendingEvents() throws Exception {
+        AtomicInteger writeCount = new AtomicInteger();
+        ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> {
+            writeCount.incrementAndGet();
+            return true;
+        });
+        ServiceInfo serviceInfo = createServiceInfo("a@@b@@c", "1.1.1.1", 1);
+        refresher.publishEvent(
+            new ServiceInfoDiskCacheRefreshEvent(serviceInfo.getKeyWithoutClusters(), serviceInfo,
+                "cache"));
+        
+        refresher.shutdown();
+        
+        assertEquals(1, writeCount.get());
+        assertTrue(refresher.isShutdown());
+        assertEquals(0, refresher.pendingEventSize());
+    }
+    
+    @Test
+    void testShutdownWithRepeatedFailureWillExit() throws Exception {
+        ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> false);
+        ServiceInfo serviceInfo = createServiceInfo("a@@b@@c", "1.1.1.1", 1);
+        refresher.publishEvent(
+            new ServiceInfoDiskCacheRefreshEvent(serviceInfo.getKeyWithoutClusters(), serviceInfo,
+                "cache"));
+        
+        refresher.shutdown();
+        
+        assertTrue(refresher.isShutdown());
+        assertEquals(1, refresher.pendingEventSize());
+    }
+    
+    private ServiceInfoDiskCacheRefresher createRefresher(
+        ServiceInfoDiskCacheRefresher.DiskCacheWriter writer) {
+        return new ServiceInfoDiskCacheRefresher(TimeUnit.DAYS.toMillis(1), 50L, writer);
+    }
+    
+    private ServiceInfo createServiceInfo(String serviceKey, String ip, int port) {
+        ServiceInfo serviceInfo = new ServiceInfo(serviceKey);
+        Instance instance = new Instance();
+        instance.setIp(ip);
+        instance.setPort(port);
+        serviceInfo.setHosts(Collections.singletonList(instance));
+        return serviceInfo;
+    }
+}

--- a/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefresherTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoDiskCacheRefresherTest.java
@@ -20,14 +20,20 @@ import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ServiceInfoDiskCacheRefresherTest {
@@ -58,6 +64,28 @@ class ServiceInfoDiskCacheRefresherTest {
             assertEquals(0, refresher.pendingEventSize());
         } finally {
             refresher.shutdown();
+        }
+    }
+    
+    @Test
+    void testDefaultConstructorShutdownFlushPendingEvents() throws Exception {
+        ServiceInfoDiskCacheRefresher refresher = new ServiceInfoDiskCacheRefresher();
+        Path cacheDir = Files.createTempDirectory("service-info-disk-cache-refresher");
+        try {
+            ServiceInfo serviceInfo = createServiceInfo("a@@b@@c", "1.1.1.1", 1);
+            refresher.publishEvent(
+                new ServiceInfoDiskCacheRefreshEvent(serviceInfo.getKeyWithoutClusters(),
+                    serviceInfo,
+                    cacheDir.toString()));
+            
+            refresher.shutdown();
+            
+            assertEquals(0, refresher.pendingEventSize());
+            assertTrue(Files.exists(cacheDir.resolve(serviceInfo.getKeyEncoded())));
+        } finally {
+            if (!refresher.isShutdown()) {
+                refresher.shutdown();
+            }
         }
     }
     
@@ -122,6 +150,31 @@ class ServiceInfoDiskCacheRefresherTest {
     }
     
     @Test
+    void testFlushWriterExceptionWillBeCaught() throws Exception {
+        AtomicBoolean shouldThrow = new AtomicBoolean(true);
+        ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> {
+            if (shouldThrow.get()) {
+                throw new IllegalStateException("test");
+            }
+            return true;
+        });
+        try {
+            ServiceInfo serviceInfo = createServiceInfo("a@@b@@c", "1.1.1.1", 1);
+            refresher.publishEvent(
+                new ServiceInfoDiskCacheRefreshEvent(serviceInfo.getKeyWithoutClusters(),
+                    serviceInfo,
+                    "cache"));
+            
+            refresher.flushNow();
+            
+            assertEquals(1, refresher.pendingEventSize());
+        } finally {
+            shouldThrow.set(false);
+            refresher.shutdown();
+        }
+    }
+    
+    @Test
     void testShutdownFlushPendingEvents() throws Exception {
         AtomicInteger writeCount = new AtomicInteger();
         ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> {
@@ -141,6 +194,47 @@ class ServiceInfoDiskCacheRefresherTest {
     }
     
     @Test
+    void testShutdownTimeoutWillExit() throws Exception {
+        ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> true);
+        CountDownLatch taskStarted = new CountDownLatch(1);
+        CountDownLatch releaseTask = new CountDownLatch(1);
+        ScheduledThreadPoolExecutor refreshExecutor = getRefreshExecutor(refresher);
+        refreshExecutor.execute(() -> {
+            taskStarted.countDown();
+            try {
+                releaseTask.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertTrue(taskStarted.await(1, TimeUnit.SECONDS));
+        
+        try {
+            refresher.shutdown();
+            assertTrue(refresher.isShutdown());
+        } finally {
+            releaseTask.countDown();
+            refreshExecutor.awaitTermination(1, TimeUnit.SECONDS);
+        }
+    }
+    
+    @Test
+    void testShutdownWhenInterruptedThrowException() throws Exception {
+        ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> true);
+        try {
+            Thread.currentThread().interrupt();
+            assertThrows(com.alibaba.nacos.api.exception.NacosException.class, refresher::shutdown);
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertTrue(refresher.isShutdown());
+        } finally {
+            Thread.interrupted();
+            if (!refresher.isShutdown()) {
+                refresher.shutdown();
+            }
+        }
+    }
+    
+    @Test
     void testShutdownWithRepeatedFailureWillExit() throws Exception {
         ServiceInfoDiskCacheRefresher refresher = createRefresher((serviceInfo, cacheDir) -> false);
         ServiceInfo serviceInfo = createServiceInfo("a@@b@@c", "1.1.1.1", 1);
@@ -157,6 +251,14 @@ class ServiceInfoDiskCacheRefresherTest {
     private ServiceInfoDiskCacheRefresher createRefresher(
         ServiceInfoDiskCacheRefresher.DiskCacheWriter writer) {
         return new ServiceInfoDiskCacheRefresher(TimeUnit.DAYS.toMillis(1), 50L, writer);
+    }
+    
+    private ScheduledThreadPoolExecutor getRefreshExecutor(ServiceInfoDiskCacheRefresher refresher)
+        throws NoSuchFieldException, IllegalAccessException {
+        Field refreshExecutorField =
+            ServiceInfoDiskCacheRefresher.class.getDeclaredField("refreshExecutor");
+        refreshExecutorField.setAccessible(true);
+        return (ScheduledThreadPoolExecutor) refreshExecutorField.get(refresher);
     }
     
     private ServiceInfo createServiceInfo(String serviceKey, String ip, int port) {

--- a/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolderTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
@@ -65,7 +66,9 @@ class ServiceInfoHolderTest {
     
     @AfterEach
     void tearDown() throws Exception {
-        
+        if (holder != null) {
+            holder.shutdown();
+        }
     }
     
     @Test
@@ -195,6 +198,24 @@ class ServiceInfoHolderTest {
         }
     }
     
+    @Test
+    void testProcessServiceInfoPublishDiskCacheRefreshEvent()
+        throws NacosException, NoSuchFieldException, IllegalAccessException {
+        holder.shutdown();
+        holder = new ServiceInfoHolder("aa", "scope-001", nacosClientProperties);
+        ServiceInfo info = new ServiceInfo("a@@b@@c");
+        info.setHosts(Collections.singletonList(createInstance("1.1.1.1", 1)));
+        try (MockedStatic<DiskCache> mockedDiskCache = Mockito.mockStatic(DiskCache.class)) {
+            mockedDiskCache.when(() -> DiskCache.writeWithResult(Mockito.any(ServiceInfo.class),
+                Mockito.anyString())).thenReturn(false);
+            
+            holder.processServiceInfo(info);
+            
+            ServiceInfoDiskCacheRefresher refresher = getServiceInfoDiskCacheRefresher(holder);
+            assertEquals(1, refresher.pendingEventSize());
+        }
+    }
+    
     private ServiceInfoHolder createServiceInfoHolder(Boolean enableClientMetrics) {
         Properties properties = new Properties();
         if (enableClientMetrics != null) {
@@ -316,6 +337,17 @@ class ServiceInfoHolderTest {
     }
     
     @Test
+    void testShutdownShutdownDiskCacheRefresher()
+        throws NacosException, NoSuchFieldException, IllegalAccessException {
+        ServiceInfoDiskCacheRefresher refresher = getServiceInfoDiskCacheRefresher(holder);
+        assertFalse(refresher.isShutdown());
+        
+        holder.shutdown();
+        
+        assertTrue(refresher.isShutdown());
+    }
+    
+    @Test
     void testConstructWithCacheLoad() throws NacosException {
         nacosClientProperties.setProperty(PropertyKeyConst.NAMING_LOAD_CACHE_AT_START, "true");
         nacosClientProperties.setProperty(PropertyKeyConst.NAMING_CACHE_REGISTRY_DIR, "non-exist");
@@ -352,5 +384,12 @@ class ServiceInfoHolderTest {
         FailoverReactor mock = mock(FailoverReactor.class);
         field.set(holder, mock);
         return mock;
+    }
+    
+    private ServiceInfoDiskCacheRefresher getServiceInfoDiskCacheRefresher(ServiceInfoHolder holder)
+        throws NoSuchFieldException, IllegalAccessException {
+        Field field = ServiceInfoHolder.class.getDeclaredField("serviceInfoDiskCacheRefresher");
+        field.setAccessible(true);
+        return (ServiceInfoDiskCacheRefresher) field.get(holder);
     }
 }

--- a/console/src/test/java/com/alibaba/nacos/console/cluster/RemoteServerMemberManagerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/cluster/RemoteServerMemberManagerTest.java
@@ -59,6 +59,7 @@ class RemoteServerMemberManagerTest {
         cachedEnvironment = EnvUtil.getEnvironment();
         MockEnvironment environment = new MockEnvironment();
         environment.setProperty(Constants.Auth.NACOS_CORE_AUTH_ADMIN_ENABLED, "false");
+        environment.setProperty("nacos.member.list", "127.0.0.1:8848");
         EnvUtil.setEnvironment(environment);
         memberManager = new RemoteServerMemberManager();
     }

--- a/console/src/test/java/com/alibaba/nacos/console/config/ConsoleModuleStateBuilderTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/config/ConsoleModuleStateBuilderTest.java
@@ -21,6 +21,8 @@ import com.alibaba.nacos.sys.module.ModuleState;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -51,6 +53,7 @@ class ConsoleModuleStateBuilderTest {
     void build() {
         ModuleState state = builder.build();
         assertTrue((Boolean) state.getStates().get("console_ui_enabled"));
+        assertEquals("next", state.getStates().get("console_ui_default"));
         assertTrue((Boolean) state.getStates().get("ai_enabled"));
         assertEquals(ConsoleModuleStateBuilder.CONSOLE_MODULE, state.getModuleName());
         MockEnvironment environment = new MockEnvironment();
@@ -64,8 +67,12 @@ class ConsoleModuleStateBuilderTest {
     
     @Test
     void buildWithException() {
-        EnvUtil.setEnvironment(null);
-        ModuleState state = builder.build();
-        assertTrue(state.getStates().isEmpty());
+        try (MockedStatic<EnvUtil> mockedEnvUtil = Mockito.mockStatic(EnvUtil.class)) {
+            mockedEnvUtil.when(() -> EnvUtil.getProperty("nacos.console.ui.enabled",
+                Boolean.class, true)).thenThrow(new IllegalStateException("Mock exception"));
+            ModuleState state = builder.build();
+            assertEquals(ConsoleModuleStateBuilder.CONSOLE_MODULE, state.getModuleName());
+            assertTrue(state.getStates().isEmpty());
+        }
     }
 }

--- a/specs/en/client/client-local-cache-redo-spec.md
+++ b/specs/en/client/client-local-cache-redo-spec.md
@@ -74,12 +74,14 @@ runtime intent.
 
 Naming service-info cache stores `ServiceInfo` objects keyed by grouped service
 name and clusters. Server push or query responses update the in-memory map and
-write a disk cache when the instance view changes.
+schedule a disk-cache refresh when the instance view changes.
 
 The cache is a recovery aid:
 
 - it may be loaded at startup when the load-cache option is enabled;
 - it may serve a temporary discovery view during network disruption;
+- disk cache refresh may be asynchronous and eventually consistent with the
+  in-memory view;
 - it must not create, update, or delete Naming server-side resources.
 
 Push-empty protection may ignore empty or invalid pushes to avoid replacing a

--- a/specs/en/naming/naming-discovery-subscription-spec.md
+++ b/specs/en/naming/naming-discovery-subscription-spec.md
@@ -63,7 +63,7 @@ Server push updates the client `ServiceInfo` cache. The Java SDK:
 3. stores the service view in memory;
 4. computes instance diffs;
 5. notifies matching local listeners;
-6. writes the service view to disk cache.
+6. schedules an asynchronous refresh of the service view to disk cache.
 
 Clients may re-query the server on subscription setup, reconnect, cache miss, or
 polling fallback. Local disk cache is a recovery and failover aid, not a

--- a/specs/en/naming/naming-spec.md
+++ b/specs/en/naming/naming-spec.md
@@ -124,10 +124,10 @@ view.
 ### 5.5 Push Updates The Client View
 
 gRPC subscription push carries updated `ServiceInfo` state for a subscribed
-service. Clients store the pushed state in local memory and disk cache, compare
-instance diffs, notify listeners, and may re-query on reconnect, cache miss, or
-polling fallback. HTTP Open API does not provide long polling or push
-subscription.
+service. Clients store the pushed state in local memory, refresh disk cache
+asynchronously, compare instance diffs, notify listeners, and may re-query on
+reconnect, cache miss, or polling fallback. HTTP Open API does not provide long
+polling or push subscription.
 
 ### 5.6 Extensible Cross-cutting Behavior
 


### PR DESCRIPTION
## What is the purpose of the change

Fix issue #15321.

Currently, when the naming client handles `NotifySubscriberRequest`, it updates in-memory `ServiceInfo`,
publishes `InstancesChangeEvent`, and then synchronously writes the local disk cache before returning ACK.

This means the push ACK path is blocked by disk IO, which is unnecessary for the main runtime path because
the client primarily serves reads from memory, while the disk cache is mainly used as a local snapshot for
restart preload and failover.

This PR changes the disk cache refresh from synchronous write to internal event-driven asynchronous persistence,
so ACK only depends on in-memory update and event publication, and no longer waits for disk flush.

At the same time, to avoid async write disorder and task accumulation, this PR uses a coalescing model:
for the same `serviceKey`, only the latest `ServiceInfo` snapshot is kept pending for flush. Intermediate
states may be skipped, but stale data will not overwrite the latest state on disk.

## Brief changelog

- replace synchronous `DiskCache.write(...)` in `ServiceInfoHolder.processServiceInfo(...)`
  with internal async disk-cache refresh event publishing
- add `ServiceInfoDiskCacheRefreshEvent` to carry disk refresh payload
- add `ServiceInfoDiskCacheRefresher` to:
  - coalesce pending snapshots by `serviceKey`
  - flush pending disk cache updates in a single scheduled worker
  - retry failed writes in later rounds
  - flush pending snapshots during shutdown
- keep existing synchronous behavior unchanged for:
  - in-memory `serviceInfoMap` update
  - `InstancesChangeEvent` publishing
  - `NotifySubscriberResponse` return path
- add unit tests for async refresh, latest-state coalescing, retry, and shutdown flush
- update related naming/client specs to clarify the new async disk-cache semantics

## Verifying this change

Executed targeted verification locally:

- `./mvnw -pl client -am -Dtest=ServiceInfoHolderTest,ServiceInfoDiskCacheRefresherTest test -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw -pl client -am spotless:check`

Verified by tests that:

- memory cache update flow remains unchanged
- async disk cache refresh no longer blocks the main update path
- repeated updates for the same `serviceKey` only persist the latest snapshot
- failed disk writes are retained and retried in later flush cycles
- shutdown triggers a final flush of pending disk cache updates

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.