### PR TITLE
[ISSUE #14466] Add Jackson 2 JSON adapter

### DIFF
--- a/api/src/test/java/com/alibaba/nacos/api/utils/json/JsonAdapterSelectorTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/utils/json/JsonAdapterSelectorTest.java
@@ -20,16 +20,27 @@ import com.alibaba.nacos.api.exception.runtime.NacosLoadException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Enumeration;
+import java.util.ServiceConfigurationError;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JsonAdapterSelectorTest {
+    
+    private static final String SERVICE_RESOURCE_NAME =
+        "META-INF/services/" + NacosJsonAdapter.class.getName();
     
     @AfterEach
     void tearDown() {
@@ -108,6 +119,92 @@ class JsonAdapterSelectorTest {
             Arrays.<NacosJsonAdapter>asList(brokenAdapter, jackson2)).select();
         
         assertSame(jackson2, selected);
+    }
+    
+    @Test
+    void testServiceConfigurationErrorAdapterIsIgnoredAndDiagnosed() {
+        ServiceConfigurationErrorAdapter brokenAdapter = new ServiceConfigurationErrorAdapter();
+        
+        NacosLoadException exception = assertThrows(NacosLoadException.class,
+            () -> new JsonAdapterSelector(
+                Collections.<NacosJsonAdapter>singletonList(brokenAdapter))
+                .select());
+        
+        assertTrue(exception.getMessage().contains("Adapter diagnostics"));
+        assertTrue(exception.getMessage().contains("broken-service"));
+        assertTrue(exception.getMessage().contains(ServiceConfigurationError.class.getName()));
+    }
+    
+    @Test
+    void testRuntimeExceptionAdapterIsIgnoredAndDiagnosed() {
+        RuntimeExceptionAdapter brokenAdapter = new RuntimeExceptionAdapter();
+        
+        NacosLoadException exception = assertThrows(NacosLoadException.class,
+            () -> new JsonAdapterSelector(
+                Collections.<NacosJsonAdapter>singletonList(brokenAdapter))
+                .select());
+        
+        assertTrue(exception.getMessage().contains("Adapter diagnostics"));
+        assertTrue(exception.getMessage().contains("broken-runtime"));
+        assertTrue(exception.getMessage().contains(IllegalStateException.class.getName()));
+    }
+    
+    @Test
+    void testFailWhenMultipleNonPreferredAdaptersAvailable() {
+        FakeAdapter custom1 = new FakeAdapter("custom1", true);
+        FakeAdapter custom2 = new FakeAdapter("custom2", true);
+        
+        NacosLoadException exception = assertThrows(NacosLoadException.class,
+            () -> new JsonAdapterSelector(Arrays.<NacosJsonAdapter>asList(custom1, custom2))
+                .select());
+        
+        assertTrue(exception.getMessage().contains("Multiple JSON adapters are available"));
+    }
+    
+    @Test
+    void testDefaultConstructorLoadsServiceProviderAndRecordsProviderFailure() throws Exception {
+        File serviceRoot = new File("target/json-adapter-service-loader");
+        File serviceDirectory = new File(serviceRoot, "META-INF/services");
+        Files.createDirectories(serviceDirectory.toPath());
+        File serviceFile = new File(serviceDirectory, NacosJsonAdapter.class.getName());
+        String providers = ServiceLoadedAdapter.class.getName() + System.lineSeparator()
+            + "com.alibaba.nacos.api.utils.json.MissingJsonAdapter" + System.lineSeparator();
+        Files.write(serviceFile.toPath(), providers.getBytes(StandardCharsets.UTF_8));
+        
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        URLClassLoader serviceClassLoader =
+            new URLClassLoader(new URL[] {serviceRoot.toURI().toURL()}, originalClassLoader);
+        try {
+            Thread.currentThread().setContextClassLoader(serviceClassLoader);
+            System.setProperty(JsonUtils.ADAPTER_PROPERTY_NAME, NacosJsonAdapterNames.JACKSON2);
+            
+            NacosLoadException exception =
+                assertThrows(NacosLoadException.class, () -> new JsonAdapterSelector().select());
+            
+            assertTrue(exception.getMessage().contains("Adapter diagnostics"));
+            assertTrue(exception.getMessage().contains("provider:"));
+            assertTrue(exception.getMessage().contains("MissingJsonAdapter"));
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+            serviceClassLoader.close();
+        }
+    }
+    
+    @Test
+    void testDefaultConstructorRecordsServiceLoaderLinkageFailure() {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread()
+            .setContextClassLoader(new ServiceResourceLinkageErrorClassLoader(originalClassLoader));
+        try {
+            NacosLoadException exception =
+                assertThrows(NacosLoadException.class, () -> new JsonAdapterSelector().select());
+            
+            assertTrue(exception.getMessage().contains("Adapter diagnostics"));
+            assertTrue(exception.getMessage().contains("provider:"));
+            assertTrue(exception.getMessage().contains("service-resource"));
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
     }
     
     @Test
@@ -210,6 +307,45 @@ class JsonAdapterSelectorTest {
         @Override
         public boolean isAvailable() {
             throw new NoClassDefFoundError("missing");
+        }
+    }
+    
+    private static class ServiceConfigurationErrorAdapter extends FakeAdapter {
+        
+        ServiceConfigurationErrorAdapter() {
+            super("broken-service", true);
+        }
+        
+        @Override
+        public boolean isAvailable() {
+            throw new ServiceConfigurationError("broken service");
+        }
+    }
+    
+    private static class RuntimeExceptionAdapter extends FakeAdapter {
+        
+        RuntimeExceptionAdapter() {
+            super("broken-runtime", true);
+        }
+        
+        @Override
+        public boolean isAvailable() {
+            throw new IllegalStateException("broken runtime");
+        }
+    }
+    
+    private static class ServiceResourceLinkageErrorClassLoader extends ClassLoader {
+        
+        ServiceResourceLinkageErrorClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+        
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (SERVICE_RESOURCE_NAME.equals(name)) {
+                throw new NoClassDefFoundError("service-resource");
+            }
+            return super.getResources(name);
         }
     }
 }

--- a/api/src/test/java/com/alibaba/nacos/api/utils/json/NacosJsonSubtypeTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/utils/json/NacosJsonSubtypeTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.utils.json;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NacosJsonSubtypeTest {
+    
+    @Test
+    void testCreateSubtype() {
+        NacosJsonSubtype subtype = new NacosJsonSubtype(Number.class, Integer.class, "integer");
+        
+        assertSame(Number.class, subtype.getBaseType());
+        assertSame(Integer.class, subtype.getSubtype());
+        assertEquals("integer", subtype.getTypeName());
+    }
+    
+    @Test
+    void testCreateSubtypeWithNullBaseType() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> new NacosJsonSubtype(null, Integer.class, "integer"));
+        
+        assertEquals("baseType must not be null", exception.getMessage());
+    }
+    
+    @Test
+    void testCreateSubtypeWithNullSubtype() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> new NacosJsonSubtype(Number.class, null, "integer"));
+        
+        assertEquals("subtype must not be null", exception.getMessage());
+    }
+    
+    @Test
+    void testCreateSubtypeWithNullTypeName() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> new NacosJsonSubtype(Number.class, Integer.class, null));
+        
+        assertEquals("typeName must not be empty", exception.getMessage());
+    }
+    
+    @Test
+    void testCreateSubtypeWithEmptyTypeName() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> new NacosJsonSubtype(Number.class, Integer.class, ""));
+        
+        assertEquals("typeName must not be empty", exception.getMessage());
+    }
+    
+    @Test
+    void testEqualsAndHashCode() {
+        NacosJsonSubtype subtype = new NacosJsonSubtype(Number.class, Integer.class, "integer");
+        NacosJsonSubtype sameSubtype = new NacosJsonSubtype(Number.class, Integer.class, "integer");
+        
+        assertTrue(subtype.equals(subtype));
+        assertEquals(subtype, sameSubtype);
+        assertEquals(subtype.hashCode(), sameSubtype.hashCode());
+        assertFalse(subtype.equals("integer"));
+        assertNotEquals(subtype, new NacosJsonSubtype(Object.class, Integer.class, "integer"));
+        assertNotEquals(subtype, new NacosJsonSubtype(Number.class, Long.class, "integer"));
+        assertNotEquals(subtype, new NacosJsonSubtype(Number.class, Integer.class, "long"));
+    }
+}

