### PR TITLE
[ISSUE #15475] Integrate control plugin with unified configuration

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/plugin/PluginStartupLifecycle.java
+++ b/api/src/main/java/com/alibaba/nacos/api/plugin/PluginStartupLifecycle.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.plugin;
+
+/**
+ * Optional lifecycle for creating plugin-owned runtime resources after configuration is applied.
+ *
+ * <p>The operation must be idempotent. Implementing this lifecycle does not imply that runtime
+ * state switching or resource rebuilding is supported.</p>
+ *
+ * @author Nacos
+ */
+public interface PluginStartupLifecycle {
+    
+    /**
+     * Initialize plugin-owned runtime resources.
+     */
+    void initialize();
+}

--- a/core/src/main/java/com/alibaba/nacos/core/control/SpringValueConfigsInitializer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/control/SpringValueConfigsInitializer.java
@@ -32,7 +32,9 @@ public class SpringValueConfigsInitializer implements ControlConfigsInitializer 
     
     private static final String CONNECTION_RUNTIME_EJECTOR = PREFIX + "connection.runtime.ejector";
     
-    private static final String CONTROL_MANAGER_TYPE = PREFIX + "manager.type";
+    private static final String CONTROL_MANAGER_TYPE = PREFIX + "type";
+    
+    private static final String LEGACY_CONTROL_MANAGER_TYPE = PREFIX + "manager.type";
     
     private static final String RULE_EXTERNAL_STORAGE = PREFIX + "rule.external.storage";
     
@@ -51,6 +53,9 @@ public class SpringValueConfigsInitializer implements ControlConfigsInitializer 
             controlConfigs.setLocalRuleStorageBaseDir(EnvUtil.getNacosHome());
         }
         controlConfigs.setRuleExternalStorage(EnvUtil.getProperty(RULE_EXTERNAL_STORAGE));
-        controlConfigs.setControlManagerType(EnvUtil.getProperty(CONTROL_MANAGER_TYPE));
+        String controlManagerType = EnvUtil.containsProperty(CONTROL_MANAGER_TYPE)
+            ? EnvUtil.getProperty(CONTROL_MANAGER_TYPE)
+            : EnvUtil.getProperty(LEGACY_CONTROL_MANAGER_TYPE);
+        controlConfigs.setControlManagerType(controlManagerType);
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.api.plugin.PluginProvider;
+import com.alibaba.nacos.api.plugin.PluginStartupLifecycle;
 import com.alibaba.nacos.api.plugin.PluginStateChecker;
 import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.api.plugin.PluginType;
@@ -100,6 +101,11 @@ public class PluginManager
      * Configurable plugins that have been discovered but not initialized successfully.
      */
     private final Set<String> pendingConfigInitializationPluginIds = new HashSet<>();
+    
+    /**
+     * Startup lifecycle plugins that have been discovered but not initialized successfully.
+     */
+    private final Set<String> pendingStartupInitializationPluginIds = new HashSet<>();
     
     private final PluginConfigService pluginConfigService;
     
@@ -361,6 +367,7 @@ public class PluginManager
         ensureCriticalTypesAvailable();
         refreshAllCriticalFlags();
         initializePluginConfigs(pendingConfigInitializationPluginIds);
+        initializePluginLifecycles(pendingStartupInitializationPluginIds);
     }
     
     /**
@@ -463,6 +470,9 @@ public class PluginManager
                 pendingConfigInitializationPluginIds.add(pluginId);
             }
         }
+        if (instance instanceof PluginStartupLifecycle) {
+            pendingStartupInitializationPluginIds.add(pluginId);
+        }
         
         pluginRegistry.put(pluginId, info);
         pluginInstances.put(pluginId, instance);
@@ -483,6 +493,7 @@ public class PluginManager
         // Load configs
         pluginConfigService.initializeRuntimePersistedConfigs();
         initializePluginConfigs(pluginRegistry.keySet());
+        initializePluginLifecycles(pendingStartupInitializationPluginIds);
     }
     
     private void loadPersistedStates(Collection<String> pluginIds) {
@@ -522,6 +533,26 @@ public class PluginManager
             if (info.isConfigurable()) {
                 pluginConfigService.initializePluginConfig(info, pluginInstances.get(pluginId));
                 pendingConfigInitializationPluginIds.remove(pluginId);
+            }
+        }
+    }
+    
+    private void initializePluginLifecycles(Collection<String> pluginIds) {
+        for (String pluginId : new HashSet<>(pluginIds)) {
+            PluginInfo info = pluginRegistry.get(pluginId);
+            if (!info.isEnabled()) {
+                continue;
+            }
+            PluginStartupLifecycle lifecycle =
+                (PluginStartupLifecycle) pluginInstances.get(pluginId);
+            try {
+                lifecycle.initialize();
+                pendingStartupInitializationPluginIds.remove(pluginId);
+            } catch (RuntimeException e) {
+                LOGGER.error("[PluginManager] Failed to initialize plugin startup lifecycle, "
+                    + "pluginId={}", pluginId, e);
+                throw new IllegalStateException(
+                    "Failed to initialize plugin startup lifecycle: " + pluginId, e);
             }
         }
     }

--- a/core/src/test/java/com/alibaba/nacos/core/control/SpringValueConfigsInitializerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/control/SpringValueConfigsInitializerTest.java
@@ -73,7 +73,7 @@ class SpringValueConfigsInitializerTest {
     }
     
     @Test
-    void testInitializeWithRuleExternalStorageAndControlManagerType() {
+    void testInitializeWithRuleExternalStorageAndLegacyControlManagerType() {
         environment.setProperty("nacos.plugin.control.rule.external.storage", "mysql");
         environment.setProperty("nacos.plugin.control.manager.type", "local");
         ControlConfigs configs = new ControlConfigs();
@@ -81,5 +81,26 @@ class SpringValueConfigsInitializerTest {
         initializer.initialize(configs);
         assertEquals("mysql", configs.getRuleExternalStorage());
         assertEquals("local", configs.getControlManagerType());
+    }
+    
+    @Test
+    void testInitializeWithStandardControlManagerType() {
+        environment.setProperty("nacos.plugin.control.type", "standard");
+        ControlConfigs configs = new ControlConfigs();
+        
+        new SpringValueConfigsInitializer().initialize(configs);
+        
+        assertEquals("standard", configs.getControlManagerType());
+    }
+    
+    @Test
+    void testStandardControlManagerTypeTakesPrecedence() {
+        environment.setProperty("nacos.plugin.control.type", "standard");
+        environment.setProperty("nacos.plugin.control.manager.type", "legacy");
+        ControlConfigs configs = new ControlConfigs();
+        
+        new SpringValueConfigsInitializer().initialize(configs);
+        
+        assertEquals("standard", configs.getControlManagerType());
     }
 }

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
@@ -23,6 +23,7 @@ import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
 import com.alibaba.nacos.api.plugin.ConfigItemEffectMode;
 import com.alibaba.nacos.api.plugin.PluginConfigSpec;
 import com.alibaba.nacos.api.plugin.PluginProvider;
+import com.alibaba.nacos.api.plugin.PluginStartupLifecycle;
 import com.alibaba.nacos.api.plugin.PluginStateCheckerHolder;
 import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.common.spi.NacosServiceLoader;
@@ -119,7 +120,7 @@ class PluginManagerTest {
             .thenReturn(Collections.emptySet());
         lenient().when(policyRegistry.getSelectionProperty(any())).thenAnswer(invocation -> {
             PluginType type = invocation.getArgument(0);
-            return PluginType.CONTROL == type ? "nacos.plugin.control.manager.type"
+            return PluginType.CONTROL == type ? "nacos.plugin.control.type"
                 : "nacos.plugin." + type.getType() + ".type";
         });
         lenient().when(policyRegistry.getActivationDescription(any()))
@@ -561,7 +562,7 @@ class PluginManagerTest {
         NacosApiException exception = assertThrows(NacosApiException.class,
             () -> manager.setPluginEnabled("control:remote", true));
         
-        assertTrue(exception.getErrMsg().contains("nacos.plugin.control.manager.type"));
+        assertTrue(exception.getErrMsg().contains("nacos.plugin.control.type"));
     }
     
     @Test
@@ -684,6 +685,62 @@ class PluginManagerTest {
         
         verify(provider).getAllPlugins();
         verify(configService, times(2)).initializePluginConfig(any(), eq(plugin));
+    }
+    
+    @Test
+    void initializeRunsConfigBeforeStartupLifecycleTest() {
+        TestStartupPlugin plugin = new TestStartupPlugin();
+        ConfigItemDefinition definition = new ConfigItemDefinition();
+        definition.setKey("key");
+        definition.setDefaultValue("default");
+        plugin.setConfigDefinitions(Collections.singletonList(definition));
+        ReflectionTestUtils.invokeMethod(manager, "registerPlugin", PluginType.TRACE,
+            "lifecycle", plugin);
+        
+        ReflectionTestUtils.invokeMethod(manager, "loadPersistedData");
+        
+        assertEquals(java.util.Arrays.asList("apply", "initialize"), plugin.getOperations());
+        assertEquals("default", plugin.getCurrentConfig().get("key"));
+    }
+    
+    @Test
+    void initializeRunsStartupLifecycleForZeroConfigPluginTest() {
+        TestStartupPlugin plugin = new TestStartupPlugin();
+        ReflectionTestUtils.invokeMethod(manager, "registerPlugin", PluginType.TRACE,
+            "lifecycle", plugin);
+        
+        ReflectionTestUtils.invokeMethod(manager, "loadPersistedData");
+        
+        assertEquals(Collections.singletonList("initialize"), plugin.getOperations());
+    }
+    
+    @Test
+    void initializeSkipsStartupLifecycleForDisabledPluginTest() {
+        when(policyRegistry.isPluginEnabledByDefault(PluginType.TRACE, "disabled"))
+            .thenReturn(false);
+        TestStartupPlugin plugin = new TestStartupPlugin();
+        ReflectionTestUtils.invokeMethod(manager, "registerPlugin", PluginType.TRACE,
+            "disabled", plugin);
+        
+        ReflectionTestUtils.invokeMethod(manager, "loadPersistedData");
+        
+        assertTrue(plugin.getOperations().isEmpty());
+    }
+    
+    @Test
+    void initializeRetriesFailedStartupLifecycleTest() {
+        TestStartupPlugin plugin = new TestStartupPlugin();
+        plugin.setInitializationFailures(1);
+        ReflectionTestUtils.invokeMethod(manager, "registerPlugin", PluginType.TRACE,
+            "retry", plugin);
+        
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> ReflectionTestUtils.invokeMethod(manager, "loadPersistedData"));
+        ReflectionTestUtils.invokeMethod(manager, "loadPersistedData");
+        
+        assertTrue(exception.getMessage().contains("trace:retry"));
+        assertEquals(2, plugin.getInitializationAttempts());
+        assertEquals(Collections.singletonList("initialize"), plugin.getOperations());
     }
     
     @Test
@@ -1445,6 +1502,44 @@ class PluginManagerTest {
         @Override
         public Map<String, String> getCurrentConfig() {
             return new HashMap<>();
+        }
+    }
+    
+    static class TestStartupPlugin extends TestConfigurablePlugin
+        implements PluginStartupLifecycle {
+        
+        private final List<String> operations = new ArrayList<>();
+        
+        private int initializationFailures;
+        
+        private int initializationAttempts;
+        
+        @Override
+        public void applyConfig(Map<String, String> config) {
+            super.applyConfig(config);
+            operations.add("apply");
+        }
+        
+        @Override
+        public void initialize() {
+            initializationAttempts++;
+            if (initializationFailures > 0) {
+                initializationFailures--;
+                throw new IllegalStateException("initialization failed");
+            }
+            operations.add("initialize");
+        }
+        
+        void setInitializationFailures(int initializationFailures) {
+            this.initializationFailures = initializationFailures;
+        }
+        
+        int getInitializationAttempts() {
+            return initializationAttempts;
+        }
+        
+        List<String> getOperations() {
+            return operations;
         }
     }
 }

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -370,7 +370,9 @@ nacos.plugin.visibility.nacos.enabled=true
 #nacos.plugin.visibility.type=nacos
 
 #*************** Control Plugin Related Configurations ***************#
-# plugin type
+# Control plugin implementation selector:
+#nacos.plugin.control.type=nacos
+# Deprecated selector retained for compatibility. The standard key above takes precedence:
 #nacos.plugin.control.manager.type=nacos
 
 # local control rule storage dir, default ${nacos.home}/data/connection and ${nacos.home}/data/tps

--- a/plugin-default-impl/nacos-default-control-plugin/src/test/java/com/alibaba/nacos/plugin/control/impl/NacosControlManagerBuilderTest.java
+++ b/plugin-default-impl/nacos-default-control-plugin/src/test/java/com/alibaba/nacos/plugin/control/impl/NacosControlManagerBuilderTest.java
@@ -20,7 +20,10 @@ import com.alibaba.nacos.plugin.control.connection.ConnectionControlManager;
 import com.alibaba.nacos.plugin.control.tps.TpsControlManager;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NacosControlManagerBuilderTest {
     
@@ -28,12 +31,14 @@ class NacosControlManagerBuilderTest {
     void test() {
         NacosControlManagerBuilder nacosControlManagerBuilder = new NacosControlManagerBuilder();
         ConnectionControlManager connectionControlManager =
-            nacosControlManagerBuilder.buildConnectionControlManager();
-        TpsControlManager tpsControlManager = nacosControlManagerBuilder.buildTpsControlManager();
+            nacosControlManagerBuilder.buildConnectionControlManager(Collections.emptyMap());
+        TpsControlManager tpsControlManager =
+            nacosControlManagerBuilder.buildTpsControlManager(Collections.emptyMap());
         
         assertEquals("nacos", tpsControlManager.getName());
         assertEquals("nacos", connectionControlManager.getName());
         assertEquals("nacos", nacosControlManagerBuilder.getName());
+        assertTrue(nacosControlManagerBuilder.getConfigDefinitions().isEmpty());
     }
     
 }

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/ControlManagerBundle.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/ControlManagerBundle.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control;
+
+import com.alibaba.nacos.plugin.control.connection.ConnectionControlManager;
+import com.alibaba.nacos.plugin.control.tps.TpsControlManager;
+
+import java.util.Objects;
+
+/**
+ * Immutable connection and TPS control manager bundle.
+ *
+ * @author Nacos
+ */
+public final class ControlManagerBundle {
+    
+    private final ConnectionControlManager connectionControlManager;
+    
+    private final TpsControlManager tpsControlManager;
+    
+    /**
+     * Create control manager bundle.
+     *
+     * @param connectionControlManager connection control manager
+     * @param tpsControlManager TPS control manager
+     */
+    public ControlManagerBundle(ConnectionControlManager connectionControlManager,
+        TpsControlManager tpsControlManager) {
+        this.connectionControlManager = Objects.requireNonNull(connectionControlManager,
+            "Connection control manager cannot be null");
+        this.tpsControlManager = Objects.requireNonNull(tpsControlManager,
+            "TPS control manager cannot be null");
+    }
+    
+    /**
+     * Get connection control manager.
+     *
+     * @return connection control manager
+     */
+    public ConnectionControlManager getConnectionControlManager() {
+        return connectionControlManager;
+    }
+    
+    /**
+     * Get TPS control manager.
+     *
+     * @return TPS control manager
+     */
+    public TpsControlManager getTpsControlManager() {
+        return tpsControlManager;
+    }
+}

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/ControlManagerCenter.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/ControlManagerCenter.java
@@ -17,19 +17,28 @@
 package com.alibaba.nacos.plugin.control;
 
 import com.alibaba.nacos.common.notify.NotifyCenter;
