### PR TITLE
[ISSUE #14466] Add typed pipeline maintainer APIs

### DIFF
--- a/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentCardCacheHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosAgentCardCacheHolderTest.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,6 +61,7 @@ class NacosAgentCardCacheHolderTest {
     
     @BeforeEach
     void setUp() {
+        deregisterAgentCardPublisher();
         NacosClientProperties properties = NacosClientProperties.PROTOTYPE.derive();
         cacheHolder = new NacosAgentCardCacheHolder(aiGrpcClient, properties);
         subscriber = new TestAgentCardSubscriber();
@@ -72,6 +72,7 @@ class NacosAgentCardCacheHolderTest {
     void tearDown() throws Exception {
         NotifyCenter.deregisterSubscriber(subscriber);
         cacheHolder.shutdown();
+        deregisterAgentCardPublisher();
     }
     
     @Test
@@ -85,25 +86,23 @@ class NacosAgentCardCacheHolderTest {
     
     @Test
     void testProcessSameAgentCardShouldNotPublishEvent() throws InterruptedException {
-        CountingAgentCardSubscriber countingSubscriber = new CountingAgentCardSubscriber();
-        NotifyCenter.registerSubscriber(countingSubscriber);
+        AgentCardDetailInfo first = buildDetailInfo("test-agent", "1.0", true);
+        first.setSupportedInterfaces(
+            Collections.singletonList(buildInterface("http://a", "jsonrpc", "1.0")));
+        cacheHolder.processAgentCardDetailInfo(first);
+        assertTrue(subscriber.latch.await(3, TimeUnit.SECONDS));
+        
+        TestAgentCardSubscriber secondSubscriber = new TestAgentCardSubscriber();
+        NotifyCenter.registerSubscriber(secondSubscriber);
         try {
-            AgentCardDetailInfo first = buildDetailInfo("test-agent", "1.0", true);
-            first.setSupportedInterfaces(
-                Collections.singletonList(buildInterface("http://a", "jsonrpc", "1.0")));
-            cacheHolder.processAgentCardDetailInfo(first);
-            assertTrue(countingSubscriber.firstLatch.await(3, TimeUnit.SECONDS));
-            assertEquals(1, countingSubscriber.eventCount.get());
-            
             AgentCardDetailInfo second = buildDetailInfo("test-agent", "1.0", true);
             second.setSupportedInterfaces(
                 Collections.singletonList(buildInterface("http://a", "jsonrpc", "1.0")));
             cacheHolder.processAgentCardDetailInfo(second);
-            Thread.sleep(500);
-            assertEquals(1, countingSubscriber.eventCount.get(),
+            assertFalse(secondSubscriber.latch.await(500, TimeUnit.MILLISECONDS),
                 "Should NOT publish event for identical agent card");
         } finally {
-            NotifyCenter.deregisterSubscriber(countingSubscriber);
+            NotifyCenter.deregisterSubscriber(secondSubscriber);
         }
     }
     
@@ -331,6 +330,12 @@ class NacosAgentCardCacheHolderTest {
         return (Runnable) ctor.newInstance(cacheHolder, agentName, version);
     }
     
+    private static void deregisterAgentCardPublisher() {
+        if (NotifyCenter.getPublisher(AgentCardChangedEvent.class) != null) {
+            NotifyCenter.deregisterPublisher(AgentCardChangedEvent.class);
+        }
+    }
+    
     private AgentCardDetailInfo buildDetailInfo(String name, String version, boolean isLatest) {
         AgentCardDetailInfo detail = new AgentCardDetailInfo();
         detail.setName(name);
@@ -358,24 +363,6 @@ class NacosAgentCardCacheHolderTest {
         public void onEvent(AgentCardChangedEvent event) {
             lastEvent.set(event);
             latch.countDown();
-        }
-        
-        @Override
-        public Class<? extends Event> subscribeType() {
-            return AgentCardChangedEvent.class;
-        }
-    }
-    
-    private static class CountingAgentCardSubscriber extends Subscriber<AgentCardChangedEvent> {
-        
-        final AtomicInteger eventCount = new AtomicInteger(0);
-        
-        final CountDownLatch firstLatch = new CountDownLatch(1);
-        
-        @Override
-        public void onEvent(AgentCardChangedEvent event) {
-            eventCount.incrementAndGet();
-            firstLatch.countDown();
         }
         
         @Override

--- a/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosMcpServerCacheHolderTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/ai/cache/NacosMcpServerCacheHolderTest.java
@@ -60,6 +60,7 @@ class NacosMcpServerCacheHolderTest {
     
     @BeforeEach
     void setUp() {
+        deregisterMcpServerPublisher();
         Properties properties = new Properties();
         properties.put(AiConstants.AI_MCP_SERVER_CACHE_UPDATE_INTERVAL, "100");
         cacheHolder = new NacosMcpServerCacheHolder(aiGrpcClient,
@@ -69,7 +70,7 @@ class NacosMcpServerCacheHolderTest {
     @AfterEach
     void tearDown() throws NacosException {
         cacheHolder.shutdown();
-        NotifyCenter.deregisterPublisher(McpServerChangedEvent.class);
+        deregisterMcpServerPublisher();
     }
     
     @Test
@@ -128,7 +129,7 @@ class NacosMcpServerCacheHolderTest {
         mcpServerDetailInfo.setVersionDetail(new ServerVersionDetail());
         mcpServerDetailInfo.getVersionDetail().setVersion("1.0.0");
         mcpServerDetailInfo.getVersionDetail().setIs_latest(true);
-        cacheHolder.processMcpServerDetailInfo(mcpServerDetailInfo);
+        processInitialMcpServerDetailInfo(mcpServerDetailInfo);
         mcpServerDetailInfo = new McpServerDetailInfo();
         mcpServerDetailInfo.setName("test");
         mcpServerDetailInfo.setVersionDetail(new ServerVersionDetail());
@@ -158,7 +159,7 @@ class NacosMcpServerCacheHolderTest {
         mcpServerDetailInfo.setVersionDetail(new ServerVersionDetail());
         mcpServerDetailInfo.getVersionDetail().setVersion("1.0.0");
         mcpServerDetailInfo.getVersionDetail().setIs_latest(true);
-        cacheHolder.processMcpServerDetailInfo(mcpServerDetailInfo);
+        processInitialMcpServerDetailInfo(mcpServerDetailInfo);
         
         MockEventSubscriber subscriber = new MockEventSubscriber();
         NotifyCenter.registerSubscriber(subscriber);
@@ -179,7 +180,7 @@ class NacosMcpServerCacheHolderTest {
         Map<String, Object> originalConfig = new LinkedHashMap<>();
         originalConfig.put("z", "last");
         originalConfig.put("a", "first");
-        cacheHolder.processMcpServerDetailInfo(buildMcpServerDetailInfo(originalConfig));
+        processInitialMcpServerDetailInfo(buildMcpServerDetailInfo(originalConfig));
         
         MockEventSubscriber subscriber = new MockEventSubscriber();
         NotifyCenter.registerSubscriber(subscriber);
@@ -308,6 +309,32 @@ class NacosMcpServerCacheHolderTest {
         result.getVersionDetail().setIs_latest(true);
         result.setLocalServerConfig(localServerConfig);
         return result;
+    }
+    
+    private void processInitialMcpServerDetailInfo(McpServerDetailInfo detailInfo)
+        throws InterruptedException {
+        MockEventSubscriber subscriber = new MockEventSubscriber();
+        NotifyCenter.registerSubscriber(subscriber);
+        try {
+            cacheHolder.processMcpServerDetailInfo(detailInfo);
+            int retry = 0;
+            while (retry < 3) {
+                TimeUnit.MILLISECONDS.sleep(500);
+                if (subscriber.invokedMark.get()) {
+                    return;
+                }
+                retry++;
+            }
+            fail("Subscriber for initial McpServerChangedEvent don't be invoked.");
+        } finally {
+            NotifyCenter.deregisterSubscriber(subscriber);
+        }
+    }
+    
+    private static void deregisterMcpServerPublisher() {
+        if (NotifyCenter.getPublisher(McpServerChangedEvent.class) != null) {
+            NotifyCenter.deregisterPublisher(McpServerChangedEvent.class);
+        }
     }
     
     private static class MockEventSubscriber extends Subscriber<McpServerChangedEvent> {

--- a/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/PipelineRemoteHandler.java
+++ b/console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/PipelineRemoteHandler.java
@@ -19,13 +19,12 @@ package com.alibaba.nacos.console.handler.impl.remote.ai;
 import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecution;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.console.handler.ai.EnabledAiHandler;
 import com.alibaba.nacos.console.handler.ai.PipelineHandler;
 import com.alibaba.nacos.console.handler.impl.remote.EnabledRemoteHandler;
 import com.alibaba.nacos.console.handler.impl.remote.NacosMaintainerClientHolder;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Service;
 
 /**
@@ -49,18 +48,26 @@ public class PipelineRemoteHandler implements PipelineHandler {
     
     @Override
     public PipelineExecution getPipeline(String pipelineId) throws NacosException {
-        JsonNode jsonNode =
-            clientHolder.getAiMaintainerService().pipeline().getPipeline(pipelineId);
-        return JacksonUtils.toObj(jsonNode.toString(), PipelineExecution.class);
+        return unwrapSuccessData(
+            clientHolder.getAiMaintainerService().pipeline().getPipelineDetail(pipelineId));
     }
     
     @Override
     public Page<PipelineExecution> listPipelines(String resourceType, String resourceName,
         String namespaceId, String version, int pageNo, int pageSize) throws NacosException {
-        JsonNode jsonNode = clientHolder.getAiMaintainerService().pipeline()
-            .listPipelines(resourceType, resourceName, namespaceId, version, pageNo, pageSize);
-        return JacksonUtils.toObj(jsonNode.toString(),
-            new TypeReference<Page<PipelineExecution>>() {
-            });
+        return unwrapSuccessData(clientHolder.getAiMaintainerService().pipeline()
+            .listPipelineExecutions(resourceType, resourceName, namespaceId, version, pageNo,
+                pageSize));
+    }
+    
+    private static <T> T unwrapSuccessData(Result<T> result) throws NacosException {
+        if (result == null) {
+            throw new NacosException(NacosException.SERVER_ERROR, "empty Result");
+        }
+        Integer code = result.getCode();
+        if (ErrorCode.SUCCESS.getCode().equals(code) || Integer.valueOf(200).equals(code)) {
+            return result.getData();
+        }
+        throw new NacosException(NacosException.SERVER_ERROR, result.getMessage());
     }
 }

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/ai/PipelineRemoteHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/ai/PipelineRemoteHandlerTest.java
@@ -19,11 +19,11 @@ package com.alibaba.nacos.console.handler.impl.remote.ai;
 import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecution;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.console.handler.impl.remote.NacosMaintainerClientHolder;
 import com.alibaba.nacos.maintainer.client.ai.AiMaintainerService;
 import com.alibaba.nacos.maintainer.client.ai.PipelineMaintainerService;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +36,7 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -65,15 +66,14 @@ class PipelineRemoteHandlerTest {
     void testGetPipeline() throws NacosException {
         PipelineExecution execution = new PipelineExecution();
         execution.setExecutionId("pipe-123");
-        JsonNode jsonNode = JacksonUtils.toObj(JacksonUtils.toJson(execution),
-            JsonNode.class);
-        when(pipelineMaintainerService.getPipeline("pipe-123")).thenReturn(jsonNode);
+        when(pipelineMaintainerService.getPipelineDetail("pipe-123"))
+            .thenReturn(Result.success(execution));
         
         PipelineExecution result = handler.getPipeline("pipe-123");
         
         assertNotNull(result);
         assertEquals("pipe-123", result.getExecutionId());
-        verify(pipelineMaintainerService).getPipeline("pipe-123");
+        verify(pipelineMaintainerService).getPipelineDetail("pipe-123");
     }
     
     @Test
@@ -81,16 +81,51 @@ class PipelineRemoteHandlerTest {
         Page<PipelineExecution> page = new Page<>();
         page.setTotalCount(0);
         page.setPageItems(Collections.emptyList());
-        JsonNode jsonNode = JacksonUtils.toObj(JacksonUtils.toJson(page), JsonNode.class);
-        when(pipelineMaintainerService.listPipelines("prompt", "my-prompt",
-            "public", "0.0.1", 1, 10)).thenReturn(jsonNode);
+        when(pipelineMaintainerService.listPipelineExecutions("prompt", "my-prompt",
+            "public", "0.0.1", 1, 10)).thenReturn(Result.success(page));
         
         Page<PipelineExecution> result = handler.listPipelines("prompt", "my-prompt",
             "public", "0.0.1", 1, 10);
         
         assertNotNull(result);
         assertEquals(0, result.getTotalCount());
-        verify(pipelineMaintainerService).listPipelines("prompt", "my-prompt",
+        verify(pipelineMaintainerService).listPipelineExecutions("prompt", "my-prompt",
             "public", "0.0.1", 1, 10);
+    }
+    
+    @Test
+    void testGetPipelineWithHttp200ResultCode() throws NacosException {
+        PipelineExecution execution = new PipelineExecution();
+        execution.setExecutionId("pipe-200");
+        when(pipelineMaintainerService.getPipelineDetail("pipe-200"))
+            .thenReturn(new Result<>(200, "success", execution));
+        
+        PipelineExecution result = handler.getPipeline("pipe-200");
+        
+        assertNotNull(result);
+        assertEquals("pipe-200", result.getExecutionId());
+    }
+    
+    @Test
+    void testGetPipelineThrowsOnNullResult() throws NacosException {
+        when(pipelineMaintainerService.getPipelineDetail("pipe-null")).thenReturn(null);
+        
+        NacosException ex =
+            assertThrows(NacosException.class, () -> handler.getPipeline("pipe-null"));
+        
+        assertEquals(NacosException.SERVER_ERROR, ex.getErrCode());
+        assertEquals("empty Result", ex.getErrMsg());
+    }
+    
+    @Test
+    void testGetPipelineThrowsOnFailedResult() throws NacosException {
+        when(pipelineMaintainerService.getPipelineDetail("pipe-failed"))
+            .thenReturn(Result.failure(ErrorCode.DATA_ACCESS_ERROR));
+        
+        NacosException ex =
+            assertThrows(NacosException.class, () -> handler.getPipeline("pipe-failed"));
+        
+        assertEquals(NacosException.SERVER_ERROR, ex.getErrCode());
+        assertEquals(ErrorCode.DATA_ACCESS_ERROR.getMsg(), ex.getErrMsg());
     }
 }

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -175,6 +175,25 @@ Last updated: 2026-06-25.
   - `mvn -pl console spotless:apply`
   - `mvn -pl console spotless:check`
   - `mvn -pl console -am -Dtest=ConsolePipelineControllerTest,PipelineProxyTest,PipelineRemoteHandlerTest,PipelineInnerHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test`
+- 2026-06-25, stage 11 typed Pipeline maintainer API:
+  - Changed `PipelineAdminClient` to expose typed
+    `Result<PipelineExecution>` and `Result<Page<PipelineExecution>>`
+    methods while keeping deprecated `JsonNode` compatibility methods in
+    `PipelineMaintainerService`.
+  - Updated console remote Pipeline handler to consume typed maintainer-client
+    methods directly.
+  - `mvn -pl maintainer-client,console,test/maintainer-sdk-test -am -DskipTests compile`
+  - `mvn -pl maintainer-client,console -am -Dtest=PipelineMaintainerServiceImplTest,PipelineRemoteHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - `mvn -pl test/maintainer-sdk-test -am -DskipTests test-compile`
+  - `mvn -pl maintainer-client,console,test/maintainer-sdk-test spotless:apply`
+  - `mvn -pl maintainer-client,console,test/maintainer-sdk-test spotless:check`
+  - `mvn -pl maintainer-client,console,test/maintainer-sdk-test apache-rat:check`
+  - `maintainer-client/target/site/jacoco/jacoco.csv`:
+    `PipelineMaintainerServiceImpl` has `LINE_MISSED=0`.
+  - `console/target/site/jacoco/jacoco.csv`: `PipelineRemoteHandler` has
+    `LINE_MISSED=0`.
+  - `rg "com\\.fasterxml\\.jackson\\.core\\.type\\.TypeReference|new TypeReference|JavaType" maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineAdminClient.java maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerService.java maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImpl.java console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/PipelineRemoteHandler.java`
+    returns no matches.
 
 ## Implementation Principles
 
@@ -453,20 +472,22 @@ Last updated: 2026-06-25.
   - Validation:
     - `ai` unit tests and pipeline repository tests continue to pass.
 
-- `[ ]` Add typed maintainer-client methods.
+- `[x]` Add typed maintainer-client methods.
   - Files:
     - `maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineAdminClient.java`
     - `maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerService.java`
     - `maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImpl.java`
   - Plan:
     - Add:
-      - `Result<PipelineExecution> getPipelineExecution(String pipelineId)`
+      - `Result<PipelineExecution> getPipelineDetail(String pipelineId)`
       - `Result<Page<PipelineExecution>> listPipelineExecutions(...)`
     - Keep existing `JsonNode` methods as deprecated compatibility methods.
     - Use `NacosTypeReference<Result<PipelineExecution>>` and
       `NacosTypeReference<Result<Page<PipelineExecution>>>` for parsing.
   - Validation:
     - Maintainer-client pipeline tests for typed and deprecated methods.
+    - Console remote handler tests for typed success, HTTP 200 success, and
+      non-success Result handling.
 
 ### 6. Dependency and Compatibility Matrix
 

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineAdminClient.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineAdminClient.java
@@ -16,9 +16,10 @@
 
 package com.alibaba.nacos.maintainer.client.ai;
 
+import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecution;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.Result;
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Admin API client for pipeline execution queries ({@code /v3/admin/ai/pipelines/...}).
@@ -38,7 +39,7 @@ public interface PipelineAdminClient {
      * @return parsed {@link Result}; may carry non-success {@code code} when HTTP status is 200
      * @throws NacosException transport / HTTP failure (e.g. connection error, non-2xx without body)
      */
-    Result<JsonNode> getPipelineDetail(String pipelineId) throws NacosException;
+    Result<PipelineExecution> getPipelineDetail(String pipelineId) throws NacosException;
     
     /**
      * GET {@code /v3/admin/ai/pipelines/list} with pagination query parameters.
@@ -52,7 +53,7 @@ public interface PipelineAdminClient {
      * @return parsed {@link Result}; may carry non-success {@code code} when HTTP status is 200
      * @throws NacosException transport / HTTP failure
      */
-    Result<JsonNode> listPipelineExecutions(String resourceType, String resourceName,
-        String namespaceId,
-        String version, int pageNo, int pageSize) throws NacosException;
+    Result<Page<PipelineExecution>> listPipelineExecutions(String resourceType,
+        String resourceName, String namespaceId, String version, int pageNo, int pageSize)
+        throws NacosException;
 }

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerService.java
@@ -26,8 +26,8 @@ import com.fasterxml.jackson.databind.JsonNode;
  * <p>Extends {@link PipelineAdminClient} for {@link com.alibaba.nacos.api.model.v2.Result} responses.
  * Legacy {@link JsonNode}-only accessors are retained for existing callers.</p>
  *
- * <p>Deprecated {@link JsonNode} methods are kept as compatibility accessors. Typed pipeline
- * execution methods will be added on top of the public API DTOs in a follow-up change.</p>
+ * <p>Deprecated {@link JsonNode} methods are kept as compatibility accessors. Prefer typed
+ * pipeline execution methods from {@link PipelineAdminClient} for new code.</p>
  *
  * @author kiro
  * @since 3.2.0

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImpl.java
@@ -16,16 +16,19 @@
 
 package com.alibaba.nacos.maintainer.client.ai;
 
+import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecution;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
+import com.alibaba.nacos.api.utils.json.NacosTypeReference;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.utils.HttpMethod;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.maintainer.client.constants.Constants;
 import com.alibaba.nacos.maintainer.client.model.HttpRequest;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.HashMap;
@@ -39,7 +42,14 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
     }
     
     @Override
-    public Result<JsonNode> getPipelineDetail(String pipelineId) throws NacosException {
+    public Result<PipelineExecution> getPipelineDetail(String pipelineId) throws NacosException {
+        return getPipelineDetail(pipelineId,
+            new NacosTypeReference<Result<PipelineExecution>>() {
+            });
+    }
+    
+    private <T> Result<T> getPipelineDetail(String pipelineId,
+        NacosTypeReference<Result<T>> typeReference) throws NacosException {
         Map<String, String> params = new HashMap<>(2);
         params.put("pipelineId", pipelineId);
         HttpRequest httpRequest =
@@ -48,10 +58,10 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
                 .setPath(Constants.AdminApiPath.AI_PIPELINE_DETAIL_ADMIN_PATH)
                 .setParamValue(params).build();
         try {
-            return parseResultFromHttp(executeSyncHttpRequest(httpRequest));
+            return parseResultFromHttp(executeSyncHttpRequest(httpRequest), typeReference);
         } catch (NacosException e) {
             if (e.getErrCode() == NacosException.NOT_FOUND) {
-                return getPipelineDetailLegacy(pipelineId);
+                return getPipelineDetailLegacy(pipelineId, typeReference);
             }
             throw e;
         }
@@ -60,19 +70,28 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
     /**
      * Pre-3.2.1 style: GET {@code /v3/admin/ai/pipelines/{pipelineId}} when {@code /detail} is not mapped.
      */
-    private Result<JsonNode> getPipelineDetailLegacy(String pipelineId) throws NacosException {
+    private <T> Result<T> getPipelineDetailLegacy(String pipelineId,
+        NacosTypeReference<Result<T>> typeReference) throws NacosException {
         HttpRequest httpRequest =
             buildHttpRequestBuilder(buildRequestResource(StringUtils.EMPTY, pipelineId))
                 .setHttpMethod(HttpMethod.GET)
                 .setPath(Constants.AdminApiPath.AI_PIPELINE_ADMIN_PATH + "/" + pipelineId)
                 .setParamValue(new HashMap<>(2)).build();
-        return parseResultFromHttp(executeSyncHttpRequest(httpRequest));
+        return parseResultFromHttp(executeSyncHttpRequest(httpRequest), typeReference);
     }
     
     @Override
-    public Result<JsonNode> listPipelineExecutions(String resourceType, String resourceName,
-        String namespaceId,
-        String version, int pageNo, int pageSize) throws NacosException {
+    public Result<Page<PipelineExecution>> listPipelineExecutions(String resourceType,
+        String resourceName, String namespaceId, String version, int pageNo, int pageSize)
+        throws NacosException {
+        return listPipelineExecutions(resourceType, resourceName, namespaceId, version, pageNo,
+            pageSize, new NacosTypeReference<Result<Page<PipelineExecution>>>() {
+            });
+    }
+    
+    private <T> Result<T> listPipelineExecutions(String resourceType, String resourceName,
+        String namespaceId, String version, int pageNo, int pageSize,
+        NacosTypeReference<Result<T>> typeReference) throws NacosException {
         Map<String, String> params =
             buildListQueryParams(resourceType, resourceName, namespaceId, version, pageNo,
                 pageSize);
@@ -84,10 +103,11 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
                 .setPath(Constants.AdminApiPath.AI_PIPELINE_LIST_ADMIN_PATH)
                 .setParamValue(params).build();
         try {
-            return parseResultFromHttp(executeSyncHttpRequest(httpRequest));
+            return parseResultFromHttp(executeSyncHttpRequest(httpRequest), typeReference);
         } catch (NacosException e) {
             if (e.getErrCode() == NacosException.NOT_FOUND) {
-                return listPipelineExecutionsLegacy(resolvedNamespace, resourceName, params);
+                return listPipelineExecutionsLegacy(resolvedNamespace, resourceName, params,
+                    typeReference);
             }
             throw e;
         }
@@ -96,21 +116,24 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
     /**
      * Pre-3.2.1 style: GET {@code /v3/admin/ai/pipelines} when {@code /list} is not mapped.
      */
-    private Result<JsonNode> listPipelineExecutionsLegacy(String resolvedNamespace,
-        String resourceName,
-        Map<String, String> params) throws NacosException {
+    private <T> Result<T> listPipelineExecutionsLegacy(String resolvedNamespace,
+        String resourceName, Map<String, String> params,
+        NacosTypeReference<Result<T>> typeReference) throws NacosException {
         HttpRequest httpRequest =
             buildHttpRequestBuilder(buildRequestResource(resolvedNamespace, resourceName))
                 .setHttpMethod(HttpMethod.GET)
                 .setPath(Constants.AdminApiPath.AI_PIPELINE_ADMIN_PATH)
                 .setParamValue(params).build();
-        return parseResultFromHttp(executeSyncHttpRequest(httpRequest));
+        return parseResultFromHttp(executeSyncHttpRequest(httpRequest), typeReference);
     }
     
     @Override
     @Deprecated
     public JsonNode getPipeline(String pipelineId) throws NacosException {
-        return unwrapSuccessData(getPipelineDetail(pipelineId));
+        Result<Object> result = getPipelineDetail(pipelineId,
+            new NacosTypeReference<Result<Object>>() {
+            });
+        return toJsonNode(unwrapSuccessData(result));
     }
     
     @Override
@@ -118,9 +141,10 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
     public JsonNode listPipelines(String resourceType, String resourceName, String namespaceId,
         String version,
         int pageNo, int pageSize) throws NacosException {
-        return unwrapSuccessData(
-            listPipelineExecutions(resourceType, resourceName, namespaceId, version, pageNo,
-                pageSize));
+        Result<Object> result = listPipelineExecutions(resourceType, resourceName, namespaceId,
+            version, pageNo, pageSize, new NacosTypeReference<Result<Object>>() {
+            });
+        return toJsonNode(unwrapSuccessData(result));
     }
     
     private Map<String, String> buildListQueryParams(String resourceType, String resourceName,
@@ -136,16 +160,15 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
         return params;
     }
     
-    private static Result<JsonNode> parseResultFromHttp(HttpRestResult<String> restResult)
+    private static <T> Result<T> parseResultFromHttp(HttpRestResult<String> restResult,
+        NacosTypeReference<Result<T>> typeReference)
         throws NacosException {
         String body = restResult.getData();
         if (StringUtils.isBlank(body)) {
             throw new NacosException(NacosException.SERVER_ERROR, "empty response body");
         }
         try {
-            Result<JsonNode> result =
-                JacksonUtils.toObj(body, new TypeReference<Result<JsonNode>>() {
-                });
+            Result<T> result = JsonUtils.toObj(body, typeReference);
             if (result == null) {
                 throw new NacosException(NacosException.SERVER_ERROR,
                     "failed to parse Result wrapper");
@@ -157,7 +180,7 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
         }
     }
     
-    private static JsonNode unwrapSuccessData(Result<JsonNode> result) throws NacosException {
+    private static <T> T unwrapSuccessData(Result<T> result) throws NacosException {
         if (result == null) {
             throw new NacosException(NacosException.SERVER_ERROR, "empty Result");
         }
@@ -175,5 +198,9 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
             return false;
         }
         return ErrorCode.SUCCESS.getCode().equals(code) || Integer.valueOf(200).equals(code);
+    }
+    
+    private static JsonNode toJsonNode(Object data) {
+        return JacksonUtils.toObj(JsonUtils.toJson(data), JsonNode.class);
     }
 }

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImplTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImplTest.java
@@ -17,11 +17,14 @@
 package com.alibaba.nacos.maintainer.client.ai;
 
 import com.alibaba.nacos.api.PropertyKeyConst;
+import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecution;
+import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecutionStatus;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.http.HttpRestResult;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.maintainer.client.model.HttpRequest;
 import com.alibaba.nacos.maintainer.client.remote.ClientHttpProxy;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -33,6 +36,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -76,29 +84,28 @@ class PipelineMaintainerServiceImplTest {
     
     @Test
     void getPipelineDetailReturnsResultWrapper() throws NacosException {
-        JsonNode payload = JacksonUtils.toObj("{\"executionId\":\"exec-1\"}", JsonNode.class);
-        HttpRestResult<String> mockRestResult = new HttpRestResult<>();
-        mockRestResult.setData(JacksonUtils.toJson(Result.success(payload)));
+        PipelineExecution payload = newPipelineExecution("exec-1");
+        HttpRestResult<String> mockRestResult = newRestResult(Result.success(payload));
         doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
             .executeSyncHttpRequest(any(HttpRequest.class));
         
-        Result<JsonNode> result = pipelineMaintainerService.getPipelineDetail("exec-1");
+        Result<PipelineExecution> result = pipelineMaintainerService.getPipelineDetail("exec-1");
         
         assertNotNull(result);
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertNotNull(result.getData());
-        assertEquals("exec-1", result.getData().get("executionId").asText());
+        assertEquals("exec-1", result.getData().getExecutionId());
+        assertEquals(PipelineExecutionStatus.APPROVED, result.getData().getStatus());
     }
     
     @Test
     void getPipelineDetailReturnsBusinessFailureWithoutThrowing() throws NacosException {
-        HttpRestResult<String> mockRestResult = new HttpRestResult<>();
-        mockRestResult
-            .setData(JacksonUtils.toJson(Result.failure(ErrorCode.PARAMETER_VALIDATE_ERROR)));
+        HttpRestResult<String> mockRestResult =
+            newRestResult(Result.failure(ErrorCode.PARAMETER_VALIDATE_ERROR));
         doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
             .executeSyncHttpRequest(any(HttpRequest.class));
         
-        Result<JsonNode> result = pipelineMaintainerService.getPipelineDetail("exec-1");
+        Result<PipelineExecution> result = pipelineMaintainerService.getPipelineDetail("exec-1");
         
         assertNotNull(result);
         assertEquals(ErrorCode.PARAMETER_VALIDATE_ERROR.getCode(), result.getCode());
@@ -106,9 +113,8 @@ class PipelineMaintainerServiceImplTest {
     
     @Test
     void getPipelineDeprecatedUnwrapsSuccessData() throws NacosException {
-        JsonNode payload = JacksonUtils.toObj("{\"executionId\":\"exec-1\"}", JsonNode.class);
-        HttpRestResult<String> mockRestResult = new HttpRestResult<>();
-        mockRestResult.setData(JacksonUtils.toJson(Result.success(payload)));
+        PipelineExecution payload = newPipelineExecution("exec-1");
+        HttpRestResult<String> mockRestResult = newRestResult(Result.success(payload));
         doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
             .executeSyncHttpRequest(any(HttpRequest.class));
         
@@ -120,8 +126,8 @@ class PipelineMaintainerServiceImplTest {
     
     @Test
     void getPipelineDeprecatedThrowsWhenResultNotSuccess() throws NacosException {
-        HttpRestResult<String> mockRestResult = new HttpRestResult<>();
-        mockRestResult.setData(JacksonUtils.toJson(Result.failure(ErrorCode.DATA_ACCESS_ERROR)));
+        HttpRestResult<String> mockRestResult =
+            newRestResult(Result.failure(ErrorCode.DATA_ACCESS_ERROR));
         doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
             .executeSyncHttpRequest(any(HttpRequest.class));
         
@@ -133,36 +139,33 @@ class PipelineMaintainerServiceImplTest {
     
     @Test
     void listPipelineExecutionsReturnsPage() throws NacosException {
-        final String pageJson =
-            "{\"pageNumber\":1,\"pageSize\":10,\"totalCount\":0,\"pageItems\":[]}";
-        JsonNode pageNode = JacksonUtils.toObj(pageJson, JsonNode.class);
-        HttpRestResult<String> mockRestResult = new HttpRestResult<>();
-        mockRestResult.setData(JacksonUtils.toJson(Result.success(pageNode)));
+        Page<PipelineExecution> page = newPipelinePage(newPipelineExecution("exec-1"), 1);
+        HttpRestResult<String> mockRestResult = newRestResult(Result.success(page));
         doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
             .executeSyncHttpRequest(any(HttpRequest.class));
         
-        Result<JsonNode> result =
+        Result<Page<PipelineExecution>> result =
             pipelineMaintainerService.listPipelineExecutions("SKILL", null, null, null, 1, 10);
         
         assertNotNull(result);
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertNotNull(result.getData());
-        assertEquals(1, result.getData().get("pageNumber").asInt());
+        assertEquals(1, result.getData().getPageNumber());
+        assertEquals("exec-1", result.getData().getPageItems().get(0).getExecutionId());
     }
     
     @Test
     void getPipelineDetailFallsBackOn404() throws NacosException {
-        JsonNode payload = JacksonUtils.toObj("{\"executionId\":\"legacy\"}", JsonNode.class);
-        HttpRestResult<String> ok = new HttpRestResult<>();
-        ok.setData(JacksonUtils.toJson(Result.success(payload)));
+        PipelineExecution payload = newPipelineExecution("legacy");
+        HttpRestResult<String> ok = newRestResult(Result.success(payload));
         doThrow(new NacosException(NacosException.NOT_FOUND, "not found"))
             .doAnswer(invocation -> ok).when(clientHttpProxy)
             .executeSyncHttpRequest(any(HttpRequest.class));
         
-        Result<JsonNode> result = pipelineMaintainerService.getPipelineDetail("legacy");
+        Result<PipelineExecution> result = pipelineMaintainerService.getPipelineDetail("legacy");
         
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
-        assertEquals("legacy", result.getData().get("executionId").asText());
+        assertEquals("legacy", result.getData().getExecutionId());
     }
     
     // ========== Additional Tests for Coverage ==========
@@ -170,20 +173,33 @@ class PipelineMaintainerServiceImplTest {
     @Test
     @DisplayName("listPipelineExecutions falls back on 404")
     void listPipelineExecutionsFallsBackOn404() throws NacosException {
-        final String pageJson =
-            "{\"pageNumber\":1,\"pageSize\":10,\"totalCount\":0,\"pageItems\":[]}";
-        JsonNode pageNode = JacksonUtils.toObj(pageJson, JsonNode.class);
-        HttpRestResult<String> ok = new HttpRestResult<>();
-        ok.setData(JacksonUtils.toJson(Result.success(pageNode)));
+        Page<PipelineExecution> page = newPipelinePage(newPipelineExecution("legacy"), 1);
+        HttpRestResult<String> ok = newRestResult(Result.success(page));
         doThrow(new NacosException(NacosException.NOT_FOUND, "not found"))
             .doAnswer(invocation -> ok).when(clientHttpProxy)
             .executeSyncHttpRequest(any(HttpRequest.class));
         
-        Result<JsonNode> result = pipelineMaintainerService.listPipelineExecutions("SKILL", "test",
-            "public", "v1", 1, 10);
+        Result<Page<PipelineExecution>> result =
+            pipelineMaintainerService.listPipelineExecutions("SKILL", "test", "public", "v1",
+                1, 10);
         
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertNotNull(result.getData());
+        assertEquals("legacy", result.getData().getPageItems().get(0).getExecutionId());
+    }
+    
+    @Test
+    @DisplayName("listPipelineExecutions rethrows non-404 request exception")
+    void listPipelineExecutionsRethrowsNon404Exception() throws NacosException {
+        doThrow(new NacosException(NacosException.SERVER_ERROR, "server error"))
+            .when(clientHttpProxy).executeSyncHttpRequest(any(HttpRequest.class));
+        
+        NacosException ex = assertThrows(NacosException.class,
+            () -> pipelineMaintainerService.listPipelineExecutions("SKILL", "test", "public",
+                "v1", 1, 10));
+        
+        assertEquals(NacosException.SERVER_ERROR, ex.getErrCode());
+        assertTrue(ex.getErrMsg().contains("server error"));
     }
     
     @Test
@@ -201,10 +217,24 @@ class PipelineMaintainerServiceImplTest {
     }
     
     @Test
+    @DisplayName("parseResultFromHttp with null wrapper should throw SERVER_ERROR")
+    void testParseResultFromHttpWithNullWrapper() throws NacosException {
+        HttpRestResult<String> mockRestResult = new HttpRestResult<>();
+        mockRestResult.setData("null");
+        doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
+            .executeSyncHttpRequest(any(HttpRequest.class));
+        
+        NacosException ex = assertThrows(NacosException.class,
+            () -> pipelineMaintainerService.getPipelineDetail("exec-1"));
+        assertEquals(NacosException.SERVER_ERROR, ex.getErrCode());
+        assertTrue(ex.getErrMsg().contains("failed to parse Result wrapper"));
+    }
+    
+    @Test
     @DisplayName("getPipeline deprecated throws when result is not success")
     void getPipelineDeprecatedThrowsOnBusinessFailure() throws NacosException {
-        HttpRestResult<String> mockRestResult = new HttpRestResult<>();
-        mockRestResult.setData(JacksonUtils.toJson(Result.failure(ErrorCode.SERVER_ERROR)));
+        HttpRestResult<String> mockRestResult =
+            newRestResult(Result.failure(ErrorCode.SERVER_ERROR));
         doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
             .executeSyncHttpRequest(any(HttpRequest.class));
         
@@ -214,13 +244,58 @@ class PipelineMaintainerServiceImplTest {
     }
     
     @Test
+    @DisplayName("getPipeline deprecated accepts HTTP 200 result code")
+    void getPipelineDeprecatedAcceptsHttp200Code() throws NacosException {
+        PipelineExecution payload = newPipelineExecution("exec-200");
+        HttpRestResult<String> mockRestResult =
+            newRestResult(new Result<>(200, "success", payload));
+        doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
+            .executeSyncHttpRequest(any(HttpRequest.class));
+        
+        JsonNode data = pipelineMaintainerService.getPipeline("exec-200");
+        
+        assertNotNull(data);
+        assertEquals("exec-200", data.get("executionId").asText());
+    }
+    
+    @Test
+    @DisplayName("getPipeline deprecated uses default error message for null code")
+    void getPipelineDeprecatedUsesDefaultErrorMessageForNullCode() throws NacosException {
+        HttpRestResult<String> mockRestResult = new HttpRestResult<>();
+        mockRestResult.setData("{\"code\":null,\"message\":null,\"data\":{}}");
+        doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
+            .executeSyncHttpRequest(any(HttpRequest.class));
+        
+        NacosException ex = assertThrows(NacosException.class,
+            () -> pipelineMaintainerService.getPipeline("exec-null-code"));
+        
+        assertEquals(NacosException.SERVER_ERROR, ex.getErrCode());
+        assertEquals("request failed", ex.getErrMsg());
+    }
+    
+    @Test
+    @DisplayName("unwrapSuccessData rejects null Result")
+    void unwrapSuccessDataRejectsNullResult()
+        throws NoSuchMethodException, IllegalAccessException {
+        Method method =
+            PipelineMaintainerServiceImpl.class.getDeclaredMethod("unwrapSuccessData",
+                Result.class);
+        method.setAccessible(true);
+        
+        InvocationTargetException ex =
+            assertThrows(InvocationTargetException.class, () -> method.invoke(null,
+                new Object[] {null}));
+        
+        NacosException cause = (NacosException) ex.getCause();
+        assertEquals(NacosException.SERVER_ERROR, cause.getErrCode());
+        assertEquals("empty Result", cause.getErrMsg());
+    }
+    
+    @Test
     @DisplayName("listPipelines deprecated unwraps success data")
     void listPipelinesDeprecatedUnwrapsSuccessData() throws NacosException {
-        final String pageJson =
-            "{\"pageNumber\":2,\"pageSize\":20,\"totalCount\":5,\"pageItems\":[]}";
-        JsonNode pageNode = JacksonUtils.toObj(pageJson, JsonNode.class);
-        HttpRestResult<String> mockRestResult = new HttpRestResult<>();
-        mockRestResult.setData(JacksonUtils.toJson(Result.success(pageNode)));
+        Map<String, Object> page = newRawPage(2, 20, 5);
+        HttpRestResult<String> mockRestResult = newRestResult(Result.success(page));
         doAnswer(invocation -> mockRestResult).when(clientHttpProxy)
             .executeSyncHttpRequest(any(HttpRequest.class));
         
@@ -230,5 +305,40 @@ class PipelineMaintainerServiceImplTest {
         assertEquals(2, data.get("pageNumber").asInt());
         assertEquals(20, data.get("pageSize").asInt());
         assertEquals(5, data.get("totalCount").asInt());
+    }
+    
+    private PipelineExecution newPipelineExecution(String executionId) {
+        PipelineExecution execution = new PipelineExecution();
+        execution.setExecutionId(executionId);
+        execution.setResourceType("SKILL");
+        execution.setResourceName("skill");
+        execution.setNamespaceId("public");
+        execution.setVersion("v1");
+        execution.setStatus(PipelineExecutionStatus.APPROVED);
+        return execution;
+    }
+    
+    private Page<PipelineExecution> newPipelinePage(PipelineExecution execution, int pageNo) {
+        Page<PipelineExecution> page = new Page<>();
+        page.setPageNumber(pageNo);
+        page.setPageItems(Collections.singletonList(execution));
+        page.setTotalCount(1);
+        page.setPagesAvailable(1);
+        return page;
+    }
+    
+    private Map<String, Object> newRawPage(int pageNo, int pageSize, int totalCount) {
+        Map<String, Object> page = new HashMap<>();
+        page.put("pageNumber", pageNo);
+        page.put("pageSize", pageSize);
+        page.put("totalCount", totalCount);
+        page.put("pageItems", Collections.emptyList());
+        return page;
+    }
+    
+    private HttpRestResult<String> newRestResult(Result<?> result) {
+        HttpRestResult<String> restResult = new HttpRestResult<>();
+        restResult.setData(JsonUtils.toJson(result));
+        return restResult;
     }
 }

--- a/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/ai/AiMaintainerServiceMaintainerSdkITCase.java
+++ b/test/maintainer-sdk-test/src/test/java/com/alibaba/nacos/test/maintainer/ai/AiMaintainerServiceMaintainerSdkITCase.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.api.ai.model.mcp.McpServerDetailInfo;
 import com.alibaba.nacos.api.ai.model.mcp.McpTool;
 import com.alibaba.nacos.api.ai.model.mcp.McpToolSpecification;
 import com.alibaba.nacos.api.ai.model.mcp.registry.ServerVersionDetail;
+import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecution;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
 import com.alibaba.nacos.api.ai.model.skills.BatchUploadResult;
@@ -45,7 +46,6 @@ import com.alibaba.nacos.maintainer.client.ai.AiMaintainerFactory;
 import com.alibaba.nacos.maintainer.client.ai.AiMaintainerService;
 import com.alibaba.nacos.maintainer.client.ai.McpMaintainerService;
 import com.alibaba.nacos.test.maintainer.MaintainerSdkBaseITCase;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -603,9 +603,10 @@ class AiMaintainerServiceMaintainerSdkITCase extends MaintainerSdkBaseITCase {
         return page.getPageItems().stream().anyMatch(predicate);
     }
     
-    private void assertSuccessResult(Result<JsonNode> result) {
+    private void assertSuccessResult(Result<Page<PipelineExecution>> result) {
         assertNotNull(result);
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode(), result.toString());
         assertNotNull(result.getData());
+        assertPage(result.getData());
     }
 }


### PR DESCRIPTION
For #14466 

## Summary
- Change PipelineAdminClient pipeline execution queries to return typed PipelineExecution and Page<PipelineExecution> results.
- Keep deprecated PipelineMaintainerService JsonNode methods as compatibility accessors and parse through JsonUtils/NacosTypeReference internally.
- Update console remote Pipeline handling, maintainer SDK IT compile usage, and the Jackson adapter migration tracker.

## Testing
- mvn -pl maintainer-client,console,test/maintainer-sdk-test -am -DskipTests compile
- mvn -pl maintainer-client,console -am -Dtest=PipelineMaintainerServiceImplTest,PipelineRemoteHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl test/maintainer-sdk-test -am -DskipTests test-compile
- mvn -pl maintainer-client,console,test/maintainer-sdk-test spotless:apply spotless:check
- mvn -pl maintainer-client,console,test/maintainer-sdk-test apache-rat:check
- PipelineMaintainerServiceImpl and PipelineRemoteHandler have LINE_MISSED=0 in the focused JaCoCo reports.