### PR TITLE
[ISSUE #15490] Fix skill-scanner pipeline mojibake for Chinese text on Windows

### DIFF
--- a/plugin-default-impl/nacos-default-ai-pipeline-plugin/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/spi/impl/SkillScannerPipelineService.java
+++ b/plugin-default-impl/nacos-default-ai-pipeline-plugin/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/spi/impl/SkillScannerPipelineService.java
@@ -37,6 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -142,6 +143,7 @@ public class SkillScannerPipelineService implements PublishPipelineService {
             List<String> command = buildScanCommand(tempDir);
             ProcessBuilder pb = new ProcessBuilder(command);
             Map<String, String> env = pb.environment();
+            applyPythonStdoutEncoding(env);
             scanOptions.applyLlmEnvironment(env);
             pb.redirectErrorStream(true);
             Process process = pb.start();
@@ -327,6 +329,12 @@ public class SkillScannerPipelineService implements PublishPipelineService {
         }
         if (!file.delete()) {
             LOGGER.debug("[SkillScannerPipeline] 无法删除临时文件: {}", file.getAbsolutePath());
+        }
+    }
+    
+    private void applyPythonStdoutEncoding(Map<String, String> env) {
+        if (System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win")) {
+            env.put("PYTHONIOENCODING", "utf-8");
         }
     }
     


### PR DESCRIPTION
…Windows (#15490)

Please do not create a Pull Request without creating an issue first.

## What is the purpose of the change

Fix garbled Chinese characters in skill-scanner pipeline execution results on Windows.

When Nacos invokes the `skill-scanner` CLI via `ProcessBuilder`, the plugin reads subprocess stdout as UTF-8. On Windows, the Python `skill-scanner` process (no TTY) may emit stdout using the system default encoding (e.g. GBK/cp936). This causes mojibake in persisted pipeline reports (`pipeline_execution.pipeline` and version `publish_pipeline_info`), especially in LLM-generated `Code Snippet` sections that quote Chinese text from `SKILL.md` (e.g. `自动执行` → `Զִ`).

Java-hardcoded Chinese in the reject message prefix and English report content are unaffected.

This change sets `PYTHONIOENCODING=utf-8` on the skill-scanner subprocess environment on Windows before `ProcessBuilder.start()`, so stdout encoding matches the existing UTF-8 `InputStreamReader`.

Fixes #15490

## Brief changelog

- Set `PYTHONIOENCODING=utf-8` on the skill-scanner subprocess environment when running on Windows (`SkillScannerPipelineService.execute()`).
- Keep stdout decoding as `StandardCharsets.UTF_8` (unchanged).
- Scope is limited to Windows only to avoid affecting Linux/macOS deployments where subprocess stdout is typically already UTF-8.

## Verifying this change

Automated checks (run in module scope):**

```bash
mvn -pl plugin-default-impl/nacos-default-ai-pipeline-plugin spotless:apply
mvn -pl plugin-default-impl/nacos-default-ai-pipeline-plugin -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests
mvn -pl plugin-default-impl/nacos-default-ai-pipeline-plugin test
```

**Manual verification (Windows):**

1. Configure AI publish pipeline with `skill-scanner` and LLM enabled in `conf/application.properties`.
2. Submit a Skill containing Chinese instructions in `SKILL.md` (e.g. `auto-database-migration`).
3. After pipeline completion, query `pipeline_execution.pipeline` or version `publish_pipeline_info`.
4. Confirm Chinese text in the stored `message` is correct (e.g. `自动执行 KILL`, `尝试读取`, `使用 root`), not mojibake.

**Before fix:** Chinese quoted from skill content in subprocess output was garbled in DB.  
**After fix:** Full scan report message preserves Chinese correctly.

**Why no unit test:** The bug is Windows-specific Python subprocess stdout encoding (GBK vs UTF-8 pipe). CI is Linux-only and existing tests use Java stub subprocesses, so a unit test cannot reproduce or prove the fix. Manual verification on Windows (Python 3.12 + skill-scanner.exe) confirmed Chinese text is preserved in `pipeline_execution` after the change. Happy to add a helper + env-map assertion test if reviewers request it.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