--- a/api/src/test/java/com/alibaba/nacos/api/utils/json/ServiceLoadedAdapter.java
+++ b/api/src/test/java/com/alibaba/nacos/api/utils/json/ServiceLoadedAdapter.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.utils.json;
+
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+/**
+ * Test service provider for {@link JsonAdapterSelector}.
+ *
+ * @author nacos
+ */
+public class ServiceLoadedAdapter implements NacosJsonAdapter {
+    
+    @Override
+    public String name() {
+        return "service-loaded";
+    }
+    
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+    
+    @Override
+    public String toJson(Object obj) {
+        return null;
+    }
+    
+    @Override
+    public byte[] toJsonBytes(Object obj) {
+        return new byte[0];
+    }
+    
+    @Override
+    public String toCanonicalJson(Object obj) {
+        return null;
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, Class<T> cls) {
+        return null;
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, Type type) {
+        return null;
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, NacosTypeReference<T> typeReference) {
+        return null;
+    }
+    
+    @Override
+    public <T> T toObj(String json, Class<T> cls) {
+        return null;
+    }
+    
+    @Override
+    public <T> T toObj(String json, Type type) {
+        return null;
+    }
+    
+    @Override
+    public <T> T toObj(String json, NacosTypeReference<T> typeReference) {
+        return null;
+    }
+    
+    @Override
+    public <T> T toObj(InputStream inputStream, Class<T> cls) {
+        return null;
+    }
+    
+    @Override
+    public <T> T toObj(InputStream inputStream, Type type) {
+        return null;
+    }
+    
+    @Override
+    public void registerSubtype(NacosJsonSubtype subtype) {
+    }
+}

