### PR TITLE
[ISSUE #15475] Align trace and visibility plugin lifecycle

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/trace/NacosCombinedTraceSubscriber.java
+++ b/core/src/main/java/com/alibaba/nacos/core/trace/NacosCombinedTraceSubscriber.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.core.trace;
 
+import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
+import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.common.notify.Event;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.notify.listener.SmartSubscriber;
@@ -43,8 +45,8 @@ public class NacosCombinedTraceSubscriber extends SmartSubscriber {
     public NacosCombinedTraceSubscriber(Class<? extends TraceEvent> combinedEvent) {
         this.interestedEvents = new ConcurrentHashMap<>();
         TraceEventPublisherFactory.getInstance().addPublisherEvent(combinedEvent);
-        for (NacosTraceSubscriber each : NacosTracePluginManager.getInstance()
-            .getAllTraceSubscribers()) {
+        for (NacosTraceSubscriber each : NacosTracePluginManager.getInstance().getAllPlugins()
+            .values()) {
             filterInterestedEvents(each, combinedEvent);
         }
         NotifyCenter.registerSubscriber(this, TraceEventPublisherFactory.getInstance());
@@ -78,6 +80,10 @@ public class NacosCombinedTraceSubscriber extends SmartSubscriber {
         }
         TraceEvent traceEvent = (TraceEvent) event;
         for (NacosTraceSubscriber each : subscribers) {
+            if (!PluginStateCheckerHolder.isPluginEnabled(PluginType.TRACE.getType(),
+                each.getName())) {
+                continue;
+            }
             if (null != each.executor()) {
                 each.executor().execute(() -> onEvent0(each, traceEvent));
             } else {

--- a/core/src/test/java/com/alibaba/nacos/core/trace/NacosCombinedTraceSubscriberTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/trace/NacosCombinedTraceSubscriberTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.core.trace;
 
+import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.common.notify.Event;
 import com.alibaba.nacos.common.trace.DeregisterInstanceReason;
 import com.alibaba.nacos.common.trace.event.TraceEvent;
@@ -44,6 +45,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -78,6 +80,7 @@ class NacosCombinedTraceSubscriberTest {
     
     @BeforeEach
     void setUp() throws Exception {
+        PluginStateCheckerHolder.setInstance(null);
         Map<String, NacosTraceSubscriber> traceSubscribers = getTraceSubscribers();
         traceSubscribers.put("instanceSubscriber", mockInstanceSubscriber);
         traceSubscribers.put("serviceSubscriber", mockServiceSubscriber);
@@ -112,6 +115,7 @@ class NacosCombinedTraceSubscriberTest {
         traceSubscribers.remove("instanceSubscriber");
         traceSubscribers.remove("otherSubscriber");
         combinedTraceSubscriber.shutdown();
+        PluginStateCheckerHolder.setInstance(null);
     }
     
     @Test
@@ -224,6 +228,36 @@ class NacosCombinedTraceSubscriberTest {
         RegisterInstanceTraceEvent event =
             new RegisterInstanceTraceEvent(1L, "", true, "", "", "", "", 1);
         combinedTraceSubscriber.onEvent(event);
+        verify(mockInstanceSubscriber).onEvent(event);
+    }
+    
+    @Test
+    void testOnEventSkipsSubscriberDisabledAfterConstruction() {
+        when(mockInstanceSubscriber.getName()).thenReturn("instanceSubscriber");
+        PluginStateCheckerHolder.setInstance(
+            (pluginType, pluginName) -> !"instanceSubscriber".equals(pluginName));
+        RegisterInstanceTraceEvent event =
+            new RegisterInstanceTraceEvent(1L, "", true, "", "", "", "", 1);
+        
+        combinedTraceSubscriber.onEvent(event);
+        
+        verify(mockInstanceSubscriber, never()).onEvent(event);
+    }
+    
+    @Test
+    void testOnEventDispatchesSubscriberEnabledAfterConstruction() {
+        combinedTraceSubscriber.shutdown();
+        when(mockInstanceSubscriber.getName()).thenReturn("instanceSubscriber");
+        AtomicBoolean enabled = new AtomicBoolean(false);
+        PluginStateCheckerHolder.setInstance(
+            (pluginType, pluginName) -> !"instanceSubscriber".equals(pluginName) || enabled.get());
+        combinedTraceSubscriber = new NacosCombinedTraceSubscriber(NamingTraceEvent.class);
+        enabled.set(true);
+        RegisterInstanceTraceEvent event =
+            new RegisterInstanceTraceEvent(1L, "", true, "", "", "", "", 1);
+        
+        combinedTraceSubscriber.onEvent(event);
+        
         verify(mockInstanceSubscriber).onEvent(event);
     }
 }

--- a/plugin/visibility/src/main/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManager.java
+++ b/plugin/visibility/src/main/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManager.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.visibility.spi;
 
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.common.utils.StringUtils;
@@ -97,14 +98,23 @@ public class VisibilityPluginManager {
                 service.getClass());
             return;
         }
-        Properties serviceProperties = resolveServiceProperties(allProperties, serviceName);
-        try {
-            service.init(serviceProperties);
-        } catch (Throwable ex) {
-            LOGGER.warn(
-                "[VisibilityPluginManager] Initialize VisibilityService({}:{}) failed, skip.",
-                service.getClass(), serviceName, ex);
-            return;
+        if (!(service instanceof PluginConfigSpec)) {
+            Properties serviceProperties = resolveServiceProperties(allProperties, serviceName);
+            if (!serviceProperties.isEmpty()) {
+                LOGGER.warn(
+                    "[VisibilityPluginManager] VisibilityService({}:{}) uses deprecated "
+                        + "init(Properties) configuration. Implement PluginConfigSpec to use "
+                        + "unified plugin configuration.",
+                    service.getClass(), serviceName);
+            }
+            try {
+                service.init(serviceProperties);
+            } catch (Throwable ex) {
+                LOGGER.warn(
+                    "[VisibilityPluginManager] Initialize VisibilityService({}:{}) failed, skip.",
+                    service.getClass(), serviceName, ex);
+                return;
+            }
         }
         visibilityServiceMap.put(serviceName, service);
         LOGGER.info("[VisibilityPluginManager] Loaded VisibilityService({}:{}) successfully.",

--- a/plugin/visibility/src/main/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityService.java
+++ b/plugin/visibility/src/main/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityService.java
@@ -33,10 +33,15 @@ public interface VisibilityService {
      * Initialize service with external properties.
      *
      * <p>Property source is managed by {@link VisibilityPluginManager}. Default no-op keeps backward compatibility
-     * for existing SPI implementations.</p>
+     * for existing SPI implementations. The manager does not invoke this callback when the service implements
+     * {@link com.alibaba.nacos.api.plugin.PluginConfigSpec}; those services are initialized through unified plugin
+     * configuration.</p>
      *
      * @param properties service-specific properties
+     * @deprecated implement {@link com.alibaba.nacos.api.plugin.PluginConfigSpec} and use its unified configuration
+     * lifecycle instead
      */
+    @Deprecated
     default void init(Properties properties) {
     }
     

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManagerTest.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManagerTest.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.plugin.visibility.spi;
 
+import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.plugin.visibility.model.VisibilityQueryContext;
 import com.alibaba.nacos.plugin.visibility.model.VisibilityResource;
@@ -29,6 +31,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -126,6 +130,18 @@ class VisibilityPluginManagerTest {
         assertFalse(service.initProperties.containsKey("nacos.plugin.visibility.custom.timeout"));
         assertFalse(serviceMap.containsKey(""));
         assertFalse(serviceMap.containsKey("throw-init"));
+    }
+    
+    @Test
+    void testRegisterConfigurableVisibilityServiceSkipsLegacyInit() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("nacos.plugin.visibility.configurable.timeout", "1000");
+        ConfigurableVisibilityService service = new ConfigurableVisibilityService();
+        
+        registerVisibilityService(service, properties);
+        
+        assertEquals(service, serviceMap.get("configurable"));
+        assertFalse(service.legacyInitCalled);
     }
     
     @Test
@@ -256,6 +272,35 @@ class VisibilityPluginManagerTest {
         @Override
         public void init(Properties properties) {
             throw new IllegalStateException("init failed");
+        }
+    }
+    
+    private static class ConfigurableVisibilityService extends TestVisibilityService
+        implements PluginConfigSpec {
+        
+        private boolean legacyInitCalled;
+        
+        private ConfigurableVisibilityService() {
+            super("configurable");
+        }
+        
+        @Override
+        public void init(Properties properties) {
+            legacyInitCalled = true;
+        }
+        
+        @Override
+        public List<ConfigItemDefinition> getConfigDefinitions() {
+            return Collections.emptyList();
+        }
+        
+        @Override
+        public void applyConfig(Map<String, String> config) {
+        }
+        
+        @Override
+        public Map<String, String> getCurrentConfig() {
+            return Collections.emptyMap();
         }
     }
 }

--- a/specs/en/auth/visibility-plugin-spec.md
+++ b/specs/en/auth/visibility-plugin-spec.md
@@ -64,7 +64,7 @@ A visibility plugin implements `VisibilityService`.
 | Method | Requirement |
 |--------|-------------|
 | `getVisibilityServiceName()` | Return the stable plugin name. |
-| `init(properties)` | Initialize plugin-specific properties. |
+| `init(properties)` | Deprecated legacy initialization callback for implementations that do not use unified plugin configuration. |
 | `resolveDefaultScopeForCreate(identity, apiType, resourceType)` | Decide the default scope when a resource is created without an explicit scope. |
 | `validateVisibility(identity, action, apiType, resource)` | Validate visibility for one resource. |
 | `adviseQuery(identity, action, apiType, queryContext)` | Return query predicates and explicit resources for range queries. |
@@ -145,10 +145,14 @@ An external implementation may own properties under:
 nacos.plugin.visibility.{serviceName}.{itemKey}
 ```
 
-Legacy implementations receive their service-local properties once through
-`VisibilityService.init(Properties)`. Implementations that need unified source,
-metadata, masking, or update semantics should implement `PluginConfigSpec` and
-declare their own definitions.
+Legacy implementations that do not implement `PluginConfigSpec` receive their
+service-local properties once through `VisibilityService.init(Properties)`.
+Use of non-empty legacy properties emits a migration warning without logging
+configuration values. For an implementation that implements `PluginConfigSpec`,
+the visibility manager must not invoke the legacy callback; the core plugin
+manager's unified `applyConfig` lifecycle is its only configuration application
+path. Such implementations declare their own definitions and receive unified
+source, metadata, masking, and update semantics.
 
 If the selected plugin is disabled or unavailable, the current AI domain skips
 visibility filtering and single-resource visibility validation; creation falls

--- a/specs/en/plugin/trace-plugin-spec.md
+++ b/specs/en/plugin/trace-plugin-spec.md
@@ -110,6 +110,12 @@ only matching event classes to each plugin subscriber. If `executor()` returns
 remote systems, files, databases, or other slow sinks should return a dedicated
 executor.
 
+The combined subscriber records the event interests of every loaded trace
+implementation, including implementations that are disabled during startup. It
+checks unified plugin state immediately before dispatching each event. Runtime
+enable or disable changes therefore take effect without rebuilding the combined
+subscriber, and a disabled implementation receives no newly dispatched work.
+
 The trace publisher is allowed to degrade by dropping trace events under queue
 pressure, as defined by the local event degradation rules.
 

--- a/specs/zh-cn/auth/visibility-plugin-spec.md
+++ b/specs/zh-cn/auth/visibility-plugin-spec.md
@@ -58,7 +58,7 @@ NamespaceId -> resourceType -> resourceName
 | 方法 | 要求 |
 |------|------|
 | `getVisibilityServiceName()` | 返回稳定的插件名称。 |
-| `init(properties)` | 初始化插件自身属性。 |
+| `init(properties)` | 已废弃的历史初始化回调，仅供未接入统一插件配置的实现兼容使用。 |
 | `resolveDefaultScopeForCreate(identity, apiType, resourceType)` | 当创建资源未显式指定 scope 时，决定默认 scope。 |
 | `validateVisibility(identity, action, apiType, resource)` | 校验单个资源的可见性。 |
 | `adviseQuery(identity, action, apiType, queryContext)` | 为范围查询返回查询谓词和显式授权资源。 |
@@ -131,8 +131,11 @@ nacos.plugin.visibility.enabled=true
 nacos.plugin.visibility.{serviceName}.{itemKey}
 ```
 
-历史实现通过 `VisibilityService.init(Properties)` 一次性接收实现本地属性。需要统一
-source、元数据、脱敏或更新语义的实现应实现 `PluginConfigSpec` 并声明自身 definitions。
+未实现 `PluginConfigSpec` 的历史实现仍通过 `VisibilityService.init(Properties)` 一次性接收
+实现本地属性。使用非空历史属性时，服务端记录迁移告警，但不得打印配置值。对于实现了
+`PluginConfigSpec` 的实现，Visibility manager 不得再调用历史回调；核心插件管理器统一的
+`applyConfig` 生命周期是唯一配置应用入口。此类实现应声明自身 definitions，并获得统一的
+source、元数据、脱敏和更新语义。
 
 当所选插件被禁用或不可用时，当前 AI 领域会跳过可见性过滤和单资源可见性校验，创建资源时
 回退为 `PRIVATE` scope。这保持了历史关闭行为，但不能与鉴权开关混为一谈。内置实现也会在

--- a/specs/zh-cn/plugin/trace-plugin-spec.md
+++ b/specs/zh-cn/plugin/trace-plugin-spec.md
@@ -98,6 +98,10 @@ Trace 事件携带事件类型、事件时间、命名空间、分组和资源�
 订阅者。如果 `executor()` 返回 `null`，回调会在事件分发路径中执行。写远端系统、文件、
 数据库或其他慢 sink 的插件应返回专用 executor。
 
+Combined subscriber 会记录全部已加载 Trace 实现的事件兴趣，包括启动时处于 disabled 状态的
+实现；每次事件分发前再检查统一 plugin state。因此运行时启停无需重建 combined subscriber，
+disabled 实现也不会收到新分发的任务。
+
 Trace publisher 允许在队列压力下丢弃 trace event 进行降级，具体边界遵循本地事件降级规则。
 
 Trace 订阅者通过 SPI 加载。同一类型内重复名称不适合生产稳定使用，插件包应使用唯一名称。


### PR DESCRIPTION
## What is the purpose of the change

For #15475

Complete two remaining lifecycle gaps in unified plugin management:

- Trace subscribers were filtered while the combined subscriber was constructed, so a disabled subscriber could not be enabled later, while a subscriber disabled after construction could still receive events.
- Visibility services implementing `PluginConfigSpec` received both the legacy `init(Properties)` callback and the unified `applyConfig` callback.

## Brief changelog

- Retain every loaded Trace subscriber in the combined subscription table and check unified plugin state immediately before event dispatch.
- Keep legacy Visibility initialization for implementations without `PluginConfigSpec`, deprecate the callback, and emit a value-free migration warning when legacy properties are used.
- Skip legacy Visibility initialization for configurable implementations so unified `applyConfig` is their only configuration application path.
- Update the English and Chinese Trace and Visibility plugin specifications.
- Add regression tests for Trace runtime disable/re-enable and Visibility single initialization.

## Verifying this change

- `mvn -B -pl core -Dtest=NacosCombinedTraceSubscriberTest clean test`
- `mvn -B -pl plugin/visibility -Dtest=VisibilityPluginManagerTest clean test`
- `mvn -B -pl plugin/visibility test`
- `mvn -B -pl plugin/trace test`
- `mvn -B -pl core,plugin/visibility spotless:check`
- `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`

The modified production classes have 100% line coverage in the focused JaCoCo reports.

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit tests to verify the logic correction.
* [x] Run the relevant formatting, unit-test, and full static-analysis checks.
