### PR TITLE
[ISSUE #14981] Fix config duplicate key handling under concurrent publish

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -60,6 +60,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
@@ -235,7 +236,8 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 findConfigInfoState(configInfo.getDataId(), configInfo.getGroup(),
                     configInfo.getTenant());
             if (configInfoState == null) {
-                return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                return addConfigInfoWithUpdateOnDuplicateKey(srcIp, srcUser, configInfo,
+                    configAdvanceInfo);
             } else {
                 return updateConfigInfo(configInfo, srcIp, srcUser, configAdvanceInfo);
             }
@@ -257,7 +259,8 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 findConfigInfoState(configInfo.getDataId(), configInfo.getGroup(),
                     configInfo.getTenant());
             if (configInfoState == null) {
-                return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+                return addConfigInfoWithConflictOnDuplicateKey(srcIp, srcUser, configInfo,
+                    configAdvanceInfo);
             } else {
                 return updateConfigInfoCas(configInfo, srcIp, srcUser, configAdvanceInfo);
             }
@@ -268,6 +271,52 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
                 exception);
             throw exception;
         }
+    }
+    
+    private ConfigOperateResult addConfigInfoWithUpdateOnDuplicateKey(String srcIp, String srcUser,
+        ConfigInfo configInfo, Map<String, Object> configAdvanceInfo) {
+        try {
+            return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+        } catch (DataAccessException exception) {
+            if (isDuplicateKeyException(exception)) {
+                LogUtil.DEFAULT_LOG.warn(
+                    "[insert-or-update] config already exists when adding config, try to update. "
+                        + "dataId: {}, group: {}, tenant: {}, msg: {}",
+                    configInfo.getDataId(), configInfo.getGroup(), configInfo.getTenant(),
+                    exception.getMessage());
+                return updateConfigInfo(configInfo, srcIp, srcUser, configAdvanceInfo);
+            }
+            throw exception;
+        }
+    }
+    
+    private ConfigOperateResult addConfigInfoWithConflictOnDuplicateKey(String srcIp,
+        String srcUser,
+        ConfigInfo configInfo, Map<String, Object> configAdvanceInfo) {
+        try {
+            return addConfigInfo(srcIp, srcUser, configInfo, configAdvanceInfo);
+        } catch (DataAccessException exception) {
+            if (isDuplicateKeyException(exception)) {
+                LogUtil.DEFAULT_LOG.warn(
+                    "[insert-or-update-cas] config already exists when adding config. "
+                        + "dataId: {}, group: {}, tenant: {}, msg: {}",
+                    configInfo.getDataId(), configInfo.getGroup(), configInfo.getTenant(),
+                    exception.getMessage());
+                return new ConfigOperateResult(false);
+            }
+            throw exception;
+        }
+    }
+    
+    private boolean isDuplicateKeyException(Throwable exception) {
+        Throwable cause = exception;
+        while (cause != null) {
+            if (cause instanceof DuplicateKeyException) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
     
     @Override

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
@@ -46,8 +46,10 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.CannotGetJdbcConnectionException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementCreator;
@@ -336,6 +338,79 @@ class ExternalConfigInfoPersistServiceImplTest {
             assertEquals("mock fail", e.getMessage());
         }
         
+    }
+    
+    @Test
+    void testInsertOrUpdateUpdatesWhenDuplicateKeyException() {
+        ConfigOperateResult result = insertOrUpdateAfterInsertException(
+            new DuplicateKeyException("duplicate key"));
+        
+        assertTrue(result.isSuccess());
+        assertEquals(100L, result.getId());
+        verifyConfigInfoUpdated();
+    }
+    
+    @Test
+    void testInsertOrUpdateUpdatesWhenWrappedDuplicateKeyException() {
+        ConfigOperateResult result = insertOrUpdateAfterInsertException(
+            new DataIntegrityViolationException("wrapped", new DuplicateKeyException("duplicate")));
+        
+        assertTrue(result.isSuccess());
+        assertEquals(100L, result.getId());
+        verifyConfigInfoUpdated();
+    }
+    
+    @Test
+    void testInsertOrUpdateRethrowsWrappedUniqueSqlException() {
+        SQLException duplicateKeyException =
+            new SQLException("duplicate key value violates unique constraint", "23505");
+        BadSqlGrammarException exception =
+            new BadSqlGrammarException("insert", "sql", duplicateKeyException);
+        BadSqlGrammarException thrown = assertThrows(BadSqlGrammarException.class,
+            () -> insertOrUpdateAfterInsertException(exception));
+        
+        assertEquals(exception, thrown);
+        verifyConfigInfoNotUpdated();
+    }
+    
+    @Test
+    void testInsertOrUpdateRethrowsPlainDataIntegrityViolationException() {
+        DataIntegrityViolationException exception =
+            new DataIntegrityViolationException("unique constraint violated");
+        DataIntegrityViolationException thrown = assertThrows(DataIntegrityViolationException.class,
+            () -> insertOrUpdateAfterInsertException(exception));
+        
+        assertEquals(exception, thrown);
+        verifyConfigInfoNotUpdated();
+    }
+    
+    @Test
+    void testInsertOrUpdateCasReturnsFalseWhenDuplicateKeyException() {
+        ConfigOperateResult result = insertOrUpdateCasAfterInsertException(
+            new DuplicateKeyException("duplicate key"));
+        
+        assertFalse(result.isSuccess());
+        verifyConfigInfoNotUpdated();
+    }
+    
+    @Test
+    void testInsertOrUpdateCasReturnsFalseWhenWrappedDuplicateKeyException() {
+        ConfigOperateResult result = insertOrUpdateCasAfterInsertException(
+            new DataIntegrityViolationException("wrapped", new DuplicateKeyException("duplicate")));
+        
+        assertFalse(result.isSuccess());
+        verifyConfigInfoNotUpdated();
+    }
+    
+    @Test
+    void testInsertOrUpdateCasRethrowsPlainDataIntegrityViolationException() {
+        DataIntegrityViolationException exception =
+            new DataIntegrityViolationException("unique constraint violated");
+        DataIntegrityViolationException thrown = assertThrows(DataIntegrityViolationException.class,
+            () -> insertOrUpdateCasAfterInsertException(exception));
+        
+        assertEquals(exception, thrown);
+        verifyConfigInfoNotUpdated();
     }
     
     @Test
@@ -944,6 +1019,64 @@ class ExternalConfigInfoPersistServiceImplTest {
         
         assertNotNull(result);
         assertFalse(result.isSuccess());
+    }
+    
+    private ConfigOperateResult insertOrUpdateAfterInsertException(RuntimeException exception) {
+        ConfigInfo configInfo = mockInsertConfigException(exception);
+        mockFallbackUpdateConfigInfo();
+        return externalConfigInfoPersistService.insertOrUpdate("srcIp", "srcUser", configInfo,
+            new HashMap<>());
+    }
+    
+    private ConfigOperateResult insertOrUpdateCasAfterInsertException(RuntimeException exception) {
+        ConfigInfo configInfo = mockInsertConfigException(exception);
+        return externalConfigInfoPersistService.insertOrUpdateCas("srcIp", "srcUser", configInfo,
+            new HashMap<>());
+    }
+    
+    private ConfigInfo mockInsertConfigException(RuntimeException exception) {
+        String dataId = "dataId";
+        String group = "group";
+        String tenant = "tenant";
+        ConfigInfo configInfo = new ConfigInfo(dataId, group, tenant, null, "content");
+        configInfo.setEncryptedDataKey("encryptedKey");
+        ConfigInfoStateWrapper updatedState = new ConfigInfoStateWrapper();
+        updatedState.setId(100L);
+        updatedState.setLastModified(123L);
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {dataId, group, tenant}), eq(CONFIG_INFO_STATE_WRAPPER_ROW_MAPPER)))
+            .thenReturn(null, updatedState);
+        
+        GeneratedKeyHolder generatedKeyHolder = TestCaseUtils.createGeneratedKeyHolder(99L);
+        externalStorageUtilsMockedStatic.when(ExternalStorageUtils::createKeyHolder)
+            .thenReturn(generatedKeyHolder);
+        Mockito.when(jdbcTemplate.update(any(PreparedStatementCreator.class),
+            eq(generatedKeyHolder))).thenThrow(exception);
+        return configInfo;
+    }
+    
+    private void mockFallbackUpdateConfigInfo() {
+        String dataId = "dataId";
+        String group = "group";
+        String tenant = "tenant";
+        ConfigAllInfo oldConfig = new ConfigAllInfo();
+        oldConfig.setId(100L);
+        oldConfig.setDataId(dataId);
+        oldConfig.setGroup(group);
+        oldConfig.setTenant(tenant);
+        oldConfig.setAppName("oldApp");
+        Mockito.when(jdbcTemplate.queryForObject(anyString(),
+            eq(new Object[] {dataId, group, tenant}), eq(CONFIG_ALL_INFO_ROW_MAPPER)))
+            .thenReturn(oldConfig);
+        Mockito.when(jdbcTemplate.update(anyString(), Mockito.<Object[]>any())).thenReturn(1);
+    }
+    
+    private void verifyConfigInfoUpdated() {
+        Mockito.verify(jdbcTemplate, times(1)).update(anyString(), Mockito.<Object[]>any());
+    }
+    
+    private void verifyConfigInfoNotUpdated() {
+        Mockito.verify(jdbcTemplate, times(0)).update(anyString(), Mockito.<Object[]>any());
     }
     
     private ConfigAllInfo createMockConfigAllInfo(long mockId) {


### PR DESCRIPTION
## What is the purpose of the change

Fixes #14981.

Related PRs: #15272, #15278.

When Nacos uses an external database, concurrent `publishConfig` calls for the same
`dataId/group/tenant` can race in `ExternalConfigInfoPersistServiceImpl`:

1. both requests call `findConfigInfoState` and see no existing row;
2. both requests enter the insert branch;
3. one insert succeeds, while the other hits the unique key
   `uk_configinfo_datagrouptenant`.

The previous implementation propagated the database exception and could return 500 to
the client.

## Brief changelog

- Handle Spring standard `DuplicateKeyException` in the external config insert branch.
- Keep `insertOrUpdate` as non-CAS upsert semantics: duplicate key during insert falls
  back to `updateConfigInfo`.
- Keep `insertOrUpdateCas` as CAS semantics: duplicate key during insert is translated
  to `ConfigOperateResult(false)` instead of an update.
- Do not treat all `DataIntegrityViolationException` instances as duplicate-key
  conflicts. This avoids swallowing non-duplicate integrity failures.
- Add regression tests for top-level and wrapped `DuplicateKeyException`, plain
  `DataIntegrityViolationException`, and exception chains that contain only lower-level
  SQL unique-key details.

## Scope / follow-up

This PR intentionally relies only on Spring's standard `DuplicateKeyException`
semantics. Different database drivers and Spring JDBC translators may report unique
constraint conflicts as broader `DataIntegrityViolationException` instances or through
lower-level `SQLException` details. Handling those database-specific cases should be
discussed separately and likely belong in the datasource plugin layer, for example via
an `isDuplicateKey(Throwable)` or equivalent plugin extension.

## Verifying this change

- `mvn -pl config -Dtest=ExternalConfigInfoPersistServiceImplTest test`
- `mvn -pl config -Dtest=ConfigOperationServiceTest test`
- `mvn -pl config spotless:apply`
- `mvn -pl config spotless:check`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (#14981).
* [x] Format the pull request title like `[ISSUE #123] Fix ...`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction.
* [x] Run basic checks (`spotless:check`) and unit tests for the affected module.