--- a/common/src/main/java/com/alibaba/nacos/common/json/Jackson2JsonAdapter.java
+++ b/common/src/main/java/com/alibaba/nacos/common/json/Jackson2JsonAdapter.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.json;
+
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapter;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapterNames;
+import com.alibaba.nacos.api.utils.json.NacosJsonSubtype;
+import com.alibaba.nacos.api.utils.json.NacosTypeReference;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+
+/**
+ * Jackson 2 implementation of {@link NacosJsonAdapter}.
+ *
+ * @author nacos
+ */
+public class Jackson2JsonAdapter implements NacosJsonAdapter {
+    
+    private final ObjectMapper mapper = createObjectMapper();
+    
+    private final ObjectMapper canonicalMapper = createCanonicalObjectMapper();
+    
+    @Override
+    public String name() {
+        return NacosJsonAdapterNames.JACKSON2;
+    }
+    
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+    
+    @Override
+    public String toJson(Object obj) {
+        return write(obj, () -> mapper.writeValueAsString(obj));
+    }
+    
+    @Override
+    public byte[] toJsonBytes(Object obj) {
+        return write(obj, () -> mapper.writeValueAsBytes(obj));
+    }
+    
+    @Override
+    public String toCanonicalJson(Object obj) {
+        return write(obj, () -> canonicalMapper.writeValueAsString(obj));
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, Class<T> cls) {
+        return read(() -> mapper.readValue(json, cls), cls);
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, Type type) {
+        return read(() -> mapper.readValue(json, constructJavaType(type)), type);
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, NacosTypeReference<T> typeReference) {
+        return toObj(json, typeReference.getType());
+    }
+    
+    @Override
+    public <T> T toObj(String json, Class<T> cls) {
+        return read(() -> mapper.readValue(json, cls), cls);
+    }
+    
+    @Override
+    public <T> T toObj(String json, Type type) {
+        return read(() -> mapper.readValue(json, constructJavaType(type)), type);
+    }
+    
+    @Override
+    public <T> T toObj(String json, NacosTypeReference<T> typeReference) {
+        return toObj(json, typeReference.getType());
+    }
+    
+    @Override
+    public <T> T toObj(InputStream inputStream, Class<T> cls) {
+        return read(() -> mapper.readValue(inputStream, cls), cls);
+    }
+    
+    @Override
+    public <T> T toObj(InputStream inputStream, Type type) {
+        return read(() -> mapper.readValue(inputStream, constructJavaType(type)), type);
+    }
+    
+    @Override
+    public void registerSubtype(NacosJsonSubtype subtype) {
+        NamedType namedType = new NamedType(subtype.getSubtype(), subtype.getTypeName());
+        mapper.registerSubtypes(namedType);
+        canonicalMapper.registerSubtypes(namedType);
+    }
+    
+    private JavaType constructJavaType(Type type) {
+        return mapper.constructType(type);
+    }
+    
+    private <T> T write(Object obj, JsonWriter<T> writer) {
+        try {
+            return writer.write();
+        } catch (JsonProcessingException e) {
+            Class<?> serializedClass = obj == null ? Object.class : obj.getClass();
+            throw new NacosSerializationException(serializedClass, e);
+        }
+    }
+    
+    private <T> T read(JsonReader<T> reader, Class<?> cls) {
+        try {
+            return reader.read();
+        } catch (Exception e) {
+            throw new NacosDeserializationException(cls, e);
+        }
+    }
+    
+    private <T> T read(JsonReader<T> reader, Type type) {
+        try {
+            return reader.read();
+        } catch (Exception e) {
+            throw new NacosDeserializationException(type, e);
+        }
+    }
+    
+    private static ObjectMapper createObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        objectMapper.setSerializationInclusion(Include.NON_NULL);
+        return objectMapper;
+    }
+    
+    private static ObjectMapper createCanonicalObjectMapper() {
+        ObjectMapper objectMapper = createObjectMapper();
+        objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        return objectMapper;
+    }
+    
+    private interface JsonWriter<T> {
+        
+        T write() throws JsonProcessingException;
+    }
+    
+    private interface JsonReader<T> {
+        
+        T read() throws IOException;
+    }
+}

