### PR TITLE
[ISSUE #11780] Preserve console list pagination state

### DIFF
--- a/console-ui-next/src/lib/__tests__/list-navigation.test.ts
+++ b/console-ui-next/src/lib/__tests__/list-navigation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildConfigDetailPath,
+  buildConfigListPathFromDetail,
+  buildServiceDetailPath,
+  buildServiceListPathFromDetail,
+} from '../list-navigation';
+
+describe('list navigation state', () => {
+  it('preserves config list pagination when opening and returning from detail', () => {
+    const detailPath = buildConfigDetailPath('a.yaml', 'DEFAULT_GROUP', 'public', {
+      dataId: 'a',
+      groupName: 'DEFAULT',
+      appName: 'console',
+      searchMode: 'accurate',
+      pageNo: 3,
+      pageSize: 20,
+    });
+
+    const detailParams = new URLSearchParams(detailPath.split('?')[1]);
+
+    expect(detailParams.get('dataId')).toBe('a.yaml');
+    expect(detailParams.get('listPageNo')).toBe('3');
+    expect(detailParams.get('listPageSize')).toBe('20');
+    expect(buildConfigListPathFromDetail(detailParams)).toBe(
+      '/configurationManagement?dataId=a&groupName=DEFAULT&appName=console&searchMode=accurate&pageNo=3&pageSize=20'
+    );
+  });
+
+  it('preserves service list pagination when opening and returning from detail', () => {
+    const detailPath = buildServiceDetailPath('svc', 'DEFAULT_GROUP', 'public', {
+      serviceNameParam: 'svc',
+      groupNameParam: 'DEFAULT',
+      ignoreEmptyService: false,
+      pageNo: 4,
+      pageSize: 50,
+    });
+
+    const detailParams = new URLSearchParams(detailPath.split('?')[1]);
+
+    expect(detailParams.get('serviceName')).toBe('svc');
+    expect(detailParams.get('listPageNo')).toBe('4');
+    expect(detailParams.get('listPageSize')).toBe('50');
+    expect(buildServiceListPathFromDetail(detailParams, 'public')).toBe(
+      '/serviceManagement?namespace=public&serviceNameParam=svc&groupNameParam=DEFAULT&ignoreEmptyService=false&pageNo=4&pageSize=50'
+    );
+  });
+});

