### PR TITLE
[ISSUE #12323] Sync logback packagingData config for v2.x

### DIFF
--- a/logger-adapter-impl/logback-adapter-12/src/main/resources/nacos-logback12.xml
+++ b/logger-adapter-impl/logback-adapter-12/src/main/resources/nacos-logback12.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<configuration debug="false" scan="false"  packagingData="true">
+<configuration debug="false" scan="false"  packagingData="${nacos.logback.packagingData:-false}">
     <nacosClientProperty scope="context" name="logPath" source="JM.LOG.PATH" defaultValue="${user.home}/logs"/>
     <nacosClientProperty scope="context" name="logRetainCount" source="JM.LOG.RETAIN.COUNT" defaultValue="7"/>
     <nacosClientProperty scope="context" name="logFileSize" source="JM.LOG.FILE.SIZE" defaultValue="10MB"/>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <p3c-pmd.version>1.3.0</p3c-pmd.version>
 
         <!-- dependency version -->
-        <nacos.logback.adapter.version>1.1.4</nacos.logback.adapter.version>
+        <nacos.logback.adapter.version>1.1.5</nacos.logback.adapter.version>
         <spring-boot-dependencies.version>2.7.18</spring-boot-dependencies.version>
         <servlet-api.version>3.0</servlet-api.version>
         <commons-io.version>2.14.0</commons-io.version>


### PR DESCRIPTION
What is the purpose of the change

Backport #15327 to v2.x-develop for the 2.5.3 release. The develop-side change has moved to the 3.2.3 line, and v2.x still keeps Logback packagingData always enabled.

Brief changelog

- Sync logback-adapter-12 packagingData default behavior with nacos-group/logback-adapter#17.
- Make packagingData configurable through nacos.logback.packagingData with default false.
- Upgrade external logback-adapter dependency version to 1.1.5.

Verifying this change

- git diff --check -- logger-adapter-impl/logback-adapter-12/src/main/resources/nacos-logback12.xml pom.xml
- env JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_411.jdk/Contents/Home PATH=/Library/Java/JavaVirtualMachines/jdk1.8.0_411.jdk/Contents/Home/bin:/Users/xiweng.yy/apache-maven-3.9.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin mvn -pl logger-adapter-impl/logback-adapter-12 -am test