--- a/common/src/main/resources/META-INF/services/com.alibaba.nacos.api.utils.json.NacosJsonAdapter
+++ b/common/src/main/resources/META-INF/services/com.alibaba.nacos.api.utils.json.NacosJsonAdapter
@@ -1,0 +1,17 @@
+#
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.nacos.common.json.Jackson2JsonAdapter

--- a/common/src/test/java/com/alibaba/nacos/common/json/Jackson2JsonAdapterTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/json/Jackson2JsonAdapterTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.json;
+
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapter;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapterNames;
+import com.alibaba.nacos.api.utils.json.NacosJsonSubtype;
+import com.alibaba.nacos.api.utils.json.NacosTypeReference;
+import com.alibaba.nacos.common.utils.TypeUtils;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Jackson2JsonAdapterTest {
+    
+    private final Jackson2JsonAdapter adapter = new Jackson2JsonAdapter();
+    
+    @Test
+    void testNameAndAvailability() {
+        assertEquals(NacosJsonAdapterNames.JACKSON2, adapter.name());
+        assertTrue(adapter.isAvailable());
+    }
+    
+    @Test
+    void testServiceLoaderProvider() {
+        NacosJsonAdapter loadedAdapter = null;
+        for (NacosJsonAdapter each : ServiceLoader.load(NacosJsonAdapter.class)) {
+            if (NacosJsonAdapterNames.JACKSON2.equals(each.name())) {
+                loadedAdapter = each;
+                break;
+            }
+        }
+        
+        assertNotNull(loadedAdapter);
+        assertInstanceOf(Jackson2JsonAdapter.class, loadedAdapter);
+    }
+    
+    @Test
+    void testToJson() {
+        SampleModel model = new SampleModel("nacos", null);
+        
+        assertEquals("{\"name\":\"nacos\"}", adapter.toJson(model));
+        assertArrayEquals("{\"name\":\"nacos\"}".getBytes(StandardCharsets.UTF_8),
+            adapter.toJsonBytes(model));
+    }
+    
+    @Test
+    void testToCanonicalJson() {
+        Map<String, Object> source = new LinkedHashMap<String, Object>();
+        source.put("z", "last");
+        source.put("a", "first");
+        source.put("n", null);
+        
+        assertEquals("{\"a\":\"first\",\"z\":\"last\"}", adapter.toCanonicalJson(source));
+    }
+    
+    @Test
+    void testSerializeFailure() {
+        assertThrows(NacosSerializationException.class, () -> adapter.toJson(new Object()));
+    }
+    
+    @Test
+    void testToObjWithClass() {
+        byte[] jsonBytes =
+            "{\"name\":\"nacos\",\"unknown\":\"ignored\"}".getBytes(StandardCharsets.UTF_8);
+        
+        assertEquals(new SampleModel("nacos", null), adapter.toObj(jsonBytes, SampleModel.class));
+        assertEquals(new SampleModel("nacos", null),
+            adapter.toObj("{\"name\":\"nacos\",\"unknown\":\"ignored\"}", SampleModel.class));
+        assertEquals(new SampleModel("nacos", null),
+            adapter.toObj(new ByteArrayInputStream(jsonBytes), SampleModel.class));
+    }
+    
+    @Test
+    void testToObjWithType() {
+        Type listType = TypeUtils.parameterize(List.class, SampleModel.class);
+        byte[] jsonBytes = "[{\"name\":\"nacos\"}]".getBytes(StandardCharsets.UTF_8);
+        
+        assertEquals(new SampleModel("nacos", null),
+            ((List<?>) adapter.toObj(jsonBytes, listType)).get(0));
+        assertEquals(new SampleModel("nacos", null),
+            ((List<?>) adapter.toObj("[{\"name\":\"nacos\"}]", listType)).get(0));
+        assertEquals(new SampleModel("nacos", null),
+            ((List<?>) adapter.toObj(new ByteArrayInputStream(jsonBytes), listType)).get(0));
+    }
+    
+    @Test
+    void testToObjWithNacosTypeReference() {
+        NacosTypeReference<Map<String, SampleModel>> typeReference =
+            new NacosTypeReference<Map<String, SampleModel>>() {
+            };
+        byte[] jsonBytes = "{\"item\":{\"name\":\"nacos\"}}".getBytes(StandardCharsets.UTF_8);
+        
+        assertEquals(new SampleModel("nacos", null),
+            adapter.toObj(jsonBytes, typeReference).get("item"));
+        assertEquals(new SampleModel("nacos", null),
+            adapter.toObj("{\"item\":{\"name\":\"nacos\"}}", typeReference).get("item"));
+    }
+    
+    @Test
+    void testDeserializeFailureWithClass() {
+        assertThrows(NacosDeserializationException.class,
+            () -> adapter.toObj("{broken}".getBytes(StandardCharsets.UTF_8), SampleModel.class));
+    }
+    
+    @Test
+    void testDeserializeFailureWithType() {
+        Type listType = TypeUtils.parameterize(List.class, SampleModel.class);
+        
+        assertThrows(NacosDeserializationException.class,
+            () -> adapter.toObj("{broken}".getBytes(StandardCharsets.UTF_8), listType));
+    }
+    
+    @Test
+    void testRegisterSubtype() {
+        adapter.registerSubtype(new NacosJsonSubtype(BaseModel.class, SubModel.class, "sub"));
+        
+        BaseModel result = adapter.toObj("{\"@type\":\"sub\",\"name\":\"nacos\"}", BaseModel.class);
+        
+        assertEquals(new SubModel("nacos"), result);
+    }
+    
+    public static class SampleModel {
+        
+        private String name;
+        
+        private String optional;
+        
+        public SampleModel() {
+        }
+        
+        SampleModel(String name, String optional) {
+            this.name = name;
+            this.optional = optional;
+        }
+        
+        public String getName() {
+            return name;
+        }
+        
+        public void setName(String name) {
+            this.name = name;
+        }
+        
+        public String getOptional() {
+            return optional;
+        }
+        
+        public void setOptional(String optional) {
+            this.optional = optional;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SampleModel)) {
+                return false;
+            }
+            SampleModel that = (SampleModel) o;
+            return String.valueOf(name).equals(String.valueOf(that.name))
+                && String.valueOf(optional).equals(String.valueOf(that.optional));
+        }
+        
+        @Override
+        public int hashCode() {
+            int result = name == null ? 0 : name.hashCode();
+            result = 31 * result + (optional == null ? 0 : optional.hashCode());
+            return result;
+        }
+    }
+    
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+    public abstract static class BaseModel {
+        
+        private String name;
+        
+        public String getName() {
+            return name;
+        }
+        
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+    
+    public static class SubModel extends BaseModel {
+        
+        public SubModel() {
+        }
+        
+        SubModel(String name) {
+            setName(name);
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SubModel)) {
+                return false;
+            }
+            SubModel that = (SubModel) o;
+            return String.valueOf(getName()).equals(String.valueOf(that.getName()));
+        }
+        
+        @Override
+        public int hashCode() {
+            return getName() == null ? 0 : getName().hashCode();
+        }
+    }
+}

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -21,7 +21,7 @@ adapter work discussed in issue #14466 and defined by
 `specs/en/sdk/sdk-java-json-adapter-spec.md` /
 `specs/zh-cn/sdk/sdk-java-json-adapter-spec.md`.
 
