### PR TITLE
[ISSUE #14466] Add Jackson 3 JSON adapter

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -68,6 +68,18 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>commons-logging</groupId>

--- a/common/src/main/java/com/alibaba/nacos/common/json/Jackson3JsonAdapter.java
+++ b/common/src/main/java/com/alibaba/nacos/common/json/Jackson3JsonAdapter.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.json;
+
+import com.alibaba.nacos.api.exception.runtime.NacosLoadException;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapter;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapterNames;
+import com.alibaba.nacos.api.utils.json.NacosJsonSubtype;
+import com.alibaba.nacos.api.utils.json.NacosTypeReference;
+
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+
+/**
+ * Java 8 safe Jackson 3 provider facade.
+ *
+ * @author nacos
+ */
+public class Jackson3JsonAdapter implements NacosJsonAdapter {
+    
+    private static final String JACKSON3_OBJECT_MAPPER_CLASS =
+        "tools.jackson.databind.ObjectMapper";
+    
+    private static final String JACKSON3_EXCEPTION_CLASS = "tools.jackson.core.JacksonException";
+    
+    private final ClassLoader classLoader;
+    
+    private final List<NacosJsonSubtype> subtypes = new ArrayList<NacosJsonSubtype>();
+    
+    private volatile NacosJsonAdapter delegate;
+    
+    public Jackson3JsonAdapter() {
+        this(Jackson3JsonAdapter.class.getClassLoader());
+    }
+    
+    Jackson3JsonAdapter(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+    
+    @Override
+    public String name() {
+        return NacosJsonAdapterNames.JACKSON3;
+    }
+    
+    @Override
+    public boolean isAvailable() {
+        try {
+            Class.forName(JACKSON3_OBJECT_MAPPER_CLASS, false, classLoader);
+            Class.forName(JACKSON3_EXCEPTION_CLASS, false, classLoader);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        } catch (ServiceConfigurationError e) {
+            return false;
+        } catch (LinkageError e) {
+            return false;
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+    
+    @Override
+    public String toJson(Object obj) {
+        return delegate().toJson(obj);
+    }
+    
+    @Override
+    public byte[] toJsonBytes(Object obj) {
+        return delegate().toJsonBytes(obj);
+    }
+    
+    @Override
+    public String toCanonicalJson(Object obj) {
+        return delegate().toCanonicalJson(obj);
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, Class<T> cls) {
+        return delegate().toObj(json, cls);
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, Type type) {
+        return delegate().toObj(json, type);
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, NacosTypeReference<T> typeReference) {
+        return delegate().toObj(json, typeReference);
+    }
+    
+    @Override
+    public <T> T toObj(String json, Class<T> cls) {
+        return delegate().toObj(json, cls);
+    }
+    
+    @Override
+    public <T> T toObj(String json, Type type) {
+        return delegate().toObj(json, type);
+    }
+    
+    @Override
+    public <T> T toObj(String json, NacosTypeReference<T> typeReference) {
+        return delegate().toObj(json, typeReference);
+    }
+    
+    @Override
+    public <T> T toObj(InputStream inputStream, Class<T> cls) {
+        return delegate().toObj(inputStream, cls);
+    }
+    
+    @Override
+    public <T> T toObj(InputStream inputStream, Type type) {
+        return delegate().toObj(inputStream, type);
+    }
+    
+    @Override
+    public void registerSubtype(NacosJsonSubtype subtype) {
+        synchronized (subtypes) {
+            if (!subtypes.contains(subtype)) {
+                subtypes.add(subtype);
+            }
+            NacosJsonAdapter currentDelegate = delegate;
+            if (currentDelegate != null) {
+                currentDelegate.registerSubtype(subtype);
+            }
+        }
+    }
+    
+    private NacosJsonAdapter delegate() {
+        NacosJsonAdapter currentDelegate = delegate;
+        if (currentDelegate != null) {
+            return currentDelegate;
+        }
+        synchronized (this) {
+            if (delegate == null) {
+                if (!isAvailable()) {
+                    throw new NacosLoadException(
+                        "Jackson 3 is not available on the runtime classpath.");
+                }
+                delegate = createDelegate();
+            }
+            return delegate;
+        }
+    }
+    
+    private NacosJsonAdapter createDelegate() {
+        NacosJsonAdapter createdDelegate = new Jackson3JsonAdapterDelegate();
+        synchronized (subtypes) {
+            for (NacosJsonSubtype subtype : subtypes) {
+                createdDelegate.registerSubtype(subtype);
+            }
+        }
+        return createdDelegate;
+    }
+}

--- a/common/src/main/java/com/alibaba/nacos/common/json/Jackson3JsonAdapterDelegate.java
+++ b/common/src/main/java/com/alibaba/nacos/common/json/Jackson3JsonAdapterDelegate.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.json;
+
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapter;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapterNames;
+import com.alibaba.nacos.api.utils.json.NacosJsonSubtype;
+import com.alibaba.nacos.api.utils.json.NacosTypeReference;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.jsontype.NamedType;
+
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+/**
+ * Jackson 3 implementation of {@link NacosJsonAdapter}.
+ *
+ * @author nacos
+ */
+class Jackson3JsonAdapterDelegate implements NacosJsonAdapter {
+    
+    private final List<NacosJsonSubtype> subtypes = new ArrayList<NacosJsonSubtype>();
+    
+    private volatile ObjectMapper mapper = createObjectMapper(subtypes);
+    
+    private volatile ObjectMapper canonicalMapper = createCanonicalObjectMapper(subtypes);
+    
+    @Override
+    public String name() {
+        return NacosJsonAdapterNames.JACKSON3;
+    }
+    
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+    
+    @Override
+    public String toJson(Object obj) {
+        return write(obj, () -> mapper.writeValueAsString(obj));
+    }
+    
+    @Override
+    public byte[] toJsonBytes(Object obj) {
+        return write(obj, () -> mapper.writeValueAsBytes(obj));
+    }
+    
+    @Override
+    public String toCanonicalJson(Object obj) {
+        return write(obj, () -> canonicalMapper.writeValueAsString(obj));
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, Class<T> cls) {
+        return read(() -> mapper.readValue(json, cls), cls);
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, Type type) {
+        return read(() -> mapper.readValue(json, constructJavaType(type)), type);
+    }
+    
+    @Override
+    public <T> T toObj(byte[] json, NacosTypeReference<T> typeReference) {
+        return toObj(json, typeReference.getType());
+    }
+    
+    @Override
+    public <T> T toObj(String json, Class<T> cls) {
+        return read(() -> mapper.readValue(json, cls), cls);
+    }
+    
+    @Override
+    public <T> T toObj(String json, Type type) {
+        return read(() -> mapper.readValue(json, constructJavaType(type)), type);
+    }
+    
+    @Override
+    public <T> T toObj(String json, NacosTypeReference<T> typeReference) {
+        return toObj(json, typeReference.getType());
+    }
+    
+    @Override
+    public <T> T toObj(InputStream inputStream, Class<T> cls) {
+        return read(() -> mapper.readValue(inputStream, cls), cls);
+    }
+    
+    @Override
+    public <T> T toObj(InputStream inputStream, Type type) {
+        return read(() -> mapper.readValue(inputStream, constructJavaType(type)), type);
+    }
+    
+    @Override
+    public void registerSubtype(NacosJsonSubtype subtype) {
+        synchronized (subtypes) {
+            if (!subtypes.contains(subtype)) {
+                subtypes.add(subtype);
+            }
+            mapper = createObjectMapper(subtypes);
+            canonicalMapper = createCanonicalObjectMapper(subtypes);
+        }
+    }
+    
+    private JavaType constructJavaType(Type type) {
+        return mapper.constructType(type);
+    }
+    
+    private <T> T write(Object obj, JsonWriter<T> writer) {
+        try {
+            return writer.write();
+        } catch (JacksonException e) {
+            Class<?> serializedClass = obj == null ? Object.class : obj.getClass();
+            throw new NacosSerializationException(serializedClass, e);
+        }
+    }
+    
+    private <T> T read(JsonReader<T> reader, Class<?> cls) {
+        try {
+            return reader.read();
+        } catch (JacksonException e) {
+            throw new NacosDeserializationException(cls, e);
+        }
+    }
+    
+    private <T> T read(JsonReader<T> reader, Type type) {
+        try {
+            return reader.read();
+        } catch (JacksonException e) {
+            throw new NacosDeserializationException(type, e);
+        }
+    }
+    
+    private static ObjectMapper createObjectMapper(Collection<NacosJsonSubtype> subtypes) {
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        builder.changeDefaultPropertyInclusion(new NonNullPropertyInclusion());
+        registerSubtypes(builder, subtypes);
+        return builder.build();
+    }
+    
+    private static ObjectMapper createCanonicalObjectMapper(Collection<NacosJsonSubtype> subtypes) {
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        builder.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        builder.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        builder.changeDefaultPropertyInclusion(new NonNullPropertyInclusion());
+        registerSubtypes(builder, subtypes);
+        return builder.build();
+    }
+    
+    private static void registerSubtypes(JsonMapper.Builder builder,
+        Collection<NacosJsonSubtype> subtypes) {
+        for (NacosJsonSubtype subtype : subtypes) {
+            builder.registerSubtypes(new NamedType(subtype.getSubtype(), subtype.getTypeName()));
+        }
+    }
+    
+    private interface JsonWriter<T> {
+        
+        T write() throws JacksonException;
+    }
+    
+    private interface JsonReader<T> {
+        
+        T read() throws JacksonException;
+    }
+    
+    private static class NonNullPropertyInclusion implements UnaryOperator<JsonInclude.Value> {
+        
+        @Override
+        public JsonInclude.Value apply(JsonInclude.Value value) {
+            return JsonInclude.Value.construct(Include.NON_NULL, Include.NON_NULL);
+        }
+    }
+}

--- a/common/src/main/resources/META-INF/services/com.alibaba.nacos.api.utils.json.NacosJsonAdapter
+++ b/common/src/main/resources/META-INF/services/com.alibaba.nacos.api.utils.json.NacosJsonAdapter
@@ -15,3 +15,4 @@
 #
 
 com.alibaba.nacos.common.json.Jackson2JsonAdapter
+com.alibaba.nacos.common.json.Jackson3JsonAdapter

--- a/common/src/test/java/com/alibaba/nacos/common/json/Jackson3JsonAdapterTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/json/Jackson3JsonAdapterTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.json;
+
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.api.exception.runtime.NacosLoadException;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapter;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapterNames;
+import com.alibaba.nacos.api.utils.json.NacosJsonSubtype;
+import com.alibaba.nacos.api.utils.json.NacosTypeReference;
+import com.alibaba.nacos.common.utils.TypeUtils;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Jackson3JsonAdapterTest {
+    
+    private final Jackson3JsonAdapter adapter = new Jackson3JsonAdapter();
+    
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(JsonUtils.ADAPTER_PROPERTY_NAME);
+    }
+    
+    @Test
+    void testNameAndAvailability() {
+        assertEquals(NacosJsonAdapterNames.JACKSON3, adapter.name());
+        assertTrue(adapter.isAvailable());
+    }
+    
+    @Test
+    void testDelegateNameAndAvailability() {
+        Jackson3JsonAdapterDelegate delegate = new Jackson3JsonAdapterDelegate();
+        
+        assertEquals(NacosJsonAdapterNames.JACKSON3, delegate.name());
+        assertTrue(delegate.isAvailable());
+    }
+    
+    @Test
+    void testUnavailableWhenJackson3ClassMissing() {
+        Jackson3JsonAdapter unavailableAdapter =
+            new Jackson3JsonAdapter(new MissingJackson3ClassLoader(
+                Jackson3JsonAdapterTest.class.getClassLoader()));
+        
+        assertFalse(unavailableAdapter.isAvailable());
+        assertThrows(NacosLoadException.class, () -> unavailableAdapter.toJson("nacos"));
+    }
+    
+    @Test
+    void testUnavailableWhenJackson3ClassHasLinkageError() {
+        Jackson3JsonAdapter unavailableAdapter =
+            new Jackson3JsonAdapter(new LinkageErrorJackson3ClassLoader(
+                Jackson3JsonAdapterTest.class.getClassLoader()));
+        
+        assertFalse(unavailableAdapter.isAvailable());
+    }
+    
+    @Test
+    void testUnavailableWhenJackson3ClassHasServiceConfigurationError() {
+        Jackson3JsonAdapter unavailableAdapter =
+            new Jackson3JsonAdapter(new ServiceConfigurationErrorJackson3ClassLoader(
+                Jackson3JsonAdapterTest.class.getClassLoader()));
+        
+        assertFalse(unavailableAdapter.isAvailable());
+    }
+    
+    @Test
+    void testUnavailableWhenJackson3ClassHasRuntimeException() {
+        Jackson3JsonAdapter unavailableAdapter =
+            new Jackson3JsonAdapter(new RuntimeExceptionJackson3ClassLoader(
+                Jackson3JsonAdapterTest.class.getClassLoader()));
+        
+        assertFalse(unavailableAdapter.isAvailable());
+    }
+    
+    @Test
+    void testServiceLoaderProvider() {
+        NacosJsonAdapter loadedAdapter = null;
+        for (NacosJsonAdapter each : ServiceLoader.load(NacosJsonAdapter.class)) {
+            if (NacosJsonAdapterNames.JACKSON3.equals(each.name())) {
+                loadedAdapter = each;
+                break;
+            }
+        }
+        
+        assertNotNull(loadedAdapter);
+        assertInstanceOf(Jackson3JsonAdapter.class, loadedAdapter);
+    }
+    
+    @Test
+    void testJsonUtilsAutoSelectsJackson3() {
+        assertEquals(NacosJsonAdapterNames.JACKSON3, JsonUtils.selectedAdapterName());
+        assertEquals("{\"name\":\"nacos\"}", JsonUtils.toJson(new SampleModel("nacos", null)));
+    }
+    
+    @Test
+    void testToJson() {
+        SampleModel model = new SampleModel("nacos", null);
+        
+        assertEquals("{\"name\":\"nacos\"}", adapter.toJson(model));
+        assertArrayEquals("{\"name\":\"nacos\"}".getBytes(StandardCharsets.UTF_8),
+            adapter.toJsonBytes(model));
+    }
+    
+    @Test
+    void testToCanonicalJson() {
+        Map<String, Object> source = new LinkedHashMap<String, Object>();
+        source.put("z", "last");
+        source.put("a", "first");
+        source.put("n", null);
+        
+        assertEquals("{\"a\":\"first\",\"z\":\"last\"}", adapter.toCanonicalJson(source));
+    }
+    
+    @Test
+    void testSerializeFailure() {
+        assertThrows(NacosSerializationException.class, () -> adapter.toJson(new FailingModel()));
+    }
+    
+    @Test
+    void testToObjWithClass() {
+        byte[] jsonBytes =
+            "{\"name\":\"nacos\",\"unknown\":\"ignored\"}".getBytes(StandardCharsets.UTF_8);
+        
+        assertEquals(new SampleModel("nacos", null), adapter.toObj(jsonBytes, SampleModel.class));
+        assertEquals(new SampleModel("nacos", null),
+            adapter.toObj("{\"name\":\"nacos\",\"unknown\":\"ignored\"}", SampleModel.class));
+        assertEquals(new SampleModel("nacos", null),
+            adapter.toObj(new ByteArrayInputStream(jsonBytes), SampleModel.class));
+    }
+    
+    @Test
+    void testToObjWithType() {
+        Type listType = TypeUtils.parameterize(List.class, SampleModel.class);
+        byte[] jsonBytes = "[{\"name\":\"nacos\"}]".getBytes(StandardCharsets.UTF_8);
+        
+        assertEquals(new SampleModel("nacos", null),
+            ((List<?>) adapter.toObj(jsonBytes, listType)).get(0));
+        assertEquals(new SampleModel("nacos", null),
+            ((List<?>) adapter.toObj("[{\"name\":\"nacos\"}]", listType)).get(0));
+        assertEquals(new SampleModel("nacos", null),
+            ((List<?>) adapter.toObj(new ByteArrayInputStream(jsonBytes), listType)).get(0));
+    }
+    
+    @Test
+    void testToObjWithNacosTypeReference() {
+        NacosTypeReference<Map<String, SampleModel>> typeReference =
+            new NacosTypeReference<Map<String, SampleModel>>() {
+            };
+        byte[] jsonBytes = "{\"item\":{\"name\":\"nacos\"}}".getBytes(StandardCharsets.UTF_8);
+        
+        assertEquals(new SampleModel("nacos", null),
+            adapter.toObj(jsonBytes, typeReference).get("item"));
+        assertEquals(new SampleModel("nacos", null),
+            adapter.toObj("{\"item\":{\"name\":\"nacos\"}}", typeReference).get("item"));
+    }
+    
+    @Test
+    void testDeserializeFailureWithClass() {
+        assertThrows(NacosDeserializationException.class,
+            () -> adapter.toObj("{broken}".getBytes(StandardCharsets.UTF_8), SampleModel.class));
+    }
+    
+    @Test
+    void testDeserializeFailureWithType() {
+        Type listType = TypeUtils.parameterize(List.class, SampleModel.class);
+        
+        assertThrows(NacosDeserializationException.class,
+            () -> adapter.toObj("{broken}".getBytes(StandardCharsets.UTF_8), listType));
+    }
+    
+    @Test
+    void testRegisterSubtypeBeforeDelegateInitialization() {
+        adapter.registerSubtype(new NacosJsonSubtype(BaseModel.class, SubModel.class, "sub"));
+        
+        BaseModel result = adapter.toObj("{\"@type\":\"sub\",\"name\":\"nacos\"}", BaseModel.class);
+        
+        assertEquals(new SubModel("nacos"), result);
+    }
+    
+    @Test
+    void testRegisterSubtypeAfterDelegateInitialization() {
+        assertEquals("{\"name\":\"nacos\"}", adapter.toJson(new SampleModel("nacos", null)));
+        
+        adapter.registerSubtype(new NacosJsonSubtype(BaseModel.class, SubModel.class, "sub"));
+        
+        BaseModel result = adapter.toObj("{\"@type\":\"sub\",\"name\":\"nacos\"}", BaseModel.class);
+        assertEquals(new SubModel("nacos"), result);
+    }
+    
+    public static class SampleModel {
+        
+        private String name;
+        
+        private String optional;
+        
+        public SampleModel() {
+        }
+        
+        SampleModel(String name, String optional) {
+            this.name = name;
+            this.optional = optional;
+        }
+        
+        public String getName() {
+            return name;
+        }
+        
+        public void setName(String name) {
+            this.name = name;
+        }
+        
+        public String getOptional() {
+            return optional;
+        }
+        
+        public void setOptional(String optional) {
+            this.optional = optional;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SampleModel)) {
+                return false;
+            }
+            SampleModel that = (SampleModel) o;
+            return String.valueOf(name).equals(String.valueOf(that.name))
+                && String.valueOf(optional).equals(String.valueOf(that.optional));
+        }
+        
+        @Override
+        public int hashCode() {
+            int result = name == null ? 0 : name.hashCode();
+            result = 31 * result + (optional == null ? 0 : optional.hashCode());
+            return result;
+        }
+    }
+    
+    public static class FailingModel {
+        
+        public String getName() {
+            throw new IllegalStateException("broken");
+        }
+    }
+    
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+    public abstract static class BaseModel {
+        
+        private String name;
+        
+        public String getName() {
+            return name;
+        }
+        
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+    
+    public static class SubModel extends BaseModel {
+        
+        public SubModel() {
+        }
+        
+        SubModel(String name) {
+            setName(name);
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SubModel)) {
+                return false;
+            }
+            SubModel that = (SubModel) o;
+            return String.valueOf(getName()).equals(String.valueOf(that.getName()));
+        }
+        
+        @Override
+        public int hashCode() {
+            return getName() == null ? 0 : getName().hashCode();
+        }
+    }
+    
+    private static class MissingJackson3ClassLoader extends ClassLoader {
+        
+        MissingJackson3ClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+        
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("tools.jackson.")) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+    
+    private static class LinkageErrorJackson3ClassLoader extends ClassLoader {
+        
+        LinkageErrorJackson3ClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+        
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("tools.jackson.")) {
+                throw new UnsupportedClassVersionError(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+    
+    private static class ServiceConfigurationErrorJackson3ClassLoader extends ClassLoader {
+        
+        ServiceConfigurationErrorJackson3ClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+        
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("tools.jackson.")) {
+                throw new ServiceConfigurationError(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+    
+    private static class RuntimeExceptionJackson3ClassLoader extends ClassLoader {
+        
+        RuntimeExceptionJackson3ClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+        
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("tools.jackson.")) {
+                throw new IllegalStateException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+}

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -39,7 +39,7 @@ Last updated: 2026-06-16.
   `common`, `client`, `maintainer-client`, and `plugin`.
 - `[x]` Neutral JSON API, adapter SPI, adapter selector, type reference, and
   subtype registration model have been added in `nacos-api`.
-- `[ ]` Confirm final Jackson 3 Maven coordinates and version management in the
+- `[x]` Confirm final Jackson 3 Maven coordinates and version management in the
   root dependency management before implementation.
 
 ## Validation Log
@@ -54,6 +54,10 @@ Last updated: 2026-06-16.
   - `mvn -pl api,common spotless:check`
   - `mvn -pl common -am -Dtest=Jackson2JsonAdapterTest -Dsurefire.failIfNoSpecifiedTests=false test`
   - `mvn -pl common apache-rat:check`
+- 2026-06-16, stage 3 Jackson 3 adapter:
+  - `mvn -pl common -am -Dtest=Jackson2JsonAdapterTest,Jackson3JsonAdapterTest -Dsurefire.failIfNoSpecifiedTests=false clean test`
+  - `common/target/site/jacoco/jacoco.csv`: Jackson 2 and Jackson 3 adapter
+    source files have `LINE_MISSED=0`.
 
 ## Implementation Principles
 
@@ -144,7 +148,7 @@ Last updated: 2026-06-16.
       `NacosTypeReference<T>`, subtype registration, and exception mapping.
     - `mvn -pl common -am -Dtest=Jackson2JsonAdapterTest -Dsurefire.failIfNoSpecifiedTests=false test`
 
-- `[ ]` Add Jackson 3 adapter.
+- `[x]` Add Jackson 3 adapter.
   - Files:
     - `common/src/main/java/com/alibaba/nacos/common/json/Jackson3JsonAdapter.java`
     - Optional lazy delegate:
@@ -164,6 +168,8 @@ Last updated: 2026-06-16.
       selected.
     - Java 8 compatibility check must not fail just because the provider class
       is loadable.
+    - Jackson 3 facade and delegate source files have full line coverage in
+      the focused `common` module test run.
 
 - `[ ]` Add canonical JSON support.
   - Files:


### PR DESCRIPTION
## What is the purpose of the change

Add the default Jackson 3 JSON adapter implementation for the Java SDK JSON adapter migration discussed in #14466.

## Brief changelog

- Add a Java 8 safe Jackson3JsonAdapter ServiceLoader facade that uses runtime classpath availability checks and lazy delegate initialization.
- Add Jackson3JsonAdapterDelegate backed by tools.jackson APIs with neutral NacosTypeReference, Type, canonical JSON, subtype registration, and exception mapping support.
- Register the Jackson 3 adapter in nacos-common and add Jackson 3 dependencies as provided/optional.
- Add focused unit tests for availability, ServiceLoader registration, auto selection, serialization/deserialization, generic type handling, subtype registration, and error paths.
- Update the temporary Jackson migration TODO with this stage status and validation notes.

## Verifying this change

- mvn -pl common spotless:apply
- mvn -pl common spotless:check
- mvn -pl common -am -Dtest=Jackson2JsonAdapterTest,Jackson3JsonAdapterTest -Dsurefire.failIfNoSpecifiedTests=false clean test
- common/target/site/jacoco/jacoco.csv: Jackson 2 and Jackson 3 adapter source files have LINE_MISSED=0.
- mvn -pl common apache-rat:check
