### PR TITLE
[ISSUE #15543] Use case-sensitive collation for MySQL schema

### DIFF
--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/resources/META-INF/mysql-schema.sql
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/resources/META-INF/mysql-schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE `config_info` (
                                `encrypted_data_key` varchar(1024) NOT NULL DEFAULT '' COMMENT '密钥',
                                PRIMARY KEY (`id`),
                                UNIQUE KEY `uk_configinfo_datagrouptenant` (`data_id`,`group_id`,`tenant_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='config_info';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='config_info';
 
 /******************************************/
 /*   表名称 = config_info  since 2.5.0                */
@@ -61,7 +61,7 @@ CREATE TABLE `config_info_gray` (
                                     UNIQUE KEY `uk_configinfogray_datagrouptenantgray` (`data_id`,`group_id`,`tenant_id`,`gray_name`),
                                     KEY `idx_dataid_gmt_modified` (`data_id`,`gmt_modified`),
                                     KEY `idx_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='config_info_gray';
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='config_info_gray';
 
 /******************************************/
 /*   表名称 = config_tags_relation         */
@@ -77,7 +77,7 @@ CREATE TABLE `config_tags_relation` (
                                         PRIMARY KEY (`nid`),
                                         UNIQUE KEY `uk_configtagrelation_configidtag` (`id`,`tag_name`,`tag_type`),
                                         KEY `idx_tenant_id` (`tenant_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='config_tag_relation';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='config_tag_relation';
 
 /******************************************/
 /*   表名称 = group_capacity               */
@@ -95,7 +95,7 @@ CREATE TABLE `group_capacity` (
                                   `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
                                   PRIMARY KEY (`id`),
                                   UNIQUE KEY `uk_group_id` (`group_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='集群、各Group容量信息表';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='集群、各Group容量信息表';
 
 /******************************************/
 /*   表名称 = his_config_info              */
@@ -122,7 +122,7 @@ CREATE TABLE `his_config_info` (
                                    KEY `idx_gmt_create` (`gmt_create`),
                                    KEY `idx_gmt_modified` (`gmt_modified`),
                                    KEY `idx_did` (`data_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='多租户改造';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='多租户改造';
 
 
 /******************************************/
@@ -141,7 +141,7 @@ CREATE TABLE `tenant_capacity` (
                                    `gmt_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '修改时间',
                                    PRIMARY KEY (`id`),
                                    UNIQUE KEY `uk_tenant_id` (`tenant_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='租户容量信息表';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='租户容量信息表';
 
 
 CREATE TABLE `tenant_info` (
@@ -156,7 +156,7 @@ CREATE TABLE `tenant_info` (
                                PRIMARY KEY (`id`),
                                UNIQUE KEY `uk_tenant_info_kptenantid` (`kp`,`tenant_id`),
                                KEY `idx_tenant_id` (`tenant_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='tenant_info';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='tenant_info';
 
 CREATE TABLE `users` (
                          `username` varchar(50) NOT NULL PRIMARY KEY COMMENT 'username',
@@ -192,7 +192,7 @@ CREATE TABLE `pipeline_execution` (
     `create_time`   bigint(20)   NOT NULL COMMENT '创建时间',
     `update_time`   bigint(20)   NOT NULL COMMENT '修改时间',
     PRIMARY KEY (`execution_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源发布审核Pipeline执行记录';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='AI资源发布审核Pipeline执行记录';
 
 /******************************************/
 /*   表名称 = ai_resource                 */
@@ -219,7 +219,7 @@ CREATE TABLE `ai_resource` (
     KEY `idx_ai_resource_name` (`name`),
     KEY `idx_ai_resource_type` (`type`),
     KEY `idx_ai_resource_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源元数据表';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='AI资源元数据表';
 
 /******************************************/
 /*   表名称 = ai_resource_version         */
@@ -243,4 +243,4 @@ CREATE TABLE `ai_resource_version` (
     KEY `idx_ai_resource_ver_name` (`name`),
     KEY `idx_ai_resource_ver_status` (`status`),
     KEY `idx_ai_resource_ver_gmt_modified` (`gmt_modified`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI资源版本表';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='AI资源版本表';


### PR DESCRIPTION
## What is the purpose of the change

Fixes #15543

The MySQL schema currently uses `utf8mb4_unicode_ci` for Config, tenant, capacity, pipeline, and AI resource tables. This makes string comparisons and unique indexes case-insensitive, preventing identifiers that differ only by letter case from coexisting.

This change keeps the `utf8mb4` character set and replaces the explicitly declared `utf8mb4_unicode_ci` collations with the case-sensitive `utf8mb4_bin` collation.

The change only affects schemas used to initialize new databases. Existing database migration is out of scope.

The `users`, `roles`, and `permissions` tables remain unchanged and continue to inherit the database default collation.

## Brief changelog

- Changed 10 explicit table collations from `utf8mb4_unicode_ci` to `utf8mb4_bin`.
- Preserved the existing behavior of tables without an explicit collation.
- Made no Java or AI physical-key encoding changes.

## Verifying this change

- Ran `git diff --check`.
- Verified that the schema contains 10 explicit `utf8mb4_bin` declarations.
- Verified that no `utf8mb4_unicode_ci` declarations remain in `mysql-schema.sql`.
- No Java tests were run because this is a DDL-only change.