### PR TITLE
Fix trailing separator in StringUtils.join with null elements

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/utils/StringUtils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/utils/StringUtils.java
@@ -203,12 +203,14 @@ public class StringUtils {
         StringBuilder stringBuilder = new StringBuilder();
         Object[] objects = collection.toArray();
         
+        boolean first = true;
         for (int i = 0; i < collection.size(); i++) {
             if (objects[i] != null) {
-                stringBuilder.append(objects[i]);
-                if (i != collection.size() - 1 && separator != null) {
+                if (!first && separator != null) {
                     stringBuilder.append(separator);
                 }
+                stringBuilder.append(objects[i]);
+                first = false;
             }
         }
         

--- a/common/src/test/java/com/alibaba/nacos/common/utils/StringUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/StringUtilsTest.java
@@ -513,4 +513,16 @@ class StringUtilsTest {
         String str5 = "abc123";
         assertEquals("Abc123", StringUtils.capitalize(str5));
     }
+    
+    @Test
+    void testJoinWithTrailingNulls() {
+        // Trailing null elements should NOT produce a trailing separator
+        assertEquals("a", StringUtils.join(Arrays.asList("a", null), ","));
+        assertEquals("a", StringUtils.join(Arrays.asList("a", null, null), ","));
+        // Leading nulls should not produce leading separator
+        assertEquals("b", StringUtils.join(Arrays.asList(null, "b"), ","));
+        // Mixed nulls should not produce trailing separator
+        assertEquals("a,b", StringUtils.join(Arrays.asList("a", null, "b", null), ","));
+        assertEquals("a,b", StringUtils.join(Arrays.asList("a", "b", null), ","));
+    }
 }


### PR DESCRIPTION
## Problem

`StringUtils.join(Collection, String)` skips `null` elements, but it decides whether to append the separator from the element **index** (`i != collection.size() - 1`) rather than from whether another non-null element actually follows. When the collection ends with one or more `null` values, a stray trailing separator is produced:

```java
StringUtils.join(Arrays.asList("a", null), ",");          // "a,"   (expected "a")
StringUtils.join(Arrays.asList("a", null, "b", null), ","); // "a,b," (expected "a,b")
```

Leading and interior nulls combined with a trailing null are affected the same way.

## Fix

Track whether anything has been appended yet and emit the separator **before** each subsequent non-null element instead of after by index. This makes trailing, leading, and mixed null elements behave correctly while leaving the all-non-null case unchanged.

## Test

Adds `testJoinWithTrailingNulls` to `StringUtilsTest` covering trailing, leading, and mixed null cases. It fails on `develop` (`expected: <a> but was: <a,>`) and passes with this change; the full `StringUtilsTest` suite (31 tests) and `checkstyle:check` on the `common` module both pass.