--- a/console-ui-next/src/lib/list-navigation.ts
+++ b/console-ui-next/src/lib/list-navigation.ts
@@ -1,0 +1,103 @@
+type ConfigListState = {
+  dataId?: string;
+  groupName?: string;
+  appName?: string;
+  searchMode?: string;
+  pageNo?: number;
+  pageSize?: number;
+};
+
+type ServiceListState = {
+  serviceNameParam?: string;
+  groupNameParam?: string;
+  ignoreEmptyService?: boolean;
+  pageNo?: number;
+  pageSize?: number;
+};
+
+const setOptional = (params: URLSearchParams, key: string, value?: string | null) => {
+  if (value) {
+    params.set(key, value);
+  }
+};
+
+const setNonDefaultNumber = (
+  params: URLSearchParams,
+  key: string,
+  value: number | undefined,
+  defaultValue: number
+) => {
+  if (value && value !== defaultValue) {
+    params.set(key, String(value));
+  }
+};
+
+export const appendConfigListState = (params: URLSearchParams, state: ConfigListState) => {
+  setOptional(params, 'listDataId', state.dataId);
+  setOptional(params, 'listGroupName', state.groupName);
+  setOptional(params, 'listAppName', state.appName);
+  if (state.searchMode && state.searchMode !== 'blur') {
+    params.set('listSearchMode', state.searchMode);
+  }
+  setNonDefaultNumber(params, 'listPageNo', state.pageNo, 1);
+  setNonDefaultNumber(params, 'listPageSize', state.pageSize, 10);
+};
+
+export const appendServiceListState = (params: URLSearchParams, state: ServiceListState) => {
+  setOptional(params, 'listServiceNameParam', state.serviceNameParam);
+  setOptional(params, 'listGroupNameParam', state.groupNameParam);
+  if (state.ignoreEmptyService === false) {
+    params.set('listIgnoreEmptyService', 'false');
+  }
+  setNonDefaultNumber(params, 'listPageNo', state.pageNo, 1);
+  setNonDefaultNumber(params, 'listPageSize', state.pageSize, 10);
+};
+
+export const buildConfigDetailPath = (
+  dataId: string,
+  group: string,
+  namespace: string,
+  state: ConfigListState
+) => {
+  const params = new URLSearchParams({ dataId, group, namespace });
+  appendConfigListState(params, state);
+  return `/configdetail?${params.toString()}`;
+};
+
+export const buildServiceDetailPath = (
+  serviceName: string,
+  groupName: string,
+  namespace: string,
+  state: ServiceListState
+) => {
+  const params = new URLSearchParams({ serviceName, groupName, namespace });
+  appendServiceListState(params, state);
+  return `/serviceDetail?${params.toString()}`;
+};
+
+export const buildConfigListPathFromDetail = (searchParams: URLSearchParams) => {
+  const params = new URLSearchParams();
+  setOptional(params, 'dataId', searchParams.get('listDataId'));
+  setOptional(params, 'groupName', searchParams.get('listGroupName'));
+  setOptional(params, 'appName', searchParams.get('listAppName'));
+  setOptional(params, 'searchMode', searchParams.get('listSearchMode'));
+  setOptional(params, 'pageNo', searchParams.get('listPageNo'));
+  setOptional(params, 'pageSize', searchParams.get('listPageSize'));
+  const query = params.toString();
+  return query ? `/configurationManagement?${query}` : '/configurationManagement';
+};
+
+export const buildServiceListPathFromDetail = (
+  searchParams: URLSearchParams,
+  namespaceId: string
+) => {
+  const params = new URLSearchParams();
+  setOptional(params, 'namespace', namespaceId);
+  setOptional(params, 'serviceNameParam', searchParams.get('listServiceNameParam'));
+  setOptional(params, 'groupNameParam', searchParams.get('listGroupNameParam'));
+  setOptional(params, 'ignoreEmptyService', searchParams.get('listIgnoreEmptyService'));
+  setOptional(params, 'pageNo', searchParams.get('listPageNo'));
+  setOptional(params, 'pageSize', searchParams.get('listPageSize'));
+  const query = params.toString();
+  return query ? `/serviceManagement?${query}` : '/serviceManagement';
+};

--- a/console-ui-next/src/pages/configdetail/index.tsx
+++ b/console-ui-next/src/pages/configdetail/index.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, Pencil, History, Trash2, Copy, Check, Clock, FileText, Hash,
 
 import { useConfigStore } from '@/stores/config-store';
 import { configApi } from '@/api/config';
+import { buildConfigListPathFromDetail } from '@/lib/list-navigation';
 import { MonacoEditor } from '@/components/config/MonacoEditor';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -51,7 +52,7 @@ export default function ConfigDetailPage() {
   }, [dataId, group, namespace, fetchConfig, clearCurrentConfig]);
 
   const handleBack = () => {
-    navigate('/configurationManagement');
+    navigate(buildConfigListPathFromDetail(searchParams));
   };
 
   const handleEdit = () => {

--- a/console-ui-next/src/pages/configurationManagement/index.tsx
+++ b/console-ui-next/src/pages/configurationManagement/index.tsx
@@ -18,6 +18,7 @@ import {
   updateCloneItemField,
 } from './clone-items';
 import type { CloneItemField } from './clone-items';
+import { buildConfigDetailPath } from '@/lib/list-navigation';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -200,8 +201,15 @@ export default function ConfigurationManagementPage() {
     }
   };
 
