### PR TITLE
[ISSUE #14693] Fix MCP service selector pagination

### DIFF
--- a/console-ui-next/src/pages/newMcpServer/__tests__/service-options.test.ts
+++ b/console-ui-next/src/pages/newMcpServer/__tests__/service-options.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadServiceOptions } from '../service-options';
+
+describe('newMcpServer service options', () => {
+  it('loads every service page so the existing-service selector is not capped at 100 items', async () => {
+    const listServices = vi.fn()
+      .mockResolvedValueOnce({
+        data: {
+          totalCount: 101,
+          pageItems: Array.from({ length: 100 }, (_, index) => ({
+            groupName: 'DEFAULT_GROUP',
+            name: `service-${index + 1}`,
+          })),
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          totalCount: 101,
+          pageItems: [{ groupName: 'DEFAULT_GROUP', name: 'service-101' }],
+        },
+      });
+
+    const options = await loadServiceOptions('public', listServices);
+
+    expect(listServices).toHaveBeenCalledTimes(2);
+    expect(listServices).toHaveBeenNthCalledWith(1, {
+      namespaceId: 'public',
+      pageNo: 1,
+      pageSize: 100,
+      serviceNameParam: undefined,
+    });
+    expect(listServices).toHaveBeenNthCalledWith(2, {
+      namespaceId: 'public',
+      pageNo: 2,
+      pageSize: 100,
+      serviceNameParam: undefined,
+    });
+    expect(options).toHaveLength(101);
+    expect(options[options.length - 1]).toEqual({
+      label: 'DEFAULT_GROUP / service-101',
+      value: 'DEFAULT_GROUP@@service-101',
+    });
+  });
+
+  it('passes the search keyword to the service list API', async () => {
+    const listServices = vi.fn().mockResolvedValueOnce({
+      data: {
+        totalCount: 1,
+        pageItems: [{ groupName: 'DEFAULT_GROUP', name: 'payment-service' }],
+      },
+    });
+
+    await loadServiceOptions('public', listServices, 'payment');
+
+    expect(listServices).toHaveBeenCalledWith({
+      namespaceId: 'public',
+      pageNo: 1,
+      pageSize: 100,
+      serviceNameParam: 'payment',
+    });
+  });
+});

