### PR TITLE
Skip malformed config-plugin property names without a dot in refreshPluginProperties

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigs.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigs.java
@@ -58,6 +58,9 @@ public class ConfigChangeConfigs extends Subscriber<ServerConfigChangeEvent> {
             if (properties != null) {
                 for (String each : properties.stringPropertyNames()) {
                     int typeIndex = each.indexOf('.');
+                    if (typeIndex < 0) {
+                        continue;
+                    }
                     String type = each.substring(0, typeIndex);
                     String subKey = each.substring(typeIndex + 1);
                     newProperties.computeIfAbsent(type, key -> new Properties())

--- a/config/src/test/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigsTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigsTest.java
@@ -160,4 +160,38 @@ class ConfigChangeConfigsTest {
         }
     }
     
+    @Test
+    void testRefreshPluginPropertiesIgnoresMalformedPropertyWithoutDot() {
+        // Create a fresh ConfigChangeConfigs with no valid properties loaded first.
+        MockEnvironment emptyEnv = new MockEnvironment();
+        EnvUtil.setEnvironment(emptyEnv);
+        
+        // Mock PropertiesUtil to return Properties containing both a valid key
+        // ("mockPlugin.enabled") and a malformed one without any dot ("nodotvalue").
+        // When the loop hits "nodotvalue", indexOf('.') returns -1, and
+        // substring(0, -1) throws StringIndexOutOfBoundsException. The exception
+        // is caught, but the assignment `configPluginProperties = newProperties` at line 67
+        // is inside the try block BEFORE the catch, so all valid entries are lost.
+        Properties badProperties = new Properties();
+        badProperties.setProperty("mockPlugin.enabled", "true");
+        badProperties.setProperty("nodotvalue", "bad");
+        
+        try (MockedStatic<PropertiesUtil> mocked = Mockito.mockStatic(PropertiesUtil.class)) {
+            mocked.when(() -> PropertiesUtil.getPropertiesWithPrefix(Mockito.any(),
+                Mockito.eq(ConfigChangeConstants.NACOS_CORE_CONFIG_PLUGIN_PREFIX)))
+                .thenReturn(badProperties);
+            
+            // Create a brand new instance so its constructor's refreshPluginProperties()
+            // runs with the mocked badProperties — no prior valid data to fall back on.
+            ConfigChangeConfigs freshConfigs = new ConfigChangeConfigs();
+            
+            // Valid property "mockPlugin.enabled" must survive despite the malformed "nodotvalue"
+            // causing StringIndexOutOfBoundsException. If the bug exists, the exception prevents
+            // the assignment of configPluginProperties, so valid properties are wiped out.
+            assertTrue(Boolean.parseBoolean(
+                freshConfigs.getPluginProperties("mockPlugin").getProperty("enabled")),
+                "Valid property 'mockPlugin.enabled' should still be loaded even when "
+                    + "a malformed property without dot ('nodotvalue') causes StringIndexOutOfBoundsException");
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`ConfigChangeConfigs.refreshPluginProperties()` iterates the property names under the config-plugin prefix and splits each on the first dot:

```java
for (String each : properties.stringPropertyNames()) {
    int typeIndex = each.indexOf(.);
    String type = each.substring(0, typeIndex);        // typeIndex == -1 -> StringIndexOutOfBoundsException
    String subKey = each.substring(typeIndex + 1);
    ...
}
configPluginProperties = newProperties;                 // never reached if the loop threw
```

If any property name under the prefix has no dot, `indexOf(.)` returns `-1` and `substring(0, -1)` throws `StringIndexOutOfBoundsException`. The exception is caught further out, but it occurs **before** `configPluginProperties` is assigned, so every valid plugin property loaded in that pass is discarded.

## Fix

Skip property names without a dot, so a single malformed entry no longer wipes out the valid plugin properties.

## Test

Adds `testRefreshPluginPropertiesIgnoresMalformedPropertyWithoutDot` to `ConfigChangeConfigsTest`: it mocks the prefixed properties to include a valid `mockPlugin.enabled` and a malformed `nodotvalue`, and asserts the valid one is still loaded. It fails before the change (`StringIndexOutOfBoundsException` wipes the valid property) and passes after.