### PR TITLE
[ISSUE #15475] Add plugin config metadata model

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/plugin/ConfigItemDefinition.java
+++ b/api/src/main/java/com/alibaba/nacos/api/plugin/ConfigItemDefinition.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.api.plugin;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -63,6 +64,21 @@ public class ConfigItemDefinition implements Serializable {
      * Enum values (when type is ENUM).
      */
     private List<String> enumValues;
+    
+    /**
+     * Historical static configuration keys for compatibility.
+     */
+    private List<String> aliases = new ArrayList<>();
+    
+    /**
+     * Whether this item contains sensitive data.
+     */
+    private boolean sensitive;
+    
+    /**
+     * Configuration item effect mode.
+     */
+    private ConfigItemEffectMode effectMode = ConfigItemEffectMode.RESTART;
     
     public ConfigItemDefinition() {
     }
@@ -129,6 +145,30 @@ public class ConfigItemDefinition implements Serializable {
         this.enumValues = enumValues;
     }
     
+    public List<String> getAliases() {
+        return aliases;
+    }
+    
+    public void setAliases(List<String> aliases) {
+        this.aliases = aliases;
+    }
+    
+    public boolean isSensitive() {
+        return sensitive;
+    }
+    
+    public void setSensitive(boolean sensitive) {
+        this.sensitive = sensitive;
+    }
+    
+    public ConfigItemEffectMode getEffectMode() {
+        return effectMode;
+    }
+    
+    public void setEffectMode(ConfigItemEffectMode effectMode) {
+        this.effectMode = effectMode;
+    }
+    
     /**
      * Builder for ConfigItemDefinition.
      */
@@ -157,6 +197,21 @@ public class ConfigItemDefinition implements Serializable {
         
         public Builder enumValues(List<String> enumValues) {
             definition.setEnumValues(enumValues);
+            return this;
+        }
+        
+        public Builder aliases(List<String> aliases) {
+            definition.setAliases(aliases);
+            return this;
+        }
+        
+        public Builder sensitive(boolean sensitive) {
+            definition.setSensitive(sensitive);
+            return this;
+        }
+        
+        public Builder effectMode(ConfigItemEffectMode effectMode) {
+            definition.setEffectMode(effectMode);
             return this;
         }
         

--- a/api/src/main/java/com/alibaba/nacos/api/plugin/ConfigItemEffectMode.java
+++ b/api/src/main/java/com/alibaba/nacos/api/plugin/ConfigItemEffectMode.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.plugin;
+
+/**
+ * Configuration item effect mode.
+ *
+ * @author Nacos
+ * @since 3.3.0
+ */
+public enum ConfigItemEffectMode {
+    
+    /**
+     * Configuration can be applied at runtime.
+     */
+    RUNTIME,
+    
+    /**
+     * Configuration requires server restart to take effect.
+     */
+    RESTART
+}

--- a/api/src/test/java/com/alibaba/nacos/api/plugin/ConfigItemDefinitionTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/plugin/ConfigItemDefinitionTest.java
@@ -43,6 +43,10 @@ class ConfigItemDefinitionTest extends BasicRequestTest {
         assertNull(definition.getType());
         assertFalse(definition.isRequired());
         assertNull(definition.getEnumValues());
+        assertNotNull(definition.getAliases());
+        assertTrue(definition.getAliases().isEmpty());
+        assertFalse(definition.isSensitive());
+        assertEquals(ConfigItemEffectMode.RESTART, definition.getEffectMode());
     }
     
     @Test
@@ -121,6 +125,36 @@ class ConfigItemDefinitionTest extends BasicRequestTest {
     }
     
     @Test
+    @DisplayName("test getter and setter for aliases")
+    void testGetterAndSetterForAliases() {
+        ConfigItemDefinition definition = new ConfigItemDefinition();
+        List<String> aliases = new ArrayList<>();
+        aliases.add("nacos.core.auth.plugin.nacos.token.secret.key");
+        definition.setAliases(aliases);
+        assertEquals(1, definition.getAliases().size());
+        assertEquals("nacos.core.auth.plugin.nacos.token.secret.key",
+            definition.getAliases().get(0));
+    }
+    
+    @Test
+    @DisplayName("test getter and setter for sensitive")
+    void testGetterAndSetterForSensitive() {
+        ConfigItemDefinition definition = new ConfigItemDefinition();
+        definition.setSensitive(true);
+        assertTrue(definition.isSensitive());
+        definition.setSensitive(false);
+        assertFalse(definition.isSensitive());
+    }
+    
+    @Test
+    @DisplayName("test getter and setter for effectMode")
+    void testGetterAndSetterForEffectMode() {
+        ConfigItemDefinition definition = new ConfigItemDefinition();
+        definition.setEffectMode(ConfigItemEffectMode.RUNTIME);
+        assertEquals(ConfigItemEffectMode.RUNTIME, definition.getEffectMode());
+    }
+    
+    @Test
     @DisplayName("test Builder pattern")
     void testBuilderPattern() {
         ConfigItemDefinition definition =
@@ -159,6 +193,25 @@ class ConfigItemDefinitionTest extends BasicRequestTest {
     }
     
     @Test
+    @DisplayName("test Builder pattern with config metadata")
+    void testBuilderPatternWithConfigMetadata() {
+        List<String> aliases = new ArrayList<>();
+        aliases.add("nacos.core.auth.plugin.nacos.token.secret.key");
+        ConfigItemDefinition definition =
+            new ConfigItemDefinition.Builder("token.secret.key", "Token Secret",
+                ConfigItemType.STRING)
+                .aliases(aliases)
+                .sensitive(true)
+                .effectMode(ConfigItemEffectMode.RUNTIME)
+                .build();
+        
+        assertEquals("token.secret.key", definition.getKey());
+        assertEquals(1, definition.getAliases().size());
+        assertTrue(definition.isSensitive());
+        assertEquals(ConfigItemEffectMode.RUNTIME, definition.getEffectMode());
+    }
+    
+    @Test
     @DisplayName("test serialize to json")
     void testSerializeToJson() throws JsonProcessingException {
         ConfigItemDefinition definition =
@@ -166,6 +219,11 @@ class ConfigItemDefinitionTest extends BasicRequestTest {
         definition.setDescription("Test description");
         definition.setDefaultValue("defaultValue");
         definition.setRequired(true);
+        List<String> aliases = new ArrayList<>();
+        aliases.add("legacy.testKey");
+        definition.setAliases(aliases);
+        definition.setSensitive(true);
+        definition.setEffectMode(ConfigItemEffectMode.RUNTIME);
         
         String json = mapper.writeValueAsString(definition);
         assertNotNull(json);
@@ -175,6 +233,9 @@ class ConfigItemDefinitionTest extends BasicRequestTest {
         assertTrue(json.contains("\"description\":\"Test description\""));
         assertTrue(json.contains("\"defaultValue\":\"defaultValue\""));
         assertTrue(json.contains("\"required\":true"));
+        assertTrue(json.contains("\"aliases\":[\"legacy.testKey\"]"));
+        assertTrue(json.contains("\"sensitive\":true"));
+        assertTrue(json.contains("\"effectMode\":\"RUNTIME\""));
     }
     
     @Test
@@ -182,7 +243,8 @@ class ConfigItemDefinitionTest extends BasicRequestTest {
     void testDeserializeFromJson() throws JsonProcessingException {
         String json = "{\"key\":\"testKey\",\"name\":\"Test Name\",\"description\":\"Test\","
             + "\"defaultValue\":\"default\",\"type\":\"STRING\",\"required\":true,"
-            + "\"enumValues\":[\"opt1\",\"opt2\"]}";
+            + "\"enumValues\":[\"opt1\",\"opt2\"],\"aliases\":[\"legacy.testKey\"],"
+            + "\"sensitive\":true,\"effectMode\":\"RUNTIME\"}";
         
         ConfigItemDefinition definition = mapper.readValue(json, ConfigItemDefinition.class);
         assertNotNull(definition);
@@ -194,5 +256,10 @@ class ConfigItemDefinitionTest extends BasicRequestTest {
         assertTrue(definition.isRequired());
         assertNotNull(definition.getEnumValues());
         assertEquals(2, definition.getEnumValues().size());
+        assertNotNull(definition.getAliases());
+        assertEquals(1, definition.getAliases().size());
+        assertEquals("legacy.testKey", definition.getAliases().get(0));
+        assertTrue(definition.isSensitive());
+        assertEquals(ConfigItemEffectMode.RUNTIME, definition.getEffectMode());
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/model/PluginConfigSourceType.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/model/PluginConfigSourceType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin.model;
+
+/**
+ * Plugin configuration value source type.
+ *
+ * @author Nacos
+ */
+public enum PluginConfigSourceType {
+    
+    /**
+     * Value is from definition default.
+     */
+    DEFAULT,
+    
+    /**
+     * Value is from static environment configuration.
+     */
+    STATIC,
+    
+    /**
+     * Value is from runtime persisted override.
+     */
+    RUNTIME_PERSISTED,
+    
+    /**
+     * Value is from current node local-only override.
+     */
+    LOCAL_ONLY
+}

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/model/vo/PluginConfigValueMeta.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/model/vo/PluginConfigValueMeta.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin.model.vo;
+
+import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
+
+/**
+ * Plugin configuration value metadata.
+ *
+ * @author Nacos
+ */
+public class PluginConfigValueMeta {
+    
+    private String key;
+    
+    private PluginConfigSourceType source;
+    
+    private boolean overridden;
+    
+    public String getKey() {
+        return key;
+    }
+    
+    public void setKey(String key) {
+        this.key = key;
+    }
+    
+    public PluginConfigSourceType getSource() {
+        return source;
+    }
+    
+    public void setSource(PluginConfigSourceType source) {
+        this.source = source;
+    }
+    
+    public boolean isOverridden() {
+        return overridden;
+    }
+    
+    public void setOverridden(boolean overridden) {
+        this.overridden = overridden;
+    }
+    
+    @Override
+    public String toString() {
+        return "PluginConfigValueMeta{" + "key='" + key + '\'' + ", source=" + source
+            + ", overridden=" + overridden + '}';
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/model/vo/PluginDetailVO.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/model/vo/PluginDetailVO.java
@@ -44,6 +44,8 @@ public class PluginDetailVO {
     
     private List<ConfigItemDefinition> configDefinitions;
     
+    private List<PluginConfigValueMeta> configValueMetas;
+    
     public String getPluginId() {
         return pluginId;
     }
@@ -108,6 +110,14 @@ public class PluginDetailVO {
         this.configDefinitions = configDefinitions;
     }
     
+    public List<PluginConfigValueMeta> getConfigValueMetas() {
+        return configValueMetas;
+    }
+    
+    public void setConfigValueMetas(List<PluginConfigValueMeta> configValueMetas) {
+        this.configValueMetas = configValueMetas;
+    }
+    
     @Override
     public String toString() {
         return "PluginDetailVO{" + "pluginId='" + pluginId + '\'' + ", pluginType='" + pluginType
@@ -115,7 +125,7 @@ public class PluginDetailVO {
             + ", pluginName='" + pluginName + '\'' + ", enabled=" + enabled + ", critical="
             + critical
             + ", configurable=" + configurable + ", config=" + config + ", configDefinitions="
-            + configDefinitions
+            + configDefinitions + ", configValueMetas=" + configValueMetas
             + '}';
     }
 }

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/model/vo/PluginConfigValueMetaTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/model/vo/PluginConfigValueMetaTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin.model.vo;
+
+import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PluginConfigValueMetaTest {
+    
+    @Test
+    void gettersSettersAndToString() {
+        PluginConfigValueMeta meta = new PluginConfigValueMeta();
+        meta.setKey("token.secret.key");
+        meta.setSource(PluginConfigSourceType.LOCAL_ONLY);
+        meta.setOverridden(true);
+        
+        assertEquals("token.secret.key", meta.getKey());
+        assertEquals(PluginConfigSourceType.LOCAL_ONLY, meta.getSource());
+        assertTrue(meta.isOverridden());
+        assertNotNull(meta.toString());
+        assertTrue(meta.toString().contains("token.secret.key"));
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/model/vo/PluginDetailVOTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/model/vo/PluginDetailVOTest.java
@@ -16,6 +16,7 @@
 package com.alibaba.nacos.core.plugin.model.vo;
 
 import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
+import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -43,6 +44,11 @@ class PluginDetailVOTest {
         ConfigItemDefinition def = new ConfigItemDefinition();
         def.setKey("endpoint");
         vo.setConfigDefinitions(Collections.singletonList(def));
+        PluginConfigValueMeta meta = new PluginConfigValueMeta();
+        meta.setKey("endpoint");
+        meta.setSource(PluginConfigSourceType.STATIC);
+        meta.setOverridden(true);
+        vo.setConfigValueMetas(Collections.singletonList(meta));
         
         assertEquals("trace:otel", vo.getPluginId());
         assertEquals("trace", vo.getPluginType());
@@ -53,9 +59,15 @@ class PluginDetailVOTest {
         assertEquals("http://localhost", vo.getConfig().get("endpoint"));
         assertNotNull(vo.getConfigDefinitions());
         assertEquals(1, vo.getConfigDefinitions().size());
+        assertNotNull(vo.getConfigValueMetas());
+        assertEquals(1, vo.getConfigValueMetas().size());
+        assertEquals("endpoint", vo.getConfigValueMetas().get(0).getKey());
+        assertEquals(PluginConfigSourceType.STATIC, vo.getConfigValueMetas().get(0).getSource());
+        assertTrue(vo.getConfigValueMetas().get(0).isOverridden());
         
         String s = vo.toString();
         assertNotNull(s);
         assertTrue(s.contains("trace:otel"));
+        assertTrue(s.contains("configValueMetas"));
     }
 }

--- a/specs/en/http-api/v3-api-surface.md
+++ b/specs/en/http-api/v3-api-surface.md
@@ -134,6 +134,9 @@ Implemented behavior to document more explicitly:
   configured encryption handler applies.
 - AI Prompt contains deprecated compatibility endpoints and newer lifecycle
   endpoints in the same controller.
+- Plugin detail returns the current effective plugin config in its existing
+  `config` field and may add value metadata such as source and overridden state
+  without changing existing fields.
 
 ## 6. Console API Implemented Behavior
 

--- a/specs/en/plugin/plugin-spec.md
+++ b/specs/en/plugin/plugin-spec.md
@@ -159,6 +159,66 @@ config application behavior. Cluster-wide status or config changes must be
 synchronized through the plugin state operation path unless the request is
 explicitly local only.
 
+### Configuration Definition
+
+Plugin config items are described by `ConfigItemDefinition`. The `key` field is
+the canonical item key inside the plugin implementation and does not include the
+`nacos.plugin.{pluginType}.{pluginName}.` prefix. Static configuration should
+prefer this normalized full key:
+
+```text
+nacos.plugin.{pluginType}.{pluginName}.{itemKey}
+```
+
+Config definitions may declare the following metadata:
+
+| Field | Meaning |
+|-------|---------|
+| `aliases` | Historical static config keys for compatibility and migration hints. |
+| `sensitive` | Whether the value is sensitive. Query APIs must mask it before returning. |
+| `effectMode` | Effect mode. `RUNTIME` can take effect at runtime, and `RESTART` requires restart. |
+
+`aliases` are only used when reading compatible static configuration. They must
+not be written into runtime persistence files or local-only memory maps.
+
+### Config Sources And Value Metadata
+
+Effective plugin config values are computed by a unified resolution flow. Source
+priority is:
+
+```text
+LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
+```
+
+| Source | Meaning |
+|--------|---------|
+| `DEFAULT` | Value from `ConfigItemDefinition.defaultValue`. |
+| `STATIC` | Value from static configuration, such as `application.properties`, environment variables, JVM parameters, or Spring parameters. |
+| `RUNTIME_PERSISTED` | Cluster-wide runtime override. It may currently be persisted as the final content in `plugin-configs.json`. |
+| `LOCAL_ONLY` | Current-node override for diagnosis or emergency handling, not synchronized to the cluster. |
+
+Plugin detail responses may add `PluginConfigValueMeta` to describe the current
+source and overridden state of each config item. `overridden` ignores `DEFAULT`
+and should be `true` only when the same key has multiple non-default sources.
+
+Runtime persisted config and local-only config store only values by
+`pluginId + itemKey`. They do not store normalized full keys, alias keys,
+source, or version information.
+
+### Config Update Compatibility
+
+Plugin detail APIs must remain additively compatible: existing `config` and
+`configDefinitions` fields remain available. `config` may represent the current
+effective config, and the added `configValueMetas` field carries source and
+overridden metadata.
+
+`PUT /v3/admin/core/plugin/config` and the matching Console API keep the current
+full override map update semantics. `localOnly=true` updates only the current
+node local-only override; otherwise the request updates the cluster-wide runtime
+persisted override. Key normalization and `effectMode` checks are server-side
+logic and are not exposed as new API parameters. Fields marked
+`effectMode=RESTART` must not be applied immediately by runtime updates.
+
 ## Admin API
 
 The core plugin admin API is:
@@ -166,7 +226,7 @@ The core plugin admin API is:
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/v3/admin/core/plugin/list` | List loaded plugins, optionally filtered by type. |
-| `GET` | `/v3/admin/core/plugin/detail` | Read one plugin detail. |
+| `GET` | `/v3/admin/core/plugin/detail` | Read one plugin detail with effective config and optional value metadata. |
 | `PUT` | `/v3/admin/core/plugin/status` | Enable or disable a plugin. |
 | `PUT` | `/v3/admin/core/plugin/config` | Update plugin configuration. |
 

--- a/specs/zh-cn/http-api/v3-api-surface.md
+++ b/specs/zh-cn/http-api/v3-api-surface.md
@@ -127,6 +127,8 @@ Admin API 兼容开关。
 - Config 查询在返回 Admin API 详情前会解密加密内容。
 - Config 发布在未提供 encrypted data key 且适用加密处理器时会加密内容。
 - AI Prompt 在同一个 Controller 中同时包含已废弃兼容端点和新的生命周期端点。
+- Plugin detail 在已有 `config` 字段中返回当前 effective plugin config，并可以
+  追加来源、overridden 等值元数据，不改变已有字段。
 
 ## 6. Console API 已实现行为
 

--- a/specs/zh-cn/plugin/plugin-spec.md
+++ b/specs/zh-cn/plugin/plugin-spec.md
@@ -140,6 +140,59 @@ Nacos 插件包含两个相关的 SPI 层次：
 实现 `PluginConfigSpec` 的插件应暴露配置定义、当前配置和配置应用行为。除非请求明确
 声明为仅本机生效，否则集群级状态或配置变更必须通过插件状态操作链路进行同步。
 
+### 配置定义
+
+插件配置项由 `ConfigItemDefinition` 描述。`key` 表示插件实现内部的 canonical item
+key，不携带 `nacos.plugin.{pluginType}.{pluginName}.` 前缀。静态配置推荐使用以下
+normalized full key：
+
+```text
+nacos.plugin.{pluginType}.{pluginName}.{itemKey}
+```
+
+配置定义可以声明以下元数据：
+
+| 字段 | 含义 |
+|------|------|
+| `aliases` | 历史静态配置 key，用于兼容读取和迁移提示。 |
+| `sensitive` | 是否为敏感值。查询 API 返回前必须脱敏。 |
+| `effectMode` | 生效模式，`RUNTIME` 表示可运行时生效，`RESTART` 表示需要重启。 |
+
+`aliases` 只用于静态配置兼容读取，不应写入运行时持久化文件或 local-only 内存表。
+
+### 配置来源与值元数据
+
+插件配置的 effective value 由统一解析流程计算。配置来源优先级为：
+
+```text
+LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
+```
+
+| 来源 | 含义 |
+|------|------|
+| `DEFAULT` | 来自 `ConfigItemDefinition.defaultValue`。 |
+| `STATIC` | 来自 `application.properties`、环境变量、JVM 参数或 Spring 参数等静态配置。 |
+| `RUNTIME_PERSISTED` | 来自集群级运行时 override，当前可由 `plugin-configs.json` 记录终态内容。 |
+| `LOCAL_ONLY` | 当前节点的本机 override，只用于诊断或应急处理，不同步到集群。 |
+
+插件详情返回模型可以追加 `PluginConfigValueMeta`，用于描述每个配置项的当前值来源和
+是否存在多来源覆盖。`overridden` 忽略 `DEFAULT`，只有同一 key 同时存在多个非默认
+来源时才应为 `true`。
+
+运行时持久化配置和 local-only 配置只保存 `pluginId + itemKey` 对应的值，不保存
+normalized full key、alias key、source 或版本信息。
+
+### 配置更新兼容性
+
+插件详情 API 应保持 additive 兼容：已有 `config` 和 `configDefinitions` 字段继续
+保留，其中 `config` 可以表示当前 effective config，新增的 `configValueMetas` 表示
+source 和 overridden 等元信息。
+
+`PUT /v3/admin/core/plugin/config` 和对应 Console API 保持现有完整 override map
+更新语义。`localOnly=true` 表示只更新当前节点 local-only override；否则更新集群级
+runtime persisted override。key 归一化和 `effectMode` 校验由服务端内部完成，不作为
+新的 API 参数暴露。`effectMode=RESTART` 的字段不应通过运行时更新立即生效。
+
 ## 管理 API
 
 核心插件管理 API 如下：
@@ -147,7 +200,7 @@ Nacos 插件包含两个相关的 SPI 层次：
 | 方法 | 路径 | 目的 |
 |------|------|------|
 | `GET` | `/v3/admin/core/plugin/list` | 查询已加载插件，可按类型过滤。 |
-| `GET` | `/v3/admin/core/plugin/detail` | 查询单个插件详情。 |
+| `GET` | `/v3/admin/core/plugin/detail` | 查询单个插件详情，返回 effective config 和可选值元数据。 |
 | `PUT` | `/v3/admin/core/plugin/status` | 启用或禁用插件。 |
 | `PUT` | `/v3/admin/core/plugin/config` | 更新插件配置。 |
 


### PR DESCRIPTION
## Summary
- extend ConfigItemDefinition with aliases, sensitive, and effectMode metadata
- add plugin config source/value metadata models and PluginDetailVO configValueMetas
- document effective plugin config metadata contract in plugin and v3 API specs

## Tests
- mvn -pl api -Dtest=ConfigItemDefinitionTest test
- mvn -pl core -Dtest=PluginDetailVOTest,PluginConfigValueMetaTest test
- mvn -pl api spotless:apply
- mvn -pl api spotless:check
- mvn -pl core spotless:apply
- mvn -pl core spotless:check