### PR TITLE
Fix off-by-one page count in PageUtil for divisible totals

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/utils/PageUtil.java
+++ b/core/src/main/java/com/alibaba/nacos/core/utils/PageUtil.java
@@ -67,7 +67,7 @@ public class PageUtil {
         int totalCount = source.size();
         result.setTotalCount(totalCount);
         PageMetadata metadata = calculatePageMetadata(page, pageSize, totalCount);
-        int pagesAvailable = (totalCount / pageSize) + 1;
+        int pagesAvailable = (totalCount + pageSize - 1) / pageSize;
         result.setPagesAvailable(pagesAvailable);
         if (totalCount > metadata.start) {
             result.setPageItems(source.subList(metadata.start, metadata.end));

--- a/core/src/test/java/com/alibaba/nacos/core/utils/PageUtilTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/utils/PageUtilTest.java
@@ -124,7 +124,7 @@ class PageUtilTest {
         assertEquals(2, result.getTotalCount());
         assertEquals(1, result.getPagesAvailable());
     }
-
+    
     @Test
     void subPageExactDivisiblePages() {
         // 9 items / 3 per page = exactly 3 pages (no extra page)

--- a/core/src/test/java/com/alibaba/nacos/core/utils/PageUtilTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/utils/PageUtilTest.java
@@ -122,7 +122,16 @@ class PageUtilTest {
         Page<String> result = PageUtil.subPage(source, 1, 2);
         assertEquals(2, result.getPageItems().size());
         assertEquals(2, result.getTotalCount());
-        assertEquals(2, result.getPagesAvailable());
+        assertEquals(1, result.getPagesAvailable());
+    }
+
+    @Test
+    void subPageExactDivisiblePages() {
+        // 9 items / 3 per page = exactly 3 pages (no extra page)
+        List<String> source = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i");
+        Page<String> result = PageUtil.subPage(source, 1, 3);
+        assertEquals(9, result.getTotalCount());
+        assertEquals(3, result.getPagesAvailable());
     }
     
     @Test

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/CatalogServiceV2ImplTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/CatalogServiceV2ImplTest.java
@@ -307,8 +307,8 @@ class CatalogServiceV2ImplTest {
         assertNotNull(result);
         assertEquals(3, result.getTotalCount(), "Total service count should be 3");
         assertEquals(2, result.getPageNumber(), "Current page number should be 2");
-        assertEquals(4, result.getPagesAvailable(),
-            "PagesAvailable should = (totalCount / pageSize) + 1");
+        assertEquals(3, result.getPagesAvailable(),
+            "PagesAvailable should = ceil(totalCount / pageSize)");
         assertEquals(1, result.getPageItems().size(),
             "Page size is 1, so only one item should be returned");
         


### PR DESCRIPTION
`PageUtil` computes the page count as `(totalCount / pageSize) + 1`, which
reports one page too many whenever `totalCount` is an exact multiple of
`pageSize` (e.g. 9 items at 3 per page yields 4 instead of 3), and reports 1
page for an empty result. Callers that iterate `1..pagesAvailable` then visit a
trailing empty page.

Use ceiling division `(totalCount + pageSize - 1) / pageSize`. One existing
assertion in `PageUtilTest` encoded the old off-by-one value (2 pages for 2
items at 2 per page) and is corrected to 1; a test for the exactly-divisible
case is added.

## Verifying this change

`PageUtilTest` (which includes the added cases) fails on the current `develop` and passes with this change:

Before the fix (on `develop`):

```
$ mvn test -Dtest=PageUtilTest -pl core
[INFO] Running com.alibaba.nacos.core.utils.PageUtilTest
[ERROR] Tests run: 13, Failures: 2, Errors: 0, Skipped: 0 <<< FAILURE! -- in com.alibaba.nacos.core.utils.PageUtilTest
[ERROR]   PageUtilTest.subPageExactDivisiblePages:134 expected: <3> but was: <4>
[ERROR]   PageUtilTest.subPageExactlyOneFullPage:125 expected: <1> but was: <2>
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=PageUtilTest -pl core
[INFO] Running com.alibaba.nacos.core.utils.PageUtilTest
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0 -- in com.alibaba.nacos.core.utils.PageUtilTest
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