-Last updated: 2026-06-15.
+Last updated: 2026-06-16.
 
 ## Status Legend
 
@@ -48,6 +48,12 @@ Last updated: 2026-06-15.
   - `mvn -pl api -Dtest=NacosTypeReferenceTest,JsonAdapterSelectorTest,JsonUtilsTest test`
   - `mvn spotless:apply -pl api`
   - `mvn spotless:check -pl api`
+- 2026-06-16, stage 1 coverage supplement:
+  - `mvn -pl api -Dtest=NacosTypeReferenceTest,NacosJsonSubtypeTest,JsonAdapterSelectorTest,JsonUtilsTest test`
+- 2026-06-16, stage 2 Jackson 2 adapter:
+  - `mvn -pl api,common spotless:check`
+  - `mvn -pl common -am -Dtest=Jackson2JsonAdapterTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - `mvn -pl common apache-rat:check`
 
 ## Implementation Principles
 
@@ -123,7 +129,7 @@ Last updated: 2026-06-15.
 
 ### 2. Default Adapters in `nacos-common`
 
-- `[ ]` Add Jackson 2 adapter.
+- `[x]` Add Jackson 2 adapter.
   - Files:
     - `common/src/main/java/com/alibaba/nacos/common/json/Jackson2JsonAdapter.java`
     - `common/src/main/resources/META-INF/services/...NacosJsonAdapter`
@@ -136,6 +142,7 @@ Last updated: 2026-06-15.
   - Validation:
     - Unit tests for serialization, `Class<T>`, `Type`,
       `NacosTypeReference<T>`, subtype registration, and exception mapping.
+    - `mvn -pl common -am -Dtest=Jackson2JsonAdapterTest -Dsurefire.failIfNoSpecifiedTests=false test`
 
 - `[ ]` Add Jackson 3 adapter.
   - Files:


### PR DESCRIPTION
## Summary
- Add the default Jackson 2 implementation of the neutral NacosJsonAdapter in nacos-common.
- Publish the Jackson 2 adapter through ServiceLoader so nacos-common keeps existing users working by default.
- Add focused unit tests for API selector coverage and Jackson 2 serialization, deserialization, canonical JSON, subtype registration, ServiceLoader publication, and exception mapping.
- Update the temporary Jackson adapter migration TODO tracker.

## Test
- mvn -pl api,common spotless:check
- mvn -pl api -Dtest=NacosTypeReferenceTest,NacosJsonSubtypeTest,JsonAdapterSelectorTest,JsonUtilsTest test
- mvn -pl common -am -Dtest=Jackson2JsonAdapterTest -Dsurefire.failIfNoSpecifiedTests=false clean test
- mvn -pl common apache-rat:check