### PR TITLE
[ISSUE #14804] Add Agent version fingerprints and storage adapter

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -135,6 +135,20 @@ public class Constants {
             "__nacos.agent.endpoint.tenant__";
     }
     
+    public static class Agent {
+        
+        /**
+         * Resource type stored in {@code ai_resource} and {@code ai_resource_version}.
+         */
+        public static final String RESOURCE_TYPE_AGENT = "agent";
+        
+        /**
+         * Selects the AI Storage provider for Agent Version content.
+         */
+        public static final String AGENT_STORAGE_PROVIDER_CONFIG_KEY =
+            "nacos.ai.agent.storage.provider";
+    }
+    
     public static class Skills {
         
         public static final String CONSOLE_PATH = "/v3/console/ai/skills";

--- a/ai/src/main/java/com/alibaba/nacos/ai/model/agent/AgentVersionContent.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/model/agent/AgentVersionContent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.model.agent;
+
+import com.alibaba.nacos.api.ai.model.agent.AgentCallInterface;
+
+import java.util.List;
+
+/**
+ * Complete protocol-neutral content stored for one Agent Version.
+ *
+ * @author Nacos
+ */
+public class AgentVersionContent {
+    
+    public static final String KIND = "AgentVersionContent";
+    
+    public static final int SCHEMA_VERSION = 1;
+    
+    private String kind;
+    
+    private Integer schemaVersion;
+    
+    private List<AgentCallInterface> callInterfaces;
+    
+    public AgentVersionContent() {
+    }
+    
+    public AgentVersionContent(List<AgentCallInterface> callInterfaces) {
+        this.kind = KIND;
+        this.schemaVersion = SCHEMA_VERSION;
+        this.callInterfaces = callInterfaces;
+    }
+    
+    public String getKind() {
+        return kind;
+    }
+    
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+    
+    public Integer getSchemaVersion() {
+        return schemaVersion;
+    }
+    
+    public void setSchemaVersion(Integer schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+    
+    public List<AgentCallInterface> getCallInterfaces() {
+        return callInterfaces;
+    }
+    
+    public void setCallInterfaces(List<AgentCallInterface> callInterfaces) {
+        this.callInterfaces = callInterfaces;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/model/agent/AgentVersionStorageDescriptor.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/model/agent/AgentVersionStorageDescriptor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.model.agent;
+
+/**
+ * Storage descriptor persisted in the Agent Version row.
+ *
+ * @author Nacos
+ */
+public class AgentVersionStorageDescriptor {
+    
+    public static final String NACOS_CONFIG_KEY_FORMAT = "agent-version-config-v1";
+    
+    public static final String RAD_AGENT_NAME_CODEC = "rad-ascii-v1";
+    
+    public static final String MEDIA_TYPE = "application/vnd.nacos.agent-version+json";
+    
+    public static final int SCHEMA_VERSION = 1;
+    
+    private String provider;
+    
+    private String key;
+    
+    private String keyFormat;
+    
+    private String agentNameCodec;
+    
+    private String contentDigest;
+    
+    private String mediaType;
+    
+    private Integer schemaVersion;
+    
+    private Long size;
+    
+    public String getProvider() {
+        return provider;
+    }
+    
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+    
+    public String getKey() {
+        return key;
+    }
+    
+    public void setKey(String key) {
+        this.key = key;
+    }
+    
+    public String getKeyFormat() {
+        return keyFormat;
+    }
+    
+    public void setKeyFormat(String keyFormat) {
+        this.keyFormat = keyFormat;
+    }
+    
+    public String getAgentNameCodec() {
+        return agentNameCodec;
+    }
+    
+    public void setAgentNameCodec(String agentNameCodec) {
+        this.agentNameCodec = agentNameCodec;
+    }
+    
+    public String getContentDigest() {
+        return contentDigest;
+    }
+    
+    public void setContentDigest(String contentDigest) {
+        this.contentDigest = contentDigest;
+    }
+    
+    public String getMediaType() {
+        return mediaType;
+    }
+    
+    public void setMediaType(String mediaType) {
+        this.mediaType = mediaType;
+    }
+    
+    public Integer getSchemaVersion() {
+        return schemaVersion;
+    }
+    
+    public void setSchemaVersion(Integer schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+    
+    public Long getSize() {
+        return size;
+    }
+    
+    public void setSize(Long size) {
+        this.size = size;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/plugin/AiStoragePluginTypePolicy.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/plugin/AiStoragePluginTypePolicy.java
@@ -55,6 +55,8 @@ public class AiStoragePluginTypePolicy implements PluginTypePolicy {
             Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY));
         result.add(resolveProvider(configuration,
             Constants.AgentSpecs.AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY));
+        result.add(resolveProvider(configuration,
+            Constants.Agent.AGENT_STORAGE_PROVIDER_CONFIG_KEY));
         requiredPluginNames = Collections.unmodifiableSet(result);
     }
     
@@ -83,12 +85,13 @@ public class AiStoragePluginTypePolicy implements PluginTypePolicy {
     public String getSelectionProperty() {
         return Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY + ", "
             + Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY + ", "
-            + Constants.AgentSpecs.AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY;
+            + Constants.AgentSpecs.AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY + ", "
+            + Constants.Agent.AGENT_STORAGE_PROVIDER_CONFIG_KEY;
     }
     
     @Override
     public String getActivationDescription() {
-        return "the AI module requires the configured Prompt, Skill, and AgentSpec storage providers";
+        return "the AI module requires the configured Prompt, Skill, AgentSpec, and Agent storage providers";
     }
     
     private String resolveProvider(PluginTypeConfiguration configuration, String property) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/fingerprint/AgentVersionContentCodec.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/fingerprint/AgentVersionContentCodec.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.fingerprint;
+
+import com.alibaba.nacos.ai.model.agent.AgentVersionContent;
+import com.alibaba.nacos.api.ai.model.agent.AgentCallInterface;
+import com.alibaba.nacos.api.ai.model.agent.Endpoint;
+import com.alibaba.nacos.api.ai.model.agent.EndpointSource;
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.api.ai.utils.AgentModelValidator;
+import com.alibaba.nacos.api.ai.utils.EndpointCanonicalizer;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Encodes and decodes the JSON bytes stored for one Agent Version.
+ *
+ * <p>The returned bytes are the single fact used both for persistence and SHA-256 calculation, so
+ * storage content, size and digest cannot diverge through a second serialization pass.</p>
+ *
+ * @author Nacos
+ */
+public final class AgentVersionContentCodec {
+    
+    public static final String DIGEST_PREFIX = "sha256:";
+    
+    public static final int MAX_CONTENT_SIZE = 1024 * 1024;
+    
+    private static final int MAX_CALL_INTERFACES = 16;
+    
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+    
+    private AgentVersionContentCodec() {
+    }
+    
+    /**
+     * Validate and encode one Agent Version content object.
+     *
+     * @param content Agent Version content
+     * @return immutable storage encoding result
+     * @throws IllegalArgumentException when content is invalid or exceeds the storage limit
+     */
+    public static EncodedContent encode(AgentVersionContent content) {
+        validate(content);
+        final byte[] bytes;
+        try {
+            bytes = JacksonUtils.toJsonBytes(toStorageProjection(content));
+        } catch (NacosSerializationException e) {
+            throw new IllegalArgumentException("Unable to serialize AgentVersionContent", e);
+        }
+        if (bytes.length > MAX_CONTENT_SIZE) {
+            throw new IllegalArgumentException(
+                "AgentVersionContent exceeds " + MAX_CONTENT_SIZE + " bytes");
+        }
+        return new EncodedContent(bytes, digest(bytes));
+    }
+    
+    /**
+     * Compute the digest of the exact bytes read from or written to AI Storage.
+     *
+     * @param bytes persisted Agent Version content bytes
+     * @return digest token in {@code sha256:<lowercase hex>} form
+     * @throws IllegalArgumentException when bytes are null or exceed the storage limit
+     */
+    public static String digest(byte[] bytes) {
+        if (bytes == null) {
+            throw new IllegalArgumentException("AgentVersionContent bytes must not be null");
+        }
+        if (bytes.length > MAX_CONTENT_SIZE) {
+            throw new IllegalArgumentException(
+                "AgentVersionContent exceeds " + MAX_CONTENT_SIZE + " bytes");
+        }
+        return DIGEST_PREFIX + sha256Hex(bytes);
+    }
+    
+    /**
+     * Decode Agent Version bytes and verify the storage model.
+     *
+     * @param bytes persisted Agent Version content bytes
+     * @return decoded content
+     * @throws IllegalArgumentException when bytes are invalid or out of contract
+     */
+    public static AgentVersionContent decode(byte[] bytes) {
+        if (bytes == null) {
+            throw new IllegalArgumentException("AgentVersionContent bytes must not be null");
+        }
+        if (bytes.length > MAX_CONTENT_SIZE) {
+            throw new IllegalArgumentException(
+                "AgentVersionContent exceeds " + MAX_CONTENT_SIZE + " bytes");
+        }
+        final AgentVersionContent content;
+        try {
+            content = JacksonUtils.toObj(bytes, AgentVersionContent.class);
+        } catch (NacosDeserializationException e) {
+            throw new IllegalArgumentException("Invalid AgentVersionContent", e);
+        }
+        validate(content);
+        return content;
+    }
+    
+    private static void validate(AgentVersionContent content) {
+        if (content == null) {
+            throw new IllegalArgumentException("AgentVersionContent must not be null");
+        }
+        if (!AgentVersionContent.KIND.equals(content.getKind())) {
+            throw new IllegalArgumentException("AgentVersionContent kind must be "
+                + AgentVersionContent.KIND);
+        }
+        if (!Integer.valueOf(AgentVersionContent.SCHEMA_VERSION)
+            .equals(content.getSchemaVersion())) {
+            throw new IllegalArgumentException("AgentVersionContent schemaVersion must be "
+                + AgentVersionContent.SCHEMA_VERSION);
+        }
+        List<AgentCallInterface> callInterfaces = content.getCallInterfaces();
+        if (callInterfaces == null || callInterfaces.isEmpty()
+            || callInterfaces.size() > MAX_CALL_INTERFACES) {
+            throw new IllegalArgumentException(
+                "AgentVersionContent callInterfaces must contain 1 to " + MAX_CALL_INTERFACES
+                    + " items");
+        }
+        Set<String> protocols = new HashSet<String>();
+        for (AgentCallInterface callInterface : callInterfaces) {
+            AgentModelValidator.validateCallInterface(callInterface);
+            if (!protocols.add(callInterface.getProtocol())) {
+                throw new IllegalArgumentException(
+                    "Duplicate CallInterface protocol: " + callInterface.getProtocol());
+            }
+        }
+    }
+    
+    private static Map<String, Object> toStorageProjection(AgentVersionContent content) {
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        result.put("kind", AgentVersionContent.KIND);
+        result.put("schemaVersion", AgentVersionContent.SCHEMA_VERSION);
+        List<Map<String, Object>> callInterfaces = new ArrayList<Map<String, Object>>();
+        for (AgentCallInterface callInterface : content.getCallInterfaces()) {
+            callInterfaces.add(toStorageProjection(callInterface));
+        }
+        result.put("callInterfaces", callInterfaces);
+        return result;
+    }
+    
+    private static Map<String, Object> toStorageProjection(AgentCallInterface callInterface) {
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        result.put("protocol", callInterface.getProtocol());
+        if (callInterface.getProtocolVersion() != null) {
+            result.put("protocolVersion", callInterface.getProtocolVersion());
+        }
+        result.put("descriptorMediaType", callInterface.getDescriptorMediaType());
+        result.put("nativeDescriptor", callInterface.getNativeDescriptor());
+        List<String> sources = new ArrayList<String>();
+        for (EndpointSource source : callInterface.getEndpointSourceOrder()) {
+            sources.add(source.name());
+        }
+        result.put("endpointSourceOrder", sources);
+        if (callInterface.getDeclaredEndpoints() != null
+            && !callInterface.getDeclaredEndpoints().isEmpty()) {
+            List<Map<String, Object>> endpoints = new ArrayList<Map<String, Object>>();
+            for (Endpoint endpoint : callInterface.getDeclaredEndpoints()) {
+                endpoints.add(toStorageProjection(EndpointCanonicalizer.canonicalize(endpoint)));
+            }
+            result.put("declaredEndpoints", endpoints);
+        }
+        return result;
+    }
+    
+    private static Map<String, Object> toStorageProjection(Endpoint endpoint) {
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        result.put("uri", endpoint.getUri());
+        result.put("transport", endpoint.getTransport());
+        result.put("priority", endpoint.getPriority());
+        result.put("weight", endpoint.getWeight());
+        if (endpoint.getMetadata() != null && !endpoint.getMetadata().isEmpty()) {
+            result.put("metadata", endpoint.getMetadata());
+        }
+        return result;
+    }
+    
+    private static String sha256Hex(byte[] bytes) {
+        final byte[] digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256").digest(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+        char[] encoded = new char[digest.length * 2];
+        for (int i = 0; i < digest.length; i++) {
+            int value = digest[i] & 0xFF;
+            encoded[i * 2] = HEX[value >>> 4];
+            encoded[i * 2 + 1] = HEX[value & 0x0F];
+        }
+        return new String(encoded);
+    }
+    
+    /**
+     * Immutable persisted bytes, digest and byte count for one Agent Version content object.
+     */
+    public static final class EncodedContent {
+        
+        private final byte[] bytes;
+        
+        private final String contentDigest;
+        
+        private EncodedContent(byte[] bytes, String contentDigest) {
+            this.bytes = bytes;
+            this.contentDigest = contentDigest;
+        }
+        
+        /**
+         * Return a defensive copy of the persisted storage bytes.
+         *
+         * @return persisted storage bytes
+         */
+        public byte[] getBytes() {
+            return Arrays.copyOf(bytes, bytes.length);
+        }
+        
+        /**
+         * Return the SHA-256 digest of the persisted bytes.
+         *
+         * @return digest token
+         */
+        public String getContentDigest() {
+            return contentDigest;
+        }
+        
+        /**
+         * Return the persisted UTF-8 byte count.
+         *
+         * @return byte count
+         */
+        public int getSize() {
+            return bytes.length;
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/fingerprint/AgentVersionContentCodec.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/fingerprint/AgentVersionContentCodec.java
@@ -25,7 +25,10 @@ import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
 import com.alibaba.nacos.api.ai.utils.AgentModelValidator;
 import com.alibaba.nacos.api.ai.utils.EndpointCanonicalizer;
 import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
 
+import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -53,6 +56,19 @@ public final class AgentVersionContentCodec {
     private static final int MAX_CALL_INTERFACES = 16;
     
     private static final char[] HEX = "0123456789abcdef".toCharArray();
+    
+    private static final JsonFactory STRICT_JSON_FACTORY = new JsonFactory()
+        .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+    
+    private static final Set<String> CONTENT_FIELDS = new HashSet<String>(Arrays.asList(
+        "kind", "schemaVersion", "callInterfaces"));
+    
+    private static final Set<String> CALL_INTERFACE_FIELDS = new HashSet<String>(Arrays.asList(
+        "protocol", "protocolVersion", "descriptorMediaType", "nativeDescriptor",
+        "endpointSourceOrder", "declaredEndpoints"));
+    
+    private static final Set<String> ENDPOINT_FIELDS = new HashSet<String>(Arrays.asList(
+        "uri", "transport", "priority", "weight", "metadata"));
     
     private AgentVersionContentCodec() {
     }
@@ -112,6 +128,7 @@ public final class AgentVersionContentCodec {
             throw new IllegalArgumentException(
                 "AgentVersionContent exceeds " + MAX_CONTENT_SIZE + " bytes");
         }
+        validateStorageJsonShape(bytes);
         final AgentVersionContent content;
         try {
             content = JacksonUtils.toObj(bytes, AgentVersionContent.class);
@@ -214,6 +231,65 @@ public final class AgentVersionContentCodec {
             encoded[i * 2 + 1] = HEX[value & 0x0F];
         }
         return new String(encoded);
+    }
+    
+    private static void validateStorageJsonShape(byte[] bytes) {
+        validateSingleJsonValue(bytes);
+        final Map<?, ?> root;
+        try {
+            root = JacksonUtils.toObj(bytes, Map.class);
+        } catch (NacosDeserializationException e) {
+            throw new IllegalArgumentException("Invalid AgentVersionContent", e);
+        }
+        if (root == null) {
+            throw new IllegalArgumentException("AgentVersionContent must be a JSON object");
+        }
+        rejectUnknownFields(root, CONTENT_FIELDS, "AgentVersionContent");
+        Object callInterfaces = root.get("callInterfaces");
+        if (!(callInterfaces instanceof List)) {
+            return;
+        }
+        for (Object callInterface : (List<?>) callInterfaces) {
+            if (!(callInterface instanceof Map)) {
+                continue;
+            }
+            Map<?, ?> interfaceObject = (Map<?, ?>) callInterface;
+            rejectUnknownFields(interfaceObject, CALL_INTERFACE_FIELDS, "AgentCallInterface");
+            Object endpoints = interfaceObject.get("declaredEndpoints");
+            if (!(endpoints instanceof List)) {
+                continue;
+            }
+            for (Object endpoint : (List<?>) endpoints) {
+                if (endpoint instanceof Map) {
+                    rejectUnknownFields((Map<?, ?>) endpoint, ENDPOINT_FIELDS,
+                        "DeclaredEndpoint");
+                }
+            }
+        }
+    }
+    
+    private static void validateSingleJsonValue(byte[] bytes) {
+        try (JsonParser parser = STRICT_JSON_FACTORY.createParser(bytes)) {
+            if (parser.nextToken() == null) {
+                throw new IllegalArgumentException("AgentVersionContent JSON must not be empty");
+            }
+            parser.skipChildren();
+            if (parser.nextToken() != null) {
+                throw new IllegalArgumentException(
+                    "AgentVersionContent must contain one JSON value");
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Invalid AgentVersionContent", e);
+        }
+    }
+    
+    private static void rejectUnknownFields(Map<?, ?> value, Set<String> fields,
+        String objectName) {
+        for (Object field : value.keySet()) {
+            if (!fields.contains(field)) {
+                throw new IllegalArgumentException("Unknown " + objectName + " field: " + field);
+            }
+        }
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/fingerprint/RuntimeEndpointRevision.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/fingerprint/RuntimeEndpointRevision.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.fingerprint;
+
+import com.alibaba.nacos.api.ai.model.agent.Endpoint;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.api.ai.utils.EndpointCanonicalizer;
+import com.alibaba.nacos.api.ai.utils.EndpointNaturalKey;
+import org.apache.commons.codec.digest.MurmurHash3;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Generates the deterministic revision of one filtered Runtime Endpoint projection.
+ *
+ * @author Nacos
+ */
+public final class RuntimeEndpointRevision {
+    
+    public static final String ALGORITHM_ID = "murmur3-x64-128-v1";
+    
+    public static final String TOKEN_PREFIX = ALGORITHM_ID + ':';
+    
+    private static final int MAX_ENDPOINTS = 1000;
+    
+    private static final int MURMUR_SEED = 0;
+    
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+    
+    private RuntimeEndpointRevision() {
+    }
+    
+    /**
+     * Compute the opaque revision for an already aggregated and Version-filtered runtime set.
+     *
+     * @param namespaceId effective namespace used to validate and sort natural keys
+     * @param agentName original Agent name used to validate and sort natural keys
+     * @param protocol protocol group used to validate and sort natural keys
+     * @param endpoints enabled Runtime Endpoints; health must be present
+     * @return revision token in {@code murmur3-x64-128-v1:<32 lowercase hex>} form
+     * @throws IllegalArgumentException when the projection is invalid
+     */
+    public static String compute(String namespaceId, String agentName, String protocol,
+        List<Endpoint> endpoints) {
+        byte[] revisionBytes = revisionBytes(namespaceId, agentName, protocol, endpoints);
+        long[] hash = MurmurHash3.hash128x64(revisionBytes, 0, revisionBytes.length, MURMUR_SEED);
+        char[] value = new char[32];
+        appendHex(hash[0], value, 0);
+        appendHex(hash[1], value, 16);
+        return TOKEN_PREFIX + new String(value);
+    }
+    
+    static byte[] revisionBytes(String namespaceId, String agentName, String protocol,
+        List<Endpoint> endpoints) {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        AgentValidationUtils.validateAgentName(agentName);
+        AgentValidationUtils.validateProtocol(protocol);
+        if (endpoints == null) {
+            throw new IllegalArgumentException("Runtime Endpoint projection must not be null");
+        }
+        if (endpoints.size() > MAX_ENDPOINTS) {
+            throw new IllegalArgumentException(
+                "Runtime Endpoint projection exceeds " + MAX_ENDPOINTS + " items");
+        }
+        Map<EndpointNaturalKey, Endpoint> canonicalEndpoints =
+            new TreeMap<EndpointNaturalKey, Endpoint>();
+        for (Endpoint endpoint : endpoints) {
+            Endpoint canonical = EndpointCanonicalizer.canonicalize(endpoint);
+            if (canonical.getHealthy() == null) {
+                throw new IllegalArgumentException("Runtime Endpoint healthy must not be null");
+            }
+            EndpointNaturalKey key = EndpointNaturalKey.of(namespaceId, agentName, protocol,
+                canonical);
+            if (canonicalEndpoints.put(key, canonical) != null) {
+                throw new IllegalArgumentException("Duplicate Runtime Endpoint: " + key);
+            }
+        }
+        return frame(canonicalEndpoints);
+    }
+    
+    private static byte[] frame(Map<EndpointNaturalKey, Endpoint> endpoints) {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(buffer)) {
+            output.writeInt(endpoints.size());
+            for (Endpoint endpoint : endpoints.values()) {
+                writeUtf8(output, endpoint.getUri());
+                writeUtf8(output, endpoint.getTransport());
+                output.writeInt(endpoint.getPriority());
+                double weight = endpoint.getWeight() == 0D ? 0D : endpoint.getWeight();
+                output.writeLong(Double.doubleToLongBits(weight));
+                writeMetadata(output, endpoint.getMetadata());
+                output.writeBoolean(endpoint.getHealthy());
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to frame Runtime Endpoint projection", e);
+        }
+        return buffer.toByteArray();
+    }
+    
+    private static void writeUtf8(DataOutputStream output, String value) throws IOException {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        output.writeInt(bytes.length);
+        output.write(bytes);
+    }
+    
+    private static void writeMetadata(DataOutputStream output, Map<String, String> metadata)
+        throws IOException {
+        if (metadata == null || metadata.isEmpty()) {
+            output.writeInt(0);
+            return;
+        }
+        Map<String, String> sorted = new TreeMap<String, String>(metadata);
+        output.writeInt(sorted.size());
+        for (Map.Entry<String, String> entry : sorted.entrySet()) {
+            writeUtf8(output, entry.getKey());
+            writeUtf8(output, entry.getValue());
+        }
+    }
+    
+    private static void appendHex(long value, char[] target, int offset) {
+        for (int i = 15; i >= 0; i--) {
+            target[offset + i] = HEX[(int) (value & 0x0F)];
+            value >>>= 4;
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageDescriptorCodec.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageDescriptorCodec.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.storage;
+
+import com.alibaba.nacos.ai.model.agent.AgentVersionStorageDescriptor;
+import com.alibaba.nacos.ai.service.agent.fingerprint.AgentVersionContentCodec;
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * JSON codec for the storage descriptor persisted in one Agent Version row.
+ *
+ * @author Nacos
+ */
+public final class AgentVersionStorageDescriptorCodec {
+    
+    public static final String NACOS_CONFIG_PROVIDER = "nacos_config";
+    
+    public static final String NACOS_CONFIG_KEY_FORMAT =
+        AgentVersionStorageDescriptor.NACOS_CONFIG_KEY_FORMAT;
+    
+    public static final String RAD_ASCII_AGENT_NAME_CODEC =
+        AgentVersionStorageDescriptor.RAD_AGENT_NAME_CODEC;
+    
+    public static final String AGENT_VERSION_MEDIA_TYPE =
+        AgentVersionStorageDescriptor.MEDIA_TYPE;
+    
+    public static final int SCHEMA_VERSION = AgentVersionStorageDescriptor.SCHEMA_VERSION;
+    
+    public static final int MAX_CONTENT_SIZE = AgentVersionContentCodec.MAX_CONTENT_SIZE;
+    
+    private static final int MAX_PROVIDER_LENGTH = 64;
+    
+    private static final int MAX_KEY_LENGTH = 1024;
+    
+    private static final int MAX_FORMAT_LENGTH = 64;
+    
+    private static final Pattern PROVIDER_PATTERN =
+        Pattern.compile("[A-Za-z0-9][A-Za-z0-9_-]{0,63}");
+    
+    private static final Pattern DIGEST_PATTERN = Pattern.compile("sha256:[0-9a-f]{64}");
+    
+    private static final JsonFactory STRICT_JSON_FACTORY = new JsonFactory()
+        .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+    
+    private static final Set<String> FIELDS = Collections.unmodifiableSet(
+        new HashSet<String>(Arrays.asList("provider", "key", "keyFormat", "agentNameCodec",
+            "contentDigest", "mediaType", "schemaVersion", "size")));
+    
+    private AgentVersionStorageDescriptorCodec() {
+    }
+    
+    /**
+     * Validate and serialize an Agent Version storage descriptor.
+     *
+     * @param descriptor storage descriptor
+     * @return JSON stored in {@code ai_resource_version.storage}
+     * @throws IllegalArgumentException when the descriptor is invalid
+     */
+    public static String encode(AgentVersionStorageDescriptor descriptor) {
+        validate(descriptor);
+        try {
+            return JacksonUtils.toJson(descriptor);
+        } catch (NacosSerializationException e) {
+            throw new IllegalArgumentException(
+                "Unable to serialize Agent Version storage descriptor",
+                e);
+        }
+    }
+    
+    /**
+     * Deserialize and validate an Agent Version storage descriptor.
+     *
+     * @param json JSON read from {@code ai_resource_version.storage}
+     * @return decoded storage descriptor
+     * @throws IllegalArgumentException when JSON or descriptor fields are invalid
+     */
+    public static AgentVersionStorageDescriptor decode(String json) {
+        validateJsonShape(json);
+        final AgentVersionStorageDescriptor descriptor;
+        try {
+            descriptor = JacksonUtils.toObj(json, AgentVersionStorageDescriptor.class);
+        } catch (NacosDeserializationException e) {
+            throw new IllegalArgumentException("Invalid Agent Version storage descriptor", e);
+        }
+        validate(descriptor);
+        return descriptor;
+    }
+    
+    private static void validateJsonShape(String json) {
+        if (json == null || json.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Agent Version storage descriptor JSON must not be empty");
+        }
+        validateSingleJsonValue(json);
+        final Map<?, ?> root;
+        try {
+            root = JacksonUtils.toObj(json, Map.class);
+        } catch (NacosDeserializationException e) {
+            throw new IllegalArgumentException("Invalid Agent Version storage descriptor", e);
+        }
+        if (root == null) {
+            throw new IllegalArgumentException(
+                "Agent Version storage descriptor must be a JSON object");
+        }
+        for (Object fieldName : root.keySet()) {
+            if (!FIELDS.contains(fieldName)) {
+                throw new IllegalArgumentException(
+                    "Unknown Agent Version storage descriptor field: " + fieldName);
+            }
+        }
+        validateJsonText(root, "provider", false);
+        validateJsonText(root, "key", false);
+        validateJsonText(root, "keyFormat", true);
+        validateJsonText(root, "agentNameCodec", true);
+        validateJsonText(root, "contentDigest", false);
+        validateJsonText(root, "mediaType", false);
+        validateJsonInteger(root, "schemaVersion");
+        validateJsonInteger(root, "size");
+    }
+    
+    /**
+     * Validate an Agent Version storage descriptor against the internal storage schema.
+     *
+     * @param descriptor storage descriptor
+     * @throws IllegalArgumentException when the descriptor is invalid
+     */
+    public static void validate(AgentVersionStorageDescriptor descriptor) {
+        if (descriptor == null) {
+            throw new IllegalArgumentException("Agent Version storage descriptor must not be null");
+        }
+        String provider = descriptor.getProvider();
+        if (provider == null || provider.length() > MAX_PROVIDER_LENGTH
+            || !PROVIDER_PATTERN.matcher(provider).matches()) {
+            throw new IllegalArgumentException("Invalid Agent Version storage provider");
+        }
+        validateRequiredText("key", descriptor.getKey(), MAX_KEY_LENGTH);
+        validateOptionalText("keyFormat", descriptor.getKeyFormat(), MAX_FORMAT_LENGTH);
+        validateOptionalText("agentNameCodec", descriptor.getAgentNameCodec(), MAX_FORMAT_LENGTH);
+        if (descriptor.getContentDigest() == null
+            || !DIGEST_PATTERN.matcher(descriptor.getContentDigest()).matches()) {
+            throw new IllegalArgumentException("Invalid Agent Version contentDigest");
+        }
+        if (!AGENT_VERSION_MEDIA_TYPE.equals(descriptor.getMediaType())) {
+            throw new IllegalArgumentException("Agent Version mediaType must be "
+                + AGENT_VERSION_MEDIA_TYPE);
+        }
+        if (!Integer.valueOf(SCHEMA_VERSION).equals(descriptor.getSchemaVersion())) {
+            throw new IllegalArgumentException("Agent Version storage schemaVersion must be "
+                + SCHEMA_VERSION);
+        }
+        Long size = descriptor.getSize();
+        if (size == null || size < 0 || size > MAX_CONTENT_SIZE) {
+            throw new IllegalArgumentException(
+                "Agent Version storage size must be between 0 and " + MAX_CONTENT_SIZE);
+        }
+        if (NACOS_CONFIG_PROVIDER.equals(provider)) {
+            if (!NACOS_CONFIG_KEY_FORMAT.equals(descriptor.getKeyFormat())) {
+                throw new IllegalArgumentException("nacos_config keyFormat must be "
+                    + NACOS_CONFIG_KEY_FORMAT);
+            }
+            if (!RAD_ASCII_AGENT_NAME_CODEC.equals(descriptor.getAgentNameCodec())) {
+                throw new IllegalArgumentException("nacos_config agentNameCodec must be "
+                    + RAD_ASCII_AGENT_NAME_CODEC);
+            }
+        }
+    }
+    
+    private static void validateRequiredText(String field, String value, int maxLength) {
+        if (value == null || value.isEmpty() || value.length() > maxLength) {
+            throw new IllegalArgumentException("Invalid Agent Version storage " + field);
+        }
+    }
+    
+    private static void validateOptionalText(String field, String value, int maxLength) {
+        if (value != null) {
+            validateRequiredText(field, value, maxLength);
+        }
+    }
+    
+    private static void validateJsonText(Map<?, ?> root, String field, boolean optional) {
+        if (!root.containsKey(field)) {
+            if (optional) {
+                return;
+            }
+            throw new IllegalArgumentException("Missing Agent Version storage field: " + field);
+        }
+        if (!(root.get(field) instanceof String)) {
+            throw new IllegalArgumentException(
+                "Agent Version storage " + field + " must be a string");
+        }
+    }
+    
+    private static void validateJsonInteger(Map<?, ?> root, String field) {
+        Object value = root.get(field);
+        if (!(value instanceof Byte || value instanceof Short || value instanceof Integer
+            || value instanceof Long)) {
+            throw new IllegalArgumentException(
+                "Agent Version storage " + field + " must be an integer");
+        }
+    }
+    
+    private static void validateSingleJsonValue(String json) {
+        try (JsonParser parser = STRICT_JSON_FACTORY.createParser(json)) {
+            if (parser.nextToken() == null) {
+                throw new IllegalArgumentException(
+                    "Agent Version storage descriptor JSON must not be empty");
+            }
+            parser.skipChildren();
+            if (parser.nextToken() != null) {
+                throw new IllegalArgumentException(
+                    "Agent Version storage descriptor must contain one JSON value");
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Invalid Agent Version storage descriptor", e);
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageKeyComposer.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageKeyComposer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.storage;
+
+import com.alibaba.nacos.ai.service.agent.identity.RadAsciiAgentIdCodec;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+
+/**
+ * Composes the provider-neutral logical key of one Agent Version content object.
+ *
+ * <p>Every AI Storage provider receives the same logical key as an opaque value and owns its
+ * physical mapping. The built-in Nacos Config provider maps the middle segment to its Config group
+ * and the final segment to its Config dataId.</p>
+ *
+ * @author Nacos
+ */
+public final class AgentVersionStorageKeyComposer {
+    
+    public static final String AGENT_VERSION_GROUP = "agent-version";
+    
+    private static final String DATA_ID_PREFIX = "agent__";
+    
+    private static final String DATA_ID_SEPARATOR = "__";
+    
+    private static final String DATA_ID_SUFFIX = ".json";
+    
+    private AgentVersionStorageKeyComposer() {
+    }
+    
+    /**
+     * Compose a stable logical key from the public Agent identity.
+     *
+     * @param provider selected AI Storage provider
+     * @param namespaceId namespace identifier
+     * @param agentName public Agent name
+     * @param version exact Agent Version
+     * @return provider-neutral logical storage key
+     * @throws IllegalArgumentException when an identity field is invalid
+     */
+    public static StorageKey compose(String provider, String namespaceId, String agentName,
+        String version) {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        String encodedAgentId = RadAsciiAgentIdCodec.encode(agentName);
+        AgentValidationUtils.validateVersion(version);
+        String dataId = DATA_ID_PREFIX + encodedAgentId + DATA_ID_SEPARATOR + version
+            + DATA_ID_SUFFIX;
+        return new StorageKey(provider,
+            namespaceId + ':' + AGENT_VERSION_GROUP + ':' + dataId);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageService.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.storage;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.model.agent.AgentVersionContent;
+import com.alibaba.nacos.ai.model.agent.AgentVersionStorageDescriptor;
+import com.alibaba.nacos.ai.service.agent.fingerprint.AgentVersionContentCodec;
+import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
+import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Stores and verifies the complete content of one Agent Version.
+ *
+ * <p>This component owns only the content object and its storage pointer. Resource and Version row
+ * lifecycle, cross-store compensation, and derived catalog rebuilding remain the responsibility of
+ * the Agent persistence orchestration layer.</p>
+ *
+ * @author Nacos
+ */
+@Service
+public class AgentVersionStorageService {
+    
+    private static final String DEFAULT_STORAGE_PROVIDER = NacosConfigAiResourceStorage.TYPE;
+    
+    private final AiResourceStorageRouter storageRouter;
+    
+    private final Supplier<String> storageProviderSupplier;
+    
+    public AgentVersionStorageService() {
+        this(AiResourceStorageRouter.getInstance(), AgentVersionStorageService::configuredProvider);
+    }
+    
+    AgentVersionStorageService(AiResourceStorageRouter storageRouter,
+        Supplier<String> storageProviderSupplier) {
+        this.storageRouter = Objects.requireNonNull(storageRouter, "storageRouter");
+        this.storageProviderSupplier = Objects.requireNonNull(storageProviderSupplier,
+            "storageProviderSupplier");
+    }
+    
+    /**
+     * Encode and save one Agent Version content object at its stable logical key.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName Agent public name
+     * @param version exact Agent Version
+     * @param content complete Agent Version content
+     * @return descriptor persisted in the matching {@code ai_resource_version.storage} field
+     * @throws NacosException when the selected storage provider fails
+     */
+    public AgentVersionStorageDescriptor save(String namespaceId, String agentName, String version,
+        AgentVersionContent content) throws NacosException {
+        String provider = resolveStorageProvider();
+        StorageKey storageKey = AgentVersionStorageKeyComposer.compose(provider, namespaceId,
+            agentName, version);
+        AgentVersionContentCodec.EncodedContent encoded = AgentVersionContentCodec.encode(content);
+        AgentVersionStorageDescriptor descriptor = buildDescriptor(storageKey, encoded);
+        AgentVersionStorageDescriptorCodec.validate(descriptor);
+        try {
+            route(storageKey).save(storageKey, encoded.getBytes());
+        } catch (IllegalArgumentException e) {
+            throw new NacosException(NacosException.SERVER_ERROR,
+                "Agent Version content cannot be saved", e);
+        }
+        return descriptor;
+    }
+    
+    /**
+     * Read, verify, and decode one Agent Version content object.
+     *
+     * <p>Size and digest are checked against the exact bytes returned by AI Storage before JSON
+     * decoding. Unverified content is never returned.</p>
+     *
+     * @param descriptor Version storage pointer
+     * @return verified Agent Version content
+     * @throws NacosException when content is missing, corrupted, or cannot be read
+     */
+    public AgentVersionContent load(AgentVersionStorageDescriptor descriptor)
+        throws NacosException {
+        StorageKey storageKey = checkedStorageKey(descriptor);
+        byte[] bytes;
+        try {
+            bytes = route(storageKey).get(storageKey);
+        } catch (IllegalArgumentException e) {
+            throw corruptedContent("Invalid Agent Version storage key", e);
+        }
+        if (bytes == null) {
+            throw corruptedContent("Agent Version content does not exist", null);
+        }
+        if (descriptor.getSize().longValue() != bytes.length) {
+            throw corruptedContent("Agent Version content size does not match its descriptor",
+                null);
+        }
+        String actualDigest = AgentVersionContentCodec.digest(bytes);
+        if (!descriptor.getContentDigest().equals(actualDigest)) {
+            throw corruptedContent("Agent Version content digest does not match its descriptor",
+                null);
+        }
+        try {
+            return AgentVersionContentCodec.decode(bytes);
+        } catch (IllegalArgumentException e) {
+            throw corruptedContent("Agent Version content cannot be decoded", e);
+        }
+    }
+    
+    /**
+     * Delete one Agent Version content object through its persisted storage pointer.
+     *
+     * @param descriptor Version storage pointer
+     * @throws NacosException when the selected storage provider fails
+     */
+    public void delete(AgentVersionStorageDescriptor descriptor) throws NacosException {
+        StorageKey storageKey = checkedStorageKey(descriptor);
+        try {
+            route(storageKey).delete(storageKey);
+        } catch (IllegalArgumentException e) {
+            throw corruptedContent("Invalid Agent Version storage key", e);
+        }
+    }
+    
+    private AgentVersionStorageDescriptor buildDescriptor(StorageKey storageKey,
+        AgentVersionContentCodec.EncodedContent encoded) {
+        AgentVersionStorageDescriptor result = new AgentVersionStorageDescriptor();
+        result.setProvider(storageKey.getProvider());
+        result.setKey(storageKey.getKey());
+        if (NacosConfigAiResourceStorage.TYPE.equals(storageKey.getProvider())) {
+            result.setKeyFormat(AgentVersionStorageDescriptor.NACOS_CONFIG_KEY_FORMAT);
+            result.setAgentNameCodec(AgentVersionStorageDescriptor.RAD_AGENT_NAME_CODEC);
+        }
+        result.setContentDigest(encoded.getContentDigest());
+        result.setMediaType(AgentVersionStorageDescriptor.MEDIA_TYPE);
+        result.setSchemaVersion(AgentVersionStorageDescriptor.SCHEMA_VERSION);
+        result.setSize((long) encoded.getSize());
+        return result;
+    }
+    
+    private StorageKey checkedStorageKey(AgentVersionStorageDescriptor descriptor)
+        throws NacosException {
+        try {
+            AgentVersionStorageDescriptorCodec.validate(descriptor);
+        } catch (IllegalArgumentException e) {
+            throw corruptedContent("Invalid Agent Version storage descriptor", e);
+        }
+        return new StorageKey(descriptor.getProvider(), descriptor.getKey());
+    }
+    
+    private String resolveStorageProvider() {
+        String configured = storageProviderSupplier.get();
+        return StringUtils.isBlank(configured) ? DEFAULT_STORAGE_PROVIDER : configured.trim();
+    }
+    
+    private AiResourceStorage route(StorageKey storageKey) throws NacosException {
+        try {
+            return storageRouter.route(storageKey);
+        } catch (IllegalStateException e) {
+            throw new NacosException(NacosException.SERVER_ERROR,
+                "Agent Version storage provider is unavailable: " + storageKey.getProvider(), e);
+        }
+    }
+    
+    private static String configuredProvider() {
+        return EnvUtil.getProperty(Constants.Agent.AGENT_STORAGE_PROVIDER_CONFIG_KEY,
+            DEFAULT_STORAGE_PROVIDER);
+    }
+    
+    private static NacosException corruptedContent(String message, Throwable cause) {
+        return cause == null ? new NacosException(NacosException.SERVER_ERROR, message)
+            : new NacosException(NacosException.SERVER_ERROR, message, cause);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorage.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorage.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.ai.model.NacosAiConfigKeyCodec;
 import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpecUtils;
 import com.alibaba.nacos.api.ai.model.prompt.PromptUtils;
 import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
 import com.alibaba.nacos.api.config.ConfigType;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.common.utils.StringUtils;
@@ -40,11 +41,12 @@ import java.nio.charset.StandardCharsets;
 /**
  * Nacos Config based {@link AiResourceStorage} implementation.
  *
- * <p>Supports Skill, AgentSpec and Prompt resource types via parameterized group prefixes.
+ * <p>Supports Skill, AgentSpec, Prompt and Agent Version resources.
  * StorageKey.key format:
  * <ul>
  *   <li>Legacy (Skill): {@code namespaceId:name:version:filePath} (4-part, defaults to skill__ prefix)</li>
  *   <li>Typed: {@code namespaceId:resourceType:name:version:filePath} (5-part, resourceType = "skill", "agentspec" or "prompt")</li>
+ *   <li>Agent Version: {@code namespaceId:agent-version:dataId} (3-part opaque key)</li>
  * </ul>
  * File path convention: main = {@link #getMainFilePath()} / {@link #getMainFilePath(String)},
  * resources = {@link #getResourceFilePath(String, String)} / {@link #getAgentSpecResourceFilePath(String, String)},
@@ -62,6 +64,16 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
     
     /** Resource type identifier for Prompt storage keys. */
     public static final String RESOURCE_TYPE_PROMPT = "prompt";
+    
+    private static final String AGENT_VERSION_GROUP = "agent-version";
+    
+    private static final String AGENT_VERSION_DATA_ID_PREFIX = "agent__";
+    
+    private static final String AGENT_VERSION_DATA_ID_SEPARATOR = "__";
+    
+    private static final String AGENT_VERSION_DATA_ID_SUFFIX = ".json";
+    
+    private static final int MAX_ENCODED_AGENT_ID_LENGTH = 260;
     
     /**
      * Build storage key for Skill resources (legacy 4-part format).
@@ -257,8 +269,9 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
     }
     
     /**
-     * Parse StorageKey into KeyParts. Supports three key formats:
+     * Parse StorageKey into KeyParts. Supports four key formats:
      * <ul>
+     *   <li>Agent Version: {@code namespaceId:agent-version:dataId} → group = agent-version</li>
      *   <li>Legacy 4-part (Skill): {@code namespaceId:name:version:filePath} → group = skill__{name}__{version}</li>
      *   <li>Legacy 4-part manifest: {@code namespaceId:name::filePath} (blank version) → group = skill_{name}</li>
      *   <li>Typed 5-part: {@code namespaceId:resourceType:name:version:filePath} → group = {prefix}{name}__{version}</li>
@@ -268,6 +281,15 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
     static KeyParts parse(StorageKey storageKey) {
         if (storageKey == null || StringUtils.isBlank(storageKey.getKey())) {
             throw new IllegalArgumentException("StorageKey.key is blank");
+        }
+        String[] agentVersionParts = storageKey.getKey().split(":", -1);
+        if (agentVersionParts.length == 3 && AGENT_VERSION_GROUP.equals(agentVersionParts[1])
+            && agentVersionParts[2].startsWith(AGENT_VERSION_DATA_ID_PREFIX)) {
+            String namespaceId = agentVersionParts[0];
+            String dataId = agentVersionParts[2];
+            AgentValidationUtils.validateNamespaceId(namespaceId);
+            validateAgentVersionDataId(dataId);
+            return new KeyParts(namespaceId, AGENT_VERSION_GROUP, AGENT_VERSION_GROUP, dataId);
         }
         String[] parts = storageKey.getKey().split(":", 5);
         if (parts.length == 5 && !StringUtils.isBlank(parts[0]) && !StringUtils.isBlank(parts[1])
@@ -317,6 +339,40 @@ public class NacosConfigAiResourceStorage implements AiResourceStorage {
             group = SkillUtils.buildSkillVersionGroup(skillName, version);
         }
         return new KeyParts(namespaceId, group, SkillUtils.SKILL_GROUP_PREFIX, filePath);
+    }
+    
+    private static void validateAgentVersionDataId(String dataId) {
+        if (dataId == null || !dataId.startsWith(AGENT_VERSION_DATA_ID_PREFIX)
+            || !dataId.endsWith(AGENT_VERSION_DATA_ID_SUFFIX)) {
+            throw new IllegalArgumentException("Invalid Agent Version dataId: " + dataId);
+        }
+        int separatorIndex = dataId.indexOf(AGENT_VERSION_DATA_ID_SEPARATOR,
+            AGENT_VERSION_DATA_ID_PREFIX.length());
+        if (separatorIndex < 0) {
+            throw new IllegalArgumentException("Invalid Agent Version dataId: " + dataId);
+        }
+        String encodedAgentId = dataId.substring(AGENT_VERSION_DATA_ID_PREFIX.length(),
+            separatorIndex);
+        String version = dataId.substring(separatorIndex + AGENT_VERSION_DATA_ID_SEPARATOR.length(),
+            dataId.length() - AGENT_VERSION_DATA_ID_SUFFIX.length());
+        validateEncodedAgentId(encodedAgentId);
+        AgentValidationUtils.validateVersion(version);
+    }
+    
+    private static void validateEncodedAgentId(String encodedAgentId) {
+        if (StringUtils.isBlank(encodedAgentId)
+            || encodedAgentId.length() > MAX_ENCODED_AGENT_ID_LENGTH) {
+            throw new IllegalArgumentException("Invalid encodedAgentId: " + encodedAgentId);
+        }
+        for (int i = 0; i < encodedAgentId.length(); i++) {
+            char current = encodedAgentId.charAt(i);
+            boolean asciiLetterOrDigit = current >= 'A' && current <= 'Z'
+                || current >= 'a' && current <= 'z'
+                || current >= '0' && current <= '9';
+            if (!asciiLetterOrDigit && current != '-') {
+                throw new IllegalArgumentException("Invalid encodedAgentId: " + encodedAgentId);
+            }
+        }
     }
     
     record KeyParts(String namespaceId, String group, String groupPrefix, String dataId) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/model/agent/AgentVersionContentTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/model/agent/AgentVersionContentTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.model.agent;
+
+import com.alibaba.nacos.api.ai.model.agent.AgentCallInterface;
+import com.alibaba.nacos.api.ai.model.agent.EndpointSource;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AgentVersionContentTest {
+    
+    @Test
+    void testDefaultConstructorAndAccessors() {
+        AgentCallInterface callInterface = new AgentCallInterface();
+        AgentVersionContent content = new AgentVersionContent();
+        assertNull(content.getKind());
+        assertNull(content.getSchemaVersion());
+        assertNull(content.getCallInterfaces());
+        
+        content.setKind(AgentVersionContent.KIND);
+        content.setSchemaVersion(AgentVersionContent.SCHEMA_VERSION);
+        content.setCallInterfaces(Collections.singletonList(callInterface));
+        
+        assertEquals(AgentVersionContent.KIND, content.getKind());
+        assertEquals(AgentVersionContent.SCHEMA_VERSION, content.getSchemaVersion());
+        assertEquals(Collections.singletonList(callInterface), content.getCallInterfaces());
+    }
+    
+    @Test
+    void testConvenienceConstructorSetsStorageEnvelope() {
+        List<AgentCallInterface> callInterfaces = Collections.singletonList(
+            createCallInterface());
+        AgentVersionContent content = new AgentVersionContent(callInterfaces);
+        
+        assertEquals(AgentVersionContent.KIND, content.getKind());
+        assertEquals(AgentVersionContent.SCHEMA_VERSION, content.getSchemaVersion());
+        assertEquals(callInterfaces, content.getCallInterfaces());
+    }
+    
+    @Test
+    void testJacksonRoundTripUsesPlainBeanContract() throws Exception {
+        AgentVersionContent original = new AgentVersionContent(
+            Collections.singletonList(createCallInterface()));
+        ObjectMapper mapper = new ObjectMapper();
+        
+        String json = mapper.writeValueAsString(original);
+        AgentVersionContent restored = mapper.readValue(json, AgentVersionContent.class);
+        
+        assertEquals(AgentVersionContent.KIND, restored.getKind());
+        assertEquals(AgentVersionContent.SCHEMA_VERSION, restored.getSchemaVersion());
+        assertEquals(1, restored.getCallInterfaces().size());
+        AgentCallInterface restoredInterface = restored.getCallInterfaces().get(0);
+        assertEquals("a2a", restoredInterface.getProtocol());
+        assertEquals("application/json", restoredInterface.getDescriptorMediaType());
+        assertEquals("descriptor", restoredInterface.getNativeDescriptor());
+        assertEquals(Collections.singletonList(EndpointSource.RUNTIME),
+            restoredInterface.getEndpointSourceOrder());
+    }
+    
+    private AgentCallInterface createCallInterface() {
+        AgentCallInterface result = new AgentCallInterface();
+        result.setProtocol("a2a");
+        result.setDescriptorMediaType("application/json");
+        result.setNativeDescriptor("descriptor");
+        result.setEndpointSourceOrder(Collections.singletonList(EndpointSource.RUNTIME));
+        return result;
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/model/agent/AgentVersionStorageDescriptorTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/model/agent/AgentVersionStorageDescriptorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.model.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class AgentVersionStorageDescriptorTest {
+    
+    @Test
+    void testDefaultConstructorAndAccessors() {
+        AgentVersionStorageDescriptor descriptor = new AgentVersionStorageDescriptor();
+        assertNull(descriptor.getProvider());
+        assertNull(descriptor.getKey());
+        assertNull(descriptor.getKeyFormat());
+        assertNull(descriptor.getAgentNameCodec());
+        assertNull(descriptor.getContentDigest());
+        assertNull(descriptor.getMediaType());
+        assertNull(descriptor.getSchemaVersion());
+        assertNull(descriptor.getSize());
+        
+        descriptor.setProvider("nacos_config");
+        descriptor.setKey("logical-key");
+        descriptor.setKeyFormat("agent-version-config-v1");
+        descriptor.setAgentNameCodec("rad-ascii-v1");
+        descriptor.setContentDigest(digest('a'));
+        descriptor.setMediaType("application/vnd.nacos.agent-version+json");
+        descriptor.setSchemaVersion(1);
+        descriptor.setSize(128L);
+        
+        assertEquals("nacos_config", descriptor.getProvider());
+        assertEquals("logical-key", descriptor.getKey());
+        assertEquals("agent-version-config-v1", descriptor.getKeyFormat());
+        assertEquals("rad-ascii-v1", descriptor.getAgentNameCodec());
+        assertEquals(digest('a'), descriptor.getContentDigest());
+        assertEquals("application/vnd.nacos.agent-version+json", descriptor.getMediaType());
+        assertEquals(1, descriptor.getSchemaVersion());
+        assertEquals(128L, descriptor.getSize());
+    }
+    
+    @Test
+    void testJacksonRoundTripUsesPlainBeanContract() throws Exception {
+        AgentVersionStorageDescriptor original = createDescriptor();
+        ObjectMapper mapper = new ObjectMapper();
+        
+        String json = mapper.writeValueAsString(original);
+        AgentVersionStorageDescriptor restored =
+            mapper.readValue(json, AgentVersionStorageDescriptor.class);
+        
+        assertEquals(original.getProvider(), restored.getProvider());
+        assertEquals(original.getKey(), restored.getKey());
+        assertEquals(original.getKeyFormat(), restored.getKeyFormat());
+        assertEquals(original.getAgentNameCodec(), restored.getAgentNameCodec());
+        assertEquals(original.getContentDigest(), restored.getContentDigest());
+        assertEquals(original.getMediaType(), restored.getMediaType());
+        assertEquals(original.getSchemaVersion(), restored.getSchemaVersion());
+        assertEquals(original.getSize(), restored.getSize());
+    }
+    
+    private AgentVersionStorageDescriptor createDescriptor() {
+        AgentVersionStorageDescriptor result = new AgentVersionStorageDescriptor();
+        result.setProvider("nacos_config");
+        result.setKey("logical-key");
+        result.setKeyFormat("agent-version-config-v1");
+        result.setAgentNameCodec("rad-ascii-v1");
+        result.setContentDigest(digest('a'));
+        result.setMediaType("application/vnd.nacos.agent-version+json");
+        result.setSchemaVersion(1);
+        result.setSize(128L);
+        return result;
+    }
+    
+    private String digest(char value) {
+        StringBuilder result = new StringBuilder("sha256:");
+        while (result.length() < 71) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/plugin/AiStoragePluginTypePolicyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/plugin/AiStoragePluginTypePolicyTest.java
@@ -46,6 +46,8 @@ class AiStoragePluginTypePolicyTest {
             .contains(Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY));
         assertTrue(policy.getSelectionProperty()
             .contains(Constants.AgentSpecs.AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY));
+        assertTrue(policy.getSelectionProperty()
+            .contains(Constants.Agent.AGENT_STORAGE_PROVIDER_CONFIG_KEY));
     }
     
     @Test
@@ -89,13 +91,16 @@ class AiStoragePluginTypePolicyTest {
         configuration.setProperty(Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY,
             "skill-store");
         configuration.setProperty(Constants.AgentSpecs.AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY,
+            "agentspec-store");
+        configuration.setProperty(Constants.Agent.AGENT_STORAGE_PROVIDER_CONFIG_KEY,
             "agent-store");
         policy.initialize(configuration);
         
         Set<String> required = policy.getRequiredPluginNames(configuration);
-        assertEquals(3, required.size());
+        assertEquals(4, required.size());
         assertTrue(required.contains("prompt-store"));
         assertTrue(required.contains("skill-store"));
+        assertTrue(required.contains("agentspec-store"));
         assertTrue(required.contains("agent-store"));
         configuration.setProperty(Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY,
             "changed-store");

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/fingerprint/AgentVersionContentCodecTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/fingerprint/AgentVersionContentCodecTest.java
@@ -294,6 +294,27 @@ class AgentVersionContentCodecTest {
             () -> AgentVersionContentCodec.decode(invalidModel));
     }
     
+    @Test
+    void testDecodeRejectsUnknownOwnedFieldsDuplicateMembersAndTrailingJson() {
+        String valid = new String(AgentVersionContentCodec.encode(createGoldenContent()).getBytes(),
+            StandardCharsets.UTF_8);
+        assertDecodeRejected(valid.substring(0, valid.length() - 1) + ",\"unknown\":true}");
+        assertDecodeRejected(valid.replace("\"protocol\":\"a2a\",",
+            "\"protocol\":\"a2a\",\"unknown\":true,"));
+        assertDecodeRejected(valid.replace(
+            "\"uri\":\"https://example.com:443/a2a?b=2&a=1\",",
+            "\"uri\":\"https://example.com:443/a2a?b=2&a=1\",\"unknown\":true,"));
+        assertDecodeRejected(valid.replace("{\"kind\":\"AgentVersionContent\"",
+            "{\"kind\":\"AgentVersionContent\",\"kind\":\"AgentVersionContent\""));
+        assertDecodeRejected(valid + "{}");
+        
+        AgentVersionContent decoded = AgentVersionContentCodec.decode(
+            valid.getBytes(StandardCharsets.UTF_8));
+        assertTrue(decoded.getCallInterfaces().get(0).getNativeDescriptor() instanceof Map);
+        assertEquals("h", decoded.getCallInterfaces().get(0).getDeclaredEndpoints().get(0)
+            .getMetadata().get("az"));
+    }
+    
     private AgentVersionContent createGoldenContent() {
         AgentCallInterface callInterface = new AgentCallInterface();
         callInterface.setProtocol("a2a");
@@ -343,6 +364,11 @@ class AgentVersionContentCodecTest {
     private void assertEncodingRejected(AgentVersionContent content) {
         assertThrows(IllegalArgumentException.class,
             () -> AgentVersionContentCodec.encode(content));
+    }
+    
+    private void assertDecodeRejected(String content) {
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.decode(content.getBytes(StandardCharsets.UTF_8)));
     }
     
     private String repeat(char value, int count) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/fingerprint/AgentVersionContentCodecTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/fingerprint/AgentVersionContentCodecTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.fingerprint;
+
+import com.alibaba.nacos.ai.model.agent.AgentVersionContent;
+import com.alibaba.nacos.api.ai.model.agent.AgentCallInterface;
+import com.alibaba.nacos.api.ai.model.agent.Endpoint;
+import com.alibaba.nacos.api.ai.model.agent.EndpointSource;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentVersionContentCodecTest {
+    
+    @Test
+    void testEncodePersistedContentAndDecodeRoundTrip() {
+        AgentVersionContentCodec.EncodedContent encoded =
+            AgentVersionContentCodec.encode(createGoldenContent());
+        
+        String storedJson = new String(encoded.getBytes(), StandardCharsets.UTF_8);
+        assertTrue(storedJson.startsWith("{\"kind\":\"AgentVersionContent\","));
+        assertTrue(storedJson.contains("\"uri\":\"https://example.com:443/a2a?b=2&a=1\""));
+        assertTrue(storedJson.contains("\"priority\":0"));
+        assertTrue(storedJson.contains("\"weight\":1.0"));
+        assertFalse(storedJson.contains("HTTPS://Example.COM"));
+        assertEquals(encoded.getBytes().length, encoded.getSize());
+        assertEquals("sha256:" + DigestUtils.sha256Hex(encoded.getBytes()),
+            encoded.getContentDigest());
+        assertEquals(encoded.getContentDigest(),
+            AgentVersionContentCodec.digest(encoded.getBytes()));
+        
+        AgentVersionContent decoded = AgentVersionContentCodec.decode(encoded.getBytes());
+        assertEquals(AgentVersionContent.KIND, decoded.getKind());
+        assertEquals(AgentVersionContent.SCHEMA_VERSION, decoded.getSchemaVersion());
+        AgentCallInterface callInterface = decoded.getCallInterfaces().get(0);
+        assertEquals(Arrays.asList(EndpointSource.RUNTIME, EndpointSource.DECLARED),
+            callInterface.getEndpointSourceOrder());
+        Endpoint endpoint = callInterface.getDeclaredEndpoints().get(0);
+        assertEquals("https://example.com:443/a2a?b=2&a=1", endpoint.getUri());
+        assertEquals(0, endpoint.getPriority());
+        assertEquals(1D, endpoint.getWeight());
+        assertEquals(Arrays.asList("az", "zone"),
+            new ArrayList<String>(endpoint.getMetadata().keySet()));
+    }
+    
+    @Test
+    void testEndpointDefaultsAndMetadataOrderDoNotChangeEncoding() {
+        AgentVersionContent normalized = createGoldenContent();
+        AgentCallInterface normalizedInterface = normalized.getCallInterfaces().get(0);
+        Endpoint endpoint = normalizedInterface.getDeclaredEndpoints().get(0);
+        endpoint.setUri("https://example.com:443/a2a?b=2&a=1");
+        endpoint.setPriority(0);
+        endpoint.setWeight(1D);
+        Map<String, String> metadata = new LinkedHashMap<String, String>();
+        metadata.put("az", "h");
+        metadata.put("zone", "cn-hangzhou-h");
+        endpoint.setMetadata(metadata);
+        
+        AgentVersionContent original = createGoldenContent();
+        AgentVersionContentCodec.EncodedContent first = AgentVersionContentCodec.encode(original);
+        AgentVersionContentCodec.EncodedContent second =
+            AgentVersionContentCodec.encode(normalized);
+        assertArrayEquals(first.getBytes(), second.getBytes());
+        assertEquals(first.getContentDigest(), second.getContentDigest());
+    }
+    
+    @Test
+    void testDescriptorObjectOrderChangesPersistedBytes() {
+        AgentVersionContent first = createGoldenContent();
+        AgentVersionContent second = createGoldenContent();
+        Map<String, Object> reordered = new LinkedHashMap<String, Object>();
+        Map<String, Object> capabilities = new LinkedHashMap<String, Object>();
+        capabilities.put("push", false);
+        capabilities.put("streaming", true);
+        reordered.put("capabilities", capabilities);
+        reordered.put("name", "Order Agent");
+        reordered.put("title", "订单 Agent");
+        reordered.put("version", "1.0.6");
+        second.getCallInterfaces().get(0).setNativeDescriptor(reordered);
+        
+        AgentVersionContentCodec.EncodedContent firstEncoded =
+            AgentVersionContentCodec.encode(first);
+        AgentVersionContentCodec.EncodedContent secondEncoded =
+            AgentVersionContentCodec.encode(second);
+        assertFalse(Arrays.equals(firstEncoded.getBytes(), secondEncoded.getBytes()));
+        assertNotEquals(firstEncoded.getContentDigest(), secondEncoded.getContentDigest());
+    }
+    
+    @Test
+    void testBusinessArrayOrderChangesDigest() {
+        AgentCallInterface a2a = createCallInterface("a2a", "http://a.example/rpc");
+        AgentCallInterface grpc = createCallInterface("grpc", "http://g.example/rpc");
+        AgentVersionContent first = new AgentVersionContent(Arrays.asList(a2a, grpc));
+        AgentVersionContent second = new AgentVersionContent(Arrays.asList(grpc, a2a));
+        assertNotEquals(AgentVersionContentCodec.encode(first).getContentDigest(),
+            AgentVersionContentCodec.encode(second).getContentDigest());
+        
+        AgentCallInterface firstEndpoints = createCallInterface("a2a", "http://a.example/rpc");
+        firstEndpoints.getDeclaredEndpoints().add(createEndpoint("http://b.example/rpc"));
+        AgentCallInterface secondEndpoints = createCallInterface("a2a", "http://b.example/rpc");
+        secondEndpoints.getDeclaredEndpoints().add(createEndpoint("http://a.example/rpc"));
+        assertNotEquals(AgentVersionContentCodec
+            .encode(new AgentVersionContent(Collections.singletonList(firstEndpoints)))
+            .getContentDigest(),
+            AgentVersionContentCodec
+                .encode(new AgentVersionContent(Collections.singletonList(secondEndpoints)))
+                .getContentDigest());
+        
+        AgentCallInterface runtimeFirst = createCallInterface("a2a", null);
+        runtimeFirst.setEndpointSourceOrder(
+            Arrays.asList(EndpointSource.RUNTIME, EndpointSource.DECLARED));
+        AgentCallInterface declaredFirst = createCallInterface("a2a", null);
+        declaredFirst.setEndpointSourceOrder(
+            Arrays.asList(EndpointSource.DECLARED, EndpointSource.RUNTIME));
+        assertNotEquals(AgentVersionContentCodec
+            .encode(new AgentVersionContent(Collections.singletonList(runtimeFirst)))
+            .getContentDigest(),
+            AgentVersionContentCodec
+                .encode(new AgentVersionContent(Collections.singletonList(declaredFirst)))
+                .getContentDigest());
+    }
+    
+    @Test
+    void testAbsentAndEmptyDeclaredEndpointsHaveSameEncoding() {
+        AgentCallInterface absent = createCallInterface("a2a", null);
+        AgentCallInterface empty = createCallInterface("a2a", null);
+        empty.setDeclaredEndpoints(Collections.<Endpoint>emptyList());
+        
+        AgentVersionContentCodec.EncodedContent first = AgentVersionContentCodec
+            .encode(new AgentVersionContent(Collections.singletonList(absent)));
+        AgentVersionContentCodec.EncodedContent second = AgentVersionContentCodec
+            .encode(new AgentVersionContent(Collections.singletonList(empty)));
+        assertArrayEquals(first.getBytes(), second.getBytes());
+        assertEquals(first.getContentDigest(), second.getContentDigest());
+    }
+    
+    @Test
+    void testAbsentAndEmptyEndpointMetadataHaveSameEncoding() {
+        AgentCallInterface absent = createCallInterface("a2a", "http://example.com/rpc");
+        AgentCallInterface empty = createCallInterface("a2a", "http://example.com/rpc");
+        empty.getDeclaredEndpoints().get(0).setMetadata(Collections.<String, String>emptyMap());
+        
+        AgentVersionContentCodec.EncodedContent first = AgentVersionContentCodec
+            .encode(new AgentVersionContent(Collections.singletonList(absent)));
+        AgentVersionContentCodec.EncodedContent second = AgentVersionContentCodec
+            .encode(new AgentVersionContent(Collections.singletonList(empty)));
+        assertArrayEquals(first.getBytes(), second.getBytes());
+        assertEquals(first.getContentDigest(), second.getContentDigest());
+    }
+    
+    @Test
+    void testEncodedBytesAreDefensiveAndSizeUsesUtf8Bytes() {
+        AgentVersionContentCodec.EncodedContent encoded =
+            AgentVersionContentCodec.encode(createGoldenContent());
+        byte[] first = encoded.getBytes();
+        byte originalFirstByte = first[0];
+        first[0] = 0;
+        
+        assertEquals(originalFirstByte, encoded.getBytes()[0]);
+        assertEquals(encoded.getBytes().length, encoded.getSize());
+        String storedJson = new String(encoded.getBytes(), StandardCharsets.UTF_8);
+        assertTrue(encoded.getSize() > storedJson.length());
+    }
+    
+    @Test
+    void testRejectInvalidEnvelopeAndCallInterfaceSets() {
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.encode(null));
+        
+        AgentVersionContent invalid = createGoldenContent();
+        invalid.setKind("Other");
+        assertEncodingRejected(invalid);
+        invalid = createGoldenContent();
+        invalid.setSchemaVersion(2);
+        assertEncodingRejected(invalid);
+        invalid = createGoldenContent();
+        invalid.setCallInterfaces(null);
+        assertEncodingRejected(invalid);
+        invalid = new AgentVersionContent(Collections.<AgentCallInterface>emptyList());
+        assertEncodingRejected(invalid);
+        invalid = new AgentVersionContent(Collections.<AgentCallInterface>singletonList(null));
+        assertEncodingRejected(invalid);
+        
+        List<AgentCallInterface> tooMany = new ArrayList<AgentCallInterface>();
+        for (int i = 0; i < 17; i++) {
+            tooMany.add(createCallInterface("p" + i, null));
+        }
+        AgentVersionContentCodec.encode(
+            new AgentVersionContent(new ArrayList<AgentCallInterface>(tooMany.subList(0, 16))));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.encode(new AgentVersionContent(tooMany)));
+        
+        AgentCallInterface duplicate = createCallInterface("a2a", null);
+        invalid = new AgentVersionContent(
+            Arrays.asList(createCallInterface("a2a", null), duplicate));
+        assertEncodingRejected(invalid);
+        
+        AgentCallInterface boundedEndpoints = createCallInterface("a2a", null);
+        List<Endpoint> endpoints = new ArrayList<Endpoint>();
+        for (int i = 0; i < 64; i++) {
+            endpoints.add(createEndpoint("http://e" + i + ".example.com/rpc"));
+        }
+        boundedEndpoints.setDeclaredEndpoints(endpoints);
+        AgentVersionContent boundedContent =
+            new AgentVersionContent(Collections.singletonList(boundedEndpoints));
+        AgentVersionContentCodec.encode(boundedContent);
+        endpoints.add(createEndpoint("http://overflow.example.com/rpc"));
+        assertEncodingRejected(boundedContent);
+    }
+    
+    @Test
+    void testRejectMissingDescriptorAndOversizedContent() {
+        AgentVersionContent invalid = createGoldenContent();
+        invalid.getCallInterfaces().get(0).setNativeDescriptor(null);
+        assertEncodingRejected(invalid);
+        
+        invalid = createGoldenContent();
+        invalid.getCallInterfaces().get(0)
+            .setNativeDescriptor(repeat('x', AgentVersionContentCodec.MAX_CONTENT_SIZE));
+        assertEncodingRejected(invalid);
+    }
+    
+    @Test
+    void testContentSizeBoundaryUsesPersistedUtf8Bytes() {
+        AgentCallInterface callInterface = createCallInterface("a2a", null);
+        callInterface.setNativeDescriptor("");
+        AgentVersionContent content =
+            new AgentVersionContent(Collections.singletonList(callInterface));
+        int envelopeSize = AgentVersionContentCodec.encode(content).getSize();
+        callInterface.setNativeDescriptor(
+            repeat('x', AgentVersionContentCodec.MAX_CONTENT_SIZE - envelopeSize));
+        assertEquals(AgentVersionContentCodec.MAX_CONTENT_SIZE,
+            AgentVersionContentCodec.encode(content).getSize());
+        
+        callInterface.setNativeDescriptor(
+            repeat('x', AgentVersionContentCodec.MAX_CONTENT_SIZE - envelopeSize + 1));
+        assertEncodingRejected(content);
+    }
+    
+    @Test
+    void testDecodeRejectsInvalidStorageBytes() {
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.digest(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.digest(
+                new byte[AgentVersionContentCodec.MAX_CONTENT_SIZE + 1]));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.decode(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.decode(
+                new byte[AgentVersionContentCodec.MAX_CONTENT_SIZE + 1]));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.decode(new byte[] {(byte) 0xC3, 0x28}));
+        
+        byte[] persisted = AgentVersionContentCodec.encode(createGoldenContent()).getBytes();
+        byte[] whitespace = new byte[persisted.length + 1];
+        whitespace[0] = ' ';
+        System.arraycopy(persisted, 0, whitespace, 1, persisted.length);
+        assertEquals(AgentVersionContent.KIND,
+            AgentVersionContentCodec.decode(whitespace).getKind());
+        
+        byte[] invalidModel = ("{\"kind\":\"AgentVersionContent\","
+            + "\"schemaVersion\":1,\"callInterfaces\":[]}")
+            .getBytes(StandardCharsets.UTF_8);
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.decode(invalidModel));
+    }
+    
+    private AgentVersionContent createGoldenContent() {
+        AgentCallInterface callInterface = new AgentCallInterface();
+        callInterface.setProtocol("a2a");
+        callInterface.setProtocolVersion("1.0");
+        callInterface.setDescriptorMediaType("application/json");
+        Map<String, Object> capabilities = new LinkedHashMap<String, Object>();
+        capabilities.put("streaming", true);
+        capabilities.put("push", false);
+        Map<String, Object> descriptor = new LinkedHashMap<String, Object>();
+        descriptor.put("version", "1.0.6");
+        descriptor.put("title", "订单 Agent");
+        descriptor.put("name", "Order Agent");
+        descriptor.put("capabilities", capabilities);
+        callInterface.setNativeDescriptor(descriptor);
+        callInterface.setEndpointSourceOrder(
+            Arrays.asList(EndpointSource.RUNTIME, EndpointSource.DECLARED));
+        Endpoint endpoint = createEndpoint("HTTPS://Example.COM/a2a?b=2&a=1");
+        endpoint.setTransport("JSONRPC");
+        Map<String, String> metadata = new LinkedHashMap<String, String>();
+        metadata.put("zone", "cn-hangzhou-h");
+        metadata.put("az", "h");
+        endpoint.setMetadata(metadata);
+        callInterface.setDeclaredEndpoints(Collections.singletonList(endpoint));
+        return new AgentVersionContent(Collections.singletonList(callInterface));
+    }
+    
+    private AgentCallInterface createCallInterface(String protocol, String endpointUri) {
+        AgentCallInterface result = new AgentCallInterface();
+        result.setProtocol(protocol);
+        result.setDescriptorMediaType("application/json");
+        result.setNativeDescriptor(Collections.singletonMap("name", protocol));
+        result.setEndpointSourceOrder(Collections.singletonList(EndpointSource.DECLARED));
+        if (endpointUri != null) {
+            result.setDeclaredEndpoints(
+                new ArrayList<Endpoint>(Collections.singletonList(createEndpoint(endpointUri))));
+        }
+        return result;
+    }
+    
+    private Endpoint createEndpoint(String uri) {
+        Endpoint result = new Endpoint();
+        result.setUri(uri);
+        result.setTransport("HTTP");
+        return result;
+    }
+    
+    private void assertEncodingRejected(AgentVersionContent content) {
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionContentCodec.encode(content));
+    }
+    
+    private String repeat(char value, int count) {
+        char[] result = new char[count];
+        Arrays.fill(result, value);
+        return new String(result);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/fingerprint/RuntimeEndpointRevisionTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/fingerprint/RuntimeEndpointRevisionTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.fingerprint;
+
+import com.alibaba.nacos.api.ai.model.agent.Endpoint;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RuntimeEndpointRevisionTest {
+    
+    private static final String DUAL_ENDPOINT_FRAME_HEX =
+        "0000000200000017687474703a2f2f612e6578616d706c653a38302f727063000000044854"
+            + "54500000000a3fe000000000000000000000010000002168747470733a2f2f622e6578616d"
+            + "706c653a3434332f6132613f623d3226613d31000000074a534f4e525043000000003ff000"
+            + "00000000000000000200000002617a0000000162000000047a6f6e65000000027a3200";
+    
+    private static final String NATURAL_KEY_FRAME_HEX =
+        "0000000300000018687474703a2f2f73616d652e6578616d706c653a38302f61000000044752"
+            + "5043000000003ff0000000000000000000000100000018687474703a2f2f73616d652e657861"
+            + "6d706c653a38302f62000000074a534f4e525043000000003ff0000000000000000000000000"
+            + "00001a687474703a2f2f73616d652e6578616d706c653a313030302f7a000000044854545000"
+            + "0000003ff00000000000000000000001";
+    
+    @Test
+    void testEmptyProjectionGoldenVector() {
+        byte[] frame = RuntimeEndpointRevision.revisionBytes("public", "Order Agent", "a2a",
+            Collections.<Endpoint>emptyList());
+        assertEquals("00000000", toHex(frame));
+        assertEquals("murmur3-x64-128-v1:cfa0f7ddd84c76bc589623161cf526f1",
+            RuntimeEndpointRevision.compute("public", "Order Agent", "a2a",
+                Collections.<Endpoint>emptyList()));
+        assertEquals("murmur3-x64-128-v1", RuntimeEndpointRevision.ALGORITHM_ID);
+        assertEquals("murmur3-x64-128-v1:", RuntimeEndpointRevision.TOKEN_PREFIX);
+    }
+    
+    @Test
+    void testDualEndpointGoldenVectorAndNaturalKeyOrdering() {
+        Endpoint b = createEndpoint("HTTPS://B.EXAMPLE/a2a?b=2&a=1", "JSONRPC", false);
+        Map<String, String> metadata = new LinkedHashMap<String, String>();
+        metadata.put("zone", "z2");
+        metadata.put("az", "b");
+        b.setMetadata(metadata);
+        Endpoint a = createEndpoint("http://a.example/rpc", "HTTP", true);
+        a.setPriority(10);
+        a.setWeight(0.5D);
+        List<Endpoint> reversedInput = Arrays.asList(b, a);
+        
+        byte[] frame = RuntimeEndpointRevision.revisionBytes("public", "Order Agent", "a2a",
+            reversedInput);
+        assertEquals(146, frame.length);
+        assertEquals(DUAL_ENDPOINT_FRAME_HEX, toHex(frame));
+        assertEquals("murmur3-x64-128-v1:6553cc8de6bd96d7077624a5b3a5178d",
+            RuntimeEndpointRevision.compute("public", "Order Agent", "a2a", reversedInput));
+        assertArrayEquals(frame,
+            RuntimeEndpointRevision.revisionBytes("public", "Order Agent", "a2a",
+                Arrays.asList(a, b)));
+    }
+    
+    @Test
+    void testNaturalKeyOrdersNumericPortThenTransport() {
+        Endpoint port1000 = createEndpoint("http://same.example:1000/z", "HTTP", true);
+        Endpoint port80Json = createEndpoint("http://same.example/b", "JSONRPC", false);
+        Endpoint port80Grpc = createEndpoint("http://same.example/a", "GRPC", true);
+        List<Endpoint> reversed = Arrays.asList(port1000, port80Json, port80Grpc);
+        
+        byte[] frame = RuntimeEndpointRevision.revisionBytes("public", "Agent", "a2a",
+            reversed);
+        assertEquals(168, frame.length);
+        assertEquals(NATURAL_KEY_FRAME_HEX, toHex(frame));
+        assertEquals("murmur3-x64-128-v1:910d3654e3044e56d7669c07465477ef",
+            RuntimeEndpointRevision.compute("public", "Agent", "a2a", reversed));
+        assertArrayEquals(frame,
+            RuntimeEndpointRevision.revisionBytes("public", "Agent", "a2a",
+                Arrays.asList(port80Grpc, port80Json, port1000)));
+    }
+    
+    @Test
+    void testEquivalentDefaultsAndMetadataOrderHaveSameRevision() {
+        Endpoint omitted = createEndpoint("HTTP://EXAMPLE.COM/rpc", "HTTP", true);
+        Endpoint explicit = createEndpoint("http://example.com:80/rpc", "HTTP", true);
+        explicit.setPriority(0);
+        explicit.setWeight(1D);
+        explicit.setMetadata(Collections.<String, String>emptyMap());
+        assertEquals(revision(omitted), revision(explicit));
+        
+        Endpoint firstOrder = createEndpoint("http://example.com/rpc", "HTTP", true);
+        Map<String, String> firstMetadata = new LinkedHashMap<String, String>();
+        firstMetadata.put("zone", "z1");
+        firstMetadata.put("az", "a");
+        firstOrder.setMetadata(firstMetadata);
+        Endpoint secondOrder = createEndpoint("http://example.com:80/rpc", "HTTP", true);
+        Map<String, String> secondMetadata = new LinkedHashMap<String, String>();
+        secondMetadata.put("az", "a");
+        secondMetadata.put("zone", "z1");
+        secondOrder.setMetadata(secondMetadata);
+        assertEquals(revision(firstOrder), revision(secondOrder));
+    }
+    
+    @Test
+    void testEquivalentSignedZeroWeightsHaveSameRevision() {
+        Endpoint positiveZero = createEndpoint("http://example.com/rpc", "HTTP", true);
+        positiveZero.setWeight(0D);
+        Endpoint negativeZero = createEndpoint("http://example.com/rpc", "HTTP", true);
+        negativeZero.setWeight(-0D);
+        assertEquals(revision(positiveZero), revision(negativeZero));
+    }
+    
+    @Test
+    void testAdjacentWeightsHaveDifferentRevisions() {
+        Endpoint baseline = createEndpoint("http://example.com/rpc", "HTTP", true);
+        baseline.setWeight(1D);
+        Endpoint adjacent = createEndpoint("http://example.com/rpc", "HTTP", true);
+        adjacent.setWeight(Math.nextUp(1D));
+        assertNotEquals(revision(baseline), revision(adjacent));
+    }
+    
+    @Test
+    void testEveryIncludedEndpointFieldChangesRevision() {
+        String baseline = revision(createEndpoint("http://example.com/a", "HTTP", true));
+        
+        Endpoint uri = createEndpoint("http://example.com/b", "HTTP", true);
+        assertNotEquals(baseline, revision(uri));
+        Endpoint transport = createEndpoint("http://example.com/a", "JSONRPC", true);
+        assertNotEquals(baseline, revision(transport));
+        Endpoint priority = createEndpoint("http://example.com/a", "HTTP", true);
+        priority.setPriority(1);
+        assertNotEquals(baseline, revision(priority));
+        Endpoint weight = createEndpoint("http://example.com/a", "HTTP", true);
+        weight.setWeight(0.5D);
+        assertNotEquals(baseline, revision(weight));
+        Endpoint metadata = createEndpoint("http://example.com/a", "HTTP", true);
+        metadata.setMetadata(Collections.singletonMap("zone", "z1"));
+        assertNotEquals(baseline, revision(metadata));
+        Endpoint health = createEndpoint("http://example.com/a", "HTTP", false);
+        assertNotEquals(baseline, revision(health));
+    }
+    
+    @Test
+    void testProjectionIdentityIsValidatedButExcludedFromRevisionBytes() {
+        Endpoint endpoint = createEndpoint("http://example.com/rpc", "HTTP", true);
+        byte[] first = RuntimeEndpointRevision.revisionBytes("public", "Agent A", "a2a",
+            Collections.singletonList(endpoint));
+        byte[] second = RuntimeEndpointRevision.revisionBytes("tenant", "Agent B", "custom",
+            Collections.singletonList(endpoint));
+        assertArrayEquals(first, second);
+    }
+    
+    @Test
+    void testRejectInvalidProjectionAndDuplicateNaturalKeys() {
+        assertThrows(IllegalArgumentException.class,
+            () -> RuntimeEndpointRevision.compute("public", "Agent", "a2a", null));
+        assertThrows(IllegalArgumentException.class,
+            () -> RuntimeEndpointRevision.compute("", "Agent", "a2a",
+                Collections.<Endpoint>emptyList()));
+        assertThrows(IllegalArgumentException.class,
+            () -> RuntimeEndpointRevision.compute("public", "", "a2a",
+                Collections.<Endpoint>emptyList()));
+        assertThrows(IllegalArgumentException.class,
+            () -> RuntimeEndpointRevision.compute("public", "Agent", "-a2a",
+                Collections.<Endpoint>emptyList()));
+        assertThrows(IllegalArgumentException.class,
+            () -> revision(null));
+        
+        Endpoint missingHealth = createEndpoint("http://example.com/rpc", "HTTP", null);
+        assertThrows(IllegalArgumentException.class,
+            () -> revision(missingHealth));
+        
+        Endpoint first = createEndpoint("http://EXAMPLE.COM/a", "HTTP", true);
+        Endpoint duplicate = createEndpoint("http://example.com:80/b", "HTTP", false);
+        assertThrows(IllegalArgumentException.class,
+            () -> RuntimeEndpointRevision.compute("public", "Agent", "a2a",
+                Arrays.asList(first, duplicate)));
+    }
+    
+    @Test
+    void testMaximumProjectionIsBoundedAndPractical() {
+        List<Endpoint> endpoints = new ArrayList<Endpoint>();
+        for (int i = 0; i < 1000; i++) {
+            endpoints.add(createEndpoint("http://e" + i + ".example.com/rpc", "HTTP", true));
+        }
+        assertTimeout(Duration.ofSeconds(5), () -> {
+            String revision = RuntimeEndpointRevision.compute("public", "Agent", "a2a", endpoints);
+            assertTrue(revision.startsWith(RuntimeEndpointRevision.TOKEN_PREFIX));
+        });
+        
+        endpoints.add(createEndpoint("http://overflow.example.com/rpc", "HTTP", true));
+        assertThrows(IllegalArgumentException.class,
+            () -> RuntimeEndpointRevision.compute("public", "Agent", "a2a", endpoints));
+    }
+    
+    private String revision(Endpoint endpoint) {
+        return RuntimeEndpointRevision.compute("public", "Agent", "a2a",
+            Collections.singletonList(endpoint));
+    }
+    
+    private Endpoint createEndpoint(String uri, String transport, Boolean healthy) {
+        Endpoint result = new Endpoint();
+        result.setUri(uri);
+        result.setTransport(transport);
+        result.setHealthy(healthy);
+        return result;
+    }
+    
+    private String toHex(byte[] value) {
+        char[] alphabet = "0123456789abcdef".toCharArray();
+        char[] result = new char[value.length * 2];
+        for (int i = 0; i < value.length; i++) {
+            int current = value[i] & 0xFF;
+            result[i * 2] = alphabet[current >>> 4];
+            result[i * 2 + 1] = alphabet[current & 0x0F];
+        }
+        return new String(result);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageDescriptorCodecTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageDescriptorCodecTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.storage;
+
+import com.alibaba.nacos.ai.model.agent.AgentVersionStorageDescriptor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentVersionStorageDescriptorCodecTest {
+    
+    @Test
+    void testNacosConfigRoundTrip() {
+        AgentVersionStorageDescriptor original = createNacosConfigDescriptor();
+        String json = AgentVersionStorageDescriptorCodec.encode(original);
+        
+        assertTrue(json.contains("\"provider\":\"nacos_config\""));
+        assertTrue(json.contains("\"keyFormat\":\"agent-version-config-v1\""));
+        AgentVersionStorageDescriptor restored = AgentVersionStorageDescriptorCodec.decode(json);
+        assertDescriptorEquals(original, restored);
+    }
+    
+    @Test
+    void testCustomProviderMayOmitProviderSpecificFields() {
+        AgentVersionStorageDescriptor descriptor = createNacosConfigDescriptor();
+        descriptor.setProvider("object_store-v2");
+        descriptor.setKeyFormat(null);
+        descriptor.setAgentNameCodec(null);
+        
+        String json = AgentVersionStorageDescriptorCodec.encode(descriptor);
+        assertFalse(json.contains("keyFormat"));
+        assertFalse(json.contains("agentNameCodec"));
+        AgentVersionStorageDescriptor restored = AgentVersionStorageDescriptorCodec.decode(json);
+        assertNull(restored.getKeyFormat());
+        assertNull(restored.getAgentNameCodec());
+    }
+    
+    @Test
+    void testAcceptSchemaBoundaries() {
+        AgentVersionStorageDescriptor descriptor = createNacosConfigDescriptor();
+        descriptor.setProvider("a" + repeat('b', 63));
+        descriptor.setKey(repeat('k', 1024));
+        descriptor.setKeyFormat(repeat('f', 64));
+        descriptor.setAgentNameCodec(repeat('c', 64));
+        descriptor.setSize((long) AgentVersionStorageDescriptorCodec.MAX_CONTENT_SIZE);
+        AgentVersionStorageDescriptorCodec.decode(
+            AgentVersionStorageDescriptorCodec.encode(descriptor));
+        
+        descriptor.setProvider("nacos_config");
+        descriptor.setKeyFormat(AgentVersionStorageDescriptorCodec.NACOS_CONFIG_KEY_FORMAT);
+        descriptor.setAgentNameCodec(
+            AgentVersionStorageDescriptorCodec.RAD_ASCII_AGENT_NAME_CODEC);
+        descriptor.setSize(0L);
+        AgentVersionStorageDescriptorCodec.encode(descriptor);
+    }
+    
+    @Test
+    void testRejectUnknownOrInvalidJsonShape() {
+        String valid = AgentVersionStorageDescriptorCodec.encode(createNacosConfigDescriptor());
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.encode(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(""));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode("not-json"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode("[]"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode("null"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode("1"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode("\"descriptor\""));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"provider\":\"nacos_config\",", "")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"provider\":\"nacos_config\"", "\"provider\":1")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.substring(0, valid.length() - 1) + ",\"extra\":true}"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(valid + "{}"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("{\"provider\":\"nacos_config\"",
+                    "{\"provider\":\"nacos_config\",\"provider\":\"nacos_config\"")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"size\":128", "\"size\":\"large\"")));
+    }
+    
+    @Test
+    void testRejectMissingRequiredJsonFields() {
+        String valid = AgentVersionStorageDescriptorCodec.encode(createNacosConfigDescriptor());
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"key\":\"namespace:agent-version:agent__Agent__1.0.0.json\",",
+                    "")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"contentDigest\":\"sha256:" + repeat('a', 64) + "\",", "")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"mediaType\":\"application/vnd.nacos.agent-version+json\",",
+                    "")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"schemaVersion\":1,", "")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace(",\"size\":128", "")));
+    }
+    
+    @Test
+    void testRejectWrongJsonFieldTypes() {
+        String valid = AgentVersionStorageDescriptorCodec.encode(createNacosConfigDescriptor());
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"key\":\"namespace:agent-version:agent__Agent__1.0.0.json\"",
+                    "\"key\":1")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"keyFormat\":\"agent-version-config-v1\"",
+                    "\"keyFormat\":null")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"agentNameCodec\":\"rad-ascii-v1\"",
+                    "\"agentNameCodec\":false")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"contentDigest\":\"sha256:" + repeat('a', 64) + "\"",
+                    "\"contentDigest\":{}")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"mediaType\":\"application/vnd.nacos.agent-version+json\"",
+                    "\"mediaType\":[]")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"schemaVersion\":1", "\"schemaVersion\":1.0")));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.decode(
+                valid.replace("\"size\":128", "\"size\":128.5")));
+    }
+    
+    @Test
+    void testRejectInvalidProvider() {
+        assertRejected(null, descriptor -> descriptor.setProvider(null));
+        assertRejected(null, descriptor -> descriptor.setProvider(""));
+        assertRejected(null, descriptor -> descriptor.setProvider("-provider"));
+        assertRejected(null, descriptor -> descriptor.setProvider("provider.dot"));
+        assertRejected(null, descriptor -> descriptor.setProvider("a" + repeat('b', 64)));
+    }
+    
+    @Test
+    void testRejectInvalidKeyAndOptionalProviderFields() {
+        assertRejected(null, descriptor -> descriptor.setKey(null));
+        assertRejected(null, descriptor -> descriptor.setKey(""));
+        assertRejected(null, descriptor -> descriptor.setKey(repeat('k', 1025)));
+        assertRejected("custom", descriptor -> descriptor.setKeyFormat(""));
+        assertRejected("custom", descriptor -> descriptor.setKeyFormat(repeat('f', 65)));
+        assertRejected("custom", descriptor -> descriptor.setAgentNameCodec(""));
+        assertRejected("custom", descriptor -> descriptor.setAgentNameCodec(repeat('c', 65)));
+    }
+    
+    @Test
+    void testRejectInvalidDigestMediaTypeSchemaAndSize() {
+        assertRejected(null, descriptor -> descriptor.setContentDigest(null));
+        assertRejected(null,
+            descriptor -> descriptor.setContentDigest("sha256:" + repeat('a', 63)));
+        assertRejected(null,
+            descriptor -> descriptor.setContentDigest("sha256:" + repeat('A', 64)));
+        assertRejected(null, descriptor -> descriptor.setMediaType(null));
+        assertRejected(null, descriptor -> descriptor.setMediaType("application/json"));
+        assertRejected(null, descriptor -> descriptor.setSchemaVersion(null));
+        assertRejected(null, descriptor -> descriptor.setSchemaVersion(2));
+        assertRejected(null, descriptor -> descriptor.setSize(null));
+        assertRejected(null, descriptor -> descriptor.setSize(-1L));
+        assertRejected(null,
+            descriptor -> descriptor.setSize(
+                (long) AgentVersionStorageDescriptorCodec.MAX_CONTENT_SIZE + 1));
+    }
+    
+    @Test
+    void testRejectInvalidNacosConfigProviderContract() {
+        assertRejected(null, descriptor -> descriptor.setKeyFormat(null));
+        assertRejected(null, descriptor -> descriptor.setKeyFormat("other"));
+        assertRejected(null, descriptor -> descriptor.setAgentNameCodec(null));
+        assertRejected(null, descriptor -> descriptor.setAgentNameCodec("other"));
+    }
+    
+    private void assertRejected(String provider, DescriptorMutation mutation) {
+        AgentVersionStorageDescriptor descriptor = createNacosConfigDescriptor();
+        if (provider != null) {
+            descriptor.setProvider(provider);
+        }
+        mutation.apply(descriptor);
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorCodec.encode(descriptor));
+    }
+    
+    private void assertDescriptorEquals(AgentVersionStorageDescriptor expected,
+        AgentVersionStorageDescriptor actual) {
+        assertEquals(expected.getProvider(), actual.getProvider());
+        assertEquals(expected.getKey(), actual.getKey());
+        assertEquals(expected.getKeyFormat(), actual.getKeyFormat());
+        assertEquals(expected.getAgentNameCodec(), actual.getAgentNameCodec());
+        assertEquals(expected.getContentDigest(), actual.getContentDigest());
+        assertEquals(expected.getMediaType(), actual.getMediaType());
+        assertEquals(expected.getSchemaVersion(), actual.getSchemaVersion());
+        assertEquals(expected.getSize(), actual.getSize());
+    }
+    
+    private AgentVersionStorageDescriptor createNacosConfigDescriptor() {
+        AgentVersionStorageDescriptor result = new AgentVersionStorageDescriptor();
+        result.setProvider(AgentVersionStorageDescriptorCodec.NACOS_CONFIG_PROVIDER);
+        result.setKey("namespace:agent-version:agent__Agent__1.0.0.json");
+        result.setKeyFormat(AgentVersionStorageDescriptorCodec.NACOS_CONFIG_KEY_FORMAT);
+        result.setAgentNameCodec(AgentVersionStorageDescriptorCodec.RAD_ASCII_AGENT_NAME_CODEC);
+        result.setContentDigest("sha256:" + repeat('a', 64));
+        result.setMediaType(AgentVersionStorageDescriptorCodec.AGENT_VERSION_MEDIA_TYPE);
+        result.setSchemaVersion(AgentVersionStorageDescriptorCodec.SCHEMA_VERSION);
+        result.setSize(128L);
+        return result;
+    }
+    
+    private String repeat(char value, int count) {
+        StringBuilder result = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+    
+    private interface DescriptorMutation {
+        
+        void apply(AgentVersionStorageDescriptor descriptor);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageServiceTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.storage;
+
+import com.alibaba.nacos.ai.model.agent.AgentVersionContent;
+import com.alibaba.nacos.ai.model.agent.AgentVersionStorageDescriptor;
+import com.alibaba.nacos.ai.service.agent.fingerprint.AgentVersionContentCodec;
+import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
+import com.alibaba.nacos.api.ai.model.agent.AgentCallInterface;
+import com.alibaba.nacos.api.ai.model.agent.EndpointSource;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
+import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentVersionStorageServiceTest {
+    
+    private static final String NAMESPACE_ID = "public";
+    
+    private static final String AGENT_NAME = "Nacos Agent";
+    
+    private static final String VERSION = "1.0.0-RC1";
+    
+    @Mock
+    private AiResourceStorageRouter storageRouter;
+    
+    @Mock
+    private AiResourceStorage storage;
+    
+    private AgentVersionStorageService service;
+    
+    @BeforeEach
+    void setUp() {
+        service = new AgentVersionStorageService(storageRouter,
+            () -> NacosConfigAiResourceStorage.TYPE);
+    }
+    
+    @Test
+    void testSaveUsesExactEncodedBytesAndReturnsDescriptor() throws NacosException {
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        AgentVersionContent content = newContent();
+        AgentVersionContentCodec.EncodedContent expected = AgentVersionContentCodec.encode(content);
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        ArgumentCaptor<byte[]> contentCaptor = ArgumentCaptor.forClass(byte[].class);
+        
+        AgentVersionStorageDescriptor descriptor = service.save(NAMESPACE_ID, AGENT_NAME, VERSION,
+            content);
+        
+        verify(storage).save(keyCaptor.capture(), contentCaptor.capture());
+        StorageKey key = keyCaptor.getValue();
+        assertEquals(NacosConfigAiResourceStorage.TYPE, key.getProvider());
+        assertEquals("public:agent-version:agent__enc-Nacos-032Agent__1.0.0-RC1.json",
+            key.getKey());
+        assertArrayEquals(expected.getBytes(), contentCaptor.getValue());
+        assertEquals(key.getProvider(), descriptor.getProvider());
+        assertEquals(key.getKey(), descriptor.getKey());
+        assertEquals(AgentVersionStorageDescriptor.NACOS_CONFIG_KEY_FORMAT,
+            descriptor.getKeyFormat());
+        assertEquals(AgentVersionStorageDescriptor.RAD_AGENT_NAME_CODEC,
+            descriptor.getAgentNameCodec());
+        assertEquals(expected.getContentDigest(), descriptor.getContentDigest());
+        assertEquals(AgentVersionStorageDescriptor.MEDIA_TYPE, descriptor.getMediaType());
+        assertEquals(AgentVersionStorageDescriptor.SCHEMA_VERSION,
+            descriptor.getSchemaVersion());
+        assertEquals((long) expected.getSize(), descriptor.getSize());
+    }
+    
+    @Test
+    void testSaveUsesConfiguredCustomProvider() throws NacosException {
+        service = new AgentVersionStorageService(storageRouter, () -> " object-store ");
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        
+        AgentVersionStorageDescriptor descriptor = service.save(NAMESPACE_ID, AGENT_NAME, VERSION,
+            newContent());
+        
+        assertEquals("object-store", descriptor.getProvider());
+        assertNull(descriptor.getKeyFormat());
+        assertNull(descriptor.getAgentNameCodec());
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        verify(storage).save(keyCaptor.capture(), any(byte[].class));
+        assertEquals("object-store", keyCaptor.getValue().getProvider());
+        assertEquals("public:agent-version:agent__enc-Nacos-032Agent__1.0.0-RC1.json",
+            keyCaptor.getValue().getKey());
+    }
+    
+    @Test
+    void testSaveFallsBackToDefaultProviderWhenConfigurationIsBlank() throws NacosException {
+        service = new AgentVersionStorageService(storageRouter, () -> "  ");
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        
+        AgentVersionStorageDescriptor descriptor = service.save(NAMESPACE_ID, "agent", "1.0.0",
+            newContent());
+        
+        assertEquals(NacosConfigAiResourceStorage.TYPE, descriptor.getProvider());
+    }
+    
+    @Test
+    void testSaveRejectsInvalidInputBeforeRouting() {
+        assertThrows(IllegalArgumentException.class,
+            () -> service.save("invalid namespace", AGENT_NAME, VERSION, newContent()));
+        assertThrows(IllegalArgumentException.class,
+            () -> service.save(NAMESPACE_ID, "Agent代理", VERSION, newContent()));
+        assertThrows(IllegalArgumentException.class,
+            () -> service.save(NAMESPACE_ID, AGENT_NAME, "v1", newContent()));
+        assertThrows(IllegalArgumentException.class,
+            () -> service.save(NAMESPACE_ID, AGENT_NAME, VERSION, null));
+        verify(storageRouter, never()).route(any(StorageKey.class));
+    }
+    
+    @Test
+    void testLoadValidatesRawBytesBeforeDecoding() throws NacosException {
+        byte[] bytes = reorderedContentBytes();
+        AgentVersionStorageDescriptor descriptor = descriptor(bytes);
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        when(storage.get(any(StorageKey.class))).thenReturn(bytes);
+        
+        AgentVersionContent result = service.load(descriptor);
+        
+        assertEquals(AgentVersionContent.KIND, result.getKind());
+        assertEquals(AgentVersionContent.SCHEMA_VERSION, result.getSchemaVersion());
+        assertEquals("a2a", result.getCallInterfaces().get(0).getProtocol());
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        verify(storage).get(keyCaptor.capture());
+        assertEquals(descriptor.getProvider(), keyCaptor.getValue().getProvider());
+        assertEquals(descriptor.getKey(), keyCaptor.getValue().getKey());
+    }
+    
+    @Test
+    void testLoadRejectsMissingContent() throws NacosException {
+        byte[] bytes = reorderedContentBytes();
+        AgentVersionStorageDescriptor descriptor = descriptor(bytes);
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        when(storage.get(any(StorageKey.class))).thenReturn(null);
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.load(descriptor));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+    }
+    
+    @Test
+    void testLoadRejectsSizeMismatchBeforeDigest() throws NacosException {
+        byte[] bytes = reorderedContentBytes();
+        AgentVersionStorageDescriptor descriptor = descriptor(bytes);
+        descriptor.setSize(descriptor.getSize() + 1);
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        when(storage.get(any(StorageKey.class))).thenReturn(bytes);
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.load(descriptor));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        assertEquals("Agent Version content size does not match its descriptor",
+            exception.getErrMsg());
+    }
+    
+    @Test
+    void testLoadRejectsDigestMismatch() throws NacosException {
+        byte[] bytes = reorderedContentBytes();
+        AgentVersionStorageDescriptor descriptor = descriptor(bytes);
+        descriptor.setContentDigest(AgentVersionContentCodec.digest("other".getBytes(
+            StandardCharsets.UTF_8)));
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        when(storage.get(any(StorageKey.class))).thenReturn(bytes);
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.load(descriptor));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        assertEquals("Agent Version content digest does not match its descriptor",
+            exception.getErrMsg());
+    }
+    
+    @Test
+    void testLoadRejectsInvalidContentAfterIntegrityChecks() throws NacosException {
+        byte[] bytes = "{}".getBytes(StandardCharsets.UTF_8);
+        AgentVersionStorageDescriptor descriptor = descriptor(bytes);
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        when(storage.get(any(StorageKey.class))).thenReturn(bytes);
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.load(descriptor));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        assertEquals("Agent Version content cannot be decoded", exception.getErrMsg());
+    }
+    
+    @Test
+    void testLoadRejectsInvalidDescriptorBeforeRouting() {
+        AgentVersionStorageDescriptor descriptor = descriptor(reorderedContentBytes());
+        descriptor.setKey(null);
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.load(descriptor));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        verify(storageRouter, never()).route(any(StorageKey.class));
+    }
+    
+    @Test
+    void testLoadWrapsMalformedPersistedKey() throws NacosException {
+        AgentVersionStorageDescriptor descriptor = descriptor(reorderedContentBytes());
+        descriptor.setKey("malformed");
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        when(storage.get(any(StorageKey.class)))
+            .thenThrow(new IllegalArgumentException("malformed key"));
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.load(descriptor));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        assertEquals("Invalid Agent Version storage key", exception.getErrMsg());
+        assertNotNull(exception.getCause());
+    }
+    
+    @Test
+    void testDeleteUsesPersistedDescriptorKey() throws NacosException {
+        AgentVersionStorageDescriptor descriptor = descriptor(reorderedContentBytes());
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        ArgumentCaptor<StorageKey> keyCaptor = ArgumentCaptor.forClass(StorageKey.class);
+        
+        service.delete(descriptor);
+        
+        verify(storage).delete(keyCaptor.capture());
+        assertEquals(descriptor.getProvider(), keyCaptor.getValue().getProvider());
+        assertEquals(descriptor.getKey(), keyCaptor.getValue().getKey());
+    }
+    
+    @Test
+    void testDeleteWrapsMalformedPersistedKey() throws NacosException {
+        AgentVersionStorageDescriptor descriptor = descriptor(reorderedContentBytes());
+        descriptor.setKey("malformed");
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        org.mockito.Mockito.doThrow(new IllegalArgumentException("malformed key"))
+            .when(storage).delete(any(StorageKey.class));
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.delete(descriptor));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        assertEquals("Invalid Agent Version storage key", exception.getErrMsg());
+        assertNotNull(exception.getCause());
+    }
+    
+    @Test
+    void testUnavailableProviderIsReportedAsStorageFailure() {
+        AgentVersionStorageDescriptor descriptor = descriptor(reorderedContentBytes());
+        when(storageRouter.route(any(StorageKey.class)))
+            .thenThrow(new IllegalStateException("missing"));
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.load(descriptor));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        assertNotNull(exception.getCause());
+    }
+    
+    @Test
+    void testStorageExceptionIsPropagated() throws NacosException {
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        NacosException expected = new NacosException(NacosException.SERVER_ERROR, "save failed");
+        org.mockito.Mockito.doThrow(expected).when(storage)
+            .save(any(StorageKey.class), any(byte[].class));
+        
+        NacosException actual = assertThrows(NacosException.class,
+            () -> service.save(NAMESPACE_ID, AGENT_NAME, VERSION, newContent()));
+        
+        assertEquals(expected, actual);
+    }
+    
+    @Test
+    void testSaveWrapsProviderIllegalArgumentException() throws NacosException {
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        org.mockito.Mockito.doThrow(new IllegalArgumentException("provider rejected key"))
+            .when(storage).save(any(StorageKey.class), any(byte[].class));
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> service.save(NAMESPACE_ID, AGENT_NAME, VERSION, newContent()));
+        
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        assertEquals("Agent Version content cannot be saved", exception.getErrMsg());
+        assertNotNull(exception.getCause());
+    }
+    
+    @Test
+    void testGetAndDeleteStorageExceptionsArePropagated() throws NacosException {
+        AgentVersionStorageDescriptor descriptor = descriptor(reorderedContentBytes());
+        when(storageRouter.route(any(StorageKey.class))).thenReturn(storage);
+        NacosException getFailure = new NacosException(NacosException.SERVER_ERROR, "get failed");
+        when(storage.get(any(StorageKey.class))).thenThrow(getFailure);
+        
+        assertEquals(getFailure, assertThrows(NacosException.class,
+            () -> service.load(descriptor)));
+        
+        NacosException deleteFailure =
+            new NacosException(NacosException.SERVER_ERROR, "delete failed");
+        org.mockito.Mockito.doThrow(deleteFailure).when(storage).delete(any(StorageKey.class));
+        assertEquals(deleteFailure, assertThrows(NacosException.class,
+            () -> service.delete(descriptor)));
+    }
+    
+    private AgentVersionStorageDescriptor descriptor(byte[] bytes) {
+        AgentVersionStorageDescriptor result = new AgentVersionStorageDescriptor();
+        result.setProvider(NacosConfigAiResourceStorage.TYPE);
+        result.setKey("public:agent-version:agent__enc-Nacos-032Agent__1.0.0-RC1.json");
+        result.setKeyFormat(AgentVersionStorageDescriptor.NACOS_CONFIG_KEY_FORMAT);
+        result.setAgentNameCodec(AgentVersionStorageDescriptor.RAD_AGENT_NAME_CODEC);
+        result.setContentDigest(AgentVersionContentCodec.digest(bytes));
+        result.setMediaType(AgentVersionStorageDescriptor.MEDIA_TYPE);
+        result.setSchemaVersion(AgentVersionStorageDescriptor.SCHEMA_VERSION);
+        result.setSize((long) bytes.length);
+        return result;
+    }
+    
+    private AgentVersionContent newContent() {
+        AgentCallInterface callInterface = new AgentCallInterface();
+        callInterface.setProtocol("a2a");
+        callInterface.setDescriptorMediaType("application/json");
+        callInterface.setNativeDescriptor("descriptor");
+        callInterface.setEndpointSourceOrder(Collections.singletonList(EndpointSource.RUNTIME));
+        return new AgentVersionContent(Collections.singletonList(callInterface));
+    }
+    
+    private byte[] reorderedContentBytes() {
+        return ("{\"callInterfaces\":[{\"endpointSourceOrder\":[\"RUNTIME\"],"
+            + "\"nativeDescriptor\":\"descriptor\",\"descriptorMediaType\":"
+            + "\"application/json\",\"protocol\":\"a2a\"}],\"schemaVersion\":1,"
+            + "\"kind\":\"AgentVersionContent\"}").getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorageTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/storage/NacosConfigAiResourceStorageTest.java
@@ -23,6 +23,8 @@ import com.alibaba.nacos.api.ai.model.skills.SkillUtils;
 import com.alibaba.nacos.api.config.ConfigType;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.ai.service.SyncEffectService;
+import com.alibaba.nacos.ai.service.agent.identity.RadAsciiAgentIdCodec;
+import com.alibaba.nacos.ai.service.agent.storage.AgentVersionStorageKeyComposer;
 import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
 import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
 import com.alibaba.nacos.config.server.model.form.ConfigForm;
@@ -92,6 +94,90 @@ class NacosConfigAiResourceStorageTest {
         assertNotNull(key);
         assertEquals(NacosConfigAiResourceStorage.TYPE, key.getProvider());
         assertEquals("ns1:mySkill:v1:skill.json", key.getKey());
+    }
+    
+    @Test
+    void testBuildAndParseAgentVersionStorageKey() {
+        StorageKey key = AgentVersionStorageKeyComposer.compose(
+            NacosConfigAiResourceStorage.TYPE, "ns1", "Nacos Agent", "1.0.0-RC1");
+        
+        assertEquals(NacosConfigAiResourceStorage.TYPE, key.getProvider());
+        assertEquals("ns1:agent-version:agent__enc-Nacos-032Agent__1.0.0-RC1.json",
+            key.getKey());
+        NacosConfigAiResourceStorage.KeyParts parts = NacosConfigAiResourceStorage.parse(key);
+        assertEquals("ns1", parts.namespaceId());
+        assertEquals("agent-version", parts.group());
+        assertEquals("agent__enc-Nacos-032Agent__1.0.0-RC1.json", parts.dataId());
+    }
+    
+    @Test
+    void testBuildAgentVersionStorageKeyRejectsInvalidCoordinates() {
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageKeyComposer.compose(
+                NacosConfigAiResourceStorage.TYPE, "invalid namespace", "Agent", "1.0.0"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageKeyComposer.compose(
+                NacosConfigAiResourceStorage.TYPE, "ns1", "Agent代理", "1.0.0"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageKeyComposer.compose(
+                NacosConfigAiResourceStorage.TYPE, "ns1", "Agent", "v1"));
+    }
+    
+    @Test
+    void testParseRejectsMalformedAgentVersionStorageKey() {
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE,
+                "ns1:agent-version:agent__Agent_01__1.0.0.json")));
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE,
+                "ns1:agent-version:agent__Agent__v1.json")));
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE,
+                "ns1:agent-version:agent__Agent__1.0.0")));
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE,
+                "ns1:agent-version:agent__Agent1.0.0.json")));
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE,
+                "ns1:agent-version:agent____1.0.0.json")));
+        assertThrows(IllegalArgumentException.class,
+            () -> NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE,
+                "ns1:agent-version:agent__" + repeat("a", 261) + "__1.0.0.json")));
+        NacosConfigAiResourceStorage.KeyParts maximumParts =
+            NacosConfigAiResourceStorage.parse(new StorageKey(
+                NacosConfigAiResourceStorage.TYPE,
+                "ns1:agent-version:agent__" + repeat("a", 260) + "__1.0.0.json"));
+        assertEquals("agent-version", maximumParts.group());
+    }
+    
+    @Test
+    void testAgentVersionGroupTokenDoesNotBreakLegacySkillName() {
+        StorageKey versionKey = NacosConfigAiResourceStorage.buildStorageKey(
+            NacosConfigAiResourceStorage.TYPE, "ns1", "agent-version", "v1", "skill.json");
+        StorageKey manifestKey = NacosConfigAiResourceStorage.buildManifestStorageKey(
+            NacosConfigAiResourceStorage.TYPE, "ns1", "agent-version");
+        StorageKey prefixedVersionKey = NacosConfigAiResourceStorage.buildStorageKey(
+            NacosConfigAiResourceStorage.TYPE, "ns1", "agent-version", "agent__legacy",
+            "skill.json");
+        
+        NacosConfigAiResourceStorage.KeyParts versionParts =
+            NacosConfigAiResourceStorage.parse(versionKey);
+        NacosConfigAiResourceStorage.KeyParts manifestParts =
+            NacosConfigAiResourceStorage.parse(manifestKey);
+        NacosConfigAiResourceStorage.KeyParts prefixedVersionParts =
+            NacosConfigAiResourceStorage.parse(prefixedVersionKey);
+        
+        assertEquals(SkillUtils.buildSkillVersionGroup("agent-version", "v1"),
+            versionParts.group());
+        assertEquals(SkillUtils.buildSkillGroup("agent-version"), manifestParts.group());
+        assertEquals(SkillUtils.buildSkillVersionGroup("agent-version", "agent__legacy"),
+            prefixedVersionParts.group());
     }
     
     @Test
@@ -324,6 +410,21 @@ class NacosConfigAiResourceStorageTest {
         for (String[] resourceType : resourceTypes) {
             assertStorageOperationsUseSameHashedCoordinates(resourceType[0], resourceType[1]);
         }
+    }
+    
+    @Test
+    void testAgentVersionStorageOperationsUseSpecialAgentNameCoordinates()
+        throws NacosException {
+        assertAgentVersionStorageOperations("Nacos Agent", "1.0.0-RC1", false);
+    }
+    
+    @Test
+    void testAgentVersionStorageOperationsHashMaximumEncodedAgentName()
+        throws NacosException {
+        String agentName = repeat("!", 64);
+        String encodedAgentId = RadAsciiAgentIdCodec.encode(agentName);
+        assertEquals(260, encodedAgentId.length());
+        assertAgentVersionStorageOperations(agentName, "1.0.0", true);
     }
     
     @Test
@@ -607,6 +708,46 @@ class NacosConfigAiResourceStorageTest {
         assertEquals(expectedGroup, queryCaptor.getValue().getGroup());
         assertEquals(expectedDataId, deleteDataIdCaptor.getValue());
         assertEquals(expectedGroup, deleteGroupCaptor.getValue());
+    }
+    
+    private void assertAgentVersionStorageOperations(String agentName, String version,
+        boolean expectHashedDataId) throws NacosException {
+        StorageKey key = AgentVersionStorageKeyComposer.compose(
+            NacosConfigAiResourceStorage.TYPE, "public", agentName, version);
+        NacosConfigAiResourceStorage.KeyParts parts = NacosConfigAiResourceStorage.parse(key);
+        byte[] content = "content".getBytes(StandardCharsets.UTF_8);
+        ConfigQueryChainResponse response = new ConfigQueryChainResponse();
+        response.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        response.setContent("content");
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response);
+        
+        storage.save(key, content);
+        assertArrayEquals(content, storage.get(key));
+        storage.delete(key);
+        
+        ArgumentCaptor<ConfigForm> publishCaptor = ArgumentCaptor.forClass(ConfigForm.class);
+        verify(configOperationService).publishConfig(publishCaptor.capture(), any(), isNull());
+        ArgumentCaptor<ConfigQueryChainRequest> queryCaptor =
+            ArgumentCaptor.forClass(ConfigQueryChainRequest.class);
+        verify(configQueryChainService).handle(queryCaptor.capture());
+        ArgumentCaptor<String> deleteDataIdCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> deleteGroupCaptor = ArgumentCaptor.forClass(String.class);
+        verify(configOperationService).deleteConfig(deleteDataIdCaptor.capture(),
+            deleteGroupCaptor.capture(), eq("public"), isNull(), isNull(), eq("nacos"), isNull());
+        
+        String expectedDataId = NacosAiConfigKeyCodec.toPhysicalDataId(parts.dataId());
+        if (expectHashedDataId) {
+            assertTrue(expectedDataId.startsWith(NacosAiConfigKeyCodec.HASHED_PREFIX));
+        } else {
+            assertEquals(parts.dataId(), expectedDataId);
+        }
+        assertEquals(expectedDataId, publishCaptor.getValue().getDataId());
+        assertEquals(expectedDataId, queryCaptor.getValue().getDataId());
+        assertEquals(expectedDataId, deleteDataIdCaptor.getValue());
+        assertEquals("agent-version", publishCaptor.getValue().getGroup());
+        assertEquals("agent-version", queryCaptor.getValue().getGroup());
+        assertEquals("agent-version", deleteGroupCaptor.getValue());
     }
     
     private static String repeat(String value, int count) {

--- a/specs/en/ai/agent-management-spec.md
+++ b/specs/en/ai/agent-management-spec.md
@@ -180,7 +180,7 @@ An Agent Version exposes this metadata:
 | `callInterfaces[]` | Yes | Ordered protocol bindings; at least one. |
 | `author` | No | Version author. |
 | `changeDescription` | No | Version change description. |
-| `contentDigest` | Read-only | SHA-256 digest of canonical version content. |
+| `contentDigest` | Read-only | SHA-256 digest of the persisted Version content bytes. |
 | `createTime`, `updateTime` | Read-only | Audit timestamps. |
 
 The complete storage payload is one `AgentVersionContent` object:
@@ -192,9 +192,10 @@ AgentVersionContent
   callInterfaces[]
 ```
 
-Canonical serialization uses RFC 8785 JCS and preserves the business order of
-CallInterfaces and declared Endpoints. `contentDigest` uses
-`sha256:<lowercase hex>` over the canonical UTF-8 bytes. Exact I-JSON and
+The server serializes the validated object once as UTF-8 JSON. The same bytes
+are persisted, counted as `size`, and hashed as
+`sha256:<lowercase hex>`. Reads validate the digest against the bytes returned
+by AI Storage without reserializing the object. Storage normalization and
 validation rules are defined by the [Agent Storage Spec](agent-storage-spec.md).
 
 ### 4.2 Lifecycle Rules

--- a/specs/en/ai/agent-storage-spec.md
+++ b/specs/en/ai/agent-storage-spec.md
@@ -133,12 +133,32 @@ AgentVersionContent
     declaredEndpoints[]
 ```
 
-Canonical serialization uses RFC 8785 JSON Canonicalization Scheme (JCS).
-Array order is therefore preserved for CallInterfaces, source preference, and
-declared Endpoints, while object-member order and JSON number representation
-are normalized. Duplicate object keys and values that cannot be represented as
-I-JSON are rejected. `contentDigest` is `sha256:<lowercase hex>` over the
-UTF-8 JCS bytes.
+The server validates the object, creates the storage projection below, and
+serializes it once with the common Nacos JSON serializer as UTF-8. The exact
+emitted bytes are passed to AI Storage and are also used for `size` and
+`contentDigest=sha256:<lowercase hex>`. Agent storage does not define semantic
+JSON canonicalization: two JSON representations that decode to equivalent
+values are not required to produce the same digest.
+
+Before serialization, the server creates the storage projection:
+
+1. it rejects unknown schema properties on the envelope, CallInterface, and
+   Endpoint objects, then projects only schema-version-1 fields;
+2. it canonicalizes every declared Endpoint URI, and validates and preserves
+   its transport, through the common Endpoint canonicalizer;
+3. it materializes effective Endpoint `priority=0` and `weight=1`;
+4. it omits absent or empty Endpoint `metadata` and `declaredEndpoints`; and
+5. it otherwise preserves all array order and descriptor JSON values.
+
+`nativeDescriptor` JSON members and Endpoint `metadata` map entries remain
+open content within their separately defined value constraints.
+
+These projection rules normalize Agent-owned fields only. They do not reorder
+members inside `nativeDescriptor` or otherwise rewrite protocol-owned JSON.
+On read, integrity validation hashes the exact bytes returned by AI Storage
+before decoding; it must not reserialize the decoded object for digest
+comparison.
+
 The Version row's `storage` JSON contains:
 
 | Field | Value or meaning |
@@ -150,7 +170,7 @@ The Version row's `storage` JSON contains:
 | `contentDigest` | `sha256:<lowercase hex>`. |
 | `mediaType` | `application/vnd.nacos.agent-version+json`. |
 | `schemaVersion` | `1`. |
-| `size` | Canonical content byte count. |
+| `size` | Persisted content byte count. |
 
 Upper layers treat `StorageKey.key` as opaque. A replacement provider keeps
 the one-Version/one-object rule but owns its physical key. The built-in
@@ -167,7 +187,7 @@ Agent service.
 | `namespaceId` | `tenant_id=namespaceId`. |
 | Content category | `group_id=agent-version`. |
 | `agentName`, `version` | `data_id=agent__<encodedAgentId>__<version>.json`. |
-| `AgentVersionContent` | Canonical JSON `content` with `type=json`. |
+| `AgentVersionContent` | UTF-8 JSON `content` with `type=json`. |
 
 The built-in provider then applies the common `NacosAiConfigKeyCodec` to the
 complete logical group and data id. A safe value within the Config limits is
@@ -179,8 +199,8 @@ is longer than the Config physical limit.
 
 A draft update overwrites the same key. Content becomes immutable when the
 Version enters reviewing. `contentDigest` never participates in the data id;
-it validates content and cache equality. Read, review, and publish operations
-must verify the Storage pointer, byte count, and digest.
+it validates the exact persisted bytes and cache equality. Read, review, and
+publish operations must verify the Storage pointer, byte count, and digest.
 
 ### 3.3 RAD ASCII AgentName Codec
 
@@ -510,10 +530,19 @@ generates an opaque `sourceRevision` after it:
 
 1. aggregates live publisher contributions;
 2. selects bindings that contain the target Version;
-3. validates one canonical payload per natural key;
-4. removes `enabled=false` and retains both health states;
-5. sorts Endpoints by natural key and metadata by key; and
-6. computes MurmurHash3 x64 128 over canonical bytes.
+3. canonicalizes each Endpoint URI, validates and preserves transport,
+   materializes effective `priority=0` and `weight=1`, and requires `healthy`;
+4. validates one canonical payload per natural key;
+5. removes `enabled=false` and retains both health states;
+6. sorts Endpoints by natural key and metadata keys by UTF-16 code-unit ordinal
+   order; and
+7. computes MurmurHash3 x64 128 over the revision bytes defined below.
+
+Within one projection, natural-key order compares `normalizedHost` by UTF-16
+code-unit ordinal order, then `effectivePort` numerically, then transport by
+UTF-16 code-unit ordinal order. Implementations must not use locale-sensitive
+collation. URI path and query do not participate in ordering because they are
+not natural-key fields.
 
 The external token is:
 
@@ -521,7 +550,7 @@ The external token is:
 murmur3-x64-128-v1:<32 lowercase hex>
 ```
 
-Canonical input contains URI, transport, effective priority and weight, public
+Revision input contains URI, transport, effective priority and weight, public
 Endpoint metadata, and `healthy`. It excludes runtimeVersion, versionRange,
 publisher identity and count, heartbeat time, last-updated time, and Naming
 internal revisions. Runtime Version and range do not enter the hash because the
@@ -529,17 +558,28 @@ target projection has already filtered them. Range or enabled changes alter
 membership; health changes alter returned content. Both therefore advance the
 revision when the target projection changes.
 
+Absent and empty public Endpoint metadata both use a metadata entry count of
+zero.
+
 The empty set has a stable revision. An additional or removed redundant
 publisher does not change it. The token is only cache equality and watch
 deduplication; it is not identity, authorization, CAS, or tamper protection.
 
-All nodes use seed `0`. Canonical bytes start with an unsigned four-byte
-big-endian Endpoint count. For each ordered Endpoint, the six included fields
-are encoded in the stated order as RFC 8785 JSON UTF-8 and each field is
-prefixed with its unsigned four-byte big-endian byte length. The empty set is
-exactly `uint32be(0)`. The Murmur result emits `h1` followed by `h2`, each as an
-unsigned eight-byte big-endian value, and then lowercase hexadecimal. These
-rules are also machine-readable in internal storage schema version 1.
+All nodes use seed `0` and the following fixed big-endian binary layout:
+
+| Element | Encoding |
+| --- | --- |
+| Endpoint count | Unsigned four-byte integer. |
+| `uri`, `transport` | Unsigned four-byte UTF-8 byte length followed by the bytes. |
+| `priority` | Signed four-byte integer. |
+| `weight` | Eight-byte IEEE-754 binary64 bits; negative zero is normalized to positive zero. |
+| metadata | Unsigned four-byte entry count, followed by each ordered key and value using the string encoding above. |
+| `healthy` | One byte: `0` for false and `1` for true. |
+
+The empty set is exactly `uint32be(0)`. The Murmur result emits `h1` followed
+by `h2`, each as an unsigned eight-byte big-endian value, and then lowercase
+hexadecimal. These rules are also machine-readable in internal storage schema
+version 1.
 
 Implementations mark semantic projections dirty, coalesce bursts, and cache
 the result. They must not hash every heartbeat or every discovery read.

--- a/specs/en/ai/agent-storage-spec.md
+++ b/specs/en/ai/agent-storage-spec.md
@@ -172,15 +172,17 @@ The Version row's `storage` JSON contains:
 | `schemaVersion` | `1`. |
 | `size` | Persisted content byte count. |
 
-Upper layers treat `StorageKey.key` as opaque. A replacement provider keeps
-the one-Version/one-object rule but owns its physical key. The built-in
-provider uses the mapping in section 3.2.
+The Agent service composes one provider-neutral logical `StorageKey.key` and
+passes it to every provider as an opaque value. A replacement provider keeps
+the one-Version/one-object rule and owns the mapping from that logical key to
+its physical key. The built-in provider uses the mapping in section 3.2.
 
 ### 3.2 Built-in Nacos Config Mapping
 
 The `agent-version-config-v1` provider key carries this logical Config
-coordinate. Its serialized `StorageKey.key` remains provider-opaque to the
-Agent service.
+coordinate. The Agent service composes the logical `StorageKey.key`; after it
+is persisted in a descriptor, upper-layer consumers pass it through without
+parsing it. The built-in provider parses it only to perform this mapping.
 
 | Logical value | Logical `config_info` coordinate |
 | --- | --- |
@@ -196,6 +198,14 @@ stored unchanged. An overlong data id uses the codec's deterministic
 always reversible, and no upper layer may derive Agent identity from it.
 Valid Agent identity must not be rejected merely because this logical data id
 is longer than the Config physical limit.
+
+The provider-neutral `StorageKey.key` serializes the logical identity as
+`<namespaceId>:agent-version:<logicalDataId>`. Every provider receives this
+value, but only the built-in provider parses it into the Config coordinate
+above. The key has exactly three colon-delimited segments because the
+Namespace, encoded AgentName, and Version grammars exclude `:`. Existing
+four- and five-part Skill, Prompt, and AgentSpec keys retain their original
+interpretation.
 
 A draft update overwrites the same key. Content becomes immutable when the
 Version enters reviewing. `contentDigest` never participates in the data id;

--- a/specs/en/plugin/ai-storage-plugin-spec.md
+++ b/specs/en/plugin/ai-storage-plugin-spec.md
@@ -155,12 +155,12 @@ nacos.ai.agent.storage.provider=nacos_config
 They are domain routing policy, not private configuration definitions owned by
 `ai-storage:nacos_config`.
 
-When the AI module is active, all providers selected independently for Prompt, Skill, and AgentSpec
-are required implementations of this critical routed type. The same provider may satisfy multiple
-domains. Before startup succeeds, every distinct selected provider must be discovered and enabled;
-a different available provider is not a valid fallback. When the AI module is disabled by function
-mode or `nacos.extension.ai.enabled=false`, AI storage is inactive and does not impose a startup
-requirement.
+When the AI module is active, all providers selected independently for Prompt, Skill, AgentSpec,
+and Agent are required implementations of this critical routed type. The same provider may satisfy
+multiple domains. Before startup succeeds, every distinct selected provider must be discovered and
+enabled; a different available provider is not a valid fallback. When the AI module is disabled by
+function mode or `nacos.extension.ai.enabled=false`, AI storage is inactive and does not impose a
+startup requirement.
 
 AI storage implementations are built from Spring-managed services during context refresh, so this
 type does not participate in pre-refresh critical validation. The unified plugin manager performs

--- a/specs/schemas/ai/agent/internal/v1/agent-storage.schema.json
+++ b/specs/schemas/ai/agent/internal/v1/agent-storage.schema.json
@@ -167,6 +167,14 @@
         }
       ]
     },
+    "CanonicalEndpointUri": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/AbsoluteEndpointUri"
+        }
+      ],
+      "$comment": "Stored AgentVersionContent requires the exact output of the common Endpoint URI canonicalizer: lowercase scheme, normalized host, explicit effective port, preserved raw path and query, and no fragment or user info. JSON Schema cannot fully express this equality; domain validation is mandatory."
+    },
     "MediaType": {
       "type": "string",
       "minLength": 3,
@@ -330,6 +338,7 @@
     },
     "EndpointMetadata": {
       "type": "object",
+      "minProperties": 1,
       "maxProperties": 32,
       "propertyNames": {
         "$ref": "#/$defs/MetadataKey"
@@ -344,11 +353,13 @@
       "additionalProperties": false,
       "required": [
         "uri",
-        "transport"
+        "transport",
+        "priority",
+        "weight"
       ],
       "properties": {
         "uri": {
-          "$ref": "#/$defs/AbsoluteEndpointUri"
+          "$ref": "#/$defs/CanonicalEndpointUri"
         },
         "transport": {
           "$ref": "#/$defs/TransportToken"
@@ -356,14 +367,12 @@
         "priority": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 2147483647,
-          "default": 0
+          "maximum": 2147483647
         },
         "weight": {
           "type": "number",
           "minimum": 0,
-          "maximum": 10000,
-          "default": 1.0
+          "maximum": 10000
         },
         "metadata": {
           "$ref": "#/$defs/EndpointMetadata"
@@ -410,6 +419,7 @@
         },
         "declaredEndpoints": {
           "type": "array",
+          "minItems": 1,
           "maxItems": 64,
           "items": {
             "$ref": "#/$defs/DeclaredEndpoint"
@@ -441,7 +451,7 @@
           }
         }
       },
-      "description": "Serialize the complete object as RFC 8785 JSON Canonicalization Scheme bytes in UTF-8. Array order preserves CallInterface, endpoint-source, and declared Endpoint business order. The Version contentDigest is SHA-256 over those bytes. Protocol uniqueness, I-JSON validation, and descriptor-to-endpoint consistency require domain validation."
+      "description": "Storage projection serialized once with the common Nacos JSON serializer as UTF-8. The exact emitted bytes are persisted and used for size and SHA-256 contentDigest; no semantic JSON canonicalization is defined. Reject unknown schema properties on the envelope, CallInterface, and Endpoint objects; nativeDescriptor members and metadata map entries remain open within their value constraints. Before serialization, canonicalize declared Endpoint URI, validate and preserve transport, materialize priority and weight, and omit empty metadata and declaredEndpoints. Array order preserves CallInterface, endpoint-source, and declared Endpoint business order. Protocol uniqueness, URI canonicalization, and descriptor-to-endpoint consistency require domain validation."
     },
     "VersionStorageDescriptor": {
       "type": "object",
@@ -869,13 +879,19 @@
         "schemaVersion",
         "algorithm",
         "seed",
-        "canonicalForm",
         "charset",
-        "canonicalJson",
         "framing",
+        "stringEncoding",
+        "priorityEncoding",
+        "weightEncoding",
+        "metadataEncoding",
+        "healthyEncoding",
         "byteOrder",
         "longOrder",
+        "endpointNormalization",
         "endpointOrder",
+        "naturalKeyFields",
+        "stringOrder",
         "metadataOrder",
         "includedFields",
         "excludedFields",
@@ -892,17 +908,26 @@
         "seed": {
           "const": 0
         },
-        "canonicalForm": {
-          "const": "rad-runtime-endpoint-projection-v1"
-        },
         "charset": {
           "const": "UTF-8"
         },
-        "canonicalJson": {
-          "const": "RFC8785"
-        },
         "framing": {
-          "const": "uint32be-count-and-length-prefixed-fields-v1"
+          "const": "rad-runtime-endpoint-fixed-binary-v1"
+        },
+        "stringEncoding": {
+          "const": "uint32be-byte-length-followed-by-utf8"
+        },
+        "priorityEncoding": {
+          "const": "int32be"
+        },
+        "weightEncoding": {
+          "const": "ieee754-binary64-big-endian-normalize-negative-zero"
+        },
+        "metadataEncoding": {
+          "const": "uint32be-entry-count-followed-by-key-value-strings"
+        },
+        "healthyEncoding": {
+          "const": "uint8-zero-or-one"
         },
         "byteOrder": {
           "const": "BIG_ENDIAN"
@@ -921,11 +946,51 @@
           ],
           "items": false
         },
+        "endpointNormalization": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "prefixItems": [
+            {
+              "const": "canonicalize-uri"
+            },
+            {
+              "const": "validate-preserve-transport"
+            },
+            {
+              "const": "materialize-priority-weight"
+            },
+            {
+              "const": "require-healthy"
+            }
+          ],
+          "items": false
+        },
         "endpointOrder": {
           "const": "natural-key"
         },
+        "naturalKeyFields": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "prefixItems": [
+            {
+              "const": "normalizedHost"
+            },
+            {
+              "const": "effectivePort"
+            },
+            {
+              "const": "transport"
+            }
+          ],
+          "items": false
+        },
+        "stringOrder": {
+          "const": "UTF16-CODE-UNIT-ORDINAL"
+        },
         "metadataOrder": {
-          "const": "key"
+          "const": "UTF16-CODE-UNIT-ORDINAL"
         },
         "includedFields": {
           "type": "array",
@@ -1016,7 +1081,7 @@
           "const": "murmur3-x64-128-v1:"
         }
       },
-      "$comment": "For one namespaceId/agentName/targetVersion/protocol projection, aggregate publishers by natural Endpoint key, retain bindings matching targetVersion, remove enabled=false, retain both healthy values, materialize default priority=0 and weight=1.0, sort Endpoints by natural key, and sort public metadata by key. The legacy-only reserved protocolVersion metadata is not public metadata and is excluded from the revision. Canonical bytes start with a four-byte unsigned big-endian Endpoint count. For every Endpoint, encode the six included fields in their declared order as RFC 8785 canonical JSON UTF-8; prefix each field with its four-byte unsigned big-endian byte length. The empty projection is exactly uint32be(0). Hash the bytes with Apache Commons Codec MurmurHash3.hash128x64(byte[], 0, length, 0). Emit h1 followed by h2, each as eight unsigned big-endian bytes, then encode the 16 bytes as 32 lowercase hexadecimal characters. Membership changes caused by bindings or enabled state change the input set; those control fields are not serialized into an included Endpoint. Golden vectors are required across server implementations."
+      "$comment": "For one namespaceId/agentName/targetVersion/protocol projection, aggregate publishers by natural Endpoint key, retain bindings matching targetVersion, remove enabled=false, retain both healthy values, canonicalize URI, validate and preserve transport, materialize default priority=0 and weight=1.0, and require healthy. Sort Endpoints by normalizedHost UTF-16 ordinal, effectivePort numeric, then transport UTF-16 ordinal; sort public metadata keys by UTF-16 ordinal. The legacy-only reserved protocolVersion metadata is not public metadata and is excluded from the revision. Revision bytes start with a four-byte unsigned big-endian Endpoint count. For every Endpoint, encode URI and transport as uint32be length-prefixed UTF-8, priority as int32be, weight as big-endian IEEE-754 binary64 with negative zero normalized to positive zero, metadata as uint32be entry count followed by ordered length-prefixed key/value strings, and healthy as one byte 0 or 1. The empty projection is exactly uint32be(0). Hash the bytes with Apache Commons Codec MurmurHash3.hash128x64(byte[], 0, length, 0). Emit h1 followed by h2, each as eight unsigned big-endian bytes, then encode the 16 bytes as 32 lowercase hexadecimal characters. Membership changes caused by bindings or enabled state change the input set; those control fields are not serialized into an included Endpoint."
     }
   }
 }

--- a/specs/schemas/ai/agent/internal/v1/agent-storage.schema.json
+++ b/specs/schemas/ai/agent/internal/v1/agent-storage.schema.json
@@ -475,7 +475,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 1024,
-          "description": "Provider-opaque logical key. It may exceed the physical Config data-id limit; upper layers must neither reject it for that reason nor parse public Agent identity from a physical fallback value."
+          "description": "Provider-neutral logical key passed opaquely to the selected provider. It may exceed the physical Config data-id limit; upper layers must neither reject it for that reason nor parse public Agent identity from a physical fallback value."
         },
         "keyFormat": {
           "type": "string",

--- a/specs/zh-cn/ai/agent-management-spec.md
+++ b/specs/zh-cn/ai/agent-management-spec.md
@@ -164,7 +164,7 @@ Agent Version 暴露以下元数据：
 | `callInterfaces[]` | 是 | 有序协议绑定；至少一个。 |
 | `author` | 否 | Version 作者。 |
 | `changeDescription` | 否 | Version 变更说明。 |
-| `contentDigest` | 只读 | canonical Version 内容的 SHA-256 摘要。 |
+| `contentDigest` | 只读 | Version 持久化内容 bytes 的 SHA-256 摘要。 |
 | `createTime`、`updateTime` | 只读 | 审计时间。 |
 
 完整存储 payload 是一个 `AgentVersionContent` 对象：
@@ -176,9 +176,9 @@ AgentVersionContent
   callInterfaces[]
 ```
 
-Canonical 序列化使用 RFC 8785 JCS，并保留 CallInterface 和 declared Endpoint 的业务
-顺序。`contentDigest` 对 canonical UTF-8 bytes 计算并使用 `sha256:<lowercase hex>`。
-准确的 I-JSON 与校验规则由 [Agent 存储规范](agent-storage-spec.md)定义。
+服务端将校验后的对象一次序列化为 UTF-8 JSON；同一份 bytes 用于持久化、计算 `size`，并以
+`sha256:<lowercase hex>` 生成摘要。读取时直接校验 AI Storage 返回 bytes 的摘要，不重新
+序列化对象。存储规范化和校验规则由 [Agent 存储规范](agent-storage-spec.md)定义。
 
 ### 4.2 生命周期规则
 

--- a/specs/zh-cn/ai/agent-storage-spec.md
+++ b/specs/zh-cn/ai/agent-storage-spec.md
@@ -159,13 +159,15 @@ Version 行的 `storage` JSON 包含：
 | `schemaVersion` | `1`。 |
 | `size` | 持久化内容字节数。 |
 
-上层将 `StorageKey.key` 视为 opaque。替换 provider 时仍保持一个 Version 对应一个对象，
-但物理 key 由 provider 自己管理。内置 provider 使用第 3.2 节的映射。
+Agent service 生成统一的、provider-neutral 的逻辑 `StorageKey.key`，并将其作为 opaque 值
+传给所有 provider。替换 provider 时仍保持一个 Version 对应一个对象，并由 provider 管理
+该逻辑 key 到物理 key 的映射。内置 provider 使用第 3.2 节的映射。
 
 ### 3.2 内置 Nacos Config 映射
 
-`agent-version-config-v1` provider key 携带下列逻辑 Config 坐标；其序列化后的
-`StorageKey.key` 对 Agent service 保持 provider opaque。
+`agent-version-config-v1` provider key 携带下列逻辑 Config 坐标。Agent service 负责生成逻辑
+`StorageKey.key`；该值存入 descriptor 后，上层消费者只透传而不解析，内置 provider 仅在执行
+下列映射时解析它。
 
 | 逻辑值 | 逻辑 `config_info` 坐标 |
 | --- | --- |
@@ -178,6 +180,12 @@ Version 行的 `storage` JSON 包含：
 限制内的安全值原样保存；超长 data id 使用 codec 确定性的 `sha256.<digest>` 物理回退。
 因此物理 key 不一定可逆，任何上层都不得从中推导 Agent 身份。不能仅因为逻辑 data id
 长于 Config 物理限制而拒绝合法 Agent 身份。
+
+Provider-neutral 的 `StorageKey.key` 将逻辑身份序列化为
+`<namespaceId>:agent-version:<logicalDataId>`。所有 provider 都接收该值，但只有内置 provider
+将其解析为上述 Config 坐标。Namespace、编码后的 AgentName 和 Version 语法均排除 `:`，
+因此该 key 必须恰好包含三个冒号分隔段。已有 Skill、Prompt 和 AgentSpec 的四段、五段 key
+保持原解释方式。
 
 更新 draft 时覆盖相同 key。Version 进入 reviewing 后内容不可变。`contentDigest` 不参与
 data id，只用于校验实际持久化 bytes 和缓存相等性。读取、审核和发布操作必须校验

--- a/specs/zh-cn/ai/agent-storage-spec.md
+++ b/specs/zh-cn/ai/agent-storage-spec.md
@@ -124,11 +124,29 @@ AgentVersionContent
     declaredEndpoints[]
 ```
 
-Canonical 序列化使用 RFC 8785 JSON Canonicalization Scheme（JCS）。因此
-CallInterface、来源偏好和 declared Endpoint 的数组顺序保持不变，而对象成员顺序和 JSON
-数字表示被规范化。包含重复对象 key 或不能表示为 I-JSON 的值时拒绝请求。
-`contentDigest` 是对 UTF-8 JCS bytes 计算的 `sha256:<lowercase hex>`。Version 行的
-`storage` JSON 包含：
+服务端校验对象并构造下述存储投影，然后使用 Nacos 公共 JSON serializer 一次序列化为
+UTF-8。同一份输出 bytes 传递给 AI Storage，并用于计算 `size` 和
+`contentDigest=sha256:<lowercase hex>`。Agent Storage 不定义 JSON 语义规范化：两个解析后
+等价的 JSON 表达不要求得到相同摘要。
+
+序列化前，服务端先构造 storage projection：
+
+1. 拒绝 envelope、CallInterface 和 Endpoint object 上的未知 schema property，再仅投影
+   schema version 1 定义的字段；
+2. 使用公共 Endpoint canonicalizer 规范每个 declared Endpoint 的 URI，并校验且保持其
+   transport 原值；
+3. 显式写入 Endpoint 的有效默认值 `priority=0` 和 `weight=1`；
+4. 省略缺失或为空的 Endpoint `metadata` 和 `declaredEndpoints`；
+5. 除上述规范化外，保持所有数组顺序和 descriptor JSON value 不变。
+
+`nativeDescriptor` 的 JSON member 和 Endpoint `metadata` map entry 仍是开放内容，但必须
+满足各自定义的 value 约束。
+
+这些投影规则只规范 Agent 自有字段，不重排 `nativeDescriptor` 内部 member，也不改写协议
+自有 JSON。读取时先对 AI Storage 返回的原始 bytes 计算摘要再解码，不得通过重新序列化
+解码后的对象完成摘要校验。
+
+Version 行的 `storage` JSON 包含：
 
 | 字段 | 值或含义 |
 | --- | --- |
@@ -139,7 +157,7 @@ CallInterface、来源偏好和 declared Endpoint 的数组顺序保持不变，
 | `contentDigest` | `sha256:<lowercase hex>`。 |
 | `mediaType` | `application/vnd.nacos.agent-version+json`。 |
 | `schemaVersion` | `1`。 |
-| `size` | Canonical 内容字节数。 |
+| `size` | 持久化内容字节数。 |
 
 上层将 `StorageKey.key` 视为 opaque。替换 provider 时仍保持一个 Version 对应一个对象，
 但物理 key 由 provider 自己管理。内置 provider 使用第 3.2 节的映射。
@@ -154,7 +172,7 @@ CallInterface、来源偏好和 declared Endpoint 的数组顺序保持不变，
 | `namespaceId` | `tenant_id=namespaceId`。 |
 | 内容类别 | `group_id=agent-version`。 |
 | `agentName`、`version` | `data_id=agent__<encodedAgentId>__<version>.json`。 |
-| `AgentVersionContent` | `type=json` 的 canonical JSON `content`。 |
+| `AgentVersionContent` | `type=json` 的 UTF-8 JSON `content`。 |
 
 内置 provider 随后对完整逻辑 group 和 data id 应用通用 `NacosAiConfigKeyCodec`。Config
 限制内的安全值原样保存；超长 data id 使用 codec 确定性的 `sha256.<digest>` 物理回退。
@@ -162,8 +180,8 @@ CallInterface、来源偏好和 declared Endpoint 的数组顺序保持不变，
 长于 Config 物理限制而拒绝合法 Agent 身份。
 
 更新 draft 时覆盖相同 key。Version 进入 reviewing 后内容不可变。`contentDigest` 不参与
-data id，只用于内容校验和缓存相等性。读取、审核和发布操作必须校验 Storage pointer、
-byte count 和 digest。
+data id，只用于校验实际持久化 bytes 和缓存相等性。读取、审核和发布操作必须校验
+Storage pointer、byte count 和 digest。
 
 ### 3.3 RAD ASCII AgentName Codec
 
@@ -440,10 +458,16 @@ metadata。
 
 1. 聚合活跃 publisher contribution；
 2. 选择包含目标 Version 的 binding；
-3. 校验每个自然键只有一个 canonical payload；
-4. 移除 `enabled=false`，并保留两种健康状态；
-5. 按自然键排序 Endpoint，按 key 排序 metadata；
-6. 对 canonical bytes 计算 MurmurHash3 x64 128。
+3. 规范每个 Endpoint URI，校验并保持 transport，显式写入有效默认值 `priority=0` 和
+   `weight=1`，并要求 `healthy` 存在；
+4. 校验每个自然键只有一个 canonical payload；
+5. 移除 `enabled=false`，并保留两种健康状态；
+6. 按自然键排序 Endpoint，并按 UTF-16 code-unit ordinal 顺序排序 metadata key；
+7. 对下文定义的 revision bytes 计算 MurmurHash3 x64 128。
+
+在同一个投影中，自然键依次按 `normalizedHost` 的 UTF-16 code-unit ordinal 顺序、
+`effectivePort` 的数值顺序、transport 的 UTF-16 code-unit ordinal 顺序比较。实现不得使用
+locale-sensitive collation。URI path 和 query 不属于自然键，因此不参与排序。
 
 外部 token 为：
 
@@ -451,20 +475,31 @@ metadata。
 murmur3-x64-128-v1:<32 lowercase hex>
 ```
 
-Canonical 输入包含 URI、transport、effective priority 和 weight、公开 Endpoint metadata 和
+Revision 输入包含 URI、transport、effective priority 和 weight、公开 Endpoint metadata 和
 `healthy`。它不包含 runtimeVersion、versionRange、publisher identity 和 count、heartbeat
 时间、last-updated time 或 Naming 内部 revision。Runtime Version 和 range 不进入 hash，
 因为目标投影已经完成过滤。Range 或 enabled 变化会改变成员；health 变化会改变返回内容。
 目标投影变化时，两者都会推进 revision。
 
+公开 Endpoint metadata 缺失或为空时，metadata entry count 均编码为零。
+
 空集合具有稳定 revision。增加或删除冗余 publisher 不改变它。Token 只用于 cache equality 和
 Watch 去重，不用于身份、鉴权、CAS 或防篡改。
 
-所有节点使用 seed `0`。Canonical bytes 以 unsigned 四字节 big-endian Endpoint 数量开头；
-对每个有序 Endpoint，按上述顺序将六个字段编码成 RFC 8785 JSON UTF-8，并在每个字段前
-写入 unsigned 四字节 big-endian byte length。空集合恰好为 `uint32be(0)`。Murmur 结果先输出
-`h1` 再输出 `h2`，每个都是 unsigned 八字节 big-endian 值，最后编码为小写十六进制。内部
-Storage Schema version 1 同时以机器可读形式记录这些规则。
+所有节点使用 seed `0` 和以下固定的 big-endian 二进制布局：
+
+| 元素 | 编码 |
+| --- | --- |
+| Endpoint 数量 | unsigned 四字节整数。 |
+| `uri`、`transport` | unsigned 四字节 UTF-8 byte length，随后写入 bytes。 |
+| `priority` | signed 四字节整数。 |
+| `weight` | 八字节 IEEE-754 binary64 bits；negative zero 规范为 positive zero。 |
+| metadata | unsigned 四字节 entry count；随后按上述 string 编码依次写入有序 key 和 value。 |
+| `healthy` | 一个 byte：false 为 `0`，true 为 `1`。 |
+
+空集合恰好为 `uint32be(0)`。Murmur 结果先输出 `h1` 再输出 `h2`，每个都是 unsigned
+八字节 big-endian 值，最后编码为小写十六进制。内部 Storage Schema version 1 同时以
+机器可读形式记录这些规则。
 
 实现对语义投影标脏、合并突发变化并缓存结果，不得对每次 heartbeat 或每次 Discover 读取都
 执行 hash。

--- a/specs/zh-cn/plugin/ai-storage-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-storage-plugin-spec.md
@@ -128,7 +128,7 @@ nacos.ai.agent.storage.provider=nacos_config
 
 它们属于领域路由策略，不是 `ai-storage:nacos_config` 所拥有的私有配置 definitions。
 
-AI 模块 active 时，为 Prompt、Skill、AgentSpec 分别选择的所有 provider 都是该 critical
+AI 模块 active 时，为 Prompt、Skill、AgentSpec、Agent 分别选择的所有 provider 都是该 critical
 路由类型的必需实现；同一 provider 可以同时满足多个领域。Nacos 启动成功前，每个去重后的
 选中 provider 都必须已被发现且处于 enabled 状态，另一个可用 provider 不能作为 fallback。
 AI 模块因 function mode 或 `nacos.extension.ai.enabled=false` 关闭时，AI storage 为 inactive，


### PR DESCRIPTION
For #14804.

## What is the purpose of the change

This change adds the first two server-side foundations for the new Agent management and Remote Agent Discovery model:

1. deterministic Agent Version content and Runtime Endpoint fingerprints;
2. storage and integrity verification for complete Agent Version content through the AI Storage abstraction.

It intentionally does not add Agent lifecycle orchestration, public APIs, or Runtime Endpoint registration in this pull request.

## Brief changelog

- Add `AgentVersionContent` and its strict storage codec. The codec validates the version payload, normalizes Agent-owned fields, serializes it once, and calculates SHA-256 from the exact persisted bytes.
- Add deterministic Runtime Endpoint revisions based on the canonical, version-filtered endpoint projection using Murmur3 x64 128.
- Add `AgentVersionStorageDescriptor`, its validated JSON codec, and `AgentVersionStorageService` for saving, loading, deleting, and verifying Agent Version content.
- Add a provider-neutral Agent Version storage key and the built-in Nacos Config mapping:
  - group: `agent-version`
  - data ID: `agent__<encodedAgentId>__<version>.json`
- Preserve existing Prompt, Skill, and AgentSpec storage-key interpretation while adding Agent storage routing and startup provider checks.
- Update English and Chinese Agent storage and AI Storage plugin specs plus the internal Agent storage schema.
- Add unit tests for content encoding, digest generation, endpoint revisions, descriptors, routing, integrity failures, key parsing, and legacy-key compatibility.

## Verifying this change

- `mvn -pl ai -Dtest=AgentVersionContentCodecTest,AgentVersionStorageDescriptorTest,AgentVersionStorageDescriptorCodecTest,AgentVersionStorageServiceTest,NacosConfigAiResourceStorageTest,AiStoragePluginTypePolicyTest test`
  - 85 tests passed.
- `mvn -pl ai test`
  - 1559 tests passed, 2 skipped.
- `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`
  - All 60 reactor modules passed.

## Checklist

- [x] Make sure there is a GitHub issue filed for the change (usually before you start working on it).
- [x] Make sure the title of the PR follows the required format: `[ISSUE #xxx] type Something`.
- [x] Make sure the description clearly explains the problem and solution.
- [x] Make sure there are unit tests covering the code changes.
- [x] Make sure the full compile, RAT, Checkstyle, SpotBugs, and Spotless verification passes.
