### PR TITLE
[ISSUE #15468] Route duplicate-key classification through the datasource dialect SPI

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImpl.java
@@ -49,6 +49,8 @@ import com.alibaba.nacos.plugin.datasource.constants.CommonConstant;
 import com.alibaba.nacos.plugin.datasource.constants.ContextConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
+import com.alibaba.nacos.plugin.datasource.dialect.DatabaseDialect;
+import com.alibaba.nacos.plugin.datasource.manager.DatabaseDialectManager;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigTagsRelationMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
@@ -310,6 +312,13 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
     }
     
     private boolean isDuplicateKeyException(Throwable exception) {
+        DatabaseDialect dialect = resolveDatabaseDialect();
+        if (dialect != null) {
+            return dialect.isDuplicateKeyException(exception);
+        }
+        // Fallback when no dialect can be resolved (for example before datasource plugins are
+        // loaded): keep the database-agnostic Spring DuplicateKeyException classification, which is
+        // exactly what the active dialect applies as its default behavior.
         Throwable cause = exception;
         while (cause != null) {
             if (cause instanceof DuplicateKeyException) {
@@ -318,6 +327,28 @@ public class ExternalConfigInfoPersistServiceImpl implements ConfigInfoPersistSe
             cause = cause.getCause();
         }
         return false;
+    }
+    
+    /**
+     * Resolve the active datasource dialect for duplicate-key classification.
+     *
+     * <p>All duplicate-key judgement is delegated to {@link DatabaseDialect#isDuplicateKeyException},
+     * whose default already recognizes Spring {@link DuplicateKeyException} and which vendor dialects
+     * may extend with driver-specific detection. Returns {@code null} when no dialect can be resolved
+     * (for example before datasource plugins are loaded), so the caller falls back to the
+     * database-agnostic Spring classification.
+     *
+     * @return the active dialect, or {@code null} when it cannot be resolved
+     */
+    DatabaseDialect resolveDatabaseDialect() {
+        try {
+            return DatabaseDialectManager.getInstance()
+                .getDialect(dataSourceService.getDataSourceType());
+        } catch (IllegalStateException stateException) {
+            LogUtil.DEFAULT_LOG.warn("[duplicate-key] cannot resolve datasource dialect, fallback "
+                + "to spring-standard classification, msg: {}", stateException.getMessage());
+            return null;
+        }
     }
     
     @Override

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/extrnal/ExternalConfigInfoPersistServiceImplTest.java
@@ -36,6 +36,8 @@ import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.plugin.datasource.MapperManager;
 import com.alibaba.nacos.plugin.datasource.constants.TableConstant;
+import com.alibaba.nacos.plugin.datasource.dialect.DatabaseDialect;
+import com.alibaba.nacos.plugin.datasource.manager.DatabaseDialectManager;
 import com.alibaba.nacos.plugin.datasource.mapper.ConfigInfoMapper;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -411,6 +413,64 @@ class ExternalConfigInfoPersistServiceImplTest {
         
         assertEquals(exception, thrown);
         verifyConfigInfoNotUpdated();
+    }
+    
+    @Test
+    void testInsertOrUpdateUpdatesWhenDialectClassifiesDuplicateKey() {
+        DatabaseDialect dialect = Mockito.mock(DatabaseDialect.class);
+        Mockito.when(dialect.isDuplicateKeyException(any(Throwable.class))).thenReturn(true);
+        DatabaseDialectManager manager = Mockito.mock(DatabaseDialectManager.class);
+        Mockito.when(manager.getDialect(anyString())).thenReturn(dialect);
+        try (MockedStatic<DatabaseDialectManager> managerStatic =
+            Mockito.mockStatic(DatabaseDialectManager.class)) {
+            managerStatic.when(DatabaseDialectManager::getInstance).thenReturn(manager);
+            // Spring translates this vendor unique conflict to BadSqlGrammarException, not
+            // DuplicateKeyException, so only the dialect classification can recognize it.
+            SQLException vendorDuplicate =
+                new SQLException("duplicate key value violates unique constraint", "23505");
+            BadSqlGrammarException exception =
+                new BadSqlGrammarException("insert", "sql", vendorDuplicate);
+            ConfigOperateResult result = insertOrUpdateAfterInsertException(exception);
+            
+            assertTrue(result.isSuccess());
+            assertEquals(100L, result.getId());
+            verifyConfigInfoUpdated();
+        }
+    }
+    
+    @Test
+    void testInsertOrUpdateCasReturnsFalseWhenDialectClassifiesDuplicateKey() {
+        DatabaseDialect dialect = Mockito.mock(DatabaseDialect.class);
+        Mockito.when(dialect.isDuplicateKeyException(any(Throwable.class))).thenReturn(true);
+        DatabaseDialectManager manager = Mockito.mock(DatabaseDialectManager.class);
+        Mockito.when(manager.getDialect(anyString())).thenReturn(dialect);
+        try (MockedStatic<DatabaseDialectManager> managerStatic =
+            Mockito.mockStatic(DatabaseDialectManager.class)) {
+            managerStatic.when(DatabaseDialectManager::getInstance).thenReturn(manager);
+            SQLException vendorDuplicate =
+                new SQLException("duplicate key value violates unique constraint", "23505");
+            BadSqlGrammarException exception =
+                new BadSqlGrammarException("insert", "sql", vendorDuplicate);
+            ConfigOperateResult result = insertOrUpdateCasAfterInsertException(exception);
+            
+            assertFalse(result.isSuccess());
+            verifyConfigInfoNotUpdated();
+        }
+    }
+    
+    @Test
+    void testDialectDefaultRecognizesSpringDuplicateKeyException() {
+        // The DatabaseDialect default classifies a Spring DuplicateKeyException (matched by class
+        // name in the plugin module) anywhere in the cause chain, while a raw vendor SQLState that
+        // Spring could not translate is left for vendor dialects to opt into.
+        DatabaseDialect dialect = Mockito.mock(DatabaseDialect.class, Mockito.CALLS_REAL_METHODS);
+        assertTrue(dialect.isDuplicateKeyException(new DuplicateKeyException("duplicate")));
+        assertTrue(dialect.isDuplicateKeyException(
+            new DataIntegrityViolationException("wrapped",
+                new DuplicateKeyException("duplicate"))));
+        assertFalse(dialect.isDuplicateKeyException(new DataIntegrityViolationException("plain")));
+        assertFalse(dialect.isDuplicateKeyException(new BadSqlGrammarException("insert", "sql",
+            new SQLException("duplicate key value violates unique constraint", "23505"))));
     }
     
     @Test

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-base/src/test/java/com/alibaba/nacos/plugin/datasource/impl/dialect/AbstractDatabaseDialectTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-base/src/test/java/com/alibaba/nacos/plugin/datasource/impl/dialect/AbstractDatabaseDialectTest.java
@@ -19,8 +19,11 @@ package com.alibaba.nacos.plugin.datasource.impl.dialect;
 import com.alibaba.nacos.plugin.datasource.constants.PrimaryKeyConstant;
 import org.junit.jupiter.api.Test;
 
+import java.sql.SQLException;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class AbstractDatabaseDialectTest {
     
@@ -38,6 +41,19 @@ class AbstractDatabaseDialectTest {
             dialect.getReturnPrimaryKeys());
         assertEquals("test", dialect.getType());
         assertEquals("NOW()", dialect.getFunction("NOW()"));
+    }
+    
+    @Test
+    void testDefaultIsDuplicateKeyExceptionRejectsNonSpringExceptions() {
+        assertFalse(dialect.isDuplicateKeyException(new RuntimeException("boom")));
+        // The default only recognizes a Spring DuplicateKeyException in the cause chain. It must
+        // not classify a raw SQLState 23505 as duplicate on its own; vendor dialects opt in to
+        // SQLState-based classification by overriding this method. Spring is intentionally not on
+        // this module's classpath, so the Spring-positive path is verified in the config module.
+        assertFalse(dialect.isDuplicateKeyException(
+            new SQLException("duplicate key value violates unique constraint", "23505")));
+        assertFalse(dialect.isDuplicateKeyException(
+            new RuntimeException("outer", new SQLException("dup", "23505"))));
     }
     
     private static class TestDatabaseDialect extends AbstractDatabaseDialect {

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/dialect/DatabaseDialect.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/dialect/DatabaseDialect.java
@@ -23,6 +23,12 @@ package com.alibaba.nacos.plugin.datasource.dialect;
 public interface DatabaseDialect {
     
     /**
+     * Fully-qualified name of Spring's {@code DuplicateKeyException}. Matched by name rather than
+     * type so that the datasource plugin modules keep their Spring-free dependency footprint.
+     */
+    String SPRING_DUPLICATE_KEY_EXCEPTION = "org.springframework.dao.DuplicateKeyException";
+    
+    /**
      * get database type.
      * @return return database type name
      */
@@ -90,4 +96,36 @@ public interface DatabaseDialect {
      * @return function
      */
     String getFunction(String functionName);
+    
+    /**
+     * Judge whether the given throwable represents a duplicate unique-key conflict for this dialect.
+     *
+     * <p>The default implementation walks the throwable cause chain and reports a duplicate when it
+     * finds Spring's {@code DuplicateKeyException} (matched by class name, so the plugin modules
+     * stay free of a Spring dependency). This mirrors the database-agnostic classification that the
+     * config persistence layer relied on before, and deliberately does not treat a raw vendor
+     * SQLState such as {@code 23505} as a duplicate on its own.
+     *
+     * <p>Specific dialects such as PostgreSQL, MySQL, Derby, or Oracle may override this to also
+     * inspect the original driver exception (SQLState or vendor error code) when the standard Spring
+     * exception translation is not precise enough, typically combining their check with a call to
+     * this default via {@code DatabaseDialect.super.isDuplicateKeyException(throwable)}.
+     *
+     * @param throwable throwable thrown by a datasource operation, may be a wrapped exception
+     * @return {@code true} if the throwable represents a duplicate unique-key conflict
+     */
+    default boolean isDuplicateKeyException(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            Class<?> type = cause.getClass();
+            while (type != null) {
+                if (SPRING_DUPLICATE_KEY_EXCEPTION.equals(type.getName())) {
+                    return true;
+                }
+                type = type.getSuperclass();
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
 }

--- a/specs/en/plugin/datasource-dialect-plugin-spec.md
+++ b/specs/en/plugin/datasource-dialect-plugin-spec.md
@@ -72,6 +72,23 @@ Dialect implementations provide `DatabaseDialect`.
 | `getPageLastNum(page, pageSize)` | Return second pagination parameter. |
 | `getReturnPrimaryKeys()` | Return generated key columns. |
 | `getFunction(functionName)` | Map logical function names to dialect SQL functions. |
+| `isDuplicateKeyException(throwable)` | Classify whether a datasource throwable is a duplicate unique-key conflict. The default recognizes a Spring `DuplicateKeyException` in the cause chain; dialects may override for driver-specific detection. |
+
+`isDuplicateKeyException(throwable)` is the single entry point config repositories
+use to decide whether a failed insert was a duplicate unique-key conflict. The
+default implementation walks the throwable cause chain and returns `true` when it
+finds Spring's `DuplicateKeyException`, matched by class name so the datasource
+plugin modules stay free of a Spring dependency. This reproduces the previous
+database-agnostic classification as the safe baseline and deliberately does not
+treat a raw vendor SQLState such as `23505` as a duplicate on its own.
+
+Dialects such as PostgreSQL, MySQL, Derby, or Oracle may override this to also
+inspect the original driver exception (SQLState or vendor error code) when the
+standard Spring exception translation is not precise enough, typically combining
+their check with a call to the default via
+`DatabaseDialect.super.isDuplicateKeyException(throwable)`. Classification must
+remain conservative — non-duplicate integrity failures must not be reported as
+duplicates.
 
 Table mapper plugins implement `com.alibaba.nacos.plugin.datasource.mapper.Mapper`
 for table-specific SQL. Dialect and mapper implementations must be packaged and

--- a/specs/zh-cn/plugin/datasource-dialect-plugin-spec.md
+++ b/specs/zh-cn/plugin/datasource-dialect-plugin-spec.md
@@ -64,6 +64,17 @@ dialect 和另一个数据库的 mapper 是无效行为。
 | `getPageLastNum(page, pageSize)` | 返回第二个分页参数。 |
 | `getReturnPrimaryKeys()` | 返回生成主键列。 |
 | `getFunction(functionName)` | 将逻辑函数名映射到方言 SQL 函数。 |
+| `isDuplicateKeyException(throwable)` | 判定数据源抛出的异常是否为唯一键重复冲突。默认识别异常因果链中的 Spring `DuplicateKeyException`，方言可重写以实现驱动级别的判定。 |
+
+`isDuplicateKeyException(throwable)` 是 config 仓储判断插入失败是否为唯一键重复冲突的
+统一入口。默认实现会遍历异常因果链，当发现 Spring 的 `DuplicateKeyException` 时返回
+`true`，并通过类名匹配以保证数据源插件模块不引入 Spring 依赖。这复现了此前与数据库无关
+的分类作为安全基线，并刻意不将裸的厂商 SQLState（如 `23505`）本身当作重复。
+
+PostgreSQL、MySQL、Derby、Oracle 等方言可以重写该方法，在标准 Spring 异常转换不够精确
+时进一步检查原始驱动异常（SQLState 或厂商错误码），通常会通过
+`DatabaseDialect.super.isDuplicateKeyException(throwable)` 调用默认实现并与自身判定组合。
+分类必须保持保守——非重复的完整性约束失败不得被误报为重复。
 
 表级 mapper 插件实现 `com.alibaba.nacos.plugin.datasource.mapper.Mapper`，用于提供具体表的
 SQL。一个数据库族的方言和 mapper 实现必须一起打包和加载。


### PR DESCRIPTION
## What is the purpose of the change

Resolves #15468. Make the datasource dialect SPI the single entry point for classifying duplicate unique-key conflicts, following the direction agreed with @KomachiSion in the issue. This removes the hardcoded Spring `DuplicateKeyException` translation from the config persistence layer and gives vendor dialects a clean place to add driver-specific detection (for example a PostgreSQL `SQLState 23505` that Spring's generic translation cannot classify).

## Brief changelog

- `DatabaseDialect#isDuplicateKeyException(Throwable)` default now walks the throwable cause chain and recognizes Spring's `DuplicateKeyException`, matched by class name so the datasource plugin modules keep their Spring-free dependency footprint. A raw vendor `SQLState` such as `23505` is deliberately **not** treated as a duplicate on its own, preserving the `#15465` rethrow contract.
- `ExternalConfigInfoPersistServiceImpl` now delegates all duplicate-key judgement to the active dialect, and only falls back to the inline Spring `DuplicateKeyException` check when no dialect can be resolved (e.g. before datasource plugins are loaded).
- Vendor dialects (PostgreSQL/MySQL/Derby/Oracle) may override the SPI default to additionally inspect the original driver exception, typically combining their check with `DatabaseDialect.super.isDuplicateKeyException(throwable)`.
- Updated the datasource dialect plugin spec (`specs/en` + `specs/zh-cn`).

## Verifying this change

- `AbstractDatabaseDialectTest` (plugin-base, Spring-free): the default rejects `RuntimeException` and a raw `SQLState 23505`, wrapped or not.
- `ExternalConfigInfoPersistServiceImplTest` (config, 93 tests): the dialect default recognizes a wrapped Spring `DuplicateKeyException`; the persist service delegates to the dialect; and the `#15465` rethrow contract for a `BadSqlGrammarException` wrapping `SQLState 23505` is preserved.
- Local checks all pass on the affected modules: `spotless:check`, `checkstyle:check`, `spotbugs:check`, `apache-rat:check`.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (#15468).
* [x] Format the pull request title like `[ISSUE #15468] ...`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist.
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` / module checks to make sure basic checks pass.