### PR TITLE
[ISSUE #14466] Clean api Jackson databind usage

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,11 +39,17 @@
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/api/src/main/java/com/alibaba/nacos/api/config/model/ConfigBasicInfo.java
+++ b/api/src/main/java/com/alibaba/nacos/api/config/model/ConfigBasicInfo.java
@@ -16,8 +16,7 @@
 
 package com.alibaba.nacos.api.config.model;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.io.Serializable;
 
@@ -41,7 +40,7 @@ public class ConfigBasicInfo implements Serializable {
      *     such as 862926428394491904, ui will replace it as 862926428394491900, so that can't found the configuration in later operation.
      * </p>
      */
-    @JsonSerialize(using = ToStringSerializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private Long id;
     
     private String namespaceId;

--- a/api/src/main/java/com/alibaba/nacos/api/naming/pojo/healthcheck/HealthCheckerFactory.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/pojo/healthcheck/HealthCheckerFactory.java
@@ -16,14 +16,11 @@
 
 package com.alibaba.nacos.api.naming.pojo.healthcheck;
 
-import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
-import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-
-import java.io.IOException;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.AbstractHealthChecker.None;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Http;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Mysql;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Tcp;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 
 /**
  * health checker factory.
@@ -32,10 +29,11 @@ import java.io.IOException;
  */
 public class HealthCheckerFactory {
     
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    
     static {
-        MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        registerSubType(Http.class, Http.TYPE);
+        registerSubType(Mysql.class, Mysql.TYPE);
+        registerSubType(Tcp.class, Tcp.TYPE);
+        registerSubType(None.class, None.TYPE);
     }
     
     /**
@@ -56,7 +54,7 @@ public class HealthCheckerFactory {
     public static void registerSubType(
         Class<? extends AbstractHealthChecker> extendHealthCheckerClass,
         String typeName) {
-        MAPPER.registerSubtypes(new NamedType(extendHealthCheckerClass, typeName));
+        JsonUtils.registerSubtype(AbstractHealthChecker.class, extendHealthCheckerClass, typeName);
     }
     
     /**
@@ -66,24 +64,16 @@ public class HealthCheckerFactory {
      * @return new instance
      */
     public static AbstractHealthChecker deserialize(String jsonString) {
-        try {
-            return MAPPER.readValue(jsonString, AbstractHealthChecker.class);
-        } catch (IOException e) {
-            throw new NacosDeserializationException(AbstractHealthChecker.class, e);
-        }
+        return JsonUtils.toObj(jsonString, AbstractHealthChecker.class);
     }
     
     /**
      * Serialize an instance of health checker to json.
      *
      * @param healthChecker health checker instance
-     * @return son string after serializing
+     * @return json string after serializing
      */
     public static String serialize(AbstractHealthChecker healthChecker) {
-        try {
-            return MAPPER.writeValueAsString(healthChecker);
-        } catch (JsonProcessingException e) {
-            throw new NacosSerializationException(healthChecker.getClass(), e);
-        }
+        return JsonUtils.toJson(healthChecker);
     }
 }

--- a/api/src/test/java/com/alibaba/nacos/api/naming/pojo/healthcheck/HealthCheckerFactoryTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/naming/pojo/healthcheck/HealthCheckerFactoryTest.java
@@ -18,20 +18,57 @@ package com.alibaba.nacos.api.naming.pojo.healthcheck;
 
 import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
 import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.AbstractHealthChecker.None;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Http;
+import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Mysql;
 import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Tcp;
-import org.junit.jupiter.api.BeforeAll;
+import com.alibaba.nacos.api.utils.json.JsonUtilsTestHelper;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapter;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapterNames;
+import com.alibaba.nacos.api.utils.json.NacosJsonSubtype;
+import com.alibaba.nacos.api.utils.json.NacosTypeReference;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HealthCheckerFactoryTest {
     
-    @BeforeAll
-    static void beforeClass() {
+    @BeforeEach
+    void setUp() {
+        JsonUtilsTestHelper.reset();
+        JsonUtilsTestHelper.useAdapter(new JacksonTestJsonAdapter());
+        HealthCheckerFactory.registerSubType(Http.class, Http.TYPE);
+        HealthCheckerFactory.registerSubType(Mysql.class, Mysql.TYPE);
+        HealthCheckerFactory.registerSubType(Tcp.class, Tcp.TYPE);
+        HealthCheckerFactory.registerSubType(None.class, None.TYPE);
         HealthCheckerFactory.registerSubType(new TestChecker());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        JsonUtilsTestHelper.reset();
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new HealthCheckerFactory());
     }
     
     @Test
@@ -128,6 +165,120 @@ class HealthCheckerFactoryTest {
         @Override
         public AbstractHealthChecker clone() throws CloneNotSupportedException {
             return null;
+        }
+    }
+    
+    private static class JacksonTestJsonAdapter implements NacosJsonAdapter {
+        
+        private final ObjectMapper mapper = createObjectMapper();
+        
+        @Override
+        public String name() {
+            return NacosJsonAdapterNames.JACKSON2;
+        }
+        
+        @Override
+        public boolean isAvailable() {
+            return true;
+        }
+        
+        @Override
+        public String toJson(Object obj) {
+            try {
+                return mapper.writeValueAsString(obj);
+            } catch (JsonProcessingException e) {
+                throw new NacosSerializationException(obj.getClass(), e);
+            }
+        }
+        
+        @Override
+        public byte[] toJsonBytes(Object obj) {
+            return toJson(obj).getBytes(StandardCharsets.UTF_8);
+        }
+        
+        @Override
+        public String toCanonicalJson(Object obj) {
+            return toJson(obj);
+        }
+        
+        @Override
+        public <T> T toObj(byte[] json, Class<T> cls) {
+            try {
+                return mapper.readValue(json, cls);
+            } catch (IOException e) {
+                throw new NacosDeserializationException(cls, e);
+            }
+        }
+        
+        @Override
+        public <T> T toObj(byte[] json, Type type) {
+            try {
+                return mapper.readValue(json, constructJavaType(type));
+            } catch (IOException e) {
+                throw new NacosDeserializationException(type, e);
+            }
+        }
+        
+        @Override
+        public <T> T toObj(byte[] json, NacosTypeReference<T> typeReference) {
+            return toObj(json, typeReference.getType());
+        }
+        
+        @Override
+        public <T> T toObj(String json, Class<T> cls) {
+            try {
+                return mapper.readValue(json, cls);
+            } catch (IOException e) {
+                throw new NacosDeserializationException(cls, e);
+            }
+        }
+        
+        @Override
+        public <T> T toObj(String json, Type type) {
+            try {
+                return mapper.readValue(json, constructJavaType(type));
+            } catch (IOException e) {
+                throw new NacosDeserializationException(type, e);
+            }
+        }
+        
+        @Override
+        public <T> T toObj(String json, NacosTypeReference<T> typeReference) {
+            return toObj(json, typeReference.getType());
+        }
+        
+        @Override
+        public <T> T toObj(InputStream inputStream, Class<T> cls) {
+            try {
+                return mapper.readValue(inputStream, cls);
+            } catch (IOException e) {
+                throw new NacosDeserializationException(cls, e);
+            }
+        }
+        
+        @Override
+        public <T> T toObj(InputStream inputStream, Type type) {
+            try {
+                return mapper.readValue(inputStream, constructJavaType(type));
+            } catch (IOException e) {
+                throw new NacosDeserializationException(type, e);
+            }
+        }
+        
+        @Override
+        public void registerSubtype(NacosJsonSubtype subtype) {
+            mapper.registerSubtypes(new NamedType(subtype.getSubtype(), subtype.getTypeName()));
+        }
+        
+        private JavaType constructJavaType(Type type) {
+            return mapper.constructType(type);
+        }
+        
+        private static ObjectMapper createObjectMapper() {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            objectMapper.setSerializationInclusion(Include.NON_NULL);
+            return objectMapper;
         }
     }
 }

--- a/api/src/test/java/com/alibaba/nacos/api/utils/json/JsonUtilsTestHelper.java
+++ b/api/src/test/java/com/alibaba/nacos/api/utils/json/JsonUtilsTestHelper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.utils.json;
+
+import java.util.Collections;
+
+/**
+ * Test helper for configuring {@link JsonUtils}.
+ *
+ * @author nacos
+ */
+public final class JsonUtilsTestHelper {
+    
+    private JsonUtilsTestHelper() {
+    }
+    
+    /**
+     * Use a single JSON adapter for the current test.
+     *
+     * @param adapter JSON adapter
+     */
+    public static void useAdapter(NacosJsonAdapter adapter) {
+        JsonUtils.setAdapterSelectorForTest(
+            new JsonAdapterSelector(Collections.<NacosJsonAdapter>singletonList(adapter)));
+    }
+    
+    /**
+     * Reset JSON utils test state.
+     */
+    public static void reset() {
+        System.clearProperty(JsonUtils.ADAPTER_PROPERTY_NAME);
+        JsonUtils.resetForTest();
+    }
+}

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -58,6 +58,15 @@ Last updated: 2026-06-16.
   - `mvn -pl common -am -Dtest=Jackson2JsonAdapterTest,Jackson3JsonAdapterTest -Dsurefire.failIfNoSpecifiedTests=false clean test`
   - `common/target/site/jacoco/jacoco.csv`: Jackson 2 and Jackson 3 adapter
     source files have `LINE_MISSED=0`.
+- 2026-06-16, stage 4 API cleanup:
+  - `mvn -pl api spotless:apply`
+  - `mvn -pl api spotless:check`
+  - `mvn -pl api -DskipTests compile`
+  - `mvn -pl api -Dtest=HealthCheckerFactoryTest,ConfigInfoTest test`
+  - `api/target/site/jacoco/jacoco.csv`: `HealthCheckerFactory` and
+    `ConfigBasicInfo` have `LINE_MISSED=0`.
+  - `mvn -pl api apache-rat:check`
+  - `mvn -pl api dependency:tree -Dincludes=com.fasterxml.jackson.core`
 
 ## Implementation Principles
 
@@ -198,7 +207,7 @@ Last updated: 2026-06-16.
 
 ### 3. Clean `nacos-api` Main Dependencies
 
-- `[ ]` Replace databind serializer annotations in public API models.
+- `[x]` Replace databind serializer annotations in public API models.
   - Files:
     - `api/src/main/java/com/alibaba/nacos/api/config/model/ConfigBasicInfo.java`
   - Plan:
@@ -208,7 +217,7 @@ Last updated: 2026-06-16.
   - Validation:
     - Model serialization unit test for `id` remains string-valued.
 
-- `[ ]` Migrate `HealthCheckerFactory` to neutral JSON.
+- `[x]` Migrate `HealthCheckerFactory` to neutral JSON.
   - Files:
     - `api/src/main/java/com/alibaba/nacos/api/naming/pojo/healthcheck/HealthCheckerFactory.java`
     - `api/src/main/java/com/alibaba/nacos/api/naming/pojo/healthcheck/HealthCheckType.java`
@@ -220,7 +229,7 @@ Last updated: 2026-06-16.
     - Health checker serialize / deserialize tests with built-in and registered
       custom subtype.
 
-- `[ ]` Remove Jackson core/databind from `api` main dependencies.
+- `[x]` Remove Jackson core/databind from `api` main dependencies.
   - Files:
     - `api/pom.xml`
   - Plan:


### PR DESCRIPTION
## What is the purpose of the change

Clean nacos-api main code Jackson core/databind usage for the Java SDK JSON adapter migration discussed in #14466.

## Brief changelog

- Migrate HealthCheckerFactory from a local ObjectMapper to the neutral JsonUtils facade and subtype registry.
- Replace ConfigBasicInfo databind serializer usage with annotation-only JsonFormat string rendering for large long ids.
- Keep jackson-annotations as the compile dependency for public model annotations, and move jackson-core/jackson-databind to test scope in nacos-api.
- Add a test-only JsonUtils helper and focused HealthCheckerFactory coverage for the neutral adapter path.
- Update the temporary Jackson migration TODO with this stage status and validation notes.

## Verifying this change

- mvn -pl api spotless:apply
- mvn -pl api spotless:check
- mvn -pl api -DskipTests compile
- mvn -pl api -Dtest=HealthCheckerFactoryTest,ConfigInfoTest test
- api/target/site/jacoco/jacoco.csv: HealthCheckerFactory and ConfigBasicInfo have LINE_MISSED=0.
- mvn -pl api apache-rat:check
- mvn -pl api dependency:tree -Dincludes=com.fasterxml.jackson.core
