### PR TITLE
ci: pin apache/rocketmq-test-tool to a full commit SHA

### DIFF
--- a/.github/workflows/pr-e2e-test.yml
+++ b/.github/workflows/pr-e2e-test.yml
@@ -145,7 +145,7 @@ jobs:
           else
             echo "DOCKER_REPO_ACTUAL=${{ env.DOCKER_REPO_B }}" >> $GITHUB_ENV
           fi
-      - uses: apache/rocketmq-test-tool@java-dev
+      - uses: apache/rocketmq-test-tool@8089a997c62018d98cd00694442e6fd8354bd4ef # pins java-dev
         name: Deploy nacos
         with:
           yamlString: |
@@ -204,7 +204,7 @@ jobs:
             echo "CODE_PATH=java/auth" >> $GITHUB_ENV
             echo ${{ matrix.mode }}-nacos-${{ github.run_id }}-${{ strategy.job-index }}
           fi
-      - uses: apache/rocketmq-test-tool@java-dev
+      - uses: apache/rocketmq-test-tool@8089a997c62018d98cd00694442e6fd8354bd4ef # pins java-dev
         name: java e2e test
         with:
           yamlString: |
@@ -254,7 +254,7 @@ jobs:
         mode: ["cluster","standalone"]
         version: ${{ fromJSON(needs.docker.outputs.version-json) }}
     steps:
-      - uses: apache/rocketmq-test-tool@java-dev
+      - uses: apache/rocketmq-test-tool@8089a997c62018d98cd00694442e6fd8354bd4ef # pins java-dev
         name: go e2e test
         with:
           yamlString: |
@@ -305,7 +305,7 @@ jobs:
         mode: ["cluster","standalone"]
         version: ${{ fromJSON(needs.docker.outputs.version-json) }}
     steps:
-      - uses: apache/rocketmq-test-tool@java-dev
+      - uses: apache/rocketmq-test-tool@8089a997c62018d98cd00694442e6fd8354bd4ef # pins java-dev
         name: cpp e2e test
         with:
           yamlString: |
@@ -360,7 +360,7 @@ jobs:
         mode: ["cluster","standalone"]
         version: ${{ fromJSON(needs.docker.outputs.version-json) }}
     steps:
-      - uses: apache/rocketmq-test-tool@java-dev
+      - uses: apache/rocketmq-test-tool@8089a997c62018d98cd00694442e6fd8354bd4ef # pins java-dev
         name: csharp e2e test
         with:
           yamlString: |
@@ -413,7 +413,7 @@ jobs:
         mode: ["cluster","standalone"]
         version: ${{ fromJSON(needs.docker.outputs.version-json) }}
     steps:
-      - uses: apache/rocketmq-test-tool@java-dev
+      - uses: apache/rocketmq-test-tool@8089a997c62018d98cd00694442e6fd8354bd4ef # pins java-dev
         name: nodejs e2e test
         with:
           yamlString: |
@@ -464,7 +464,7 @@ jobs:
         mode: ["cluster","standalone"]
         version: ${{ fromJSON(needs.docker.outputs.version-json) }}
     steps:
-      - uses: apache/rocketmq-test-tool@java-dev
+      - uses: apache/rocketmq-test-tool@8089a997c62018d98cd00694442e6fd8354bd4ef # pins java-dev
         name: python e2e test
         with:
           yamlString: |
@@ -518,7 +518,7 @@ jobs:
         mode: ["cluster","standalone","standalone_auth"]
         version: ${{ fromJSON(needs.docker.outputs.version-json) }}
     steps:
-      - uses: apache/rocketmq-test-tool@java-dev
+      - uses: apache/rocketmq-test-tool@8089a997c62018d98cd00694442e6fd8354bd4ef # pins java-dev
         name: clean
         with:
           yamlString: |


### PR DESCRIPTION
## What
Pin `apache/rocketmq-test-tool` in `pr-e2e-test.yml` from the mutable `@java-dev` branch to the commit it currently resolves to (all 8 usages).

## Why
The e2e jobs run with repository/registry secrets in scope, and this third-party action is referenced by `@java-dev` — a moving development branch, so the exact code that runs alongside those secrets can change at any time without any change in this repository. Pinning to a full commit SHA means a change to that branch can't run in the credentialed jobs until someone consciously bumps the pin and reviews it. Behaviour is unchanged (`8089a99` is the current tip of `java-dev`).

I used AI assistance to help identify this and draft the change; I verified every line against the live workflow myself and take responsibility for it.