### PR TITLE
[ISSUE #15475] Improve plugin config unit test coverage

### DIFF
--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/core/PluginInnerHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/inner/core/PluginInnerHandlerTest.java
@@ -164,6 +164,18 @@ class PluginInnerHandlerTest {
     }
     
     @Test
+    void testGetPluginDetailFallsBackToPluginConfig() throws NacosException {
+        PluginInfo pluginInfo = createMockPluginInfo("auth:test", PluginType.AUTH, "test", true);
+        pluginInfo.setConfig(Collections.singletonMap("legacy", "value"));
+        when(pluginManager.getPlugin("auth:test")).thenReturn(Optional.of(pluginInfo));
+        when(pluginManager.resolvePluginConfig(pluginInfo)).thenReturn(null);
+        
+        PluginDetailVO result = pluginInnerHandler.getPluginDetail("auth", "test");
+        
+        assertEquals("value", result.getConfig().get("legacy"));
+    }
+    
+    @Test
     void testGetPluginDetailNotFoundTest() {
         when(pluginManager.getPlugin("auth:notexist")).thenReturn(Optional.empty());
         

--- a/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/core/PluginRemoteHandlerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/handler/impl/remote/core/PluginRemoteHandlerTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -83,6 +84,15 @@ class PluginRemoteHandlerTest extends AbstractRemoteHandlerTest {
         assertNotNull(result);
         assertEquals(1, result.size());
         verify(namingMaintainerService).listPlugins("auth");
+    }
+    
+    @Test
+    void testListPluginsReturnsEmptyForNullResponse() throws NacosException {
+        when(namingMaintainerService.listPlugins(null)).thenReturn(null);
+        
+        List<PluginInfoVO> result = pluginRemoteHandler.listPlugins(null);
+        
+        assertTrue(result.isEmpty());
     }
     
     @Test
@@ -229,6 +239,19 @@ class PluginRemoteHandlerTest extends AbstractRemoteHandlerTest {
         assertEquals(ConfigItemType.STRING, result.getConfigDefinitions().get(0).getType());
         assertEquals(PluginConfigSourceType.DEFAULT,
             result.getConfigValueMetas().get("unknown").getSource());
+    }
+    
+    @Test
+    void testConvertNullDefinitionAndValueMetaTest() throws NacosException {
+        Map<String, Object> mockDetail = createMockPluginDetailData();
+        mockDetail.put("configDefinitions", Collections.singletonList(null));
+        mockDetail.put("configValueMetas", Collections.singletonMap("unknown", null));
+        when(namingMaintainerService.getPluginDetail("auth", "test")).thenReturn(mockDetail);
+        
+        PluginDetailVO result = pluginRemoteHandler.getPluginDetail("auth", "test");
+        
+        assertNull(result.getConfigDefinitions().get(0));
+        assertNull(result.getConfigValueMetas().get("unknown"));
     }
     
     private Map<String, Object> createMockPluginData() {

--- a/core/src/test/java/com/alibaba/nacos/core/controller/v3/PluginControllerV3Test.java
+++ b/core/src/test/java/com/alibaba/nacos/core/controller/v3/PluginControllerV3Test.java
@@ -138,6 +138,18 @@ class PluginControllerV3Test {
     }
     
     @Test
+    void testGetPluginDetailFallsBackToPluginConfig() throws NacosApiException {
+        PluginInfo info = createPluginInfo("auth:nacos", PluginType.AUTH, "nacos");
+        info.setConfig(Collections.singletonMap("legacy", "value"));
+        when(unifiedPluginManager.getPlugin("auth:nacos")).thenReturn(Optional.of(info));
+        when(unifiedPluginManager.resolvePluginConfig(info)).thenReturn(null);
+        
+        Result<PluginDetailVO> result = pluginControllerV3.getPluginDetail("auth", "nacos");
+        
+        assertEquals("value", result.getData().getConfig().get("legacy"));
+    }
+    
+    @Test
     void testGetPluginDetailNotFound() {
         when(unifiedPluginManager.getPlugin("auth:missing")).thenReturn(Optional.empty());
         

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.api.plugin.ConfigItemEffectMode;
 import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.core.plugin.config.PluginConfigResolution;
+import com.alibaba.nacos.core.plugin.config.PluginConfigService;
 import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
 import com.alibaba.nacos.core.plugin.model.PluginInfo;
 import com.alibaba.nacos.core.plugin.storage.PluginStatePersistenceService;
@@ -56,7 +57,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -400,6 +403,46 @@ class PluginManagerTest {
     }
     
     @Test
+    void updatePluginConfigLocalOnlyMapsValidationFailure() {
+        TestConfigurablePlugin plugin = new TestConfigurablePlugin();
+        registerConfigurablePlugin("trace", "test", plugin);
+        PluginInfo pluginInfo = manager.getPlugin("trace:test").get();
+        Map<String, String> config = Collections.singletonMap("key", "value");
+        PluginConfigService configService = mock(PluginConfigService.class);
+        ReflectionTestUtils.setField(manager, "pluginConfigService", configService);
+        when(configService.prepareRuntimeUpdate(pluginInfo, config,
+            PluginConfigSourceType.LOCAL_ONLY)).thenReturn(config);
+        doThrow(new IllegalArgumentException("invalid config")).when(configService)
+            .updateLocalOnlyConfig(pluginInfo, plugin, config);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> manager.updatePluginConfig("trace:test", config, true));
+        
+        assertEquals(NacosException.INVALID_PARAM, exception.getErrCode());
+        assertTrue(exception.getErrMsg().contains("invalid config"));
+    }
+    
+    @Test
+    void updatePluginConfigLocalOnlyMapsUnexpectedFailure() {
+        TestConfigurablePlugin plugin = new TestConfigurablePlugin();
+        registerConfigurablePlugin("trace", "test", plugin);
+        PluginInfo pluginInfo = manager.getPlugin("trace:test").get();
+        Map<String, String> config = Collections.singletonMap("key", "value");
+        PluginConfigService configService = mock(PluginConfigService.class);
+        ReflectionTestUtils.setField(manager, "pluginConfigService", configService);
+        when(configService.prepareRuntimeUpdate(pluginInfo, config,
+            PluginConfigSourceType.LOCAL_ONLY)).thenReturn(config);
+        doThrow(new IllegalStateException("unexpected")).when(configService)
+            .updateLocalOnlyConfig(pluginInfo, plugin, config);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> manager.updatePluginConfig("trace:test", config, true));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        assertTrue(exception.getErrMsg().contains("Failed to apply local-only plugin config"));
+    }
+    
+    @Test
     void updatePluginConfigNormalizesStandardKeyTest() throws NacosApiException {
         TestConfigurablePlugin plugin = new TestConfigurablePlugin();
         ConfigItemDefinition requiredDef = new ConfigItemDefinition();
@@ -531,6 +574,18 @@ class PluginManagerTest {
         manager.applyConfigChange("trace:test", config);
         
         assertEquals("v", plugin.getCurrentConfig().get("k"));
+        verify(persistence).saveConfig("trace:test", config);
+    }
+    
+    @Test
+    void restoreConfigChangeDirectTest() {
+        TestConfigurablePlugin plugin = new TestConfigurablePlugin();
+        registerConfigurablePlugin("trace", "test", plugin);
+        Map<String, String> config = Collections.singletonMap("k", "restored");
+        
+        manager.restoreConfigChange("trace:test", config);
+        
+        assertEquals("restored", plugin.getCurrentConfig().get("k"));
         verify(persistence).saveConfig("trace:test", config);
     }
     

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigBasicCheckerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigBasicCheckerTest.java
@@ -95,7 +95,9 @@ class PluginConfigBasicCheckerTest {
         ConfigItemDefinition mode = definition("mode", ConfigItemType.ENUM,
             ConfigItemEffectMode.RUNTIME);
         mode.setEnumValues(Arrays.asList("A", "B"));
-        PluginInfo pluginInfo = pluginInfo(required, number, bool, mode);
+        ConfigItemDefinition blank = definition(" ", ConfigItemType.STRING,
+            ConfigItemEffectMode.RUNTIME);
+        PluginInfo pluginInfo = pluginInfo(blank, required, number, bool, mode);
         
         assertThrows(IllegalArgumentException.class,
             () -> checker.validateEffectiveConfig(pluginInfo, Collections.emptyMap()));

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigKeyResolverTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigKeyResolverTest.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.core.plugin.model.PluginInfo;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -46,6 +47,18 @@ class PluginConfigKeyResolverTest {
         assertEquals("nacos.plugin.trace.demo.timeout", candidate.getStandardKey());
         assertEquals("nacos.legacy.timeout", candidate.getAliasKeys().get(0));
         assertEquals("nacos.plugin.trace.demo.oldTimeout", candidate.getAliasKeys().get(1));
+    }
+    
+    @Test
+    void testResolveIgnoresBlankAliases() {
+        ConfigItemDefinition definition = new ConfigItemDefinition();
+        definition.setKey("timeout");
+        definition.setAliases(Arrays.asList(null, " ", "oldTimeout"));
+        
+        PluginConfigKeyCandidate candidate = resolver.resolve(createPluginInfo(), definition);
+        
+        assertEquals(Collections.singletonList("nacos.plugin.trace.demo.oldTimeout"),
+            candidate.getAliasKeys());
     }
     
     @Test
@@ -162,6 +175,31 @@ class PluginConfigKeyResolverTest {
         assertTrue(exception.getMessage().contains("Ambiguous plugin config key"));
         assertTrue(exception.getMessage().contains("timeout"));
         assertTrue(exception.getMessage().contains("retry"));
+    }
+    
+    @Test
+    void testNormalizeConfigIgnoresBlankDefinitionsAndAliases() {
+        ConfigItemDefinition blankDefinition = new ConfigItemDefinition();
+        blankDefinition.setKey(" ");
+        ConfigItemDefinition timeoutDefinition = new ConfigItemDefinition();
+        timeoutDefinition.setKey("timeout");
+        timeoutDefinition.setAliases(null);
+        ConfigItemDefinition retryDefinition = new ConfigItemDefinition();
+        retryDefinition.setKey("retry");
+        retryDefinition.setAliases(Arrays.asList(" ", "oldRetry"));
+        PluginInfo pluginInfo = createPluginInfo();
+        pluginInfo.setConfigDefinitions(
+            Arrays.asList(blankDefinition, timeoutDefinition, retryDefinition));
+        
+        Map<String, String> input = new LinkedHashMap<>();
+        input.put("timeout", "1000");
+        input.put("oldRetry", "3");
+        
+        Map<String, String> result = resolver.normalizeConfig(pluginInfo, input);
+        
+        assertEquals("1000", result.get("timeout"));
+        assertEquals("3", result.get("retry"));
+        assertEquals(2, result.size());
     }
     
     private PluginInfo createPluginInfo() {

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigResolverTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigResolverTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -171,6 +172,42 @@ class PluginConfigResolverTest {
                 Collections.emptyMap()));
         
         assertTrue(exception.getMessage().contains("not updatable"));
+    }
+    
+    @Test
+    void testResolveWithoutDefinitionsUsesPluginConfig() {
+        PluginInfo pluginInfo = createPluginInfo(null);
+        pluginInfo.setConfigDefinitions(null);
+        pluginInfo.setConfig(Collections.singletonMap("legacy", "value"));
+        
+        PluginConfigResolution resolution = resolver.resolve(pluginInfo, false);
+        
+        assertEquals("value", resolution.getConfig().get("legacy"));
+        assertTrue(resolution.getValueMetas().isEmpty());
+        assertTrue(resolver.getConfig(PluginConfigSourceType.DEFAULT, pluginInfo).isEmpty());
+    }
+    
+    @Test
+    void testResolveSkipsBlankDefinition() {
+        ConfigItemDefinition blankDefinition = createDefinition(" ", null, false);
+        ConfigItemDefinition timeoutDefinition = createDefinition("timeout", "1000", false);
+        PluginInfo pluginInfo = createPluginInfo(timeoutDefinition);
+        pluginInfo.setConfigDefinitions(Arrays.asList(blankDefinition, timeoutDefinition));
+        
+        PluginConfigResolution resolution = resolver.resolve(pluginInfo, false);
+        
+        assertEquals(Collections.singletonMap("timeout", "1000"), resolution.getConfig());
+        assertEquals(1, resolution.getValueMetas().size());
+    }
+    
+    @Test
+    void testGetConfigRejectsUnknownSource() {
+        PluginInfo pluginInfo = createPluginInfo(createDefinition("timeout", "1000", false));
+        
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> resolver.getConfig(null, pluginInfo));
+        
+        assertTrue(exception.getMessage().contains("source not found"));
     }
     
     private void assertMeta(PluginConfigValueMeta meta, String key,

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigServiceTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigServiceTest.java
@@ -109,6 +109,19 @@ class PluginConfigServiceTest {
     }
     
     @Test
+    void initializePluginConfigWrapsValidationFailure() {
+        ConfigItemDefinition definition = runtimeDefinition("required", null);
+        definition.setRequired(true);
+        PluginInfo pluginInfo = pluginInfo(definition);
+        RecordingPlugin plugin = new RecordingPlugin(pluginInfo.getConfigDefinitions());
+        
+        PluginConfigApplyException exception = assertThrows(PluginConfigApplyException.class,
+            () -> service.initializePluginConfig(pluginInfo, plugin));
+        
+        assertTrue(exception.getMessage().contains("Failed to initialize plugin config"));
+    }
+    
+    @Test
     void runtimeUpdatePersistsCanonicalMapAndEmptyMapFallsBack() {
         ConfigItemDefinition definition = runtimeDefinition("endpoint", "default");
         PluginInfo pluginInfo = pluginInfo(definition);
@@ -246,6 +259,28 @@ class PluginConfigServiceTest {
         assertEquals("restored", plugin.getCurrentConfig().get("endpoint"));
         verify(persistence).saveConfig(PLUGIN_ID,
             Collections.singletonMap("endpoint", "restored"));
+    }
+    
+    @Test
+    void applyRuntimePersistedConfigWithoutLocalPluginPersistsInput() {
+        Map<String, String> config = Collections.singletonMap("legacy", "value");
+        
+        service.applyRuntimePersistedConfig(PLUGIN_ID, null, null, config);
+        service.applyRuntimePersistedConfig(PLUGIN_ID, null, null, null);
+        
+        verify(persistence).saveConfig(PLUGIN_ID, config);
+        verify(persistence).saveConfig(PLUGIN_ID, Collections.emptyMap());
+    }
+    
+    @Test
+    void prepareRuntimeUpdateRejectsReadOnlySource() {
+        PluginInfo pluginInfo = pluginInfo(runtimeDefinition("endpoint", "default"));
+        
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> service.prepareRuntimeUpdate(pluginInfo, Collections.emptyMap(),
+                PluginConfigSourceType.STATIC));
+        
+        assertTrue(exception.getMessage().contains("not runtime updatable"));
     }
     
     private PluginInfo pluginInfo(ConfigItemDefinition definition) {

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigSourceResolverTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigSourceResolverTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin.config;
+
+import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
+import com.alibaba.nacos.core.plugin.model.PluginInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PluginConfigSourceResolverTest {
+    
+    @Test
+    void testReadOnlySourceRejectsUpdate() {
+        PluginConfigSourceResolver resolver = new PluginConfigSourceResolver() {
+            
+            @Override
+            public Map<String, String> getConfig(PluginInfo pluginInfo) {
+                return Collections.emptyMap();
+            }
+            
+            @Override
+            public PluginConfigSourceType getSourceType() {
+                return PluginConfigSourceType.STATIC;
+            }
+        };
+        
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+            () -> resolver.updateConfig("trace:demo", Collections.emptyMap()));
+        
+        assertFalse(resolver.isUpdatable());
+        assertTrue(exception.getMessage().contains("STATIC"));
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/config/StaticPluginConfigSourceResolverTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/config/StaticPluginConfigSourceResolverTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin.config;
+
+import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
+import com.alibaba.nacos.api.plugin.PluginType;
+import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
+import com.alibaba.nacos.core.plugin.model.PluginInfo;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StaticPluginConfigSourceResolverTest {
+    
+    private final StaticPluginConfigSourceResolver resolver =
+        new StaticPluginConfigSourceResolver();
+    
+    private ConfigurableEnvironment cachedEnvironment;
+    
+    private MockEnvironment environment;
+    
+    @BeforeEach
+    void setUp() {
+        cachedEnvironment = EnvUtil.getEnvironment();
+        environment = new MockEnvironment();
+        EnvUtil.setEnvironment(environment);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(cachedEnvironment);
+    }
+    
+    @Test
+    void testGetConfigWithoutEnvironment() {
+        EnvUtil.setEnvironment(null);
+        
+        assertTrue(resolver.getConfig(createPluginInfo(Collections.emptyList())).isEmpty());
+        assertEquals(PluginConfigSourceType.STATIC, resolver.getSourceType());
+    }
+    
+    @Test
+    void testGetConfigSkipsBlankDefinitionAndUsesFirstConfiguredAlias() {
+        ConfigItemDefinition blankDefinition = new ConfigItemDefinition();
+        blankDefinition.setKey(" ");
+        ConfigItemDefinition definition = new ConfigItemDefinition();
+        definition.setKey("token");
+        definition.setAliases(Arrays.asList("nacos.legacy.missing", "nacos.legacy.first",
+            "nacos.legacy.second"));
+        environment.setProperty("nacos.legacy.first", "first-value");
+        environment.setProperty("nacos.legacy.second", "second-value");
+        
+        Map<String, String> config =
+            resolver.getConfig(createPluginInfo(Arrays.asList(blankDefinition, definition)));
+        
+        assertEquals(Collections.singletonMap("token", "first-value"), config);
+    }
+    
+    private PluginInfo createPluginInfo(List<ConfigItemDefinition> definitions) {
+        PluginInfo pluginInfo = new PluginInfo();
+        pluginInfo.setPluginId("trace:demo");
+        pluginInfo.setPluginType(PluginType.TRACE);
+        pluginInfo.setPluginName("demo");
+        pluginInfo.setConfigDefinitions(definitions);
+        return pluginInfo;
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/monitor/NamingDynamicMeterRefreshServiceTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/monitor/NamingDynamicMeterRefreshServiceTest.java
@@ -16,75 +16,82 @@
 
 package com.alibaba.nacos.naming.monitor;
 
+import com.alibaba.nacos.common.utils.Pair;
 import com.alibaba.nacos.core.monitor.NacosMeterRegistryCenter;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.misc.UtilsAndCommons;
-import com.alibaba.nacos.sys.env.EnvUtil;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.mock.env.MockEnvironment;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.ref.Reference;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NamingDynamicMeterRefreshServiceTest {
     
     private final NamingDynamicMeterRefreshService refreshService =
         new NamingDynamicMeterRefreshService();
     
-    private ConfigurableEnvironment cachedEnvironment;
+    private CompositeMeterRegistry meterRegistry;
     
     private SimpleMeterRegistry simpleMeterRegistry;
     
     @BeforeEach
     void setUp() {
-        cachedEnvironment = EnvUtil.getEnvironment();
-        EnvUtil.setEnvironment(new MockEnvironment());
+        meterRegistry = NacosMeterRegistryCenter.getMeterRegistry(
+            NacosMeterRegistryCenter.TOPN_SERVICE_CHANGE_REGISTRY);
+        meterRegistry.clear();
         simpleMeterRegistry = new SimpleMeterRegistry();
-        NacosMeterRegistryCenter.getMeterRegistry(
-            NacosMeterRegistryCenter.TOPN_SERVICE_CHANGE_REGISTRY).add(simpleMeterRegistry);
-        MetricsMonitor.getServiceChangeCount().reset();
-        NacosMeterRegistryCenter.clear(NacosMeterRegistryCenter.TOPN_SERVICE_CHANGE_REGISTRY);
+        meterRegistry.add(simpleMeterRegistry);
     }
     
     @AfterEach
     void tearDown() {
-        MetricsMonitor.getServiceChangeCount().reset();
-        NacosMeterRegistryCenter.clear(NacosMeterRegistryCenter.TOPN_SERVICE_CHANGE_REGISTRY);
-        EnvUtil.setEnvironment(cachedEnvironment);
+        meterRegistry.clear();
+        meterRegistry.remove(simpleMeterRegistry);
     }
     
     @Test
     void testRefreshTopnServiceChangeCountRegistersGauge() {
         Service service = Service.newService("namespace", "group", "service");
-        MetricsMonitor.getServiceChangeCount().set(service, 7);
+        String serviceKey = "namespace" + UtilsAndCommons.NAMESPACE_SERVICE_CONNECTOR
+            + service.getGroupedServiceName();
+        // Micrometer gauges weakly reference their backing number.
+        AtomicInteger serviceChangeCount = new AtomicInteger(7);
+        ServiceTopNCounter counter = Mockito.mock(ServiceTopNCounter.class);
+        Mockito.when(counter.getCounterOfTopN(10))
+            .thenReturn(Collections.singletonList(Pair.with(serviceKey, serviceChangeCount)));
+        try (MockedStatic<MetricsMonitor> metricsMonitor =
+            Mockito.mockStatic(MetricsMonitor.class)) {
+            metricsMonitor.when(MetricsMonitor::getServiceChangeCount).thenReturn(counter);
+            refreshService.refreshTopnServiceChangeCount();
+        }
         
-        refreshService.refreshTopnServiceChangeCount();
-        
-        CompositeMeterRegistry registry = NacosMeterRegistryCenter.getMeterRegistry(
-            NacosMeterRegistryCenter.TOPN_SERVICE_CHANGE_REGISTRY);
-        Gauge gauge = registry.find("service_change_count")
-            .tag("service",
-                "namespace" + UtilsAndCommons.NAMESPACE_SERVICE_CONNECTOR
-                    + service.getGroupedServiceName())
+        Gauge gauge = simpleMeterRegistry.find("service_change_count")
+            .tag("service", serviceKey)
             .gauge();
         assertNotNull(gauge);
         assertEquals(7D, gauge.value());
+        Reference.reachabilityFence(serviceChangeCount);
     }
     
     @Test
     void testResetTopnServiceChangeCountClearsCounter() {
-        MetricsMonitor.getServiceChangeCount()
-            .set(Service.newService("namespace", "group", "service"), 3);
-        
-        refreshService.resetTopnServiceChangeCount();
-        
-        assertTrue(MetricsMonitor.getServiceChangeCount().getCounterOfTopN(10).isEmpty());
+        ServiceTopNCounter counter = Mockito.mock(ServiceTopNCounter.class);
+        try (MockedStatic<MetricsMonitor> metricsMonitor =
+            Mockito.mockStatic(MetricsMonitor.class)) {
+            metricsMonitor.when(MetricsMonitor::getServiceChangeCount).thenReturn(counter);
+            refreshService.resetTopnServiceChangeCount();
+        }
+        Mockito.verify(counter).reset();
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/utils/ServiceUtilTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/utils/ServiceUtilTest.java
@@ -26,10 +26,9 @@ import com.alibaba.nacos.naming.pojo.Subscriber;
 import com.alibaba.nacos.naming.selector.SelectorManager;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.springframework.context.ConfigurableApplicationContext;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,11 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ServiceUtilTest {
-    
-    @AfterEach
-    void tearDown() {
-        ApplicationUtils.injectContext(null);
-    }
     
     @Test
     void testConstructor() {
@@ -159,19 +153,20 @@ class ServiceUtilTest {
         ServiceMetadata serviceMetadata = new ServiceMetadata();
         serviceMetadata.setProtectThreshold(0.6F);
         SelectorManager selectorManager = Mockito.mock(SelectorManager.class);
-        ConfigurableApplicationContext context = Mockito.mock(ConfigurableApplicationContext.class);
-        ApplicationUtils.injectContext(context);
-        Mockito.when(context.getBean(SelectorManager.class)).thenReturn(selectorManager);
         Mockito.when(selectorManager.select(Mockito.any(), Mockito.eq("2.2.2.2"),
             Mockito.anyList())).thenAnswer(invocation -> invocation.getArgument(2));
-        
-        ServiceInfo result =
-            ServiceUtil.selectInstancesWithHealthyProtection(serviceInfo, serviceMetadata,
-                "clusterA", false, false, "2.2.2.2");
-        
-        assertTrue(result.isReachProtectionThreshold());
-        assertEquals(2, result.getHosts().size());
-        assertTrue(result.getHosts().stream().allMatch(Instance::isHealthy));
+        try (MockedStatic<ApplicationUtils> applicationUtils =
+            Mockito.mockStatic(ApplicationUtils.class)) {
+            applicationUtils.when(() -> ApplicationUtils.getBean(SelectorManager.class))
+                .thenReturn(selectorManager);
+            ServiceInfo result =
+                ServiceUtil.selectInstancesWithHealthyProtection(serviceInfo, serviceMetadata,
+                    "clusterA", false, false, "2.2.2.2");
+            
+            assertTrue(result.isReachProtectionThreshold());
+            assertEquals(2, result.getHosts().size());
+            assertTrue(result.getHosts().stream().allMatch(Instance::isHealthy));
+        }
     }
     
     @Test
@@ -183,18 +178,19 @@ class ServiceUtilTest {
         ServiceMetadata serviceMetadata = new ServiceMetadata();
         serviceMetadata.setProtectThreshold(-1F);
         SelectorManager selectorManager = Mockito.mock(SelectorManager.class);
-        ConfigurableApplicationContext context = Mockito.mock(ConfigurableApplicationContext.class);
-        ApplicationUtils.injectContext(context);
-        Mockito.when(context.getBean(SelectorManager.class)).thenReturn(selectorManager);
         Mockito.when(selectorManager.select(Mockito.any(), Mockito.eq("2.2.2.2"),
             Mockito.anyList())).thenReturn(Arrays.asList(healthy, unhealthy));
-        
-        ServiceInfo result =
-            ServiceUtil.selectInstancesWithHealthyProtection(serviceInfo, serviceMetadata,
-                "clusterA", false, false, "2.2.2.2");
-        
-        assertFalse(result.isReachProtectionThreshold());
-        assertEquals(Arrays.asList(healthy, unhealthy), result.getHosts());
+        try (MockedStatic<ApplicationUtils> applicationUtils =
+            Mockito.mockStatic(ApplicationUtils.class)) {
+            applicationUtils.when(() -> ApplicationUtils.getBean(SelectorManager.class))
+                .thenReturn(selectorManager);
+            ServiceInfo result =
+                ServiceUtil.selectInstancesWithHealthyProtection(serviceInfo, serviceMetadata,
+                    "clusterA", false, false, "2.2.2.2");
+            
+            assertFalse(result.isReachProtectionThreshold());
+            assertEquals(Arrays.asList(healthy, unhealthy), result.getHosts());
+        }
     }
     
     private ServiceInfo serviceInfo(Instance... instances) {


### PR DESCRIPTION
## What is the purpose of the change

Improve unit test coverage for the plugin configuration refactoring introduced by #15479, #15485, and #15496 before continuing with plugin-family integration.

## Brief changelog

- Cover plugin config key normalization, source resolution, validation, initialization, runtime update, and error mapping boundaries.
- Cover static/default/read-only source behavior and alias fallback handling.
- Cover Admin/Console detail fallback and remote model compatibility branches.
- Bring all newly introduced plugin configuration classes and all refactoring-added lines to 100% line coverage.

## Verifying this change

- `mvn -B -pl core,console clean test -DtrimStackTrace=false`
  - core: 1451 tests, 0 failures, 0 errors
  - console: 780 tests, 0 failures, 0 errors
- `mvn -B -pl core,console spotless:check`
- Verified the fresh JaCoCo reports for the affected plugin configuration classes and changed lines.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit tests to verify the behavior.
* [x] Run the affected module tests and formatting checks.