### PR TITLE
[ISSUE #14932] Refactor MemoryMcpCacheIndex to remove read-path LRU contention

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/index/MemoryMcpCacheIndex.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/index/MemoryMcpCacheIndex.java
@@ -19,38 +19,37 @@ package com.alibaba.nacos.ai.index;
 import com.alibaba.nacos.ai.config.McpCacheIndexProperties;
 import com.alibaba.nacos.ai.model.mcp.McpServerIndexData;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalCause;
+import com.google.common.cache.RemovalNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Iterator;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * Memory-based MCP cache index implementation with optimized locking.
+ * Memory-based MCP cache index implementation backed by a Guava {@link Cache}.
  *
  * <p>
- * TODO This Memory cache might include some design issues:
- * <ul>
- *     <li>
- *         1. The read method in cache include LRU operation(write), which means read lock can't intercept write operation
- *          in multiple threads reading and cause thread-safe problem.
- *     </li>
- *     <li>
- *         2. For solve problem 1. Use {@code synchronized} wrapper {@link #removeFromLru} and {@link #moveToHead} method,
- *         which may cause the read operation performance will be affected in high qps.
- *     </li>
- *     <li>
- *         3. The next consider it whether keep the LRU behavior in next versions when qps improved. If keep it, the LRU cache should
- *         be re-designed or use stabled high performance LRU cache such as guava.
- *     </li>
- * </ul>
+ * The primary {@code mcpId -> data} store delegates LRU eviction and time-based expiration to
+ * Guava, which removes the read-path lock contention of the previous hand-written LRU linked
+ * list. Reads ({@link #getMcpId} / {@link #getMcpServerById}) no longer mutate any shared list
+ * under a lock; Guava records access recency internally without blocking concurrent readers.
+ * A single segment ({@code concurrencyLevel(1)}) keeps size-based eviction as strict global LRU
+ * while still leaving reads lock-free.
+ * </p>
+ *
+ * <p>
+ * The lightweight {@code namespaceId::mcpName -> mcpId} secondary index is kept consistent through
+ * a removal listener: when Guava evicts or expires an entry, the related name mappings are cleaned
+ * up automatically. Explicit removals and replacements are handled directly by the mutating
+ * methods, so the listener only reacts to genuine evictions.
  * </p>
  *
  * @author misselvexu
@@ -61,21 +60,13 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
     
     private static final int DEFAULT_SHUTDOWN_TIMEOUT_SECONDS = 5;
     
+    private static final String NAME_KEY_SEPARATOR = "::";
+    
     private final McpCacheIndexProperties properties;
     
-    private final ConcurrentHashMap<String, CacheNode> idToEntry;
+    private final Cache<String, McpServerIndexData> idCache;
     
     private final ConcurrentHashMap<String, String> nameKeyToId;
-    
-    private final CacheNode head;
-    
-    private final CacheNode tail;
-    
-    private final ReentrantReadWriteLock lock;
-    
-    private final ReentrantReadWriteLock.ReadLock readLock;
-    
-    private final ReentrantReadWriteLock.WriteLock writeLock;
     
     private final AtomicLong hitCount;
     
@@ -89,26 +80,11 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
     
     public MemoryMcpCacheIndex(McpCacheIndexProperties properties) {
         this.properties = properties;
-        
-        // Initialize cache storage
-        this.idToEntry = new ConcurrentHashMap<>(properties.getMaxSize());
         this.nameKeyToId = new ConcurrentHashMap<>();
-        
-        // Initialize LRU linked list
-        this.head = new CacheNode("", null, 0);
-        this.tail = new CacheNode("", null, 0);
-        this.head.next = this.tail;
-        this.tail.prev = this.head;
-        
-        // Initialize lock
-        this.lock = new ReentrantReadWriteLock();
-        this.readLock = lock.readLock();
-        this.writeLock = lock.writeLock();
-        
-        // Initialize statistics
         this.hitCount = new AtomicLong(0);
         this.missCount = new AtomicLong(0);
         this.evictionCount = new AtomicLong(0);
+        this.idCache = buildCache(properties);
         
         // Start cleanup scheduler
         this.cleanupScheduler = new ScheduledThreadPoolExecutor(1, r -> {
@@ -117,10 +93,24 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
             return t;
         }, new ThreadPoolExecutor.CallerRunsPolicy());
         
-        // Schedule periodic cleanup
+        // Schedule periodic cleanup to proactively drain expired entries
         this.cleanupScheduler.scheduleWithFixedDelay(this::cleanupExpiredEntries,
             properties.getCleanupIntervalSeconds(), properties.getCleanupIntervalSeconds(),
             TimeUnit.SECONDS);
+    }
+    
+    private Cache<String, McpServerIndexData> buildCache(McpCacheIndexProperties cacheProperties) {
+        CacheBuilder<String, McpServerIndexData> builder = CacheBuilder.newBuilder()
+            .maximumSize(cacheProperties.getMaxSize())
+            // Single segment keeps size eviction as strict global LRU while reads stay lock-free.
+            .concurrencyLevel(1)
+            .removalListener(this::onRemoval);
+        long expireTimeSeconds = cacheProperties.getExpireTimeSeconds();
+        // Non-positive expire time means entries never expire, matching the previous behavior.
+        if (expireTimeSeconds > 0) {
+            builder.expireAfterWrite(expireTimeSeconds, TimeUnit.SECONDS);
+        }
+        return builder.build();
     }
     
     @Override
@@ -130,33 +120,22 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
         }
         
         String key = buildNameKey(namespaceId, mcpName);
-        readLock.lock();
-        try {
-            String id = nameKeyToId.get(key);
-            if (id == null) {
-                missCount.incrementAndGet();
-                return null;
-            }
-            
-            CacheNode node = idToEntry.get(id);
-            if (node == null || node.isExpired(properties.getExpireTimeSeconds())) {
-                // Clean up invalid mapping
-                nameKeyToId.remove(key, id);
-                if (node != null) {
-                    removeFromLru(node);
-                    idToEntry.remove(id, node);
-                }
-                missCount.incrementAndGet();
-                return null;
-            }
-            
-            // Update LRU position
-            moveToHead(node);
-            hitCount.incrementAndGet();
-            return id;
-        } finally {
-            readLock.unlock();
+        String id = nameKeyToId.get(key);
+        if (id == null) {
+            missCount.incrementAndGet();
+            return null;
         }
+        
+        McpServerIndexData data = idCache.getIfPresent(id);
+        if (data == null) {
+            // Entry has been evicted or expired; drop the stale name mapping.
+            nameKeyToId.remove(key, id);
+            missCount.incrementAndGet();
+            return null;
+        }
+        
+        hitCount.incrementAndGet();
+        return id;
     }
     
     @Override
@@ -174,26 +153,14 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
             return null;
         }
         
-        readLock.lock();
-        try {
-            CacheNode node = idToEntry.get(mcpId);
-            if (node == null || node.isExpired(properties.getExpireTimeSeconds())) {
-                if (node != null) {
-                    removeFromLru(node);
-                    idToEntry.remove(mcpId, node);
-                    cleanupInvalidMappings(mcpId);
-                }
-                missCount.incrementAndGet();
-                return null;
-            }
-            
-            // Update LRU position
-            moveToHead(node);
-            hitCount.incrementAndGet();
-            return node.data;
-        } finally {
-            readLock.unlock();
+        McpServerIndexData data = idCache.getIfPresent(mcpId);
+        if (data == null) {
+            missCount.incrementAndGet();
+            return null;
         }
+        
+        hitCount.incrementAndGet();
+        return data;
     }
     
     @Override
@@ -204,30 +171,9 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
         }
         
         McpServerIndexData data = McpServerIndexData.newIndexData(mcpId, namespaceId);
-        CacheNode newNode = new CacheNode(mcpId, data, System.currentTimeMillis() / 1000);
-        
-        writeLock.lock();
-        try {
-            CacheNode oldNode = idToEntry.put(mcpId, newNode);
-            if (oldNode != null) {
-                // Remove old node from LRU list
-                removeFromLru(oldNode);
-            }
-            
-            // Add to head of LRU list
-            addToHead(newNode);
-            
-            // Check if eviction is needed and evict until size is correct
-            while (idToEntry.size() > properties.getMaxSize()) {
-                evictLeastRecentlyUsed();
-            }
-            
-            // Update name mapping
-            String key = buildNameKey(namespaceId, mcpName);
-            nameKeyToId.put(key, mcpId);
-        } finally {
-            writeLock.unlock();
-        }
+        // Guava handles LRU insertion and size-based eviction internally.
+        idCache.put(mcpId, data);
+        nameKeyToId.put(buildNameKey(namespaceId, mcpName), mcpId);
     }
     
     @Override
