### PR TITLE
Polish unused code follow-up

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/pipeline/repository/PipelineExecutionRepositoryImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/pipeline/repository/PipelineExecutionRepositoryImpl.java
@@ -63,10 +63,6 @@ public class PipelineExecutionRepositoryImpl implements PipelineExecutionReposit
     private static final String SQL_FIND_BY_ID =
         "SELECT * FROM pipeline_execution WHERE execution_id=?";
     
-    private static final String SQL_FIND_BY_RESOURCE = "SELECT * FROM pipeline_execution "
-        + "WHERE resource_type=? AND resource_name=? AND namespace_id=? AND version=? "
-        + "ORDER BY create_time DESC";
-    
     private static final PipelineExecutionRowMapper ROW_MAPPER = new PipelineExecutionRowMapper();
     
     private final JdbcTemplate injectedJdbcTemplate;

--- a/api/src/main/java/com/alibaba/nacos/api/config/filter/IConfigRequest.java
+++ b/api/src/main/java/com/alibaba/nacos/api/config/filter/IConfigRequest.java
@@ -43,7 +43,9 @@ public interface IConfigRequest {
      * get config context.
      *
      * @return {@link IConfigContext}
+     * @deprecated Unused by current config filter flow; kept temporarily for compatibility.
      */
+    @Deprecated
     IConfigContext getConfigContext();
     
 }


### PR DESCRIPTION
## Summary
- Remove a leftover unused SQL constant from PipelineExecutionRepositoryImpl.
- Mark IConfigRequest#getConfigContext as deprecated to match the existing IConfigResponse compatibility marker.

## Testing
- mvn -pl ai,api spotless:apply spotless:check -DskipTests
- mvn -pl ai,api -am -DskipTests compile
- mvn -pl ai -am -Dtest=PipelineExecutionRepositoryImplTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test