### PR TITLE
Correct @Since annotations for skill upload APIs

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
@@ -225,7 +225,7 @@ public class SkillAdminController {
      * @return list of precheck results in the same order as input
      * @throws NacosException if precheck failed unexpectedly
      */
-    @Since("3.2.3")
+    @Since("3.3.0")
     @PostMapping(value = "/upload/batch/precheck")
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.ADMIN_API)
     @ExtractorManager.Extractor(httpExtractor = ExtractorManager.DefaultHttpExtractor.class)

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
@@ -212,7 +212,7 @@ public class ConsoleSkillController {
      * @return list of precheck results in the same order as input
      * @throws NacosException if precheck failed unexpectedly
      */
-    @Since("3.2.3")
+    @Since("3.3.0")
     @PostMapping(value = "/upload/batch/precheck")
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
     @ExtractorManager.Extractor(httpExtractor = ExtractorManager.DefaultHttpExtractor.class)

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerService.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/SkillMaintainerService.java
@@ -274,7 +274,7 @@ public interface SkillMaintainerService {
      * @return skill name
      * @throws NacosException if fail to upload skill
      */
-    @Since("3.2.3")
+    @Since("3.3.0")
     default String uploadSkillFromZip(String namespaceId, byte[] zipBytes, boolean overwrite,
         String targetVersion, String commitMsg, String uploadAction)
         throws NacosException {
@@ -288,7 +288,7 @@ public interface SkillMaintainerService {
      * @return list of precheck results in the same order as input
      * @throws NacosException if precheck failed unexpectedly
      */
-    @Since("3.2.3")
+    @Since("3.3.0")
     default java.util.List<SkillUploadPrecheckResult> batchPrecheckUploadSkill(
         java.util.List<SkillUploadPrecheckRequest> requests) throws NacosException {
         return java.util.Collections.emptyList();


### PR DESCRIPTION
## Describe

Closes #15466

## What type of PR is it?

Bug Fix / Documentation

## What is the changes?

Some Skill upload related APIs are marked with `@Since("3.2.3")`, but these APIs belong to the 3.3.0 API surface. Updated the annotations from `3.2.3` to `3.3.0` to keep the generated API metadata and documentation aligned with the release version.

### Affected APIs

- Admin Skill batch upload precheck endpoint (`SkillAdminController.java`)
- Console Skill batch upload precheck endpoint (`ConsoleSkillController.java`)
- Maintainer client Skill upload and batch precheck methods (`SkillMaintainerService.java`)

## Does this PR introduce a user-facing change?

No, this is a metadata/documentation correction only and does not change runtime behavior.