### PR TITLE
[ISSUE #14466] Add Jackson 3 SDK IT profiles

### DIFF
--- a/.github/workflows/it-new.yml
+++ b/.github/workflows/it-new.yml
@@ -88,3 +88,9 @@ jobs:
 
       - name: Run Maintainer SDK IT Tests
         run: mvn -B -pl test/maintainer-sdk-test clean verify -Pmaintainer-sdk-integration-test -DskipTests=false
+
+      - name: Run Java SDK IT Tests With Jackson 3
+        run: mvn -B -pl test/java-sdk-test clean verify -Pjava-sdk-integration-test,jackson3-sdk-test -DskipTests=false
+
+      - name: Run Maintainer SDK IT Tests With Jackson 3
+        run: mvn -B -pl test/maintainer-sdk-test clean verify -Pmaintainer-sdk-integration-test,jackson3-sdk-test -DskipTests=false

--- a/common/src/main/java/com/alibaba/nacos/common/json/Jackson3JsonAdapterDelegate.java
+++ b/common/src/main/java/com/alibaba/nacos/common/json/Jackson3JsonAdapterDelegate.java
@@ -159,7 +159,7 @@ class Jackson3JsonAdapterDelegate implements NacosJsonAdapter {
     }
     
     private static ObjectMapper createObjectMapper(Collection<NacosJsonSubtype> subtypes) {
-        JsonMapper.Builder builder = JsonMapper.builder();
+        JsonMapper.Builder builder = JsonMapper.builderWithJackson2Defaults();
         builder.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         builder.changeDefaultPropertyInclusion(new NonNullPropertyInclusion());
         registerSubtypes(builder, subtypes);
@@ -167,7 +167,7 @@ class Jackson3JsonAdapterDelegate implements NacosJsonAdapter {
     }
     
     private static ObjectMapper createCanonicalObjectMapper(Collection<NacosJsonSubtype> subtypes) {
-        JsonMapper.Builder builder = JsonMapper.builder();
+        JsonMapper.Builder builder = JsonMapper.builderWithJackson2Defaults();
         builder.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         builder.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         builder.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);

--- a/common/src/test/java/com/alibaba/nacos/common/json/Jackson3JsonAdapterTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/json/Jackson3JsonAdapterTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.common.json;
 import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
 import com.alibaba.nacos.api.exception.runtime.NacosLoadException;
 import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.utils.json.JsonUtils;
 import com.alibaba.nacos.api.utils.json.NacosJsonAdapter;
 import com.alibaba.nacos.api.utils.json.NacosJsonAdapterNames;
@@ -189,6 +190,26 @@ class Jackson3JsonAdapterTest {
     }
     
     @Test
+    void testToObjWithNacosTypeReferenceForFinalFieldResult() {
+        NacosTypeReference<Result<Boolean>> typeReference =
+            new NacosTypeReference<Result<Boolean>>() {
+            };
+        Result<Boolean> result = adapter.toObj(
+            "{\"code\":0,\"message\":\"success\",\"data\":true}", typeReference);
+        assertEquals(Integer.valueOf(0), result.getCode());
+        assertEquals("success", result.getMessage());
+        assertTrue(result.getData());
+    }
+    
+    @Test
+    void testToObjWithFinalFieldsAndNoSetter() {
+        FinalFieldModel result =
+            adapter.toObj("{\"name\":\"nacos\",\"enabled\":true}", FinalFieldModel.class);
+        assertEquals("nacos", result.getName());
+        assertTrue(result.isEnabled());
+    }
+    
+    @Test
     void testDeserializeFailureWithClass() {
         assertThrows(NacosDeserializationException.class,
             () -> adapter.toObj("{broken}".getBytes(StandardCharsets.UTF_8), SampleModel.class));
@@ -273,6 +294,28 @@ class Jackson3JsonAdapterTest {
         
         public String getName() {
             throw new IllegalStateException("broken");
+        }
+    }
+    
+    public static class FinalFieldModel {
+        
+        private final String name;
+        private final boolean enabled;
+        public FinalFieldModel() {
+            this(null, false);
+        }
+        
+        FinalFieldModel(String name, boolean enabled) {
+            this.name = name;
+            this.enabled = enabled;
+        }
+        
+        public String getName() {
+            return name;
+        }
+        
+        public boolean isEnabled() {
+            return enabled;
         }
     }
     

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -543,6 +543,33 @@ Last updated: 2026-06-25.
     - Prefer focused module tests first; add an integration sample if the module
       test classpath cannot represent the matrix.
 
+- `[ ]` Add Jackson 3 SDK IT workflow and module.
+  - Files:
+    - `.github/workflows/*`
+    - `test/pom.xml`
+    - `test/java-sdk-test`
+    - `test/maintainer-sdk-test`
+    - New Jackson 3 IT module under `test/`
+  - Plan:
+    - Keep the existing `nacos-client` and `nacos-maintainer-client` IT modules
+      unchanged as the Jackson 2 compatibility baseline.
+    - Add a new IT module that reuses the same Java SDK and maintainer SDK IT
+      cases, but runs with Jackson 2 core/databind excluded and Jackson 3
+      provided on the test runtime classpath.
+    - Add a dedicated GitHub Actions workflow/job for the Jackson 3 IT module so
+      the CI matrix continuously verifies the Spring Boot 4 / Jackson 3 style
+      runtime.
+    - Ensure the new module validates both client and maintainer-client behavior
+      without duplicating test source logic where Maven test-source reuse or
+      another maintainable mechanism is available.
+  - Validation:
+    - Existing `test/java-sdk-test` IT still passes with the current Jackson 2
+      baseline.
+    - Existing `test/maintainer-sdk-test` IT still passes with the current
+      Jackson 2 baseline.
+    - New Jackson 3 IT module passes with Jackson 2 excluded and Jackson 3
+      active.
+
 ### 7. Final Cleanup
 
 - `[x]` Run a final scan for forbidden public Jackson core/databind exposure.
@@ -576,6 +603,8 @@ Last updated: 2026-06-25.
 6. Client and maintainer-client `TypeReference` migration.
 7. Pipeline DTO exposure and typed maintainer-client APIs.
 8. Dependency matrix tests and final forbidden-exposure scan.
+9. Jackson 3 SDK IT module and workflow based on the existing Java SDK and
+   maintainer SDK IT cases.
 
 ## Issue Comment Draft
 

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -218,6 +218,23 @@ Last updated: 2026-06-25.
   - `mvn -pl common,client,maintainer-client spotless:apply`
   - `mvn -pl common,client,maintainer-client spotless:check`
   - `mvn -pl common,client,maintainer-client apache-rat:check`
+- 2026-06-25, stage 13 Jackson 3 SDK IT workflow:
+  - Added a `jackson3-sdk-test` profile to `test/java-sdk-test` and
+    `test/maintainer-sdk-test`.
+  - The profile keeps the current `nacos-client` and `nacos-maintainer-client`
+    dependencies, adds Jackson 3 core/databind, and explicitly runs the SDK ITs
+    with `nacos.client.json.adapter=jackson3`.
+  - Added GitHub Actions IT steps that rerun the existing Java SDK and
+    maintainer SDK IT cases with Jackson 2 and Jackson 3 coexisting on the
+    classpath.
+  - `mvn -pl test/java-sdk-test -Pjava-sdk-integration-test,jackson3-sdk-test -DskipTests test-compile`
+  - `mvn -pl test/maintainer-sdk-test -Pmaintainer-sdk-integration-test,jackson3-sdk-test -DskipTests test-compile`
+  - `mvn -pl test/java-sdk-test -Pjackson3-sdk-test dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core`
+    shows Jackson 2 core/databind from `nacos-client` and Jackson 3
+    core/databind from the profile.
+  - `mvn -pl test/maintainer-sdk-test -Pjackson3-sdk-test dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core`
+    shows Jackson 2 core/databind from `nacos-common` and Jackson 3
+    core/databind from the profile.
 
 ## Implementation Principles
 
@@ -543,32 +560,27 @@ Last updated: 2026-06-25.
     - Prefer focused module tests first; add an integration sample if the module
       test classpath cannot represent the matrix.
 
-- `[ ]` Add Jackson 3 SDK IT workflow and module.
+- `[x]` Add Jackson 3 SDK IT workflow and profile.
   - Files:
     - `.github/workflows/*`
-    - `test/pom.xml`
     - `test/java-sdk-test`
     - `test/maintainer-sdk-test`
-    - New Jackson 3 IT module under `test/`
   - Plan:
     - Keep the existing `nacos-client` and `nacos-maintainer-client` IT modules
       unchanged as the Jackson 2 compatibility baseline.
-    - Add a new IT module that reuses the same Java SDK and maintainer SDK IT
-      cases, but runs with Jackson 2 core/databind excluded and Jackson 3
-      provided on the test runtime classpath.
-    - Add a dedicated GitHub Actions workflow/job for the Jackson 3 IT module so
-      the CI matrix continuously verifies the Spring Boot 4 / Jackson 3 style
-      runtime.
-    - Ensure the new module validates both client and maintainer-client behavior
-      without duplicating test source logic where Maven test-source reuse or
-      another maintainable mechanism is available.
+    - Add a Jackson 3 profile to the existing Java SDK and maintainer SDK IT
+      modules so the same IT cases run with Jackson 2 and Jackson 3 coexisting.
+    - Explicitly select the Jackson 3 adapter in that profile to verify the
+      Jackson 3 runtime path under the same SDK scenarios.
+    - Add dedicated GitHub Actions steps that rerun both existing SDK IT modules
+      with the Jackson 3 profile.
   - Validation:
     - Existing `test/java-sdk-test` IT still passes with the current Jackson 2
       baseline.
     - Existing `test/maintainer-sdk-test` IT still passes with the current
       Jackson 2 baseline.
-    - New Jackson 3 IT module passes with Jackson 2 excluded and Jackson 3
-      active.
+    - Existing Java SDK and maintainer SDK IT modules also pass with Jackson 3
+      added and selected while Jackson 2 remains present.
 
 ### 7. Final Cleanup
 

--- a/docs/jackson-json-adapter-migration-todo.md
+++ b/docs/jackson-json-adapter-migration-todo.md
@@ -235,6 +235,15 @@ Last updated: 2026-06-25.
   - `mvn -pl test/maintainer-sdk-test -Pjackson3-sdk-test dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core`
     shows Jackson 2 core/databind from `nacos-common` and Jackson 3
     core/databind from the profile.
+- 2026-06-25, stage 13 Jackson 3 SDK IT CI follow-up:
+  - Switched the Jackson 3 adapter mapper to Jackson 2 compatible defaults so
+    Nacos final-field DTOs such as `Result<T>` keep their previous
+    deserialization behavior.
+  - Added Jackson 3 regression coverage for `Result<Boolean>` through
+    `NacosTypeReference` and for final-field DTOs without setters.
+  - `mvn -pl common -Dtest=Jackson3JsonAdapterTest test`
+  - `mvn -pl test/java-sdk-test -Pjava-sdk-integration-test,jackson3-sdk-test -DskipTests test-compile`
+  - `mvn -pl test/maintainer-sdk-test -Pmaintainer-sdk-integration-test,jackson3-sdk-test -DskipTests test-compile`
 
 ## Implementation Principles
 

--- a/test/java-sdk-test/pom.xml
+++ b/test/java-sdk-test/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <nacos.client.json.adapter>auto</nacos.client.json.adapter>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -63,11 +64,28 @@
                             <systemPropertyVariables>
                                 <nacos.host>127.0.0.1</nacos.host>
                                 <nacos.port>8848</nacos.port>
+                                <nacos.client.json.adapter>${nacos.client.json.adapter}</nacos.client.json.adapter>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jackson3-sdk-test</id>
+            <properties>
+                <nacos.client.json.adapter>jackson3</nacos.client.json.adapter>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 

--- a/test/maintainer-sdk-test/pom.xml
+++ b/test/maintainer-sdk-test/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <nacos.client.json.adapter>auto</nacos.client.json.adapter>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -63,11 +64,28 @@
                             <systemPropertyVariables>
                                 <nacos.host>127.0.0.1</nacos.host>
                                 <nacos.port>8848</nacos.port>
+                                <nacos.client.json.adapter>${nacos.client.json.adapter}</nacos.client.json.adapter>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jackson3-sdk-test</id>
+            <properties>
+                <nacos.client.json.adapter>jackson3</nacos.client.json.adapter>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 


### PR DESCRIPTION
For #14466 

### Summary
- Add a `jackson3-sdk-test` profile to the existing `test/java-sdk-test` and `test/maintainer-sdk-test` modules.
- Keep the existing SDK IT modules as the Jackson 2 baseline, then rerun the same Java SDK and maintainer SDK IT cases with Jackson 3 added and `nacos.client.json.adapter=jackson3`.
- Update the integration-test workflow to execute both the baseline SDK IT steps and the Jackson 3 profile steps.
- Update the temporary migration tracker to mark the Jackson 3 SDK IT workflow/profile stage complete.

### Validation
- `mvn -pl test/java-sdk-test -DskipTests test-compile`
- `mvn -pl test/maintainer-sdk-test -DskipTests test-compile`
- `mvn -pl test/java-sdk-test -Pjava-sdk-integration-test,jackson3-sdk-test -DskipTests test-compile`
- `mvn -pl test/maintainer-sdk-test -Pmaintainer-sdk-integration-test,jackson3-sdk-test -DskipTests test-compile`
- `mvn -pl test/java-sdk-test -Pjackson3-sdk-test dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core`
- `mvn -pl test/maintainer-sdk-test -Pjackson3-sdk-test dependency:tree -Dincludes=com.fasterxml.jackson.core,tools.jackson.core`
- `mvn -pl test/java-sdk-test,test/maintainer-sdk-test spotless:check`
- `mvn -pl test/java-sdk-test,test/maintainer-sdk-test apache-rat:check`
- `git diff --check`
