### PR TITLE
Guard BatchTaskCounter.batchSuccess against out-of-range batch index

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/task/BatchTaskCounter.java
+++ b/common/src/main/java/com/alibaba/nacos/common/task/BatchTaskCounter.java
@@ -49,7 +49,7 @@ public class BatchTaskCounter {
      * @param batch succeed batch.
      */
     public void batchSuccess(int batch) {
-        if (batch <= batchCounter.size()) {
+        if (batch >= 1 && batch <= batchCounter.size()) {
             batchCounter.get(batch - 1).set(true);
         }
     }

--- a/common/src/test/java/com/alibaba/nacos/common/task/BatchTaskCounterTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/task/BatchTaskCounterTest.java
@@ -53,9 +53,10 @@ class BatchTaskCounterTest {
     @DisplayName("batchSuccess with invalid batch should not throw")
     void testBatchSuccessWithInvalidBatchShouldNotThrow() {
         BatchTaskCounter counter = new BatchTaskCounter(2);
-        // batch > size is handled gracefully by source code
-        // batch = 0 would cause IndexOutOfBounds, so we only test batch > size
+        // Out-of-range batch indices are ignored, just like batch > size.
         counter.batchSuccess(10);
+        counter.batchSuccess(0);
+        counter.batchSuccess(-1);
         assertFalse(counter.batchCompleted());
     }
     


### PR DESCRIPTION
`BatchTaskCounter.batchSuccess(int batch)` only checks the upper bound:

```java
public void batchSuccess(int batch) {
    if (batch <= batchCounter.size()) {
        batchCounter.get(batch - 1).set(true);
    }
}
```

so `batch > size` is silently ignored, but `batch <= 0` passes the check and then `get(batch - 1)` throws `IndexOutOfBoundsException` — e.g. `batchSuccess(0)` calls `get(-1)`. The existing `BatchTaskCounterTest` even documents this gap in a comment ("batch = 0 would cause IndexOutOfBounds, so we only test batch > size").

This adds the missing lower-bound check so out-of-range indices are ignored consistently with the existing `batch > size` behavior, and extends the test to cover `batchSuccess(0)` and `batchSuccess(-1)` (which previously threw).

## Verifying this change

The added `BatchTaskCounterTest#testBatchSuccessWithInvalidBatchShouldNotThrow` fails before this change and passes after:

Before the fix (on `develop`):

```
$ mvn test -Dtest=BatchTaskCounterTest -pl common
[INFO] Running com.alibaba.nacos.common.task.BatchTaskCounterTest
[ERROR] Tests run: 6, Failures: 0, Errors: 1, Skipped: 0 <<< ERROR!
com.alibaba.nacos.common.task.BatchTaskCounterTest.testBatchSuccessWithInvalidBatchShouldNotThrow <<< ERROR!
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 2
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=BatchTaskCounterTest -pl common
[INFO] Running com.alibaba.nacos.common.task.BatchTaskCounterTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

