### PR TITLE
[ISSUE #14466] Migrate client HTTP JSON parsing

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxy.java
@@ -21,6 +21,8 @@ import com.alibaba.nacos.api.ai.model.prompt.Prompt;
 import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
+import com.alibaba.nacos.api.utils.json.NacosTypeReference;
 import com.alibaba.nacos.client.env.NacosClientProperties;
 import com.alibaba.nacos.client.naming.core.NamingServerListManager;
 import com.alibaba.nacos.client.naming.remote.http.NamingHttpClientManager;
@@ -32,11 +34,9 @@ import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.tls.TlsSystemConfig;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.utils.ThreadUtils;
 import com.alibaba.nacos.plugin.auth.api.RequestResource;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -134,7 +134,7 @@ public class AiHttpClientProxy implements AiClientProxy {
         
         String responseBody = reqApi(PROMPT_CLIENT_PATH, params, resource);
         Result<Prompt> result =
-            JacksonUtils.toObj(responseBody, new TypeReference<Result<Prompt>>() {
+            JsonUtils.toObj(responseBody, new NacosTypeReference<Result<Prompt>>() {
             });
         return result.getData();
     }
@@ -237,7 +237,7 @@ public class AiHttpClientProxy implements AiClientProxy {
             AGENTSPEC_CLIENT_PATH, params, resource);
         String responseBody = restResult.getData();
         Result<AgentSpec> result =
-            JacksonUtils.toObj(responseBody, new TypeReference<Result<AgentSpec>>() {
+            JsonUtils.toObj(responseBody, new NacosTypeReference<Result<AgentSpec>>() {
             });
         String publishedMd5 = restResult.getHeader().getValue("X-Nacos-AgentSpec-Md5");
         String resolvedVersion = restResult.getHeader()

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -28,6 +28,8 @@ import com.alibaba.nacos.api.naming.utils.NamingUtils;
 import com.alibaba.nacos.api.selector.AbstractSelector;
 import com.alibaba.nacos.api.selector.ExpressionSelector;
 import com.alibaba.nacos.api.selector.SelectorType;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
+import com.alibaba.nacos.api.utils.json.NacosTypeReference;
 import com.alibaba.nacos.client.address.ServerListChangeEvent;
 import com.alibaba.nacos.client.env.NacosClientProperties;
 import com.alibaba.nacos.client.monitor.MetricsMonitor;
@@ -47,8 +49,6 @@ import com.alibaba.nacos.common.utils.HttpMethod;
 import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.hc.core5.http.HttpStatus;
 
 import java.util.Collections;
@@ -232,7 +232,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         params.put(CommonParams.GROUP_NAME, groupName);
         
         String result = reqApi(UtilAndComs.nacosUrlService, params, HttpMethod.GET);
-        return JacksonUtils.toObj(result, Service.class);
+        return JsonUtils.toObj(result, Service.class);
     }
     
     @Override
@@ -287,9 +287,11 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         try {
             String result = reqApi(UtilAndComs.webContext + "/v3/admin/core/state/liveness",
                 new HashMap<>(8), HttpMethod.GET);
-            JsonNode json = JacksonUtils.toObj(result);
-            int statusCode = json.get("code").asInt();
-            return 0 == statusCode;
+            Map<String, Object> json =
+                JsonUtils.toObj(result, new NacosTypeReference<Map<String, Object>>() {
+                });
+            Object statusCode = json.get("code");
+            return statusCode instanceof Number && 0 == ((Number) statusCode).intValue();
         } catch (Exception e) {
             return false;
         }
@@ -321,11 +323,14 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         
         String result = reqApi(UtilAndComs.nacosUrlBase + "/service/list", params, HttpMethod.GET);
         
-        JsonNode json = JacksonUtils.toObj(result);
+        Map<String, Object> json =
+            JsonUtils.toObj(result, new NacosTypeReference<Map<String, Object>>() {
+            });
         ListView<String> listView = new ListView<>();
-        listView.setCount(json.get("count").asInt());
-        listView.setData(
-            JacksonUtils.toObj(json.get("doms").toString(), new TypeReference<List<String>>() {
+        Object count = json.get("count");
+        listView.setCount(count instanceof Number ? ((Number) count).intValue() : 0);
+        listView.setData(JsonUtils.toObj(JsonUtils.toJson(json.get("doms")),
+            new NacosTypeReference<List<String>>() {
             }));
         
         return listView;

--- a/client/src/test/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxyTest.java
@@ -16,8 +16,10 @@
 
 package com.alibaba.nacos.client.ai.remote;
 
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
 import com.alibaba.nacos.api.ai.model.prompt.Prompt;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.client.naming.core.NamingServerListManager;
 import com.alibaba.nacos.client.security.SecurityProxy;
 import com.alibaba.nacos.common.http.HttpRestResult;
@@ -25,7 +27,6 @@ import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
 import com.alibaba.nacos.common.utils.JacksonUtils;
-import com.alibaba.nacos.api.model.v2.Result;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -189,6 +190,37 @@ class AiHttpClientProxyTest {
         // Pass null promptKey to exercise StringUtils.EMPTY branch (line 130)
         Prompt actual = httpClientProxy.queryPrompt(null, null, null, null);
         assertNotNull(actual);
+    }
+    
+    @Test
+    void queryAgentSpecSuccess() throws Exception {
+        AgentSpec expectedAgentSpec = new AgentSpec();
+        expectedAgentSpec.setName("agent-a");
+        expectedAgentSpec.setNamespaceId("public");
+        expectedAgentSpec.setDescription("test agent");
+        Result<AgentSpec> result = Result.success(expectedAgentSpec);
+        
+        HttpRestResult<String> httpResult = new HttpRestResult<>();
+        httpResult.setCode(200);
+        httpResult.setData(JacksonUtils.toJson(result));
+        httpResult.setHeader(Header.newInstance().addParam("X-Nacos-AgentSpec-Md5", "md5-value")
+            .addParam("X-Nacos-AgentSpec-Resolved-Version", "1.0.0"));
+        
+        when(serverListManager.getServerList()).thenReturn(Arrays.asList("127.0.0.1:8848"));
+        when(serverListManager.getContextPath()).thenReturn("/nacos");
+        when(securityProxy.getIdentityContext(any())).thenReturn(new HashMap<>());
+        doReturn(httpResult).when(nacosRestTemplate).get(anyString(), any(Header.class),
+            any(Query.class), eq(String.class));
+        
+        AgentSpecQueryResponse actual =
+            httpClientProxy.queryAgentSpec("agent-a", "1.0.0", null, null);
+        
+        assertNotNull(actual);
+        assertEquals("agent-a", actual.getAgentSpec().getName());
+        assertEquals("public", actual.getAgentSpec().getNamespaceId());
+        assertEquals("test agent", actual.getAgentSpec().getDescription());
+        assertEquals("md5-value", actual.getMd5());
+        assertEquals("1.0.0", actual.getResolvedVersion());
     }
     
     @Test

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -81,6 +81,17 @@ Last updated: 2026-06-16.
   - `common/target/site/jacoco/jacoco.csv`: `AbstractNacosRestTemplate` has
     `LINE_MISSED=0`.
   - `mvn -pl common apache-rat:check`
+- 2026-06-17, stage 7 client HTTP response JSON cleanup:
+  - `mvn -pl client spotless:apply`
+  - `mvn -pl client spotless:check`
+  - `mvn -pl client -am -Dtest=NamingHttpClientProxyTest,AiHttpClientProxyTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - `client/target/site/jacoco/jacoco.xml`: changed response parsing lines in
+    `NamingHttpClientProxy` and `AiHttpClientProxy` have covered instructions;
+    the classes still have pre-existing uncovered legacy branches.
+  - `rg "com\\.fasterxml\\.jackson\\.core\\.type\\.TypeReference|com\\.fasterxml\\.jackson\\.databind\\.JsonNode|new TypeReference|JsonNode" client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java client/src/main/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxy.java`
+    returns no matches.
+  - `mvn -pl client apache-rat:check`
+  - `mvn apache-rat:check -DskipTests`
 
 ## Implementation Principles
 
@@ -280,14 +291,15 @@ Last updated: 2026-06-16.
   - Validation:
     - HTTP response handler selection unit tests.
 
-- `[ ]` Migrate client HTTP response parsing from Jackson `TypeReference`.
+- `[x]` Migrate client HTTP response parsing from Jackson `TypeReference`.
   - Files:
     - `client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java`
     - `client/src/main/java/com/alibaba/nacos/client/ai/remote/AiHttpClientProxy.java`
   - Plan:
     - Replace `TypeReference<T>` with `NacosTypeReference<T>`.
-    - Replace `JacksonUtils.toObj(...)` with `JsonUtils.toObj(...)`.
-    - Replace simple `JsonNode` reads with DTOs or `Map<String, Object>`.
+    - Replace HTTP response `JacksonUtils.toObj(...)` calls with
+      `JsonUtils.toObj(...)`.
+    - Replace simple `JsonNode` reads with `Map<String, Object>`.
   - Validation:
     - Naming HTTP proxy tests.
     - AI HTTP proxy tests.


### PR DESCRIPTION
## What is changed
- Replace Jackson TypeReference based HTTP response parsing in client HTTP proxies with neutral JsonUtils and NacosTypeReference.
- Replace simple JsonNode response reads in NamingHttpClientProxy with Map based parsing.
- Add AgentSpec HTTP proxy coverage and update the Jackson adapter migration tracker.

## Validation
- mvn -pl client spotless:apply
- mvn -pl client spotless:check
- mvn -pl client -am -Dtest=NamingHttpClientProxyTest,AiHttpClientProxyTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl client apache-rat:check
- mvn apache-rat:check -DskipTests
- target production files have no Jackson TypeReference or JsonNode matches
- changed response parsing lines in AiHttpClientProxy and NamingHttpClientProxy have no missed JaCoCo instructions