### PR TITLE
[ISSUE #14466] Finalize Jackson adapter dependency checks

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/ai/cache/NacosAgentCardCacheHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/cache/NacosAgentCardCacheHolder.java
@@ -28,7 +28,7 @@ import com.alibaba.nacos.common.executor.NameThreadFactory;
 import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.CollectionUtils;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +95,7 @@ public class NacosAgentCardCacheHolder implements Closeable {
         }
         if (isAgentCardChanged(oldAgentCard, detailInfo)) {
             LOGGER.info("agent card {} changed, from {} -> {}.", detailInfo.getName(),
-                JacksonUtils.toJson(oldAgentCard), JacksonUtils.toJson(detailInfo));
+                JsonUtils.toJson(oldAgentCard), JsonUtils.toJson(detailInfo));
             NotifyCenter.publishEvent(new AgentCardChangedEvent(detailInfo));
         }
     }
@@ -133,7 +133,7 @@ public class NacosAgentCardCacheHolder implements Closeable {
         AgentCardDetailInfo newAgentCard) {
         if (null == oldAgentCard) {
             LOGGER.info("init new agent card: {} -> {}", newAgentCard.getName(),
-                JacksonUtils.toJson(newAgentCard));
+                JsonUtils.toJson(newAgentCard));
             return true;
         }
         if (!Objects.equals(oldAgentCard.getVersion(), newAgentCard.getVersion())) {

--- a/client/src/main/java/com/alibaba/nacos/client/ai/cache/NacosPromptCacheHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/cache/NacosPromptCacheHolder.java
@@ -27,7 +27,7 @@ import com.alibaba.nacos.common.executor.NameThreadFactory;
 import com.alibaba.nacos.client.utils.LogUtils;
 import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.NotifyCenter;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import org.slf4j.Logger;
 
@@ -158,8 +158,8 @@ public class NacosPromptCacheHolder implements Closeable {
     }
     
     private boolean isPromptChanged(Prompt oldPrompt, Prompt newPrompt) {
-        String oldJson = oldPrompt == null ? StringUtils.EMPTY : JacksonUtils.toJson(oldPrompt);
-        String newJson = newPrompt == null ? StringUtils.EMPTY : JacksonUtils.toJson(newPrompt);
+        String oldJson = oldPrompt == null ? StringUtils.EMPTY : JsonUtils.toJson(oldPrompt);
+        String newJson = newPrompt == null ? StringUtils.EMPTY : JsonUtils.toJson(newPrompt);
         return !StringUtils.equals(oldJson, newJson);
     }
     

--- a/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiGrpcClient.java
+++ b/client/src/main/java/com/alibaba/nacos/client/ai/remote/AiGrpcClient.java
@@ -71,7 +71,7 @@ import com.alibaba.nacos.common.remote.client.RpcClient;
 import com.alibaba.nacos.common.remote.client.RpcClientConfigFactory;
 import com.alibaba.nacos.common.remote.client.RpcClientFactory;
 import com.alibaba.nacos.common.remote.client.grpc.GrpcClientConfig;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.utils.ThreadUtils;
 import com.alibaba.nacos.plugin.auth.api.RequestResource;
@@ -651,7 +651,7 @@ public class AiGrpcClient implements AiClientProxy {
     }
     
     private AgentCard buildLegacyCompatibleAgentCard(AgentCard source) {
-        AgentCard result = JacksonUtils.toObj(JacksonUtils.toJson(source), AgentCard.class);
+        AgentCard result = JsonUtils.toObj(JsonUtils.toJson(source), AgentCard.class);
         List<AgentInterface> supportedInterfaces = result.getSupportedInterfaces();
         if (null != supportedInterfaces && !supportedInterfaces.isEmpty()) {
             AgentInterface preferred = supportedInterfaces.get(0);

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -69,7 +69,7 @@ import com.alibaba.nacos.common.remote.client.grpc.GrpcClientConfig;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.ConnLabelsUtils;
 import com.alibaba.nacos.common.utils.ConvertUtils;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.utils.ThreadUtils;
@@ -616,7 +616,7 @@ public class ClientWorker implements Closeable {
             getMetricsValue(metricsKeys);
         metric.put("metricValues", metricValues);
         Map<String, Object> metrics = new HashMap<>(1);
-        metrics.put(uuid, JacksonUtils.toJson(metric));
+        metrics.put(uuid, JsonUtils.toJson(metric));
         return metrics;
     }
     

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigHttpClientManager.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ConfigHttpClientManager.java
@@ -31,7 +31,7 @@ import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.model.RequestHttpEntity;
 import com.alibaba.nacos.common.utils.ExceptionUtil;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import org.slf4j.Logger;
 
@@ -136,7 +136,7 @@ public class ConfigHttpClientManager implements Closeable {
         public boolean isIntercept(URI uri, String httpMethod,
             RequestHttpEntity requestHttpEntity) {
             final String body = requestHttpEntity.isEmptyBody() ? ""
-                : JacksonUtils.toJson(requestHttpEntity.getBody());
+                : JsonUtils.toJson(requestHttpEntity.getBody());
             return Limiter.isLimit(MD5Utils.md5Hex(uri + body, Constants.ENCODE));
         }
         

--- a/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/NacosNamingService.java
@@ -52,7 +52,7 @@ import com.alibaba.nacos.client.utils.ValidatorUtils;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.FuzzyGroupKeyPattern;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 import java.util.ArrayList;
@@ -379,7 +379,7 @@ public class NacosNamingService implements NamingService {
             if (serviceInfo != null && !serviceInfo.getHosts().isEmpty()) {
                 NAMING_LOGGER.debug("getServiceInfo from failover,serviceName: {}  data:{}",
                     serviceName,
-                    JacksonUtils.toJson(serviceInfo.getHosts()));
+                    JsonUtils.toJson(serviceInfo.getHosts()));
                 return serviceInfo;
             }
         }

--- a/client/src/main/java/com/alibaba/nacos/client/naming/backups/FailoverReactor.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/backups/FailoverReactor.java
@@ -26,7 +26,7 @@ import com.alibaba.nacos.common.executor.NameThreadFactory;
 import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.spi.NacosServiceLoader;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.ThreadUtils;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.ImmutableTag;
@@ -113,7 +113,7 @@ public class FailoverReactor implements Closeable {
                         if (diff.hasDifferent()) {
                             NAMING_LOGGER.info(
                                 "[NA] failoverdata isChangedServiceInfo. newService:{}",
-                                JacksonUtils.toJson(newService));
+                                JsonUtils.toJson(newService));
                             NotifyCenter.publishEvent(new InstancesChangeEvent(notifierEventScope,
                                 newService.getName(),
                                 newService.getGroupName(), newService.getClusters(),

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/DiskCache.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/DiskCache.java
@@ -21,7 +21,7 @@ import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
 import com.alibaba.nacos.client.utils.ConcurrentDiskUtil;
 import com.alibaba.nacos.common.utils.CollectionUtils;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 import java.io.BufferedReader;
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -68,14 +68,14 @@ public class DiskCache {
             String json = dom.getJsonFromServer();
             
             if (StringUtils.isEmpty(json)) {
-                json = JacksonUtils.toJson(dom);
+                json = JsonUtils.toJson(dom);
             }
             
             keyContentBuffer.append(json);
             
             //Use the concurrent API to ensure the consistency.
             ConcurrentDiskUtil.writeFileContent(file, keyContentBuffer.toString(),
-                Charset.defaultCharset().toString());
+                StandardCharsets.UTF_8.name());
             return true;
         } catch (Throwable e) {
             NAMING_LOGGER.error("[NA] failed to write cache for dom:" + dom.getName(), e);
@@ -133,7 +133,7 @@ public class DiskCache {
             ServiceInfo newFormat = null;
             try (BufferedReader reader = new BufferedReader(
                 new StringReader(ConcurrentDiskUtil.getFileContent(file,
-                    Charset.defaultCharset().toString())))) {
+                    StandardCharsets.UTF_8.name())))) {
                 
                 String json;
                 while ((json = reader.readLine()) != null) {
@@ -142,10 +142,10 @@ public class DiskCache {
                             continue;
                         }
                         
-                        newFormat = JacksonUtils.toObj(json, ServiceInfo.class);
+                        newFormat = JsonUtils.toObj(json, ServiceInfo.class);
                         
                         if (StringUtils.isEmpty(newFormat.getName())) {
-                            ips.add(JacksonUtils.toObj(json, Instance.class));
+                            ips.add(JsonUtils.toObj(json, Instance.class));
                         }
                     } catch (Throwable e) {
                         NAMING_LOGGER.error("[NA] error while parsing cache file: " + json, e);

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/InstancesDiffer.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/InstancesDiffer.java
@@ -19,7 +19,7 @@ package com.alibaba.nacos.client.naming.cache;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
 import com.alibaba.nacos.client.naming.event.InstancesDiff;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 import java.util.ArrayList;
@@ -50,7 +50,7 @@ public final class InstancesDiffer {
         if (null == oldService) {
             NAMING_LOGGER.info("init new ips({}) service: {} -> {}", newService.ipCount(),
                 newService.getKey(),
-                JacksonUtils.toJson(newService.getHosts()));
+                JsonUtils.toJson(newService.getHosts()));
             instancesDiff.setAddedInstances(newService.getHosts());
             return instancesDiff;
         }
@@ -103,21 +103,21 @@ public final class InstancesDiffer {
         if (newHosts.size() > 0) {
             NAMING_LOGGER.info("new ips({}) service: {} -> {}", newHosts.size(),
                 newService.getKey(),
-                JacksonUtils.toJson(newHosts));
+                JsonUtils.toJson(newHosts));
             instancesDiff.setAddedInstances(newHosts);
         }
         
         if (remvHosts.size() > 0) {
             NAMING_LOGGER.info("removed ips({}) service: {} -> {}", remvHosts.size(),
                 newService.getKey(),
-                JacksonUtils.toJson(remvHosts));
+                JsonUtils.toJson(remvHosts));
             instancesDiff.setRemovedInstances(remvHosts);
         }
         
         if (modHosts.size() > 0) {
             NAMING_LOGGER.info("modified ips({}) service: {} -> {}", modHosts.size(),
                 newService.getKey(),
-                JacksonUtils.toJson(modHosts));
+                JsonUtils.toJson(modHosts));
             instancesDiff.setModifiedInstances(modHosts);
         }
         return instancesDiff;

--- a/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/cache/ServiceInfoHolder.java
@@ -29,7 +29,7 @@ import com.alibaba.nacos.client.naming.utils.CacheDirUtil;
 import com.alibaba.nacos.common.lifecycle.Closeable;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.ConvertUtils;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 
 import java.util.Map;
@@ -115,7 +115,7 @@ public class ServiceInfoHolder implements Closeable {
      * @return service info
      */
     public ServiceInfo processServiceInfo(String json) {
-        ServiceInfo serviceInfo = JacksonUtils.toObj(json, ServiceInfo.class);
+        ServiceInfo serviceInfo = JsonUtils.toObj(json, ServiceInfo.class);
         serviceInfo.setJsonFromServer(json);
         return processServiceInfo(serviceInfo);
     }
@@ -130,7 +130,7 @@ public class ServiceInfoHolder implements Closeable {
         String serviceKey = serviceInfo.getKeyWithoutClusters();
         if (serviceKey == null) {
             NAMING_LOGGER.warn("process service info but serviceKey is null, service host: {}",
-                JacksonUtils.toJson(serviceInfo.getHosts()));
+                JsonUtils.toJson(serviceInfo.getHosts()));
             return null;
         }
         ServiceInfo oldService = serviceInfoMap.get(serviceKey);
@@ -145,7 +145,7 @@ public class ServiceInfoHolder implements Closeable {
         serviceInfoMap.put(serviceKey, serviceInfo);
         InstancesDiff diff = getServiceInfoDiff(oldService, serviceInfo);
         if (StringUtils.isBlank(serviceInfo.getJsonFromServer())) {
-            serviceInfo.setJsonFromServer(JacksonUtils.toJson(serviceInfo));
+            serviceInfo.setJsonFromServer(JsonUtils.toJson(serviceInfo));
         }
         
         if (enableClientMetrics) {
@@ -159,7 +159,7 @@ public class ServiceInfoHolder implements Closeable {
         if (diff.hasDifferent()) {
             NAMING_LOGGER.info("current ips:({}) service: {} -> {}", serviceInfo.ipCount(),
                 serviceKey,
-                JacksonUtils.toJson(serviceInfo.getHosts()));
+                JsonUtils.toJson(serviceInfo.getHosts()));
             
             if (!failoverReactor.isFailoverSwitch(serviceKey)) {
                 NotifyCenter.publishEvent(

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/gprc/NamingGrpcClientProxy.java
@@ -67,7 +67,7 @@ import com.alibaba.nacos.common.remote.client.RpcClientFactory;
 import com.alibaba.nacos.common.remote.client.ServerListFactory;
 import com.alibaba.nacos.common.remote.client.grpc.GrpcClientConfig;
 import com.alibaba.nacos.common.utils.CollectionUtils;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -405,7 +405,7 @@ public class NamingGrpcClientProxy extends AbstractNamingClientProxy {
             new ServiceListRequest(namespaceId, groupName, pageNo, pageSize);
         if (selector != null) {
             if (SelectorType.valueOf(selector.getType()) == SelectorType.label) {
-                request.setSelector(JacksonUtils.toJson(selector));
+                request.setSelector(JsonUtils.toJson(selector));
             }
         }
         ServiceListResponse response = requestToServer(request, ServiceListResponse.class);

--- a/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
+++ b/client/src/main/java/com/alibaba/nacos/client/naming/remote/http/NamingHttpClientProxy.java
@@ -47,7 +47,6 @@ import com.alibaba.nacos.common.utils.CollectionUtils;
 import com.alibaba.nacos.common.utils.ConvertUtils;
 import com.alibaba.nacos.common.utils.HttpMethod;
 import com.alibaba.nacos.common.utils.InternetAddressUtil;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import org.apache.hc.core5.http.HttpStatus;
 
@@ -153,7 +152,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         params.put(REGISTER_ENABLE_PARAM, String.valueOf(instance.isEnabled()));
         params.put(HEALTHY_PARAM, String.valueOf(instance.isHealthy()));
         params.put(EPHEMERAL_PARAM, String.valueOf(instance.isEphemeral()));
-        params.put(META_PARAM, JacksonUtils.toJson(instance.getMetadata()));
+        params.put(META_PARAM, JsonUtils.toJson(instance.getMetadata()));
         reqApi(UtilAndComs.nacosUrlInstance, params, HttpMethod.POST);
     }
     
@@ -208,7 +207,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         params.put(WEIGHT_PARAM, String.valueOf(instance.getWeight()));
         params.put(ENABLE_PARAM, String.valueOf(instance.isEnabled()));
         params.put(EPHEMERAL_PARAM, String.valueOf(instance.isEphemeral()));
-        params.put(META_PARAM, JacksonUtils.toJson(instance.getMetadata()));
+        params.put(META_PARAM, JsonUtils.toJson(instance.getMetadata()));
         
         reqApi(UtilAndComs.nacosUrlInstance, params, HttpMethod.PUT);
     }
@@ -245,8 +244,8 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         params.put(CommonParams.SERVICE_NAME, service.getName());
         params.put(CommonParams.GROUP_NAME, service.getGroupName());
         params.put(PROTECT_THRESHOLD_PARAM, String.valueOf(service.getProtectThreshold()));
-        params.put(META_PARAM, JacksonUtils.toJson(service.getMetadata()));
-        params.put(SELECTOR_PARAM, JacksonUtils.toJson(selector));
+        params.put(META_PARAM, JsonUtils.toJson(service.getMetadata()));
+        params.put(SELECTOR_PARAM, JsonUtils.toJson(selector));
         
         reqApi(UtilAndComs.nacosUrlService, params, HttpMethod.POST);
         
@@ -276,8 +275,8 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
         params.put(CommonParams.SERVICE_NAME, service.getName());
         params.put(CommonParams.GROUP_NAME, service.getGroupName());
         params.put(PROTECT_THRESHOLD_PARAM, String.valueOf(service.getProtectThreshold()));
-        params.put(META_PARAM, JacksonUtils.toJson(service.getMetadata()));
-        params.put(SELECTOR_PARAM, JacksonUtils.toJson(selector));
+        params.put(META_PARAM, JsonUtils.toJson(service.getMetadata()));
+        params.put(SELECTOR_PARAM, JsonUtils.toJson(selector));
         
         reqApi(UtilAndComs.nacosUrlService, params, HttpMethod.PUT);
     }
@@ -314,7 +313,7 @@ public class NamingHttpClientProxy extends AbstractNamingClientProxy {
                     break;
                 case label:
                     ExpressionSelector expressionSelector = (ExpressionSelector) selector;
-                    params.put(SELECTOR_PARAM, JacksonUtils.toJson(expressionSelector));
+                    params.put(SELECTOR_PARAM, JsonUtils.toJson(expressionSelector));
                     break;
                 default:
                     break;

--- a/common/src/main/java/com/alibaba/nacos/common/http/HttpUtils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/HttpUtils.java
@@ -20,7 +20,7 @@ import com.alibaba.nacos.common.constant.HttpHeaderConsts;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.MediaType;
 import com.alibaba.nacos.common.http.param.Query;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.utils.UuidUtils;
 import com.alibaba.nacos.common.utils.VersionUtils;
@@ -101,7 +101,7 @@ public final class HttpUtils {
                 entity = new ByteArrayEntity((byte[]) body, contentType);
             } else {
                 entity = new StringEntity(
-                    body instanceof String ? (String) body : JacksonUtils.toJson(body),
+                    body instanceof String ? (String) body : JsonUtils.toJson(body),
                     contentType);
             }
             request.setEntity(entity);

--- a/common/src/main/java/com/alibaba/nacos/common/http/client/handler/BeanResponseHandler.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/handler/BeanResponseHandler.java
@@ -19,7 +19,7 @@ package com.alibaba.nacos.common.http.client.handler;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.http.client.response.HttpClientResponse;
 import com.alibaba.nacos.common.http.param.Header;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 
 import java.lang.reflect.Type;
 
@@ -35,7 +35,7 @@ public class BeanResponseHandler<T> extends AbstractResponseHandler<T> {
     public HttpRestResult<T> convertResult(HttpClientResponse response, Type responseType)
         throws Exception {
         final Header headers = response.getHeaders();
-        T extractBody = JacksonUtils.toObj(response.getBody(), responseType);
+        T extractBody = JsonUtils.toObj(response.getBody(), responseType);
         return new HttpRestResult<>(headers, response.getStatusCode(), extractBody, null);
     }
 }

--- a/common/src/main/java/com/alibaba/nacos/common/http/client/handler/RestResultResponseHandler.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/handler/RestResultResponseHandler.java
@@ -20,7 +20,7 @@ import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.http.client.response.HttpClientResponse;
 import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.model.RestResult;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 
 import java.lang.reflect.Type;
 
@@ -36,7 +36,7 @@ public class RestResultResponseHandler<T> extends AbstractResponseHandler<T> {
     public HttpRestResult<T> convertResult(HttpClientResponse response, Type responseType)
         throws Exception {
         final Header headers = response.getHeaders();
-        T extractBody = JacksonUtils.toObj(response.getBody(), responseType);
+        T extractBody = JsonUtils.toObj(response.getBody(), responseType);
         HttpRestResult<T> httpRestResult = convert((RestResult<T>) extractBody);
         httpRestResult.setHeader(headers);
         return httpRestResult;

--- a/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
+++ b/common/src/main/java/com/alibaba/nacos/common/http/client/request/JdkHttpClientRequest.java
@@ -25,7 +25,7 @@ import com.alibaba.nacos.common.http.param.Header;
 import com.alibaba.nacos.common.http.param.MediaType;
 import com.alibaba.nacos.common.model.RequestHttpEntity;
 import com.alibaba.nacos.common.utils.IoUtils;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -108,9 +108,9 @@ public class JdkHttpClientRequest implements HttpClientRequest {
                     handleFileUpload(conn, (File) body);
                 }
                 String contentType = headers.getValue(HttpHeaderConsts.CONTENT_TYPE);
-                String bodyStr = body instanceof String ? (String) body : JacksonUtils.toJson(body);
+                String bodyStr = body instanceof String ? (String) body : JsonUtils.toJson(body);
                 if (MediaType.APPLICATION_FORM_URLENCODED.equals(contentType)) {
-                    Map<String, String> map = JacksonUtils.toObj(bodyStr, HashMap.class);
+                    Map<String, String> map = JsonUtils.toObj(bodyStr, HashMap.class);
                     bodyStr = HttpUtils.encodingParams(map, headers.getCharset());
                 }
                 if (bodyStr != null) {

--- a/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClient.java
+++ b/common/src/main/java/com/alibaba/nacos/common/remote/client/grpc/GrpcClient.java
@@ -40,7 +40,7 @@ import com.alibaba.nacos.common.remote.client.RpcClientStatus;
 import com.alibaba.nacos.common.remote.client.RpcClientTlsConfig;
 import com.alibaba.nacos.common.remote.client.ServerListFactory;
 import com.alibaba.nacos.common.remote.client.ServerRequestHandler;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.common.utils.LoggerUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.utils.ThreadFactoryBuilder;
@@ -207,7 +207,7 @@ public abstract class GrpcClient extends RpcClient {
     private ManagedChannel createNewManagedChannel(String serverIp, int serverPort) {
         LOGGER.info("grpc client connection server: {} ip, serverPort: {}, grpcTslConfig: {}",
             serverIp, serverPort,
-            JacksonUtils.toJson(clientConfig.tlsConfig()));
+            JsonUtils.toJson(clientConfig.tlsConfig()));
         ManagedChannelBuilder<?> managedChannelBuilder =
             buildChannel(serverIp, serverPort, buildSslContext()).executor(
                 grpcExecutor).compressorRegistry(CompressorRegistry.getDefaultInstance())

--- a/common/src/test/java/com/alibaba/nacos/common/json/JacksonAdapterCompatibilityTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/json/JacksonAdapterCompatibilityTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.common.json;
+
+import com.alibaba.nacos.api.utils.json.JsonUtils;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapter;
+import com.alibaba.nacos.api.utils.json.NacosJsonAdapterNames;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JacksonAdapterCompatibilityTest {
+    
+    @AfterEach
+    void tearDown() throws Exception {
+        System.clearProperty(JsonUtils.ADAPTER_PROPERTY_NAME);
+        resetJsonUtils();
+    }
+    
+    @Test
+    void testDefaultAdaptersAreRegisteredAndAvailable() {
+        Map<String, NacosJsonAdapter> adapters = loadAdapters();
+        
+        assertTrue(adapters.containsKey(NacosJsonAdapterNames.JACKSON2));
+        assertTrue(adapters.containsKey(NacosJsonAdapterNames.JACKSON3));
+        assertTrue(adapters.get(NacosJsonAdapterNames.JACKSON2).isAvailable());
+        assertTrue(adapters.get(NacosJsonAdapterNames.JACKSON3).isAvailable());
+    }
+    
+    @Test
+    void testAutoSelectsJackson3WhenBothAdaptersAreAvailable() {
+        assertEquals(NacosJsonAdapterNames.JACKSON3, JsonUtils.selectedAdapterName());
+        assertEquals("{\"name\":\"nacos\"}", JsonUtils.toJson(new SampleModel("nacos")));
+    }
+    
+    @Test
+    void testExplicitJackson2SelectionWorks() throws Exception {
+        System.setProperty(JsonUtils.ADAPTER_PROPERTY_NAME, NacosJsonAdapterNames.JACKSON2);
+        resetJsonUtils();
+        
+        assertEquals(NacosJsonAdapterNames.JACKSON2, JsonUtils.selectedAdapterName());
+        assertEquals(new SampleModel("nacos"),
+            JsonUtils.toObj("{\"name\":\"nacos\",\"unknown\":\"ignored\"}", SampleModel.class));
+    }
+    
+    @Test
+    void testExplicitJackson3SelectionWorks() throws Exception {
+        System.setProperty(JsonUtils.ADAPTER_PROPERTY_NAME, NacosJsonAdapterNames.JACKSON3);
+        resetJsonUtils();
+        
+        assertEquals(NacosJsonAdapterNames.JACKSON3, JsonUtils.selectedAdapterName());
+        assertEquals(new SampleModel("nacos"),
+            JsonUtils.toObj("{\"name\":\"nacos\",\"unknown\":\"ignored\"}", SampleModel.class));
+    }
+    
+    private Map<String, NacosJsonAdapter> loadAdapters() {
+        Map<String, NacosJsonAdapter> result = new HashMap<String, NacosJsonAdapter>();
+        for (NacosJsonAdapter adapter : ServiceLoader.load(NacosJsonAdapter.class)) {
+            result.put(adapter.name(), adapter);
+        }
+        return result;
+    }
+    
+    private void resetJsonUtils() throws Exception {
+        Method resetMethod = JsonUtils.class.getDeclaredMethod("resetForTest");
+        resetMethod.setAccessible(true);
+        resetMethod.invoke(null);
+    }
+    
+    public static class SampleModel {
+        
+        private String name;
+        
+        public SampleModel() {
+        }
+        
+        SampleModel(String name) {
+            this.name = name;
+        }
+        
+        public String getName() {
+            return name;
+        }
+        
+        public void setName(String name) {
+            this.name = name;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SampleModel)) {
+                return false;
+            }
+            SampleModel that = (SampleModel) o;
+            return String.valueOf(name).equals(String.valueOf(that.name));
+        }
+        
+        @Override
+        public int hashCode() {
+            return name == null ? 0 : name.hashCode();
+        }
+    }
+}

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -194,6 +194,30 @@ Last updated: 2026-06-25.
     `LINE_MISSED=0`.
   - `rg "com\\.fasterxml\\.jackson\\.core\\.type\\.TypeReference|new TypeReference|JavaType" maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineAdminClient.java maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerService.java maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImpl.java console/src/main/java/com/alibaba/nacos/console/handler/impl/remote/ai/PipelineRemoteHandler.java`
     returns no matches.
+- 2026-06-25, stage 12 dependency matrix and runtime JSON cleanup:
+  - Migrated remaining neutral-compatible main-code `JacksonUtils` usages in
+    `common`, `client`, and `maintainer-client` to `JsonUtils`; remaining
+    `JacksonUtils` usage is limited to the legacy compatibility facade and the
+    deprecated Pipeline `JsonNode` compatibility path.
+  - Added `JacksonAdapterCompatibilityTest` to verify both default adapters are
+    registered by `ServiceLoader`, both are available on the common test
+    classpath, auto mode selects Jackson 3, and explicit Jackson 2 / Jackson 3
+    selection works.
+  - Fixed naming disk cache read/write charset to UTF-8 so Jackson 3 literal
+    non-ASCII JSON and existing UTF-8 cache files are handled consistently.
+  - `mvn -pl common -am -Dtest=JacksonAdapterCompatibilityTest,Jackson2JsonAdapterTest,Jackson3JsonAdapterTest,BeanResponseHandlerTest,RestResultResponseHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - `mvn -pl client -am -Dtest=NacosPromptCacheHolderTest,NacosAgentCardCacheHolderTest,AiGrpcClientTest,NamingHttpClientProxyTest,NacosNamingServiceTest,DiskCacheTest,ServiceInfoHolderTest,NamingGrpcClientProxyTest,FailoverReactorTest,ClientWorkerTest,ConfigHttpClientManagerTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - `mvn -pl maintainer-client -am -Dtest=A2aMaintainerServiceImplTest,SkillMaintainerServiceImplTest,NacosAiMaintainerServiceImplTest,AiMaintainerServiceDefaultMethodsTest,AbstractCoreMaintainerServiceTest,NacosConfigMaintainerServiceImplTest,NacosNamingMaintainerServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test`
+  - `mvn -pl api dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core`
+  - `mvn -pl common dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core`
+  - `mvn -pl client dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core`
+  - `mvn -pl maintainer-client dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core`
+  - `rg "com\\.fasterxml\\.jackson\\.core\\.type\\.TypeReference|com\\.fasterxml\\.jackson\\.databind\\.(JsonNode|ObjectNode|ArrayNode|JavaType|ObjectMapper)|tools\\.jackson\\.databind\\.(JsonNode|ObjectNode|ArrayNode|JavaType|JsonMapper)|new TypeReference|JsonNode|JavaType|ObjectMapper|JsonMapper" api/src/main/java common/src/main/java client/src/main/java maintainer-client/src/main/java -g '*.java'`
+    returns only adapter internals, legacy `JacksonUtils`, and deprecated
+    Pipeline `JsonNode` compatibility methods.
+  - `mvn -pl common,client,maintainer-client spotless:apply`
+  - `mvn -pl common,client,maintainer-client spotless:check`
+  - `mvn -pl common,client,maintainer-client apache-rat:check`
 
 ## Implementation Principles
 
@@ -320,7 +344,7 @@ Last updated: 2026-06-25.
   - Validation:
     - Unit tests that property order is stable for simple DTOs and maps.
 
-- `[ ]` Keep and narrow `JacksonUtils`.
+- `[x]` Keep and narrow `JacksonUtils`.
   - Files:
     - `common/src/main/java/com/alibaba/nacos/common/utils/JacksonUtils.java`
   - Plan:
@@ -491,7 +515,7 @@ Last updated: 2026-06-25.
 
 ### 6. Dependency and Compatibility Matrix
 
-- `[ ]` Adjust dependency management.
+- `[x]` Adjust dependency management.
   - Files:
     - Root `pom.xml`
     - `api/pom.xml`
@@ -508,7 +532,7 @@ Last updated: 2026-06-25.
     - Dependency tree checks for `nacos-api`, `nacos-client`, and
       `nacos-maintainer-client`.
 
-- `[ ]` Add dependency conflict guard tests / samples.
+- `[x]` Add dependency conflict guard tests / samples.
   - Plan:
     - Jackson 2 only: default behavior unchanged.
     - Jackson 3 only: Java 17 / Spring Boot 4 style classpath works.
@@ -521,7 +545,7 @@ Last updated: 2026-06-25.
 
 ### 7. Final Cleanup
 
-- `[ ]` Run a final scan for forbidden public Jackson core/databind exposure.
+- `[x]` Run a final scan for forbidden public Jackson core/databind exposure.
   - Command shape:
     - `rg "com\\.fasterxml\\.jackson\\.(core|databind)|tools\\.jackson|JsonNode|TypeReference|JavaType" api client common maintainer-client plugin -g '*.java'`
   - Expected result:
@@ -529,7 +553,7 @@ Last updated: 2026-06-25.
     - Remaining Jackson 2 exposure is limited to legacy `JacksonUtils` and
       deprecated compatibility methods.
 
-- `[ ]` Update specs if implementation discovers a mismatch.
+- `[x]` Update specs if implementation discovers a mismatch.
   - Files:
     - `specs/en/sdk/sdk-java-json-adapter-spec.md`
     - `specs/zh-cn/sdk/sdk-java-json-adapter-spec.md`

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/A2aMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/A2aMaintainerServiceImpl.java
@@ -29,7 +29,6 @@ import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.api.utils.json.NacosTypeReference;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.utils.HttpMethod;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.maintainer.client.constants.Constants;
 import com.alibaba.nacos.maintainer.client.model.HttpRequest;
@@ -74,7 +73,7 @@ final class A2aMaintainerServiceImpl extends AbstractAiDelegateMaintainerService
         String registrationType)
         throws NacosException {
         Map<String, String> params = new HashMap<>(4);
-        params.put("agentCard", JacksonUtils.toJson(agentCard));
+        params.put("agentCard", JsonUtils.toJson(agentCard));
         params.put("namespaceId", namespaceId);
         params.put("agentName", agentCard.getName());
         params.put("registrationType", registrationType);
@@ -130,7 +129,7 @@ final class A2aMaintainerServiceImpl extends AbstractAiDelegateMaintainerService
     private boolean doUpdateAgentCard(AgentCard agentCard, String namespaceId, boolean setAsLatest,
         String registrationType) throws NacosException {
         Map<String, String> params = new HashMap<>(5);
-        params.put("agentCard", JacksonUtils.toJson(agentCard));
+        params.put("agentCard", JsonUtils.toJson(agentCard));
         params.put("namespaceId", namespaceId);
         params.put("agentName", agentCard.getName());
         params.put("setAsLatest", String.valueOf(setAsLatest));
@@ -227,7 +226,7 @@ final class A2aMaintainerServiceImpl extends AbstractAiDelegateMaintainerService
     }
     
     private AgentCard buildLegacyCompatibleAgentCard(AgentCard source) {
-        AgentCard result = JsonUtils.toObj(JacksonUtils.toJson(source), AgentCard.class);
+        AgentCard result = JsonUtils.toObj(JsonUtils.toJson(source), AgentCard.class);
         List<AgentInterface> supportedInterfaces = result.getSupportedInterfaces();
         if (null != supportedInterfaces && !supportedInterfaces.isEmpty()) {
             AgentInterface preferred = supportedInterfaces.get(0);

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/McpMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/McpMaintainerServiceImpl.java
@@ -29,7 +29,6 @@ import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.api.utils.json.NacosTypeReference;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.utils.HttpMethod;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.maintainer.client.constants.Constants;
 import com.alibaba.nacos.maintainer.client.model.HttpRequest;
 
@@ -167,12 +166,12 @@ final class McpMaintainerServiceImpl extends AbstractAiDelegateMaintainerService
         McpEndpointSpec endpointSpec) {
         Map<String, String> params = new HashMap<>(4);
         params.put("mcpName", serverSpec.getName());
-        params.put("serverSpecification", JacksonUtils.toJson(serverSpec));
+        params.put("serverSpecification", JsonUtils.toJson(serverSpec));
         if (null != toolSpec) {
-            params.put("toolSpecification", JacksonUtils.toJson(toolSpec));
+            params.put("toolSpecification", JsonUtils.toJson(toolSpec));
         }
         if (null != endpointSpec) {
-            params.put("endpointSpecification", JacksonUtils.toJson(endpointSpec));
+            params.put("endpointSpecification", JsonUtils.toJson(endpointSpec));
         }
         return params;
     }

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerServiceImpl.java
@@ -30,7 +30,6 @@ import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.api.utils.json.NacosTypeReference;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.utils.HttpMethod;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.maintainer.client.constants.Constants;
 import com.alibaba.nacos.maintainer.client.model.HttpRequest;
@@ -204,7 +203,7 @@ public class SkillMaintainerServiceImpl extends AbstractAiDelegateMaintainerServ
             buildRequestResource(firstNs, null))
             .setHttpMethod(HttpMethod.POST)
             .setPath(Constants.AdminApiPath.AI_SKILL_BATCH_UPLOAD_PRECHECK_ADMIN_PATH)
-            .setBody(JacksonUtils.toJson(requests)).build();
+            .setBody(JsonUtils.toJson(requests)).build();
         HttpRestResult<String> restResult = executeSyncHttpRequest(httpRequest);
         Result<List<SkillUploadPrecheckResult>> result = JsonUtils.toObj(restResult.getData(),
             new NacosTypeReference<Result<List<SkillUploadPrecheckResult>>>() {

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/config/NacosConfigMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/config/NacosConfigMaintainerServiceImpl.java
@@ -32,7 +32,6 @@ import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.api.utils.json.NacosTypeReference;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.utils.HttpMethod;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.maintainer.client.constants.Constants;
 import com.alibaba.nacos.maintainer.client.core.AbstractCoreMaintainerService;
@@ -309,7 +308,7 @@ public class NacosConfigMaintainerServiceImpl extends AbstractCoreMaintainerServ
             buildRequestResource(namespaceId, StringUtils.EMPTY, StringUtils.EMPTY);
         HttpRequest httpRequest = buildRequestWithResource(resource).setHttpMethod(HttpMethod.POST)
             .setPath(Constants.AdminApiPath.CONFIG_ADMIN_PATH + "/clone").setParamValue(params)
-            .setBody(JacksonUtils.toJson(cloneInfos)).build();
+            .setBody(JsonUtils.toJson(cloneInfos)).build();
         HttpRestResult<String> httpRestResult =
             getClientHttpProxy().executeSyncHttpRequest(httpRequest);
         Result<Map<String, Object>> result = JsonUtils.toObj(httpRestResult.getData(),

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/core/AbstractCoreMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/core/AbstractCoreMaintainerService.java
@@ -27,7 +27,6 @@ import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.api.utils.json.NacosTypeReference;
 import com.alibaba.nacos.common.http.HttpRestResult;
 import com.alibaba.nacos.common.utils.HttpMethod;
-import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.maintainer.client.constants.Constants;
 import com.alibaba.nacos.maintainer.client.model.HttpRequest;
 import com.alibaba.nacos.maintainer.client.remote.ClientHttpProxy;
@@ -377,7 +376,7 @@ public abstract class AbstractCoreMaintainerService implements CoreMaintainerSer
         Map<String, String> params = new HashMap<>(8);
         params.put("pluginType", pluginType);
         params.put("pluginName", pluginName);
-        params.put("config", JacksonUtils.toJson(config));
+        params.put("config", JsonUtils.toJson(config));
         params.put("localOnly", String.valueOf(localOnly));
         
         HttpRequest httpRequest = new HttpRequest.Builder().setHttpMethod(HttpMethod.PUT)

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/utils/RequestUtil.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/utils/RequestUtil.java
@@ -19,7 +19,7 @@ package com.alibaba.nacos.maintainer.client.utils;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.Service;
 import com.alibaba.nacos.api.naming.pojo.maintainer.ClusterInfo;
-import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -43,10 +43,10 @@ public class RequestUtil {
         params.put("namespaceId", service.getNamespaceId());
         params.put("groupName", service.getGroupName());
         params.put("serviceName", service.getName());
-        params.put("metadata", JacksonUtils.toJson(service.getMetadata()));
+        params.put("metadata", JsonUtils.toJson(service.getMetadata()));
         params.put("ephemeral", String.valueOf(service.isEphemeral()));
         params.put("protectThreshold", String.valueOf(service.getProtectThreshold()));
-        params.put("selector", JacksonUtils.toJson(service.getSelector()));
+        params.put("selector", JsonUtils.toJson(service.getSelector()));
         return params;
     }
     
@@ -68,7 +68,7 @@ public class RequestUtil {
         params.put("weight", String.valueOf(instance.getWeight()));
         params.put("healthy", String.valueOf(instance.isHealthy()));
         params.put("enabled", String.valueOf(instance.isEnabled()));
-        params.put("metadata", JacksonUtils.toJson(instance.getMetadata()));
+        params.put("metadata", JsonUtils.toJson(instance.getMetadata()));
         params.put("ephemeral", String.valueOf(instance.isEphemeral()));
         return params;
     }
@@ -87,9 +87,9 @@ public class RequestUtil {
         params.put("namespaceId", service.getNamespaceId());
         params.put("groupName", service.getGroupName());
         params.put("serviceName", service.getName());
-        params.put("instances", JacksonUtils.toJson(instances));
+        params.put("instances", JsonUtils.toJson(instances));
         params.put("consistencyType", instances.get(0).isEphemeral() ? "ephemeral" : "persist");
-        params.put("metadata", JacksonUtils.toJson(newMetadata));
+        params.put("metadata", JsonUtils.toJson(newMetadata));
         return params;
     }
     
@@ -108,8 +108,8 @@ public class RequestUtil {
         params.put("clusterName", cluster.getClusterName());
         params.put("checkPort", String.valueOf(cluster.getHealthyCheckPort()));
         params.put("useInstancePort4Check", String.valueOf(cluster.isUseInstancePortForCheck()));
-        params.put("healthChecker", JacksonUtils.toJson(cluster.getHealthChecker()));
-        params.put("metadata", JacksonUtils.toJson(cluster.getMetadata()));
+        params.put("healthChecker", JsonUtils.toJson(cluster.getHealthChecker()));
+        params.put("metadata", JsonUtils.toJson(cluster.getMetadata()));
         return params;
     }
 }


### PR DESCRIPTION
For #14466 

### Summary
- Migrate remaining neutral-compatible JSON calls in common, client, and maintainer-client from JacksonUtils to JsonUtils.
- Add ServiceLoader compatibility coverage for default Jackson 2 and Jackson 3 adapters, auto mode preferring Jackson 3, and explicit adapter selection.
- Validate the api/common/client/maintainer-client Jackson dependency matrix and keep the remaining JacksonUtils/deprecated JsonNode usage as compatibility-only paths.
- Fix naming disk cache reads and writes to use UTF-8 consistently for Jackson 3 literal non-ASCII JSON.

### Validation
- mvn -pl common -am -Dtest=JacksonAdapterCompatibilityTest,Jackson2JsonAdapterTest,Jackson3JsonAdapterTest,BeanResponseHandlerTest,RestResultResponseHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl client -am -Dtest=NacosPromptCacheHolderTest,NacosAgentCardCacheHolderTest,AiGrpcClientTest,NamingHttpClientProxyTest,NacosNamingServiceTest,DiskCacheTest,ServiceInfoHolderTest,NamingGrpcClientProxyTest,FailoverReactorTest,ClientWorkerTest,ConfigHttpClientManagerTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl maintainer-client -am -Dtest=A2aMaintainerServiceImplTest,SkillMaintainerServiceImplTest,NacosAiMaintainerServiceImplTest,AiMaintainerServiceDefaultMethodsTest,AbstractCoreMaintainerServiceTest,NacosConfigMaintainerServiceImplTest,NacosNamingMaintainerServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl api dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core
- mvn -pl common dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core
- mvn -pl client dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core
- mvn -pl maintainer-client dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core
- mvn -pl common,client,maintainer-client spotless:check
- mvn -pl common,client,maintainer-client apache-rat:check
- git diff --check