### PR TITLE
[ISSUE #15475] Encapsulate persisted plugin config source

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
@@ -442,11 +442,7 @@ public class PluginManager
         refreshAllCriticalFlags();
         
         // Load configs
-        Map<String, Map<String, String>> configs = persistence.loadAllConfigs();
-        configs.forEach((pluginId, config) -> {
-            PluginInfo info = pluginRegistry.get(pluginId);
-            pluginConfigService.loadRuntimePersistedConfig(info, pluginId, config);
-        });
+        pluginConfigService.initializeRuntimePersistedConfigs();
         pluginRegistry.forEach((pluginId, info) -> {
             if (info.isConfigurable()) {
                 pluginConfigService.initializePluginConfig(info, pluginInstances.get(pluginId));
@@ -618,15 +614,27 @@ public class PluginManager
     }
     
     /**
-     * Restore config change from a consensus snapshot.
+     * Get all runtime persisted configs for a consensus snapshot.
      *
-     * @param pluginId plugin ID
-     * @param config configuration
+     * @return complete runtime persisted config snapshot
      */
-    public void restoreConfigChange(String pluginId, Map<String, String> config) {
-        PluginInfo info = pluginRegistry.get(pluginId);
-        pluginConfigService.restoreRuntimePersistedConfig(pluginId, info,
-            pluginInstances.get(pluginId), config);
+    public Map<String, Map<String, String>> getRuntimePersistedConfigs() {
+        return pluginConfigService.getAllRuntimePersistedConfigs();
+    }
+    
+    /**
+     * Restore all runtime persisted configs from a consensus snapshot.
+     *
+     * @param configs complete runtime persisted config snapshot
+     */
+    public synchronized void restorePluginConfigs(Map<String, Map<String, String>> configs) {
+        pluginConfigService.restoreRuntimePersistedConfigs(configs);
+        pluginRegistry.forEach((pluginId, info) -> {
+            if (info.isConfigurable()) {
+                pluginConfigService.applyRestoredPluginConfig(info,
+                    pluginInstances.get(pluginId));
+            }
+        });
     }
     
     /**

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PluginStateSnapshotOperation.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PluginStateSnapshotOperation.java
@@ -78,7 +78,8 @@ public class PluginStateSnapshotOperation implements SnapshotOperation {
         try {
             // Load all states and configs
             Map<String, Boolean> states = persistence.loadAllStates();
-            Map<String, Map<String, String>> configs = persistence.loadAllConfigs();
+            Map<String, Map<String, String>> configs =
+                pluginManager.getRuntimePersistedConfigs();
             
             // Create snapshot
             PluginStateSnapshot snapshot = new PluginStateSnapshot();
@@ -152,9 +153,7 @@ public class PluginStateSnapshotOperation implements SnapshotOperation {
             // Restore configs
             Map<String, Map<String, String>> configs = snapshot.getConfigs();
             if (configs != null) {
-                for (Map.Entry<String, Map<String, String>> entry : configs.entrySet()) {
-                    pluginManager.restoreConfigChange(entry.getKey(), entry.getValue());
-                }
+                pluginManager.restorePluginConfigs(configs);
             }
             
             LOGGER.info("[PluginStateSnapshotOperation] Snapshot loaded: {} states, {} configs",

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/config/AbstractMapPluginConfigSourceResolver.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/config/AbstractMapPluginConfigSourceResolver.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 abstract class AbstractMapPluginConfigSourceResolver implements PluginConfigSourceResolver {
     
-    private final Map<String, Map<String, String>> configs = new ConcurrentHashMap<>();
+    private volatile Map<String, Map<String, String>> configs = new ConcurrentHashMap<>();
     
     /**
      * Update source config for one plugin.
@@ -56,6 +56,31 @@ abstract class AbstractMapPluginConfigSourceResolver implements PluginConfigSour
     public Map<String, String> getConfig(PluginInfo pluginInfo) {
         Map<String, String> config = configs.get(pluginInfo.getPluginId());
         return config == null ? null : new HashMap<>(config);
+    }
+    
+    /**
+     * Replace configs for all plugins.
+     *
+     * @param configs complete source config
+     */
+    protected void replaceAllConfigs(Map<String, Map<String, String>> configs) {
+        Map<String, Map<String, String>> replacement = new ConcurrentHashMap<>();
+        if (configs != null) {
+            configs.forEach((pluginId, config) -> replacement.put(pluginId,
+                config == null ? Collections.emptyMap() : new HashMap<>(config)));
+        }
+        this.configs = replacement;
+    }
+    
+    /**
+     * Get configs for all plugins.
+     *
+     * @return complete source config snapshot
+     */
+    protected Map<String, Map<String, String>> getAllConfigsSnapshot() {
+        Map<String, Map<String, String>> result = new HashMap<>();
+        configs.forEach((pluginId, config) -> result.put(pluginId, new HashMap<>(config)));
+        return result;
     }
     
     @Override

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/config/PersistedPluginConfigSourceResolver.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/config/PersistedPluginConfigSourceResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin.config;
+
+import java.util.Map;
+
+/**
+ * Resolver contract for a persisted plugin configuration source.
+ *
+ * @author Nacos
+ */
+interface PersistedPluginConfigSourceResolver extends PluginConfigSourceResolver {
+    
+    /**
+     * Load the complete persisted source during startup.
+     */
+    void initialize();
+    
+    /**
+     * Get the complete persisted source snapshot.
+     *
+     * @return plugin ID to source config map
+     */
+    Map<String, Map<String, String>> getAllConfigs();
+    
+    /**
+     * Replace the complete persisted source while restoring a snapshot.
+     *
+     * @param configs complete persisted source snapshot
+     */
+    void restoreConfigs(Map<String, Map<String, String>> configs);
+}

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/config/PluginConfigResolver.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/config/PluginConfigResolver.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
 import com.alibaba.nacos.core.plugin.model.PluginInfo;
 import com.alibaba.nacos.core.plugin.model.vo.PluginConfigValueMeta;
+import com.alibaba.nacos.core.plugin.storage.PluginStatePersistenceService;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,6 +46,10 @@ public class PluginConfigResolver {
         this(new PluginConfigSourceRegistry());
     }
     
+    PluginConfigResolver(PluginStatePersistenceService persistence) {
+        this(new PluginConfigSourceRegistry(persistence));
+    }
+    
     PluginConfigResolver(PluginConfigSourceRegistry sourceRegistry) {
         this.sourceRegistry = sourceRegistry;
     }
@@ -67,6 +72,22 @@ public class PluginConfigResolver {
      */
     public void initializeStaticConfig(PluginInfo pluginInfo) {
         sourceRegistry.initializeConfig(PluginConfigSourceType.STATIC, pluginInfo);
+    }
+    
+    /**
+     * Load all runtime persisted source configs during startup.
+     */
+    public void initializeRuntimePersistedConfigs() {
+        sourceRegistry.initializePersistedConfigs();
+    }
+    
+    /**
+     * Normalize one loaded runtime persisted source config with plugin definitions.
+     *
+     * @param pluginInfo plugin info
+     */
+    public void initializeRuntimePersistedConfig(PluginInfo pluginInfo) {
+        sourceRegistry.initializeConfig(PluginConfigSourceType.RUNTIME_PERSISTED, pluginInfo);
     }
     
     /**
@@ -105,6 +126,24 @@ public class PluginConfigResolver {
     public Map<String, String> getConfig(PluginConfigSourceType sourceType,
         PluginInfo pluginInfo) {
         return sourceRegistry.getSourceResolver(sourceType).getConfig(pluginInfo);
+    }
+    
+    /**
+     * Get all runtime persisted source configs for a snapshot.
+     *
+     * @return complete runtime persisted source snapshot
+     */
+    public Map<String, Map<String, String>> getAllRuntimePersistedConfigs() {
+        return sourceRegistry.getAllPersistedConfigs();
+    }
+    
+    /**
+     * Restore all runtime persisted source configs from a snapshot.
+     *
+     * @param configs complete runtime persisted source snapshot
+     */
+    public void restoreRuntimePersistedConfigs(Map<String, Map<String, String>> configs) {
+        sourceRegistry.restorePersistedConfigs(configs);
     }
     
     /**

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/config/PluginConfigService.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/config/PluginConfigService.java
@@ -45,21 +45,18 @@ public class PluginConfigService {
     
     private final PluginConfigApplier applier;
     
-    private final PluginStatePersistenceService persistence;
-    
     private final Map<String, Object> pluginLocks = new ConcurrentHashMap<>();
     
     public PluginConfigService(PluginStatePersistenceService persistence) {
-        this(new PluginConfigResolver(), new PluginConfigBasicChecker(),
-            new PluginConfigApplier(), persistence);
+        this(new PluginConfigResolver(persistence), new PluginConfigBasicChecker(),
+            new PluginConfigApplier());
     }
     
     PluginConfigService(PluginConfigResolver resolver, PluginConfigBasicChecker checker,
-        PluginConfigApplier applier, PluginStatePersistenceService persistence) {
+        PluginConfigApplier applier) {
         this.resolver = resolver;
         this.checker = checker;
         this.applier = applier;
-        this.persistence = persistence;
     }
     
     /**
@@ -83,18 +80,10 @@ public class PluginConfigService {
     }
     
     /**
-     * Load one persisted source snapshot without applying it.
-     *
-     * @param pluginInfo plugin info, may be {@code null} when the plugin is not loaded locally
-     * @param pluginId plugin id
-     * @param config persisted config
+     * Load the complete runtime persisted source during startup.
      */
-    public void loadRuntimePersistedConfig(PluginInfo pluginInfo, String pluginId,
-        Map<String, String> config) {
-        synchronized (getPluginLock(pluginId)) {
-            resolver.updateConfig(PluginConfigSourceType.RUNTIME_PERSISTED, pluginId,
-                normalizeConfig(pluginInfo, config));
-        }
+    public void initializeRuntimePersistedConfigs() {
+        resolver.initializeRuntimePersistedConfigs();
     }
     
     /**
@@ -105,6 +94,7 @@ public class PluginConfigService {
      */
     public void initializePluginConfig(PluginInfo pluginInfo, Object pluginInstance) {
         synchronized (getPluginLock(pluginInfo.getPluginId())) {
+            resolver.initializeRuntimePersistedConfig(pluginInfo);
             resolver.initializeStaticConfig(pluginInfo);
             PluginConfigResolution resolution = resolver.resolve(pluginInfo, false);
             try {
@@ -157,7 +147,7 @@ public class PluginConfigService {
     public void updateLocalOnlyConfig(PluginInfo pluginInfo, Object pluginInstance,
         Map<String, String> config) {
         replaceAndApply(pluginInfo.getPluginId(), pluginInfo, pluginInstance,
-            PluginConfigSourceType.LOCAL_ONLY, config, true, false);
+            PluginConfigSourceType.LOCAL_ONLY, config, true);
     }
     
     /**
@@ -171,21 +161,48 @@ public class PluginConfigService {
     public void applyRuntimePersistedConfig(String pluginId, PluginInfo pluginInfo,
         Object pluginInstance, Map<String, String> config) {
         replaceAndApply(pluginId, pluginInfo, pluginInstance,
-            PluginConfigSourceType.RUNTIME_PERSISTED, config, true, true);
+            PluginConfigSourceType.RUNTIME_PERSISTED, config, true);
     }
     
     /**
-     * Restore a runtime source snapshot and effective config while loading a Raft snapshot.
+     * Get the complete runtime persisted source for a Raft snapshot.
      *
-     * @param pluginId plugin id
-     * @param pluginInfo plugin info, may be {@code null} when not loaded locally
-     * @param pluginInstance plugin instance
-     * @param config full override map
+     * @return complete runtime persisted source snapshot
      */
-    public void restoreRuntimePersistedConfig(String pluginId, PluginInfo pluginInfo,
-        Object pluginInstance, Map<String, String> config) {
-        replaceAndApply(pluginId, pluginInfo, pluginInstance,
-            PluginConfigSourceType.RUNTIME_PERSISTED, config, false, true);
+    public Map<String, Map<String, String>> getAllRuntimePersistedConfigs() {
+        return resolver.getAllRuntimePersistedConfigs();
+    }
+    
+    /**
+     * Restore the complete runtime persisted source from a Raft snapshot.
+     *
+     * @param configs complete runtime persisted source snapshot
+     */
+    public void restoreRuntimePersistedConfigs(Map<String, Map<String, String>> configs) {
+        resolver.restoreRuntimePersistedConfigs(configs);
+    }
+    
+    /**
+     * Resolve and apply effective config after restoring the persisted source.
+     *
+     * @param pluginInfo plugin info
+     * @param pluginInstance plugin instance
+     */
+    public void applyRestoredPluginConfig(PluginInfo pluginInfo, Object pluginInstance) {
+        synchronized (getPluginLock(pluginInfo.getPluginId())) {
+            resolver.initializeRuntimePersistedConfig(pluginInfo);
+            PluginConfigResolution resolution = resolver.resolve(pluginInfo, false);
+            try {
+                checker.validateEffectiveConfig(pluginInfo, resolution.getConfig());
+                applier.apply(pluginInfo.getPluginId(), pluginInstance, resolution.getConfig());
+            } catch (RuntimeException e) {
+                LOGGER.error("[PluginConfigService] Failed to apply restored plugin config, "
+                    + "pluginId={}", pluginInfo.getPluginId(), e);
+                throw new PluginConfigApplyException("Failed to apply restored plugin config: "
+                    + pluginInfo.getPluginId(), e);
+            }
+            pluginInfo.setConfig(copyConfig(resolution.getConfig()));
+        }
     }
     
     /**
@@ -203,16 +220,13 @@ public class PluginConfigService {
     
     private void replaceAndApply(String pluginId, PluginInfo pluginInfo, Object pluginInstance,
         PluginConfigSourceType sourceType, Map<String, String> config,
-        boolean validateRuntimeUpdate, boolean persist) {
+        boolean validateRuntimeUpdate) {
         synchronized (getPluginLock(pluginId)) {
             Map<String, String> normalizedConfig = normalizeConfig(pluginInfo, config);
             if (validateRuntimeUpdate && pluginInfo != null) {
                 normalizedConfig = preserveMaskedSensitiveValues(pluginInfo, normalizedConfig,
                     sourceType);
                 validateRuntimeUpdate(pluginInfo, normalizedConfig, sourceType);
-            }
-            if (persist) {
-                persistence.saveConfig(pluginId, normalizedConfig);
             }
             resolver.updateConfig(sourceType, pluginId, normalizedConfig);
             if (pluginInfo == null) {

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/config/PluginConfigSourceRegistry.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/config/PluginConfigSourceRegistry.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.core.plugin.config;
 
 import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
 import com.alibaba.nacos.core.plugin.model.PluginInfo;
+import com.alibaba.nacos.core.plugin.storage.PluginStatePersistenceService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,8 +42,12 @@ class PluginConfigSourceRegistry {
         new EnumMap<>(PluginConfigSourceType.class);
     
     PluginConfigSourceRegistry() {
+        this((PluginStatePersistenceService) null);
+    }
+    
+    PluginConfigSourceRegistry(PluginStatePersistenceService persistence) {
         this(Arrays.asList(new LocalOnlyPluginConfigSourceResolver(),
-            new RuntimePersistedPluginConfigSourceResolver(),
+            new RuntimePersistedPluginConfigSourceResolver(persistence),
             new StaticPluginConfigSourceResolver(), new DefaultPluginConfigSourceResolver()));
     }
     
@@ -59,6 +64,11 @@ class PluginConfigSourceRegistry {
                 throw new IllegalArgumentException(
                     "Required plugin config source not found: " + sourceType);
             }
+        }
+        if (!(this.sourceResolvers.get(
+            PluginConfigSourceType.RUNTIME_PERSISTED) instanceof PersistedPluginConfigSourceResolver)) {
+            throw new IllegalArgumentException("Runtime persisted plugin config source must "
+                + "support persistence lifecycle");
         }
     }
     
@@ -84,5 +94,22 @@ class PluginConfigSourceRegistry {
     
     void refreshConfig(PluginConfigSourceType sourceType, PluginInfo pluginInfo) {
         getSourceResolver(sourceType).refreshConfig(pluginInfo);
+    }
+    
+    void initializePersistedConfigs() {
+        getPersistedSourceResolver().initialize();
+    }
+    
+    Map<String, Map<String, String>> getAllPersistedConfigs() {
+        return getPersistedSourceResolver().getAllConfigs();
+    }
+    
+    void restorePersistedConfigs(Map<String, Map<String, String>> configs) {
+        getPersistedSourceResolver().restoreConfigs(configs);
+    }
+    
+    private PersistedPluginConfigSourceResolver getPersistedSourceResolver() {
+        return (PersistedPluginConfigSourceResolver) getSourceResolver(
+            PluginConfigSourceType.RUNTIME_PERSISTED);
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/config/RuntimePersistedPluginConfigSourceResolver.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/config/RuntimePersistedPluginConfigSourceResolver.java
@@ -17,16 +17,85 @@
 package com.alibaba.nacos.core.plugin.config;
 
 import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
+import com.alibaba.nacos.core.plugin.model.PluginInfo;
+import com.alibaba.nacos.core.plugin.storage.PluginStatePersistenceService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Resolver for runtime persisted plugin configuration source.
  *
  * @author Nacos
  */
-class RuntimePersistedPluginConfigSourceResolver extends AbstractMapPluginConfigSourceResolver {
+class RuntimePersistedPluginConfigSourceResolver extends AbstractMapPluginConfigSourceResolver
+    implements PersistedPluginConfigSourceResolver {
+    
+    private final PluginStatePersistenceService persistence;
+    
+    private final PluginConfigKeyResolver keyResolver = new PluginConfigKeyResolver();
+    
+    RuntimePersistedPluginConfigSourceResolver() {
+        this(null);
+    }
+    
+    RuntimePersistedPluginConfigSourceResolver(PluginStatePersistenceService persistence) {
+        this.persistence = persistence;
+    }
+    
+    @Override
+    public void initialize() {
+        if (persistence != null) {
+            replaceAllConfigs(persistence.loadAllConfigs());
+        }
+    }
+    
+    @Override
+    public void initializeConfig(PluginInfo pluginInfo) {
+        Map<String, String> config = super.getConfig(pluginInfo);
+        if (config != null) {
+            super.updateConfig(pluginInfo.getPluginId(), keyResolver.normalizeConfig(pluginInfo,
+                config));
+        }
+    }
+    
+    @Override
+    public void updateConfig(String pluginId, Map<String, String> config) {
+        Map<String, String> configToStore = config == null ? Collections.emptyMap()
+            : new HashMap<>(config);
+        if (persistence != null) {
+            persistence.saveConfig(pluginId, configToStore);
+        }
+        super.updateConfig(pluginId, configToStore);
+    }
+    
+    @Override
+    public Map<String, Map<String, String>> getAllConfigs() {
+        return getAllConfigsSnapshot();
+    }
+    
+    @Override
+    public void restoreConfigs(Map<String, Map<String, String>> configs) {
+        Map<String, Map<String, String>> configsToRestore = copyConfigs(configs);
+        if (persistence != null) {
+            persistence.replaceAllConfigs(configsToRestore);
+        }
+        replaceAllConfigs(configsToRestore);
+    }
     
     @Override
     public PluginConfigSourceType getSourceType() {
         return PluginConfigSourceType.RUNTIME_PERSISTED;
+    }
+    
+    private Map<String, Map<String, String>> copyConfigs(
+        Map<String, Map<String, String>> configs) {
+        Map<String, Map<String, String>> result = new HashMap<>();
+        if (configs != null) {
+            configs.forEach((pluginId, config) -> result.put(pluginId,
+                config == null ? Collections.emptyMap() : new HashMap<>(config)));
+        }
+        return result;
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/storage/FilePluginStatePersistenceImpl.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/storage/FilePluginStatePersistenceImpl.java
@@ -129,6 +129,20 @@ public class FilePluginStatePersistenceImpl implements PluginStatePersistenceSer
         }
     }
     
+    @Override
+    public void replaceAllConfigs(Map<String, Map<String, String>> configs) {
+        synchronized (configLock) {
+            try {
+                Map<String, Map<String, String>> configsToStore = configs == null
+                    ? new HashMap<>() : new HashMap<>(configs);
+                writeJsonToFile(PLUGIN_CONFIG_FILE, configsToStore);
+                LOGGER.debug("[FilePluginStatePersistenceImpl] Replaced all plugin configs");
+            } catch (Exception e) {
+                throw new PluginPersistenceException("Failed to replace all plugin configs", e);
+            }
+        }
+    }
+    
     /**
      * Load all plugin states.
      *

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/storage/PluginStatePersistenceService.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/storage/PluginStatePersistenceService.java
@@ -65,6 +65,22 @@ public interface PluginStatePersistenceService {
     void saveConfig(String pluginId, Map<String, String> config);
     
     /**
+     * Replace all plugin configurations.
+     *
+     * @param configs complete plugin configuration map
+     */
+    default void replaceAllConfigs(Map<String, Map<String, String>> configs) {
+        Map<String, Map<String, String>> targetConfigs = configs == null
+            ? java.util.Collections.emptyMap() : configs;
+        for (String pluginId : new java.util.HashSet<>(loadAllConfigs().keySet())) {
+            if (!targetConfigs.containsKey(pluginId)) {
+                deleteConfig(pluginId);
+            }
+        }
+        targetConfigs.forEach(this::saveConfig);
+    }
+    
+    /**
      * Delete plugin configuration.
      *
      * @param pluginId plugin ID

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
@@ -1017,19 +1017,21 @@ class PluginManagerTest {
         manager.applyConfigChange("trace:test", config);
         
         assertEquals("v", plugin.getCurrentConfig().get("k"));
+        assertEquals(config, manager.getRuntimePersistedConfigs().get("trace:test"));
         verify(persistence).saveConfig("trace:test", config);
     }
     
     @Test
-    void restoreConfigChangeDirectTest() {
+    void restorePluginConfigsReplacesCompleteSourceTest() {
         TestConfigurablePlugin plugin = new TestConfigurablePlugin();
         registerConfigurablePlugin("trace", "test", plugin);
         Map<String, String> config = Collections.singletonMap("k", "restored");
+        Map<String, Map<String, String>> configs = Collections.singletonMap("trace:test", config);
         
-        manager.restoreConfigChange("trace:test", config);
+        manager.restorePluginConfigs(configs);
         
         assertEquals("restored", plugin.getCurrentConfig().get("k"));
-        verify(persistence).saveConfig("trace:test", config);
+        verify(persistence).replaceAllConfigs(configs);
     }
     
     @Test

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/PluginStateSnapshotOperationTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/PluginStateSnapshotOperationTest.java
@@ -47,11 +47,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -107,7 +105,7 @@ class PluginStateSnapshotOperationTest {
         configs.put("trace:otel", otelConfig);
         
         when(persistence.loadAllStates()).thenReturn(states);
-        when(persistence.loadAllConfigs()).thenReturn(configs);
+        when(pluginManager.getRuntimePersistedConfigs()).thenReturn(configs);
         when(writer.getPath()).thenReturn(tempDir.toString());
         when(writer.addFile(eq("plugin_state.zip"), any(LocalFileMeta.class))).thenReturn(true);
         
@@ -127,7 +125,7 @@ class PluginStateSnapshotOperationTest {
     @Test
     void onSnapshotSaveEmptyDataTest() throws Exception {
         when(persistence.loadAllStates()).thenReturn(new HashMap<>());
-        when(persistence.loadAllConfigs()).thenReturn(new HashMap<>());
+        when(pluginManager.getRuntimePersistedConfigs()).thenReturn(new HashMap<>());
         when(writer.getPath()).thenReturn(tempDir.toString());
         when(writer.addFile(eq("plugin_state.zip"), any(LocalFileMeta.class))).thenReturn(true);
         
@@ -143,7 +141,7 @@ class PluginStateSnapshotOperationTest {
     @Test
     void onSnapshotSaveFailureTest() throws Exception {
         when(persistence.loadAllStates()).thenReturn(new HashMap<>());
-        when(persistence.loadAllConfigs()).thenReturn(new HashMap<>());
+        when(pluginManager.getRuntimePersistedConfigs()).thenReturn(new HashMap<>());
         when(writer.getPath()).thenReturn(tempDir.toString());
         when(writer.addFile(eq("plugin_state.zip"), any(LocalFileMeta.class))).thenReturn(false);
         
@@ -203,13 +201,13 @@ class PluginStateSnapshotOperationTest {
         when(reader.getFileMeta("plugin_state.zip")).thenReturn(fileMeta);
         
         doNothing().when(pluginManager).restorePluginStates(anyMap());
-        doNothing().when(pluginManager).restoreConfigChange(anyString(), anyMap());
+        doNothing().when(pluginManager).restorePluginConfigs(anyMap());
         
         boolean result = snapshotOperation.onSnapshotLoad(reader);
         
         assertTrue(result);
         verify(pluginManager).restorePluginStates(states);
-        verify(pluginManager, times(1)).restoreConfigChange(anyString(), anyMap());
+        verify(pluginManager).restorePluginConfigs(configs);
     }
     
     @Test
@@ -237,7 +235,7 @@ class PluginStateSnapshotOperationTest {
         
         assertTrue(result);
         verify(pluginManager, never()).restorePluginStates(anyMap());
-        verify(pluginManager, never()).restoreConfigChange(anyString(), anyMap());
+        verify(pluginManager, never()).restorePluginConfigs(anyMap());
     }
     
     @Test

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigServiceTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigServiceTest.java
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PluginConfigServiceTest {
@@ -99,8 +100,9 @@ class PluginConfigServiceTest {
         definition.setDefaultValue("default");
         PluginInfo pluginInfo = pluginInfo(definition);
         RecordingPlugin plugin = new RecordingPlugin(pluginInfo.getConfigDefinitions());
-        service.loadRuntimePersistedConfig(pluginInfo, PLUGIN_ID,
-            Collections.singletonMap("nacos.plugin.trace.test.endpoint", "persisted"));
+        when(persistence.loadAllConfigs()).thenReturn(Collections.singletonMap(PLUGIN_ID,
+            Collections.singletonMap("nacos.plugin.trace.test.endpoint", "persisted")));
+        service.initializeRuntimePersistedConfigs();
         
         service.initializePluginConfig(pluginInfo, plugin);
         
@@ -276,8 +278,9 @@ class PluginConfigServiceTest {
         ConfigItemDefinition definition = runtimeDefinition("secret", "secret-value");
         definition.setSensitive(true);
         PluginInfo pluginInfo = pluginInfo(definition);
-        service.loadRuntimePersistedConfig(pluginInfo, PLUGIN_ID,
-            Collections.singletonMap("secret", "runtime-secret"));
+        when(persistence.loadAllConfigs()).thenReturn(Collections.singletonMap(PLUGIN_ID,
+            Collections.singletonMap("secret", "runtime-secret")));
+        service.initializeRuntimePersistedConfigs();
         
         for (String maskedValue : new String[] {"******", "a******z", "ab******yz"}) {
             Map<String, String> prepared = service.prepareRuntimeUpdate(pluginInfo,
@@ -303,7 +306,7 @@ class PluginConfigServiceTest {
     }
     
     @Test
-    void restoreRuntimePersistedConfigAllowsRestartField() {
+    void restoreRuntimePersistedConfigsAllowsRestartField() {
         ConfigItemDefinition definition = new ConfigItemDefinition("endpoint", "endpoint",
             ConfigItemType.STRING);
         definition.setDefaultValue("default");
@@ -312,12 +315,31 @@ class PluginConfigServiceTest {
         RecordingPlugin plugin = new RecordingPlugin(pluginInfo.getConfigDefinitions());
         service.initializePluginConfig(pluginInfo, plugin);
         
-        service.restoreRuntimePersistedConfig(PLUGIN_ID, pluginInfo, plugin,
+        Map<String, Map<String, String>> restored = Collections.singletonMap(PLUGIN_ID,
             Collections.singletonMap("endpoint", "restored"));
+        service.restoreRuntimePersistedConfigs(restored);
+        service.applyRestoredPluginConfig(pluginInfo, plugin);
         
         assertEquals("restored", plugin.getCurrentConfig().get("endpoint"));
-        verify(persistence).saveConfig(PLUGIN_ID,
-            Collections.singletonMap("endpoint", "restored"));
+        assertEquals(restored, service.getAllRuntimePersistedConfigs());
+        verify(persistence).replaceAllConfigs(restored);
+    }
+    
+    @Test
+    void applyRestoredPluginConfigWrapsApplyFailure() {
+        ConfigItemDefinition definition = runtimeDefinition("endpoint", "default");
+        PluginInfo pluginInfo = pluginInfo(definition);
+        FailOncePlugin plugin = new FailOncePlugin(pluginInfo.getConfigDefinitions());
+        service.initializePluginConfig(pluginInfo, plugin);
+        service.restoreRuntimePersistedConfigs(Collections.singletonMap(PLUGIN_ID,
+            Collections.singletonMap("endpoint", "bad")));
+        
+        PluginConfigApplyException exception = assertThrows(PluginConfigApplyException.class,
+            () -> service.applyRestoredPluginConfig(pluginInfo, plugin));
+        
+        assertTrue(exception.getMessage().contains("Failed to apply restored plugin config"));
+        assertEquals("default", plugin.getCurrentConfig().get("endpoint"));
+        assertEquals("bad", service.resolve(pluginInfo, false).getConfig().get("endpoint"));
     }
     
     @Test

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigSourceRegistryTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/config/PluginConfigSourceRegistryTest.java
@@ -50,16 +50,24 @@ class PluginConfigSourceRegistryTest {
     @Test
     void testRegistryDelegatesSourceLifecycle() {
         TestSourceResolver staticResolver = new TestSourceResolver(PluginConfigSourceType.STATIC);
-        PluginConfigSourceRegistry registry = registryWithStaticResolver(staticResolver);
+        TestPersistedSourceResolver persistedResolver = new TestPersistedSourceResolver();
+        PluginConfigSourceRegistry registry = registryWithResolvers(staticResolver,
+            persistedResolver);
         PluginInfo pluginInfo = new PluginInfo();
+        Map<String, Map<String, String>> restored = Collections.singletonMap("trace:test",
+            Collections.singletonMap("key", "value"));
         
         registry.initializeConfig(PluginConfigSourceType.STATIC, pluginInfo);
         registry.refreshConfig(PluginConfigSourceType.STATIC, pluginInfo);
+        registry.initializePersistedConfigs();
+        registry.restorePersistedConfigs(restored);
         
         assertSame(staticResolver,
             registry.getSourceResolver(PluginConfigSourceType.STATIC));
         assertTrue(staticResolver.initialized);
         assertTrue(staticResolver.refreshed);
+        assertTrue(persistedResolver.persistedInitialized);
+        assertEquals(restored, registry.getAllPersistedConfigs());
     }
     
     @Test
@@ -73,15 +81,24 @@ class PluginConfigSourceRegistryTest {
             () -> new PluginConfigSourceRegistry(Collections.emptyList()));
         IllegalArgumentException unknownException = assertThrows(IllegalArgumentException.class,
             () -> new PluginConfigSourceRegistry().getSourceResolver(null));
+        List<PluginConfigSourceResolver> unsupportedPersistedSource = defaultSources();
+        unsupportedPersistedSource.set(1,
+            new TestSourceResolver(PluginConfigSourceType.RUNTIME_PERSISTED));
+        IllegalArgumentException unsupportedException = assertThrows(
+            IllegalArgumentException.class,
+            () -> new PluginConfigSourceRegistry(unsupportedPersistedSource));
         
         assertTrue(duplicateException.getMessage().contains("Duplicate"));
         assertTrue(missingException.getMessage().contains("Required"));
         assertTrue(unknownException.getMessage().contains("not found"));
+        assertTrue(unsupportedException.getMessage().contains("persistence lifecycle"));
     }
     
-    private PluginConfigSourceRegistry registryWithStaticResolver(
-        PluginConfigSourceResolver staticResolver) {
+    private PluginConfigSourceRegistry registryWithResolvers(
+        PluginConfigSourceResolver staticResolver,
+        PersistedPluginConfigSourceResolver persistedResolver) {
         List<PluginConfigSourceResolver> sources = defaultSources();
+        sources.set(1, persistedResolver);
         sources.set(2, staticResolver);
         return new PluginConfigSourceRegistry(sources);
     }
@@ -89,9 +106,36 @@ class PluginConfigSourceRegistryTest {
     private List<PluginConfigSourceResolver> defaultSources() {
         return new java.util.ArrayList<>(Arrays.asList(
             new TestSourceResolver(PluginConfigSourceType.LOCAL_ONLY),
-            new TestSourceResolver(PluginConfigSourceType.RUNTIME_PERSISTED),
+            new TestPersistedSourceResolver(),
             new TestSourceResolver(PluginConfigSourceType.STATIC),
             new TestSourceResolver(PluginConfigSourceType.DEFAULT)));
+    }
+    
+    private static class TestPersistedSourceResolver extends TestSourceResolver
+        implements PersistedPluginConfigSourceResolver {
+        
+        private boolean persistedInitialized;
+        
+        private Map<String, Map<String, String>> configs = Collections.emptyMap();
+        
+        TestPersistedSourceResolver() {
+            super(PluginConfigSourceType.RUNTIME_PERSISTED);
+        }
+        
+        @Override
+        public void initialize() {
+            persistedInitialized = true;
+        }
+        
+        @Override
+        public Map<String, Map<String, String>> getAllConfigs() {
+            return configs;
+        }
+        
+        @Override
+        public void restoreConfigs(Map<String, Map<String, String>> configs) {
+            this.configs = configs;
+        }
     }
     
     private static class TestSourceResolver implements PluginConfigSourceResolver {

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/config/RuntimePersistedPluginConfigSourceResolverTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/config/RuntimePersistedPluginConfigSourceResolverTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin.config;
+
+import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
+import com.alibaba.nacos.api.plugin.PluginType;
+import com.alibaba.nacos.core.plugin.model.PluginConfigSourceType;
+import com.alibaba.nacos.core.plugin.model.PluginInfo;
+import com.alibaba.nacos.core.plugin.storage.PluginPersistenceException;
+import com.alibaba.nacos.core.plugin.storage.PluginStatePersistenceService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RuntimePersistedPluginConfigSourceResolverTest {
+    
+    private static final String PLUGIN_ID = "trace:test";
+    
+    @Mock
+    private PluginStatePersistenceService persistence;
+    
+    @Test
+    void testInitializeAndNormalizeLoadedConfig() {
+        Map<String, String> loadedConfig = Collections.singletonMap(
+            "nacos.plugin.trace.test.endpoint", "loaded");
+        when(persistence.loadAllConfigs()).thenReturn(
+            Collections.singletonMap(PLUGIN_ID, loadedConfig));
+        RuntimePersistedPluginConfigSourceResolver resolver =
+            new RuntimePersistedPluginConfigSourceResolver(persistence);
+        PluginInfo pluginInfo = pluginInfo();
+        
+        resolver.initialize();
+        resolver.initializeConfig(pluginInfo);
+        
+        assertEquals(Collections.singletonMap("endpoint", "loaded"),
+            resolver.getConfig(pluginInfo));
+        assertEquals(PluginConfigSourceType.RUNTIME_PERSISTED, resolver.getSourceType());
+        verify(persistence).loadAllConfigs();
+    }
+    
+    @Test
+    void testUpdatePersistsBeforeReplacingSource() {
+        RuntimePersistedPluginConfigSourceResolver resolver =
+            new RuntimePersistedPluginConfigSourceResolver(persistence);
+        Map<String, String> config = new HashMap<>();
+        config.put("endpoint", "new");
+        
+        resolver.updateConfig(PLUGIN_ID, config);
+        config.put("endpoint", "mutated");
+        
+        assertEquals("new", resolver.getConfig(pluginInfo()).get("endpoint"));
+        verify(persistence).saveConfig(PLUGIN_ID,
+            Collections.singletonMap("endpoint", "new"));
+        
+        resolver.updateConfig(PLUGIN_ID, null);
+        assertTrue(resolver.getConfig(pluginInfo()).isEmpty());
+        verify(persistence).saveConfig(PLUGIN_ID, Collections.emptyMap());
+    }
+    
+    @Test
+    void testPersistenceFailureKeepsCurrentSource() {
+        RuntimePersistedPluginConfigSourceResolver resolver =
+            new RuntimePersistedPluginConfigSourceResolver(persistence);
+        resolver.updateConfig(PLUGIN_ID, Collections.singletonMap("endpoint", "current"));
+        doThrow(new PluginPersistenceException("save failed")).when(persistence)
+            .saveConfig(PLUGIN_ID, Collections.singletonMap("endpoint", "failed"));
+        
+        assertThrows(PluginPersistenceException.class, () -> resolver.updateConfig(PLUGIN_ID,
+            Collections.singletonMap("endpoint", "failed")));
+        
+        assertEquals("current", resolver.getConfig(pluginInfo()).get("endpoint"));
+    }
+    
+    @Test
+    void testSnapshotIsDefensiveCopy() {
+        RuntimePersistedPluginConfigSourceResolver resolver =
+            new RuntimePersistedPluginConfigSourceResolver();
+        resolver.initialize();
+        resolver.updateConfig(PLUGIN_ID, Collections.singletonMap("endpoint", "value"));
+        
+        Map<String, Map<String, String>> snapshot = resolver.getAllConfigs();
+        snapshot.get(PLUGIN_ID).put("endpoint", "mutated");
+        snapshot.put("other:test", Collections.emptyMap());
+        
+        assertEquals("value", resolver.getConfig(pluginInfo()).get("endpoint"));
+        assertEquals(1, resolver.getAllConfigs().size());
+    }
+    
+    @Test
+    void testRestoreReplacesCompleteSource() {
+        RuntimePersistedPluginConfigSourceResolver resolver =
+            new RuntimePersistedPluginConfigSourceResolver(persistence);
+        resolver.updateConfig(PLUGIN_ID, Collections.singletonMap("old", "value"));
+        Map<String, Map<String, String>> restored = new HashMap<>();
+        Map<String, String> restoredPluginConfig = new HashMap<>();
+        restoredPluginConfig.put("endpoint", "restored");
+        restored.put(PLUGIN_ID, restoredPluginConfig);
+        restored.put("unknown:test", null);
+        
+        resolver.restoreConfigs(restored);
+        restored.get(PLUGIN_ID).put("endpoint", "mutated");
+        
+        assertEquals(Collections.singletonMap("endpoint", "restored"),
+            resolver.getConfig(pluginInfo()));
+        PluginInfo unknownPlugin = new PluginInfo();
+        unknownPlugin.setPluginId("unknown:test");
+        assertTrue(resolver.getConfig(unknownPlugin).isEmpty());
+        verify(persistence).replaceAllConfigs(org.mockito.ArgumentMatchers
+            .argThat(configs -> "restored".equals(configs.get(PLUGIN_ID).get("endpoint"))
+                && configs.get("unknown:test").isEmpty()));
+        
+        resolver.restoreConfigs(null);
+        assertTrue(resolver.getAllConfigs().isEmpty());
+        verify(persistence).replaceAllConfigs(Collections.emptyMap());
+    }
+    
+    @Test
+    void testRestoreFailureKeepsCurrentSource() {
+        RuntimePersistedPluginConfigSourceResolver resolver =
+            new RuntimePersistedPluginConfigSourceResolver(persistence);
+        resolver.updateConfig(PLUGIN_ID, Collections.singletonMap("endpoint", "current"));
+        Map<String, Map<String, String>> restored = Collections.singletonMap(PLUGIN_ID,
+            Collections.singletonMap("endpoint", "failed"));
+        doThrow(new PluginPersistenceException("restore failed")).when(persistence)
+            .replaceAllConfigs(restored);
+        
+        assertThrows(PluginPersistenceException.class,
+            () -> resolver.restoreConfigs(restored));
+        assertEquals("current", resolver.getConfig(pluginInfo()).get("endpoint"));
+    }
+    
+    private PluginInfo pluginInfo() {
+        ConfigItemDefinition definition = new ConfigItemDefinition();
+        definition.setKey("endpoint");
+        PluginInfo result = new PluginInfo();
+        result.setPluginId(PLUGIN_ID);
+        result.setPluginType(PluginType.TRACE);
+        result.setPluginName("test");
+        result.setConfigDefinitions(Collections.singletonList(definition));
+        return result;
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/storage/FilePluginStatePersistenceImplTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/storage/FilePluginStatePersistenceImplTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,12 +31,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -147,6 +150,29 @@ class FilePluginStatePersistenceImplTest {
         assertEquals(2, configs.size());
         assertEquals("value1", configs.get("trace:test1").get("key1"));
         assertEquals("value2", configs.get("auth:test2").get("key2"));
+    }
+    
+    @Test
+    void replaceAllConfigsTest() {
+        persistence.saveConfig("trace:old", Collections.singletonMap("key", "old"));
+        Map<String, Map<String, String>> replacement = new HashMap<>();
+        replacement.put("trace:new", Collections.singletonMap("key", "new"));
+        
+        persistence.replaceAllConfigs(replacement);
+        
+        assertEquals(replacement, persistence.loadAllConfigs());
+        
+        persistence.replaceAllConfigs(null);
+        assertTrue(persistence.loadAllConfigs().isEmpty());
+    }
+    
+    @Test
+    void replaceAllConfigsFailureTest() {
+        ReflectionTestUtils.setField(persistence, "dataDir",
+            tempDir.resolve("missing").toString());
+        
+        assertThrows(PluginPersistenceException.class,
+            () -> persistence.replaceAllConfigs(Collections.emptyMap()));
     }
     
     @Test

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/storage/PluginStatePersistenceServiceTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/storage/PluginStatePersistenceServiceTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin.storage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PluginStatePersistenceServiceTest {
+    
+    @Test
+    void testDefaultReplaceAllConfigs() {
+        InMemoryPersistence persistence = new InMemoryPersistence();
+        persistence.saveConfig("trace:old", Collections.singletonMap("key", "old"));
+        persistence.saveConfig("trace:updated", Collections.singletonMap("key", "before"));
+        Map<String, Map<String, String>> replacement = new HashMap<>();
+        replacement.put("trace:updated", Collections.singletonMap("key", "after"));
+        replacement.put("trace:new", Collections.singletonMap("key", "new"));
+        
+        persistence.replaceAllConfigs(replacement);
+        
+        assertEquals(replacement, persistence.loadAllConfigs());
+        
+        persistence.replaceAllConfigs(null);
+        assertTrue(persistence.loadAllConfigs().isEmpty());
+    }
+    
+    private static class InMemoryPersistence implements PluginStatePersistenceService {
+        
+        private final Map<String, Map<String, String>> configs = new HashMap<>();
+        
+        @Override
+        public Map<String, Boolean> loadAllStates() {
+            return Collections.emptyMap();
+        }
+        
+        @Override
+        public void saveState(String pluginId, boolean enabled) {
+        }
+        
+        @Override
+        public void deleteState(String pluginId) {
+        }
+        
+        @Override
+        public Map<String, Map<String, String>> loadAllConfigs() {
+            return new HashMap<>(configs);
+        }
+        
+        @Override
+        public void saveConfig(String pluginId, Map<String, String> config) {
+            configs.put(pluginId, config);
+        }
+        
+        @Override
+        public void deleteConfig(String pluginId) {
+            configs.remove(pluginId);
+        }
+    }
+}

--- a/specs/en/plugin/plugin-spec.md
+++ b/specs/en/plugin/plugin-spec.md
@@ -331,6 +331,14 @@ Runtime persisted config and local-only config store only values by
 `pluginId + itemKey`. They do not store normalized full keys, alias keys,
 source, or version information.
 
+The runtime persisted source resolver owns its persistence lifecycle. It loads
+the complete source before plugin config initialization, persists a normalized
+complete map before replacing one plugin source, exports the in-memory terminal
+map for consensus snapshots, and replaces the complete persisted source before
+applying a restored snapshot. Plugin orchestration does not directly read or
+write `plugin-configs.json`. Persisted plugin enabled state remains owned by the
+state-management path.
+
 Every internal source resolver must expose its canonical item-key map through
 `getConfig(PluginInfo)`. Reading is independent from update capability:
 `DEFAULT` reads definition defaults, `STATIC` reads normalized and alias keys
@@ -404,8 +412,8 @@ only `pluginId`, item key, and target source, and must not log the value.
 Startup and runtime updates use the same source resolver and effective config
 calculation:
 
-1. Startup loads all `plugin-configs.json` entries into the runtime persisted
-   source before applying any plugin config.
+1. The runtime persisted source resolver loads all `plugin-configs.json`
+   entries before any plugin config is applied.
 2. Every loaded configurable plugin is then resolved and applied, including
    plugins without a persisted override. Startup may apply both `RUNTIME` and
    `RESTART` fields because the plugin is being initialized.

--- a/specs/zh-cn/plugin/plugin-spec.md
+++ b/specs/zh-cn/plugin/plugin-spec.md
@@ -289,6 +289,12 @@ LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
 运行时持久化配置和 local-only 配置只保存 `pluginId + itemKey` 对应的值，不保存
 normalized full key、alias key、source 或版本信息。
 
+runtime persisted source resolver 负责完整的持久化生命周期：在插件配置初始化前加载
+全部 source；单插件更新时先持久化归一化后的完整 map，再替换内存 source；为一致性
+快照导出内存终态 map；恢复快照时先完整替换持久化 source，再应用插件配置。
+插件编排层不得直接读写 `plugin-configs.json`。插件 enabled state 的持久化仍由状态管理
+链路负责。
+
 每个内部 source resolver 都必须通过 `getConfig(PluginInfo)` 返回使用 canonical
 item key 的完整 map。读取能力与写入能力相互独立：`DEFAULT` 从 definition 读取默认值，
 `STATIC` 根据标准 key 和 alias 从环境读取，两个运行时 source 读取各自内部 map。
@@ -343,8 +349,8 @@ source 的 effective value 复制成 runtime override。服务端应记录 WARN 
 
 启动和运行时更新复用同一套 source resolver 与 effective config 计算逻辑：
 
-1. 启动时先将 `plugin-configs.json` 中的全部内容装载到 runtime persisted source，
-   再开始应用插件配置。
+1. runtime persisted source resolver 先将 `plugin-configs.json` 中的全部内容装载到
+   source，再开始应用插件配置。
 2. 随后对每个已加载的可配置插件执行 resolve 和 apply，即使该插件没有持久化
    override 也要处理。启动属于初始化阶段，可以同时应用 `RUNTIME` 和 `RESTART`
    字段。


### PR DESCRIPTION
## What is the purpose of the change

For #15475.

Move the complete RUNTIME_PERSISTED configuration lifecycle into its source resolver. The resolver now owns startup loading, persistence-before-memory replacement, consensus snapshot export, and complete snapshot restore, while PluginManager and PluginConfigService remain orchestration layers.

## Brief changelog

- encapsulate runtime persisted config loading, updates, snapshots, and restores in RuntimePersistedPluginConfigSourceResolver
- restore consensus snapshots as one complete terminal map while retaining configs for plugins not loaded locally
- keep persisted enabled-state ownership unchanged and preserve storage compatibility through a default replacement operation
- update English and Chinese plugin specs and add focused failure and defensive-copy coverage

## Verifying this change

- mvn -pl core spotless:apply
- mvn -pl core spotless:check
- mvn -pl core test
- mvn -pl core -Dtest=RuntimePersistedPluginConfigSourceResolverTest,PluginConfigServiceTest,PluginConfigSourceRegistryTest,PluginConfigResolverTest,PluginManagerTest,PluginStateSnapshotOperationTest,PluginStatePersistenceServiceTest,FilePluginStatePersistenceImplTest test
- mvn -B clean install -Prelease-nacos -DskipTests=true
- mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e
- verified an isolated standalone distribution can load preseeded runtime config, replace it through PUT, clear it with an empty map, preserve an unknown plugin entry, and recover the terminal config after restart

The focused suite ran 135 tests with no failures. Changed runtime source classes have 100% line coverage, and every added FilePluginStatePersistenceImpl line is covered.

No HTTP API or public Java SDK contract changes are introduced, so OpenAPI and Java SDK IT matrices are unaffected.

- [x] There is an existing GitHub issue for the change.
- [x] The PR contains focused unit tests and spec updates.
- [x] Formatting, static analysis, unit tests, release build, and standalone live verification pass.