-  const handleDetail = (dataId: string, groupName: string) => {
-    navigate(`/configdetail?dataId=${encodeURIComponent(dataId)}&group=${encodeURIComponent(groupName)}&namespace=${encodeURIComponent(currentNamespace)}`);
+  const handleDetail = (targetDataId: string, targetGroupName: string) => {
+    navigate(buildConfigDetailPath(targetDataId, targetGroupName, currentNamespace, {
+      dataId,
+      groupName,
+      appName,
+      searchMode,
+      pageNo,
+      pageSize,
+    }));
   };
 
   const handleEdit = (dataId: string, groupName: string) => {

--- a/console-ui-next/src/pages/serviceDetail/__tests__/namespace-routing.test.ts
+++ b/console-ui-next/src/pages/serviceDetail/__tests__/namespace-routing.test.ts
@@ -22,6 +22,7 @@ const SERVICE_STORE_SOURCE = fs.readFileSync(
 
 describe('Naming namespace routing', () => {
   it('carries the current namespace when opening service detail and subscriber pages', () => {
+    expect(MANAGEMENT_SOURCE).toContain('buildServiceDetailPath(svc.name, svc.groupName, currentNamespace');
     expect(MANAGEMENT_SOURCE).toContain('&namespace=${encodeURIComponent(currentNamespace)}');
   });
 
@@ -32,7 +33,7 @@ describe('Naming namespace routing', () => {
   });
 
   it('keeps service detail back navigation inside the active namespace', () => {
-    expect(DETAIL_SOURCE).toContain('getServiceManagementPath(activeNamespace)');
+    expect(DETAIL_SOURCE).toContain('buildServiceListPathFromDetail(searchParams, activeNamespace)');
   });
 
   it('guards namespace switching while a service detail dialog is open', () => {

--- a/console-ui-next/src/pages/serviceDetail/index.tsx
+++ b/console-ui-next/src/pages/serviceDetail/index.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, Pencil, ChevronLeft, ChevronRight, Server, Hash, Shield, Tog
 import { serviceApi } from '@/api/service';
 import { useServiceStore } from '@/stores/service-store';
 import { useNamespaceStore } from '@/stores/namespace-store';
+import { buildServiceListPathFromDetail } from '@/lib/list-navigation';
 import type { Instance, InstanceListResponse, ClusterInfo, ServiceDetailInfo } from '@/types/service';
 import { patchInstance, removeInstance, type InstancesByCluster } from './instance-state';
 
@@ -41,15 +42,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-
-const getServiceManagementPath = (namespaceId: string) => {
-  const params = new URLSearchParams();
-  if (namespaceId) {
-    params.set('namespace', namespaceId);
-  }
-  const query = params.toString();
-  return query ? `/serviceManagement?${query}` : '/serviceManagement';
-};
 
 export default function ServiceDetailPage() {
   const { t } = useTranslation();
@@ -469,7 +461,7 @@ export default function ServiceDetailPage() {
   if (!currentService) {
     return (
       <div className="flex flex-col gap-4">
-        <Button variant="ghost" onClick={() => navigate(getServiceManagementPath(activeNamespace))} className="gap-2 w-fit">
+        <Button variant="ghost" onClick={() => navigate(buildServiceListPathFromDetail(searchParams, activeNamespace))} className="gap-2 w-fit">
           <ArrowLeft className="h-4 w-4" />
           {t('common.back')}
         </Button>
@@ -486,7 +478,7 @@ export default function ServiceDetailPage() {
     <div className="flex flex-col gap-4">
       {/* Back + Title */}
       <div className="flex items-center gap-4">
-        <Button variant="ghost" size="sm" onClick={() => navigate(getServiceManagementPath(activeNamespace))}>
+        <Button variant="ghost" size="sm" onClick={() => navigate(buildServiceListPathFromDetail(searchParams, activeNamespace))}>
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <h1 className="text-2xl font-semibold text-foreground">{serviceName}</h1>

--- a/console-ui-next/src/pages/serviceManagement/index.tsx
+++ b/console-ui-next/src/pages/serviceManagement/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import { Plus, Search, RotateCcw, ChevronLeft, ChevronRight } from 'lucide-react';
@@ -7,6 +7,7 @@ import { Plus, Search, RotateCcw, ChevronLeft, ChevronRight } from 'lucide-react
 import { serviceApi } from '@/api/service';
 import { useServiceStore } from '@/stores/service-store';
 import { useNamespaceStore } from '@/stores/namespace-store';
+import { buildServiceDetailPath } from '@/lib/list-navigation';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -43,6 +44,7 @@ import { Textarea } from '@/components/ui/textarea';
 export default function ServiceManagementPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [urlSearchParams, setUrlSearchParams] = useSearchParams();
   const { currentNamespace } = useNamespaceStore();
 
   const {
@@ -85,6 +87,43 @@ export default function ServiceManagementPage() {
     metadata: '',
   });
   const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    const urlServiceName = urlSearchParams.get('serviceNameParam') || '';
+    const urlGroupName = urlSearchParams.get('groupNameParam') || '';
+    const urlIgnoreEmptyService = urlSearchParams.get('ignoreEmptyService') !== 'false';
+    const urlPageNo = parseInt(urlSearchParams.get('pageNo') || '1', 10);
+    const urlPageSize = parseInt(urlSearchParams.get('pageSize') || '10', 10);
+
+    setLocalServiceName(urlServiceName);
+    setLocalGroupName(urlGroupName);
+    setSearchParams({
+      serviceNameParam: urlServiceName,
+      groupNameParam: urlGroupName,
+      ignoreEmptyService: urlIgnoreEmptyService,
+    });
+    setPage(urlPageNo, urlPageSize);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (currentNamespace) params.set('namespace', currentNamespace);
+    if (serviceNameParam) params.set('serviceNameParam', serviceNameParam);
+    if (groupNameParam) params.set('groupNameParam', groupNameParam);
+    if (!ignoreEmptyService) params.set('ignoreEmptyService', 'false');
+    if (pageNo !== 1) params.set('pageNo', pageNo.toString());
+    if (pageSize !== 10) params.set('pageSize', pageSize.toString());
+    setUrlSearchParams(params, { replace: true });
+  }, [
+    currentNamespace,
+    groupNameParam,
+    ignoreEmptyService,
+    pageNo,
+    pageSize,
+    serviceNameParam,
+    setUrlSearchParams,
+  ]);
 
   const loadServices = useCallback(() => {
     fetchServices(currentNamespace);
@@ -318,7 +357,13 @@ export default function ServiceManagementPage() {
                           variant="ghost"
                           size="sm"
                           onClick={() =>
-                            navigate(`/serviceDetail?serviceName=${encodeURIComponent(svc.name)}&groupName=${encodeURIComponent(svc.groupName)}&namespace=${encodeURIComponent(currentNamespace)}`)
+                            navigate(buildServiceDetailPath(svc.name, svc.groupName, currentNamespace, {
+                              serviceNameParam,
+                              groupNameParam,
+                              ignoreEmptyService,
+                              pageNo,
+                              pageSize,
+                            }))
                           }
                         >
                           {t('common.detail')}


### PR DESCRIPTION
## What is the purpose of the change

Fixes #11780.

Preserve console list query and pagination state when users open a config/service detail page and then navigate back to the list page.

## Brief changelog

- Preserve configuration list filters, page number, and page size when opening config detail.
- Restore configuration list state when returning from config detail.
- Sync service list filters and pagination state with URL query parameters.
- Preserve service list filters, page number, and page size when opening service detail.
- Restore service list state when returning from service detail.
- Add regression tests for list navigation state preservation.

## Verifying this change

- `npm test -- --run src/lib/__tests__/list-navigation.test.ts src/pages/serviceDetail/__tests__/namespace-routing.test.ts`
- `.\node_modules\.bin\tsc.cmd -b`
- `git diff --check`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.