### PR TITLE
[ISSUE #15466] Correct skill API @Since annotations

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
@@ -225,7 +225,7 @@ public class SkillAdminController {
      * @return list of precheck results in the same order as input
      * @throws NacosException if precheck failed unexpectedly
      */
-    @Since("3.2.3")
+    @Since("3.3.0")
     @PostMapping(value = "/upload/batch/precheck")
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.ADMIN_API)
     @ExtractorManager.Extractor(httpExtractor = ExtractorManager.DefaultHttpExtractor.class)

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
@@ -212,7 +212,7 @@ public class ConsoleSkillController {
      * @return list of precheck results in the same order as input
      * @throws NacosException if precheck failed unexpectedly
      */
-    @Since("3.2.3")
+    @Since("3.3.0")
     @PostMapping(value = "/upload/batch/precheck")
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
     @ExtractorManager.Extractor(httpExtractor = ExtractorManager.DefaultHttpExtractor.class)

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerService.java
@@ -274,7 +274,7 @@ public interface SkillMaintainerService {
      * @return skill name
      * @throws NacosException if fail to upload skill
      */
-    @Since("3.2.3")
+    @Since("3.3.0")
     default String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite,
         String targetVersion, String commitMsg, String uploadAction)
         throws NacosException {
@@ -288,7 +288,7 @@ public interface SkillMaintainerService {
      * @return list of precheck results in the same order as input
      * @throws NacosException if precheck failed unexpectedly
      */
-    @Since("3.2.3")
+    @Since("3.3.0")
     default java.util.List<SkillUploadPrecheckResult> batchPrecheckUploadSkill(
         java.util.List<SkillUploadPrecheckRequest> requests) throws NacosException {
         return java.util.Collections.emptyList();


### PR DESCRIPTION
Please do not create a Pull Request without creating an issue first.

Fixes #15466

## What is the purpose of the change

Correct Skill upload related `@Since` metadata so the admin API, console API, and maintainer client API annotations align with the 3.3.0 release surface. This is a metadata/documentation correction only and does not change runtime behavior.

## Brief changelog

- Update Admin Skill batch upload precheck `@Since` annotation to `3.3.0`.
- Update Console Skill batch upload precheck `@Since` annotation to `3.3.0`.
- Update maintainer client Skill upload and batch precheck method `@Since` annotations to `3.3.0`.

## Verifying this change

- `mvn -pl ai,console,maintainer-client spotless:apply -DskipTests`
- `mvn -pl ai,console,maintainer-client spotless:check -DskipTests`
- `mvn -pl ai,console,maintainer-client -DskipTests -Dcheckstyle.consoleOutput=true checkstyle:check`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.