### PR TITLE
Upgrade Central Publishing Maven Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <ojdbc.version>19.7.0.0</ojdbc.version>
 
         <!-- Maven Central Portal -->
-        <central.publishing.maven.version>0.7.0</central.publishing.maven.version>
+        <central.publishing.maven.version>0.11.0</central.publishing.maven.version>
 
         <!-- Override micrometer version for Spring Boot 3.5.x compatibility,
              see https://github.com/alibaba/nacos/issues/15033 -->


### PR DESCRIPTION
## What is the purpose of the change

Upgrade the Central Publishing Maven Plugin from 0.7.0 to 0.11.0 so Maven Central publish responses containing the new warnings field can be parsed successfully.

## Brief changelog

- Upgrade central-publishing-maven-plugin to 0.11.0.

## Verifying this change

- mvn -N -DskipTests validate

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.