### PR TITLE
[ISSUE #15359] Fix AI registry version deletion

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
@@ -624,7 +624,7 @@ public class McpServerOperationService {
                 namespaceId, null, null,
                 "nacos", null);
         }
-
+        
         String serverVersionDataId = McpConfigUtils.formatServerVersionInfoDataId(mcpServerId);
         if (deleteAllVersions) {
             configOperationService.deleteConfig(serverVersionDataId,
@@ -647,7 +647,7 @@ public class McpServerOperationService {
                 : AiResourceTraceService.OP_DELETE_RESOURCE,
             VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
-
+    
     private void electLatestMcpServerVersion(McpServerVersionInfo mcpServerVersionInfo) {
         List<ServerVersionDetail> versionDetails = mcpServerVersionInfo.getVersionDetails();
         if (CollectionUtils.isEmpty(versionDetails)) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpServerOperationService.java
@@ -609,6 +609,9 @@ public class McpServerOperationService {
                 .map(ServerVersionDetail::getVersion)
                 .collect(Collectors.toList());
         }
+        List<String> deletedVersions = new ArrayList<>(versionsNeedDelete);
+        boolean deleteAllVersions = mcpServerVersionInfo.getVersionDetails().stream()
+            .map(ServerVersionDetail::getVersion).allMatch(deletedVersions::contains);
         
         for (String versionNeedDelete : versionsNeedDelete) {
             toolOperationService.deleteMcpTool(namespaceId, mcpServerId, versionNeedDelete);
@@ -620,10 +623,21 @@ public class McpServerOperationService {
             configOperationService.deleteConfig(serverSpecDataId, Constants.MCP_SERVER_GROUP,
                 namespaceId, null, null,
                 "nacos", null);
-            String serverVersionDataId = McpConfigUtils.formatServerVersionInfoDataId(mcpServerId);
+        }
+
+        String serverVersionDataId = McpConfigUtils.formatServerVersionInfoDataId(mcpServerId);
+        if (deleteAllVersions) {
             configOperationService.deleteConfig(serverVersionDataId,
                 Constants.MCP_SERVER_VERSIONS_GROUP, namespaceId,
                 null, null, "nacos", null);
+        } else {
+            mcpServerVersionInfo.getVersionDetails()
+                .removeIf(versionDetail -> deletedVersions.contains(versionDetail.getVersion()));
+            electLatestMcpServerVersion(mcpServerVersionInfo);
+            ConfigFormV3 mcpServerVersionForm =
+                buildMcpServerVersionForm(namespaceId, mcpServerVersionInfo);
+            configOperationService.publishConfig(mcpServerVersionForm, new ConfigRequestInfo(),
+                null);
         }
         
         // Delete the relevant cache after a successful database operation
@@ -632,6 +646,37 @@ public class McpServerOperationService {
             StringUtils.isNotEmpty(version) ? AiResourceTraceService.OP_DELETE_VERSION
                 : AiResourceTraceService.OP_DELETE_RESOURCE,
             VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
+    }
+
+    private void electLatestMcpServerVersion(McpServerVersionInfo mcpServerVersionInfo) {
+        List<ServerVersionDetail> versionDetails = mcpServerVersionInfo.getVersionDetails();
+        if (CollectionUtils.isEmpty(versionDetails)) {
+            mcpServerVersionInfo.setLatestPublishedVersion(null);
+            mcpServerVersionInfo.setVersion(null);
+            mcpServerVersionInfo.setVersionDetail(null);
+            return;
+        }
+        String latestVersion = mcpServerVersionInfo.getLatestPublishedVersion();
+        boolean latestVersionExists = false;
+        for (ServerVersionDetail versionDetail : versionDetails) {
+            if (StringUtils.equals(versionDetail.getVersion(), latestVersion)) {
+                latestVersionExists = true;
+                break;
+            }
+        }
+        if (!latestVersionExists) {
+            latestVersion = versionDetails.get(versionDetails.size() - 1).getVersion();
+            mcpServerVersionInfo.setLatestPublishedVersion(latestVersion);
+        }
+        for (ServerVersionDetail versionDetail : versionDetails) {
+            boolean isLatest = StringUtils.equals(versionDetail.getVersion(), latestVersion);
+            versionDetail.setIs_latest(isLatest);
+            if (isLatest) {
+                mcpServerVersionInfo.setVersion(latestVersion);
+                mcpServerVersionInfo.setVersionDetail(versionDetail);
+            }
+        }
+        mcpServerVersionInfo.setVersions(versionDetails);
     }
     
     private void injectMcpDescriptionsAndEndpoint(String namespaceId, String mcpServerId,

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationService.java
@@ -175,8 +175,7 @@ public class A2aServerOperationService {
                     .removeIf(versionDetail -> versionDetail.getVersion().equals(version));
                 
                 if (isLatestVersion) {
-                    agentCardVersionInfo.setLatestPublishedVersion(null);
-                    agentCardVersionInfo.setVersion(null);
+                    electLatestAgentVersion(agentCardVersionInfo);
                 }
                 
                 ConfigForm updateForm =
@@ -201,6 +200,21 @@ public class A2aServerOperationService {
             StringUtils.isNotEmpty(version) ? AiResourceTraceService.OP_DELETE_VERSION
                 : AiResourceTraceService.OP_DELETE_RESOURCE,
             VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
+    }
+
+    private void electLatestAgentVersion(AgentCardVersionInfo agentCardVersionInfo) {
+        List<AgentVersionDetail> versionDetails = agentCardVersionInfo.getVersionDetails();
+        if (versionDetails == null || versionDetails.isEmpty()) {
+            agentCardVersionInfo.setLatestPublishedVersion(null);
+            agentCardVersionInfo.setVersion(null);
+            return;
+        }
+        AgentVersionDetail latestVersion = versionDetails.get(versionDetails.size() - 1);
+        agentCardVersionInfo.setLatestPublishedVersion(latestVersion.getVersion());
+        agentCardVersionInfo.setVersion(latestVersion.getVersion());
+        versionDetails.forEach(
+            versionDetail -> versionDetail.setLatest(StringUtils.equals(versionDetail.getVersion(),
+                latestVersion.getVersion())));
     }
     
     /**
@@ -391,7 +405,8 @@ public class A2aServerOperationService {
         if (AiConstants.A2a.A2A_ENDPOINT_TYPE_SERVICE.equalsIgnoreCase(registrationType)) {
             injectEndpoint(result, namespaceId);
         }
-        if (agentCardVersionInfo.getLatestPublishedVersion().equals(result.getVersion())) {
+        if (StringUtils.equals(agentCardVersionInfo.getLatestPublishedVersion(),
+            result.getVersion())) {
             result.setLatestVersion(true);
         }
         return result;

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationService.java
@@ -201,7 +201,7 @@ public class A2aServerOperationService {
                 : AiResourceTraceService.OP_DELETE_RESOURCE,
             VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
     }
-
+    
     private void electLatestAgentVersion(AgentCardVersionInfo agentCardVersionInfo) {
         List<AgentVersionDetail> versionDetails = agentCardVersionInfo.getVersionDetails();
         if (versionDetails == null || versionDetails.isEmpty()) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
@@ -1018,7 +1018,7 @@ class McpServerOperationServiceTest {
         assertTrue(allArgs.contains("mcpName::9.9.9"), "Missing deletion call for version 9.9.9");
         
         String serverVersionDataId = McpConfigUtils.formatServerVersionInfoDataId(id);
-        verify(configOperationService, times(2)).deleteConfig(serverVersionDataId,
+        verify(configOperationService, times(1)).deleteConfig(serverVersionDataId,
             Constants.MCP_SERVER_VERSIONS_GROUP,
             AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
         verify(mcpServerIndex, times(0))
@@ -1064,7 +1064,7 @@ class McpServerOperationServiceTest {
             .removeMcpServerByName(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, "mcpName");
         verify(mcpServerIndex, times(0)).removeMcpServerById(null);
         String serverVersionDataId = McpConfigUtils.formatServerVersionInfoDataId(id);
-        verify(configOperationService, times(2)).deleteConfig(serverVersionDataId,
+        verify(configOperationService, times(1)).deleteConfig(serverVersionDataId,
             Constants.MCP_SERVER_VERSIONS_GROUP,
             AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
         for (ServerVersionDetail each : mockServerVersionInfo(id).getVersionDetails()) {
@@ -1095,9 +1095,21 @@ class McpServerOperationServiceTest {
             AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,
             "mcpName::1.0.0");
         String serverVersionDataId = McpConfigUtils.formatServerVersionInfoDataId(id);
-        verify(configOperationService).deleteConfig(serverVersionDataId,
-            Constants.MCP_SERVER_VERSIONS_GROUP,
-            AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, null, null, "nacos", null);
+        verify(configOperationService, never()).deleteConfig(eq(serverVersionDataId),
+            eq(Constants.MCP_SERVER_VERSIONS_GROUP),
+            eq(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE), isNull(), isNull(), eq("nacos"),
+            isNull());
+        ArgumentCaptor<ConfigFormV3> configCaptor = ArgumentCaptor.forClass(ConfigFormV3.class);
+        verify(configOperationService).publishConfig(configCaptor.capture(),
+            any(ConfigRequestInfo.class), isNull());
+        assertEquals(serverVersionDataId, configCaptor.getValue().getDataId());
+
+        McpServerVersionInfo updatedVersionInfo =
+            JacksonUtils.toObj(configCaptor.getValue().getContent(), McpServerVersionInfo.class);
+        assertEquals("9.9.9", updatedVersionInfo.getLatestPublishedVersion());
+        assertEquals(1, updatedVersionInfo.getVersionDetails().size());
+        assertEquals("9.9.9", updatedVersionInfo.getVersionDetails().get(0).getVersion());
+        assertTrue(updatedVersionInfo.getVersionDetails().get(0).getIs_latest());
         verify(toolOperationService).deleteMcpTool(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE, id,
             "1.0.0");
         verify(resourceOperationService).deleteMcpResource(AiConstants.Mcp.MCP_DEFAULT_NAMESPACE,

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpServerOperationServiceTest.java
@@ -1103,7 +1103,7 @@ class McpServerOperationServiceTest {
         verify(configOperationService).publishConfig(configCaptor.capture(),
             any(ConfigRequestInfo.class), isNull());
         assertEquals(serverVersionDataId, configCaptor.getValue().getDataId());
-
+        
         McpServerVersionInfo updatedVersionInfo =
             JacksonUtils.toObj(configCaptor.getValue().getContent(), McpServerVersionInfo.class);
         assertEquals("9.9.9", updatedVersionInfo.getLatestPublishedVersion());

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationServiceTest.java
@@ -254,42 +254,43 @@ public class A2aServerOperationServiceTest {
             eq(Constants.A2A.AGENT_GROUP),
             eq(TEST_NAMESPACE_ID), eq(null), eq(null), eq("nacos"), eq(null));
     }
-
+    
     @Test
     void testDeleteAgentLatestVersionElectsRemainingVersion() throws NacosException {
         AgentCardVersionInfo versionInfo = buildTestAgentCardVersionInfo();
         AgentVersionDetail currentVersion = versionInfo.getVersionDetails().get(0);
         currentVersion.setLatest(false);
-
+        
         AgentVersionDetail latestVersion = new AgentVersionDetail();
         latestVersion.setVersion("2.0.0");
         latestVersion.setLatest(true);
         versionInfo.setVersion("2.0.0");
         versionInfo.setLatestPublishedVersion("2.0.0");
         versionInfo.setVersionDetails(new LinkedList<>(List.of(currentVersion, latestVersion)));
-
+        
         ConfigQueryChainResponse response = mock(ConfigQueryChainResponse.class);
         when(response.getStatus())
             .thenReturn(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
         when(response.getContent()).thenReturn(JacksonUtils.toJson(versionInfo));
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
             .thenReturn(response);
-
+        
         a2aServerOperationService.deleteAgent(TEST_NAMESPACE_ID, TEST_AGENT_NAME, "2.0.0");
-
+        
         verify(configOperationService).deleteConfig(eq(ENCODED_AGENT_NAME + "-2.0.0"),
             eq(Constants.A2A.AGENT_VERSION_GROUP), eq(TEST_NAMESPACE_ID), eq(null), eq(null),
             eq("nacos"), eq(null));
         ArgumentCaptor<ConfigForm> configCaptor = forClass(ConfigForm.class);
         verify(configOperationService).publishConfig(configCaptor.capture(),
             any(ConfigRequestInfo.class), eq(null));
-
+        
         AgentCardVersionInfo updatedVersionInfo =
             JacksonUtils.toObj(configCaptor.getValue().getContent(), AgentCardVersionInfo.class);
         assertEquals(TEST_AGENT_VERSION, updatedVersionInfo.getLatestPublishedVersion());
         assertEquals(TEST_AGENT_VERSION, updatedVersionInfo.getVersion());
         assertEquals(1, updatedVersionInfo.getVersionDetails().size());
-        assertEquals(TEST_AGENT_VERSION, updatedVersionInfo.getVersionDetails().get(0).getVersion());
+        assertEquals(TEST_AGENT_VERSION,
+            updatedVersionInfo.getVersionDetails().get(0).getVersion());
         assertEquals(true, updatedVersionInfo.getVersionDetails().get(0).isLatest());
     }
     

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationServiceTest.java
@@ -254,6 +254,44 @@ public class A2aServerOperationServiceTest {
             eq(Constants.A2A.AGENT_GROUP),
             eq(TEST_NAMESPACE_ID), eq(null), eq(null), eq("nacos"), eq(null));
     }
+
+    @Test
+    void testDeleteAgentLatestVersionElectsRemainingVersion() throws NacosException {
+        AgentCardVersionInfo versionInfo = buildTestAgentCardVersionInfo();
+        AgentVersionDetail currentVersion = versionInfo.getVersionDetails().get(0);
+        currentVersion.setLatest(false);
+
+        AgentVersionDetail latestVersion = new AgentVersionDetail();
+        latestVersion.setVersion("2.0.0");
+        latestVersion.setLatest(true);
+        versionInfo.setVersion("2.0.0");
+        versionInfo.setLatestPublishedVersion("2.0.0");
+        versionInfo.setVersionDetails(new LinkedList<>(List.of(currentVersion, latestVersion)));
+
+        ConfigQueryChainResponse response = mock(ConfigQueryChainResponse.class);
+        when(response.getStatus())
+            .thenReturn(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        when(response.getContent()).thenReturn(JacksonUtils.toJson(versionInfo));
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response);
+
+        a2aServerOperationService.deleteAgent(TEST_NAMESPACE_ID, TEST_AGENT_NAME, "2.0.0");
+
+        verify(configOperationService).deleteConfig(eq(ENCODED_AGENT_NAME + "-2.0.0"),
+            eq(Constants.A2A.AGENT_VERSION_GROUP), eq(TEST_NAMESPACE_ID), eq(null), eq(null),
+            eq("nacos"), eq(null));
+        ArgumentCaptor<ConfigForm> configCaptor = forClass(ConfigForm.class);
+        verify(configOperationService).publishConfig(configCaptor.capture(),
+            any(ConfigRequestInfo.class), eq(null));
+
+        AgentCardVersionInfo updatedVersionInfo =
+            JacksonUtils.toObj(configCaptor.getValue().getContent(), AgentCardVersionInfo.class);
+        assertEquals(TEST_AGENT_VERSION, updatedVersionInfo.getLatestPublishedVersion());
+        assertEquals(TEST_AGENT_VERSION, updatedVersionInfo.getVersion());
+        assertEquals(1, updatedVersionInfo.getVersionDetails().size());
+        assertEquals(TEST_AGENT_VERSION, updatedVersionInfo.getVersionDetails().get(0).getVersion());
+        assertEquals(true, updatedVersionInfo.getVersionDetails().get(0).isLatest());
+    }
     
     @Test
     void testDeleteAgentWhenAgentNotFound() throws NacosException {


### PR DESCRIPTION
## Summary
- re-elect a remaining A2A agent version when deleting the latest version
- keep the MCP server version aggregate when deleting only one version, and publish the remaining version list
- delete the MCP version aggregate only when all versions are removed

## Root cause
Deleting a target version updated the per-version config but left aggregate metadata inconsistent. For A2A, deleting the latest version could leave latest/version empty while older versions still existed. For MCP, deleting one version removed the whole version aggregate, so the server and endpoints disappeared.

## Tests
- JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -s .codex-empty-settings.xml -pl ai -am -Dtest=A2aServerOperationServiceTest#testDeleteAgentLatestVersionElectsRemainingVersion,McpServerOperationServiceTest#deleteMcpServerForTargetVersion -Dsurefire.failIfNoSpecifiedTests=false test
- JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -s .codex-empty-settings.xml -pl ai -am -Dtest=A2aServerOperationServiceTest,McpServerOperationServiceTest -Dsurefire.failIfNoSpecifiedTests=false test
- JAVA_HOME=$(/usr/libexec/java_home -v 17) ./mvnw -s .codex-empty-settings.xml -pl ai -am -Dsurefire.failIfNoSpecifiedTests=false test

Fixes #15359