### PR TITLE
[ISSUE #15437] fix: backport thread leak and executor safety fixes to v2.x

### DIFF
--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/CacheData.java
@@ -33,6 +33,7 @@ import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.common.utils.NumberUtils;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.common.utils.ThreadUtils;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -76,8 +77,11 @@ public class CacheData {
         return notifyWarnTimeout;
     }
     
-    static ScheduledThreadPoolExecutor scheduledExecutor;
-    
+    /**
+     * double check lock initialization of scheduledExecutor.
+     */
+    static volatile ScheduledThreadPoolExecutor scheduledExecutor;
+
     static ScheduledThreadPoolExecutor getNotifyBlockMonitor() {
         if (scheduledExecutor == null) {
             synchronized (CacheData.class) {
@@ -86,10 +90,27 @@ public class CacheData {
                             new NameThreadFactory("com.alibaba.nacos.client.notify.block.monitor"),
                             new ThreadPoolExecutor.DiscardPolicy());
                     scheduledExecutor.setRemoveOnCancelPolicy(true);
+                    // it will shut down when jvm exit.
+                    ThreadUtils.addShutdownHook(CacheData::shutdownScheduledExecutor);
                 }
             }
         }
         return scheduledExecutor;
+    }
+
+    /**
+     * shutdownScheduledExecutor.
+     */
+    public static void shutdownScheduledExecutor() {
+        if (scheduledExecutor != null && !scheduledExecutor.isShutdown()) {
+            try {
+                scheduledExecutor.shutdown();
+                // help gc
+                scheduledExecutor = null;
+            } catch (Exception e) {
+                // ignore
+            }
+        }
     }
     
     static boolean initSnapshot;

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -656,6 +656,12 @@ public class ClientWorker implements Closeable {
                 
                 LOGGER.info("Shutdown executor {}", executor);
                 executor.shutdown();
+                multiTaskExecutor.values().forEach((taskExecutor) -> {
+                    if (taskExecutor != null && !taskExecutor.isShutdown()) {
+                        LOGGER.info("Shutdown multi task executor {}", taskExecutor);
+                        taskExecutor.shutdown();
+                    }
+                });
                 Map<String, CacheData> stringCacheDataMap = cacheMap.get();
                 for (Map.Entry<String, CacheData> entry : stringCacheDataMap.entrySet()) {
                     entry.getValue().setConsistentWithServer(false);

--- a/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
+++ b/client/src/main/java/com/alibaba/nacos/client/config/impl/ClientWorker.java
@@ -89,6 +89,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -609,7 +610,7 @@ public class ClientWorker implements Closeable {
     
     public class ConfigRpcTransportClient extends ConfigTransportClient {
         
-        Map<String, ExecutorService> multiTaskExecutor = new HashMap<>();
+        Map<String, ExecutorService> multiTaskExecutor = new ConcurrentHashMap<>();
         
         private final BlockingQueue<Object> listenExecutebell = new ArrayBlockingQueue<>(1);
         
@@ -937,15 +938,12 @@ public class ClientWorker implements Closeable {
         }
         
         private ExecutorService ensureSyncExecutor(String taskId) {
-            if (!multiTaskExecutor.containsKey(taskId)) {
-                multiTaskExecutor.put(taskId,
-                        new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), r -> {
-                            Thread thread = new Thread(r, "nacos.client.config.listener.task-" + taskId);
-                            thread.setDaemon(true);
-                            return thread;
-                        }));
-            }
-            return multiTaskExecutor.get(taskId);
+            return multiTaskExecutor.computeIfAbsent(taskId, k -> new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<>(), r -> {
+                        Thread thread = new Thread(r, "nacos.client.config.listener.task-" + taskId);
+                        thread.setDaemon(true);
+                        return thread;
+                    }));
         }
         
         private void refreshContentAndCheck(RpcClient rpcClient, String groupKey, boolean notify) {

--- a/common/src/main/java/com/alibaba/nacos/common/notify/DefaultPublisher.java
+++ b/common/src/main/java/com/alibaba/nacos/common/notify/DefaultPublisher.java
@@ -153,6 +153,8 @@ public class DefaultPublisher extends Thread implements EventPublisher {
     public void shutdown() {
         this.shutdown = true;
         this.queue.clear();
+        // Interrupt the thread to stop processing events: queue.take().
+        this.interrupt();
     }
     
     public boolean isInitialized() {


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Backports fixes for thread/executor leaks on client shutdown to `v2.x-develop`.

## Brief changelog

1. Resource cleanup on shutdown (backported from #13646, credit to @FangYuan33):
- `ConfigRpcTransportClient.shutdown()`: shut down all executors in `multiTaskExecutor`
- `CacheData.scheduledExecutor`: add `volatile`, register JVM shutdown hook, add `shutdownScheduledExecutor()`
- `DefaultPublisher.shutdown()`: add `this.interrupt()` to unblock threads waiting on `queue.take()`

2. Concurrent safety of executor creation (backported from #14927, credit to @LiyunZhang10):
- Replace `multiTaskExecutor` `HashMap` with `ConcurrentHashMap`
- Refactor `ensureSyncExecutor()` to use `computeIfAbsent()`, eliminating TOCTOU race