-import com.alibaba.nacos.common.spi.NacosServiceLoader;
-import com.alibaba.nacos.common.utils.StringUtils;
-import com.alibaba.nacos.plugin.control.configs.ControlConfigs;
 import com.alibaba.nacos.plugin.control.connection.ConnectionControlManager;
 import com.alibaba.nacos.plugin.control.connection.DefaultConnectionControlManager;
+import com.alibaba.nacos.plugin.control.connection.request.ConnectionCheckRequest;
+import com.alibaba.nacos.plugin.control.connection.response.ConnectionCheckResponse;
+import com.alibaba.nacos.plugin.control.connection.rule.ConnectionControlRule;
 import com.alibaba.nacos.plugin.control.event.ConnectionLimitRuleChangeEvent;
 import com.alibaba.nacos.plugin.control.event.TpsControlRuleChangeEvent;
+import com.alibaba.nacos.plugin.control.rule.parser.ConnectionControlRuleParser;
+import com.alibaba.nacos.plugin.control.rule.parser.TpsControlRuleParser;
 import com.alibaba.nacos.plugin.control.rule.storage.RuleStorageProxy;
-import com.alibaba.nacos.plugin.control.spi.ControlManagerBuilder;
-import com.alibaba.nacos.plugin.control.tps.TpsControlManager;
 import com.alibaba.nacos.plugin.control.tps.DefaultTpsControlManager;
+import com.alibaba.nacos.plugin.control.tps.TpsControlManager;
+import com.alibaba.nacos.plugin.control.tps.barrier.TpsBarrier;
+import com.alibaba.nacos.plugin.control.tps.request.TpsCheckRequest;
+import com.alibaba.nacos.plugin.control.tps.response.TpsCheckResponse;
+import com.alibaba.nacos.plugin.control.tps.rule.TpsControlRule;
 