--- a/console-ui-next/src/pages/newMcpServer/index.tsx
+++ b/console-ui-next/src/pages/newMcpServer/index.tsx
@@ -54,6 +54,7 @@ import type {
 import { cn } from '@/lib/utils';
 import ToolManager from './tool-manager';
 import { resolveMcpEndpointUrl, shouldUseExistingService } from './endpoint-utils';
+import { loadServiceOptions } from './service-options';
 
 const PROTOCOL_CARD_CONFIG: Record<string, { icon: typeof Terminal; label: string; color: string; bg: string; dot: string; ring: string }> = {
   stdio: {
@@ -130,6 +131,7 @@ export default function NewMcpServerPage() {
   const [exportPath, setExportPath] = useState('');
   const [selectedService, setSelectedService] = useState(''); // format: groupName@@serviceName
   const [serviceList, setServiceList] = useState<{ label: string; value: string }[]>([]);
+  const [serviceSearch, setServiceSearch] = useState('');
 
   // Stdio config
   const [localServerConfig, setLocalServerConfig] = useState('');
@@ -226,23 +228,22 @@ export default function NewMcpServerPage() {
 
   // Fetch service list for "use existing service" mode
   useEffect(() => {
-    serviceApi
-      .listServices({ namespaceId, pageNo: 1, pageSize: 100 })
-      .then((response) => {
-        const result = (response as unknown as { data: { pageItems: Array<{ name: string; groupName: string }> } }).data;
-        if (result?.pageItems) {
-          setServiceList(
-            result.pageItems.map((item) => ({
-              label: `${item.groupName} / ${item.name}`,
-              value: `${item.groupName}@@${item.name}`,
-            }))
-          );
+    let cancelled = false;
+    loadServiceOptions(namespaceId, serviceApi.listServices, serviceSearch)
+      .then((options) => {
+        if (!cancelled) {
+          setServiceList(options);
         }
       })
       .catch(() => {
-        // silently ignore - user can still type manually
+        if (!cancelled) {
+          setServiceList([]);
+        }
       });
-  }, [namespaceId]);
+    return () => {
+      cancelled = true;
+    };
+  }, [namespaceId, serviceSearch]);
 
   const populateForm = (data: McpServerDetailInfo) => {
     setServerName(data.name);
@@ -870,6 +871,11 @@ export default function NewMcpServerPage() {
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
                       <div className="space-y-2.5">
                         <Label>{t('mcp.selectService')}</Label>
+                        <Input
+                          value={serviceSearch}
+                          onChange={(e) => setServiceSearch(e.target.value)}
+                          placeholder={t('service.serviceName')}
+                        />
                         {serviceList.length > 0 ? (
                           <Select value={selectedService} onValueChange={setSelectedService}>
                             <SelectTrigger>

--- a/console-ui-next/src/pages/newMcpServer/service-options.ts
+++ b/console-ui-next/src/pages/newMcpServer/service-options.ts
@@ -1,0 +1,52 @@
+import type { ServiceListParams, ServiceListResponse } from '@/types/service';
+
+const SERVICE_SELECTOR_PAGE_SIZE = 100;
+
+type ListServices = (params: ServiceListParams) => Promise<unknown>;
+
+type ServiceOption = {
+  label: string;
+  value: string;
+};
+
+function unwrapServiceListResponse(response: unknown): ServiceListResponse {
+  return (response as { data?: ServiceListResponse }).data || { totalCount: 0, pageItems: [] };
+}
+
+export async function loadServiceOptions(
+  namespaceId: string,
+  listServices: ListServices,
+  serviceNameParam?: string
+): Promise<ServiceOption[]> {
+  const options: ServiceOption[] = [];
+  const trimmedKeyword = serviceNameParam?.trim();
+  let pageNo = 1;
+  let totalCount = Number.POSITIVE_INFINITY;
+
+  while (options.length < totalCount) {
+    const data = unwrapServiceListResponse(
+      await listServices({
+        namespaceId,
+        pageNo,
+        pageSize: SERVICE_SELECTOR_PAGE_SIZE,
+        serviceNameParam: trimmedKeyword || undefined,
+      })
+    );
+    const pageItems = data.pageItems || [];
+    totalCount = data.totalCount ?? options.length + pageItems.length;
+
+    options.push(
+      ...pageItems.map((item) => ({
+        label: `${item.groupName} / ${item.name}`,
+        value: `${item.groupName}@@${item.name}`,
+      }))
+    );
+
+    if (pageItems.length === 0) {
+      break;
+    }
+    pageNo += 1;
+  }
+
+  return options;
+}

--- a/console-ui/src/pages/AI/NewMcpServer/NewMcpServer.js
+++ b/console-ui/src/pages/AI/NewMcpServer/NewMcpServer.js
@@ -881,30 +881,46 @@ class NewMcpServer extends React.Component {
   // }
 
   getServiceList = async namespaceId => {
-    const data = {
-      ignoreEmptyService: false,
-      withInstances: false,
-      pageNo: 1,
-      pageSize: 100,
-      namespaceId: namespaceId,
-    };
-    const result = await request({
-      url: 'v3/console/ns/service/list',
-      method: 'get',
-      data,
-    });
+    const pageSize = 100;
+    let pageNo = 1;
+    let totalCount = Infinity;
+    const serviceList = [];
 
-    if (result.code === 0) {
-      this.setState({
-        serviceList: result.data.pageItems.map(item => ({
-          label: `${item.groupName} / ${item.name}`,
-          value: item.groupName + '@@' + item.name,
-          ...item,
-        })),
+    while (serviceList.length < totalCount) {
+      const result = await request({
+        url: 'v3/console/ns/service/list',
+        method: 'get',
+        data: {
+          ignoreEmptyService: false,
+          withInstances: false,
+          pageNo,
+          pageSize,
+          namespaceId,
+        },
       });
-    } else {
-      Message.error(result.message);
+
+      if (result.code !== 0) {
+        Message.error(result.message);
+        return;
+      }
+
+      const pageItems = result.data?.pageItems || [];
+      totalCount = result.data?.totalCount ?? serviceList.length + pageItems.length;
+      serviceList.push(...pageItems);
+
+      if (pageItems.length === 0) {
+        break;
+      }
+      pageNo += 1;
     }
+
+    this.setState({
+      serviceList: serviceList.map(item => ({
+        label: `${item.groupName} / ${item.name}`,
+        value: item.groupName + '@@' + item.name,
+        ...item,
+      })),
+    });
   };
 
   // 解析 MCP Server Endpoint 并更新相关字段
@@ -981,18 +997,13 @@ class NewMcpServer extends React.Component {
 
     const preservedExtensions = {};
     Object.keys(sourceExtensions || {}).forEach(key => {
-      if (
-        key !== 'server.defaultDownstreamSecurity' &&
-        key !== 'server.defaultUpstreamSecurity'
-      ) {
+      if (key !== 'server.defaultDownstreamSecurity' && key !== 'server.defaultUpstreamSecurity') {
         preservedExtensions[key] = sourceExtensions[key];
       }
     });
 
     const downstreamId = this.field.getValue('defaultDownstreamSecurityId');
-    const downstreamPassthrough = this.field.getValue(
-      'defaultDownstreamSecurityPassthrough'
-    );
+    const downstreamPassthrough = this.field.getValue('defaultDownstreamSecurityPassthrough');
     if (downstreamId) {
       preservedExtensions['server.defaultDownstreamSecurity'] = {
         id: downstreamId,
@@ -1039,7 +1050,6 @@ class NewMcpServer extends React.Component {
     }
 
     return extensions;
-
   };
 
   // 切换高级配置展开/折叠状态
@@ -2047,7 +2057,8 @@ class NewMcpServer extends React.Component {
                                 },
                               })}
                               placeholder={
-                                locale.upstreamCredentialPlaceholder || 'Optional credential override'
+                                locale.upstreamCredentialPlaceholder ||
+                                'Optional credential override'
                               }
                               autoHeight={{ minRows: 2, maxRows: 4 }}
                               disabled={!this.field.getValue('defaultUpstreamSecurityId')}


### PR DESCRIPTION
## What changed

This PR fixes the MCP server creation page when selecting an existing Nacos service.

The selector previously loaded only the first service page with `pageSize: 100`, so services after the first 100 records could not be selected from the UI.

Changes:
- load all pages for the existing-service selector in the next console
- keep a small service-name filter so large namespaces can still be narrowed before selection
- apply the same pagination behavior to the legacy console page
- add focused tests for the new console service-option loader

## Validation

```bash
cd console-ui-next
npm test -- src/pages/newMcpServer/__tests__/endpoint-utils.test.ts src/pages/newMcpServer/__tests__/service-options.test.ts
npx tsc -b
npx eslint src/pages/newMcpServer/index.tsx src/pages/newMcpServer/service-options.ts src/pages/newMcpServer/__tests__/service-options.test.ts
npm run build

cd ../console-ui
npm ci
npm run build

git diff --check
```

Notes:
- The targeted next-console eslint command reports one existing `react-hooks/exhaustive-deps` warning in `index.tsx` around the edit/version data-loading effect; this PR does not modify that effect.
- The legacy console eslint command currently hits an ESLint 6 internal TypeError on existing code, so the legacy page was validated through the webpack production build instead.

Closes #14693