@@ -236,18 +182,9 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
             return;
         }
         
-        writeLock.lock();
-        try {
-            String key = buildNameKey(namespaceId, mcpName);
-            String id = nameKeyToId.remove(key);
-            if (id != null) {
-                CacheNode node = idToEntry.remove(id);
-                if (node != null) {
-                    removeFromLru(node);
-                }
-            }
-        } finally {
-            writeLock.unlock();
+        String id = nameKeyToId.remove(buildNameKey(namespaceId, mcpName));
+        if (id != null) {
+            idCache.invalidate(id);
         }
     }
     
@@ -257,30 +194,14 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
             return;
         }
         
-        writeLock.lock();
-        try {
-            CacheNode node = idToEntry.remove(mcpId);
-            if (node != null) {
-                removeFromLru(node);
-            }
-            cleanupInvalidMappings(mcpId);
-        } finally {
-            writeLock.unlock();
-        }
+        idCache.invalidate(mcpId);
+        cleanupInvalidMappings(mcpId);
     }
     
     @Override
     public void clear() {
-        writeLock.lock();
-        try {
-            idToEntry.clear();
-            nameKeyToId.clear();
-            head.next = tail;
-            tail.prev = head;
-        } finally {
-            writeLock.unlock();
-        }
-        
+        idCache.invalidateAll();
+        nameKeyToId.clear();
         hitCount.set(0);
         missCount.set(0);
         evictionCount.set(0);
@@ -288,7 +209,9 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
     
     @Override
     public int getSize() {
-        return idToEntry.size();
+        // Force pending eviction/expiration so the reported size reflects live entries only.
+        idCache.cleanUp();
+        return (int) idCache.size();
     }
     
     @Override
@@ -317,11 +240,39 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
     }
     
     private String buildNameKey(String namespaceId, String mcpName) {
-        return namespaceId + "::" + mcpName;
+        return namespaceId + NAME_KEY_SEPARATOR + mcpName;
     }
     
     private void cleanupInvalidMappings(String mcpId) {
         nameKeyToId.entrySet().removeIf(entry -> mcpId.equals(entry.getValue()));
+    }
+    
+    /**
+     * Handle Guava cache removals. Only genuine evictions (size, expiration, garbage collection)
+     * trigger secondary-index cleanup; explicit removals and replacements are handled by the
+     * mutating methods themselves.
+     */
+    private void onRemoval(RemovalNotification<String, McpServerIndexData> notification) {
+        if (isEviction(notification.getCause())) {
+            evictionCount.incrementAndGet();
+            String removedId = notification.getKey();
+            if (removedId != null) {
+                cleanupInvalidMappings(removedId);
+            }
+        }
+    }
+    
+    /**
+     * Whether the removal was caused by a genuine eviction (size limit, expiration or garbage
+     * collection) rather than an explicit removal or replacement. Mirrors the package-private
+     * {@code RemovalCause#wasEvicted()} using the public enum constants.
+     *
+     * @param cause removal cause reported by Guava
+     * @return {@code true} if the entry was evicted rather than explicitly removed or replaced
+     */
+    private boolean isEviction(RemovalCause cause) {
+        return cause == RemovalCause.SIZE || cause == RemovalCause.EXPIRED
+            || cause == RemovalCause.COLLECTED;
     }
     
     private void cleanupExpiredEntries() {
@@ -330,89 +281,11 @@ public class MemoryMcpCacheIndex implements McpCacheIndex {
         }
         
         try {
-            Iterator<Map.Entry<String, CacheNode>> iterator = idToEntry.entrySet().iterator();
-            
-            while (iterator.hasNext()) {
-                Map.Entry<String, CacheNode> entry = iterator.next();
-                CacheNode node = entry.getValue();
-                
-                if (node.isExpired(properties.getExpireTimeSeconds())) {
-                    iterator.remove();
-                    removeFromLru(node);
-                    cleanupInvalidMappings(entry.getKey());
-                    evictionCount.incrementAndGet();
-                }
-            }
+            // Guava drains expired entries during cleanUp and fires the removal listener,
+            // which keeps the name index consistent.
+            idCache.cleanUp();
         } catch (Exception e) {
             LOGGER.error("Clean up expired mcp id and name cache failed.", e);
-        }
-    }
-    
-    private void evictLeastRecentlyUsed() {
-        CacheNode last = tail.prev;
-        if (last != head) {
-            CacheNode removed = idToEntry.remove(last.key);
-            if (removed != null) {
-                removeFromLru(last);
-                cleanupInvalidMappings(last.key);
-                evictionCount.incrementAndGet();
-            }
-        }
-    }
-    
-    private void addToHead(CacheNode node) {
-        node.prev = head;
-        node.next = head.next;
-        head.next.prev = node;
-        head.next = node;
-    }
-    
-    private synchronized void removeFromLru(CacheNode node) {
-        if (node.prev != null && node.next != null) {
-            node.prev.next = node.next;
-            node.next.prev = node.prev;
-        }
-    }
-    
-    private synchronized void moveToHead(CacheNode node) {
-        // Remove from current position
-        if (node.prev != null && node.next != null) {
-            node.prev.next = node.next;
-            node.next.prev = node.prev;
-        }
-        // Add to head
-        node.prev = head;
-        node.next = head.next;
-        head.next.prev = node;
-        head.next = node;
-    }
-    
-    // Inner classes
-    
-    private static class CacheNode {
-        
-        final String key;
-        
-        final McpServerIndexData data;
-        
-        final long createTimeSeconds;
-        
-        volatile CacheNode prev;
-        
-        volatile CacheNode next;
-        
-        CacheNode(String key, McpServerIndexData data, long createTimeSeconds) {
-            this.key = key;
-            this.data = data;
-            this.createTimeSeconds = createTimeSeconds;
-        }
-        
-        boolean isExpired(long expireTimeSeconds) {
-            if (expireTimeSeconds <= 0) {
-                return false;
-            }
-            long currentTimeSeconds = System.currentTimeMillis() / 1000;
-            return (currentTimeSeconds - createTimeSeconds) >= expireTimeSeconds;
         }
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/index/MemoryMcpCacheIndexEvictionConsistencyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/index/MemoryMcpCacheIndexEvictionConsistencyTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.index;
+
+import com.alibaba.nacos.ai.config.McpCacheIndexProperties;
+import com.alibaba.nacos.ai.model.mcp.McpServerIndexData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Focused tests for the Guava-backed {@link MemoryMcpCacheIndex} refactor.
+ *
+ * <p>
+ * The read path no longer mutates a shared LRU list under a lock; instead the primary store is a
+ * Guava cache and the {@code name -> id} secondary index is kept consistent through a removal
+ * listener. These tests target that new consistency guarantee under size-based eviction and under
+ * concurrent read/write pressure.
+ * </p>
+ */
+class MemoryMcpCacheIndexEvictionConsistencyTest {
+    
+    private MemoryMcpCacheIndex cache;
+    
+    private McpCacheIndexProperties props;
+    
+    @BeforeEach
+    void setUp() {
+        props = new McpCacheIndexProperties();
+        props.setMaxSize(3);
+        props.setExpireTimeSeconds(60);
+        // Disable background cleanup so the scheduler cannot race with the assertions.
+        props.setCleanupIntervalSeconds(3600);
+        cache = new MemoryMcpCacheIndex(props);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        cache.shutdown();
+    }
+    
+    @Test
+    void testNameIndexHasNoDanglingMappingAfterSizeEviction() {
+        int total = 50;
+        for (int i = 0; i < total; i++) {
+            cache.updateIndex("ns", "name" + i, "id" + i);
+        }
+        
+        // Only maxSize entries survive; every surviving name mapping must resolve to a live entry,
+        // and evicted names must have been cleaned from the secondary index by the removal listener.
+        assertEquals(props.getMaxSize(), cache.getSize());
+        
+        int resolvable = 0;
+        for (int i = 0; i < total; i++) {
+            String id = cache.getMcpId("ns", "name" + i);
+            if (id != null) {
+                assertNotNull(cache.getMcpServerById(id),
+                    "surviving name mapping must not dangle after eviction");
+                resolvable++;
+            }
+        }
+        assertEquals(props.getMaxSize(), resolvable,
+            "resolvable name mappings must equal the live cache size");
+    }
+    
+    @Test
+    void testEvictionCountReflectsSizeEvictions() {
+        int total = 20;
+        for (int i = 0; i < total; i++) {
+            cache.updateIndex("ns", "name" + i, "id" + i);
+        }
+        // Inserting 20 distinct ids into a size-3 cache evicts 17 of them.
+        assertEquals(total - props.getMaxSize(), cache.getStats().getEvictionCount());
+    }
+    
+    @Test
+    void testConcurrentReadsOnHotKeyRemainConsistent() throws InterruptedException {
+        cache.updateIndex("ns", "hot", "hot-id");
+        
+        int readerThreads = 16;
+        int opsPerThread = 2000;
+        ExecutorService pool = Executors.newFixedThreadPool(readerThreads + 1);
+        CountDownLatch latch = new CountDownLatch(readerThreads + 1);
+        AtomicInteger errors = new AtomicInteger(0);
+        
+        // Concurrent readers hammering the same hot key must never block each other or observe
+        // an inconsistent value, even while a writer churns other keys and triggers evictions.
+        for (int t = 0; t < readerThreads; t++) {
+            pool.submit(() -> {
+                try {
+                    for (int i = 0; i < opsPerThread; i++) {
+                        McpServerIndexData data = cache.getMcpServerById("hot-id");
+                        if (data != null && !"hot-id".equals(data.getId())) {
+                            errors.incrementAndGet();
+                        }
+                    }
+                } catch (Throwable ex) {
+                    errors.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        
+        pool.submit(() -> {
+            try {
+                for (int i = 0; i < opsPerThread; i++) {
+                    cache.updateIndex("ns", "cold" + i, "cold-id" + i);
+                    // Keep the hot key alive so concurrent readers always have a target.
+                    cache.updateIndex("ns", "hot", "hot-id");
+                }
+            } catch (Throwable ex) {
+                errors.incrementAndGet();
+            } finally {
+                latch.countDown();
+            }
+        });
+        
+        assertTrue(latch.await(30, TimeUnit.SECONDS), "All threads must finish in time");
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS), "Pool must terminate in time");
+        assertEquals(0, errors.get(), "Concurrent reads must stay consistent and exception-free");
+        assertEquals("hot-id", cache.getMcpId("ns", "hot"), "Hot key must remain resolvable");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes #14932.

`MemoryMcpCacheIndex` (the default `McpCacheIndex`) previously maintained a hand-written LRU doubly-linked list. Its read paths (`getMcpId`, `getMcpServerById`) mutate the LRU order, so reads carry write semantics: the list moves were guarded by a `ReentrantReadWriteLock` **plus** `synchronized`, which serializes hot reads and becomes a contention hotspot under high-QPS MCP lookups. The class's own TODO already called this out and suggested reusing a stable, high-performance cache such as Guava.

This change replaces the custom LRU with a Guava `Cache`, following the direction agreed in the issue (reuse Guava, which is already on the classpath transitively via `nacos-common`/grpc, rather than adding a new dependency).

## Brief changelog

- Replace the hand-written LRU linked list + `ReentrantReadWriteLock` + `synchronized` node moves with a Guava `Cache<String, McpServerIndexData>` (`maximumSize` + `expireAfterWrite`). Reads become lock-free `getIfPresent`, removing the read-path contention.
- `concurrencyLevel(1)` keeps size-based eviction as strict global LRU while leaving reads lock-free.
- The `namespaceId::mcpName -> mcpId` secondary index is kept consistent via a removal listener that reacts only to genuine evictions (size / expiration / GC); explicit removals and replacements are handled by the mutating methods themselves.
- `McpCacheIndex` interface, `MemoryMcpCacheIndex` class name, hit/miss/eviction stats, the cleanup scheduler and all configuration properties (`nacos.mcp.cache.*`) are unchanged — no caller or configuration impact, and no new dependency.

## Verifying this change

- All existing `MemoryMcpCacheIndex` tests (behavioral: put/get, LRU eviction, expiration, stats, remove-by-name/id, concurrency, shutdown/cleanup) pass unchanged, demonstrating behavior is preserved.
- Adds `MemoryMcpCacheIndexEvictionConsistencyTest` with focused tests for `name -> id` index consistency after size eviction, eviction-count accuracy, and concurrent reads on a hot key while a writer churns entries.
- `mvn -pl ai spotless:check checkstyle:check spotbugs:check apache-rat:check` passes (0 violations / 0 bugs / 0 unapproved licenses); `mvn -pl ai test` is green.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (#14932).
* [x] Format the pull request title like `[ISSUE #123] ...`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction. This change is an internal refactor with no interface/behavior change; existing tests are preserved and focused tests are added.
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` and module unit tests to make sure basic checks pass.