### PR TITLE
[ISSUE #15468] Recognize PostgreSQL unique_violation in the datasource dialect duplicate-key hook

### DIFF
--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dialect/PostgresqlDatabaseDialect.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/main/java/com/alibaba/nacos/plugin/datasource/impl/dialect/PostgresqlDatabaseDialect.java
@@ -19,6 +19,8 @@ package com.alibaba.nacos.plugin.datasource.impl.dialect;
 import com.alibaba.nacos.plugin.datasource.constants.DatabaseTypeConstant;
 import com.alibaba.nacos.plugin.datasource.impl.enums.postgresql.TrustedPostgresqlFunctionEnum;
 
+import java.sql.SQLException;
+
 /**
  * PostgreSQL database dialect.
  *
@@ -26,9 +28,32 @@ import com.alibaba.nacos.plugin.datasource.impl.enums.postgresql.TrustedPostgres
  */
 public class PostgresqlDatabaseDialect extends AbstractDatabaseDialect {
     
+    /**
+     * PostgreSQL SQLState for {@code unique_violation}. The driver raises it when an insert breaks
+     * a unique or primary key constraint, even in cases where Spring's exception translation cannot
+     * classify the failure as a {@code DuplicateKeyException}.
+     */
+    private static final String UNIQUE_VIOLATION_SQL_STATE = "23505";
+    
     @Override
     public String getType() {
         return DatabaseTypeConstant.POSTGRESQL;
+    }
+    
+    @Override
+    public boolean isDuplicateKeyException(Throwable throwable) {
+        if (super.isDuplicateKeyException(throwable)) {
+            return true;
+        }
+        Throwable cause = throwable;
+        while (cause != null) {
+            if (cause instanceof SQLException
+                && UNIQUE_VIOLATION_SQL_STATE.equals(((SQLException) cause).getSQLState())) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
     
     @Override

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/dialect/PostgresqlDatabaseDialectTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-postgresql/src/test/java/com/alibaba/nacos/plugin/datasource/impl/dialect/PostgresqlDatabaseDialectTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.datasource.impl.dialect;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostgresqlDatabaseDialectTest {
+    
+    private final PostgresqlDatabaseDialect dialect = new PostgresqlDatabaseDialect();
+    
+    @Test
+    void testIsDuplicateKeyExceptionForUniqueViolationSqlState() {
+        assertTrue(dialect.isDuplicateKeyException(
+            new SQLException("duplicate key value violates unique constraint", "23505")));
+    }
+    
+    @Test
+    void testIsDuplicateKeyExceptionForWrappedUniqueViolationSqlState() {
+        // The unique_violation may be wrapped by the driver or the persistence layer, so the
+        // classification must walk the cause chain rather than only inspect the top throwable.
+        assertTrue(dialect.isDuplicateKeyException(
+            new RuntimeException("wrapped", new SQLException("duplicate", "23505"))));
+    }
+    
+    @Test
+    void testIsDuplicateKeyExceptionFalseForOtherSqlState() {
+        // A different SQLState (for example syntax_error) is not a duplicate-key conflict.
+        assertFalse(dialect.isDuplicateKeyException(new SQLException("syntax error", "42601")));
+    }
+    
+    @Test
+    void testIsDuplicateKeyExceptionFalseForNonSqlException() {
+        assertFalse(dialect.isDuplicateKeyException(new RuntimeException("boom")));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Follow-up requested by @KomachiSion on #15509: now that `DatabaseDialect#isDuplicateKeyException` exists as the single duplicate-key classification entry point, add the PostgreSQL dialect override so the `postgresql` plugin can recognize a `unique_violation` (`SQLState 23505`) that Spring's database-agnostic exception translation cannot classify as a `DuplicateKeyException` (it may surface as a `BadSqlGrammarException`). This closes the PostgreSQL duplicate-key gap discussed in #15278 / #15465.

## Brief changelog

- `PostgresqlDatabaseDialect#isDuplicateKeyException(Throwable)` overrides the SPI default: it first delegates to the default (Spring `DuplicateKeyException` detection), then walks the throwable cause chain for a `SQLException` whose `SQLState` is `23505` (`unique_violation`).
- No dependency on the PostgreSQL JDBC driver classes — detection is by standard `SQLState`, so the plugin keeps its existing dependency footprint.
- Other SQLStates and non-`SQLException` throwables remain non-duplicates, so the classification stays conservative.

## Verifying this change

- New `PostgresqlDatabaseDialectTest` covers: `unique_violation` (`23505`), a wrapped `unique_violation` in the cause chain, a different SQLState (`42601`, not a duplicate), and a non-SQL throwable (not a duplicate).
- Local checks pass on the affected module: `spotless:check`, `checkstyle:check`, `spotbugs:check`, `apache-rat:check`; unit tests green.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (#15468; this is the follow-up @KomachiSion requested on #15509).
* [x] Format the pull request title like `[ISSUE #15468] ...`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction.
* [x] Run the module checks (`spotless`, `checkstyle`, `spotbugs`, `apache-rat`) to make sure basic checks pass.