-import java.util.Optional;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * control manager center.
@@ -42,66 +51,27 @@ public class ControlManagerCenter {
     
     private final RuleStorageProxy ruleStorageProxy;
     
-    private TpsControlManager tpsControlManager;
+    private final Object installationMonitor = new Object();
     
-    private ConnectionControlManager connectionControlManager;
+    private final Set<String> registeredTpsPoints = new LinkedHashSet<>();
     
-    private ControlManagerCenter() {
+    private final ConnectionControlManager bootstrapConnectionControlManager;
+    
+    private final TpsControlManager bootstrapTpsControlManager;
+    
+    private final AtomicReference<ControlManagerBundle> managerBundle;
+    
+    private final TpsControlManager tpsControlManagerFacade;
+    
+    private final ConnectionControlManager connectionControlManagerFacade;
+    
+    ControlManagerCenter() {
         ruleStorageProxy = RuleStorageProxy.getInstance();
-        Optional<ControlManagerBuilder> controlManagerBuilder = findTargetControlManagerBuilder();
-        if (controlManagerBuilder.isPresent()) {
-            initConnectionManager(controlManagerBuilder.get());
-            initTpsControlManager(controlManagerBuilder.get());
-        } else {
-            buildNoLimitControlManagers();
-        }
-    }
-    
-    private void initConnectionManager(ControlManagerBuilder controlManagerBuilder) {
-        try {
-            connectionControlManager = controlManagerBuilder.buildConnectionControlManager();
-            Loggers.CONTROL.info("Build connection control manager, class={}",
-                connectionControlManager.getClass().getCanonicalName());
-        } catch (Exception e) {
-            Loggers.CONTROL
-                .warn("Build connection control manager failed, use no limit manager replaced.", e);
-            connectionControlManager = new DefaultConnectionControlManager();
-        }
-    }
-    
-    private void initTpsControlManager(ControlManagerBuilder controlManagerBuilder) {
-        try {
-            tpsControlManager = controlManagerBuilder.buildTpsControlManager();
-            Loggers.CONTROL
-                .info("Build tps control manager, class={}",
-                    tpsControlManager.getClass().getCanonicalName());
-        } catch (Exception e) {
-            Loggers.CONTROL.warn("Build tps control manager failed, use no limit manager replaced.",
-                e);
-            tpsControlManager = new DefaultTpsControlManager();
-        }
-    }
-    
-    private Optional<ControlManagerBuilder> findTargetControlManagerBuilder() {
-        String controlManagerType = ControlConfigs.getInstance().getControlManagerType();
-        if (StringUtils.isEmpty(controlManagerType)) {
-            Loggers.CONTROL
-                .info("Not configure type of control plugin, no limit control for current node.");
-            return Optional.empty();
-        }
-        for (ControlManagerBuilder each : NacosServiceLoader.load(ControlManagerBuilder.class)) {
-            Loggers.CONTROL.info("Found control manager plugin of name={}", each.getName());
-            if (controlManagerType.equalsIgnoreCase(each.getName())) {
-                return Optional.of(each);
-            }
-        }
-        Loggers.CONTROL.warn("Not found control manager plugin of name");
-        return Optional.empty();
-    }
-    
-    private void buildNoLimitControlManagers() {
-        connectionControlManager = new DefaultConnectionControlManager();
-        tpsControlManager = new DefaultTpsControlManager();
+        bootstrapConnectionControlManager = new BootstrapConnectionControlManager();
+        bootstrapTpsControlManager = new DefaultTpsControlManager();
+        managerBundle = new AtomicReference<>();
+        tpsControlManagerFacade = new DelegatingTpsControlManager();
+        connectionControlManagerFacade = new DelegatingConnectionControlManager();
     }
     
     public RuleStorageProxy getRuleStorageProxy() {
@@ -109,11 +79,11 @@ public class ControlManagerCenter {
     }
     
     public TpsControlManager getTpsControlManager() {
-        return tpsControlManager;
+        return tpsControlManagerFacade;
     }
     
     public ConnectionControlManager getConnectionControlManager() {
-        return connectionControlManager;
+        return connectionControlManagerFacade;
     }
     
     public static ControlManagerCenter getInstance() {
@@ -127,12 +97,130 @@ public class ControlManagerCenter {
         return instance;
     }
     
+    /**
+     * Install the selected startup manager bundle.
+     *
+     * @param targetManagerBundle selected manager bundle
+     */
+    public void install(ControlManagerBundle targetManagerBundle) {
+        Objects.requireNonNull(targetManagerBundle, "Control manager bundle cannot be null");
+        synchronized (installationMonitor) {
+            if (managerBundle.get() != null) {
+                throw new IllegalStateException(
+                    "Control manager bundle has already been installed");
+            }
+            for (String pointName : registeredTpsPoints) {
+                targetManagerBundle.getTpsControlManager().registerTpsPoint(pointName);
+            }
+            managerBundle.set(targetManagerBundle);
+            Loggers.CONTROL.info(
+                "Installed control manager bundle, connection={}, tps={}",
+                targetManagerBundle.getConnectionControlManager().getName(),
+                targetManagerBundle.getTpsControlManager().getName());
+        }
+    }
+    
     public void reloadTpsControlRule(String pointName, boolean external) {
         NotifyCenter.publishEvent(new TpsControlRuleChangeEvent(pointName, external));
     }
     
     public void reloadConnectionControlRule(boolean external) {
         NotifyCenter.publishEvent(new ConnectionLimitRuleChangeEvent(external));
+    }
+    
+    private TpsControlManager currentTpsControlManager() {
+        ControlManagerBundle current = managerBundle.get();
+        return current == null ? bootstrapTpsControlManager : current.getTpsControlManager();
+    }
+    
+    private ConnectionControlManager currentConnectionControlManager() {
+        ControlManagerBundle current = managerBundle.get();
+        return current == null ? bootstrapConnectionControlManager
+            : current.getConnectionControlManager();
+    }
+    
+    private final class DelegatingTpsControlManager extends TpsControlManager {
+        
+        @Override
+        public TpsControlRuleParser getTpsControlRuleParser() {
+            return currentTpsControlManager().getTpsControlRuleParser();
+        }
+        
+        @Override
+        public void registerTpsPoint(String pointName) {
+            synchronized (installationMonitor) {
+                registeredTpsPoints.add(pointName);
+                ControlManagerBundle current = managerBundle.get();
+                if (current != null) {
+                    current.getTpsControlManager().registerTpsPoint(pointName);
+                }
+            }
+        }
+        
+        @Override
+        public Map<String, TpsBarrier> getPoints() {
+            return currentTpsControlManager().getPoints();
+        }
+        
+        @Override
+        public Map<String, TpsControlRule> getRules() {
+            return currentTpsControlManager().getRules();
+        }
+        
+        @Override
+        public void applyTpsRule(String pointName, TpsControlRule rule) {
+            currentTpsControlManager().applyTpsRule(pointName, rule);
+        }
+        
+        @Override
+        public TpsCheckResponse check(TpsCheckRequest tpsRequest) {
+            return currentTpsControlManager().check(tpsRequest);
+        }
+        
+        @Override
+        public String getName() {
+            return currentTpsControlManager().getName();
+        }
+    }
+    
+    private final class DelegatingConnectionControlManager extends ConnectionControlManager {
+        
+        private DelegatingConnectionControlManager() {
+            super(false);
+        }
+        
+        @Override
+        public String getName() {
+            return currentConnectionControlManager().getName();
+        }
+        
+        @Override
+        public ConnectionControlRuleParser getConnectionControlRuleParser() {
+            return currentConnectionControlManager().getConnectionControlRuleParser();
+        }
+        
+        @Override
+        public ConnectionControlRule getConnectionLimitRule() {
+            return currentConnectionControlManager().getConnectionLimitRule();
+        }
+        
+        @Override
+        public void applyConnectionLimitRule(ConnectionControlRule connectionControlRule) {
+            currentConnectionControlManager().applyConnectionLimitRule(connectionControlRule);
+        }
+        
+        @Override
+        public ConnectionCheckResponse check(ConnectionCheckRequest connectionCheckRequest) {
+            return currentConnectionControlManager().check(connectionCheckRequest);
+        }
+    }
+    
+    private static final class BootstrapConnectionControlManager
+        extends DefaultConnectionControlManager {
+        
+        private BootstrapConnectionControlManager() {
+            super(false);
+        }
     }
     
 }

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/ControlPluginAdapter.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/ControlPluginAdapter.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control;
+
+import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
+import com.alibaba.nacos.api.plugin.ConfigItemEffectMode;
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
+import com.alibaba.nacos.api.plugin.PluginStartupLifecycle;
+import com.alibaba.nacos.plugin.control.connection.ConnectionControlManager;
+import com.alibaba.nacos.plugin.control.connection.DefaultConnectionControlManager;
+import com.alibaba.nacos.plugin.control.spi.ControlManagerBuilder;
+import com.alibaba.nacos.plugin.control.tps.DefaultTpsControlManager;
+import com.alibaba.nacos.plugin.control.tps.TpsControlManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Stable plugin adapter for one control manager builder.
+ *
+ * @author Nacos
+ */
+public final class ControlPluginAdapter implements PluginConfigSpec, PluginStartupLifecycle {
+    
+    private final ControlManagerBuilder builder;
+    
+    private final ControlManagerCenter managerCenter;
+    
+    private final List<ConfigItemDefinition> configDefinitions;
+    
+    private volatile Map<String, String> currentConfig = Collections.emptyMap();
+    
+    private boolean initialized;
+    
+    /**
+     * Create control plugin adapter.
+     *
+     * @param builder control manager builder
+     */
+    public ControlPluginAdapter(ControlManagerBuilder builder) {
+        this(builder, ControlManagerCenter.getInstance());
+    }
+    
+    ControlPluginAdapter(ControlManagerBuilder builder, ControlManagerCenter managerCenter) {
+        this.builder = Objects.requireNonNull(builder, "Control manager builder cannot be null");
+        this.managerCenter =
+            Objects.requireNonNull(managerCenter, "Control manager center cannot be null");
+        this.configDefinitions = validateConfigDefinitions(builder);
+    }
+    
+    /**
+     * Get control plugin name.
+     *
+     * @return plugin name
+     */
+    public String getPluginName() {
+        return builder.getName();
+    }
+    
+    @Override
+    public List<ConfigItemDefinition> getConfigDefinitions() {
+        return configDefinitions;
+    }
+    
+    @Override
+    public void applyConfig(Map<String, String> config) {
+        Map<String, String> target =
+            config == null ? Collections.emptyMap() : new LinkedHashMap<>(config);
+        currentConfig = Collections.unmodifiableMap(target);
+    }
+    
+    @Override
+    public Map<String, String> getCurrentConfig() {
+        return new LinkedHashMap<>(currentConfig);
+    }
+    
+    @Override
+    public synchronized void initialize() {
+        if (initialized) {
+            return;
+        }
+        Map<String, String> configSnapshot = currentConfig;
+        ConnectionControlManager connectionControlManager =
+            buildConnectionControlManager(configSnapshot);
+        TpsControlManager tpsControlManager = buildTpsControlManager(configSnapshot);
+        managerCenter.install(
+            new ControlManagerBundle(connectionControlManager, tpsControlManager));
+        initialized = true;
+    }
+    
+    private ConnectionControlManager buildConnectionControlManager(
+        Map<String, String> configSnapshot) {
+        try {
+            ConnectionControlManager result =
+                builder.buildConnectionControlManager(configSnapshot);
+            if (result != null) {
+                return result;
+            }
+            Loggers.CONTROL.warn(
+                "Control plugin '{}' returned null connection manager, use no-limit manager.",
+                getPluginName());
+        } catch (RuntimeException e) {
+            Loggers.CONTROL.warn(
+                "Control plugin '{}' failed to build connection manager, use no-limit manager.",
+                getPluginName(), e);
+        }
+        return new DefaultConnectionControlManager();
+    }
+    
+    private TpsControlManager buildTpsControlManager(Map<String, String> configSnapshot) {
+        try {
+            TpsControlManager result = builder.buildTpsControlManager(configSnapshot);
+            if (result != null) {
+                return result;
+            }
+            Loggers.CONTROL.warn(
+                "Control plugin '{}' returned null TPS manager, use no-limit manager.",
+                getPluginName());
+        } catch (RuntimeException e) {
+            Loggers.CONTROL.warn(
+                "Control plugin '{}' failed to build TPS manager, use no-limit manager.",
+                getPluginName(), e);
+        }
+        return new DefaultTpsControlManager();
+    }
+    
+    private static List<ConfigItemDefinition> validateConfigDefinitions(
+        ControlManagerBuilder builder) {
+        List<ConfigItemDefinition> definitions = builder.getConfigDefinitions();
+        if (definitions == null || definitions.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<ConfigItemDefinition> result = new ArrayList<>(definitions.size());
+        for (ConfigItemDefinition definition : definitions) {
+            if (definition == null) {
+                throw new IllegalStateException(
+                    "Control plugin config definition cannot be null: " + builder.getName());
+            }
+            if (ConfigItemEffectMode.RESTART != definition.getEffectMode()) {
+                throw new IllegalStateException(
+                    "Control plugin config must use RESTART effect mode: " + builder.getName()
+                        + ":" + definition.getKey());
+            }
+            result.add(definition);
+        }
+        return Collections.unmodifiableList(result);
+    }
+}

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/connection/ConnectionControlManager.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/connection/ConnectionControlManager.java
@@ -28,6 +28,7 @@ import com.alibaba.nacos.plugin.control.rule.parser.NacosConnectionControlRulePa
 import com.alibaba.nacos.plugin.control.rule.storage.RuleStorageProxy;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -49,11 +50,24 @@ public abstract class ConnectionControlManager {
     private ScheduledExecutorService executorService;
     
     public ConnectionControlManager() {
+        this(true);
+    }
+    
+    /**
+     * Construct connection control manager.
+     *
+     * @param initialize whether to load rules, metrics collectors and reporter resources
+     */
+    protected ConnectionControlManager(boolean initialize) {
+        this.connectionControlRuleParser = buildConnectionControlRuleParser();
+        if (!initialize) {
+            metricsCollectorList = Collections.emptyList();
+            return;
+        }
         metricsCollectorList = NacosServiceLoader.load(ConnectionMetricsCollector.class);
         Loggers.CONTROL.info("Load connection metrics collector,size={},{}",
             metricsCollectorList.size(),
             metricsCollectorList);
-        this.connectionControlRuleParser = buildConnectionControlRuleParser();
         initConnectionRule();
         if (!metricsCollectorList.isEmpty()) {
             initExecuteService();

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/connection/DefaultConnectionControlManager.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/connection/DefaultConnectionControlManager.java
@@ -39,6 +39,15 @@ public class DefaultConnectionControlManager extends ConnectionControlManager {
         super();
     }
     
+    /**
+     * Construct a no-limit manager with optional runtime resource initialization.
+     *
+     * @param initialize whether to initialize runtime resources
+     */
+    protected DefaultConnectionControlManager(boolean initialize) {
+        super(initialize);
+    }
+    
     @Override
     public void applyConnectionLimitRule(ConnectionControlRule connectionControlRule) {
         super.connectionControlRule = connectionControlRule;

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/spi/ControlManagerBuilder.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/spi/ControlManagerBuilder.java
@@ -16,15 +16,18 @@
 
 package com.alibaba.nacos.plugin.control.spi;
 
+import com.alibaba.nacos.api.plugin.PluginConfigDefinitionSpec;
 import com.alibaba.nacos.plugin.control.connection.ConnectionControlManager;
 import com.alibaba.nacos.plugin.control.tps.TpsControlManager;
+
+import java.util.Map;
 
 /**
  * Nacos control plugin manager builder SPI.
  *
  * @author xiweng.yy
  */
-public interface ControlManagerBuilder {
+public interface ControlManagerBuilder extends PluginConfigDefinitionSpec {
     
     /**
      * Get plugin name.
@@ -41,9 +44,29 @@ public interface ControlManagerBuilder {
     ConnectionControlManager buildConnectionControlManager();
     
     /**
+     * Build {@link ConnectionControlManager} with effective plugin configuration.
+     *
+     * @param config canonical effective plugin configuration
+     * @return ConnectionControlManager implementation
+     */
+    default ConnectionControlManager buildConnectionControlManager(Map<String, String> config) {
+        return buildConnectionControlManager();
+    }
+    
+    /**
      * Build {@link TpsControlManager} implementation for current plugin.
      *
      * @return TpsControlManager implementation
      */
     TpsControlManager buildTpsControlManager();
+    
+    /**
+     * Build {@link TpsControlManager} with effective plugin configuration.
+     *
+     * @param config canonical effective plugin configuration
+     * @return TpsControlManager implementation
+     */
+    default TpsControlManager buildTpsControlManager(Map<String, String> config) {
+        return buildTpsControlManager();
+    }
 }

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/spi/ControlPluginProvider.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/spi/ControlPluginProvider.java
@@ -18,11 +18,13 @@ package com.alibaba.nacos.plugin.control.spi;
 
 import com.alibaba.nacos.api.plugin.PluginProvider;
 import com.alibaba.nacos.api.plugin.PluginType;
-import com.alibaba.nacos.common.spi.NacosServiceLoader;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.control.ControlPluginAdapter;
+import com.alibaba.nacos.plugin.control.Loggers;
+import com.alibaba.nacos.plugin.control.configs.ControlConfigs;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Control plugin provider implementation.
@@ -30,7 +32,17 @@ import java.util.Map;
  * @author WangzJi
  * @since 3.2.0
  */
-public class ControlPluginProvider implements PluginProvider<ControlManagerBuilder> {
+public class ControlPluginProvider implements PluginProvider<ControlPluginAdapter> {
+    
+    private final Supplier<ControlPluginRegistry> registrySupplier;
+    
+    public ControlPluginProvider() {
+        this(ControlPluginRegistry::getInstance);
+    }
+    
+    ControlPluginProvider(Supplier<ControlPluginRegistry> registrySupplier) {
+        this.registrySupplier = registrySupplier;
+    }
     
     @Override
     public PluginType getPluginType() {
@@ -38,12 +50,14 @@ public class ControlPluginProvider implements PluginProvider<ControlManagerBuild
     }
     
     @Override
-    public Map<String, ControlManagerBuilder> getAllPlugins() {
-        Collection<ControlManagerBuilder> builders =
-            NacosServiceLoader.load(ControlManagerBuilder.class);
-        Map<String, ControlManagerBuilder> result = new HashMap<>(builders.size());
-        for (ControlManagerBuilder builder : builders) {
-            result.put(builder.getName(), builder);
+    public Map<String, ControlPluginAdapter> getAllPlugins() {
+        Map<String, ControlPluginAdapter> result = registrySupplier.get().getPlugins();
+        String selectedPlugin = ControlConfigs.getInstance().getControlManagerType();
+        if (StringUtils.isNotBlank(selectedPlugin)
+            && result.keySet().stream().noneMatch(selectedPlugin::equalsIgnoreCase)) {
+            Loggers.CONTROL.warn(
+                "Selected control plugin '{}' was not found, use no-limit managers.",
+                selectedPlugin);
         }
         return result;
     }

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/spi/ControlPluginRegistry.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/spi/ControlPluginRegistry.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.spi;
+
+import com.alibaba.nacos.common.spi.NacosServiceLoader;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.control.ControlPluginAdapter;
+import com.alibaba.nacos.plugin.control.Loggers;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Single registry for control manager builders and stable plugin adapters.
+ *
+ * @author Nacos
+ */
+public final class ControlPluginRegistry {
+    
+    private final Map<String, ControlPluginAdapter> plugins;
+    
+    ControlPluginRegistry(Collection<ControlManagerBuilder> builders) {
+        Map<String, ControlPluginAdapter> result = new LinkedHashMap<>();
+        Map<String, String> normalizedNames = new LinkedHashMap<>();
+        if (builders != null) {
+            for (ControlManagerBuilder builder : builders) {
+                registerBuilder(result, normalizedNames, builder);
+            }
+        }
+        plugins = Collections.unmodifiableMap(result);
+    }
+    
+    public static ControlPluginRegistry getInstance() {
+        return RegistryHolder.INSTANCE;
+    }
+    
+    /**
+     * Get stable control plugin adapters.
+     *
+     * @return plugin name to adapter map
+     */
+    public Map<String, ControlPluginAdapter> getPlugins() {
+        return plugins;
+    }
+    
+    private void registerBuilder(Map<String, ControlPluginAdapter> result,
+        Map<String, String> normalizedNames, ControlManagerBuilder builder) {
+        if (builder == null) {
+            throw new IllegalStateException("Control manager builder cannot be null");
+        }
+        String pluginName = builder.getName();
+        if (StringUtils.isBlank(pluginName)) {
+            throw new IllegalStateException(
+                "Control manager builder name cannot be blank: " + builder.getClass().getName());
+        }
+        String normalizedName = pluginName.toLowerCase(Locale.ROOT);
+        String existingName = normalizedNames.putIfAbsent(normalizedName, pluginName);
+        if (existingName != null) {
+            throw new IllegalStateException(
+                "Duplicate control plugin name: " + existingName + ", " + pluginName);
+        }
+        result.put(pluginName, new ControlPluginAdapter(builder));
+        Loggers.CONTROL.info("Found control manager plugin, name={}, class={}", pluginName,
+            builder.getClass().getName());
+    }
+    
+    private static final class RegistryHolder {
+        
+        private static final ControlPluginRegistry INSTANCE =
+            new ControlPluginRegistry(NacosServiceLoader.load(ControlManagerBuilder.class));
+    }
+}

--- a/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/spi/ControlPluginTypePolicy.java
+++ b/plugin/control/src/main/java/com/alibaba/nacos/plugin/control/spi/ControlPluginTypePolicy.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.api.plugin.PluginTypeConfiguration;
 import com.alibaba.nacos.api.plugin.PluginTypePolicy;
 import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.control.Loggers;
 
 /**
  * Control plugin type policy.
@@ -28,7 +29,26 @@ import com.alibaba.nacos.common.utils.StringUtils;
  */
 public class ControlPluginTypePolicy implements PluginTypePolicy {
     
-    public static final String CONTROL_TYPE_PROPERTY = "nacos.plugin.control.manager.type";
+    public static final String CONTROL_TYPE_PROPERTY = "nacos.plugin.control.type";
+    
+    public static final String LEGACY_CONTROL_TYPE_PROPERTY =
+        "nacos.plugin.control.manager.type";
+    
+    private String selectedPlugin = "";
+    
+    @Override
+    public void initialize(PluginTypeConfiguration configuration) {
+        if (configuration.containsProperty(CONTROL_TYPE_PROPERTY)) {
+            selectedPlugin = normalize(configuration.getProperty(CONTROL_TYPE_PROPERTY));
+            return;
+        }
+        selectedPlugin = normalize(configuration.getProperty(LEGACY_CONTROL_TYPE_PROPERTY));
+        if (StringUtils.isNotBlank(selectedPlugin)) {
+            Loggers.CONTROL.warn(
+                "Control plugin selection uses deprecated key '{}'; migrate to '{}'.",
+                LEGACY_CONTROL_TYPE_PROPERTY, CONTROL_TYPE_PROPERTY);
+        }
+    }
     
     @Override
     public PluginType getPluginType() {
@@ -38,12 +58,21 @@ public class ControlPluginTypePolicy implements PluginTypePolicy {
     @Override
     public boolean isPluginEnabledByDefault(String pluginName,
         PluginTypeConfiguration configuration) {
-        String selected = configuration.getProperty(CONTROL_TYPE_PROPERTY);
-        return StringUtils.isNotBlank(selected) && pluginName.equalsIgnoreCase(selected.trim());
+        return StringUtils.isNotBlank(selectedPlugin)
+            && pluginName.equalsIgnoreCase(selectedPlugin);
+    }
+    
+    @Override
+    public boolean isLoadingEnabled(PluginTypeConfiguration configuration) {
+        return StringUtils.isNotBlank(selectedPlugin);
     }
     
     @Override
     public String getSelectionProperty() {
         return CONTROL_TYPE_PROPERTY;
+    }
+    
+    private String normalize(String value) {
+        return StringUtils.isBlank(value) ? "" : value.trim();
     }
 }

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlManagerCenterTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlManagerCenterTest.java
@@ -19,10 +19,18 @@ package com.alibaba.nacos.plugin.control;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.plugin.control.configs.ControlConfigs;
 import com.alibaba.nacos.plugin.control.connection.ConnectionControlManager;
+import com.alibaba.nacos.plugin.control.connection.DefaultConnectionControlManager;
+import com.alibaba.nacos.plugin.control.connection.request.ConnectionCheckRequest;
+import com.alibaba.nacos.plugin.control.connection.response.ConnectionCheckCode;
+import com.alibaba.nacos.plugin.control.connection.response.ConnectionCheckResponse;
 import com.alibaba.nacos.plugin.control.connection.rule.ConnectionControlRule;
 import com.alibaba.nacos.plugin.control.rule.storage.RuleStorageProxy;
 import com.alibaba.nacos.plugin.control.tps.MonitorType;
 import com.alibaba.nacos.plugin.control.tps.TpsControlManager;
+import com.alibaba.nacos.plugin.control.tps.barrier.TpsBarrier;
+import com.alibaba.nacos.plugin.control.tps.request.TpsCheckRequest;
+import com.alibaba.nacos.plugin.control.tps.response.TpsCheckResponse;
+import com.alibaba.nacos.plugin.control.tps.response.TpsResultCode;
 import com.alibaba.nacos.plugin.control.tps.rule.RuleDetail;
 import com.alibaba.nacos.plugin.control.tps.rule.TpsControlRule;
 import com.alibaba.nacos.plugin.control.utils.EnvUtils;
@@ -35,10 +43,17 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ControlManagerCenterTest {
     
@@ -86,14 +101,50 @@ class ControlManagerCenterTest {
     }
     
     @Test
-    void testGetInstance() {
-        ControlConfigs.getInstance().setControlManagerType("test");
+    void testInstallKeepsStableFacadesAndReplaysRegisteredPoints() {
         ControlManagerCenter controlManagerCenter = ControlManagerCenter.getInstance();
-        ConnectionControlManager connectionControlManager =
+        ConnectionControlManager connectionFacade =
             controlManagerCenter.getConnectionControlManager();
-        assertEquals("testConnection", connectionControlManager.getName());
-        TpsControlManager tpsControlManager = controlManagerCenter.getTpsControlManager();
-        assertEquals("testTps", tpsControlManager.getName());
+        TpsControlManager tpsFacade = controlManagerCenter.getTpsControlManager();
+        tpsFacade.registerTpsPoint("before-install");
+        assertEquals(Collections.emptyMap(), tpsFacade.getPoints());
+        TestConnectionControlManager connectionTarget =
+            new TestConnectionControlManager("testConnection");
+        TestTpsControlManager tpsTarget = new TestTpsControlManager("testTps");
+        
+        controlManagerCenter.install(
+            new ControlManagerBundle(connectionTarget, tpsTarget));
+        
+        assertSame(connectionFacade, controlManagerCenter.getConnectionControlManager());
+        assertSame(tpsFacade, controlManagerCenter.getTpsControlManager());
+        assertEquals("testConnection", connectionFacade.getName());
+        assertEquals("testTps", tpsFacade.getName());
+        assertEquals(Collections.singletonList("before-install"),
+            tpsTarget.getRegisteredPoints());
+        assertSame(connectionTarget.getConnectionControlRuleParser(),
+            connectionFacade.getConnectionControlRuleParser());
+        assertSame(tpsTarget.getTpsControlRuleParser(), tpsFacade.getTpsControlRuleParser());
+        
+        ConnectionControlRule connectionRule = new ConnectionControlRule();
+        connectionRule.setCountLimit(10);
+        connectionFacade.applyConnectionLimitRule(connectionRule);
+        assertSame(connectionRule, connectionFacade.getConnectionLimitRule());
+        assertEquals(ConnectionCheckCode.CHECK_SKIP,
+            connectionFacade.check(
+                new ConnectionCheckRequest("127.0.0.1", "test", "test")).getCode());
+        
+        tpsFacade.registerTpsPoint("after-install");
+        assertEquals(java.util.Arrays.asList("before-install", "after-install"),
+            tpsTarget.getRegisteredPoints());
+        assertSame(tpsTarget.getPoints(), tpsFacade.getPoints());
+        assertSame(tpsTarget.getRules(), tpsFacade.getRules());
+        tpsFacade.applyTpsRule("point", null);
+        assertEquals(TpsResultCode.CHECK_SKIP,
+            tpsFacade.check(new TpsCheckRequest()).getCode());
+        
+        assertThrows(IllegalStateException.class,
+            () -> controlManagerCenter.install(
+                new ControlManagerBundle(connectionTarget, tpsTarget)));
         assertNotNull(controlManagerCenter.getRuleStorageProxy());
     }
     
@@ -108,13 +159,28 @@ class ControlManagerCenterTest {
     }
     
     @Test
-    void testGetInstanceFallbackWhenBuilderThrows() {
-        ControlConfigs.getInstance().setControlManagerType("throw");
-        
+    void testInstallRejectsNullBundle() {
         ControlManagerCenter controlManagerCenter = ControlManagerCenter.getInstance();
         
-        assertEquals("noLimit", controlManagerCenter.getConnectionControlManager().getName());
-        assertEquals("noLimit", controlManagerCenter.getTpsControlManager().getName());
+        assertThrows(NullPointerException.class, () -> controlManagerCenter.install(null));
+    }
+    
+    @Test
+    void testConnectionManagerLoadsExternalRule() throws Exception {
+        String localRuleStorageBaseDir =
+            EnvUtils.getNacosHome() + File.separator + "tmpConnection" + File.separator
+                + "externalStartup" + File.separator;
+        ControlConfigs.getInstance().setLocalRuleStorageBaseDir(localRuleStorageBaseDir);
+        ControlConfigs.getInstance().setRuleExternalStorage("test");
+        resetRuleStorageProxy();
+        ConnectionControlRule rule = new ConnectionControlRule();
+        rule.setCountLimit(300);
+        RuleStorageProxy.getInstance().getExternalStorage().saveConnectionRule(
+            JacksonUtils.toJson(rule));
+        
+        ConnectionControlManager manager = new DefaultConnectionControlManager();
+        
+        assertEquals(300, manager.getConnectionLimitRule().getCountLimit());
     }
     
     @Test
@@ -288,5 +354,83 @@ class ControlManagerCenterTest {
         ConnectionControlRule connectionLimitRule3 =
             connectionControlManager.getConnectionLimitRule();
         assertEquals(200, connectionLimitRule3.getCountLimit());
+    }
+    
+    private static final class TestConnectionControlManager extends ConnectionControlManager {
+        
+        private final String name;
+        
+        private TestConnectionControlManager(String name) {
+            super(false);
+            this.name = name;
+        }
+        
+        @Override
+        public String getName() {
+            return name;
+        }
+        
+        @Override
+        public void applyConnectionLimitRule(ConnectionControlRule connectionControlRule) {
+            this.connectionControlRule = connectionControlRule;
+        }
+        
+        @Override
+        public ConnectionCheckResponse check(ConnectionCheckRequest connectionCheckRequest) {
+            ConnectionCheckResponse result = new ConnectionCheckResponse();
+            result.setSuccess(true);
+            result.setCode(ConnectionCheckCode.CHECK_SKIP);
+            return result;
+        }
+    }
+    
+    private static final class TestTpsControlManager extends TpsControlManager {
+        
+        private final String name;
+        
+        private final List<String> registeredPoints = new ArrayList<>();
+        
+        private final Map<String, TpsBarrier> points = Collections.emptyMap();
+        
+        private final Map<String, TpsControlRule> rules = Collections.emptyMap();
+        
+        private TestTpsControlManager(String name) {
+            this.name = name;
+        }
+        
+        @Override
+        public void registerTpsPoint(String pointName) {
+            registeredPoints.add(pointName);
+        }
+        
+        @Override
+        public Map<String, TpsBarrier> getPoints() {
+            return points;
+        }
+        
+        @Override
+        public Map<String, TpsControlRule> getRules() {
+            return rules;
+        }
+        
+        @Override
+        public void applyTpsRule(String pointName, TpsControlRule rule) {
+            assertEquals("point", pointName);
+            assertNull(rule);
+        }
+        
+        @Override
+        public TpsCheckResponse check(TpsCheckRequest tpsRequest) {
+            return new TpsCheckResponse(true, TpsResultCode.CHECK_SKIP, "skip");
+        }
+        
+        @Override
+        public String getName() {
+            return name;
+        }
+        
+        private List<String> getRegisteredPoints() {
+            return registeredPoints;
+        }
     }
 }

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlPluginAdapterTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/ControlPluginAdapterTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control;
+
+import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
+import com.alibaba.nacos.api.plugin.ConfigItemEffectMode;
+import com.alibaba.nacos.api.plugin.ConfigItemType;
+import com.alibaba.nacos.plugin.control.connection.ConnectionControlManager;
+import com.alibaba.nacos.plugin.control.spi.ControlManagerBuilder;
+import com.alibaba.nacos.plugin.control.tps.TpsControlManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ControlPluginAdapterTest {
+    
+    @Test
+    void testApplyConfigBeforeIdempotentInitialization() {
+        ConfigItemDefinition definition =
+            new ConfigItemDefinition("endpoint", "Endpoint", ConfigItemType.STRING);
+        RecordingBuilder builder =
+            new RecordingBuilder(Collections.singletonList(definition));
+        ControlManagerCenter managerCenter = new ControlManagerCenter();
+        ControlPluginAdapter adapter = new ControlPluginAdapter(builder, managerCenter);
+        Map<String, String> input = new LinkedHashMap<>();
+        input.put("endpoint", "first");
+        
+        adapter.applyConfig(input);
+        input.put("endpoint", "changed");
+        Map<String, String> returnedConfig = adapter.getCurrentConfig();
+        returnedConfig.put("endpoint", "returned-change");
+        adapter.initialize();
+        adapter.initialize();
+        
+        assertEquals("test", adapter.getPluginName());
+        assertEquals(Collections.singletonList(definition), adapter.getConfigDefinitions());
+        assertThrows(UnsupportedOperationException.class,
+            () -> adapter.getConfigDefinitions().add(definition));
+        assertEquals("first", adapter.getCurrentConfig().get("endpoint"));
+        assertNotSame(returnedConfig, adapter.getCurrentConfig());
+        assertEquals(Collections.singletonMap("endpoint", "first"), builder.getReceivedConfig());
+        assertEquals(1, builder.getConnectionBuildCount());
+        assertEquals(1, builder.getTpsBuildCount());
+        assertEquals("testConnection",
+            managerCenter.getConnectionControlManager().getName());
+        assertEquals("testTps", managerCenter.getTpsControlManager().getName());
+    }
+    
+    @Test
+    void testNullConfigAndDefinitions() {
+        RecordingBuilder builder = new RecordingBuilder(null);
+        ControlPluginAdapter adapter =
+            new ControlPluginAdapter(builder, new ControlManagerCenter());
+        
+        adapter.applyConfig(null);
+        
+        assertTrue(adapter.getConfigDefinitions().isEmpty());
+        assertTrue(adapter.getCurrentConfig().isEmpty());
+    }
+    
+    @Test
+    void testNullConnectionAndThrowingTpsFallbackIndependently() {
+        FailureBuilder builder = new FailureBuilder(false, true);
+        ControlManagerCenter managerCenter = new ControlManagerCenter();
+        ControlPluginAdapter adapter = new ControlPluginAdapter(builder, managerCenter);
+        
+        adapter.initialize();
+        
+        assertEquals("noLimit", managerCenter.getConnectionControlManager().getName());
+        assertEquals("noLimit", managerCenter.getTpsControlManager().getName());
+    }
+    
+    @Test
+    void testThrowingConnectionAndNullTpsFallbackIndependently() {
+        FailureBuilder builder = new FailureBuilder(true, false);
+        ControlManagerCenter managerCenter = new ControlManagerCenter();
+        ControlPluginAdapter adapter = new ControlPluginAdapter(builder, managerCenter);
+        
+        adapter.initialize();
+        
+        assertEquals("noLimit", managerCenter.getConnectionControlManager().getName());
+        assertEquals("noLimit", managerCenter.getTpsControlManager().getName());
+    }
+    
+    @Test
+    void testRejectInvalidDependenciesAndDefinitions() {
+        RecordingBuilder validBuilder =
+            new RecordingBuilder(Collections.emptyList());
+        assertThrows(NullPointerException.class, () -> new ControlPluginAdapter(null));
+        assertThrows(NullPointerException.class,
+            () -> new ControlPluginAdapter(validBuilder, null));
+        
+        List<ConfigItemDefinition> nullItemDefinitions = new ArrayList<>();
+        nullItemDefinitions.add(null);
+        assertThrows(IllegalStateException.class,
+            () -> new ControlPluginAdapter(new RecordingBuilder(nullItemDefinitions),
+                new ControlManagerCenter()));
+        
+        ConfigItemDefinition runtimeDefinition =
+            new ConfigItemDefinition("runtime", "Runtime", ConfigItemType.STRING);
+        runtimeDefinition.setEffectMode(ConfigItemEffectMode.RUNTIME);
+        assertThrows(IllegalStateException.class,
+            () -> new ControlPluginAdapter(
+                new RecordingBuilder(Collections.singletonList(runtimeDefinition)),
+                new ControlManagerCenter()));
+    }
+    
+    @Test
+    void testControlManagerBundleRejectsNullManager() {
+        ControlManagerBuilderTest builder = new ControlManagerBuilderTest();
+        ConnectionControlManager connectionManager =
+            builder.buildConnectionControlManager();
+        TpsControlManager tpsManager = builder.buildTpsControlManager();
+        
+        assertThrows(NullPointerException.class,
+            () -> new ControlManagerBundle(null, tpsManager));
+        assertThrows(NullPointerException.class,
+            () -> new ControlManagerBundle(connectionManager, null));
+    }
+    
+    private static class RecordingBuilder extends ControlManagerBuilderTest {
+        
+        private final List<ConfigItemDefinition> definitions;
+        
+        private Map<String, String> receivedConfig;
+        
+        private int connectionBuildCount;
+        
+        private int tpsBuildCount;
+        
+        private RecordingBuilder(List<ConfigItemDefinition> definitions) {
+            this.definitions = definitions;
+        }
+        
+        @Override
+        public List<ConfigItemDefinition> getConfigDefinitions() {
+            return definitions;
+        }
+        
+        @Override
+        public ConnectionControlManager buildConnectionControlManager(
+            Map<String, String> config) {
+            receivedConfig = new LinkedHashMap<>(config);
+            connectionBuildCount++;
+            return super.buildConnectionControlManager();
+        }
+        
+        @Override
+        public TpsControlManager buildTpsControlManager(Map<String, String> config) {
+            receivedConfig = new LinkedHashMap<>(config);
+            tpsBuildCount++;
+            return super.buildTpsControlManager();
+        }
+        
+        private Map<String, String> getReceivedConfig() {
+            return receivedConfig;
+        }
+        
+        private int getConnectionBuildCount() {
+            return connectionBuildCount;
+        }
+        
+        private int getTpsBuildCount() {
+            return tpsBuildCount;
+        }
+    }
+    
+    private static class FailureBuilder implements ControlManagerBuilder {
+        
+        private final boolean connectionThrows;
+        
+        private final boolean tpsThrows;
+        
+        private FailureBuilder(boolean connectionThrows, boolean tpsThrows) {
+            this.connectionThrows = connectionThrows;
+            this.tpsThrows = tpsThrows;
+        }
+        
+        @Override
+        public String getName() {
+            return "failure";
+        }
+        
+        @Override
+        public ConnectionControlManager buildConnectionControlManager() {
+            if (connectionThrows) {
+                throw new IllegalStateException("connection failed");
+            }
+            return null;
+        }
+        
+        @Override
+        public TpsControlManager buildTpsControlManager() {
+            if (tpsThrows) {
+                throw new IllegalStateException("tps failed");
+            }
+            return null;
+        }
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/spi/ControlPluginRegistryTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/spi/ControlPluginRegistryTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.control.spi;
+
+import com.alibaba.nacos.api.plugin.PluginType;
+import com.alibaba.nacos.plugin.control.ControlManagerBuilderTest;
+import com.alibaba.nacos.plugin.control.ControlPluginAdapter;
+import com.alibaba.nacos.plugin.control.configs.ControlConfigs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ControlPluginRegistryTest {
+    
+    @AfterEach
+    void tearDown() {
+        ControlConfigs.getInstance().setControlManagerType(null);
+    }
+    
+    @Test
+    void testRegisterBuildersAndExposeImmutableAdapters() {
+        NamedBuilder first = new NamedBuilder("first");
+        NamedBuilder second = new NamedBuilder("second");
+        
+        ControlPluginRegistry registry =
+            new ControlPluginRegistry(Arrays.asList(first, second));
+        Map<String, ControlPluginAdapter> plugins = registry.getPlugins();
+        
+        assertEquals(2, plugins.size());
+        assertEquals("first", plugins.get("first").getPluginName());
+        assertEquals("second", plugins.get("second").getPluginName());
+        assertThrows(UnsupportedOperationException.class,
+            () -> plugins.put("third", plugins.get("first")));
+    }
+    
+    @Test
+    void testNullBuilderCollectionCreatesEmptyRegistry() {
+        assertTrue(new ControlPluginRegistry(null).getPlugins().isEmpty());
+    }
+    
+    @Test
+    void testRejectInvalidBuilders() {
+        assertThrows(IllegalStateException.class,
+            () -> new ControlPluginRegistry(Collections.singletonList(null)));
+        assertThrows(IllegalStateException.class,
+            () -> new ControlPluginRegistry(
+                Collections.singletonList(new NamedBuilder(" "))));
+        assertThrows(IllegalStateException.class,
+            () -> new ControlPluginRegistry(
+                Arrays.asList(new NamedBuilder("same"), new NamedBuilder("SAME"))));
+    }
+    
+    @Test
+    void testSingletonLoadsSpiBuilders() {
+        ControlPluginRegistry registry = ControlPluginRegistry.getInstance();
+        
+        assertNotNull(registry);
+        assertTrue(registry.getPlugins().containsKey("test"));
+        assertTrue(registry.getPlugins().containsKey("throw"));
+        assertSame(registry, ControlPluginRegistry.getInstance());
+    }
+    
+    @Test
+    void testProviderLoadsRegistryLazily() {
+        ControlPluginRegistry registry =
+            new ControlPluginRegistry(Collections.singletonList(new NamedBuilder("selected")));
+        AtomicInteger calls = new AtomicInteger();
+        ControlPluginProvider provider = new ControlPluginProvider(() -> {
+            calls.incrementAndGet();
+            return registry;
+        });
+        assertEquals(0, calls.get());
+        assertEquals(PluginType.CONTROL, provider.getPluginType());
+        
+        ControlConfigs.getInstance().setControlManagerType("SELECTED");
+        assertSame(registry.getPlugins(), provider.getAllPlugins());
+        assertEquals(1, calls.get());
+        
+        ControlConfigs.getInstance().setControlManagerType("missing");
+        assertSame(registry.getPlugins(), provider.getAllPlugins());
+        assertEquals(2, calls.get());
+        
+        ControlConfigs.getInstance().setControlManagerType("");
+        assertFalse(provider.getAllPlugins().isEmpty());
+        assertEquals(3, calls.get());
+    }
+    
+    private static final class NamedBuilder extends ControlManagerBuilderTest {
+        
+        private final String name;
+        
+        private NamedBuilder(String name) {
+            this.name = name;
+        }
+        
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/spi/ControlPluginTypePolicyTest.java
+++ b/plugin/control/src/test/java/com/alibaba/nacos/plugin/control/spi/ControlPluginTypePolicyTest.java
@@ -41,11 +41,41 @@ class ControlPluginTypePolicyTest {
     @Test
     void testInitialSelection() {
         MapConfiguration configuration = new MapConfiguration();
+        policy.initialize(configuration);
         assertFalse(policy.isPluginEnabledByDefault("local", configuration));
+        assertFalse(policy.isLoadingEnabled(configuration));
         
         configuration.setProperty(ControlPluginTypePolicy.CONTROL_TYPE_PROPERTY, " local ");
+        policy.initialize(configuration);
         assertTrue(policy.isPluginEnabledByDefault("LOCAL", configuration));
         assertFalse(policy.isPluginEnabledByDefault("remote", configuration));
+        assertTrue(policy.isLoadingEnabled(configuration));
+        
+        configuration.setProperty(ControlPluginTypePolicy.CONTROL_TYPE_PROPERTY, "remote");
+        assertTrue(policy.isPluginEnabledByDefault("local", configuration));
+    }
+    
+    @Test
+    void testLegacySelection() {
+        MapConfiguration configuration = new MapConfiguration();
+        configuration.setProperty(ControlPluginTypePolicy.LEGACY_CONTROL_TYPE_PROPERTY, " local ");
+        
+        policy.initialize(configuration);
+        
+        assertTrue(policy.isPluginEnabledByDefault("LOCAL", configuration));
+        assertTrue(policy.isLoadingEnabled(configuration));
+    }
+    
+    @Test
+    void testStandardSelectionTakesPrecedence() {
+        MapConfiguration configuration = new MapConfiguration();
+        configuration.setProperty(ControlPluginTypePolicy.CONTROL_TYPE_PROPERTY, " ");
+        configuration.setProperty(ControlPluginTypePolicy.LEGACY_CONTROL_TYPE_PROPERTY, "legacy");
+        
+        policy.initialize(configuration);
+        
+        assertFalse(policy.isPluginEnabledByDefault("legacy", configuration));
+        assertFalse(policy.isLoadingEnabled(configuration));
     }
     
     private static class MapConfiguration implements PluginTypeConfiguration {

--- a/specs/en/plugin/control-plugin-spec.md
+++ b/specs/en/plugin/control-plugin-spec.md
@@ -22,11 +22,13 @@ The control plugin type provides runtime traffic and connection control for
 Nacos server nodes. It covers connection admission, TPS checks, rule parsing,
 rule storage, and optional metrics collection.
 
-This is a configured single-service plugin. The configured control manager type
-selects one `ControlManagerBuilder`. If no type is configured or the selected
-plugin cannot be loaded, Nacos uses no-limit default managers. Common lifecycle
-and state rules are defined by the [Nacos Plugin Spec](plugin-spec.md), and the
-bundled implementation is defined by the
+This is a configured single-service plugin. The configured control type selects
+one `ControlManagerBuilder`. A stable adapter exposes the selected builder to
+the unified plugin configuration lifecycle and creates its manager bundle only
+after effective configuration is applied. If no type is configured or the
+selected plugin cannot be loaded, Nacos uses no-limit default managers. Common
+lifecycle and state rules are defined by the
+[Nacos Plugin Spec](plugin-spec.md), and the bundled implementation is defined by the
 [Default Control Plugin Implementation Spec](default-control-plugin-spec.md).
 
 Control is an anti-fragility mechanism. It protects a Nacos node by rejecting or
@@ -55,18 +57,56 @@ no-limit for that dimension.
 
 ## SPI
 
-Control plugins implement `ControlManagerBuilder`.
+Control plugins implement `ControlManagerBuilder`. The builder extends
+`PluginConfigDefinitionSpec`: it declares configuration metadata before manager
+construction but does not own effective configuration.
 
 | Method | Requirement |
 |--------|-------------|
 | `getName()` | Stable plugin name. |
 | `buildConnectionControlManager()` | Build connection control manager. |
 | `buildTpsControlManager()` | Build TPS control manager. |
+| `buildConnectionControlManager(config)` | Build with canonical effective plugin config; the compatibility default delegates to the no-argument method. |
+| `buildTpsControlManager(config)` | Build with canonical effective plugin config; the compatibility default delegates to the no-argument method. |
+
+Every builder definition has `RESTART` effect mode until Control defines a
+controlled manager replacement and close lifecycle. Runtime or local-only
+updates to those fields are rejected by the unified plugin configuration API.
+
+The Control provider wraps each builder in one stable `PluginConfigSpec`
+adapter. The adapter delegates definitions to the builder, owns an immutable
+effective configuration snapshot, and implements `PluginStartupLifecycle`.
+Builder SPI discovery happens once in the Control registry; the provider,
+plugin manager, and manager center must not perform independent loads.
 
 External rule storage plugins implement `ExternalRuleStorageBuilder` and are
 selected independently through control configuration.
 
 The plugin is exposed to the core plugin manager as type `control`.
+
+## Startup Lifecycle
+
+The Control type uses this startup order:
+
+1. capture the static implementation selection;
+2. discover builders once and register stable adapters;
+3. restore unified implementation state;
+4. resolve and apply effective configuration to configurable adapters;
+5. invoke `initialize()` only for the selected, enabled adapter;
+6. build connection and TPS managers from the accepted configuration snapshot;
+7. install both results as one manager bundle before Nacos is marked as started.
+
+An unselected adapter remains visible in plugin inventory but must not build
+managers or start background resources. A zero-config legacy builder still
+receives the startup lifecycle with an empty configuration snapshot.
+
+`ControlManagerCenter` exposes stable connection and TPS facades. Callers may
+retain those facade references; installing the startup bundle changes the
+delegates behind both facades through one bundle reference. TPS points
+registered before installation are replayed to the selected TPS manager.
+Before installation, the facades provide lightweight no-limit behavior without
+creating rule loaders, metrics reporters, or TPS barriers. The manager center
+must not reload `ControlManagerBuilder` through SPI.
 
 ## Managers
 
@@ -150,14 +190,22 @@ algorithms by overriding the barrier creator.
 
 ## Selection And State
 
-The selected manager implementation is named by:
+The selected manager implementation is named by the standard key:
+
+```properties
+nacos.plugin.control.type=${controlPluginName}
+```
+
+The historical key remains a static compatibility alias:
 
 ```properties
 nacos.plugin.control.manager.type=${controlPluginName}
 ```
 
-The selected control plugin must also respect unified plugin state for
-`control:{pluginName}` when integrated through the core plugin manager.
+The standard key wins when both are present, and use of the historical key
+emits a migration warning. Selection has `RESTART` semantics. The selected
+adapter is enabled at startup, other discovered adapters are disabled, and the
+plugin status API rejects runtime selection changes.
 
 Point names are part of the public control contract. New `@TpsControl` points
 must use stable names, document the protected operation, and preserve the name
@@ -165,9 +213,12 @@ when HTTP and gRPC endpoints represent the same semantic operation.
 
 ## Degradation
 
-Control plugins affect request admission. If plugin construction fails, Nacos
-must fall back to no-limit managers and log the failure unless the deployment
-explicitly configures a fail-fast policy.
+Control plugins affect request admission. Connection and TPS construction
+remain independent for compatibility: when construction of one dimension fails
+or returns null, that dimension falls back to its no-limit manager and logs the
+failure. The two final results are installed together as one bundle, so callers
+cannot observe a partially replaced startup state. If the selected builder is
+missing, both dimensions remain no-limit.
 
 Runtime plugin exceptions must not corrupt request state. For monitoring-only
 rules, failures should be logged and skipped. For intercepting rules, the

--- a/specs/en/plugin/default-control-plugin-spec.md
+++ b/specs/en/plugin/default-control-plugin-spec.md
@@ -32,12 +32,13 @@ storage plugin or operational synchronization outside this implementation.
 Enable the implementation with:
 
 ```properties
-nacos.plugin.control.manager.type=nacos
+nacos.plugin.control.type=nacos
 ```
 
-If this property is absent, the control manager center uses no-limit managers.
-If the `nacos` builder fails to create either manager, that manager falls back to
-the no-limit implementation and logs the failure.
+`nacos.plugin.control.manager.type=nacos` remains a compatibility alias. If
+neither property is present, the control manager center uses no-limit managers.
+If the `nacos` builder fails to create either manager, that manager falls back
+to the no-limit implementation and logs the failure.
 
 ## Local Rule Files
 

--- a/specs/en/plugin/plugin-spec.md
+++ b/specs/en/plugin/plugin-spec.md
@@ -124,9 +124,10 @@ Unified domain plugin SPIs extend `PluginConfigSpec`. Its compatibility defaults
 definitions, an empty current map, and a no-op apply callback, so an implementation compiled against
 an older domain SPI and a new zero-config implementation both remain `configurable=false`. A plugin
 that declares at least one `ConfigItemDefinition` is configurable and must implement the current-map
-and apply callbacks. `environment` and `control` remain bootstrap exceptions until their unified
-configuration lifecycle is designed; `ai-resource-import` remains outside unified management until
-its redesign. A plugin category that supports enable or disable checks must use
+and apply callbacks. `environment` remains a bootstrap exception until its unified configuration
+lifecycle is designed. `control` uses a definition-only builder plus a stable `PluginConfigSpec`
+adapter. `ai-resource-import` remains outside unified management until its redesign. A plugin
+category that supports enable or disable checks must use
 `PluginStateCheckerHolder` rather than keeping an independent status source.
 
 `PluginConfigDefinitionSpec` is the definition-only parent contract for a factory
@@ -154,6 +155,16 @@ The loading predicate does not replace implementation state. Its default is `tru
 compatibility and a domain should override it only when it owns a type-wide module or capability
 switch. A deferred type is enabled through that static or domain switch rather than by addressing
 an implementation that has not yet been discovered through the plugin API.
+
+An adapter that must create domain runtime resources after effective configuration has been
+accepted may implement the optional `PluginStartupLifecycle`. Core invokes `initialize()` only for
+an enabled implementation, after persisted state is restored and after `applyConfig`, but before
+Nacos is marked as started. This lifecycle is independent from
+`PluginConfigSpec.isConfigurable()`: a zero-config adapter may still require initialization, while
+a configurable adapter need not implement the lifecycle. The operation must be idempotent and is
+also applied after deferred type loading. It does not by itself permit runtime state switching or
+resource rebuilding; a plugin type must continue to reject those operations until its domain
+defines a controlled replace and close lifecycle.
 
 `ApplicationReadyEvent` is only an idempotent fallback for non-standard embedded startup paths.
 Domain managers may construct their services earlier through SPI, but a type that opts into
@@ -269,16 +280,16 @@ selection keys are aliases:
 |------|--------------|------------------|---------|
 | `auth` | `nacos.plugin.auth.type` | `nacos.core.auth.system.type` | `nacos` |
 | `datasource-dialect` | `nacos.plugin.datasource-dialect.type` | `spring.sql.init.platform` | `derby` |
+| `control` | `nacos.plugin.control.type` | `nacos.plugin.control.manager.type` | empty, meaning no-limit |
 
 The standard key takes precedence when both forms are present, and reading an alias must emit a
 migration warning. Exclusive selection currently affects startup resources such as Spring beans
 and datasources, so the plugin status API must not report a switch as dynamically effective.
 Changing selection requires updating the static key and restarting the server. Runtime selection
 may only be opened after the owning domain provides a controlled reinitialization lifecycle.
-`control` remains a bootstrap exception: its current selector is
-`nacos.plugin.control.manager.type`. The management API reports the selected builder but rejects
-runtime state changes until the control manager has a controlled rebuild lifecycle and its selector
-is migrated to the standard form.
+Control builds its selected manager bundle during `PluginStartupLifecycle`. Its selection remains
+startup-only and the management API rejects runtime state switching. The stable control facade may
+install the startup bundle once; this is not a runtime rebuild lifecycle.
 
 Non-exclusive implementations may provide an initial enabled state with:
 
@@ -402,10 +413,11 @@ definition. Core and Console API adapters must not maintain separate hard-coded 
 critical implementation lists.
 
 Bootstrap or build-time types cannot satisfy this contract with a late runtime
-check. `control` caches managers built before unified persisted state is loaded,
-and `environment` transforms Spring properties before the core plugin manager
-is ready. Their status capability and restart/bootstrap semantics must be
-defined before management APIs can report a state update as effective.
+check. `control` completes unified config apply before building and installing
+its startup manager bundle, and rejects runtime selection changes.
+`environment` still transforms Spring properties before the core plugin manager
+is ready; its status capability and restart/bootstrap semantics must be defined
+before management APIs can report a state update as effective.
 `ai-resource-import` is not currently exposed through `PluginProvider` and is
 outside unified state management.
 

--- a/specs/zh-cn/plugin/control-plugin-spec.md
+++ b/specs/zh-cn/plugin/control-plugin-spec.md
@@ -21,9 +21,11 @@
 Control 插件为 Nacos 服务端节点提供运行时流量和连接控制。它覆盖连接准入、TPS 检查、规则
 解析、规则存储和可选指标采集。
 
-这是配置选择的单服务插件。配置的 control manager type 会选择一个 `ControlManagerBuilder`。
-如果未配置类型，或选中的插件无法加载，Nacos 使用无上限的默认 manager。通用生命周期和
-状态规则由 [Nacos 插件化规范](plugin-spec.md) 定义，内置实现由
+这是配置选择的单服务插件。配置的 control type 会选择一个 `ControlManagerBuilder`。
+稳定 adapter 会把选中的 builder 接入统一插件配置生命周期，并且只在 effective config
+完成 apply 后创建 manager bundle。如果未配置类型，或选中的插件无法加载，Nacos 使用
+无上限的默认 manager。通用生命周期和状态规则由 [Nacos 插件化规范](plugin-spec.md) 定义，
+内置实现由
 [默认 Control 插件实现规范](default-control-plugin-spec.md) 定义。
 
 Control 是 Nacos 的反脆弱机制。它在某个控制点访问量超过规则时，对连接或请求进行监控或
@@ -49,17 +51,50 @@ HTTP 和 gRPC TPS control 钩子通过
 
 ## SPI
 
-Control 插件实现 `ControlManagerBuilder`。
+Control 插件实现 `ControlManagerBuilder`。builder 继承 `PluginConfigDefinitionSpec`，
+在 manager 构建前声明配置元数据，但不持有 effective config。
 
 | 方法 | 要求 |
 |------|------|
 | `getName()` | 稳定插件名称。 |
 | `buildConnectionControlManager()` | 构造连接控制 manager。 |
 | `buildTpsControlManager()` | 构造 TPS 控制 manager。 |
+| `buildConnectionControlManager(config)` | 使用 canonical effective plugin config 构造；兼容默认实现委托无参数方法。 |
+| `buildTpsControlManager(config)` | 使用 canonical effective plugin config 构造；兼容默认实现委托无参数方法。 |
+
+在 Control 定义受控的 manager 替换和 close 生命周期前，所有 builder definition 的
+effect mode 必须为 `RESTART`。统一插件配置 API 会拒绝这些字段的 runtime 或 local-only
+更新。
+
+Control provider 会为每个 builder 创建一个稳定 `PluginConfigSpec` adapter。adapter 委托
+builder 提供 definitions，持有不可变的 effective config 快照，并实现
+`PluginStartupLifecycle`。Control registry 只执行一次 builder SPI 发现；provider、插件
+管理器和 manager center 不得分别重复加载。
 
 外部规则存储插件实现 `ExternalRuleStorageBuilder`，并通过 control 配置独立选择。
 
 该插件以 `control` 类型暴露给核心插件管理器。
+
+## 启动生命周期
+
+Control 类型使用以下启动顺序：
+
+1. 快照静态实现选择；
+2. 只发现一次 builder，并注册稳定 adapter；
+3. 恢复统一实现 state；
+4. 为可配置 adapter 解析并 apply effective config；
+5. 只为选中且 enabled 的 adapter 调用 `initialize()`；
+6. 使用已接受的配置快照构建 Connection 和 TPS manager；
+7. 在 Nacos 报告启动成功前，把两个最终结果作为一个 manager bundle 安装。
+
+未选中的 adapter 仍可在插件 inventory 中展示，但不得构建 manager 或启动后台资源。零配置
+旧 builder 仍会使用空配置快照执行启动 lifecycle。
+
+`ControlManagerCenter` 对外暴露稳定的 Connection 和 TPS facade。调用方可以持有 facade
+引用；安装启动 bundle 时，通过同一个 bundle 引用同时切换两个 facade 的 delegate。安装前
+注册的 TPS point 必须重放给选中的 TPS manager。manager center 不得再次通过 SPI 加载
+`ControlManagerBuilder`。安装前 facade 直接提供轻量 no-limit 行为，不得提前创建规则加载器、
+指标上报任务或 TPS barrier。
 
 ## Manager
 
@@ -139,22 +174,31 @@ nacos.plugin.control.rule.local.basedir=${expectedDir}
 
 ## 选择与状态
 
-选中的 manager 实现由以下配置指定：
+选中的 manager 实现由标准 key 指定：
+
+```properties
+nacos.plugin.control.type=${controlPluginName}
+```
+
+历史 key 保留为静态配置兼容 alias：
 
 ```properties
 nacos.plugin.control.manager.type=${controlPluginName}
 ```
 
-当通过核心插件管理器集成时，选中的 control 插件还必须遵守 `control:{pluginName}` 的
-统一插件状态。
+两者同时存在时标准 key 优先；读取历史 key 时输出迁移 WARN。选择按 `RESTART` 生效。启动时
+选中的 adapter 为 enabled，其他已发现 adapter 为 disabled，插件 status API 拒绝运行时
+切换选择。
 
 Point name 属于公开 control 契约。新增 `@TpsControl` point 时，必须使用稳定名称，
 记录被保护的操作，并在 HTTP 与 gRPC 端点表达同一个语义操作时复用该名称。
 
 ## 降级
 
-Control 插件会影响请求准入。如果插件构造失败，除非部署明确配置 fail-fast 策略，否则 Nacos
-必须回退到无上限 manager，并记录失败日志。
+Control 插件会影响请求准入。为保持兼容，Connection 和 TPS 的构建继续相互独立：某一维度
+构建失败或返回 null 时，该维度回退到无上限 manager 并记录日志。两个最终结果仍作为一个
+bundle 同时安装，调用方不能观察到只替换一个维度的启动中间态。选中的 builder 不存在时，
+两个维度都保持无上限。
 
 运行时插件异常不得破坏请求状态。对于只观测规则，失败应记录并跳过。对于拦截规则，失败后
 通过、拒绝或 fail fast 由被选中的插件决定，并必须在实现规范中记录。

--- a/specs/zh-cn/plugin/default-control-plugin-spec.md
+++ b/specs/zh-cn/plugin/default-control-plugin-spec.md
@@ -30,11 +30,12 @@
 通过以下配置启用：
 
 ```properties
-nacos.plugin.control.manager.type=nacos
+nacos.plugin.control.type=nacos
 ```
 
-如果该配置不存在，control manager center 使用无上限 manager。如果 `nacos` builder
-创建任一 manager 失败，该 manager 会回退到无上限实现并记录日志。
+`nacos.plugin.control.manager.type=nacos` 保留为兼容 alias。如果两个配置都不存在，
+control manager center 使用无上限 manager。如果 `nacos` builder 创建任一 manager 失败，
+该 manager 会回退到无上限实现并记录日志。
 
 ## 本地规则文件
 

--- a/specs/zh-cn/plugin/plugin-spec.md
+++ b/specs/zh-cn/plugin/plugin-spec.md
@@ -110,8 +110,9 @@ Nacos 插件包含两个相关的 SPI 层次：
 已接入统一配置的领域插件 SPI 统一继承 `PluginConfigSpec`。该契约的兼容默认实现返回空
 definitions、空 current map，并提供空 apply 回调，因此按旧版领域 SPI 编译的实现和新版
 零配置实现都会保持 `configurable=false`。声明至少一个 `ConfigItemDefinition` 的插件属于
-可配置实现，必须实现 current-map 和 apply 回调。`environment`、`control` 在统一 bootstrap
-配置生命周期完成设计前继续作为例外；`ai-resource-import` 在自身重构前仍不进入统一管理。
+可配置实现，必须实现 current-map 和 apply 回调。`environment` 在统一 bootstrap 配置生命周期
+完成设计前继续作为例外；`control` 使用只声明 definitions 的 builder 和稳定的
+`PluginConfigSpec` adapter。`ai-resource-import` 在自身重构前仍不进入统一管理。
 支持启停状态判断的插件类别，应通过 `PluginStateCheckerHolder` 获取状态，而不是维护一套
 独立状态来源。
 
@@ -134,6 +135,14 @@ definitions、空 current map，并提供空 apply 回调，因此按旧版领�
 加载判据不能替代实现级 state。为保持二进制兼容，其默认值为 true；只有拥有类型级模块或
 能力总开关的领域才应覆盖该判据。尚未发现的实现不能通过插件 API 定向启用，延迟类型应先
 通过其静态或领域总开关开启。
+
+如果 adapter 必须在 effective config 被接受后创建领域运行资源，可以实现可选的
+`PluginStartupLifecycle`。Core 只为 enabled 实现调用 `initialize()`，调用发生在持久化 state
+恢复和 `applyConfig` 完成之后、Nacos 报告启动成功之前。该生命周期与
+`PluginConfigSpec.isConfigurable()` 相互独立：零配置 adapter 仍可能需要初始化，可配置
+adapter 也可以不实现该生命周期。该操作必须幂等，类型延迟加载时遵守同样顺序。它本身不代表
+支持运行时状态切换或资源重建；在领域定义受控的替换和 close 生命周期前，相关类型仍必须拒绝
+这些操作。
 
 `ApplicationReadyEvent` 只作为非标准嵌入启动流程的幂等兜底。领域管理器也可以通过 SPI
 提前构造自身领域服务，但选择延迟加载的类型在加载判据为 false 时不得自行实例化实现。
@@ -231,14 +240,15 @@ nacos.plugin.{pluginType}.type={pluginName}
 |------|----------|------------|--------|
 | `auth` | `nacos.plugin.auth.type` | `nacos.core.auth.system.type` | `nacos` |
 | `datasource-dialect` | `nacos.plugin.datasource-dialect.type` | `spring.sql.init.platform` | `derby` |
+| `control` | `nacos.plugin.control.type` | `nacos.plugin.control.manager.type` | 空，表示 no-limit |
 
 标准 key 与 alias 同时存在时标准 key 优先，读取 alias 时服务端应记录迁移提示日志。当前
 互斥类型的选择会影响 Spring Bean、数据源等启动资源，插件 status API 不得把切换报告为
 运行时已生效；修改选择必须更新上述静态 key 并重启。只有领域实现具备受控重建生命周期后，
 才能进一步开放对应类型的运行时切换。
-`control` 仍属于 bootstrap 特例，当前选择 key 为
-`nacos.plugin.control.manager.type`。在 control manager 具备受控重建生命周期且选择 key
-迁移为标准格式之前，管理 API 只反映启动时选中的 builder，并拒绝运行时状态切换。
+Control 在 `PluginStartupLifecycle` 阶段构建选中的 manager bundle。该选择仍只在启动时
+生效，管理 API 拒绝运行时状态切换。稳定 Control facade 只允许在启动时安装一次 bundle，
+这不代表已经具备运行时重建生命周期。
 
 非互斥插件实现可以通过以下标准静态 key 提供初始启用状态：
 
@@ -341,9 +351,10 @@ core source registry 统一持有已启用 resolver 及其固定顺序。四个�
 插件类型的执行形态和 critical 能力必须由共享的 `PluginType` 定义提供。Core 和 Console
 的 API 适配层不得分别维护硬编码的互斥类型或关键实现列表。
 
-启动期或构建期插件不能通过较晚的运行时检查满足该契约。`control` 会在统一持久化状态加载前
-构建并缓存 manager，`environment` 会在 core 插件管理器就绪前转换 Spring 属性。管理 API
-能够把这两类插件的状态更新报告为已生效之前，必须先定义其状态能力和重启/bootstrap 语义。
+启动期或构建期插件不能通过较晚的运行时检查满足该契约。`control` 会先完成统一配置 apply，
+再构建并安装启动期 manager bundle，同时拒绝运行时切换实现。`environment` 仍会在 core
+插件管理器就绪前转换 Spring 属性；管理 API 能够把它的状态更新报告为已生效之前，必须先
+定义其状态能力和重启/bootstrap 语义。
 `ai-resource-import` 当前没有通过 `PluginProvider` 暴露，不属于统一状态管理范围。
 
 ### 配置更新兼容性


### PR DESCRIPTION
For #15475

## What is the purpose of the change

Integrate the Control plugin with the unified plugin configuration and startup
lifecycle. Effective configuration is now applied before Control-owned runtime
resources are created, while the no-selector no-limit behavior and legacy
selection key remain compatible.

## Brief changelog

* Add an optional idempotent `PluginStartupLifecycle` hook and invoke it after
  effective plugin configuration has been applied.
* Adapt `ControlManagerBuilder` implementations into stable configurable plugin
  instances, and install the selected connection/TPS manager bundle through
  `ControlManagerCenter`.
* Standardize the selector as `nacos.plugin.control.type`, retain
  `nacos.plugin.control.manager.type` as a deprecated alias, and update the
  English/Chinese plugin specs and configuration template.
* Add focused unit coverage for lifecycle initialization, registry behavior,
  delegation, compatibility, and failure paths.

## Verifying this change

* `mvn -B -pl api,plugin/control,plugin-default-impl/nacos-default-control-plugin,core spotless:apply`
* `mvn -B -pl api,plugin/control,plugin-default-impl/nacos-default-control-plugin,core spotless:check`
* `mvn -B -pl plugin/control,plugin-default-impl/nacos-default-control-plugin,core test -DtrimStackTrace=false`
  * `plugin/control`: 56 tests
  * `core`: 1554 tests
  * `nacos-default-control-plugin`: 15 tests
* `mvn -B clean install -Prelease-nacos -DskipTests=true`
* `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e`
* Standalone live verification:
  * no selector: no Control implementation was initialized and no-limit
    behavior remained active;
  * `nacos.plugin.control.type=nacos`: the selected implementation initialized
    once;
  * connection count limit `1`: one of five independent clients connected and
    completed a Config RPC, while four were rejected;
  * connection count limit `5`: all five independent clients connected and
    completed a Config RPC without rejection.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
