### PR TITLE
[ISSUE #15475] Unify plugin configuration SPI contracts

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/plugin/PluginConfigDefinitionSpec.java
+++ b/api/src/main/java/com/alibaba/nacos/api/plugin/PluginConfigDefinitionSpec.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.api.plugin;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -33,5 +34,7 @@ public interface PluginConfigDefinitionSpec {
      *
      * @return list of configuration item definitions
      */
-    List<ConfigItemDefinition> getConfigDefinitions();
+    default List<ConfigItemDefinition> getConfigDefinitions() {
+        return Collections.emptyList();
+    }
 }

--- a/api/src/main/java/com/alibaba/nacos/api/plugin/PluginConfigSpec.java
+++ b/api/src/main/java/com/alibaba/nacos/api/plugin/PluginConfigSpec.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.api.plugin;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -28,16 +30,32 @@ import java.util.Map;
 public interface PluginConfigSpec extends PluginConfigDefinitionSpec {
     
     /**
+     * Whether this plugin exposes configurable items.
+     *
+     * <p>The default keeps legacy and zero-config implementations non-configurable while allowing
+     * domain plugin SPIs to inherit this contract without breaking existing implementations.</p>
+     *
+     * @return {@code true} when at least one configuration item is declared
+     */
+    default boolean isConfigurable() {
+        List<ConfigItemDefinition> definitions = getConfigDefinitions();
+        return definitions != null && !definitions.isEmpty();
+    }
+    
+    /**
      * Apply configuration to the plugin.
      *
      * @param config configuration key-value pairs
      */
-    void applyConfig(Map<String, String> config);
+    default void applyConfig(Map<String, String> config) {
+    }
     
     /**
      * Get current configuration.
      *
      * @return current configuration as key-value pairs
      */
-    Map<String, String> getCurrentConfig();
+    default Map<String, String> getCurrentConfig() {
+        return Collections.emptyMap();
+    }
 }

--- a/api/src/test/java/com/alibaba/nacos/api/plugin/PluginConfigSpecTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/plugin/PluginConfigSpecTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PluginConfigSpecTest {
+    
+    @Test
+    void defaultContractIsNotConfigurable() {
+        PluginConfigSpec spec = new PluginConfigSpec() {
+        };
+        
+        assertFalse(spec.isConfigurable());
+        assertTrue(spec.getConfigDefinitions().isEmpty());
+        assertTrue(spec.getCurrentConfig().isEmpty());
+        spec.applyConfig(Collections.singletonMap("key", "value"));
+    }
+    
+    @Test
+    void declaredDefinitionsMakePluginConfigurable() {
+        PluginConfigSpec spec = new PluginConfigSpec() {
+            
+            @Override
+            public List<ConfigItemDefinition> getConfigDefinitions() {
+                return Collections.singletonList(new ConfigItemDefinition());
+            }
+        };
+        
+        assertTrue(spec.isConfigurable());
+    }
+    
+    @Test
+    void nullDefinitionsKeepPluginNonConfigurable() {
+        PluginConfigSpec spec = new PluginConfigSpec() {
+            
+            @Override
+            public List<ConfigItemDefinition> getConfigDefinitions() {
+                return null;
+            }
+        };
+        
+        assertFalse(spec.isConfigurable());
+    }
+}

--- a/config/src/main/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspect.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspect.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.nacos.config.server.aspect;
 
-import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.configuration.ConfigChangeConfigs;
 import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
@@ -315,9 +314,9 @@ public class ConfigChangeAspect {
     
     private Properties resolvePluginProperties(
         ConfigChangePluginService configChangePluginService) {
-        if (configChangePluginService instanceof PluginConfigSpec) {
+        if (configChangePluginService.isConfigurable()) {
             Properties result = new Properties();
-            result.putAll(((PluginConfigSpec) configChangePluginService).getCurrentConfig());
+            result.putAll(configChangePluginService.getCurrentConfig());
             return result;
         }
         String serviceType = configChangePluginService.getServiceType().toLowerCase(Locale.ROOT);

--- a/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigs.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/configuration/ConfigChangeConfigs.java
@@ -37,8 +37,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * config change plugin configs.
  *
  * @author liyunfei
- * @deprecated use {@link com.alibaba.nacos.api.plugin.PluginConfigSpec} to declare and apply
- *             config change plugin configuration
+ * @deprecated declare config definitions and implement the unified config callbacks on
+ *             {@link com.alibaba.nacos.plugin.config.spi.ConfigChangePluginService}
  **/
 @Deprecated
 @Configuration
@@ -83,8 +83,8 @@ public class ConfigChangeConfigs extends Subscriber<ServerConfigChangeEvent> {
     public Properties getPluginProperties(String configPluginType) {
         if (legacyUsageWarnedPlugins.add(configPluginType)) {
             LOGGER.warn("[ConfigChangeConfigs] Applying deprecated legacy configuration with "
-                + "prefix '{}' to config change plugin '{}'. Implement PluginConfigSpec "
-                + "to use unified plugin configuration management.", PREFIX,
+                + "prefix '{}' to config change plugin '{}'. Declare configuration definitions "
+                + "and implement the unified configuration callbacks to migrate.", PREFIX,
                 configPluginType);
         }
         Properties properties = configPluginProperties.get(configPluginType);

--- a/config/src/test/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspectTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/aspect/ConfigChangeAspectTest.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.nacos.config.server.aspect;
 
-import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.common.event.ServerConfigChangeEvent;
 import com.alibaba.nacos.config.server.configuration.ConfigChangeConfigs;
@@ -515,17 +514,17 @@ class ConfigChangeAspectTest {
     }
     
     @Test
-    void testPluginConfigSpecUsesCurrentEffectiveConfig() throws Throwable {
+    void testConfigurablePluginUsesCurrentEffectiveConfig() throws Throwable {
         ConfigChangePluginManager.reset();
-        ConfigChangePluginService configurableService = Mockito.mock(
-            ConfigChangePluginService.class,
-            Mockito.withSettings().extraInterfaces(PluginConfigSpec.class));
+        ConfigChangePluginService configurableService =
+            Mockito.mock(ConfigChangePluginService.class);
         Mockito.when(configurableService.getServiceType()).thenReturn("configurable");
         Mockito.when(configurableService.pointcutMethodNames())
             .thenReturn(ConfigChangePointCutTypes.values());
         Mockito.when(configurableService.executeType())
             .thenReturn(ConfigChangeExecuteTypes.EXECUTE_BEFORE_TYPE);
-        Mockito.when(((PluginConfigSpec) configurableService).getCurrentConfig())
+        Mockito.when(configurableService.isConfigurable()).thenReturn(true);
+        Mockito.when(configurableService.getCurrentConfig())
             .thenReturn(Collections.singletonMap("endpoint", "runtime-endpoint"));
         ConfigChangePluginManager.join(configurableService);
         

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
@@ -399,9 +399,11 @@ public class PluginManager
         // Check if plugin supports configuration
         if (instance instanceof PluginConfigSpec) {
             PluginConfigSpec configSpec = (PluginConfigSpec) instance;
-            info.setConfigurable(true);
-            info.setConfigDefinitions(configSpec.getConfigDefinitions());
-            info.setConfig(configSpec.getCurrentConfig());
+            info.setConfigurable(configSpec.isConfigurable());
+            if (info.isConfigurable()) {
+                info.setConfigDefinitions(configSpec.getConfigDefinitions());
+                info.setConfig(configSpec.getCurrentConfig());
+            }
         }
         
         pluginRegistry.put(pluginId, info);

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
@@ -55,6 +55,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -588,6 +589,20 @@ class PluginManagerTest {
         assertTrue(info.isConfigurable());
         assertEquals(plugin.getConfigDefinitions(), info.getConfigDefinitions());
         assertEquals(plugin.getCurrentConfig(), info.getConfig());
+    }
+    
+    @Test
+    void registerPluginKeepsZeroConfigSpecNonConfigurableTest() {
+        PluginConfigSpec plugin = new PluginConfigSpec() {
+        };
+        
+        ReflectionTestUtils.invokeMethod(manager, "registerPlugin", PluginType.TRACE,
+            "zero-config", plugin);
+        
+        PluginInfo info = manager.getPlugin("trace:zero-config").get();
+        assertFalse(info.isConfigurable());
+        assertNull(info.getConfigDefinitions());
+        assertNull(info.getConfig());
     }
     
     @Test

--- a/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/storage/spi/AiResourceStorage.java
+++ b/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/storage/spi/AiResourceStorage.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.plugin.ai.storage.spi;
 
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
 
 /**
@@ -30,7 +31,7 @@ import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
  * @author mosong.lp
  * @since 3.2.0
  */
-public interface AiResourceStorage {
+public interface AiResourceStorage extends PluginConfigSpec {
     
     /**
      * Type identifier, corresponding to {@link StorageKey#getProvider()}.

--- a/plugin/auth/src/main/java/com/alibaba/nacos/plugin/auth/spi/server/AuthPluginService.java
+++ b/plugin/auth/src/main/java/com/alibaba/nacos/plugin/auth/spi/server/AuthPluginService.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.auth.spi.server;
 
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.plugin.auth.api.AuthResult;
 import com.alibaba.nacos.plugin.auth.api.IdentityContext;
 import com.alibaba.nacos.plugin.auth.api.Permission;
@@ -31,7 +32,7 @@ import java.util.Collection;
  * @author Wuyfee
  * @author xiweng.yy
  */
-public interface AuthPluginService {
+public interface AuthPluginService extends PluginConfigSpec {
     
     /**
      * Define which identity information needed from request. e.q: username, password, accessToken.

--- a/plugin/config/src/main/java/com/alibaba/nacos/plugin/config/spi/ConfigChangePluginService.java
+++ b/plugin/config/src/main/java/com/alibaba/nacos/plugin/config/spi/ConfigChangePluginService.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.config.spi;
 
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.plugin.config.constants.ConfigChangeConstants;
 import com.alibaba.nacos.plugin.config.constants.ConfigChangeExecuteTypes;
 import com.alibaba.nacos.plugin.config.constants.ConfigChangePointCutTypes;
@@ -27,7 +28,7 @@ import com.alibaba.nacos.plugin.config.model.ConfigChangeResponse;
  *
  * @author liyunfei
  */
-public interface ConfigChangePluginService {
+public interface ConfigChangePluginService extends PluginConfigSpec {
     
     /**
      * execute config change plugin service.

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/dialect/DatabaseDialect.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/dialect/DatabaseDialect.java
@@ -16,11 +16,13 @@
 
 package com.alibaba.nacos.plugin.datasource.dialect;
 
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
+
 /**
  * DatabaseDialect interface.
  * @author Long Yu
  */
-public interface DatabaseDialect {
+public interface DatabaseDialect extends PluginConfigSpec {
     
     /**
      * Fully-qualified name of Spring's {@code DuplicateKeyException}. Matched by name rather than

--- a/plugin/encryption/src/main/java/com/alibaba/nacos/plugin/encryption/spi/EncryptionPluginService.java
+++ b/plugin/encryption/src/main/java/com/alibaba/nacos/plugin/encryption/spi/EncryptionPluginService.java
@@ -16,12 +16,14 @@
 
 package com.alibaba.nacos.plugin.encryption.spi;
 
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
+
 /**
  * Encryption and decryption spi.
  *
  * @author lixiaoshuang
  */
-public interface EncryptionPluginService {
+public interface EncryptionPluginService extends PluginConfigSpec {
     
     /**
      * Encrypted interface.

--- a/plugin/trace/src/main/java/com/alibaba/nacos/plugin/trace/spi/NacosTraceSubscriber.java
+++ b/plugin/trace/src/main/java/com/alibaba/nacos/plugin/trace/spi/NacosTraceSubscriber.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.trace.spi;
 
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.common.trace.event.TraceEvent;
 
 import java.util.List;
@@ -26,7 +27,7 @@ import java.util.concurrent.Executor;
  *
  * @author xiweng.yy
  */
-public interface NacosTraceSubscriber {
+public interface NacosTraceSubscriber extends PluginConfigSpec {
     
     /**
      * Get the plugin name, if the same name has loaded by nacos, the older one will be replaced by new one.

--- a/plugin/visibility/src/main/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManager.java
+++ b/plugin/visibility/src/main/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManager.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.nacos.plugin.visibility.spi;
 
-import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.common.utils.StringUtils;
@@ -98,12 +97,12 @@ public class VisibilityPluginManager {
                 service.getClass());
             return;
         }
-        if (!(service instanceof PluginConfigSpec)) {
+        if (!service.isConfigurable()) {
             Properties serviceProperties = resolveServiceProperties(allProperties, serviceName);
             if (!serviceProperties.isEmpty()) {
                 LOGGER.warn(
                     "[VisibilityPluginManager] VisibilityService({}:{}) uses deprecated "
-                        + "init(Properties) configuration. Implement PluginConfigSpec to use "
+                        + "init(Properties) configuration. Declare configuration definitions to use "
                         + "unified plugin configuration.",
                     service.getClass(), serviceName);
             }

--- a/plugin/visibility/src/main/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityService.java
+++ b/plugin/visibility/src/main/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityService.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.plugin.visibility.spi;
 
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
 import com.alibaba.nacos.plugin.visibility.model.VisibilityQueryContext;
 import com.alibaba.nacos.plugin.visibility.model.VisibilityResource;
@@ -27,19 +28,17 @@ import java.util.Properties;
  *
  * @author xiweng.yy
  */
-public interface VisibilityService {
+public interface VisibilityService extends PluginConfigSpec {
     
     /**
      * Initialize service with external properties.
      *
      * <p>Property source is managed by {@link VisibilityPluginManager}. Default no-op keeps backward compatibility
-     * for existing SPI implementations. The manager does not invoke this callback when the service implements
-     * {@link com.alibaba.nacos.api.plugin.PluginConfigSpec}; those services are initialized through unified plugin
-     * configuration.</p>
+     * for existing SPI implementations. The manager does not invoke this callback when the service declares
+     * configurable items; those services are initialized through unified plugin configuration.</p>
      *
      * @param properties service-specific properties
-     * @deprecated implement {@link com.alibaba.nacos.api.plugin.PluginConfigSpec} and use its unified configuration
-     * lifecycle instead
+     * @deprecated declare configuration definitions and use the unified configuration lifecycle instead
      */
     @Deprecated
     default void init(Properties properties) {

--- a/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManagerTest.java
+++ b/plugin/visibility/src/test/java/com/alibaba/nacos/plugin/visibility/spi/VisibilityPluginManagerTest.java
@@ -17,7 +17,6 @@
 package com.alibaba.nacos.plugin.visibility.spi;
 
 import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
-import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.plugin.visibility.model.VisibilityQueryContext;
 import com.alibaba.nacos.plugin.visibility.model.VisibilityResource;
@@ -275,8 +274,7 @@ class VisibilityPluginManagerTest {
         }
     }
     
-    private static class ConfigurableVisibilityService extends TestVisibilityService
-        implements PluginConfigSpec {
+    private static class ConfigurableVisibilityService extends TestVisibilityService {
         
         private boolean legacyInitCalled;
         
@@ -291,7 +289,7 @@ class VisibilityPluginManagerTest {
         
         @Override
         public List<ConfigItemDefinition> getConfigDefinitions() {
-            return Collections.emptyList();
+            return Collections.singletonList(new ConfigItemDefinition());
         }
         
         @Override

--- a/specs/en/auth/visibility-plugin-spec.md
+++ b/specs/en/auth/visibility-plugin-spec.md
@@ -137,19 +137,20 @@ implementation state comes from the compatibility selector
 precedence over both, but cannot override the family-wide gate.
 Implementation-level runtime changes use the plugin management API.
 
-The built-in `visibility:nacos` implementation has no private configuration,
-does not implement `PluginConfigSpec`, and is exposed as `configurable=false`.
+`VisibilityService` extends `PluginConfigSpec`. The built-in `visibility:nacos` implementation has
+no private configuration, declares no definitions, and is exposed as `configurable=false`.
 An external implementation may own properties under:
 
 ```properties
 nacos.plugin.visibility.{serviceName}.{itemKey}
 ```
 
-Legacy implementations that do not implement `PluginConfigSpec` receive their
-service-local properties once through `VisibilityService.init(Properties)`.
+Legacy implementations compiled against the older SPI, and implementations that declare no
+definitions, receive their service-local properties once through
+`VisibilityService.init(Properties)`.
 Use of non-empty legacy properties emits a migration warning without logging
-configuration values. For an implementation that implements `PluginConfigSpec`,
-the visibility manager must not invoke the legacy callback; the core plugin
+configuration values. When an implementation reports `isConfigurable()=true`, the visibility
+manager must not invoke the legacy callback; the core plugin
 manager's unified `applyConfig` lifecycle is its only configuration application
 path. Such implementations declare their own definitions and receive unified
 source, metadata, masking, and update semantics.

--- a/specs/en/plugin/ai-storage-plugin-spec.md
+++ b/specs/en/plugin/ai-storage-plugin-spec.md
@@ -167,10 +167,10 @@ type does not participate in pre-refresh critical validation. The unified plugin
 the same provider-specific validation immediately after the storage builders register their
 instances and before Nacos reports startup success.
 
-The built-in provider has no private configuration, does not implement
-`PluginConfigSpec`, and is exposed as `configurable=false`. A built
-`AiResourceStorage` implementation that owns private configuration may
-implement `PluginConfigSpec` and declare canonical keys under:
+`AiResourceStorage` extends `PluginConfigSpec`. The built-in provider has no private configuration,
+declares no definitions, and is exposed as `configurable=false`. A built storage implementation
+that owns private configuration declares definitions and callbacks through the inherited contract,
+using canonical keys under:
 
 ```properties
 nacos.plugin.ai-storage.{provider}.{itemKey}

--- a/specs/en/plugin/config-change-plugin-spec.md
+++ b/specs/en/plugin/config-change-plugin-spec.md
@@ -118,8 +118,9 @@ committed config mutation.
 
 ### Unified Plugin Configuration
 
-A config change plugin that owns configurable properties should also implement
-`PluginConfigSpec`. Its canonical full keys use the standard prefix:
+`ConfigChangePluginService` extends `PluginConfigSpec`. A config change plugin that owns
+configurable properties declares them through that inherited contract. Its canonical full keys use
+the standard prefix:
 
 ```properties
 nacos.plugin.config-change.{pluginName}.{itemKey}
@@ -129,8 +130,8 @@ The implementation declares item keys, legacy aliases, sensitivity, and effect
 mode through `ConfigItemDefinition`. The common plugin configuration resolver
 loads and applies the effective configuration. For compatibility with the
 config change SPI request contract, `ConfigChangeConstants.PLUGIN_PROPERTIES`
-contains the implementation's current effective item-key map when the service
-implements `PluginConfigSpec`.
+contains the implementation's current effective item-key map when the service reports
+`isConfigurable()=true`.
 
 Plugin enablement is unified plugin state for
 `config-change:{pluginName}` and is not a `ConfigItemDefinition`. Pointcut
@@ -138,8 +139,9 @@ candidate lookup is the only runtime enablement gate.
 
 ### Legacy Compatibility
 
-Plugins that do not implement `PluginConfigSpec` remain supported through the
-deprecated legacy configuration adapter. Their properties continue to use:
+Plugins compiled against the older SPI, and implementations that declare no configuration
+definitions, remain supported through the deprecated legacy configuration adapter. Their properties
+continue to use:
 
 ```properties
 nacos.core.config.plugin.{pluginName}.{propertyKey}

--- a/specs/en/plugin/datasource-dialect-plugin-spec.md
+++ b/specs/en/plugin/datasource-dialect-plugin-spec.md
@@ -156,10 +156,10 @@ the database driver. They are standardized under the following module prefix:
 nacos.plugin.datasource.db.{item}
 ```
 
-This namespace does not make a database dialect configurable. The built-in
-`datasource-dialect:{databaseType}` instances still expose
-`configurable=false`, because connection credentials and pool settings belong
-to one server datasource rather than to each loaded dialect. These settings are
+This namespace does not make a database dialect configurable. `DatabaseDialect` inherits the common
+configuration contract, but the built-in `datasource-dialect:{databaseType}` instances declare no
+definitions and still expose `configurable=false`, because connection credentials and pool settings
+belong to one server datasource rather than to each loaded dialect. These settings are
 static, take effect on restart, and are not accepted by the plugin detail/PUT
 configuration API. A future management surface must first define one unique
 datasource configuration owner instead of copying the same credentials into

--- a/specs/en/plugin/default-datasource-dialect-plugin-spec.md
+++ b/specs/en/plugin/default-datasource-dialect-plugin-spec.md
@@ -87,7 +87,7 @@ The datasource-dialect type is critical while loaded. The selected built-in
 dialect cannot be disabled through runtime plugin state, but another bundled
 dialect is not individually critical merely because it is present.
 
-Built-in dialect implementations do not own datasource connection or pool
-configuration and do not implement `PluginConfigSpec`. They are exposed as
-`configurable=false`; datasource module configuration is defined by the parent
-dialect plugin spec.
+Built-in dialect implementations do not own datasource connection or pool configuration. They
+inherit `PluginConfigSpec` through `DatabaseDialect` but declare no definitions, so they are exposed
+as `configurable=false`; datasource module configuration is defined by the parent dialect plugin
+spec.

--- a/specs/en/plugin/plugin-spec.md
+++ b/specs/en/plugin/plugin-spec.md
@@ -106,9 +106,9 @@ the mode consistently.
 Execution mode and criticality are plugin-type capabilities rather than properties of a particular
 built-in implementation. The shared `PluginType` must expose `executionMode` and `critical`.
 The existing `exclusive` information remains derived from `executionMode == EXCLUSIVE` for API
-compatibility. Whether an implementation is configurable is derived from whether that instance
-implements `PluginConfigSpec`; configurable and zero-config implementations may coexist under the
-same plugin type.
+compatibility. Whether an implementation is configurable is derived from
+`PluginConfigSpec.isConfigurable()`; configurable and zero-config implementations may coexist under
+the same plugin type.
 
 ## SPI Layers
 
@@ -120,8 +120,13 @@ Nacos plugins have two related SPI layers:
    plugin manager for listing, status management, configuration, and
    observability.
 
-A plugin that needs dynamic configuration implements `PluginConfigSpec`. A
-plugin category that supports enable or disable checks must use
+Unified domain plugin SPIs extend `PluginConfigSpec`. Its compatibility defaults expose no
+definitions, an empty current map, and a no-op apply callback, so an implementation compiled against
+an older domain SPI and a new zero-config implementation both remain `configurable=false`. A plugin
+that declares at least one `ConfigItemDefinition` is configurable and must implement the current-map
+and apply callbacks. `environment` and `control` remain bootstrap exceptions until their unified
+configuration lifecycle is designed; `ai-resource-import` remains outside unified management until
+its redesign. A plugin category that supports enable or disable checks must use
 `PluginStateCheckerHolder` rather than keeping an independent status source.
 
 `PluginConfigDefinitionSpec` is the definition-only parent contract for a factory
@@ -268,10 +273,10 @@ currently be disabled by itself, so it may change as peer implementation states 
 detail responses add `typeCritical` and `executionMode`; the existing `exclusive` field remains and
 is derived from the execution mode.
 
-Plugins with `PluginConfigSpec` expose config definitions, current config, and
-config application behavior. Cluster-wide status or config changes must be
-synchronized through the plugin state operation path unless the request is
-explicitly local only.
+Plugins for which `PluginConfigSpec.isConfigurable()` returns `true` expose config definitions,
+current config, and config application behavior. Its default implementation returns `true` only
+when `getConfigDefinitions()` is non-null and non-empty. Cluster-wide status or config changes must
+be synchronized through the plugin state operation path unless the request is explicitly local only.
 
 ### Configuration Definition
 

--- a/specs/zh-cn/auth/visibility-plugin-spec.md
+++ b/specs/zh-cn/auth/visibility-plugin-spec.md
@@ -124,16 +124,17 @@ nacos.plugin.visibility.enabled=true
 `nacos.plugin.visibility.{serviceName}.enabled` 覆盖；持久化 state 优先于二者，但不能绕过
 插件族总开关。实现级运行时变更通过插件管理 API 完成。
 
-内置 `visibility:nacos` 没有私有配置，不实现 `PluginConfigSpec`，并以
-`configurable=false` 暴露。外部实现可以拥有以下前缀的配置：
+`VisibilityService` 统一继承 `PluginConfigSpec`。内置 `visibility:nacos` 没有私有配置、
+不声明 definitions，并以 `configurable=false` 暴露。外部实现可以拥有以下前缀的配置：
 
 ```properties
 nacos.plugin.visibility.{serviceName}.{itemKey}
 ```
 
-未实现 `PluginConfigSpec` 的历史实现仍通过 `VisibilityService.init(Properties)` 一次性接收
-实现本地属性。使用非空历史属性时，服务端记录迁移告警，但不得打印配置值。对于实现了
-`PluginConfigSpec` 的实现，Visibility manager 不得再调用历史回调；核心插件管理器统一的
+按旧版 SPI 编译的历史实现，以及没有声明 definitions 的实现，仍通过
+`VisibilityService.init(Properties)` 一次性接收实现本地属性。使用非空历史属性时，服务端
+记录迁移告警，但不得打印配置值。对于返回 `isConfigurable()=true` 的实现，Visibility
+manager 不得再调用历史回调；核心插件管理器统一的
 `applyConfig` 生命周期是唯一配置应用入口。此类实现应声明自身 definitions，并获得统一的
 source、元数据、脱敏和更新语义。
 

--- a/specs/zh-cn/plugin/ai-storage-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-storage-plugin-spec.md
@@ -138,8 +138,9 @@ AI storage 实现需要在 context refresh 期间使用 Spring 管理的服务�
 pre-refresh critical 校验。storage builder 注册完实例后，统一插件管理器必须立即执行相同的
 provider 级校验，并且必须在 Nacos 报告启动成功前完成。
 
-内置 provider 没有私有配置，不实现 `PluginConfigSpec`，并以 `configurable=false` 暴露。
-拥有私有配置的 `AiResourceStorage` 构建结果可以实现 `PluginConfigSpec`，并声明以下标准 key：
+`AiResourceStorage` 统一继承 `PluginConfigSpec`。内置 provider 没有私有配置、不声明
+definitions，并以 `configurable=false` 暴露。拥有私有配置的构建结果通过继承契约声明
+definitions 和配置回调，并使用以下标准 key：
 
 ```properties
 nacos.plugin.ai-storage.{provider}.{itemKey}

--- a/specs/zh-cn/plugin/config-change-plugin-spec.md
+++ b/specs/zh-cn/plugin/config-change-plugin-spec.md
@@ -108,7 +108,8 @@ Nacos 还会通过 request arguments 传递 `ConfigChangeConstants.ORIGINAL_ARGS
 
 ### 统一插件配置
 
-拥有可配置属性的配置变更插件应同时实现 `PluginConfigSpec`。标准完整配置 key 使用统一前缀：
+`ConfigChangePluginService` 统一继承 `PluginConfigSpec`。拥有可配置属性的配置变更插件通过
+该继承契约声明配置，标准完整配置 key 使用统一前缀：
 
 ```properties
 nacos.plugin.config-change.{pluginName}.{itemKey}
@@ -116,15 +117,16 @@ nacos.plugin.config-change.{pluginName}.{itemKey}
 
 插件实现通过 `ConfigItemDefinition` 声明 item key、历史 alias、敏感性和生效模式，通用插件
 配置 resolver 负责加载 effective config 并 apply。为兼容配置变更 SPI 的请求契约，当服务
-实现 `PluginConfigSpec` 时，`ConfigChangeConstants.PLUGIN_PROPERTIES` 中传递该实现当前
-effective config 的 item-key map。
+返回 `isConfigurable()=true` 时，`ConfigChangeConstants.PLUGIN_PROPERTIES` 中传递
+该实现当前 effective config 的 item-key map。
 
 `config-change:{pluginName}` 的启停属于统一 plugin state，不是 `ConfigItemDefinition`。
 pointcut 候选查询是运行时唯一的启停 gate。
 
 ### 历史兼容
 
-未实现 `PluginConfigSpec` 的插件继续由已废弃的历史配置适配器支持，其属性仍使用：
+按旧版 SPI 编译的插件，以及没有声明配置 definitions 的实现，继续由已废弃的历史配置
+适配器支持，其属性仍使用：
 
 ```properties
 nacos.core.config.plugin.{pluginName}.{propertyKey}

--- a/specs/zh-cn/plugin/datasource-dialect-plugin-spec.md
+++ b/specs/zh-cn/plugin/datasource-dialect-plugin-spec.md
@@ -133,9 +133,9 @@ nacos.plugin.datasource-dialect.type=${databaseType}
 nacos.plugin.datasource.db.{item}
 ```
 
-该命名空间不会让数据库方言变为可配置插件。内置
-`datasource-dialect:{databaseType}` 仍以 `configurable=false` 暴露，因为连接凭据和连接池
-参数属于服务端唯一数据源，而不是分别属于每个已加载方言。这些配置均为静态配置，只在重启后
+该命名空间不会让数据库方言变为可配置插件。`DatabaseDialect` 虽继承统一配置契约，但内置
+`datasource-dialect:{databaseType}` 不声明 definitions，仍以 `configurable=false` 暴露，
+因为连接凭据和连接池参数属于服务端唯一数据源，而不是分别属于每个已加载方言。这些配置均为静态配置，只在重启后
 生效，当前不进入插件 detail/PUT 配置 API。未来若要提供统一管理入口，必须先定义唯一的
 datasource 配置 owner，不能把同一份凭据复制到所有方言。
 

--- a/specs/zh-cn/plugin/default-datasource-dialect-plugin-spec.md
+++ b/specs/zh-cn/plugin/default-datasource-dialect-plugin-spec.md
@@ -75,5 +75,6 @@ Nacos 从 `nacos.plugin.datasource-dialect.type` 选择启动数据库类型。
 `datasource-dialect` 类型加载后属于 critical。当前选中的内置方言不能通过运行时插件状态
 禁用，但其他已加载内置方言不会仅因存在就分别成为 critical。
 
-内置方言实现不持有数据源连接或连接池配置，也不实现 `PluginConfigSpec`，因此以
-`configurable=false` 暴露。Datasource 模块配置由上层数据源方言插件规范定义。
+内置方言实现不持有数据源连接或连接池配置。它们通过 `DatabaseDialect` 继承
+`PluginConfigSpec`，但不声明 definitions，因此以 `configurable=false` 暴露。Datasource
+模块配置由上层数据源方言插件规范定义。

--- a/specs/zh-cn/plugin/plugin-spec.md
+++ b/specs/zh-cn/plugin/plugin-spec.md
@@ -96,8 +96,8 @@ Nacos 资源身份、鉴权和 payload 语义，因为它们会影响 SDK 发出
 
 执行形态和关键能力属于插件类型，而不是某个内置实现。共享 `PluginType` 必须暴露
 `executionMode` 和 `critical`；已有 `exclusive` 信息继续由
-`executionMode == EXCLUSIVE` 推导，以保持 API 兼容。插件实现是否可配置则由该实例是否
-实现 `PluginConfigSpec` 决定，同一插件类型下允许同时存在可配置和零配置实现。
+`executionMode == EXCLUSIVE` 推导，以保持 API 兼容。插件实现是否可配置由
+`PluginConfigSpec.isConfigurable()` 决定，同一插件类型下允许同时存在可配置和零配置实现。
 
 ## SPI 层次
 
@@ -107,8 +107,13 @@ Nacos 插件包含两个相关的 SPI 层次：
 2. 核心插件 SPI，即 `PluginProvider`，将插件实例暴露给核心插件管理器，用于列表查询、
    状态管理、配置管理和运行时观测。
 
-需要动态配置的插件应实现 `PluginConfigSpec`。支持启停状态判断的插件类别，应通过
-`PluginStateCheckerHolder` 获取状态，而不是维护一套独立状态来源。
+已接入统一配置的领域插件 SPI 统一继承 `PluginConfigSpec`。该契约的兼容默认实现返回空
+definitions、空 current map，并提供空 apply 回调，因此按旧版领域 SPI 编译的实现和新版
+零配置实现都会保持 `configurable=false`。声明至少一个 `ConfigItemDefinition` 的插件属于
+可配置实现，必须实现 current-map 和 apply 回调。`environment`、`control` 在统一 bootstrap
+配置生命周期完成设计前继续作为例外；`ai-resource-import` 在自身重构前仍不进入统一管理。
+支持启停状态判断的插件类别，应通过 `PluginStateCheckerHolder` 获取状态，而不是维护一套
+独立状态来源。
 
 `PluginConfigDefinitionSpec` 是仅暴露 definitions 的父契约，供必须在创建实例之前声明
 配置元数据的 factory 使用。参与统一配置生命周期的运行时插件实例仍必须实现完整的
@@ -233,7 +238,8 @@ nacos.plugin.{pluginType}.{pluginName}.enabled=true|false
 实现的状态动态变化。列表和详情响应追加 `typeCritical` 和 `executionMode`；已有
 `exclusive` 字段保留并从执行形态推导。
 
-实现 `PluginConfigSpec` 的插件应暴露配置定义、当前配置和配置应用行为。除非请求明确
+`PluginConfigSpec.isConfigurable()` 返回 `true` 的插件应暴露配置定义、当前配置和配置应用
+行为；默认实现仅在 `getConfigDefinitions()` 非空且非空列表时返回 `true`。除非请求明确
 声明为仅本机生效，否则集群级状态或配置变更必须通过插件状态操作链路进行同步。
 
 ### 配置定义


### PR DESCRIPTION
## What is the purpose of the change

For #15475.

Unify completed domain plugin SPIs with the common PluginConfigSpec contract while preserving binary compatibility for plugins compiled against older SPI versions. Zero-config and legacy implementations remain non-configurable through compatibility defaults, while implementations with declared definitions enter the unified configuration lifecycle.

## Brief changelog

- add compatibility defaults and definition-based isConfigurable() to PluginConfigSpec
- make auth, config-change, datasource-dialect, encryption, trace, visibility, and AI storage SPIs inherit the common configuration contract
- update PluginManager and legacy ConfigChange/Visibility adapters to use the capability method
- update English and Chinese plugin specs and add focused unit coverage

## Verifying this change

- mvn -B -pl api,plugin/auth,plugin/config,plugin/datasource,plugin/encryption,plugin/trace,plugin/visibility,plugin/ai,core,config spotless:apply
- mvn -B -pl api,plugin/auth,plugin/config,plugin/datasource,plugin/encryption,plugin/trace,plugin/visibility,plugin/ai,core,config spotless:check
- mvn -B -pl api,plugin/auth,plugin/config,plugin/datasource,plugin/encryption,plugin/trace,plugin/visibility,plugin/ai test
- mvn -B -pl core,config test
- mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e
- mvn -B '-Prelease-nacos,!dev' clean install -Drat.skip=true -Dspotbugs.skip=true -DtrimStackTrace=false -U -e
- verified a ConfigChangePluginService binary compiled against the previous SPI can load and execute through the deprecated properties adapter without linkage errors

No HTTP API or public Java SDK behavior changes are introduced, so OpenAPI and Java SDK IT matrices are unaffected.

- [x] There is an existing GitHub issue for the change.
- [x] The PR contains focused unit tests and spec updates.
- [x] Formatting, static analysis, affected-module tests, full unit tests, and compatibility live verification pass.