### PR TITLE
[ISSUE #15584] Upgrade maven-compiler-plugin from 3.5.1 to 3.15.0 for JDK 25 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency-mediator-maven-plugin.version>1.0.2</dependency-mediator-maven-plugin.version>
         <clirr-maven-plugin.version>2.7</clirr-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-        <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>


### PR DESCRIPTION
https://github.com/alibaba/nacos/issues/15584

## What is the purpose of the change

Upgrade `maven-compiler-plugin` from `3.5.1` to `3.15.0` to fix compilation failure on JDK 25.

The older version `3.5.1` of `maven-compiler-plugin` is incompatible with JDK 25,
causing the build to fail. Version `3.15.0` adds support for newer JDK versions.

## Brief changelog

- Bump `maven-compiler-plugin.version` from `3.5.1` to `3.15.0` in root `pom.xml`

## Verifying this change

JDK 25：`mvn -V -e clean package -DskipTests -Prelease-nacos -am`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.

