### PR TITLE
[ISSUE #14466] Remove Jackson JavaType from rest template

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/http/client/AbstractNacosRestTemplate.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/AbstractNacosRestTemplate.java
@@ -22,10 +22,9 @@ import com.alibaba.nacos.common.http.client.handler.ByteArrayResponseHandler;
 import com.alibaba.nacos.common.http.client.handler.ResponseHandler;
 import com.alibaba.nacos.common.http.client.handler.RestResultResponseHandler;
 import com.alibaba.nacos.common.http.client.handler.StringResponseHandler;
-import com.alibaba.nacos.common.utils.JacksonUtils;
-import com.fasterxml.jackson.databind.JavaType;
 import org.slf4j.Logger;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
@@ -79,9 +78,10 @@ public abstract class AbstractNacosRestTemplate {
             responseHandler = responseHandlerMap.get(ResponseHandlerType.STRING_TYPE);
         }
         if (responseHandler == null) {
-            JavaType javaType = JacksonUtils.constructJavaType(responseType);
-            String name = javaType.getRawClass().getName();
-            responseHandler = responseHandlerMap.get(name);
+            Class<?> rawClass = resolveRawClass(responseType);
+            if (rawClass != null) {
+                responseHandler = responseHandlerMap.get(rawClass.getName());
+            }
         }
         // When the corresponding type of response handler cannot be obtained,
         // the default bean response handler is used
@@ -90,5 +90,18 @@ public abstract class AbstractNacosRestTemplate {
         }
         responseHandler.setResponseType(responseType);
         return responseHandler;
+    }
+    
+    private Class<?> resolveRawClass(Type responseType) {
+        if (responseType instanceof Class) {
+            return (Class<?>) responseType;
+        }
+        if (responseType instanceof ParameterizedType) {
+            Type rawType = ((ParameterizedType) responseType).getRawType();
+            if (rawType instanceof Class) {
+                return (Class<?>) rawType;
+            }
+        }
+        return null;
     }
 }

--- a/common/src/test/java/com/alibaba/nacos/common/http/client/AbstractNacosRestTemplateTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/http/client/AbstractNacosRestTemplateTest.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.common.http.client.handler.ResponseHandler;
 import com.alibaba.nacos.common.http.client.handler.RestResultResponseHandler;
 import com.alibaba.nacos.common.http.client.handler.StringResponseHandler;
 import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.common.utils.TypeUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +48,8 @@ class AbstractNacosRestTemplateTest {
         restTemplate = new MockNacosRestTemplate(null);
         restTemplate.registerResponseHandler(MockNacosRestTemplate.class.getName(),
             mockResponseHandler);
+        restTemplate.registerResponseHandler(MockGenericResponse.class.getName(),
+            mockResponseHandler);
     }
     
     @Test
@@ -58,6 +61,15 @@ class AbstractNacosRestTemplateTest {
     void testSelectResponseHandlerForRestResult() {
         assertTrue(restTemplate
             .testFindResponseHandler(RestResult.class) instanceof RestResultResponseHandler);
+    }
+    
+    @Test
+    void testSelectResponseHandlerForParameterizedRestResult() {
+        Type responseType = TypeUtils.parameterize(RestResult.class, String.class);
+        
+        assertTrue(
+            restTemplate
+                .testFindResponseHandler(responseType) instanceof RestResultResponseHandler);
     }
     
     @Test
@@ -73,9 +85,25 @@ class AbstractNacosRestTemplateTest {
     }
     
     @Test
+    void testSelectResponseHandlerForUnsupportedType() {
+        Type responseType = new Type() {
+        };
+        
+        assertTrue(
+            restTemplate.testFindResponseHandler(responseType) instanceof BeanResponseHandler);
+    }
+    
+    @Test
     void testSelectResponseHandlerForCustom() {
         assertEquals(mockResponseHandler,
             restTemplate.testFindResponseHandler(MockNacosRestTemplate.class));
+    }
+    
+    @Test
+    void testSelectResponseHandlerForParameterizedCustom() {
+        Type responseType = TypeUtils.parameterize(MockGenericResponse.class, String.class);
+        
+        assertEquals(mockResponseHandler, restTemplate.testFindResponseHandler(responseType));
     }
     
     private static class MockNacosRestTemplate extends AbstractNacosRestTemplate {
@@ -87,5 +115,8 @@ class AbstractNacosRestTemplateTest {
         private ResponseHandler testFindResponseHandler(Type responseType) {
             return super.selectResponseHandler(responseType);
         }
+    }
+    
+    private static class MockGenericResponse<T> {
     }
 }

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -74,6 +74,13 @@ Last updated: 2026-06-16.
   - `common/target/site/jacoco/jacoco.csv`: `GrpcUtils` and
     `ByteBufferInputStream` have `LINE_MISSED=0`.
   - `mvn -pl common apache-rat:check`
+- 2026-06-17, stage 6 common response type cleanup:
+  - `mvn -pl common spotless:apply`
+  - `mvn -pl common spotless:check`
+  - `mvn -pl common -am -Dtest=AbstractNacosRestTemplateTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - `common/target/site/jacoco/jacoco.csv`: `AbstractNacosRestTemplate` has
+    `LINE_MISSED=0`.
+  - `mvn -pl common apache-rat:check`
 
 ## Implementation Principles
 
@@ -263,13 +270,13 @@ Last updated: 2026-06-16.
     - Existing gRPC payload conversion tests.
     - Unit tests for the Nacos-owned `ByteBufferInputStream`.
 
-- `[ ]` Remove `JavaType` from `AbstractNacosRestTemplate`.
+- `[x]` Remove `JavaType` from `AbstractNacosRestTemplate`.
   - Files:
     - `common/src/main/java/com/alibaba/nacos/common/http/client/AbstractNacosRestTemplate.java`
   - Plan:
-    - Replace `JacksonUtils.constructJavaType(responseType).getRawClass()` with
-      neutral raw-class resolution for `Class`, `ParameterizedType`, and common
-      response types.
+    - Replace `JacksonUtils.constructJavaType(responseType).getRawClass()`
+      with neutral raw-class resolution for `Class`, `ParameterizedType`, and
+      unsupported `Type` fallback.
   - Validation:
     - HTTP response handler selection unit tests.
 


### PR DESCRIPTION
### Motivation\nPart of the Jackson 2 / Jackson 3 adapter migration for issue #14466. This step removes the direct Jackson JavaType usage from common HTTP response handler selection.\n\n### Modifications\n- Replace JacksonUtils.constructJavaType(responseType).getRawClass() in AbstractNacosRestTemplate with JDK Type raw-class resolution.\n- Preserve response handler selection for Class and ParameterizedType response types.\n- Add tests for parameterized RestResult, custom parameterized response types, and unsupported Type fallback.\n- Update docs/jackson-json-adapter-migration-todo.md with stage 6 status and validation.\n\n### Verification\n- mvn -pl common spotless:apply\n- mvn -pl common spotless:check\n- mvn -pl common -am -Dtest=AbstractNacosRestTemplateTest -Dsurefire.failIfNoSpecifiedTests=false test\n- common/target/site/jacoco/jacoco.csv: AbstractNacosRestTemplate has LINE_MISSED=0\n- mvn -pl common apache-rat:check