### PR TITLE
[ISSUE #14466] Remove Jackson byte buffer stream from GrpcUtils

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcUtils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcUtils.java
@@ -23,10 +23,10 @@ import com.alibaba.nacos.api.remote.request.Request;
 import com.alibaba.nacos.api.remote.request.RequestMeta;
 import com.alibaba.nacos.api.remote.response.Response;
 import com.alibaba.nacos.api.utils.NetUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.remote.PayloadRegistry;
 import com.alibaba.nacos.common.remote.exception.RemoteException;
-import com.alibaba.nacos.common.utils.JacksonUtils;
-import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+import com.alibaba.nacos.common.utils.ByteBufferInputStream;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
@@ -96,7 +96,7 @@ public class GrpcUtils {
      * @return payload.
      */
     public static Payload convert(Response response) {
-        byte[] jsonBytes = JacksonUtils.toJsonBytes(response);
+        byte[] jsonBytes = JsonUtils.toJsonBytes(response);
         
         Metadata.Builder metaBuilder =
             Metadata.newBuilder().setType(response.getClass().getSimpleName());
@@ -108,7 +108,7 @@ public class GrpcUtils {
     private static byte[] convertRequestToByte(Request request) {
         Map<String, String> requestHeaders = new HashMap<>(request.getHeaders());
         request.clearHeaders();
-        byte[] jsonBytes = JacksonUtils.toJsonBytes(request);
+        byte[] jsonBytes = JsonUtils.toJsonBytes(request);
         request.putAllHeader(requestHeaders);
         return jsonBytes;
     }
@@ -124,7 +124,7 @@ public class GrpcUtils {
         if (classType != null) {
             ByteString byteString = payload.getBody().getValue();
             ByteBuffer byteBuffer = byteString.asReadOnlyByteBuffer();
-            Object obj = JacksonUtils.toObj(new ByteBufferBackedInputStream(byteBuffer), classType);
+            Object obj = JsonUtils.toObj(new ByteBufferInputStream(byteBuffer), classType);
             if (obj instanceof Request) {
                 ((Request) obj).putAllHeader(payload.getMetadata().getHeadersMap());
             }

--- a/common/src/main/java/com/alibaba/nacos/common/utils/ByteBufferInputStream.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/ByteBufferInputStream.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.utils;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * Input stream backed by a {@link ByteBuffer}.
+ *
+ * @author nacos
+ */
+public class ByteBufferInputStream extends InputStream {
+    
+    private final ByteBuffer byteBuffer;
+    
+    public ByteBufferInputStream(ByteBuffer byteBuffer) {
+        this.byteBuffer = Objects.requireNonNull(byteBuffer, "byteBuffer").slice();
+    }
+    
+    @Override
+    public int read() {
+        if (!byteBuffer.hasRemaining()) {
+            return -1;
+        }
+        return byteBuffer.get() & 0xff;
+    }
+    
+    @Override
+    public int read(byte[] bytes, int offset, int length) {
+        Objects.requireNonNull(bytes, "bytes");
+        if (offset < 0 || length < 0 || length > bytes.length - offset) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (length == 0) {
+            return 0;
+        }
+        if (!byteBuffer.hasRemaining()) {
+            return -1;
+        }
+        int lengthToRead = Math.min(length, byteBuffer.remaining());
+        byteBuffer.get(bytes, offset, lengthToRead);
+        return lengthToRead;
+    }
+    
+    @Override
+    public int available() {
+        return byteBuffer.remaining();
+    }
+}

--- a/common/src/test/java/com/alibaba/nacos/common/remote/client/grpc/GrpcUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/remote/client/grpc/GrpcUtilsTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -72,6 +73,11 @@ class GrpcUtilsTest {
         request.putHeader("h2", "v2");
         request.putHeader("h3", "v3");
         return request;
+    }
+    
+    @Test
+    void testConstructor() {
+        assertNotNull(new GrpcUtils());
     }
     
     @Test

--- a/common/src/test/java/com/alibaba/nacos/common/utils/ByteBufferInputStreamTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/ByteBufferInputStreamTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ByteBufferInputStreamTest {
+    
+    @Test
+    void testReadSingleByteAndBytes() {
+        ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[] {0, 1, 2, 3});
+        byteBuffer.position(1);
+        byteBuffer.limit(3);
+        ByteBufferInputStream inputStream = new ByteBufferInputStream(byteBuffer);
+        
+        assertEquals(2, inputStream.available());
+        assertEquals(1, inputStream.read());
+        assertEquals(1, inputStream.available());
+        
+        byte[] bytes = new byte[] {9, 9, 9};
+        assertEquals(1, inputStream.read(bytes, 1, 2));
+        assertArrayEquals(new byte[] {9, 2, 9}, bytes);
+        assertEquals(0, inputStream.available());
+        assertEquals(-1, inputStream.read());
+        assertEquals(-1, inputStream.read(bytes, 0, bytes.length));
+        assertEquals(1, byteBuffer.position());
+    }
+    
+    @Test
+    void testReadZeroLength() {
+        ByteBufferInputStream inputStream = new ByteBufferInputStream(ByteBuffer.allocate(0));
+        
+        assertEquals(0, inputStream.read(new byte[0], 0, 0));
+        assertEquals(-1, inputStream.read());
+    }
+    
+    @Test
+    void testConstructorRejectsNull() {
+        assertThrows(NullPointerException.class, () -> new ByteBufferInputStream(null));
+    }
+    
+    @Test
+    void testReadRejectsInvalidArguments() {
+        ByteBufferInputStream inputStream =
+            new ByteBufferInputStream(ByteBuffer.wrap(new byte[] {1}));
+        
+        assertThrows(NullPointerException.class, () -> inputStream.read(null, 0, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> inputStream.read(new byte[1], -1, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> inputStream.read(new byte[1], 0, 2));
+    }
+}

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -67,6 +67,13 @@ Last updated: 2026-06-16.
     `ConfigBasicInfo` have `LINE_MISSED=0`.
   - `mvn -pl api apache-rat:check`
   - `mvn -pl api dependency:tree -Dincludes=com.fasterxml.jackson.core`
+- 2026-06-16, stage 5 common gRPC JSON cleanup:
+  - `mvn -pl common spotless:apply`
+  - `mvn -pl common spotless:check`
+  - `mvn -pl common -am -Dtest=GrpcUtilsTest,ByteBufferInputStreamTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - `common/target/site/jacoco/jacoco.csv`: `GrpcUtils` and
+    `ByteBufferInputStream` have `LINE_MISSED=0`.
+  - `mvn -pl common apache-rat:check`
 
 ## Implementation Principles
 
@@ -243,17 +250,18 @@ Last updated: 2026-06-16.
 
 ### 4. Migrate Common and Client Runtime Usage
 
-- `[ ]` Replace Jackson `ByteBufferBackedInputStream`.
+- `[x]` Replace Jackson `ByteBufferBackedInputStream`.
   - Files:
     - `common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcUtils.java`
     - New helper such as
       `common/src/main/java/com/alibaba/nacos/common/utils/ByteBufferInputStream.java`
   - Plan:
-    - Add a small Nacos-owned `InputStream` over `ByteBuffer` or switch to a
-      byte-array path if the copy is acceptable.
-    - Use neutral `JsonUtils.toObj(...)` in the parse path.
+    - Add a small Nacos-owned `InputStream` over `ByteBuffer`.
+    - Use neutral `JsonUtils` in the gRPC payload serialization and parse
+      paths.
   - Validation:
     - Existing gRPC payload conversion tests.
+    - Unit tests for the Nacos-owned `ByteBufferInputStream`.
 
 - `[ ]` Remove `JavaType` from `AbstractNacosRestTemplate`.
   - Files:


### PR DESCRIPTION
### Motivation\nPart of the Jackson 2 / Jackson 3 adapter migration for issue #14466. This step removes the direct Jackson ByteBufferBackedInputStream usage from the common gRPC payload parsing path.\n\n### Modifications\n- Add a Nacos-owned ByteBufferInputStream helper backed by ByteBuffer.\n- Migrate GrpcUtils request/response JSON serialization and payload parsing to the neutral JsonUtils facade.\n- Add focused tests for ByteBufferInputStream and complete GrpcUtils line coverage in the targeted run.\n- Update docs/jackson-json-adapter-migration-todo.md with stage 5 status and validation.\n\n### Verification\n- mvn -pl common spotless:apply\n- mvn -pl common spotless:check\n- mvn -pl common -am -Dtest=GrpcUtilsTest,ByteBufferInputStreamTest -Dsurefire.failIfNoSpecifiedTests=false test\n- common/target/site/jacoco/jacoco.csv: GrpcUtils and ByteBufferInputStream have LINE_MISSED=0\n- mvn -pl common apache-rat:check