### PR TITLE
[ISSUE #14036] Support TLS prefix for HTTP login

### DIFF
--- a/client-basic/src/main/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessor.java
+++ b/client-basic/src/main/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessor.java
@@ -129,5 +129,5 @@ public class HttpLoginProcessor implements LoginProcessor {
     private static String getProtocolPrefix() {
         return Boolean.getBoolean(TlsSystemConfig.TLS_ENABLE) ? HTTPS_PREFIX : HTTP_PREFIX;
     }
-
+    
 }

--- a/client-basic/src/main/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessor.java
+++ b/client-basic/src/main/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessor.java
@@ -26,6 +26,7 @@ import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.tls.TlsSystemConfig;
 import com.alibaba.nacos.common.utils.InternetAddressUtil;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
@@ -74,7 +75,7 @@ public class HttpLoginProcessor implements LoginProcessor {
                 server = server + InternetAddressUtil.IP_PORT_SPLITER
                     + ClientBasicParamUtil.getDefaultServerPort();
             }
-            server = HTTP_PREFIX + server;
+            server = getProtocolPrefix() + server;
         }
         
         String url = server + contextPath + LOGIN_V3_URL;
@@ -125,4 +126,8 @@ public class HttpLoginProcessor implements LoginProcessor {
         }
     }
     
+    private static String getProtocolPrefix() {
+        return Boolean.getBoolean(TlsSystemConfig.TLS_ENABLE) ? HTTPS_PREFIX : HTTP_PREFIX;
+    }
+
 }

--- a/client-basic/src/test/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessorTest.java
+++ b/client-basic/src/test/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessorTest.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.http.client.NacosRestTemplate;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.tls.TlsSystemConfig;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.plugin.auth.api.LoginIdentityContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +40,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -96,6 +99,27 @@ class HttpLoginProcessorTest {
         assertNull(loginProcessor.getResponse(properties));
     }
     
+    @Test
+    void testGetResponseUsesHttpsWhenTlsEnabled() throws Exception {
+        String previousTlsEnable = System.getProperty(TlsSystemConfig.TLS_ENABLE);
+        System.setProperty(TlsSystemConfig.TLS_ENABLE, "true");
+        try {
+            properties.setProperty(NacosAuthLoginConstant.SERVER, "localhost");
+            when(restTemplate.postForm(anyString(),
+                eq(Header.EMPTY),
+                any(Query.class), anyMap(), eq(String.class))).thenReturn(result);
+            assertNull(loginProcessor.getResponse(properties));
+            verify(restTemplate).postForm(eq("https://localhost:8848/nacos/v3/auth/user/login"),
+                eq(Header.EMPTY), any(Query.class), anyMap(), eq(String.class));
+        } finally {
+            if (previousTlsEnable == null) {
+                System.clearProperty(TlsSystemConfig.TLS_ENABLE);
+            } else {
+                System.setProperty(TlsSystemConfig.TLS_ENABLE, previousTlsEnable);
+            }
+        }
+    }
+
     @Test
     void testGetResponseSuccessFromV1() throws Exception {
         properties.setProperty(NacosAuthLoginConstant.SERVER, "localhost");

--- a/client-basic/src/test/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessorTest.java
+++ b/client-basic/src/test/java/com/alibaba/nacos/client/auth/impl/process/HttpLoginProcessorTest.java
@@ -119,7 +119,7 @@ class HttpLoginProcessorTest {
             }
         }
     }
-
+    
     @Test
     void testGetResponseSuccessFromV1() throws Exception {
         properties.setProperty(NacosAuthLoginConstant.SERVER, "localhost");


### PR DESCRIPTION
## What is the purpose of the change

Fixes #14036.

When `HttpLoginProcessor` receives a server address without an explicit `http://` or `https://` prefix, it currently always prepends `http://`. That makes the login request ignore the Nacos client TLS switch and prevents HTTPS login for callers that pass plain addresses.

This change keeps explicitly prefixed addresses unchanged, and only uses the Nacos client TLS property when the prefix is missing. If `tls.enable=true`, the login URL is built with `https://`; otherwise it keeps the existing default `http://` behavior.

## Brief changelog

- Use `TlsSystemConfig.TLS_ENABLE` when `HttpLoginProcessor` needs to infer a missing protocol prefix.
- Add a regression test covering `tls.enable=true` with a plain server address.

## Verifying this change

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -s .codex-empty-settings.xml -pl client-basic -am -Dtest=HttpLoginProcessorTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -s .codex-empty-settings.xml -pl client-basic -am -DskipITs -DskipRat test`
  - Reactor modules all `SUCCESS`; `nacos-client-basic` reported `Tests run: 281, Failures: 0, Errors: 0, Skipped: 0`.
- `git diff --check`

Checklist:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] ...`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction.
* [ ] Run full `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` / full integration-test suite.
