### PR TITLE
[ISSUE #14466] Clean up client JSON runtime paths

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/ai/cache/NacosMcpServerCacheHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/cache/NacosMcpServerCacheHolder.java
@@ -19,6 +19,8 @@ package com.alibaba.nacos.client.ai.cache;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.client.ai.event.McpServerChangedEvent;
 import com.alibaba.nacos.client.ai.remote.AiGrpcClient;
 import com.alibaba.nacos.client.ai.utils.CacheKeyUtils;
@@ -27,12 +29,6 @@ import com.alibaba.nacos.common.executor.NameThreadFactory;
 import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.StringUtils;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,8 +52,6 @@ public class NacosMcpServerCacheHolder implements Closeable {
     
     private final Map<String, McpServerDetailInfo> mcpServerCache;
     
-    private final ObjectMapper objectMapper;
-    
     private final ScheduledExecutorService updaterExecutor;
     
     private final long updateIntervalMillis;
@@ -68,10 +62,6 @@ public class NacosMcpServerCacheHolder implements Closeable {
         this.aiGrpcClient = aiGrpcClient;
         this.mcpServerCache = new ConcurrentHashMap<>(4);
         this.updateTaskMap = new ConcurrentHashMap<>(4);
-        this.objectMapper =
-            JsonMapper.builder().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build()
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
         this.updaterExecutor = new ScheduledThreadPoolExecutor(1,
             new NameThreadFactory("com.alibaba.nacos.client.ai.mcp.server.updater"));
         this.updateIntervalMillis =
@@ -138,17 +128,17 @@ public class NacosMcpServerCacheHolder implements Closeable {
     private boolean isMcpServerChanged(McpServerDetailInfo oldMcpServer,
         McpServerDetailInfo detailInfo) {
         try {
-            String newJson = objectMapper.writeValueAsString(detailInfo);
+            String newJson = JsonUtils.toCanonicalJson(detailInfo);
             if (null == oldMcpServer) {
                 LOGGER.info("init new mcp service: {} -> {}", detailInfo.getName(), newJson);
                 return true;
             }
-            String oldJson = objectMapper.writeValueAsString(oldMcpServer);
+            String oldJson = JsonUtils.toCanonicalJson(oldMcpServer);
             if (!StringUtils.equals(oldJson, newJson)) {
                 LOGGER.info("mcp service changed: {} -> {}", oldJson, newJson);
                 return true;
             }
-        } catch (JsonProcessingException e) {
+        } catch (NacosSerializationException e) {
             LOGGER.error("Compare mcp server info failed: ", e);
         }
         return false;

--- a/client/src/main/java/com/alibaba/nacos/client/naming/utils/InitUtils.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/utils/InitUtils.java
@@ -19,16 +19,13 @@ package com.alibaba.nacos.client.naming.utils;
 import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.SystemPropertyKeyConst;
 import com.alibaba.nacos.api.common.Constants;
-import com.alibaba.nacos.api.selector.ExpressionSelector;
-import com.alibaba.nacos.api.selector.NoneSelector;
-import com.alibaba.nacos.api.selector.SelectorType;
+import com.alibaba.nacos.api.selector.SelectorFactory;
 import com.alibaba.nacos.client.env.NacosClientProperties;
 import com.alibaba.nacos.client.env.SourceType;
 import com.alibaba.nacos.client.utils.ContextPathUtil;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.client.utils.TemplateUtils;
 import com.alibaba.nacos.client.utils.TenantUtil;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 /**
@@ -117,7 +114,6 @@ public class InitUtils {
      */
     public static void initSerialization() {
         // TODO register in implementation class or remove subType
-        JacksonUtils.registerSubtype(NoneSelector.class, SelectorType.none.name());
-        JacksonUtils.registerSubtype(ExpressionSelector.class, SelectorType.label.name());
+        SelectorFactory.preload();
     }
 }

--- a/client/src/main/java/com/alibaba/nacos/client/utils/PreInitUtils.java
+++ b/client/src/main/java/com/alibaba/nacos/client/utils/PreInitUtils.java
@@ -16,14 +16,14 @@
 
 package com.alibaba.nacos.client.utils;
 
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.client.auth.ram.utils.SpasAdapter;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 
 /**
  * Async do pre init to load some cost component.
  *
  * <ul>
- *     <li>JacksonUtil</li>
+ *     <li>JsonUtils</li>
  *     <li>SpasAdapter</li>
  * </ul>
  *
@@ -35,12 +35,14 @@ public class PreInitUtils {
      * Async pre load cost component.
      */
     public static void asyncPreLoadCostComponent() {
-        Thread preLoadThread = new Thread(() -> {
-            // Jackson util will init static {@code ObjectMapper}, which will cost hundreds milliseconds.
-            JacksonUtils.createEmptyJsonNode();
-            // Ram auth plugin will try to get credential from env and system when leak input identity by properties.
-            SpasAdapter.getAk();
-        });
+        Thread preLoadThread = new Thread(PreInitUtils::preLoadCostComponent);
         preLoadThread.start();
+    }
+    
+    static void preLoadCostComponent() {
+        // JSON adapter initialization may cost hundreds milliseconds on first use.
+        JsonUtils.preload();
+        // Ram auth plugin will try to get credential from env and system when leak input identity by properties.
+        SpasAdapter.getAk();
     }
 }

--- a/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosMcpServerCacheHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosMcpServerCacheHolderTest.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.client.ai.cache;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,7 +72,7 @@ class NacosMcpServerCacheHolderTest {
         NotifyCenter.deregisterPublisher(McpServerChangedEvent.class);
     }
     
-    @Test()
+    @Test
     void processMcpServerDetailInfo() throws InterruptedException {
         assertNull(cacheHolder.getMcpServer("test", "1.0.0"));
         MockEventSubscriber subscriber = new MockEventSubscriber();
@@ -94,7 +96,7 @@ class NacosMcpServerCacheHolderTest {
         fail("Subscriber for McpServerChangedEvent don't be invoked.");
     }
     
-    @Test()
+    @Test
     void processMcpServerDetailInfoLatest() throws InterruptedException {
         assertNull(cacheHolder.getMcpServer("test", "1.0.0"));
         MockEventSubscriber subscriber = new MockEventSubscriber();
@@ -162,6 +164,50 @@ class NacosMcpServerCacheHolderTest {
         NotifyCenter.registerSubscriber(subscriber);
         cacheHolder.processMcpServerDetailInfo(mcpServerDetailInfo);
         assertEquals(mcpServerDetailInfo, cacheHolder.getMcpServer("test", "1.0.0"));
+        int retry = 0;
+        while (retry < 3) {
+            TimeUnit.MILLISECONDS.sleep(500);
+            if (subscriber.invokedMark.get()) {
+                fail("Subscriber for McpServerChangedEvent should not be invoked, but invoked.");
+            }
+            retry++;
+        }
+    }
+    
+    @Test()
+    void processMcpServerDetailInfoNoDiffWithDifferentMapOrder() throws InterruptedException {
+        Map<String, Object> originalConfig = new LinkedHashMap<>();
+        originalConfig.put("z", "last");
+        originalConfig.put("a", "first");
+        cacheHolder.processMcpServerDetailInfo(buildMcpServerDetailInfo(originalConfig));
+        
+        MockEventSubscriber subscriber = new MockEventSubscriber();
+        NotifyCenter.registerSubscriber(subscriber);
+        Map<String, Object> reorderedConfig = new LinkedHashMap<>();
+        reorderedConfig.put("a", "first");
+        reorderedConfig.put("z", "last");
+        McpServerDetailInfo reorderedDetailInfo = buildMcpServerDetailInfo(reorderedConfig);
+        cacheHolder.processMcpServerDetailInfo(reorderedDetailInfo);
+        assertEquals(reorderedDetailInfo, cacheHolder.getMcpServer("test", "1.0.0"));
+        int retry = 0;
+        while (retry < 3) {
+            TimeUnit.MILLISECONDS.sleep(500);
+            if (subscriber.invokedMark.get()) {
+                fail("Subscriber for McpServerChangedEvent should not be invoked, but invoked.");
+            }
+            retry++;
+        }
+    }
+    
+    @Test()
+    void processMcpServerDetailInfoWithSerializationException() throws InterruptedException {
+        Map<String, Object> cyclicConfig = new LinkedHashMap<>();
+        cyclicConfig.put("self", cyclicConfig);
+        MockEventSubscriber subscriber = new MockEventSubscriber();
+        NotifyCenter.registerSubscriber(subscriber);
+        
+        cacheHolder.processMcpServerDetailInfo(buildMcpServerDetailInfo(cyclicConfig));
+        
         int retry = 0;
         while (retry < 3) {
             TimeUnit.MILLISECONDS.sleep(500);
@@ -252,6 +298,16 @@ class NacosMcpServerCacheHolderTest {
         cacheHolder.removeMcpServerUpdateTask("test", "1.0.0");
         TimeUnit.MILLISECONDS.sleep(110);
         verify(aiGrpcClient, never()).queryMcpServer("test", null);
+    }
+    
+    private McpServerDetailInfo buildMcpServerDetailInfo(Map<String, Object> localServerConfig) {
+        McpServerDetailInfo result = new McpServerDetailInfo();
+        result.setName("test");
+        result.setVersionDetail(new ServerVersionDetail());
+        result.getVersionDetail().setVersion("1.0.0");
+        result.getVersionDetail().setIs_latest(true);
+        result.setLocalServerConfig(localServerConfig);
+        return result;
     }
     
     private static class MockEventSubscriber extends Subscriber<McpServerChangedEvent> {

--- a/client/src/test/java/com/alibaba/nacos/client/naming/utils/InitUtilsTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/naming/utils/InitUtilsTest.java
@@ -18,6 +18,9 @@ package com.alibaba.nacos.client.naming.utils;
 
 import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.SystemPropertyKeyConst;
+import com.alibaba.nacos.api.selector.AbstractSelector;
+import com.alibaba.nacos.api.selector.ExpressionSelector;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.client.env.NacosClientProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -146,6 +149,18 @@ class InitUtilsTest {
         assertEquals("/nacos", UtilAndComs.webContext);
         assertEquals("/nacos/v1/ns", UtilAndComs.nacosUrlBase);
         assertEquals("/nacos/v1/ns/instance", UtilAndComs.nacosUrlInstance);
+    }
+    
+    @Test
+    void testInitSerializationRegistersSelectorSubtypes() {
+        InitUtils.initSerialization();
+        
+        AbstractSelector selector =
+            JsonUtils.toObj("{\"type\":\"LabelSelector\",\"expression\":\"k=v\"}",
+                AbstractSelector.class);
+        
+        assertEquals(ExpressionSelector.class, selector.getClass());
+        assertEquals("k=v", ((ExpressionSelector) selector).getExpression());
     }
     
     @Test

--- a/client/src/test/java/com/alibaba/nacos/client/utils/PreInitUtilsTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/utils/PreInitUtilsTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.client.utils;
 
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -32,6 +33,13 @@ class PreInitUtilsTest {
         // No exception is ok.
         // Let async thread run completed
         TimeUnit.SECONDS.sleep(2);
+    }
+    
+    @Test
+    void testPreLoadCostComponent() {
+        PreInitUtils.preLoadCostComponent();
+        
+        assertNotNull(JsonUtils.selectedAdapterName());
     }
     
     @Test

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -136,14 +136,18 @@ Last updated: 2026-06-24.
   - `mvn -pl console -am -Dtest=ConsoleCopilotConfigControllerTest -Dsurefire.failIfNoSpecifiedTests=false test`
   - `mvn -pl console spotless:apply`
   - `mvn -pl console spotless:check`
-- 2026-06-24, stage 9 preload cleanup:
+- 2026-06-24, stage 9 client runtime cleanup:
   - Replaced client and maintainer-client selector subtype preload paths with
     `SelectorFactory.preload()`.
   - Replaced client JSON pre-warm from `JacksonUtils.createEmptyJsonNode()` to
     neutral `JsonUtils.preload()`.
-  - `mvn -pl client,maintainer-client -am -Dtest=InitUtilsTest,PreInitUtilsTest,ParamUtilTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - Replaced `NacosMcpServerCacheHolder` local Jackson 2 canonical mapper with
+    neutral `JsonUtils.toCanonicalJson(...)`.
+  - `mvn -pl client,maintainer-client -am -Dtest=InitUtilsTest,PreInitUtilsTest,ParamUtilTest,NacosMcpServerCacheHolderTest -Dsurefire.failIfNoSpecifiedTests=false test`
   - `client/target/site/jacoco/jacoco.csv`: `InitUtils` and `PreInitUtils`
     have `LINE_MISSED=0`.
+  - `client/target/site/jacoco/jacoco.csv`: `NacosMcpServerCacheHolder` has
+    `LINE_MISSED=0`.
   - `maintainer-client/target/site/jacoco/jacoco.csv`: `ParamUtil` has
     `LINE_MISSED=0`.
   - `mvn -pl client,maintainer-client spotless:apply`
@@ -261,7 +265,7 @@ Last updated: 2026-06-24.
     - Jackson 3 facade and delegate source files have full line coverage in
       the focused `common` module test run.
 
-- `[ ]` Add canonical JSON support.
+- `[x]` Add canonical JSON support.
   - Files:
     - `api/.../JsonUtils.java`
     - `common/.../Jackson2JsonAdapter.java`
@@ -398,7 +402,7 @@ Last updated: 2026-06-24.
     - Ensure async preload still initializes the selected adapter without
       forcing Jackson 2.
 
-- `[ ]` Migrate MCP cache canonical comparison.
+- `[x]` Migrate MCP cache canonical comparison.
   - Files:
     - `client/src/main/java/com/alibaba/nacos/client/ai/cache/NacosMcpServerCacheHolder.java`
   - Plan:

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -136,6 +136,18 @@ Last updated: 2026-06-24.
   - `mvn -pl console -am -Dtest=ConsoleCopilotConfigControllerTest -Dsurefire.failIfNoSpecifiedTests=false test`
   - `mvn -pl console spotless:apply`
   - `mvn -pl console spotless:check`
+- 2026-06-24, stage 9 preload cleanup:
+  - Replaced client and maintainer-client selector subtype preload paths with
+    `SelectorFactory.preload()`.
+  - Replaced client JSON pre-warm from `JacksonUtils.createEmptyJsonNode()` to
+    neutral `JsonUtils.preload()`.
+  - `mvn -pl client,maintainer-client -am -Dtest=InitUtilsTest,PreInitUtilsTest,ParamUtilTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - `client/target/site/jacoco/jacoco.csv`: `InitUtils` and `PreInitUtils`
+    have `LINE_MISSED=0`.
+  - `maintainer-client/target/site/jacoco/jacoco.csv`: `ParamUtil` has
+    `LINE_MISSED=0`.
+  - `mvn -pl client,maintainer-client spotless:apply`
+  - `mvn -pl client,maintainer-client spotless:check`
 
 ## Implementation Principles
 
@@ -364,7 +376,7 @@ Last updated: 2026-06-24.
     - Changed response parsing lines have no missed JaCoCo instructions in the
       focused stage 8 test run.
 
-- `[ ]` Migrate subtype preload paths.
+- `[x]` Migrate subtype preload paths.
   - Files:
     - `client/src/main/java/com/alibaba/nacos/client/naming/utils/InitUtils.java`
     - `maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/utils/ParamUtil.java`
@@ -376,7 +388,7 @@ Last updated: 2026-06-24.
   - Validation:
     - Selector serialization / deserialization tests.
 
-- `[ ]` Replace JSON pre-warm path.
+- `[x]` Replace JSON pre-warm path.
   - Files:
     - `client/src/main/java/com/alibaba/nacos/client/utils/PreInitUtils.java`
   - Plan:

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/utils/ParamUtil.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/utils/ParamUtil.java
@@ -17,11 +17,8 @@
 package com.alibaba.nacos.maintainer.client.utils;
 
 import com.alibaba.nacos.api.common.Constants;
-import com.alibaba.nacos.api.selector.ExpressionSelector;
-import com.alibaba.nacos.api.selector.NoneSelector;
-import com.alibaba.nacos.api.selector.SelectorType;
+import com.alibaba.nacos.api.selector.SelectorFactory;
 import com.alibaba.nacos.client.env.NacosClientProperties;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -176,9 +173,6 @@ public class ParamUtil {
      */
     public static void initSerialization() {
         // TODO register in implementation class or remove subType
-        JacksonUtils.registerSubtype(NoneSelector.class, SelectorType.none.name());
-        JacksonUtils.registerSubtype(NoneSelector.class, "NoneSelector");
-        JacksonUtils.registerSubtype(ExpressionSelector.class, SelectorType.label.name());
-        JacksonUtils.registerSubtype(ExpressionSelector.class, "LabelSelector");
+        SelectorFactory.preload();
     }
 }

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/utils/ParamUtilTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/utils/ParamUtilTest.java
@@ -18,6 +18,9 @@
 
 package com.alibaba.nacos.maintainer.client.utils;
 
+import com.alibaba.nacos.api.selector.AbstractSelector;
+import com.alibaba.nacos.api.selector.ExpressionSelector;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +29,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,6 +73,15 @@ class ParamUtilTest {
         int expect = 3000;
         ParamUtil.setReadTimeout(expect);
         assertEquals(expect, ParamUtil.getReadTimeout());
+    }
+    
+    @Test
+    void testDefaultValues() {
+        assertEquals(3, ParamUtil.getMaxRetryTimes());
+        assertEquals("public", ParamUtil.getDefaultNamespaceId());
+        assertEquals("DEFAULT_GROUP", ParamUtil.getDefaultGroupName());
+        assertEquals(5000, ParamUtil.getRefreshIntervalMills());
+        assertNotNull(new ParamUtil());
     }
     
     @Test
@@ -137,5 +150,17 @@ class ParamUtilTest {
         });
         assertTrue(exception.getMessage().contains(invalidValue),
             "Exception message should contain the invalid input value");
+    }
+    
+    @Test
+    void testInitSerializationRegistersSelectorSubtypes() {
+        ParamUtil.initSerialization();
+        
+        AbstractSelector selector =
+            JsonUtils.toObj("{\"type\":\"LabelSelector\",\"expression\":\"k=v\"}",
+                AbstractSelector.class);
+        
+        assertEquals(ExpressionSelector.class, selector.getClass());
+        assertEquals("k=v", ((ExpressionSelector) selector).getExpression());
     }
 }


### PR DESCRIPTION
## Summary
- Replace client and maintainer selector subtype preload paths with SelectorFactory.preload().
- Replace client JSON pre-warm from JacksonUtils.createEmptyJsonNode() to JsonUtils.preload().
- Replace NacosMcpServerCacheHolder local Jackson 2 canonical mapper with JsonUtils.toCanonicalJson(...).
- Update the temporary Jackson adapter migration TODO with the completed client runtime cleanup items.

## Test
- mvn -pl client,maintainer-client -am -Dtest=InitUtilsTest,PreInitUtilsTest,ParamUtilTest,NacosMcpServerCacheHolderTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl client,maintainer-client spotless:apply
- mvn -pl client,maintainer-client spotless:check

## Coverage
- client/target/site/jacoco/jacoco.csv: InitUtils, PreInitUtils, and NacosMcpServerCacheHolder have LINE_MISSED=0.
- maintainer-client/target/site/jacoco/jacoco.csv: ParamUtil has LINE_MISSED=0.