### PR TITLE
[ISSUE #14466] Clarify selected JSON adapter log

### DIFF
--- a/common/src/main/java/com/alibaba/nacos/common/json/JsonAdapterLogUtils.java
+++ b/common/src/main/java/com/alibaba/nacos/common/json/JsonAdapterLogUtils.java
@@ -41,11 +41,26 @@ public final class JsonAdapterLogUtils {
      * Log selected JSON adapter once for current JVM.
      */
     public static void logSelectedAdapter() {
-        String selectedAdapter = JsonUtils.selectedAdapterName();
         if (LOGGED.compareAndSet(false, true)) {
-            LOGGER.info("[json-adapter] selected adapter: {}, configured adapter: {}",
-                selectedAdapter, configuredAdapterName());
+            LOGGER.info("[json-adapter] {}",
+                formatLogMessage(JsonUtils.selectedAdapterName(), configuredAdapterName()));
         }
+    }
+    
+    private static String formatLogMessage(String effectiveAdapter, String configuredAdapter) {
+        return "effective Jackson adapter: " + formatEffectiveAdapter(effectiveAdapter)
+            + ", configured "
+            + JsonUtils.ADAPTER_PROPERTY_NAME + ": " + configuredAdapter;
+    }
+    
+    private static String formatEffectiveAdapter(String effectiveAdapter) {
+        if (NacosJsonAdapterNames.JACKSON2.equals(effectiveAdapter)) {
+            return "Jackson 2 (adapter: " + effectiveAdapter + ")";
+        }
+        if (NacosJsonAdapterNames.JACKSON3.equals(effectiveAdapter)) {
+            return "Jackson 3 (adapter: " + effectiveAdapter + ")";
+        }
+        return effectiveAdapter;
     }
     
     private static String configuredAdapterName() {

--- a/common/src/test/java/com/alibaba/nacos/common/json/JsonAdapterLogUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/json/JsonAdapterLogUtilsTest.java
@@ -51,7 +51,7 @@ class JsonAdapterLogUtilsTest {
         JsonAdapterLogUtils.logSelectedAdapter();
         JsonAdapterLogUtils.logSelectedAdapter();
         
-        assertNotNull(JsonUtils.selectedAdapterName());
+        assertEquals(NacosJsonAdapterNames.JACKSON3, JsonUtils.selectedAdapterName());
     }
     
     @Test
@@ -70,6 +70,24 @@ class JsonAdapterLogUtilsTest {
         constructor.setAccessible(true);
         
         assertNotNull(constructor.newInstance());
+    }
+    
+    @Test
+    void testFormatLogMessage() throws Exception {
+        Method formatMethod = JsonAdapterLogUtils.class.getDeclaredMethod("formatLogMessage",
+            String.class, String.class);
+        formatMethod.setAccessible(true);
+        
+        assertEquals("effective Jackson adapter: Jackson 3 (adapter: jackson3), "
+            + "configured nacos.client.json.adapter: auto",
+            formatMethod.invoke(null, NacosJsonAdapterNames.JACKSON3, NacosJsonAdapterNames.AUTO));
+        assertEquals("effective Jackson adapter: Jackson 2 (adapter: jackson2), "
+            + "configured nacos.client.json.adapter: jackson2",
+            formatMethod.invoke(null, NacosJsonAdapterNames.JACKSON2,
+                NacosJsonAdapterNames.JACKSON2));
+        assertEquals(
+            "effective Jackson adapter: custom, configured nacos.client.json.adapter: custom",
+            formatMethod.invoke(null, "custom", "custom"));
     }
     
     private void resetJsonUtils() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Clarify the JSON adapter startup diagnostic log so auto mode shows the final effective Jackson adapter version, not only the configured property value.

Example log after this change:

[json-adapter] effective Jackson adapter: Jackson 3 (adapter: jackson3), configured nacos.client.json.adapter: auto

## Brief changelog

- Print the effective Jackson adapter/version in JsonAdapterLogUtils.
- Keep the configured nacos.client.json.adapter value in the same log line for comparison.
- Add unit coverage for auto mode selected adapter and the formatted diagnostic message.

## Verifying this change

- mvn -pl common spotless:apply
- mvn -pl common spotless:check
- mvn -pl common -am -Dtest=JsonAdapterLogUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl common apache-rat:check