### PR TITLE
Avoid ArrayIndexOutOfBoundsException in NamingUtils.getServiceName for trailing separator

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
+++ b/api/src/main/java/com/alibaba/nacos/api/naming/utils/NamingUtils.java
@@ -95,7 +95,7 @@ public class NamingUtils {
         if (!serviceNameWithGroup.contains(Constants.SERVICE_INFO_SPLITER)) {
             return serviceNameWithGroup;
         }
-        return serviceNameWithGroup.split(Constants.SERVICE_INFO_SPLITER)[1];
+        return serviceNameWithGroup.split(Constants.SERVICE_INFO_SPLITER, -1)[1];
     }
     
     public static String getGroupName(final String serviceNameWithGroup) {

--- a/api/src/test/java/com/alibaba/nacos/api/naming/utils/NamingUtilsTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/naming/utils/NamingUtilsTest.java
@@ -73,6 +73,12 @@ class NamingUtilsTest {
     }
     
     @Test
+    void testGetServiceNameTrailingSpliter() {
+        // When input is "group@@", the serviceName after "@@" is empty; should return "" not crash
+        assertEquals(StringUtils.EMPTY, NamingUtils.getServiceName("group@@"));
+    }
+    
+    @Test
     void testGetGroupName() {
         String validServiceName = "group@@serviceName";
         assertEquals("group", NamingUtils.getGroupName(validServiceName));


### PR DESCRIPTION
`NamingUtils.getServiceName(serviceNameWithGroup)` does
`serviceNameWithGroup.split(Constants.SERVICE_INFO_SPLITER)[1]`. Java's
single-arg `split` discards trailing empty strings, so an input ending in the
`@@` separator (group present, empty service name) produces a length-1 array and
the `[1]` access throws `ArrayIndexOutOfBoundsException` instead of returning the
empty service name.

Pass limit `-1` to keep the trailing empty segment. Added a regression test for
the trailing-separator input.

## Verifying this change

The added `NamingUtilsTest#testGetServiceNameTrailingSpliter` fails on the current `develop` and passes with this change:

Before the fix (on `develop`):

```
$ mvn test -Dtest=NamingUtilsTest -pl api
[ERROR] com.alibaba.nacos.api.naming.utils.NamingUtilsTest.testGetServiceNameTrailingSpliter <<< ERROR!
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
	at com.alibaba.nacos.api.naming.utils.NamingUtils.getServiceName(NamingUtils.java:98)
[ERROR] Tests run: 23, Failures: 0, Errors: 1, Skipped: 0
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=NamingUtilsTest -pl api
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0 -- in com.alibaba.nacos.api.naming.utils.NamingUtilsTest
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

