### PR TITLE
Add MiniMax copilot provider support

### DIFF
--- a/console-ui-next/src/pages/settingCenter/index.tsx
+++ b/console-ui-next/src/pages/settingCenter/index.tsx
@@ -21,26 +21,38 @@ import {
 interface CopilotConfig {
   apiKey: string;
   provider: string;
+  protocol: string;
+  region: string;
   model: string;
   baseUrl: string;
 }
 
-const COPILOT_MODELS = [
-  { value: 'qwen-turbo', label: 'qwen-turbo', desc: 'DashScope Fast' },
-  { value: 'qwen-plus', label: 'qwen-plus', desc: 'DashScope Enhanced' },
-  { value: 'qwen-max', label: 'qwen-max', desc: 'DashScope Strongest' },
-  { value: 'qwen-7b-chat', label: 'qwen-7b-chat', desc: 'DashScope 7B' },
-  { value: 'qwen-14b-chat', label: 'qwen-14b-chat', desc: 'DashScope 14B' },
-  { value: 'qwen-72b-chat', label: 'qwen-72b-chat', desc: 'DashScope 72B' },
-  { value: 'qwen3-turbo', label: 'qwen3-turbo', desc: 'DashScope Qwen3 Fast' },
-  { value: 'qwen3-plus', label: 'qwen3-plus', desc: 'DashScope Qwen3 Enhanced' },
-  { value: 'qwen3-max', label: 'qwen3-max', desc: 'DashScope Qwen3 Strongest' },
-  { value: 'qwen3-7b-instruct', label: 'qwen3-7b-instruct', desc: 'DashScope 7B' },
-  { value: 'qwen3-14b-instruct', label: 'qwen3-14b-instruct', desc: 'DashScope 14B' },
-  { value: 'qwen3-32b-instruct', label: 'qwen3-32b-instruct', desc: 'DashScope 32B' },
-  { value: 'qwen3-72b-instruct', label: 'qwen3-72b-instruct', desc: 'DashScope 72B' },
-  { value: 'MiniMax-M3', label: 'MiniMax-M3', desc: 'MiniMax' },
-];
+interface ModelMetadata {
+  modelId: string;
+}
+
+interface EndpointMetadata {
+  region: string;
+  baseUrl: string;
+}
+
+interface ProtocolMetadata {
+  name: string;
+  endpoints: EndpointMetadata[];
+}
+
+interface ProviderMetadata {
+  name: string;
+  defaultModel: string;
+  defaultProtocol?: string;
+  defaultRegion?: string;
+  models: ModelMetadata[];
+  protocols: ProtocolMetadata[];
+}
+
+const findBaseUrl = (provider: ProviderMetadata | undefined, protocol: string, region: string) =>
+  provider?.protocols.find((item) => item.name === protocol)?.endpoints
+    .find((item) => item.region === region)?.baseUrl || '';
 
 export default function SettingCenterPage() {
   const { t } = useTranslation();
@@ -59,20 +71,35 @@ export default function SettingCenterPage() {
   const [showApiKey, setShowApiKey] = useState(false);
 
   const [apiKey, setApiKey] = useState('');
+  const [providers, setProviders] = useState<ProviderMetadata[]>([]);
   const [provider, setProvider] = useState('DashScope');
+  const [protocol, setProtocol] = useState('');
+  const [region, setRegion] = useState('');
   const [model, setModel] = useState('qwen-turbo');
   const [baseUrl, setBaseUrl] = useState('');
 
   const loadConfig = useCallback(async () => {
     setLoading(true);
     try {
-      const response = await client.get('v3/console/copilot/config');
-      const body = response as unknown as { data: CopilotConfig };
-      const config = body.data || ({} as CopilotConfig);
+      const [configResponse, providersResponse] = await Promise.all([
+        client.get('v3/console/copilot/config'),
+        client.get('v3/console/copilot/config/providers'),
+      ]);
+      const configBody = configResponse as unknown as { data: CopilotConfig };
+      const providersBody = providersResponse as unknown as { data: ProviderMetadata[] };
+      const config = configBody.data || ({} as CopilotConfig);
+      const providerOptions = providersBody.data || [];
+      const providerName = config.provider || 'DashScope';
+      const providerMetadata = providerOptions.find((item) => item.name === providerName);
+      const protocolName = config.protocol || providerMetadata?.defaultProtocol || '';
+      const regionName = config.region || providerMetadata?.defaultRegion || '';
+      setProviders(providerOptions);
       setApiKey(config.apiKey || '');
-      setProvider(config.provider || 'DashScope');
-      setModel(config.model || 'qwen-turbo');
-      setBaseUrl(config.baseUrl || '');
+      setProvider(providerName);
+      setProtocol(protocolName);
+      setRegion(regionName);
+      setModel(config.model || providerMetadata?.defaultModel || 'qwen-turbo');
+      setBaseUrl(config.baseUrl || findBaseUrl(providerMetadata, protocolName, regionName));
     } catch {
       // Error handled by interceptor
     } finally {
@@ -92,6 +119,8 @@ export default function SettingCenterPage() {
       const config: CopilotConfig = {
         apiKey: apiKey.trim(),
         provider: provider || 'DashScope',
+        protocol,
+        region,
         model: model || 'qwen-turbo',
         baseUrl: baseUrl.trim(),
       };
@@ -106,6 +135,30 @@ export default function SettingCenterPage() {
     } finally {
       setSaving(false);
     }
+  };
+
+  const selectedProvider = providers.find((item) => item.name === provider);
+  const selectedProtocol = selectedProvider?.protocols.find((item) => item.name === protocol);
+
+  const handleProviderChange = (value: string) => {
+    const metadata = providers.find((item) => item.name === value);
+    const nextProtocol = metadata?.defaultProtocol || '';
+    const nextRegion = metadata?.defaultRegion || '';
+    setProvider(value);
+    setProtocol(nextProtocol);
+    setRegion(nextRegion);
+    setModel(metadata?.defaultModel || 'qwen-turbo');
+    setBaseUrl(findBaseUrl(metadata, nextProtocol, nextRegion));
+  };
+
+  const handleProtocolChange = (value: string) => {
+    setProtocol(value);
+    setBaseUrl(findBaseUrl(selectedProvider, value, region));
+  };
+
+  const handleRegionChange = (value: string) => {
+    setRegion(value);
+    setBaseUrl(findBaseUrl(selectedProvider, protocol, value));
   };
 
   return (
@@ -167,16 +220,49 @@ export default function SettingCenterPage() {
                 {/* Provider */}
                 <div className="space-y-2.5">
                   <Label>Provider</Label>
-                  <Select value={provider} onValueChange={setProvider}>
+                  <Select value={provider} onValueChange={handleProviderChange}>
                     <SelectTrigger>
                       <SelectValue placeholder="Select provider" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="DashScope">DashScope</SelectItem>
-                      <SelectItem value="MiniMax">MiniMax</SelectItem>
+                      {providers.map((item) => (
+                        <SelectItem key={item.name} value={item.name}>{item.name}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </div>
+
+                {selectedProvider && selectedProvider.protocols.length > 0 && (
+                  <div className="space-y-2.5">
+                    <Label>Protocol</Label>
+                    <Select value={protocol} onValueChange={handleProtocolChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select protocol" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {selectedProvider.protocols.map((item) => (
+                          <SelectItem key={item.name} value={item.name}>{item.name}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+
+                {selectedProtocol && (
+                  <div className="space-y-2.5">
+                    <Label>Region</Label>
+                    <Select value={region} onValueChange={handleRegionChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select region" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {selectedProtocol.endpoints.map((item) => (
+                          <SelectItem key={item.region} value={item.region}>{item.region}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
 
                 {/* Model */}
                 <div className="space-y-2.5">
@@ -186,10 +272,9 @@ export default function SettingCenterPage() {
                       <SelectValue placeholder={t('settings.modelPlaceholder')} />
                     </SelectTrigger>
                     <SelectContent>
-                      {COPILOT_MODELS.map((m) => (
-                        <SelectItem key={m.value} value={m.value}>
-                          <span>{m.label}</span>
-                          <span className="ml-2 text-muted-foreground text-xs">({m.desc})</span>
+                      {selectedProvider?.models.map((item) => (
+                        <SelectItem key={item.modelId} value={item.modelId}>
+                          {item.modelId}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -197,14 +282,16 @@ export default function SettingCenterPage() {
                 </div>
 
                 {/* Base URL */}
-                <div className="space-y-2.5">
-                  <Label>Base URL</Label>
-                  <Input
-                    placeholder="https://api.minimax.io/v1"
-                    value={baseUrl}
-                    onChange={(e) => setBaseUrl(e.target.value)}
-                  />
-                </div>
+                {selectedProtocol && (
+                  <div className="space-y-2.5">
+                    <Label>Base URL</Label>
+                    <Input
+                      placeholder={findBaseUrl(selectedProvider, protocol, region)}
+                      value={baseUrl}
+                      onChange={(e) => setBaseUrl(e.target.value)}
+                    />
+                  </div>
+                )}
               </div>
             )}
 

--- a/console-ui-next/src/pages/settingCenter/index.tsx
+++ b/console-ui-next/src/pages/settingCenter/index.tsx
@@ -20,23 +20,26 @@ import {
 
 interface CopilotConfig {
   apiKey: string;
+  provider: string;
   model: string;
+  baseUrl: string;
 }
 
-const QWEN_MODELS = [
-  { value: 'qwen-turbo', label: 'qwen-turbo', desc: 'Fast' },
-  { value: 'qwen-plus', label: 'qwen-plus', desc: 'Enhanced' },
-  { value: 'qwen-max', label: 'qwen-max', desc: 'Strongest' },
-  { value: 'qwen-7b-chat', label: 'qwen-7b-chat', desc: '7B' },
-  { value: 'qwen-14b-chat', label: 'qwen-14b-chat', desc: '14B' },
-  { value: 'qwen-72b-chat', label: 'qwen-72b-chat', desc: '72B' },
-  { value: 'qwen3-turbo', label: 'qwen3-turbo', desc: 'Qwen3 Fast' },
-  { value: 'qwen3-plus', label: 'qwen3-plus', desc: 'Qwen3 Enhanced' },
-  { value: 'qwen3-max', label: 'qwen3-max', desc: 'Qwen3 Strongest' },
-  { value: 'qwen3-7b-instruct', label: 'qwen3-7b-instruct', desc: '7B' },
-  { value: 'qwen3-14b-instruct', label: 'qwen3-14b-instruct', desc: '14B' },
-  { value: 'qwen3-32b-instruct', label: 'qwen3-32b-instruct', desc: '32B' },
-  { value: 'qwen3-72b-instruct', label: 'qwen3-72b-instruct', desc: '72B' },
+const COPILOT_MODELS = [
+  { value: 'qwen-turbo', label: 'qwen-turbo', desc: 'DashScope Fast' },
+  { value: 'qwen-plus', label: 'qwen-plus', desc: 'DashScope Enhanced' },
+  { value: 'qwen-max', label: 'qwen-max', desc: 'DashScope Strongest' },
+  { value: 'qwen-7b-chat', label: 'qwen-7b-chat', desc: 'DashScope 7B' },
+  { value: 'qwen-14b-chat', label: 'qwen-14b-chat', desc: 'DashScope 14B' },
+  { value: 'qwen-72b-chat', label: 'qwen-72b-chat', desc: 'DashScope 72B' },
+  { value: 'qwen3-turbo', label: 'qwen3-turbo', desc: 'DashScope Qwen3 Fast' },
+  { value: 'qwen3-plus', label: 'qwen3-plus', desc: 'DashScope Qwen3 Enhanced' },
+  { value: 'qwen3-max', label: 'qwen3-max', desc: 'DashScope Qwen3 Strongest' },
+  { value: 'qwen3-7b-instruct', label: 'qwen3-7b-instruct', desc: 'DashScope 7B' },
+  { value: 'qwen3-14b-instruct', label: 'qwen3-14b-instruct', desc: 'DashScope 14B' },
+  { value: 'qwen3-32b-instruct', label: 'qwen3-32b-instruct', desc: 'DashScope 32B' },
+  { value: 'qwen3-72b-instruct', label: 'qwen3-72b-instruct', desc: 'DashScope 72B' },
+  { value: 'MiniMax-M3', label: 'MiniMax-M3', desc: 'MiniMax' },
 ];
 
 export default function SettingCenterPage() {
@@ -56,7 +59,9 @@ export default function SettingCenterPage() {
   const [showApiKey, setShowApiKey] = useState(false);
 
   const [apiKey, setApiKey] = useState('');
+  const [provider, setProvider] = useState('DashScope');
   const [model, setModel] = useState('qwen-turbo');
+  const [baseUrl, setBaseUrl] = useState('');
 
   const loadConfig = useCallback(async () => {
     setLoading(true);
@@ -65,7 +70,9 @@ export default function SettingCenterPage() {
       const body = response as unknown as { data: CopilotConfig };
       const config = body.data || ({} as CopilotConfig);
       setApiKey(config.apiKey || '');
+      setProvider(config.provider || 'DashScope');
       setModel(config.model || 'qwen-turbo');
+      setBaseUrl(config.baseUrl || '');
     } catch {
       // Error handled by interceptor
     } finally {
@@ -84,7 +91,9 @@ export default function SettingCenterPage() {
     try {
       const config: CopilotConfig = {
         apiKey: apiKey.trim(),
+        provider: provider || 'DashScope',
         model: model || 'qwen-turbo',
+        baseUrl: baseUrl.trim(),
       };
 
       await client.post('v3/console/copilot/config', JSON.stringify(config), {
@@ -155,6 +164,20 @@ export default function SettingCenterPage() {
                   <p className="text-xs text-muted-foreground">{t('settings.apiKeyHint')}</p>
                 </div>
 
+                {/* Provider */}
+                <div className="space-y-2.5">
+                  <Label>Provider</Label>
+                  <Select value={provider} onValueChange={setProvider}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select provider" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="DashScope">DashScope</SelectItem>
+                      <SelectItem value="MiniMax">MiniMax</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
                 {/* Model */}
                 <div className="space-y-2.5">
                   <Label>{t('settings.model')}</Label>
@@ -163,7 +186,7 @@ export default function SettingCenterPage() {
                       <SelectValue placeholder={t('settings.modelPlaceholder')} />
                     </SelectTrigger>
                     <SelectContent>
-                      {QWEN_MODELS.map((m) => (
+                      {COPILOT_MODELS.map((m) => (
                         <SelectItem key={m.value} value={m.value}>
                           <span>{m.label}</span>
                           <span className="ml-2 text-muted-foreground text-xs">({m.desc})</span>
@@ -171,6 +194,16 @@ export default function SettingCenterPage() {
                       ))}
                     </SelectContent>
                   </Select>
+                </div>
+
+                {/* Base URL */}
+                <div className="space-y-2.5">
+                  <Label>Base URL</Label>
+                  <Input
+                    placeholder="https://api.minimax.io/v1"
+                    value={baseUrl}
+                    onChange={(e) => setBaseUrl(e.target.value)}
+                  />
                 </div>
               </div>
             )}

--- a/console-ui/src/pages/SettingCenter/CopilotConfig.js
+++ b/console-ui/src/pages/SettingCenter/CopilotConfig.js
@@ -21,6 +21,11 @@ import requestUtils from '../../utils/request';
 
 const FormItem = Form.Item;
 
+const findBaseUrl = (provider, protocol, region) => {
+  const protocolMetadata = provider?.protocols?.find(item => item.name === protocol);
+  return protocolMetadata?.endpoints?.find(item => item.region === region)?.baseUrl || '';
+};
+
 class CopilotConfig extends React.Component {
   static propTypes = {
     locale: PropTypes.object,
@@ -33,6 +38,7 @@ class CopilotConfig extends React.Component {
     this.state = {
       loading: false,
       config: null,
+      providers: [],
     };
   }
 
@@ -47,21 +53,36 @@ class CopilotConfig extends React.Component {
   loadConfig = async () => {
     try {
       this.setState({ loading: true });
-      const response = await requestUtils.get('v3/console/copilot/config');
+      const [response, providersResponse] = await Promise.all([
+        requestUtils.get('v3/console/copilot/config'),
+        requestUtils.get('v3/console/copilot/config/providers'),
+      ]);
       // Result format: {code: 0, message: "...", data: {...}}
       const config = (response && response.data) ? response.data : (response || {});
-      this.setState({ config });
+      let providers = [];
+      if (providersResponse && providersResponse.data) {
+        providers = providersResponse.data;
+      } else if (Array.isArray(providersResponse)) {
+        providers = providersResponse;
+      }
+      const providerName = config.provider || 'DashScope';
+      const providerMetadata = providers.find(item => item.name === providerName);
+      const protocol = config.protocol || providerMetadata?.defaultProtocol || '';
+      const region = config.region || providerMetadata?.defaultRegion || '';
+      this.setState({ config, providers });
       // Process studioUrl: remove trailing slash if exists
       let studioUrl = config.studioUrl || '';
       if (studioUrl && studioUrl.endsWith('/')) {
         studioUrl = studioUrl.slice(0, -1);
       }
-      // Set form values - only apiKey, model, studioUrl and studioProject
+      // Set all console-managed configuration values.
       this.field.setValues({
         apiKey: config.apiKey || '',
-        provider: config.provider || 'DashScope',
-        model: config.model || 'qwen-turbo',
-        baseUrl: config.baseUrl || '',
+        provider: providerName,
+        protocol,
+        region,
+        model: config.model || providerMetadata?.defaultModel || 'qwen-turbo',
+        baseUrl: config.baseUrl || findBaseUrl(providerMetadata, protocol, region),
         studioUrl,
         studioProject: config.studioProject || 'NacosCopilot',
       });
@@ -84,10 +105,12 @@ class CopilotConfig extends React.Component {
       if (studioUrl && studioUrl.endsWith('/')) {
         studioUrl = studioUrl.slice(0, -1);
       }
-      // Only send apiKey, model, studioUrl and studioProject
+      // Send all console-managed configuration values.
       const config = {
         apiKey: values.apiKey || '',
         provider: values.provider || 'DashScope',
+        protocol: values.protocol || '',
+        region: values.region || '',
         model: values.model || 'qwen-turbo',
         baseUrl: values.baseUrl || '',
         studioUrl,
@@ -118,27 +141,51 @@ class CopilotConfig extends React.Component {
     }
   };
 
+  handleProviderChange = value => {
+    const provider = this.state.providers.find(item => item.name === value);
+    const protocol = provider?.defaultProtocol || '';
+    const region = provider?.defaultRegion || '';
+    this.field.setValues({
+      provider: value,
+      protocol,
+      region,
+      model: provider?.defaultModel || 'qwen-turbo',
+      baseUrl: findBaseUrl(provider, protocol, region),
+    });
+  };
+
+  handleProtocolChange = value => {
+    const providerName = this.field.getValue('provider') || 'DashScope';
+    const provider = this.state.providers.find(item => item.name === providerName);
+    const region = this.field.getValue('region') || provider?.defaultRegion || '';
+    this.field.setValues({
+      protocol: value,
+      baseUrl: findBaseUrl(provider, value, region),
+    });
+  };
+
+  handleRegionChange = value => {
+    const providerName = this.field.getValue('provider') || 'DashScope';
+    const provider = this.state.providers.find(item => item.name === providerName);
+    const protocol = this.field.getValue('protocol') || provider?.defaultProtocol || '';
+    this.field.setValues({
+      region: value,
+      baseUrl: findBaseUrl(provider, protocol, value),
+    });
+  };
+
   render() {
     const { locale = {} } = this.props;
     const { init } = this.field;
-
-    // Copilot LLM model list
-    const copilotModels = [
-      { value: 'qwen-turbo', label: 'qwen-turbo (DashScope 快速版)' },
-      { value: 'qwen-plus', label: 'qwen-plus (DashScope 增强版)' },
-      { value: 'qwen-max', label: 'qwen-max (DashScope 最强版)' },
-      { value: 'qwen-7b-chat', label: 'qwen-7b-chat (DashScope)' },
-      { value: 'qwen-14b-chat', label: 'qwen-14b-chat (DashScope)' },
-      { value: 'qwen-72b-chat', label: 'qwen-72b-chat (DashScope)' },
-      { value: 'qwen3-turbo', label: 'qwen3-turbo (DashScope 千问3快速版)' },
-      { value: 'qwen3-plus', label: 'qwen3-plus (DashScope 千问3增强版)' },
-      { value: 'qwen3-max', label: 'qwen3-max (DashScope 千问3最强版)' },
-      { value: 'qwen3-7b-instruct', label: 'qwen3-7b-instruct (DashScope)' },
-      { value: 'qwen3-14b-instruct', label: 'qwen3-14b-instruct (DashScope)' },
-      { value: 'qwen3-32b-instruct', label: 'qwen3-32b-instruct (DashScope)' },
-      { value: 'qwen3-72b-instruct', label: 'qwen3-72b-instruct (DashScope)' },
-      { value: 'MiniMax-M3', label: 'MiniMax-M3 (MiniMax)' },
-    ];
+    const providerName = this.field.getValue('provider') || 'DashScope';
+    const provider = this.state.providers.find(item => item.name === providerName);
+    const protocolName = this.field.getValue('protocol') || provider?.defaultProtocol || '';
+    const protocol = provider?.protocols?.find(item => item.name === protocolName);
+    const region = this.field.getValue('region') || provider?.defaultRegion || '';
+    const modelOptions = (provider?.models || []).map(item => ({
+      value: item.modelId,
+      label: item.modelId,
+    }));
 
     return (
       <div style={{ width: '100%', maxWidth: '800px' }}>
@@ -182,34 +229,65 @@ class CopilotConfig extends React.Component {
             {...init('provider', {
               initValue: 'DashScope',
             })}
-            dataSource={[
-              { value: 'DashScope', label: 'DashScope' },
-              { value: 'MiniMax', label: 'MiniMax' },
-            ]}
-            placeholder="请选择 Provider"
+            dataSource={this.state.providers.map(item => ({ value: item.name, label: item.name }))}
+            onChange={this.handleProviderChange}
+            placeholder="Select provider"
             style={{ width: '100%' }}
           />
         </FormItem>
+
+        {provider?.protocols?.length > 0 && (
+          <FormItem label="Protocol">
+            <Select
+              {...init('protocol', {
+                initValue: provider.defaultProtocol || '',
+              })}
+              dataSource={provider.protocols.map(item => ({ value: item.name, label: item.name }))}
+              onChange={this.handleProtocolChange}
+              placeholder="Select protocol"
+              style={{ width: '100%' }}
+            />
+          </FormItem>
+        )}
+
+        {protocol && (
+          <FormItem label="Region">
+            <Select
+              {...init('region', {
+                initValue: provider.defaultRegion || '',
+              })}
+              dataSource={protocol.endpoints.map(item => ({
+                value: item.region,
+                label: item.region,
+              }))}
+              onChange={this.handleRegionChange}
+              placeholder="Select region"
+              style={{ width: '100%' }}
+            />
+          </FormItem>
+        )}
 
         <FormItem label={locale.copilotLlmModelName || 'Model'}>
           <Select
             {...init('model', {
               initValue: 'qwen-turbo',
             })}
-            dataSource={copilotModels}
+            dataSource={modelOptions}
             placeholder={locale.copilotLlmModelNamePlaceholder || '请选择模型'}
             style={{ width: '100%' }}
           />
         </FormItem>
 
-        <FormItem label="Base URL">
-          <Input
-            {...init('baseUrl', {
-              initValue: '',
-            })}
-            placeholder="https://api.minimax.io/v1"
-          />
-        </FormItem>
+        {protocol && (
+          <FormItem label="Base URL">
+            <Input
+              {...init('baseUrl', {
+                initValue: '',
+              })}
+              placeholder={findBaseUrl(provider, protocolName, region)}
+            />
+          </FormItem>
+        )}
 
         <FormItem label={locale.copilotStudioUrl || 'Studio URL'}>
           <Input

--- a/console-ui/src/pages/SettingCenter/CopilotConfig.js
+++ b/console-ui/src/pages/SettingCenter/CopilotConfig.js
@@ -59,7 +59,9 @@ class CopilotConfig extends React.Component {
       // Set form values - only apiKey, model, studioUrl and studioProject
       this.field.setValues({
         apiKey: config.apiKey || '',
+        provider: config.provider || 'DashScope',
         model: config.model || 'qwen-turbo',
+        baseUrl: config.baseUrl || '',
         studioUrl,
         studioProject: config.studioProject || 'NacosCopilot',
       });
@@ -85,7 +87,9 @@ class CopilotConfig extends React.Component {
       // Only send apiKey, model, studioUrl and studioProject
       const config = {
         apiKey: values.apiKey || '',
+        provider: values.provider || 'DashScope',
         model: values.model || 'qwen-turbo',
+        baseUrl: values.baseUrl || '',
         studioUrl,
         studioProject: values.studioProject || 'NacosCopilot',
       };
@@ -118,21 +122,22 @@ class CopilotConfig extends React.Component {
     const { locale = {} } = this.props;
     const { init } = this.field;
 
-    // 千问系列常见文本模型列表
-    const qwenModels = [
-      { value: 'qwen-turbo', label: 'qwen-turbo (快速版)' },
-      { value: 'qwen-plus', label: 'qwen-plus (增强版)' },
-      { value: 'qwen-max', label: 'qwen-max (最强版)' },
-      { value: 'qwen-7b-chat', label: 'qwen-7b-chat' },
-      { value: 'qwen-14b-chat', label: 'qwen-14b-chat' },
-      { value: 'qwen-72b-chat', label: 'qwen-72b-chat' },
-      { value: 'qwen3-turbo', label: 'qwen3-turbo (千问3快速版)' },
-      { value: 'qwen3-plus', label: 'qwen3-plus (千问3增强版)' },
-      { value: 'qwen3-max', label: 'qwen3-max (千问3最强版)' },
-      { value: 'qwen3-7b-instruct', label: 'qwen3-7b-instruct' },
-      { value: 'qwen3-14b-instruct', label: 'qwen3-14b-instruct' },
-      { value: 'qwen3-32b-instruct', label: 'qwen3-32b-instruct' },
-      { value: 'qwen3-72b-instruct', label: 'qwen3-72b-instruct' },
+    // Copilot LLM model list
+    const copilotModels = [
+      { value: 'qwen-turbo', label: 'qwen-turbo (DashScope 快速版)' },
+      { value: 'qwen-plus', label: 'qwen-plus (DashScope 增强版)' },
+      { value: 'qwen-max', label: 'qwen-max (DashScope 最强版)' },
+      { value: 'qwen-7b-chat', label: 'qwen-7b-chat (DashScope)' },
+      { value: 'qwen-14b-chat', label: 'qwen-14b-chat (DashScope)' },
+      { value: 'qwen-72b-chat', label: 'qwen-72b-chat (DashScope)' },
+      { value: 'qwen3-turbo', label: 'qwen3-turbo (DashScope 千问3快速版)' },
+      { value: 'qwen3-plus', label: 'qwen3-plus (DashScope 千问3增强版)' },
+      { value: 'qwen3-max', label: 'qwen3-max (DashScope 千问3最强版)' },
+      { value: 'qwen3-7b-instruct', label: 'qwen3-7b-instruct (DashScope)' },
+      { value: 'qwen3-14b-instruct', label: 'qwen3-14b-instruct (DashScope)' },
+      { value: 'qwen3-32b-instruct', label: 'qwen3-32b-instruct (DashScope)' },
+      { value: 'qwen3-72b-instruct', label: 'qwen3-72b-instruct (DashScope)' },
+      { value: 'MiniMax-M3', label: 'MiniMax-M3 (MiniMax)' },
     ];
 
     return (
@@ -172,14 +177,37 @@ class CopilotConfig extends React.Component {
           />
         </FormItem>
 
+        <FormItem label="Provider">
+          <Select
+            {...init('provider', {
+              initValue: 'DashScope',
+            })}
+            dataSource={[
+              { value: 'DashScope', label: 'DashScope' },
+              { value: 'MiniMax', label: 'MiniMax' },
+            ]}
+            placeholder="请选择 Provider"
+            style={{ width: '100%' }}
+          />
+        </FormItem>
+
         <FormItem label={locale.copilotLlmModelName || 'Model'}>
           <Select
             {...init('model', {
               initValue: 'qwen-turbo',
             })}
-            dataSource={qwenModels}
+            dataSource={copilotModels}
             placeholder={locale.copilotLlmModelNamePlaceholder || '请选择模型'}
             style={{ width: '100%' }}
+          />
+        </FormItem>
+
+        <FormItem label="Base URL">
+          <Input
+            {...init('baseUrl', {
+              initValue: '',
+            })}
+            placeholder="https://api.minimax.io/v1"
           />
         </FormItem>
 

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleCopilotConfigController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleCopilotConfigController.java
@@ -31,7 +31,9 @@ import com.alibaba.nacos.config.server.model.form.ConfigForm;
 import com.alibaba.nacos.config.server.utils.RequestUtil;
 import com.alibaba.nacos.console.proxy.config.ConfigProxy;
 import com.alibaba.nacos.copilot.config.CopilotAgentManager;
+import com.alibaba.nacos.copilot.config.CopilotModelProviderRegistry;
 import com.alibaba.nacos.copilot.config.CopilotProperties;
+import com.alibaba.nacos.copilot.config.CopilotProviderMetadata;
 import com.alibaba.nacos.copilot.constant.CopilotConstants;
 import jakarta.servlet.http.HttpServletRequest;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
@@ -43,6 +45,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * Console Copilot configuration controller.
@@ -70,20 +74,23 @@ public class ConsoleCopilotConfigController {
     
     private final ConfigProxy configProxy;
     
+    private final CopilotModelProviderRegistry providerRegistry;
+    
     @Value("${nacos.copilot.config.namespace:public}")
     private String configNamespace;
     
     @Autowired
     public ConsoleCopilotConfigController(CopilotAgentManager agentManager,
-        ConfigProxy configProxy) {
+        ConfigProxy configProxy, CopilotModelProviderRegistry providerRegistry) {
         this.agentManager = agentManager;
         this.configProxy = configProxy;
+        this.providerRegistry = providerRegistry;
     }
     
     /**
-     * Get current Copilot configuration. Only returns apiKey, model, studioUrl and studioProject fields.
+     * Get current Copilot configuration.
      *
-     * @return Simplified CopilotProperties with only apiKey, model, studioUrl and studioProject
+     * @return console-managed Copilot configuration
      */
     @Since("3.2.0")
     @GetMapping
@@ -95,10 +102,14 @@ public class ConsoleCopilotConfigController {
             config = new CopilotProperties();
         }
         
-        // Create simplified config with only apiKey, model, studioUrl and studioProject
+        // Return only fields managed by the console.
         CopilotProperties simplifiedConfig = new CopilotProperties();
         simplifiedConfig.setApiKey(config.getApiKey());
+        simplifiedConfig.setProvider(config.getProvider());
+        simplifiedConfig.setProtocol(config.getProtocol());
+        simplifiedConfig.setRegion(config.getRegion());
         simplifiedConfig.setModel(config.getModel());
+        simplifiedConfig.setBaseUrl(config.getBaseUrl());
         simplifiedConfig.setStudioUrl(config.getStudioUrl());
         simplifiedConfig.setStudioProject(config.getStudioProject());
         
@@ -106,11 +117,22 @@ public class ConsoleCopilotConfigController {
     }
     
     /**
-     * Create or update Copilot configuration. Only accepts apiKey, model, studioUrl and studioProject fields, other
-     * fields use defaults.
+     * Get available Copilot providers and their configuration options.
+     *
+     * @return provider metadata
+     */
+    @Since("3.2.0")
+    @GetMapping("/providers")
+    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
+    public Result<List<CopilotProviderMetadata>> getProviders() {
+        return Result.success(providerRegistry.getProviderMetadata());
+    }
+    
+    /**
+     * Create or update Copilot configuration.
      *
      * @param request HTTP servlet request.
-     * @param config Simplified CopilotProperties with only apiKey, model, studioUrl and studioProject
+     * @param config console-managed Copilot configuration
      * @return success result
      */
     @Since("3.2.0")
@@ -128,25 +150,42 @@ public class ConsoleCopilotConfigController {
         CopilotProperties fullConfig;
         
         if (existingConfig != null) {
-            // Use existing config and only update apiKey, model, studioUrl and studioProject
+            // Preserve fields that are not managed by the console.
             fullConfig = existingConfig;
         } else {
             // Create new config with default values
             fullConfig = new CopilotProperties();
         }
         
-        // Update only apiKey, model, studioUrl and studioProject
+        // Update only fields managed by the console.
         if (config.getApiKey() != null) {
             fullConfig.setApiKey(config.getApiKey());
         }
+        if (config.getProvider() != null) {
+            fullConfig.setProvider(config.getProvider());
+        }
+        if (config.getProtocol() != null) {
+            fullConfig.setProtocol(config.getProtocol());
+        }
+        if (config.getRegion() != null) {
+            fullConfig.setRegion(config.getRegion());
+        }
         if (config.getModel() != null) {
             fullConfig.setModel(config.getModel());
+        }
+        if (config.getBaseUrl() != null) {
+            fullConfig.setBaseUrl(config.getBaseUrl());
         }
         if (config.getStudioUrl() != null) {
             fullConfig.setStudioUrl(config.getStudioUrl());
         }
         if (config.getStudioProject() != null) {
             fullConfig.setStudioProject(config.getStudioProject());
+        }
+        try {
+            providerRegistry.validate(fullConfig);
+        } catch (IllegalArgumentException e) {
+            throw new NacosException(NacosException.INVALID_PARAM, e.getMessage());
         }
         
         boolean success = publishStoredConfig(request, fullConfig);

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleCopilotConfigControllerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleCopilotConfigControllerTest.java
@@ -23,7 +23,9 @@ import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
 import com.alibaba.nacos.config.server.model.form.ConfigForm;
 import com.alibaba.nacos.console.proxy.config.ConfigProxy;
 import com.alibaba.nacos.copilot.config.CopilotAgentManager;
+import com.alibaba.nacos.copilot.config.CopilotModelProviderRegistry;
 import com.alibaba.nacos.copilot.config.CopilotProperties;
+import com.alibaba.nacos.copilot.config.CopilotProviderMetadata;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -65,12 +70,15 @@ class ConsoleCopilotConfigControllerTest {
     @Mock
     private ConfigProxy configProxy;
     
+    @Mock
+    private CopilotModelProviderRegistry providerRegistry;
+    
     private MockMvc mockMvc;
     
     @BeforeEach
     void setUp() {
         ConsoleCopilotConfigController controller =
-            new ConsoleCopilotConfigController(agentManager, configProxy);
+            new ConsoleCopilotConfigController(agentManager, configProxy, providerRegistry);
         ReflectionTestUtils.setField(controller, "configNamespace", NAMESPACE);
         mockMvc = MockMvcBuilders.standaloneSetup(
             controller).build();
@@ -80,7 +88,11 @@ class ConsoleCopilotConfigControllerTest {
     void testGetConfigReturnsSimplifiedConfig() throws Exception {
         CopilotProperties config = new CopilotProperties();
         config.setApiKey("test-key");
-        config.setModel("qwen-plus");
+        config.setProvider("MiniMax");
+        config.setProtocol("anthropic");
+        config.setRegion("cn_zh");
+        config.setModel("MiniMax-M3");
+        config.setBaseUrl("https://api.minimaxi.com/anthropic");
         config.setStudioUrl("http://studio.example.com");
         config.setStudioProject("TestProject");
         when(configProxy.getConfigDetail(DATA_ID, GROUP, NAMESPACE))
@@ -95,9 +107,30 @@ class ConsoleCopilotConfigControllerTest {
             });
         assertNotNull(result.getData());
         assertEquals("test-key", result.getData().getApiKey());
-        assertEquals("qwen-plus", result.getData().getModel());
+        assertEquals("MiniMax", result.getData().getProvider());
+        assertEquals("anthropic", result.getData().getProtocol());
+        assertEquals("cn_zh", result.getData().getRegion());
+        assertEquals("MiniMax-M3", result.getData().getModel());
+        assertEquals("https://api.minimaxi.com/anthropic", result.getData().getBaseUrl());
         assertEquals("http://studio.example.com", result.getData().getStudioUrl());
         assertEquals("TestProject", result.getData().getStudioProject());
+    }
+    
+    @Test
+    void testGetProvidersReturnsRegistryMetadata() throws Exception {
+        CopilotProviderMetadata metadata = new CopilotProviderMetadata("MiniMax", "MiniMax-M3",
+            "openai", "global_en", true, List.of(), List.of());
+        when(providerRegistry.getProviderMetadata()).thenReturn(List.of(metadata));
+        
+        MockHttpServletResponse response = mockMvc.perform(
+            get("/v3/console/copilot/config/providers"))
+            .andExpect(status().isOk()).andReturn().getResponse();
+        Result<List<Map<String, Object>>> result = JacksonUtils.toObj(
+            response.getContentAsString(), new TypeReference<>() {
+            });
+        assertEquals(1, result.getData().size());
+        assertEquals("MiniMax", result.getData().get(0).get("name"));
+        assertEquals("MiniMax-M3", result.getData().get(0).get("defaultModel"));
     }
     
     @Test
@@ -120,7 +153,9 @@ class ConsoleCopilotConfigControllerTest {
         when(configProxy.getConfigDetail(DATA_ID, GROUP, NAMESPACE)).thenReturn(null);
         when(configProxy.publishConfig(any(), any())).thenReturn(true);
         
-        String body = "{\"apiKey\":\"new-key\",\"model\":\"qwen-max\","
+        String body = "{\"apiKey\":\"new-key\",\"provider\":\"MiniMax\","
+            + "\"protocol\":\"openai\",\"region\":\"global_en\","
+            + "\"model\":\"MiniMax-M3\",\"baseUrl\":\"https://api.minimax.io/v1\","
             + "\"studioUrl\":\"http://new.url\",\"studioProject\":\"Proj\"}";
         
         MockHttpServletResponse response = mockMvc.perform(
@@ -146,6 +181,13 @@ class ConsoleCopilotConfigControllerTest {
         assertEquals("Copilot configuration", configFormCaptor.getValue().getDesc());
         assertEquals("json", configFormCaptor.getValue().getType());
         assertEquals("http", requestInfoCaptor.getValue().getSrcType());
+        CopilotProperties saved = JacksonUtils.toObj(configFormCaptor.getValue().getContent(),
+            CopilotProperties.class);
+        assertEquals("MiniMax", saved.getProvider());
+        assertEquals("openai", saved.getProtocol());
+        assertEquals("global_en", saved.getRegion());
+        assertEquals("MiniMax-M3", saved.getModel());
+        assertEquals("https://api.minimax.io/v1", saved.getBaseUrl());
     }
     
     @Test
@@ -190,14 +232,19 @@ class ConsoleCopilotConfigControllerTest {
     void testSaveConfigWithExplicitNullFieldsPreservesExisting() throws Exception {
         CopilotProperties existing = new CopilotProperties();
         existing.setApiKey("keep-this");
+        existing.setProvider("MiniMax");
+        existing.setProtocol("anthropic");
+        existing.setRegion("cn_zh");
         existing.setModel("keep-model");
+        existing.setBaseUrl("https://api.minimaxi.com/anthropic");
         existing.setStudioUrl("keep-url");
         existing.setStudioProject("keep-proj");
         when(configProxy.getConfigDetail(DATA_ID, GROUP, NAMESPACE))
             .thenReturn(configDetail(existing));
         when(configProxy.publishConfig(any(), any())).thenReturn(true);
         
-        String body = "{\"apiKey\":null,\"model\":null,\"studioUrl\":null,"
+        String body = "{\"apiKey\":null,\"provider\":null,\"protocol\":null,"
+            + "\"region\":null,\"model\":null,\"baseUrl\":null,\"studioUrl\":null,"
             + "\"studioProject\":null}";
         
         mockMvc.perform(post("/v3/console/copilot/config")
@@ -209,7 +256,11 @@ class ConsoleCopilotConfigControllerTest {
         CopilotProperties actual = JacksonUtils.toObj(captor.getValue().getContent(),
             CopilotProperties.class);
         assertEquals("keep-this", actual.getApiKey());
+        assertEquals("MiniMax", actual.getProvider());
+        assertEquals("anthropic", actual.getProtocol());
+        assertEquals("cn_zh", actual.getRegion());
         assertEquals("keep-model", actual.getModel());
+        assertEquals("https://api.minimaxi.com/anthropic", actual.getBaseUrl());
         assertEquals("keep-url", actual.getStudioUrl());
         assertEquals("keep-proj", actual.getStudioProject());
     }

--- a/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotAgentManager.java
+++ b/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotAgentManager.java
@@ -19,6 +19,8 @@ package com.alibaba.nacos.copilot.config;
 import com.alibaba.nacos.common.utils.StringUtils;
 import io.agentscope.core.ReActAgent;
 import io.agentscope.core.model.DashScopeChatModel;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.OpenAIChatModel;
 import io.agentscope.core.studio.StudioManager;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
@@ -147,13 +149,8 @@ public class CopilotAgentManager {
         }
         
         // Create model
-        DashScopeChatModel model = DashScopeChatModel.builder()
-            .apiKey(apiKey)
-            .modelName(config.getModel())
-            .stream(true)
-            .enableThinking(true)
-            .build();
-        
+        Model model = createModel(config, apiKey);
+
         // Create agent
         ReActAgent.Builder agentBuilder = ReActAgent.builder()
             .name("CopilotAgent")
@@ -201,6 +198,31 @@ public class CopilotAgentManager {
         return defaultProperties;
     }
     
+    /**
+     * Create AgentScope model with current configuration.
+     *
+     * @param config CopilotProperties
+     * @param apiKey API key
+     * @return AgentScope model
+     */
+    private Model createModel(CopilotProperties config, String apiKey) {
+        if (StringUtils.equalsIgnoreCase("MiniMax", config.getProvider())) {
+            return OpenAIChatModel.builder()
+                .apiKey(apiKey)
+                .baseUrl(StringUtils.isBlank(config.getBaseUrl())
+                    ? "https://api.minimax.io/v1" : config.getBaseUrl())
+                .modelName(config.getModel())
+                .stream(true)
+                .build();
+        }
+        return DashScopeChatModel.builder()
+            .apiKey(apiKey)
+            .modelName(config.getModel())
+            .stream(true)
+            .enableThinking(true)
+            .build();
+    }
+
     /**
      * Get API key from environment variable or config.
      *

--- a/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotAgentManager.java
+++ b/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotAgentManager.java
@@ -18,9 +18,7 @@ package com.alibaba.nacos.copilot.config;
 
 import com.alibaba.nacos.common.utils.StringUtils;
 import io.agentscope.core.ReActAgent;
-import io.agentscope.core.model.DashScopeChatModel;
 import io.agentscope.core.model.Model;
-import io.agentscope.core.model.OpenAIChatModel;
 import io.agentscope.core.studio.StudioManager;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
@@ -44,6 +42,7 @@ public class CopilotAgentManager {
     private final CopilotConfigStorage configStorage;
     private final CopilotProperties defaultProperties;
     private final Environment environment;
+    private final CopilotModelProviderRegistry providerRegistry;
     
     private volatile CopilotProperties currentConfig;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
@@ -51,10 +50,11 @@ public class CopilotAgentManager {
     @Autowired
     public CopilotAgentManager(CopilotConfigStorage configStorage,
         CopilotProperties defaultProperties,
-        Environment environment) {
+        Environment environment, CopilotModelProviderRegistry providerRegistry) {
         this.configStorage = configStorage;
         this.defaultProperties = defaultProperties;
         this.environment = environment;
+        this.providerRegistry = providerRegistry;
     }
     
     /**
@@ -149,8 +149,8 @@ public class CopilotAgentManager {
         }
         
         // Create model
-        Model model = createModel(config, apiKey);
-
+        Model model = providerRegistry.createModel(config, apiKey);
+        
         // Create agent
         ReActAgent.Builder agentBuilder = ReActAgent.builder()
             .name("CopilotAgent")
@@ -198,31 +198,6 @@ public class CopilotAgentManager {
         return defaultProperties;
     }
     
-    /**
-     * Create AgentScope model with current configuration.
-     *
-     * @param config CopilotProperties
-     * @param apiKey API key
-     * @return AgentScope model
-     */
-    private Model createModel(CopilotProperties config, String apiKey) {
-        if (StringUtils.equalsIgnoreCase("MiniMax", config.getProvider())) {
-            return OpenAIChatModel.builder()
-                .apiKey(apiKey)
-                .baseUrl(StringUtils.isBlank(config.getBaseUrl())
-                    ? "https://api.minimax.io/v1" : config.getBaseUrl())
-                .modelName(config.getModel())
-                .stream(true)
-                .build();
-        }
-        return DashScopeChatModel.builder()
-            .apiKey(apiKey)
-            .modelName(config.getModel())
-            .stream(true)
-            .enableThinking(true)
-            .build();
-    }
-
     /**
      * Get API key from environment variable or config.
      *

--- a/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotModelProvider.java
+++ b/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotModelProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.copilot.config;
+
+import io.agentscope.core.model.Model;
+
+/**
+ * Creates an AgentScope model and exposes configuration metadata for one provider.
+ *
+ * @author nacos
+ */
+public interface CopilotModelProvider {
+    
+    String getName();
+    
+    CopilotProviderMetadata getMetadata();
+    
+    void validate(CopilotProperties config);
+    
+    Model createModel(CopilotProperties config, String apiKey);
+}

--- a/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotModelProviderRegistry.java
+++ b/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotModelProviderRegistry.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.copilot.config;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+import io.agentscope.core.model.Model;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Registry of available Copilot model providers.
+ *
+ * @author nacos
+ */
+@Component
+public class CopilotModelProviderRegistry {
+    
+    private static final String DEFAULT_PROVIDER = "DashScope";
+    
+    private final Map<String, CopilotModelProvider> providers;
+    
+    @Autowired
+    public CopilotModelProviderRegistry(List<CopilotModelProvider> providerList) {
+        providers = new LinkedHashMap<>();
+        for (CopilotModelProvider provider : providerList) {
+            String key = normalize(provider.getName());
+            if (providers.putIfAbsent(key, provider) != null) {
+                throw new IllegalStateException(
+                    "Duplicate Copilot provider: " + provider.getName());
+            }
+        }
+    }
+    
+    public List<CopilotProviderMetadata> getProviderMetadata() {
+        return providers.values().stream().map(CopilotModelProvider::getMetadata).toList();
+    }
+    
+    public void validate(CopilotProperties config) {
+        resolve(config.getProvider()).validate(config);
+    }
+    
+    /**
+     * Create a model from the provider selected in the configuration.
+     *
+     * @param config Copilot configuration
+     * @param apiKey provider API key
+     * @return configured AgentScope model
+     */
+    public Model createModel(CopilotProperties config, String apiKey) {
+        CopilotModelProvider provider = resolve(config.getProvider());
+        provider.validate(config);
+        return provider.createModel(config, apiKey);
+    }
+    
+    private CopilotModelProvider resolve(String name) {
+        String effectiveName = StringUtils.isBlank(name) ? DEFAULT_PROVIDER : name;
+        CopilotModelProvider provider = providers.get(normalize(effectiveName));
+        if (provider == null) {
+            throw new IllegalArgumentException("Unsupported Copilot provider: " + effectiveName);
+        }
+        return provider;
+    }
+    
+    private static String normalize(String name) {
+        return name.toLowerCase(Locale.ROOT);
+    }
+}

--- a/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotProperties.java
+++ b/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotProperties.java
@@ -44,10 +44,20 @@ public class CopilotProperties {
     private String apiKey;
     
     /**
+     * LLM provider name.
+     */
+    private String provider = "DashScope";
+
+    /**
      * Model name.
      */
     private String model = "qwen-turbo";
-    
+
+    /**
+     * OpenAI-compatible base URL.
+     */
+    private String baseUrl;
+
     /**
      * AgentScope Studio URL.
      */
@@ -93,6 +103,24 @@ public class CopilotProperties {
     }
     
     /**
+     * Get provider name.
+     *
+     * @return provider name
+     */
+    public String getProvider() {
+        return provider;
+    }
+
+    /**
+     * Set provider name.
+     *
+     * @param provider provider name
+     */
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    /**
      * Get model name.
      *
      * @return model name
@@ -110,6 +138,24 @@ public class CopilotProperties {
         this.model = model;
     }
     
+    /**
+     * Get OpenAI-compatible base URL.
+     *
+     * @return base URL
+     */
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    /**
+     * Set OpenAI-compatible base URL.
+     *
+     * @param baseUrl base URL
+     */
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
     /**
      * Get Studio URL.
      *

--- a/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotProperties.java
+++ b/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotProperties.java
@@ -47,17 +47,27 @@ public class CopilotProperties {
      * LLM provider name.
      */
     private String provider = "DashScope";
-
+    
+    /**
+     * Provider API protocol.
+     */
+    private String protocol;
+    
+    /**
+     * Provider endpoint region.
+     */
+    private String region;
+    
     /**
      * Model name.
      */
     private String model = "qwen-turbo";
-
+    
     /**
      * OpenAI-compatible base URL.
      */
     private String baseUrl;
-
+    
     /**
      * AgentScope Studio URL.
      */
@@ -110,7 +120,7 @@ public class CopilotProperties {
     public String getProvider() {
         return provider;
     }
-
+    
     /**
      * Set provider name.
      *
@@ -119,7 +129,43 @@ public class CopilotProperties {
     public void setProvider(String provider) {
         this.provider = provider;
     }
-
+    
+    /**
+     * Get provider API protocol.
+     *
+     * @return provider API protocol
+     */
+    public String getProtocol() {
+        return protocol;
+    }
+    
+    /**
+     * Set provider API protocol.
+     *
+     * @param protocol provider API protocol
+     */
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+    
+    /**
+     * Get provider endpoint region.
+     *
+     * @return provider endpoint region
+     */
+    public String getRegion() {
+        return region;
+    }
+    
+    /**
+     * Set provider endpoint region.
+     *
+     * @param region provider endpoint region
+     */
+    public void setRegion(String region) {
+        this.region = region;
+    }
+    
     /**
      * Get model name.
      *
@@ -146,7 +192,7 @@ public class CopilotProperties {
     public String getBaseUrl() {
         return baseUrl;
     }
-
+    
     /**
      * Set OpenAI-compatible base URL.
      *
@@ -155,7 +201,7 @@ public class CopilotProperties {
     public void setBaseUrl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
-
+    
     /**
      * Get Studio URL.
      *

--- a/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotProviderMetadata.java
+++ b/copilot/src/main/java/com/alibaba/nacos/copilot/config/CopilotProviderMetadata.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.copilot.config;
+
+import java.util.List;
+
+/**
+ * Console-facing metadata for a Copilot model provider.
+ *
+ * @author nacos
+ */
+public class CopilotProviderMetadata {
+    
+    private final String name;
+    
+    private final String defaultModel;
+    
+    private final String defaultProtocol;
+    
+    private final String defaultRegion;
+    
+    private final boolean streaming;
+    
+    private final List<ModelMetadata> models;
+    
+    private final List<ProtocolMetadata> protocols;
+    
+    public CopilotProviderMetadata(String name, String defaultModel, String defaultProtocol,
+        String defaultRegion, boolean streaming, List<ModelMetadata> models,
+        List<ProtocolMetadata> protocols) {
+        this.name = name;
+        this.defaultModel = defaultModel;
+        this.defaultProtocol = defaultProtocol;
+        this.defaultRegion = defaultRegion;
+        this.streaming = streaming;
+        this.models = List.copyOf(models);
+        this.protocols = List.copyOf(protocols);
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public String getDefaultModel() {
+        return defaultModel;
+    }
+    
+    public String getDefaultProtocol() {
+        return defaultProtocol;
+    }
+    
+    public String getDefaultRegion() {
+        return defaultRegion;
+    }
+    
+    public boolean isStreaming() {
+        return streaming;
+    }
+    
+    public List<ModelMetadata> getModels() {
+        return models;
+    }
+    
+    public List<ProtocolMetadata> getProtocols() {
+        return protocols;
+    }
+    
+    /**
+     * Model option exposed by a provider.
+     */
+    public static class ModelMetadata {
+        
+        private final String modelId;
+        
+        private final Integer contextWindow;
+        
+        private final List<String> inputModalities;
+        
+        private final List<String> thinking;
+        
+        public ModelMetadata(String modelId, Integer contextWindow, List<String> inputModalities,
+            List<String> thinking) {
+            this.modelId = modelId;
+            this.contextWindow = contextWindow;
+            this.inputModalities = List.copyOf(inputModalities);
+            this.thinking = List.copyOf(thinking);
+        }
+        
+        public String getModelId() {
+            return modelId;
+        }
+        
+        public Integer getContextWindow() {
+            return contextWindow;
+        }
+        
+        public List<String> getInputModalities() {
+            return inputModalities;
+        }
+        
+        public List<String> getThinking() {
+            return thinking;
+        }
+    }
+    
+    /**
+     * API protocol exposed by a provider.
+     */
+    public static class ProtocolMetadata {
+        
+        private final String name;
+        
+        private final List<EndpointMetadata> endpoints;
+        
+        public ProtocolMetadata(String name, List<EndpointMetadata> endpoints) {
+            this.name = name;
+            this.endpoints = List.copyOf(endpoints);
+        }
+        
+        public String getName() {
+            return name;
+        }
+        
+        public List<EndpointMetadata> getEndpoints() {
+            return endpoints;
+        }
+    }
+    
+    /**
+     * Regional API endpoint exposed by a protocol.
+     */
+    public static class EndpointMetadata {
+        
+        private final String region;
+        
+        private final String baseUrl;
+        
+        public EndpointMetadata(String region, String baseUrl) {
+            this.region = region;
+            this.baseUrl = baseUrl;
+        }
+        
+        public String getRegion() {
+            return region;
+        }
+        
+        public String getBaseUrl() {
+            return baseUrl;
+        }
+    }
+}

--- a/copilot/src/main/java/com/alibaba/nacos/copilot/config/DashScopeModelProvider.java
+++ b/copilot/src/main/java/com/alibaba/nacos/copilot/config/DashScopeModelProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.copilot.config;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+import io.agentscope.core.model.DashScopeChatModel;
+import io.agentscope.core.model.Model;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * DashScope Copilot model provider.
+ *
+ * @author nacos
+ */
+@Order(0)
+@Component
+public class DashScopeModelProvider implements CopilotModelProvider {
+    
+    private static final String NAME = "DashScope";
+    
+    private static final String DEFAULT_MODEL = "qwen-turbo";
+    
+    private static final CopilotProviderMetadata METADATA = new CopilotProviderMetadata(NAME,
+        DEFAULT_MODEL, null, null, true, List.of(model("qwen-turbo"), model("qwen-plus"),
+            model("qwen-max"), model("qwen-7b-chat"), model("qwen-14b-chat"),
+            model("qwen-72b-chat"), model("qwen3-turbo"), model("qwen3-plus"),
+            model("qwen3-max"), model("qwen3-7b-instruct"), model("qwen3-14b-instruct"),
+            model("qwen3-32b-instruct"), model("qwen3-72b-instruct")),
+        List.of());
+    
+    @Override
+    public String getName() {
+        return NAME;
+    }
+    
+    @Override
+    public CopilotProviderMetadata getMetadata() {
+        return METADATA;
+    }
+    
+    @Override
+    public void validate(CopilotProperties config) {
+        if (StringUtils.isBlank(config.getModel())) {
+            throw new IllegalArgumentException("Copilot model cannot be blank");
+        }
+    }
+    
+    @Override
+    public Model createModel(CopilotProperties config, String apiKey) {
+        String modelName =
+            StringUtils.isBlank(config.getModel()) ? DEFAULT_MODEL : config.getModel();
+        return DashScopeChatModel.builder().apiKey(apiKey).modelName(modelName).stream(true)
+            .enableThinking(true).build();
+    }
+    
+    private static CopilotProviderMetadata.ModelMetadata model(String modelId) {
+        return new CopilotProviderMetadata.ModelMetadata(modelId, null, List.of("text"), List.of());
+    }
+}

--- a/copilot/src/main/java/com/alibaba/nacos/copilot/config/MiniMaxModelProvider.java
+++ b/copilot/src/main/java/com/alibaba/nacos/copilot/config/MiniMaxModelProvider.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.copilot.config;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+import io.agentscope.core.model.AnthropicChatModel;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.OpenAIChatModel;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * MiniMax Copilot model provider.
+ *
+ * @author nacos
+ */
+@Order(1)
+@Component
+public class MiniMaxModelProvider implements CopilotModelProvider {
+    
+    static final String NAME = "MiniMax";
+    
+    static final String MODEL_M3 = "MiniMax-M3";
+    
+    static final String MODEL_M27 = "MiniMax-M2.7";
+    
+    static final String PROTOCOL_OPENAI = "openai";
+    
+    static final String PROTOCOL_ANTHROPIC = "anthropic";
+    
+    static final String REGION_GLOBAL = "global_en";
+    
+    static final String REGION_CHINA = "cn_zh";
+    
+    private static final CopilotProviderMetadata METADATA = new CopilotProviderMetadata(NAME,
+        MODEL_M3, PROTOCOL_OPENAI, REGION_GLOBAL, true,
+        List.of(new CopilotProviderMetadata.ModelMetadata(MODEL_M3, 1_000_000,
+            List.of("text", "image", "video"), List.of("adaptive", "disabled")),
+            new CopilotProviderMetadata.ModelMetadata(MODEL_M27, 204_800, List.of("text"),
+                List.of("always_on"))),
+        List.of(protocol(PROTOCOL_OPENAI, "https://api.minimax.io/v1",
+            "https://api.minimaxi.com/v1"),
+            protocol(PROTOCOL_ANTHROPIC, "https://api.minimax.io/anthropic",
+                "https://api.minimaxi.com/anthropic")));
+    
+    @Override
+    public String getName() {
+        return NAME;
+    }
+    
+    @Override
+    public CopilotProviderMetadata getMetadata() {
+        return METADATA;
+    }
+    
+    @Override
+    public void validate(CopilotProperties config) {
+        String model = effectiveModel(config);
+        if (!MODEL_M3.equals(model) && !MODEL_M27.equals(model)) {
+            throw new IllegalArgumentException("Unsupported MiniMax model: " + model);
+        }
+        String protocol = effectiveProtocol(config);
+        if (!PROTOCOL_OPENAI.equals(protocol) && !PROTOCOL_ANTHROPIC.equals(protocol)) {
+            throw new IllegalArgumentException("Unsupported MiniMax protocol: " + protocol);
+        }
+        String region = effectiveRegion(config);
+        if (!REGION_GLOBAL.equals(region) && !REGION_CHINA.equals(region)) {
+            throw new IllegalArgumentException("Unsupported MiniMax region: " + region);
+        }
+        validateBaseUrl(effectiveBaseUrl(config, protocol, region), protocol);
+    }
+    
+    @Override
+    public Model createModel(CopilotProperties config, String apiKey) {
+        String protocol = effectiveProtocol(config);
+        String baseUrl = effectiveBaseUrl(config, protocol, effectiveRegion(config));
+        if (PROTOCOL_ANTHROPIC.equals(protocol)) {
+            return AnthropicChatModel.builder().apiKey(apiKey).baseUrl(baseUrl)
+                .modelName(effectiveModel(config)).stream(true).build();
+        }
+        return OpenAIChatModel.builder().apiKey(apiKey).baseUrl(baseUrl)
+            .modelName(effectiveModel(config)).stream(true).build();
+    }
+    
+    private static String effectiveModel(CopilotProperties config) {
+        return StringUtils.isBlank(config.getModel()) ? MODEL_M3 : config.getModel();
+    }
+    
+    private static String effectiveProtocol(CopilotProperties config) {
+        return StringUtils.isBlank(config.getProtocol()) ? PROTOCOL_OPENAI
+            : config.getProtocol().toLowerCase(Locale.ROOT);
+    }
+    
+    private static String effectiveRegion(CopilotProperties config) {
+        return StringUtils.isBlank(config.getRegion()) ? REGION_GLOBAL
+            : config.getRegion().toLowerCase(Locale.ROOT);
+    }
+    
+    private static String effectiveBaseUrl(CopilotProperties config, String protocol,
+        String region) {
+        if (StringUtils.isNotBlank(config.getBaseUrl())) {
+            return stripTrailingSlash(config.getBaseUrl());
+        }
+        return METADATA.getProtocols().stream().filter(item -> item.getName().equals(protocol))
+            .flatMap(item -> item.getEndpoints().stream())
+            .filter(item -> item.getRegion().equals(region)).map(
+                CopilotProviderMetadata.EndpointMetadata::getBaseUrl)
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(
+                "No MiniMax endpoint for protocol " + protocol + " and region " + region));
+    }
+    
+    private static void validateBaseUrl(String baseUrl, String protocol) {
+        URI uri;
+        try {
+            uri = URI.create(baseUrl);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid MiniMax base URL", e);
+        }
+        if (uri.getHost() == null || (!"https".equalsIgnoreCase(uri.getScheme())
+            && !"http".equalsIgnoreCase(uri.getScheme()))) {
+            throw new IllegalArgumentException("MiniMax base URL must be an absolute HTTP URL");
+        }
+        String expectedSuffix = PROTOCOL_ANTHROPIC.equals(protocol) ? "/anthropic" : "/v1";
+        if (!stripTrailingSlash(uri.getPath()).endsWith(expectedSuffix)) {
+            throw new IllegalArgumentException(
+                "MiniMax " + protocol + " base URL must end with " + expectedSuffix);
+        }
+    }
+    
+    private static CopilotProviderMetadata.ProtocolMetadata protocol(String name,
+        String globalBaseUrl, String chinaBaseUrl) {
+        return new CopilotProviderMetadata.ProtocolMetadata(name,
+            List.of(new CopilotProviderMetadata.EndpointMetadata(REGION_GLOBAL, globalBaseUrl),
+                new CopilotProviderMetadata.EndpointMetadata(REGION_CHINA, chinaBaseUrl)));
+    }
+    
+    private static String stripTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+}

--- a/copilot/src/test/java/com/alibaba/nacos/copilot/config/CopilotAgentManagerTest.java
+++ b/copilot/src/test/java/com/alibaba/nacos/copilot/config/CopilotAgentManagerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
+import io.agentscope.core.model.Model;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -29,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test for CopilotAgentManager.
@@ -47,12 +49,16 @@ class CopilotAgentManagerTest {
     @Mock
     private Environment environment;
     
+    @Mock
+    private CopilotModelProviderRegistry providerRegistry;
+    
     private CopilotAgentManager copilotAgentManager;
     
     @BeforeEach
     void setUp() {
         copilotAgentManager =
-            new CopilotAgentManager(configStorage, defaultProperties, environment);
+            new CopilotAgentManager(configStorage, defaultProperties, environment,
+                providerRegistry);
     }
     
     @Test
@@ -157,6 +163,21 @@ class CopilotAgentManagerTest {
         
         // Then
         assertNotNull(config);
+    }
+    
+    @Test
+    void testCreateAgentUsesConfiguredProvider() {
+        Model model = org.mockito.Mockito.mock(Model.class);
+        when(configStorage.isAvailable()).thenReturn(false);
+        when(defaultProperties.isEnabled()).thenReturn(true);
+        when(defaultProperties.getApiKey()).thenReturn("config-api-key");
+        when(environment.getProperty(eq("COPILOT_API_KEY"))).thenReturn(null);
+        when(providerRegistry.createModel(defaultProperties, "config-api-key"))
+            .thenReturn(model);
+        copilotAgentManager.refreshConfig();
+        
+        assertNotNull(copilotAgentManager.createAgent("test prompt"));
+        verify(providerRegistry).createModel(defaultProperties, "config-api-key");
     }
     
     @Test

--- a/copilot/src/test/java/com/alibaba/nacos/copilot/config/CopilotModelProviderTest.java
+++ b/copilot/src/test/java/com/alibaba/nacos/copilot/config/CopilotModelProviderTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.copilot.config;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.agentscope.core.message.Msg;
+import io.agentscope.core.model.AnthropicChatModel;
+import io.agentscope.core.model.DashScopeChatModel;
+import io.agentscope.core.model.Model;
+import io.agentscope.core.model.OpenAIChatModel;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CopilotModelProviderTest {
+    
+    @Test
+    void testRegistryCreatesModelsForEachProviderProtocol() {
+        CopilotModelProviderRegistry registry = new CopilotModelProviderRegistry(
+            List.of(new DashScopeModelProvider(), new MiniMaxModelProvider()));
+        CopilotProperties config = new CopilotProperties();
+        assertInstanceOf(DashScopeChatModel.class, registry.createModel(config, "test-key"));
+        
+        config.setProvider(MiniMaxModelProvider.NAME);
+        config.setModel(MiniMaxModelProvider.MODEL_M3);
+        config.setProtocol(MiniMaxModelProvider.PROTOCOL_OPENAI);
+        config.setRegion(MiniMaxModelProvider.REGION_GLOBAL);
+        assertInstanceOf(OpenAIChatModel.class, registry.createModel(config, "test-key"));
+        
+        config.setProtocol(MiniMaxModelProvider.PROTOCOL_ANTHROPIC);
+        assertInstanceOf(AnthropicChatModel.class, registry.createModel(config, "test-key"));
+    }
+    
+    @Test
+    void testMiniMaxMetadataCoversModelsProtocolsAndRegions() {
+        CopilotProviderMetadata metadata = new MiniMaxModelProvider().getMetadata();
+        assertEquals(List.of(MiniMaxModelProvider.MODEL_M3, MiniMaxModelProvider.MODEL_M27),
+            metadata.getModels().stream().map(
+                CopilotProviderMetadata.ModelMetadata::getModelId).toList());
+        assertEquals(List.of(MiniMaxModelProvider.PROTOCOL_OPENAI,
+            MiniMaxModelProvider.PROTOCOL_ANTHROPIC),
+            metadata.getProtocols().stream().map(
+                CopilotProviderMetadata.ProtocolMetadata::getName).toList());
+        for (CopilotProviderMetadata.ProtocolMetadata protocol : metadata.getProtocols()) {
+            assertEquals(List.of(MiniMaxModelProvider.REGION_GLOBAL,
+                MiniMaxModelProvider.REGION_CHINA),
+                protocol.getEndpoints().stream().map(
+                    CopilotProviderMetadata.EndpointMetadata::getRegion).toList());
+        }
+        assertEquals(1_000_000, metadata.getModels().get(0).getContextWindow());
+        assertEquals(List.of("text", "image", "video"),
+            metadata.getModels().get(0).getInputModalities());
+        assertEquals(List.of("adaptive", "disabled"),
+            metadata.getModels().get(0).getThinking());
+        assertEquals(204_800, metadata.getModels().get(1).getContextWindow());
+        assertEquals(List.of("always_on"), metadata.getModels().get(1).getThinking());
+    }
+    
+    @Test
+    void testMiniMaxProviderRejectsProtocolPathMismatch() {
+        CopilotProperties config = miniMaxConfig(MiniMaxModelProvider.PROTOCOL_ANTHROPIC);
+        config.setBaseUrl("https://api.minimax.io/v1");
+        assertThrows(IllegalArgumentException.class,
+            () -> new MiniMaxModelProvider().validate(config));
+    }
+    
+    @Test
+    void testOpenAiAdapterAppendsChatCompletionsPath() throws Exception {
+        assertEquals("/v1/chat/completions", capturePath(
+            MiniMaxModelProvider.PROTOCOL_OPENAI, "/v1"));
+    }
+    
+    @Test
+    void testAnthropicAdapterAppendsMessagesPath() throws Exception {
+        assertEquals("/anthropic/v1/messages", capturePath(
+            MiniMaxModelProvider.PROTOCOL_ANTHROPIC, "/anthropic"));
+    }
+    
+    private String capturePath(String protocol, String basePath) throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        AtomicReference<String> requestPath = new AtomicReference<>();
+        server.createContext("/", exchange -> {
+            requestPath.set(exchange.getRequestURI().getPath());
+            writeResponse(exchange, protocol);
+        });
+        server.start();
+        try {
+            String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort() + basePath;
+            Model model = MiniMaxModelProvider.PROTOCOL_ANTHROPIC.equals(protocol)
+                ? AnthropicChatModel.builder().apiKey("test-key").baseUrl(baseUrl)
+                    .modelName(MiniMaxModelProvider.MODEL_M3).stream(false).build()
+                : OpenAIChatModel.builder().apiKey("test-key").baseUrl(baseUrl)
+                    .modelName(MiniMaxModelProvider.MODEL_M3).stream(false).build();
+            model.stream(List.of(Msg.builder().textContent("Hello").build()), List.of(), null)
+                .blockLast();
+            return requestPath.get();
+        } finally {
+            server.stop(0);
+        }
+    }
+    
+    private void writeResponse(HttpExchange exchange, String protocol) throws IOException {
+        String response = MiniMaxModelProvider.PROTOCOL_ANTHROPIC.equals(protocol)
+            ? "{\"id\":\"msg_test\",\"type\":\"message\",\"role\":\"assistant\","
+                + "\"model\":\"MiniMax-M3\",\"content\":[{\"type\":\"text\","
+                + "\"text\":\"ok\"}],\"stop_reason\":\"end_turn\","
+                + "\"stop_sequence\":null,\"usage\":{\"input_tokens\":1,"
+                + "\"output_tokens\":1}}"
+            : "{\"id\":\"chatcmpl_test\",\"object\":\"chat.completion\","
+                + "\"created\":1,\"model\":\"MiniMax-M3\",\"choices\":[{\"index\":0,"
+                + "\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},"
+                + "\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,"
+                + "\"completion_tokens\":1,\"total_tokens\":2}}";
+        byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+    
+    private CopilotProperties miniMaxConfig(String protocol) {
+        CopilotProperties config = new CopilotProperties();
+        config.setProvider(MiniMaxModelProvider.NAME);
+        config.setModel(MiniMaxModelProvider.MODEL_M3);
+        config.setProtocol(protocol);
+        config.setRegion(MiniMaxModelProvider.REGION_GLOBAL);
+        return config;
+    }
+}

--- a/copilot/src/test/java/com/alibaba/nacos/copilot/config/CopilotPropertiesTest.java
+++ b/copilot/src/test/java/com/alibaba/nacos/copilot/config/CopilotPropertiesTest.java
@@ -37,6 +37,7 @@ class CopilotPropertiesTest {
         // Then
         assertTrue(properties.isEnabled());
         assertEquals("public", properties.getDefaultNamespace());
+        assertEquals("DashScope", properties.getProvider());
         assertEquals("qwen-turbo", properties.getModel());
         assertEquals("NacosCopilot", properties.getStudioProject());
     }
@@ -84,6 +85,18 @@ class CopilotPropertiesTest {
     }
     
     @Test
+    void testProvider() {
+        // Given
+        CopilotProperties properties = new CopilotProperties();
+
+        // When
+        properties.setProvider("MiniMax");
+
+        // Then
+        assertEquals("MiniMax", properties.getProvider());
+    }
+
+    @Test
     void testModel() {
         // Given
         CopilotProperties properties = new CopilotProperties();
@@ -95,6 +108,18 @@ class CopilotPropertiesTest {
         assertEquals("gpt-4", properties.getModel());
     }
     
+    @Test
+    void testBaseUrl() {
+        // Given
+        CopilotProperties properties = new CopilotProperties();
+
+        // When
+        properties.setBaseUrl("https://api.minimax.io/v1");
+
+        // Then
+        assertEquals("https://api.minimax.io/v1", properties.getBaseUrl());
+    }
+
     @Test
     void testStudioUrl() {
         // Given

--- a/copilot/src/test/java/com/alibaba/nacos/copilot/config/CopilotPropertiesTest.java
+++ b/copilot/src/test/java/com/alibaba/nacos/copilot/config/CopilotPropertiesTest.java
@@ -88,14 +88,28 @@ class CopilotPropertiesTest {
     void testProvider() {
         // Given
         CopilotProperties properties = new CopilotProperties();
-
+        
         // When
         properties.setProvider("MiniMax");
-
+        
         // Then
         assertEquals("MiniMax", properties.getProvider());
     }
-
+    
+    @Test
+    void testProtocol() {
+        CopilotProperties properties = new CopilotProperties();
+        properties.setProtocol("anthropic");
+        assertEquals("anthropic", properties.getProtocol());
+    }
+    
+    @Test
+    void testRegion() {
+        CopilotProperties properties = new CopilotProperties();
+        properties.setRegion("cn_zh");
+        assertEquals("cn_zh", properties.getRegion());
+    }
+    
     @Test
     void testModel() {
         // Given
@@ -112,14 +126,14 @@ class CopilotPropertiesTest {
     void testBaseUrl() {
         // Given
         CopilotProperties properties = new CopilotProperties();
-
+        
         // When
         properties.setBaseUrl("https://api.minimax.io/v1");
-
+        
         // Then
         assertEquals("https://api.minimax.io/v1", properties.getBaseUrl());
     }
-
+    
     @Test
     void testStudioUrl() {
         // Given

--- a/specs/en/integration/integration-adapter-spec.md
+++ b/specs/en/integration/integration-adapter-spec.md
@@ -173,8 +173,20 @@ Current enablement and surface:
 - stream operations use server-sent events rather than the ordinary JSON
   response wrapper;
 - LLM access is configured through `nacos.copilot.apiKey`,
-  `nacos.copilot.model`, `nacos.copilot.studioUrl`, and
-  `nacos.copilot.studioProject`.
+  `nacos.copilot.provider`, `nacos.copilot.protocol`,
+  `nacos.copilot.region`, `nacos.copilot.model`,
+  `nacos.copilot.baseUrl`, `nacos.copilot.studioUrl`, and
+  `nacos.copilot.studioProject`;
+- `GET /v3/console/copilot/config/providers` is the source of truth for the
+  provider, model, protocol, region, streaming, thinking, modality, context,
+  and default endpoint options shown by the console;
+- the MiniMax provider exposes `MiniMax-M3` and `MiniMax-M2.7` through both
+  `openai` and `anthropic` protocols in the `global_en` and `cn_zh` regions;
+- the global OpenAI and Anthropic Base URLs are `https://api.minimax.io/v1`
+  and `https://api.minimax.io/anthropic`; the China Base URLs are
+  `https://api.minimaxi.com/v1` and `https://api.minimaxi.com/anthropic`;
+- Anthropic Base URLs end at `/anthropic`; the Anthropic client appends
+  `/v1/messages` when it sends a request.
 
 Rules:
 


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Introduce an extensible Copilot model-provider registry shared by runtime configuration and both console UIs.
- Register `MiniMax-M3` and `MiniMax-M2.7` with OpenAI- and Anthropic-compatible endpoints for global and China regions.
- Persist and return provider, protocol, region, model, and Base URL settings through the console configuration controller.
- Add registry metadata, validation, request-capture tests, controller coverage, and integration-spec documentation.

## Test plan
- `./mvnw -q -pl copilot -am -DskipRat=true -Dcheckstyle.skip=true -Djacoco.skip=true -DskipITs -Dtest=CopilotModelProviderTest,CopilotPropertiesTest,CopilotAgentManagerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -q -pl console -am -DskipRat=true -Dcheckstyle.skip=true -Djacoco.skip=true -DskipITs -Dtest=ConsoleCopilotConfigControllerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -q -pl copilot,console -DskipTests checkstyle:check spotless:check`
- `cd console-ui-next && ./node_modules/.bin/eslint src/pages/settingCenter/index.tsx && ./node_modules/.bin/tsc -b --pretty false && ./node_modules/.bin/vite build`
- `cd console-ui && ./node_modules/.bin/eslint src/pages/SettingCenter/CopilotConfig.js`
- `cd console-ui && NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production ./node_modules/.bin/webpack --config build/webpack.prod.conf.js`
