### PR TITLE
[ISSUE #14804] Align Agent contracts and improve test coverage

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/metadata/AgentVersionCatalogBuilder.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/metadata/AgentVersionCatalogBuilder.java
@@ -30,10 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 /**
- * Rebuilds the server-derived Agent Version catalog, latest label, and protocol set.
+ * Rebuilds the server-derived Agent Version catalog and latest label.
  *
  * @author Nacos
  */
@@ -54,7 +53,7 @@ public final class AgentVersionCatalogBuilder {
      *
      * @param onlineVersionProtocols online Version to ordered protocol mapping
      * @param labels complete label facts
-     * @return deterministic build result with immutable label and protocol collections
+     * @return deterministic build result with immutable labels
      */
     public static Result build(Map<String, List<String>> onlineVersionProtocols,
         Map<String, String> labels) {
@@ -91,19 +90,17 @@ public final class AgentVersionCatalogBuilder {
         catalog.setLatestVersion(normalizedLabels.get("latest"));
         List<AgentVersionCatalogEntry> entries =
             new ArrayList<AgentVersionCatalogEntry>(versions.size());
-        Set<String> protocols = new TreeSet<String>();
         for (String version : versions) {
             AgentVersionCatalogEntry entry = new AgentVersionCatalogEntry();
             entry.setVersion(version);
             entry.setLabels(labelsForVersion(normalizedLabels, version));
             List<String> versionProtocols = protocolsByVersion.get(version);
             entry.setProtocols(Collections.unmodifiableList(versionProtocols));
-            protocols.addAll(versionProtocols);
             entries.add(entry);
         }
         catalog.setOnlineVersions(Collections.unmodifiableList(entries));
         AgentModelValidator.validateVersionCatalog(catalog);
-        return new Result(catalog, normalizedLabels, new ArrayList<String>(protocols));
+        return new Result(catalog, normalizedLabels);
     }
     
     private static Map<String, List<String>> validateAndCopyProtocols(
@@ -165,14 +162,10 @@ public final class AgentVersionCatalogBuilder {
         
         private final Map<String, String> labels;
         
-        private final List<String> protocols;
-        
-        private Result(AgentVersionCatalog versionCatalog, Map<String, String> labels,
-            List<String> protocols) {
+        private Result(AgentVersionCatalog versionCatalog, Map<String, String> labels) {
             this.versionCatalog = versionCatalog;
             this.labels = Collections.unmodifiableMap(
                 new LinkedHashMap<String, String>(labels));
-            this.protocols = Collections.unmodifiableList(protocols);
         }
         
         public AgentVersionCatalog getVersionCatalog() {
@@ -183,8 +176,5 @@ public final class AgentVersionCatalogBuilder {
             return labels;
         }
         
-        public List<String> getProtocols() {
-            return protocols;
-        }
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/AgentPersistenceServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/AgentPersistenceServiceTest.java
@@ -62,7 +62,9 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -201,6 +203,14 @@ class AgentPersistenceServiceTest {
     }
     
     @Test
+    void testCreateRejectsNullInputsBeforePersistence() {
+        assertThrows(IllegalArgumentException.class, () -> service.create(null, initialDraft));
+        assertThrows(IllegalArgumentException.class, () -> service.create(agent, null));
+        
+        verifyNoInteractions(resourcePersistService, versionPersistService, storageService);
+    }
+    
+    @Test
     void testCreateRejectsTagsExceedingPersistedColumnCapacity() throws NacosException {
         List<String> tags = new ArrayList<String>();
         for (int i = 0; i < 32; i++) {
@@ -290,6 +300,48 @@ class AgentPersistenceServiceTest {
     }
     
     @Test
+    void testCreateRejectsEveryChangedResourceIdentityAndMetadata() throws NacosException {
+        List<AiResource> conflictingResources = createConflictingResources();
+        AtomicInteger index = new AtomicInteger();
+        stubPrepare();
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenAnswer(
+                invocation -> conflictingResources.get(index.getAndIncrement()));
+        
+        for (int i = 0; i < conflictingResources.size(); i++) {
+            assertConflict(assertThrows(NacosApiException.class,
+                () -> service.create(agent, initialDraft)));
+        }
+        
+        assertEquals(conflictingResources.size(), index.get());
+        verifyNoInteractions(versionPersistService);
+        verify(resourcePersistService, never()).insert(any(AiResource.class));
+        verify(storageService, never()).save(any(PreparedAgentVersionWrite.class));
+    }
+    
+    @Test
+    void testCreateRejectsEveryChangedVersionIdentityAndMetadata() throws NacosException {
+        List<AiResourceVersion> conflictingVersions = createConflictingVersions();
+        AtomicInteger index = new AtomicInteger();
+        stubPrepare();
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(null);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenAnswer(
+                invocation -> conflictingVersions.get(index.getAndIncrement()));
+        
+        for (int i = 0; i < conflictingVersions.size(); i++) {
+            assertConflict(assertThrows(NacosApiException.class,
+                () -> service.create(agent, initialDraft)));
+        }
+        
+        assertEquals(conflictingVersions.size(), index.get());
+        verify(versionPersistService, never()).insert(any(AiResourceVersion.class));
+        verify(resourcePersistService, never()).insert(any(AiResource.class));
+        verify(storageService, never()).save(any(PreparedAgentVersionWrite.class));
+    }
+    
+    @Test
     void testVersionInsertRaceMapsToConflictWithoutStorageWrite() throws NacosException {
         stubPrepare();
         when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
@@ -346,6 +398,66 @@ class AgentPersistenceServiceTest {
         assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
         verify(storageService, never()).save(any(PreparedAgentVersionWrite.class));
         verify(storageService, never()).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testVersionInsertInvalidIdMapsToServerError() throws NacosException {
+        stubPrepare();
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(null);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(null);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(0L);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.create(agent, initialDraft));
+        
+        assertServerError(exception);
+        verify(storageService, never()).save(any(PreparedAgentVersionWrite.class));
+        verify(resourcePersistService, never()).insert(any(AiResource.class));
+    }
+    
+    @Test
+    void testVersionDuplicateInsertAndReadbackFailureMapsToConflict() throws NacosException {
+        DuplicateKeyException insertFailure = new DuplicateKeyException("duplicate");
+        IllegalStateException readFailure = new IllegalStateException("read failed");
+        stubPrepare();
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(null);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(null)
+            .thenThrow(readFailure);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenThrow(insertFailure);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.create(agent, initialDraft));
+        
+        assertConflict(exception);
+        assertSame(insertFailure, exception.getCause());
+        assertSame(readFailure, insertFailure.getSuppressed()[0]);
+        verify(storageService, never()).save(any(PreparedAgentVersionWrite.class));
+    }
+    
+    @Test
+    void testVersionUnknownInsertAndReadbackFailureMapsToServerError() throws NacosException {
+        IllegalStateException insertFailure =
+            new IllegalStateException("unknown insert outcome");
+        IllegalStateException readFailure = new IllegalStateException("read failed");
+        stubPrepare();
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(null);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(null)
+            .thenThrow(readFailure);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenThrow(insertFailure);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.create(agent, initialDraft));
+        
+        assertServerError(exception);
+        assertSame(insertFailure, exception.getCause());
+        assertSame(readFailure, insertFailure.getSuppressed()[0]);
+        verify(storageService, never()).save(any(PreparedAgentVersionWrite.class));
     }
     
     @Test
@@ -621,6 +733,63 @@ class AgentPersistenceServiceTest {
     }
     
     @Test
+    void testResourceInsertInvalidIdMapsToServerError() throws NacosException {
+        stubUntilVersionInsert();
+        when(resourcePersistService.insert(any(AiResource.class))).thenReturn(0L);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.create(agent, initialDraft));
+        
+        assertServerError(exception);
+        verify(storageService).save(prepared);
+        verify(storageService, never()).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testResourceDuplicateInsertAndReadbackFailureMapsToConflict() throws NacosException {
+        DuplicateKeyException insertFailure = new DuplicateKeyException("duplicate");
+        IllegalStateException readFailure = new IllegalStateException("read failed");
+        stubPrepare();
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(null).thenThrow(readFailure);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(null);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(VERSION_ID);
+        when(resourcePersistService.insert(any(AiResource.class))).thenThrow(insertFailure);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.create(agent, initialDraft));
+        
+        assertConflict(exception);
+        assertSame(insertFailure, exception.getCause());
+        assertSame(readFailure, insertFailure.getSuppressed()[0]);
+        verify(storageService).save(prepared);
+    }
+    
+    @Test
+    void testResourceUnknownInsertAndReadbackFailureMapsToServerError()
+        throws NacosException {
+        IllegalStateException insertFailure =
+            new IllegalStateException("unknown insert outcome");
+        IllegalStateException readFailure = new IllegalStateException("read failed");
+        stubPrepare();
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(null).thenThrow(readFailure);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(null);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(VERSION_ID);
+        when(resourcePersistService.insert(any(AiResource.class))).thenThrow(insertFailure);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.create(agent, initialDraft));
+        
+        assertServerError(exception);
+        assertSame(insertFailure, exception.getCause());
+        assertSame(readFailure, insertFailure.getSuppressed()[0]);
+        verify(storageService).save(prepared);
+    }
+    
+    @Test
     void testPostCommitReadFailureDoesNotRollbackCommittedState() throws NacosException {
         stubPrepare();
         when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
@@ -635,6 +804,47 @@ class AgentPersistenceServiceTest {
         
         assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
         verify(storageService, never()).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testPostCommitMissingVersionMapsToServerError() throws NacosException {
+        stubSuccessfulWritesForPostCommit(storedResource(), null);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.create(agent, initialDraft));
+        
+        assertServerError(exception);
+        verify(storageService, never()).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testPostCommitInvalidVersionSummaryMapsToServerError() throws NacosException {
+        AiResourceVersion invalidVersion = storedVersion();
+        invalidVersion.setStorage("{}");
+        stubSuccessfulWritesForPostCommit(storedResource(), invalidVersion);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.create(agent, initialDraft));
+        
+        assertServerError(exception);
+        verify(storageService, never()).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testUnexpectedPersistenceFailureIsMappedToNacosServerError() throws NacosException {
+        IllegalStateException persistenceFailure =
+            new IllegalStateException("resource lookup failed");
+        stubPrepare();
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenThrow(persistenceFailure);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.create(agent, initialDraft));
+        
+        assertServerError(exception);
+        assertSame(persistenceFailure, exception.getCause());
+        verifyNoInteractions(versionPersistService);
+        verify(storageService, never()).save(any(PreparedAgentVersionWrite.class));
     }
     
     @Test
@@ -693,6 +903,34 @@ class AgentPersistenceServiceTest {
     }
     
     @Test
+    void testGetAgentNormalizesNullAndBlankPersistedTags() throws NacosException {
+        AiResource nullTags = storedResource();
+        nullTags.setBizTags(null);
+        AiResource blankTags = storedResource();
+        blankTags.setBizTags("  ");
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(nullTags, blankTags);
+        
+        assertTrue(service.getAgent(NAMESPACE_ID, AGENT_NAME).getTags().isEmpty());
+        assertTrue(service.getAgent(NAMESPACE_ID, AGENT_NAME).getTags().isEmpty());
+    }
+    
+    @Test
+    void testGetAgentRejectsMalformedAndNullJsonPersistedTags() {
+        AiResource malformedTags = storedResource();
+        malformedTags.setBizTags("[");
+        AiResource nullJsonTags = storedResource();
+        nullJsonTags.setBizTags("null");
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(malformedTags, nullJsonTags);
+        
+        assertServerError(assertThrows(NacosApiException.class,
+            () -> service.getAgent(NAMESPACE_ID, AGENT_NAME)));
+        assertServerError(assertThrows(NacosApiException.class,
+            () -> service.getAgent(NAMESPACE_ID, AGENT_NAME)));
+    }
+    
+    @Test
     void testGetAgentRejectsNonStringPersistedTag() {
         AiResource row = storedResource();
         row.setBizTags("[1]");
@@ -703,6 +941,24 @@ class AgentPersistenceServiceTest {
             () -> service.getAgent(NAMESPACE_ID, AGENT_NAME));
         
         assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+    }
+    
+    @Test
+    void testReadProjectionsRejectNullDatabaseTimestamps() throws NacosException {
+        AiResource invalidResource = storedResource();
+        invalidResource.setGmtCreate(null);
+        AiResourceVersion invalidVersion = storedVersion();
+        invalidVersion.setGmtModified(null);
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(invalidResource, storedResource());
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(invalidVersion);
+        when(storageService.load(any(AgentVersionStorageDescriptor.class))).thenReturn(content);
+        
+        assertServerError(assertThrows(NacosApiException.class,
+            () -> service.getAgent(NAMESPACE_ID, AGENT_NAME)));
+        assertServerError(assertThrows(NacosApiException.class,
+            () -> service.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION)));
     }
     
     @Test
@@ -764,6 +1020,26 @@ class AgentPersistenceServiceTest {
         verify(storageService, never()).load(any(AgentVersionStorageDescriptor.class));
     }
     
+    @Test
+    void testGetExactVersionRejectsInvalidLoadedVersionAndContent() throws NacosException {
+        AiResourceVersion invalidStatus = storedVersion();
+        invalidStatus.setStatus("invalid");
+        AgentVersionContent invalidContent =
+            new AgentVersionContent(Collections.<AgentCallInterface>emptyList());
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(invalidStatus,
+                storedVersion());
+        when(storageService.load(any(AgentVersionStorageDescriptor.class))).thenReturn(content,
+            invalidContent);
+        
+        assertServerError(assertThrows(NacosApiException.class,
+            () -> service.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION)));
+        assertServerError(assertThrows(NacosApiException.class,
+            () -> service.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION)));
+    }
+    
     private void stubPrepare() {
         when(storageService.prepare(anyString(), anyString(), anyString(),
             any(AgentVersionContent.class))).thenReturn(prepared);
@@ -776,6 +1052,102 @@ class AgentPersistenceServiceTest {
         when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
             Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(null);
         when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(VERSION_ID);
+    }
+    
+    private void stubSuccessfulWritesForPostCommit(AiResource resource,
+        AiResourceVersion version) {
+        stubPrepare();
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(null, resource);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(null, version);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(VERSION_ID);
+        when(resourcePersistService.insert(any(AiResource.class))).thenReturn(RESOURCE_ID);
+    }
+    
+    private List<AiResource> createConflictingResources() {
+        List<AiResource> result = new ArrayList<AiResource>();
+        result.add(mutatedResource(resource -> resource.setNamespaceId("other")));
+        result.add(mutatedResource(resource -> resource.setName("Other Agent")));
+        result.add(mutatedResource(resource -> resource.setType("prompt")));
+        result.add(mutatedResource(
+            resource -> resource.setStatus(AiConstants.Agent.RESOURCE_STATUS_DISABLE)));
+        result.add(mutatedResource(resource -> resource.setFrom("remote")));
+        result.add(mutatedResource(resource -> resource.setScope("PUBLIC")));
+        result.add(mutatedResource(resource -> resource.setOwner("bob")));
+        result.add(mutatedResource(resource -> resource.setBizTags("[\"other\"]")));
+        result.add(mutatedResourceExt(ext -> ext.setDisplayName("Other Display")));
+        result.add(mutatedResourceExt(ext -> ext.setIconUrl("https://example.com/other.png")));
+        result.add(mutatedResourceExt(ext -> ext.setProvider(null)));
+        result.add(mutatedResourceExt(ext -> ext.getProvider().setName("Other Provider")));
+        result.add(mutatedResourceExt(ext -> ext.getProvider().setUrl("https://example.com")));
+        result.add(mutatedResourceExt(
+            ext -> ext.setExtensions(Collections.<String, Object>singletonMap("x-team", "other"))));
+        
+        ResourceVersionInfo onlineCount = initialVersionInfo(VERSION);
+        onlineCount.setOnlineCnt(1);
+        result.add(mutatedResource(
+            resource -> resource.setVersionInfo(JacksonUtils.toJson(onlineCount))));
+        ResourceVersionInfo labels = initialVersionInfo(VERSION);
+        labels.setLabels(Collections.singletonMap("stable", VERSION));
+        result.add(mutatedResource(
+            resource -> resource.setVersionInfo(JacksonUtils.toJson(labels))));
+        
+        AgentVersionCatalog onlineCatalog = AgentVersionCatalogBuilder.build(
+            Collections.singletonMap("1.0.0", Collections.singletonList("a2a")),
+            Collections.<String, String>emptyMap()).getVersionCatalog();
+        result.add(mutatedResourceExt(ext -> ext.setVersionCatalog(onlineCatalog)));
+        return result;
+    }
+    
+    private List<AiResourceVersion> createConflictingVersions() {
+        List<AiResourceVersion> result = new ArrayList<AiResourceVersion>();
+        result.add(mutatedVersion(version -> version.setNamespaceId("other")));
+        result.add(mutatedVersion(version -> version.setName("Other Agent")));
+        result.add(mutatedVersion(version -> version.setType("prompt")));
+        result.add(mutatedVersion(version -> version.setVersion("1.0.0")));
+        result.add(mutatedVersion(
+            version -> version.setStatus(AiConstants.Agent.VERSION_STATUS_REVIEWING)));
+        result.add(mutatedVersion(version -> version.setAuthor("bob")));
+        result.add(mutatedVersion(version -> version.setDesc("Other change")));
+        result.add(mutatedVersionDescriptor(descriptor -> descriptor.setProvider("custom")));
+        result.add(mutatedVersionDescriptor(descriptor -> descriptor.setKey("other-key")));
+        result.add(mutatedVersionDescriptor(descriptor -> descriptor.setContentDigest(
+            "sha256:" + repeat('b', 64))));
+        result.add(mutatedVersionDescriptor(
+            descriptor -> descriptor.setSize(descriptor.getSize() + 1)));
+        result.add(mutatedVersion(
+            version -> version.setPublishPipelineInfo("{\"executionId\":\"other\"}")));
+        return result;
+    }
+    
+    private AiResource mutatedResource(Consumer<AiResource> mutation) {
+        AiResource result = equivalentStoredResource();
+        mutation.accept(result);
+        return result;
+    }
+    
+    private AiResource mutatedResourceExt(Consumer<AgentResourceExt> mutation) {
+        AiResource result = equivalentStoredResource();
+        AgentResourceExt ext = AgentResourceExtSerializer.deserialize(result.getExt());
+        mutation.accept(ext);
+        result.setExt(AgentResourceExtSerializer.serialize(ext));
+        return result;
+    }
+    
+    private AiResourceVersion mutatedVersion(Consumer<AiResourceVersion> mutation) {
+        AiResourceVersion result = storedVersion();
+        mutation.accept(result);
+        return result;
+    }
+    
+    private AiResourceVersion mutatedVersionDescriptor(
+        Consumer<AgentVersionStorageDescriptor> mutation) {
+        AiResourceVersion result = storedVersion();
+        AgentVersionStorageDescriptor descriptor = prepared.getDescriptor();
+        mutation.accept(descriptor);
+        result.setStorage(AgentVersionStorageDescriptorSerializer.serialize(descriptor));
+        return result;
     }
     
     private Agent newAgent() {
@@ -922,6 +1294,14 @@ class AgentPersistenceServiceTest {
             Collections.<String, String>emptyMap()).getVersionCatalog();
     }
     
+    private String repeat(char value, int count) {
+        StringBuilder result = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+    
     private void assertCreatedOverview(AgentOverview result) {
         assertNotNull(result);
         assertEquals(AGENT_NAME, result.getAgent().getAgentName());
@@ -964,5 +1344,10 @@ class AgentPersistenceServiceTest {
     private void assertConflict(NacosApiException exception) {
         assertEquals(NacosException.CONFLICT, exception.getErrCode());
         assertEquals(ErrorCode.RESOURCE_CONFLICT.getCode(), exception.getDetailErrCode());
+    }
+    
+    private void assertServerError(NacosApiException exception) {
+        assertEquals(NacosException.SERVER_ERROR, exception.getErrCode());
+        assertEquals(ErrorCode.SERVER_ERROR.getCode(), exception.getDetailErrCode());
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/metadata/AgentVersionCatalogBuilderTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/metadata/AgentVersionCatalogBuilderTest.java
@@ -47,7 +47,6 @@ class AgentVersionCatalogBuilderTest {
         assertEquals(Collections.emptyList(),
             result.getVersionCatalog().getOnlineVersions());
         assertEquals(Collections.singletonMap("archived", "0.9.0"), result.getLabels());
-        assertEquals(Collections.emptyList(), result.getProtocols());
     }
     
     @Test
@@ -78,8 +77,6 @@ class AgentVersionCatalogBuilderTest {
             catalog.getOnlineVersions().get(2).getLabels());
         assertEquals(Arrays.asList("grpc", "a2a"),
             catalog.getOnlineVersions().get(2).getProtocols());
-        assertEquals(Arrays.asList("A2A-v1", "a2a", "grpc", "json-rpc"),
-            result.getProtocols());
         assertEquals(Arrays.asList("beta", "canary", "latest", "offline", "stable"),
             new ArrayList<String>(result.getLabels().keySet()));
     }
@@ -112,7 +109,8 @@ class AgentVersionCatalogBuilderTest {
         
         assertEquals(Arrays.asList("1.0.0-rc1", "1.0.0-RC1"),
             catalogVersions(result.getVersionCatalog()));
-        assertEquals(Arrays.asList("A2A", "a2a"), result.getProtocols());
+        assertEquals(Arrays.asList("A2A", "a2a"),
+            result.getVersionCatalog().getOnlineVersions().get(1).getProtocols());
     }
     
     @Test
@@ -123,8 +121,6 @@ class AgentVersionCatalogBuilderTest {
         
         assertThrows(UnsupportedOperationException.class,
             () -> result.getLabels().put("stable", "1.0.0"));
-        assertThrows(UnsupportedOperationException.class,
-            () -> result.getProtocols().add("grpc"));
         assertThrows(UnsupportedOperationException.class,
             () -> result.getVersionCatalog().getOnlineVersions().add(
                 new AgentVersionCatalogEntry()));

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionContentSerializerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionContentSerializerTest.java
@@ -280,6 +280,8 @@ class AgentVersionContentSerializerTest {
                 new byte[AgentVersionContentSerializer.MAX_CONTENT_SIZE + 1]));
         assertThrows(IllegalArgumentException.class,
             () -> AgentVersionContentSerializer.deserialize(new byte[] {(byte) 0xC3, 0x28}));
+        assertDecodeRejected("   ");
+        assertDecodeRejected("null");
         
         byte[] persisted =
             AgentVersionContentSerializer.serialize(createGoldenContent()).getBytes();
@@ -294,6 +296,19 @@ class AgentVersionContentSerializerTest {
             .getBytes(StandardCharsets.UTF_8);
         assertThrows(IllegalArgumentException.class,
             () -> AgentVersionContentSerializer.deserialize(invalidModel));
+    }
+    
+    @Test
+    void testDecodeRejectsInvalidNestedJsonTypes() {
+        assertDecodeRejected("{\"kind\":\"AgentVersionContent\",\"schemaVersion\":1,"
+            + "\"callInterfaces\":[1]}");
+        assertDecodeRejected("{\"kind\":\"AgentVersionContent\",\"schemaVersion\":1,"
+            + "\"callInterfaces\":{}}");
+        assertDecodeRejected("{\"kind\":\"AgentVersionContent\",\"schemaVersion\":1,"
+            + "\"callInterfaces\":[{\"protocol\":\"a2a\","
+            + "\"descriptorMediaType\":\"application/json\","
+            + "\"nativeDescriptor\":{},\"endpointSourceOrder\":[\"DECLARED\"],"
+            + "\"declaredEndpoints\":[1]}]}");
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageDescriptorSerializerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageDescriptorSerializerTest.java
@@ -85,6 +85,8 @@ class AgentVersionStorageDescriptorSerializerTest {
         assertThrows(IllegalArgumentException.class,
             () -> AgentVersionStorageDescriptorSerializer.deserialize(""));
         assertThrows(IllegalArgumentException.class,
+            () -> AgentVersionStorageDescriptorSerializer.deserialize("   "));
+        assertThrows(IllegalArgumentException.class,
             () -> AgentVersionStorageDescriptorSerializer.deserialize("not-json"));
         assertThrows(IllegalArgumentException.class,
             () -> AgentVersionStorageDescriptorSerializer.deserialize("[]"));

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/agent/Endpoint.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/agent/Endpoint.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.nacos.api.ai.model.agent;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.io.Serializable;
@@ -31,10 +30,6 @@ import java.util.Map;
 public class Endpoint implements Serializable {
     
     private static final long serialVersionUID = 1L;
-    
-    private static final int DEFAULT_PRIORITY = 0;
-    
-    private static final double DEFAULT_WEIGHT = 1.0D;
     
     private String uri;
     
@@ -94,26 +89,6 @@ public class Endpoint implements Serializable {
     
     public void setHealthy(Boolean healthy) {
         this.healthy = healthy;
-    }
-    
-    /**
-     * Return priority after applying the protocol default.
-     *
-     * @return effective priority
-     */
-    @JsonIgnore
-    public int getEffectivePriority() {
-        return priority == null ? DEFAULT_PRIORITY : priority;
-    }
-    
-    /**
-     * Return weight after applying the protocol default.
-     *
-     * @return effective weight
-     */
-    @JsonIgnore
-    public double getEffectiveWeight() {
-        return weight == null ? DEFAULT_WEIGHT : weight;
     }
     
 }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/utils/AgentModelValidator.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/utils/AgentModelValidator.java
@@ -65,8 +65,6 @@ public final class AgentModelValidator {
     
     private static final int MAX_OWNER_LENGTH = 128;
     
-    private static final int MAX_SCOPE_LENGTH = 64;
-    
     private static final int MAX_AUTHOR_LENGTH = 128;
     
     private static final int MAX_TAGS = 32;
@@ -315,7 +313,7 @@ public final class AgentModelValidator {
         validateTags(tags);
         validateResourceStatus(status);
         validateRequiredLength(owner, MAX_OWNER_LENGTH, "owner");
-        validateRequiredLength(scope, MAX_SCOPE_LENGTH, "scope");
+        validateScope(scope);
         validateVersionInfo(versionInfo);
         validateVersionCatalog(versionCatalog);
         validateVersionInfoCatalogConsistency(versionInfo, versionCatalog);
@@ -331,6 +329,12 @@ public final class AgentModelValidator {
         validateRequiredLength(provider.getName(), MAX_PROVIDER_NAME_LENGTH, "provider.name");
         if (provider.getUrl() != null) {
             validateAbsoluteUri(provider.getUrl(), "provider.url");
+        }
+    }
+    
+    private static void validateScope(String scope) {
+        if (!"PUBLIC".equals(scope) && !"PRIVATE".equals(scope)) {
+            throw new IllegalArgumentException("scope must be PUBLIC or PRIVATE");
         }
     }
     

--- a/api/src/main/java/com/alibaba/nacos/api/ai/utils/AgentValidationUtils.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/utils/AgentValidationUtils.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
  */
 public final class AgentValidationUtils {
     
-    private static final int MAX_NAMESPACE_LENGTH = 64;
+    private static final int MAX_NAMESPACE_LENGTH = 128;
     
     private static final int MAX_AGENT_NAME_LENGTH = 64;
     

--- a/api/src/main/java/com/alibaba/nacos/api/ai/utils/RadModelValidator.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/utils/RadModelValidator.java
@@ -411,8 +411,8 @@ public final class RadModelValidator {
             EndpointNaturalKey currentKey =
                 EndpointNaturalKey.of(namespaceId, agentName, protocol, canonical);
             if (previous != null) {
-                int priorityComparison = Integer.compare(previous.getEffectivePriority(),
-                    canonical.getEffectivePriority());
+                int priorityComparison =
+                    Integer.compare(previous.getPriority(), canonical.getPriority());
                 if (priorityComparison > 0
                     || priorityComparison == 0 && previousKey.compareTo(currentKey) > 0) {
                     throw invalid("Discovery endpoints must be sorted by priority and natural key");

--- a/api/src/test/java/com/alibaba/nacos/api/ai/model/agent/AgentContractModelTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/model/agent/AgentContractModelTest.java
@@ -42,8 +42,6 @@ class AgentContractModelTest extends BasicRequestTest {
         endpoint.setTransport("JSON-RPC");
         endpoint.setMetadata(Collections.singletonMap("zone", "cn-hangzhou-a"));
         
-        assertEquals(0, endpoint.getEffectivePriority());
-        assertEquals(1.0D, endpoint.getEffectiveWeight());
         String json = mapper.writeValueAsString(endpoint);
         assertFalse(json.contains("effectivePriority"));
         assertFalse(json.contains("effectiveWeight"));
@@ -71,8 +69,6 @@ class AgentContractModelTest extends BasicRequestTest {
         assertEquals(Integer.valueOf(10), deserialized.getPriority());
         assertEquals(Double.valueOf(2.5D), deserialized.getWeight());
         assertEquals(Boolean.FALSE, deserialized.getHealthy());
-        assertEquals(10, deserialized.getEffectivePriority());
-        assertEquals(2.5D, deserialized.getEffectiveWeight());
     }
     
     @Test
@@ -108,7 +104,7 @@ class AgentContractModelTest extends BasicRequestTest {
         assertEquals("blue", restored.getExtensions().get("example.com/color"));
         assertEquals(AiConstants.Agent.RESOURCE_STATUS_ENABLE, restored.getStatus());
         assertEquals("nacos", restored.getOwner());
-        assertEquals("public", restored.getScope());
+        assertEquals("PUBLIC", restored.getScope());
         assertVersionInfo(restored.getVersionInfo());
         assertVersionCatalog(restored.getVersionCatalog());
         assertEquals(Long.valueOf(3L), restored.getMetaVersion());
@@ -128,7 +124,7 @@ class AgentContractModelTest extends BasicRequestTest {
         summary.setTags(Arrays.asList("assistant", "demo"));
         summary.setStatus(AiConstants.Agent.RESOURCE_STATUS_ENABLE);
         summary.setOwner("nacos");
-        summary.setScope("public");
+        summary.setScope("PUBLIC");
         summary.setVersionInfo(newVersionInfo());
         summary.setVersionCatalog(newVersionCatalog());
         summary.setMetaVersion(3L);
@@ -146,7 +142,7 @@ class AgentContractModelTest extends BasicRequestTest {
         assertEquals(Arrays.asList("assistant", "demo"), restored.getTags());
         assertEquals(AiConstants.Agent.RESOURCE_STATUS_ENABLE, restored.getStatus());
         assertEquals("nacos", restored.getOwner());
-        assertEquals("public", restored.getScope());
+        assertEquals("PUBLIC", restored.getScope());
         assertVersionInfo(restored.getVersionInfo());
         assertVersionCatalog(restored.getVersionCatalog());
         assertEquals(Long.valueOf(3L), restored.getMetaVersion());
@@ -248,7 +244,7 @@ class AgentContractModelTest extends BasicRequestTest {
         agent.setExtensions(extensions);
         agent.setStatus(AiConstants.Agent.RESOURCE_STATUS_ENABLE);
         agent.setOwner("nacos");
-        agent.setScope("public");
+        agent.setScope("PUBLIC");
         agent.setVersionInfo(newVersionInfo());
         agent.setVersionCatalog(newVersionCatalog());
         agent.setMetaVersion(3L);

--- a/api/src/test/java/com/alibaba/nacos/api/ai/utils/AgentModelValidatorTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/utils/AgentModelValidatorTest.java
@@ -217,6 +217,19 @@ class AgentModelValidatorTest {
     }
     
     @Test
+    void testRejectsUnsupportedVisibilityScope() {
+        Agent lowercaseScope = newValidAgent();
+        lowercaseScope.setScope("public");
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentModelValidator.validateAgent(lowercaseScope));
+        
+        Agent customScope = newValidAgent();
+        customScope.setScope("TEAM");
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentModelValidator.validateAgent(customScope));
+    }
+    
+    @Test
     void testRejectsInconsistentCatalogLabels() {
         Agent catalogLabelMismatch = newValidAgent();
         catalogLabelMismatch.getVersionInfo().getLabels().put("stable", "2.0.0");
@@ -478,7 +491,7 @@ class AgentModelValidatorTest {
         agent.setExtensions(Collections.<String, Object>singletonMap("example.com/color", "blue"));
         agent.setStatus(AiConstants.Agent.RESOURCE_STATUS_ENABLE);
         agent.setOwner("nacos");
-        agent.setScope("public");
+        agent.setScope("PUBLIC");
         agent.setVersionInfo(versionInfo);
         agent.setVersionCatalog(catalog);
         agent.setMetaVersion(1L);

--- a/api/src/test/java/com/alibaba/nacos/api/ai/utils/AgentValidationUtilsTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/ai/utils/AgentValidationUtilsTest.java
@@ -28,74 +28,260 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AgentValidationUtilsTest {
     
     @Test
-    void testIdentityValidatorsPreserveCaseAndSpaces() {
+    void testValidateNamespaceId() {
+        assertDoesNotThrow(() -> AgentValidationUtils.validateNamespaceId("a"));
         assertDoesNotThrow(() -> AgentValidationUtils.validateNamespaceId("Name_space-1"));
-        assertDoesNotThrow(() -> AgentValidationUtils.validateAgentName("Nacos Agent"));
-        assertDoesNotThrow(() -> AgentValidationUtils.validateProtocol("A2A-v1"));
-        assertDoesNotThrow(() -> AgentValidationUtils.validateProtocolVersion("V1.0"));
-        assertDoesNotThrow(() -> AgentValidationUtils.validateLabel("Release_RC1"));
-        assertDoesNotThrow(() -> AgentValidationUtils.validateTransport("JSON-RPC"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateNamespaceId(repeat('a', 128)));
         
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateNamespaceId(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateNamespaceId(""));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateNamespaceId(repeat('a', 129)));
         assertThrows(IllegalArgumentException.class,
             () -> AgentValidationUtils.validateNamespaceId("bad space"));
         assertThrows(IllegalArgumentException.class,
-            () -> AgentValidationUtils.validateAgentName("   "));
+            () -> AgentValidationUtils.validateNamespaceId("bad.namespace"));
         assertThrows(IllegalArgumentException.class,
-            () -> AgentValidationUtils.validateAgentName("Agent\nName"));
-        assertThrows(IllegalArgumentException.class,
-            () -> AgentValidationUtils.validateProtocol("a2a_rpc"));
-        assertThrows(IllegalArgumentException.class,
-            () -> AgentValidationUtils.validateProtocolVersion("v 1"));
-        assertThrows(IllegalArgumentException.class,
-            () -> AgentValidationUtils.validateLabel("-label"));
-        assertThrows(IllegalArgumentException.class,
-            () -> AgentValidationUtils.validateTransport("json_rpc"));
-        assertThrows(IllegalArgumentException.class,
-            () -> AgentValidationUtils.validateNonLatestLabel("latest"));
+            () -> AgentValidationUtils.validateNamespaceId("命名空间"));
+    }
+    
+    @Test
+    void testValidateAgentName() {
+        assertDoesNotThrow(() -> AgentValidationUtils.validateAgentName("A"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateAgentName("Nacos Agent"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateAgentName(" !\"#$%&'()*+,-./"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateAgentName(
+            repeat(' ', 63) + "~"));
+        
         assertThrows(IllegalArgumentException.class,
             () -> AgentValidationUtils.validateAgentName(null));
         assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateAgentName(""));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateAgentName(repeat('A', 65)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateAgentName(repeat(' ', 64)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateAgentName("Agent\u001fName"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateAgentName("Agent\u007fName"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateAgentName("Nacos代理"));
+    }
+    
+    @Test
+    void testValidateProtocol() {
+        assertDoesNotThrow(() -> AgentValidationUtils.validateProtocol("A"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateProtocol("A2A-v1"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateProtocol(repeat('a', 32)));
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocol(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocol(""));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocol(repeat('a', 33)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocol("a2a_rpc"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocol("-a2a"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocol("a2a.v1"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocol("a2a v1"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocol("协议"));
+    }
+    
+    @Test
+    void testValidateProtocolVersion() {
+        assertDoesNotThrow(() -> AgentValidationUtils.validateProtocolVersion("!"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateProtocolVersion("V1.0"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateProtocolVersion(repeat('~', 64)));
+        
+        assertThrows(IllegalArgumentException.class,
             () -> AgentValidationUtils.validateProtocolVersion(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocolVersion(""));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocolVersion(repeat('a', 65)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocolVersion("v 1"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocolVersion("v\u001f1"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocolVersion("v\u007f1"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateProtocolVersion("版本1"));
+    }
+    
+    @Test
+    void testValidateLabel() {
+        assertDoesNotThrow(() -> AgentValidationUtils.validateLabel("A"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateLabel("Release_RC1.0"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateLabel("A" + repeat('.', 63)));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateLabel("latest"));
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateLabel(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateLabel(""));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateLabel("A" + repeat('.', 64)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateLabel("-label"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateLabel("_label"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateLabel(".label"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateLabel("release label"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateLabel("发布"));
+    }
+    
+    @Test
+    void testValidateNonLatestLabel() {
+        assertDoesNotThrow(() -> AgentValidationUtils.validateNonLatestLabel("Latest"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateNonLatestLabel("stable"));
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateNonLatestLabel("latest"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateNonLatestLabel("-invalid"));
+    }
+    
+    @Test
+    void testValidateTransport() {
+        assertDoesNotThrow(() -> AgentValidationUtils.validateTransport("-"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateTransport("JSON-RPC"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateTransport(repeat('A', 64)));
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateTransport(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateTransport(""));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateTransport(repeat('A', 65)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateTransport("json_rpc"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateTransport("json.rpc"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateTransport("json rpc"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateTransport("传输"));
     }
     
     @Test
     void testVersionValidators() {
         assertDoesNotThrow(() -> AgentValidationUtils.validateVersion("1.0.0-RC1"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateVersion(
+            "1.0.0-" + repeat('A', 58)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateVersion(null));
         assertThrows(IllegalArgumentException.class,
             () -> AgentValidationUtils.validateVersion("1.0"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateVersion("1.0.0-" + repeat('A', 59)));
         assertDoesNotThrow(() -> AgentValidationUtils.validateVersionRange("[1.0.0,2.0.0)"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateVersionRange(null));
         assertThrows(IllegalArgumentException.class,
             () -> AgentValidationUtils.validateVersionRange("[2.0.0,1.0.0]"));
     }
     
     @Test
-    void testDigestAndMediaTypeValidators() {
+    void testValidateContentDigest() {
         assertDoesNotThrow(() -> AgentValidationUtils.validateContentDigest("sha256:"
             + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"));
-        assertDoesNotThrow(
-            () -> AgentValidationUtils.validateMediaType("application/json;charset=utf-8"));
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateContentDigest(null));
         assertThrows(IllegalArgumentException.class,
             () -> AgentValidationUtils.validateContentDigest("sha256:ABC"));
         assertThrows(IllegalArgumentException.class,
-            () -> AgentValidationUtils.validateMediaType("application json"));
+            () -> AgentValidationUtils.validateContentDigest("SHA256:" + repeat('a', 64)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateContentDigest("sha256:" + repeat('a', 63)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateContentDigest("sha256:" + repeat('a', 65)));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateContentDigest("sha256:" + repeat('g', 64)));
     }
     
     @Test
-    void testEndpointMetadataConstraints() {
+    void testValidateMediaType() {
+        assertDoesNotThrow(() -> AgentValidationUtils.validateMediaType("a/b"));
+        assertDoesNotThrow(
+            () -> AgentValidationUtils.validateMediaType("application/json;charset=utf-8"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateMediaType(
+            repeat('a', 63) + "/" + repeat('b', 64)));
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateMediaType(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateMediaType(""));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateMediaType("application"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateMediaType("application/"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateMediaType("/json"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateMediaType("application json"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateMediaType("application/\njson"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateMediaType("应用/json"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateMediaType(
+                repeat('a', 64) + "/" + repeat('b', 64)));
+    }
+    
+    @Test
+    void testValidateNonNullJsonValue() {
+        assertDoesNotThrow(() -> AgentValidationUtils.validateNonNullJsonValue("", "field"));
+        assertDoesNotThrow(() -> AgentValidationUtils.validateNonNullJsonValue(0, "field"));
+        assertDoesNotThrow(
+            () -> AgentValidationUtils.validateNonNullJsonValue(Boolean.FALSE, "field"));
+        assertDoesNotThrow(() -> AgentValidationUtils
+            .validateNonNullJsonValue(Collections.emptyMap(), "field"));
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentValidationUtils.validateNonNullJsonValue(null, "nativeDescriptor"));
+    }
+    
+    @Test
+    void testValidateEndpointMetadata() {
         Map<String, String> metadata = new LinkedHashMap<String, String>();
         metadata.put("zone", "cn-hangzhou-a");
         metadata.put("环境", "生产");
+        metadata.put(repeat("😀", 64), repeat("😀", 256));
         assertDoesNotThrow(() -> AgentValidationUtils.validateEndpointMetadata(metadata));
         assertDoesNotThrow(() -> AgentValidationUtils.validateEndpointMetadata(null));
         assertDoesNotThrow(() -> AgentValidationUtils
             .validateEndpointMetadata(Collections.<String, String>emptyMap()));
         
+        Map<String, String> maximumEntries = new LinkedHashMap<String, String>();
+        for (int i = 0; i < 32; i++) {
+            maximumEntries.put("key-" + i, "");
+        }
+        assertDoesNotThrow(
+            () -> AgentValidationUtils.validateEndpointMetadata(maximumEntries));
+        
         assertInvalidMetadata("preserved.heart.beat.interval", "1000");
         assertInvalidMetadata("preserved.heart.beat.timeout", "3000");
         assertInvalidMetadata("preserved.ip.delete.timeout", "5000");
+        assertInvalidMetadata("__nacos.agent.endpoint.", "value");
         assertInvalidMetadata("__nacos.agent.endpoint.versionRange__", "[1.0.0]");
+        assertInvalidMetadata(null, "value");
         assertInvalidMetadata("", "value");
+        assertInvalidMetadata(repeat("😀", 65), "value");
         assertInvalidMetadata("key", null);
+        assertInvalidMetadata("key", repeat("😀", 257));
         
         Map<String, String> tooMany = new LinkedHashMap<String, String>();
         for (int i = 0; i < 33; i++) {
@@ -109,5 +295,21 @@ class AgentValidationUtilsTest {
         assertThrows(IllegalArgumentException.class,
             () -> AgentValidationUtils
                 .validateEndpointMetadata(Collections.singletonMap(key, value)));
+    }
+    
+    private String repeat(char value, int count) {
+        StringBuilder result = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+    
+    private String repeat(String value, int count) {
+        StringBuilder result = new StringBuilder(value.length() * count);
+        for (int i = 0; i < count; i++) {
+            result.append(value);
+        }
+        return result.toString();
     }
 }

--- a/specs/en/ai/agent-management-spec.md
+++ b/specs/en/ai/agent-management-spec.md
@@ -133,7 +133,7 @@ The Agent resource contains the following fields:
 
 | Field | Required | Meaning |
 | --- | :---: | --- |
-| `namespaceId` | Yes | Isolation boundary. |
+| `namespaceId` | Yes | Nacos namespace isolation boundary; 1 to 128 `[A-Za-z0-9_-]` characters. |
 | `agentName` | Yes | Stable public identity. |
 | `displayName` | No | Unicode presentation name. |
 | `description` | No | Catalog description. |
@@ -143,7 +143,7 @@ The Agent resource contains the following fields:
 | `extensions` | No | Namespaced `Map<String, JsonValue>` for public Agent-level extensions. |
 | `status` | Yes | `enable` or `disable`. |
 | `owner` | Yes | Management owner. |
-| `scope` | Yes | Visibility scope. |
+| `scope` | Yes | Shared visibility scope; `PUBLIC` or `PRIVATE` in this version. |
 | `versionInfo` | Read-only | Shared editing, reviewing, online-count, and label summary. |
 | `versionCatalog` | Read-only | Compact catalog of online versions and protocols. |
 | `metaVersion` | Read-only | Metadata CAS version. |

--- a/specs/en/ai/agent-storage-spec.md
+++ b/specs/en/ai/agent-storage-spec.md
@@ -82,7 +82,8 @@ follows:
 | `versionCatalog` | Server | Derived online Version catalog. |
 
 `versionCatalog` contains `latestVersion` and `onlineVersions[]`; each entry
-contains only `version`, `labels[]`, and `protocols[]`. Version status and
+contains only `version`, `labels[]`, and `protocols[]`. `onlineVersions` is
+stored in descending Agent Version precedence order. Version status and
 `version_info.labels` remain the facts. Publish, online, offline, delete, label,
 or latest changes rebuild the catalog as one logical Resource update.
 

--- a/specs/en/ai/rad-protocol-spec.md
+++ b/specs/en/ai/rad-protocol-spec.md
@@ -75,7 +75,8 @@ Every operation executes in exactly one effective namespace.
 - Cache, watch, authorization, and publisher-contribution keys MUST include the
   effective namespace.
 
-`namespaceId` contains 1 to 64 characters from `[A-Za-z0-9_-]`.
+`namespaceId` follows the Nacos namespace contract and contains 1 to 128
+characters from `[A-Za-z0-9_-]`.
 
 ### 2.2 Agent, Protocol, And Label Identity
 
@@ -93,7 +94,7 @@ The public Agent identity is `(namespaceId, agentName)`.
 matches `[A-Za-z0-9][A-Za-z0-9._-]{0,63}`. Both are case-sensitive.
 
 `latest` is a reserved label that resolves to the Agent's current latest
-version. It MUST NOT appear in `AgentVersionCatalog.labels`.
+version. It MUST NOT appear in `AgentCatalogVersion.labels`.
 
 ### 2.3 Agent Version
 
@@ -189,7 +190,7 @@ tags.
 Characters such as `%` and `_` that are special to a backing query language
 MUST be treated as literals.
 
-### 3.4 `AgentCatalogPage`, `AgentCatalogEntry`, And `AgentVersionCatalog`
+### 3.4 `AgentCatalogPage`, `AgentCatalogEntry`, And `AgentCatalogVersion`
 
 `AgentCatalogPage` contains:
 
@@ -203,7 +204,7 @@ namespace:
 ```text
 agentName / displayName? / description? / iconUrl? / provider?
 tags? / latestVersion
-versions[] AgentVersionCatalog {
+versions[] AgentCatalogVersion {
   version
   labels[]?
   protocols[]

--- a/specs/schemas/ai/agent/0.1.0/agent-management.schema.json
+++ b/specs/schemas/ai/agent/0.1.0/agent-management.schema.json
@@ -19,7 +19,7 @@
     "NamespaceId": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 64,
+      "maxLength": 128,
       "pattern": "^[A-Za-z0-9_-]+$"
     },
     "AgentName": {
@@ -225,7 +225,7 @@
         }
       }
     },
-    "VersionCatalogEntry": {
+    "AgentVersionCatalogEntry": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -255,7 +255,7 @@
         }
       }
     },
-    "VersionCatalog": {
+    "AgentVersionCatalog": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -268,7 +268,7 @@
         "onlineVersions": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/VersionCatalogEntry"
+            "$ref": "#/$defs/AgentVersionCatalogEntry"
           }
         }
       },
@@ -354,14 +354,16 @@
         },
         "scope": {
           "type": "string",
-          "minLength": 1,
-          "maxLength": 64
+          "enum": [
+            "PUBLIC",
+            "PRIVATE"
+          ]
         },
         "versionInfo": {
           "$ref": "#/$defs/AgentVersionInfo"
         },
         "versionCatalog": {
-          "$ref": "#/$defs/VersionCatalog"
+          "$ref": "#/$defs/AgentVersionCatalog"
         },
         "metaVersion": {
           "type": "integer",
@@ -430,14 +432,16 @@
         },
         "scope": {
           "type": "string",
-          "minLength": 1,
-          "maxLength": 64
+          "enum": [
+            "PUBLIC",
+            "PRIVATE"
+          ]
         },
         "versionInfo": {
           "$ref": "#/$defs/AgentVersionInfo"
         },
         "versionCatalog": {
-          "$ref": "#/$defs/VersionCatalog"
+          "$ref": "#/$defs/AgentVersionCatalog"
         },
         "metaVersion": {
           "type": "integer",

--- a/specs/schemas/ai/agent/internal/v1/agent-storage.schema.json
+++ b/specs/schemas/ai/agent/internal/v1/agent-storage.schema.json
@@ -36,9 +36,9 @@
   },
   "x-entrypoints": {
     "AgentResourceExt": "#/$defs/AgentResourceExt",
-    "VersionCatalog": "#/$defs/VersionCatalog",
+    "AgentVersionCatalog": "#/$defs/AgentVersionCatalog",
     "AgentVersionContent": "#/$defs/AgentVersionContent",
-    "VersionStorageDescriptor": "#/$defs/VersionStorageDescriptor",
+    "AgentVersionStorageDescriptor": "#/$defs/AgentVersionStorageDescriptor",
     "NamingRuntimePublication": "#/$defs/NamingRuntimePublication",
     "RadAsciiAgentIdCodecContract": "#/$defs/RadAsciiAgentIdCodecContract",
     "AgentVersionDataIdComposerContract": "#/$defs/AgentVersionDataIdComposerContract",
@@ -53,7 +53,7 @@
     "NamespaceId": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 64,
+      "maxLength": 128,
       "pattern": "^[A-Za-z0-9_-]+$"
     },
     "AgentName": {
@@ -213,7 +213,7 @@
       "additionalProperties": true,
       "description": "Canonical JSON size must not exceed 16 KiB; JSON Schema cannot enforce encoded byte size."
     },
-    "VersionCatalogEntry": {
+    "AgentVersionCatalogEntry": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -243,7 +243,7 @@
         }
       }
     },
-    "VersionCatalog": {
+    "AgentVersionCatalog": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -256,7 +256,7 @@
         "onlineVersions": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/VersionCatalogEntry"
+            "$ref": "#/$defs/AgentVersionCatalogEntry"
           }
         }
       },
@@ -310,7 +310,7 @@
           "$ref": "#/$defs/Extensions"
         },
         "versionCatalog": {
-          "$ref": "#/$defs/VersionCatalog"
+          "$ref": "#/$defs/AgentVersionCatalog"
         }
       }
     },
@@ -452,7 +452,7 @@
       },
       "description": "Storage projection serialized once with the common Nacos JSON serializer as UTF-8. The exact emitted bytes are persisted and used for size and SHA-256 contentDigest; no semantic JSON canonicalization is defined. Reject unknown schema properties on the envelope, CallInterface, and Endpoint objects; nativeDescriptor members and metadata map entries remain open within their value constraints. Before serialization, canonicalize declared Endpoint URI, validate and preserve transport, materialize priority and weight, and omit empty metadata and declaredEndpoints. Array order preserves CallInterface, endpoint-source, and declared Endpoint business order. Protocol uniqueness, URI canonicalization, and descriptor-to-endpoint consistency require domain validation."
     },
-    "VersionStorageDescriptor": {
+    "AgentVersionStorageDescriptor": {
       "type": "object",
       "additionalProperties": false,
       "required": [

--- a/specs/schemas/ai/rad/0.1.0/rad-protocol.schema.json
+++ b/specs/schemas/ai/rad/0.1.0/rad-protocol.schema.json
@@ -18,7 +18,7 @@
     "NamespaceId": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 64,
+      "maxLength": 128,
       "pattern": "^[A-Za-z0-9_-]+$"
     },
     "AgentName": {

--- a/specs/zh-cn/ai/agent-management-spec.md
+++ b/specs/zh-cn/ai/agent-management-spec.md
@@ -122,7 +122,7 @@ Agent 资源包含以下字段：
 
 | 字段 | 必选 | 含义 |
 | --- | :---: | --- |
-| `namespaceId` | 是 | 隔离边界。 |
+| `namespaceId` | 是 | Nacos Namespace 隔离边界；1～128 个 `[A-Za-z0-9_-]` 字符。 |
 | `agentName` | 是 | 稳定公开身份。 |
 | `displayName` | 否 | Unicode 展示名称。 |
 | `description` | 否 | 目录描述。 |
@@ -132,7 +132,7 @@ Agent 资源包含以下字段：
 | `extensions` | 否 | 用于公开 Agent 级扩展的命名空间化 `Map<String, JsonValue>`。 |
 | `status` | 是 | `enable` 或 `disable`。 |
 | `owner` | 是 | 管理 owner。 |
-| `scope` | 是 | 可见性 scope。 |
+| `scope` | 是 | 共享可见性 scope；本版本为 `PUBLIC` 或 `PRIVATE`。 |
 | `versionInfo` | 只读 | 共享的 editing、reviewing、online count 和 label 摘要。 |
 | `versionCatalog` | 只读 | online Version 和 protocol 的紧凑目录。 |
 | `metaVersion` | 只读 | 元数据 CAS 版本。 |

--- a/specs/zh-cn/ai/agent-storage-spec.md
+++ b/specs/zh-cn/ai/agent-storage-spec.md
@@ -77,9 +77,9 @@ Watch 对象都是上述事实的读取投影。
 | `versionCatalog` | 服务端 | 派生的 online Version 目录。 |
 
 `versionCatalog` 包含 `latestVersion` 和 `onlineVersions[]`；每个条目只包含
-`version`、`labels[]` 和 `protocols[]`。Version status 和 `version_info.labels` 仍然是
-事实。Publish、online、offline、delete、label 或 latest 变化时，目录作为一次 Resource 逻辑
-更新进行重建。
+`version`、`labels[]` 和 `protocols[]`；`onlineVersions` 按 Agent Version 优先级降序
+存储。Version status 和 `version_info.labels` 仍然是事实。Publish、online、offline、
+delete、label 或 latest 变化时，目录作为一次 Resource 逻辑更新进行重建。
 
 `biz_tags` 不保存服务端派生索引；写入和读取投影必须保持用户 tag 的值和顺序。
 

--- a/specs/zh-cn/ai/rad-protocol-spec.md
+++ b/specs/zh-cn/ai/rad-protocol-spec.md
@@ -69,7 +69,8 @@ MCP、调用代理、凭据、重试或负载均衡。Agent 资源和版本语�
   缺省命名空间规范化为 `public`。
 - 缓存、订阅、鉴权和发布者贡献键必须包含生效命名空间。
 
-`namespaceId` 包含 1～64 个 `[A-Za-z0-9_-]` 字符。
+`namespaceId` 遵循 Nacos 公共 Namespace 契约，包含 1～128 个
+`[A-Za-z0-9_-]` 字符。
 
 ### 2.2 Agent、Protocol 与 Label 身份
 
@@ -87,7 +88,7 @@ Agent 的公开身份是 `(namespaceId, agentName)`。
 `[A-Za-z0-9][A-Za-z0-9._-]{0,63}`。两者均大小写敏感。
 
 `latest` 是保留 Label，用于解析 Agent 当前的 latest 版本。它不得出现在
-`AgentVersionCatalog.labels` 中。
+`AgentCatalogVersion.labels` 中。
 
 ### 2.3 Agent 版本
 
@@ -168,7 +169,7 @@ Schema 只暴露以下六个根消息：
 
 `%`、`_` 等对底层查询语言具有特殊含义的字符必须作为普通字面量处理。
 
-### 3.4 `AgentCatalogPage`、`AgentCatalogEntry` 与 `AgentVersionCatalog`
+### 3.4 `AgentCatalogPage`、`AgentCatalogEntry` 与 `AgentCatalogVersion`
 
 `AgentCatalogPage` 包含：
 
@@ -181,7 +182,7 @@ totalCount / pageNumber / pagesAvailable / pageItems[]
 ```text
 agentName / displayName? / description? / iconUrl? / provider?
 tags? / latestVersion
-versions[] AgentVersionCatalog {
+versions[] AgentCatalogVersion {
   version
   labels[]?
   protocols[]


### PR DESCRIPTION
## What is the purpose of the change

Audit the recently merged Agent/RAD foundations, close meaningful unit-test gaps reported by
Codecov, and align the implementation, Specs, and Schemas with the accepted Agent management
design.

For #14804

## Brief changelog

- Expand `AgentPersistenceService` tests for validation, concurrent inserts, uncertain write
  recovery, idempotent retries, storage failures, corrupt persisted data, and exact Version reads.
- Complete boundary tests for Agent validation and add missing storage serializer scenarios.
- Remove the unmodeled Endpoint effective-value helpers and the obsolete aggregate protocol
  projection left from the discarded `biz_tags` protocol-index approach.
- Align Namespace length, Agent scope values, RAD catalog type names, and internal Schema component
  names with the design; document deterministic online Version catalog ordering.
- Improve `AgentPersistenceService` line coverage from 89.2% to 96.8%, branch coverage from 63.2%
  to 85.3%, and method coverage to 100%.

## Verifying this change

- `mvn clean test -pl api,ai`
  - API: 1,157 tests passed.
  - AI: 1,650 tests passed, 2 skipped.
- `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`
- Parsed all three changed JSON Schemas and verified their local `$ref` targets.
- No HTTP API or Java SDK behavior is introduced by this PR, so no OpenAPI or SDK integration-test
  matrix changes are required.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit tests to verify the logic correction.
* [x] Run the required local formatting, unit-test, license, Checkstyle, SpotBugs, and compile checks.
