### PR TITLE
[ISSUE #14804] Implement Agent lifecycle persistence

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/AgentOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/AgentOperationService.java
@@ -1,0 +1,552 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
+import com.alibaba.nacos.ai.service.VisibilityHelper;
+import com.alibaba.nacos.ai.service.resource.AiResourceManager;
+import com.alibaba.nacos.ai.service.resource.PublishPipelineInfo;
+import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
+import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.model.agent.Agent;
+import com.alibaba.nacos.api.ai.model.agent.AgentCallInterface;
+import com.alibaba.nacos.api.ai.model.agent.AgentOverview;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionDetail;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionSummary;
+import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecutionResult;
+import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecutionStatus;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Application service for the complete Agent Version lifecycle.
+ *
+ * <p>This service applies Agent-specific state guards and delegates content ownership to
+ * {@link AgentPersistenceService}. It deliberately does not expose HTTP, SDK, Runtime Registry, or
+ * legacy A2A bindings.</p>
+ *
+ * @author Nacos
+ */
+@Service
+public class AgentOperationService {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(AgentOperationService.class);
+    
+    private static final String RESOURCE_TYPE = Constants.Agent.RESOURCE_TYPE_AGENT;
+    
+    private final AgentPersistenceService persistenceService;
+    
+    private final AiResourceManager resourceManager;
+    
+    private final PublishPipelineExecutor publishPipelineExecutor;
+    
+    public AgentOperationService(AgentPersistenceService persistenceService,
+        AiResourceManager resourceManager, PublishPipelineExecutor publishPipelineExecutor) {
+        this.persistenceService = persistenceService;
+        this.resourceManager = resourceManager;
+        this.publishPipelineExecutor = publishPipelineExecutor;
+    }
+    
+    /**
+     * Create an Agent and its initial draft.
+     *
+     * @param agent writable Agent fields
+     * @param initialDraft initial draft
+     * @return created Agent overview
+     * @throws NacosException when creation fails
+     */
+    public AgentOverview create(Agent agent, AgentVersionDetail initialDraft)
+        throws NacosException {
+        AgentOverview result = persistenceService.create(agent, initialDraft);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE, agent.getAgentName(),
+            initialDraft.getVersion(), AiResourceTraceService.OP_CREATE_DRAFT,
+            VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
+        return result;
+    }
+    
+    /**
+     * Read one Agent after applying resource visibility.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @return Agent resource
+     * @throws NacosException when absent or unreadable
+     */
+    public Agent getAgent(String namespaceId, String agentName) throws NacosException {
+        AiResource meta = requireMeta(namespaceId, agentName);
+        resourceManager.ensureReadableOrNotFound(meta, "Agent not found: " + agentName);
+        return persistenceService.getAgent(namespaceId, agentName);
+    }
+    
+    /**
+     * Read one exact Agent Version after applying resource visibility.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact Agent Version
+     * @return verified Version detail
+     * @throws NacosException when absent or unreadable
+     */
+    public AgentVersionDetail getVersion(String namespaceId, String agentName, String version)
+        throws NacosException {
+        AiResource meta = requireMeta(namespaceId, agentName);
+        resourceManager.ensureReadableOrNotFound(meta, "Agent not found: " + agentName);
+        return persistenceService.getAgentVersion(namespaceId, agentName, version);
+    }
+    
+    /**
+     * List Agent Version summaries after applying resource visibility.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param status optional status filter
+     * @param pageNo page number
+     * @param pageSize page size
+     * @return Version summary page
+     * @throws NacosException when absent or unreadable
+     */
+    public Page<AgentVersionSummary> listVersions(String namespaceId, String agentName,
+        String status, int pageNo, int pageSize) throws NacosException {
+        AiResource meta = requireMeta(namespaceId, agentName);
+        resourceManager.ensureReadableOrNotFound(meta, "Agent not found: " + agentName);
+        return persistenceService.listAgentVersions(namespaceId, agentName, status, pageNo,
+            pageSize);
+    }
+    
+    /**
+     * Create one subsequent Agent draft.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param draft new draft
+     * @param basedOnVersion optional exact source Version
+     * @return verified draft detail
+     * @throws NacosException when creation fails
+     */
+    public AgentVersionDetail createDraft(String namespaceId, String agentName,
+        AgentVersionDetail draft, String basedOnVersion) throws NacosException {
+        requireWritableMeta(namespaceId, agentName);
+        AgentVersionDetail result =
+            persistenceService.createDraft(namespaceId, agentName, draft, basedOnVersion);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, draft.getVersion(),
+            AiResourceTraceService.OP_CREATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+            VisibilityHelper.resolveClientIp());
+        return result;
+    }
+    
+    /**
+     * Replace one exact Agent draft.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact draft Version
+     * @param callInterfaces replacement content
+     * @param changeDescription replacement description
+     * @return verified draft detail
+     * @throws NacosException when update fails
+     */
+    public AgentVersionDetail updateDraft(String namespaceId, String agentName, String version,
+        List<AgentCallInterface> callInterfaces, String changeDescription) throws NacosException {
+        requireWritableMeta(namespaceId, agentName);
+        AgentVersionDetail result = persistenceService.updateDraft(namespaceId, agentName, version,
+            callInterfaces, changeDescription);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, version,
+            AiResourceTraceService.OP_UPDATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+            VisibilityHelper.resolveClientIp());
+        return result;
+    }
+    
+    /**
+     * Delete one exact current draft.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact draft Version
+     * @throws NacosException when deletion fails
+     */
+    public void deleteDraft(String namespaceId, String agentName, String version)
+        throws NacosException {
+        requireWritableMeta(namespaceId, agentName);
+        persistenceService.deleteDraft(namespaceId, agentName, version);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, version,
+            AiResourceTraceService.OP_DELETE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
+            VisibilityHelper.resolveClientIp());
+    }
+    
+    /**
+     * Delete an Agent definition and all Version content without touching Runtime Endpoint state.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @throws NacosException when deletion fails
+     */
+    public void deleteAgent(String namespaceId, String agentName) throws NacosException {
+        requireWritableMeta(namespaceId, agentName);
+        persistenceService.deleteAgent(namespaceId, agentName);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, null,
+            AiResourceTraceService.OP_DELETE_RESOURCE, VisibilityHelper.resolveCurrentIdentity(),
+            VisibilityHelper.resolveClientIp());
+    }
+    
+    /**
+     * Submit one exact draft to Pipeline or publish it directly when no Agent Pipeline exists.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact draft Version
+     * @return resulting Version summary
+     * @throws NacosException when the transition is illegal or persistence fails
+     */
+    public AgentVersionSummary submit(String namespaceId, String agentName, String version)
+        throws NacosException {
+        AiResource meta = requireWritableMeta(namespaceId, agentName);
+        AiResourceVersion row = requireVersionState(namespaceId, agentName, version,
+            AiConstants.Agent.VERSION_STATUS_DRAFT);
+        requireWorkingPointer(meta, version, true);
+        persistenceService.getAgentVersion(namespaceId, agentName, version);
+        
+        PublishPipelineContext context = new PublishPipelineContext();
+        context.setResourceType(PublishPipelineResourceType.AGENT);
+        context.setNamespaceId(namespaceId);
+        context.setResourceName(agentName);
+        context.setVersion(version);
+        ResourceVersionInfo versionInfo = AiResourceManager.requireVersionInfo(meta);
+        if (!publishPipelineExecutor.isPipelineAvailable(PublishPipelineResourceType.AGENT)) {
+            transitionToOnline(namespaceId, agentName, row, true, false);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, version,
+                AiResourceTraceService.OP_SUBMIT_REVIEW,
+                VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp(),
+                "pipeline=none;targetStatus=online");
+            return persistenceService.getAgentVersionSummary(namespaceId, agentName, version);
+        }
+        
+        resourceManager.moveToReviewing(namespaceId, agentName, RESOURCE_TYPE, version, meta,
+            versionInfo);
+        if (!startPipeline(namespaceId, agentName, version, context)) {
+            AiResourceVersion reviewing = requireVersionState(namespaceId, agentName, version,
+                AiConstants.Agent.VERSION_STATUS_REVIEWING);
+            transitionToOnline(namespaceId, agentName, reviewing, false, true);
+        }
+        return persistenceService.getAgentVersionSummary(namespaceId, agentName, version);
+    }
+    
+    /**
+     * Publish one exact reviewed and approved Agent Version.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact reviewed Version
+     * @return online Version summary
+     * @throws NacosException when the transition is illegal or persistence fails
+     */
+    public AgentVersionSummary publish(String namespaceId, String agentName, String version)
+        throws NacosException {
+        AiResource meta = requireWritableMeta(namespaceId, agentName);
+        AiResourceVersion row = requireVersionState(namespaceId, agentName, version,
+            AiConstants.Agent.VERSION_STATUS_REVIEWED);
+        requireWorkingPointer(meta, version, false);
+        requireApprovedPipeline(row, agentName, version);
+        transitionToOnline(namespaceId, agentName, row, false, true);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, version,
+            AiResourceTraceService.OP_PUBLISH, VisibilityHelper.resolveCurrentIdentity(),
+            VisibilityHelper.resolveClientIp());
+        return persistenceService.getAgentVersionSummary(namespaceId, agentName, version);
+    }
+    
+    /**
+     * Force-publish one exact draft, reviewing, or reviewed Agent Version.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact Version
+     * @return online Version summary
+     * @throws NacosException when the transition is illegal or persistence fails
+     */
+    public AgentVersionSummary forcePublish(String namespaceId, String agentName, String version)
+        throws NacosException {
+        String fromStatus = "unknown";
+        String operator = VisibilityHelper.resolveCurrentIdentity();
+        String clientIp = VisibilityHelper.resolveClientIp();
+        try {
+            AiResource meta = requireWritableMeta(namespaceId, agentName);
+            AiResourceVersion row =
+                persistenceService.requireVersionRow(namespaceId, agentName, version);
+            fromStatus = row.getStatus();
+            if (!AiConstants.Agent.VERSION_STATUS_DRAFT.equals(fromStatus)
+                && !AiConstants.Agent.VERSION_STATUS_REVIEWING.equals(fromStatus)
+                && !AiConstants.Agent.VERSION_STATUS_REVIEWED.equals(fromStatus)) {
+                throw illegalState("Agent force-publish requires draft, reviewing, or reviewed: "
+                    + agentName + '@' + version);
+            }
+            requireWorkingPointer(meta, version,
+                AiConstants.Agent.VERSION_STATUS_DRAFT.equals(fromStatus));
+            transitionToOnline(namespaceId, agentName, row,
+                AiConstants.Agent.VERSION_STATUS_DRAFT.equals(fromStatus),
+                !AiConstants.Agent.VERSION_STATUS_DRAFT.equals(fromStatus));
+            String transition = forcePublishTrace(fromStatus);
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, version,
+                AiResourceTraceService.OP_FORCE_PUBLISH, operator, clientIp, transition);
+            return persistenceService.getAgentVersionSummary(namespaceId, agentName, version);
+        } catch (Exception e) {
+            AiResourceTraceService.log(RESOURCE_TYPE, agentName, version,
+                AiResourceTraceService.OP_FORCE_PUBLISH, AiResourceTraceService.STATUS_FAILURE,
+                operator, clientIp, forcePublishTrace(fromStatus) + ";error=" + e.getMessage());
+            throw e instanceof NacosException ? (NacosException) e
+                : new NacosException(NacosException.SERVER_ERROR,
+                    "Failed to force-publish Agent " + agentName + '@' + version, e);
+        }
+    }
+    
+    /**
+     * Move one exact reviewed Version back to draft.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact reviewed Version
+     * @return draft Version summary
+     * @throws NacosException when the transition is illegal
+     */
+    public AgentVersionSummary redraft(String namespaceId, String agentName, String version)
+        throws NacosException {
+        AiResource meta = requireWritableMeta(namespaceId, agentName);
+        requireVersionState(namespaceId, agentName, version,
+            AiConstants.Agent.VERSION_STATUS_REVIEWED);
+        ResourceVersionInfo versionInfo = requireWorkingPointer(meta, version, false);
+        if (StringUtils.isNotBlank(versionInfo.getEditingVersion())) {
+            throw conflict("Agent already has an editing Version: "
+                + versionInfo.getEditingVersion());
+        }
+        resourceManager.doRedraft(namespaceId, agentName, RESOURCE_TYPE, version);
+        return persistenceService.getAgentVersionSummary(namespaceId, agentName, version);
+    }
+    
+    /**
+     * Bring one exact offline Agent Version online.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact offline Version
+     * @return online Version summary
+     * @throws NacosException when the transition is illegal
+     */
+    public AgentVersionSummary online(String namespaceId, String agentName, String version)
+        throws NacosException {
+        requireWritableMeta(namespaceId, agentName);
+        AiResourceVersion row = requireVersionState(namespaceId, agentName, version,
+            AiConstants.Agent.VERSION_STATUS_OFFLINE);
+        transitionToOnline(namespaceId, agentName, row, false, false);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, version,
+            AiResourceTraceService.OP_ONLINE_VERSION, VisibilityHelper.resolveCurrentIdentity(),
+            VisibilityHelper.resolveClientIp());
+        return persistenceService.getAgentVersionSummary(namespaceId, agentName, version);
+    }
+    
+    /**
+     * Take one exact online Agent Version offline.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact online Version
+     * @return offline Version summary
+     * @throws NacosException when the transition is illegal
+     */
+    public AgentVersionSummary offline(String namespaceId, String agentName, String version)
+        throws NacosException {
+        requireWritableMeta(namespaceId, agentName);
+        requireVersionState(namespaceId, agentName, version,
+            AiConstants.Agent.VERSION_STATUS_ONLINE);
+        persistenceService.updateVersionStatus(namespaceId, agentName, version,
+            AiConstants.Agent.VERSION_STATUS_OFFLINE);
+        persistenceService.synchronizeDerivedState(namespaceId, agentName, null, null, null, null);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, version,
+            AiResourceTraceService.OP_OFFLINE_VERSION, VisibilityHelper.resolveCurrentIdentity(),
+            VisibilityHelper.resolveClientIp());
+        return persistenceService.getAgentVersionSummary(namespaceId, agentName, version);
+    }
+    
+    /**
+     * Replace custom labels while preserving the service-managed latest label.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param labels complete custom label map
+     * @return updated Agent
+     * @throws NacosException when a target Version is absent or in a working state
+     */
+    public Agent updateLabels(String namespaceId, String agentName, Map<String, String> labels)
+        throws NacosException {
+        requireWritableMeta(namespaceId, agentName);
+        Agent result = persistenceService.synchronizeDerivedState(namespaceId, agentName, null,
+            labels, null, null);
+        AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, null,
+            AiResourceTraceService.OP_UPDATE_LABELS, VisibilityHelper.resolveCurrentIdentity(),
+            VisibilityHelper.resolveClientIp());
+        return result;
+    }
+    
+    private boolean startPipeline(String namespaceId, String agentName, String version,
+        PublishPipelineContext context) throws NacosException {
+        String executionId = UUID.randomUUID().toString();
+        PublishPipelineInfo pipelineInfo = new PublishPipelineInfo();
+        pipelineInfo.setExecutionId(executionId);
+        pipelineInfo.setStatus(PipelineExecutionStatus.IN_PROGRESS);
+        pipelineInfo.setPipeline(new ArrayList<>());
+        persistenceService.updatePublishPipelineInfo(namespaceId, agentName, version,
+            JacksonUtils.toJson(pipelineInfo));
+        String result = publishPipelineExecutor.execute(context,
+            pipelineResult -> onPipelineComplete(namespaceId, agentName, version, executionId,
+                pipelineResult),
+            executionId);
+        if (StringUtils.isBlank(result)) {
+            persistenceService.updatePublishPipelineInfo(namespaceId, agentName, version, null);
+            return false;
+        }
+        return true;
+    }
+    
+    private void onPipelineComplete(String namespaceId, String agentName, String version,
+        String executionId, PipelineExecutionResult result) {
+        try {
+            AiResourceVersion current =
+                persistenceService.requireVersionRow(namespaceId, agentName, version);
+            PublishPipelineInfo currentInfo =
+                AiResourceManager.parsePublishPipelineInfo(current.getPublishPipelineInfo());
+            if (currentInfo == null || !executionId.equals(currentInfo.getExecutionId())) {
+                LOGGER.warn("Ignore stale Agent pipeline callback for {}@{}, executionId={}",
+                    agentName, version, executionId);
+                return;
+            }
+            PublishPipelineInfo completed = new PublishPipelineInfo();
+            completed.setExecutionId(executionId);
+            completed.setStatus(result == null ? PipelineExecutionStatus.REJECTED
+                : result.getStatus());
+            completed.setPipeline(result == null ? null : result.getPipeline());
+            persistenceService.updatePublishPipelineInfo(namespaceId, agentName, version,
+                JacksonUtils.toJson(completed));
+            
+            AiResourceVersion latest =
+                persistenceService.requireVersionRow(namespaceId, agentName, version);
+            PublishPipelineInfo latestInfo =
+                AiResourceManager.parsePublishPipelineInfo(latest.getPublishPipelineInfo());
+            if (AiConstants.Agent.VERSION_STATUS_REVIEWING.equals(latest.getStatus())
+                && latestInfo != null && executionId.equals(latestInfo.getExecutionId())) {
+                persistenceService.updateVersionStatus(namespaceId, agentName, version,
+                    AiConstants.Agent.VERSION_STATUS_REVIEWED);
+            }
+            boolean approved = completed.getStatus() == PipelineExecutionStatus.APPROVED;
+            AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, version,
+                approved ? AiResourceTraceService.OP_REVIEW_APPROVED
+                    : AiResourceTraceService.OP_REVIEW_REJECTED,
+                "system", "", "executionId=" + executionId);
+        } catch (Throwable e) {
+            LOGGER.error("Agent pipeline callback failed for {}@{}, executionId={}", agentName,
+                version, executionId, e);
+        }
+    }
+    
+    private void transitionToOnline(String namespaceId, String agentName, AiResourceVersion row,
+        boolean clearEditing, boolean clearReviewing) throws NacosException {
+        String version = row.getVersion();
+        persistenceService.getAgentVersion(namespaceId, agentName, version);
+        persistenceService.updateVersionStatus(namespaceId, agentName, version,
+            AiConstants.Agent.VERSION_STATUS_ONLINE);
+        persistenceService.synchronizeDerivedState(namespaceId, agentName, version, null,
+            clearEditing ? version : null, clearReviewing ? version : null);
+    }
+    
+    private AiResource requireMeta(String namespaceId, String agentName) throws NacosException {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        AgentValidationUtils.validateAgentName(agentName);
+        return resourceManager.requireMeta(namespaceId, agentName, RESOURCE_TYPE);
+    }
+    
+    private AiResource requireWritableMeta(String namespaceId, String agentName)
+        throws NacosException {
+        AiResource result = requireMeta(namespaceId, agentName);
+        VisibilityHelper.checkWritableResource(result);
+        return result;
+    }
+    
+    private AiResourceVersion requireVersionState(String namespaceId, String agentName,
+        String version, String expectedStatus) throws NacosException {
+        AgentValidationUtils.validateVersion(version);
+        AiResourceVersion result =
+            persistenceService.requireVersionRow(namespaceId, agentName, version);
+        if (!expectedStatus.equals(result.getStatus())) {
+            throw illegalState("Agent Version " + agentName + '@' + version + " must be "
+                + expectedStatus + ", actual status is " + result.getStatus());
+        }
+        return result;
+    }
+    
+    private ResourceVersionInfo requireWorkingPointer(AiResource meta, String version,
+        boolean editing) throws NacosException {
+        ResourceVersionInfo result = AiResourceManager.requireVersionInfo(meta);
+        String actual = editing ? result.getEditingVersion() : result.getReviewingVersion();
+        if (!version.equals(actual)) {
+            throw illegalState("Agent Version is not the current "
+                + (editing ? "editing" : "reviewing") + " Version: " + meta.getName() + '@'
+                + version);
+        }
+        return result;
+    }
+    
+    private void requireApprovedPipeline(AiResourceVersion row, String agentName, String version)
+        throws NacosException {
+        PublishPipelineInfo info =
+            AiResourceManager.parsePublishPipelineInfo(row.getPublishPipelineInfo());
+        if (info == null || info.getStatus() != PipelineExecutionStatus.APPROVED
+            || Boolean.TRUE.equals(info.getHistorical())) {
+            throw illegalState("Agent Version Pipeline is not approved: " + agentName + '@'
+                + version);
+        }
+    }
+    
+    private String forcePublishTrace(String fromStatus) {
+        return "fromStatus=" + fromStatus + ";targetStatus="
+            + AiConstants.Agent.VERSION_STATUS_ONLINE;
+    }
+    
+    private NacosApiException illegalState(String message) {
+        return new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.ILLEGAL_STATE,
+            message);
+    }
+    
+    private NacosApiException conflict(String message) {
+        return new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
+            message);
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/AgentPersistenceService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/AgentPersistenceService.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.ai.service.agent;
 
+import com.alibaba.nacos.ai.constant.AiResourceConstants;
 import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.model.AiResourceVersion;
@@ -51,6 +52,7 @@ import com.alibaba.nacos.api.exception.runtime.NacosSerializationException;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
@@ -58,7 +60,9 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -78,6 +82,8 @@ public class AgentPersistenceService {
     private static final String RESOURCE_SOURCE_LOCAL = "local";
     
     private static final int MAX_BIZ_TAGS_LENGTH = 1024;
+    
+    private static final int VERSION_SCAN_PAGE_SIZE = 100;
     
     private static final String VALIDATION_CONTENT_DIGEST =
         AgentVersionContentSerializer.digest(new byte[0]);
@@ -288,6 +294,476 @@ public class AgentPersistenceService {
         } catch (Exception e) {
             throw asNacosException("Failed to update Agent draft " + agentName + '@' + version, e);
         }
+    }
+    
+    /**
+     * Create one subsequent draft from direct content or one exact existing Version.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact, case-sensitive Agent name
+     * @param draft new draft metadata and optional direct CallInterface content
+     * @param basedOnVersion exact source Version when direct content is absent
+     * @return persisted and storage-verified draft
+     * @throws NacosException when the Agent, source Version, or persistence operation fails
+     */
+    public AgentVersionDetail createDraft(String namespaceId, String agentName,
+        AgentVersionDetail draft, String basedOnVersion) throws NacosException {
+        validateSubsequentDraftInputs(namespaceId, agentName, draft, basedOnVersion);
+        try {
+            Agent currentAgent = getAgent(namespaceId, agentName);
+            ensureDraftSlotAvailable(currentAgent, draft.getVersion());
+            List<AgentCallInterface> callInterfaces = draft.getCallInterfaces();
+            if (callInterfaces == null) {
+                AgentVersionDetail source =
+                    getAgentVersion(namespaceId, agentName, basedOnVersion);
+                callInterfaces = source.getCallInterfaces();
+            }
+            AgentVersionContent content = new AgentVersionContent(callInterfaces);
+            PreparedAgentVersionWrite prepared = storageService.prepare(namespaceId, agentName,
+                draft.getVersion(), content);
+            AgentVersionDetail normalizedDraft =
+                normalizeSubsequentDraft(namespaceId, agentName, draft, callInterfaces,
+                    prepared.getDescriptor());
+            AgentModelValidator.validateVersionDetail(normalizedDraft);
+            claimVersion(toVersionRow(normalizedDraft, prepared.getDescriptor()));
+            storageService.save(prepared);
+            markEditingVersion(namespaceId, agentName, draft.getVersion());
+            return getAgentVersion(namespaceId, agentName, draft.getVersion());
+        } catch (Exception e) {
+            throw asNacosException("Failed to create Agent draft " + agentName + '@'
+                + draft.getVersion(), e);
+        }
+    }
+    
+    /**
+     * Delete one exact current draft and its Agent Version content.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact, case-sensitive Agent name
+     * @param version exact draft Version
+     * @throws NacosException when the target is not a draft or cleanup fails
+     */
+    public void deleteDraft(String namespaceId, String agentName, String version)
+        throws NacosException {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        AgentValidationUtils.validateAgentName(agentName);
+        AgentValidationUtils.validateVersion(version);
+        try {
+            AiResourceVersion versionRow = findVersion(namespaceId, agentName, version);
+            if (!AiConstants.Agent.VERSION_STATUS_DRAFT.equals(versionRow.getStatus())) {
+                throw illegalState("Agent Version is not a draft: " + agentName + '@' + version);
+            }
+            AgentVersionStorageDescriptor descriptor =
+                requireStorageDescriptor(versionRow, agentName, version);
+            clearEditingVersion(namespaceId, agentName, version);
+            int deleted = versionPersistService.delete(namespaceId, agentName,
+                Constants.Agent.RESOURCE_TYPE_AGENT, version);
+            if (deleted != 1) {
+                throw serverError("Agent draft Version row was not deleted: " + agentName + '@'
+                    + version, null);
+            }
+            storageService.delete(descriptor);
+        } catch (Exception e) {
+            throw asNacosException("Failed to delete Agent draft " + agentName + '@' + version, e);
+        }
+    }
+    
+    /**
+     * Delete an Agent definition, every Version row, and all referenced Version content.
+     *
+     * <p>Runtime Endpoint publisher state is intentionally not touched.</p>
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact, case-sensitive Agent name
+     * @throws NacosException when metadata or Version content cleanup fails
+     */
+    public void deleteAgent(String namespaceId, String agentName) throws NacosException {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        AgentValidationUtils.validateAgentName(agentName);
+        getAgent(namespaceId, agentName);
+        List<AiResourceVersion> versionRows =
+            listAllVersionRows(namespaceId, agentName, null);
+        List<AgentVersionStorageDescriptor> descriptors =
+            new ArrayList<AgentVersionStorageDescriptor>(versionRows.size());
+        try {
+            for (AiResourceVersion row : versionRows) {
+                descriptors.add(requireStorageDescriptor(row, agentName, row.getVersion()));
+            }
+        } catch (Exception e) {
+            throw asNacosException("Failed to read Agent Version storage descriptors for "
+                + agentName, e);
+        }
+        
+        int deletedResources = resourcePersistService.delete(namespaceId, agentName,
+            Constants.Agent.RESOURCE_TYPE_AGENT);
+        if (deletedResources != 1) {
+            throw serverError("Agent Resource row was not deleted: " + agentName, null);
+        }
+        int deletedVersions = versionPersistService.deleteByNameAndType(namespaceId, agentName,
+            Constants.Agent.RESOURCE_TYPE_AGENT);
+        if (!versionRows.isEmpty() && deletedVersions <= 0) {
+            throw serverError("Agent Version rows were not deleted: " + agentName, null);
+        }
+        NacosException firstFailure = null;
+        for (AgentVersionStorageDescriptor descriptor : descriptors) {
+            try {
+                storageService.delete(descriptor);
+            } catch (NacosException e) {
+                if (firstFailure == null) {
+                    firstFailure = e;
+                } else {
+                    firstFailure.addSuppressed(e);
+                }
+            }
+        }
+        if (firstFailure != null) {
+            throw serverError("Agent definition was deleted but some Version content could not be "
+                + "cleaned: " + agentName, firstFailure);
+        }
+    }
+    
+    /**
+     * List Agent Version summaries without loading Version content.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param status optional Version status filter
+     * @param pageNo page number
+     * @param pageSize page size
+     * @return Version summary page
+     * @throws NacosException when the Agent or stored descriptor is invalid
+     */
+    public Page<AgentVersionSummary> listAgentVersions(String namespaceId, String agentName,
+        String status, int pageNo, int pageSize) throws NacosException {
+        getAgent(namespaceId, agentName);
+        Page<AiResourceVersion> source = versionPersistService.list(namespaceId, agentName,
+            Constants.Agent.RESOURCE_TYPE_AGENT, status, pageNo, pageSize);
+        List<AgentVersionSummary> summaries = new ArrayList<AgentVersionSummary>();
+        try {
+            if (source != null && source.getPageItems() != null) {
+                for (AiResourceVersion row : source.getPageItems()) {
+                    AgentVersionSummary summary = toVersionSummary(row);
+                    AgentModelValidator.validateVersionSummary(summary);
+                    summaries.add(summary);
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            throw serverError("Stored Agent Version summary is invalid: " + agentName, e);
+        }
+        Page<AgentVersionSummary> result = new Page<AgentVersionSummary>();
+        result.setPageNumber(pageNo);
+        result.setTotalCount(source == null ? 0 : source.getTotalCount());
+        result.setPagesAvailable(source == null ? 0 : source.getPagesAvailable());
+        result.setPageItems(summaries);
+        return result;
+    }
+    
+    /**
+     * Read one exact Agent Version summary without loading Version content.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName exact Agent name
+     * @param version exact Agent Version
+     * @return Version summary
+     * @throws NacosException when the Version is absent or invalid
+     */
+    public AgentVersionSummary getAgentVersionSummary(String namespaceId, String agentName,
+        String version) throws NacosException {
+        getAgent(namespaceId, agentName);
+        try {
+            AgentVersionSummary result =
+                toVersionSummary(findVersion(namespaceId, agentName, version));
+            AgentModelValidator.validateVersionSummary(result);
+            return result;
+        } catch (IllegalArgumentException e) {
+            throw serverError("Stored Agent Version metadata is invalid: " + agentName + '@'
+                + version, e);
+        }
+    }
+    
+    AiResourceVersion requireVersionRow(String namespaceId, String agentName, String version)
+        throws NacosApiException {
+        return findVersion(namespaceId, agentName, version);
+    }
+    
+    void updateVersionStatus(String namespaceId, String agentName, String version, String status)
+        throws NacosException {
+        int updated = versionPersistService.updateStatus(namespaceId, agentName,
+            Constants.Agent.RESOURCE_TYPE_AGENT, version, status);
+        if (updated != 1) {
+            throw serverError("Agent Version status was not updated: " + agentName + '@'
+                + version, null);
+        }
+    }
+    
+    void updatePublishPipelineInfo(String namespaceId, String agentName, String version,
+        String publishPipelineInfo) throws NacosException {
+        int updated = versionPersistService.updatePublishPipelineInfo(namespaceId, agentName,
+            Constants.Agent.RESOURCE_TYPE_AGENT, version, publishPipelineInfo);
+        if (updated != 1) {
+            throw serverError("Agent Version pipeline info was not updated: " + agentName + '@'
+                + version, null);
+        }
+    }
+    
+    /**
+     * Rebuild Agent lifecycle summary and Version catalog from current online Version facts.
+     *
+     * <p>The Resource CAS writes {@code version_info} and {@code ext.versionCatalog} together.
+     * Every retry re-reads Version status and verified content so a stale catalog is never copied
+     * over a concurrent Resource update.</p>
+     */
+    Agent synchronizeDerivedState(String namespaceId, String agentName, String preferredLatest,
+        Map<String, String> requestedLabels, String clearEditingVersion,
+        String clearReviewingVersion) throws NacosException {
+        for (int i = 0; i < AiResourceConstants.MAX_WORKING_VERSION_RETRY; i++) {
+            AiResource meta = resourcePersistService.find(namespaceId, agentName,
+                Constants.Agent.RESOURCE_TYPE_AGENT);
+            if (!matches(meta, namespaceId, agentName)) {
+                throw notFound("Agent not found: " + agentName);
+            }
+            if (meta.getMetaVersion() == null) {
+                throw serverError("Stored Agent metaVersion is missing: " + agentName, null);
+            }
+            ResourceVersionInfo versionInfo = AiResourceManager.requireVersionInfo(meta);
+            if (StringUtils.equals(versionInfo.getEditingVersion(), clearEditingVersion)) {
+                versionInfo.setEditingVersion(null);
+            }
+            if (StringUtils.equals(versionInfo.getReviewingVersion(), clearReviewingVersion)) {
+                versionInfo.setReviewingVersion(null);
+            }
+            Map<String, String> labels = mergeRequestedLabels(versionInfo, requestedLabels);
+            if (preferredLatest != null) {
+                AgentValidationUtils.validateVersion(preferredLatest);
+                labels.put(AiResourceConstants.LABEL_LATEST, preferredLatest);
+            }
+            validateLabelTargets(namespaceId, agentName, labels);
+            Map<String, List<String>> onlineVersionProtocols =
+                loadOnlineVersionProtocols(namespaceId, agentName);
+            AgentVersionCatalogBuilder.Result derived =
+                AgentVersionCatalogBuilder.build(onlineVersionProtocols, labels);
+            versionInfo.setOnlineCnt(onlineVersionProtocols.size());
+            versionInfo.setLabels(new LinkedHashMap<String, String>(derived.getLabels()));
+            
+            AgentResourceExt resourceExt = AgentResourceExtSerializer.deserialize(meta.getExt());
+            resourceExt.setVersionCatalog(derived.getVersionCatalog());
+            AiResource updateValue = buildMetaUpdateValue(meta, versionInfo, resourceExt);
+            if (resourcePersistService.updateMetaCas(namespaceId, agentName,
+                Constants.Agent.RESOURCE_TYPE_AGENT, meta.getMetaVersion(), updateValue)) {
+                return getAgent(namespaceId, agentName);
+            }
+        }
+        throw conflict("Agent lifecycle metadata changed concurrently: " + agentName, null);
+    }
+    
+    private void validateSubsequentDraftInputs(String namespaceId, String agentName,
+        AgentVersionDetail draft, String basedOnVersion) {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        AgentValidationUtils.validateAgentName(agentName);
+        if (draft == null) {
+            throw new IllegalArgumentException("Agent draft must not be null");
+        }
+        AgentValidationUtils.validateVersion(draft.getVersion());
+        if (draft.getNamespaceId() != null
+            && !namespaceId.equals(draft.getNamespaceId())) {
+            throw new IllegalArgumentException("Agent draft namespaceId does not match request");
+        }
+        if (draft.getAgentName() != null && !agentName.equals(draft.getAgentName())) {
+            throw new IllegalArgumentException("Agent draft agentName does not match request");
+        }
+        if (draft.getStatus() != null
+            && !AiConstants.Agent.VERSION_STATUS_DRAFT.equals(draft.getStatus())) {
+            throw new IllegalArgumentException("Agent draft status must be draft");
+        }
+        if (draft.getContentDigest() != null || draft.getCreateTime() != null
+            || draft.getUpdateTime() != null) {
+            throw new IllegalArgumentException(
+                "Agent draft must not contain read-only projection fields");
+        }
+        boolean directContent = draft.getCallInterfaces() != null;
+        boolean copiedContent = StringUtils.isNotBlank(basedOnVersion);
+        if (directContent == copiedContent) {
+            throw new IllegalArgumentException(
+                "Agent draft must contain either callInterfaces or basedOnVersion");
+        }
+        if (copiedContent) {
+            AgentValidationUtils.validateVersion(basedOnVersion);
+            if (draft.getVersion().equals(basedOnVersion)) {
+                throw new IllegalArgumentException(
+                    "Agent draft Version must differ from basedOnVersion");
+            }
+        }
+    }
+    
+    private AgentVersionDetail normalizeSubsequentDraft(String namespaceId, String agentName,
+        AgentVersionDetail source, List<AgentCallInterface> callInterfaces,
+        AgentVersionStorageDescriptor descriptor) {
+        AgentVersionDetail result = new AgentVersionDetail();
+        result.setNamespaceId(namespaceId);
+        result.setAgentName(agentName);
+        result.setVersion(source.getVersion());
+        result.setStatus(AiConstants.Agent.VERSION_STATUS_DRAFT);
+        result.setCallInterfaces(callInterfaces);
+        result.setAuthor(source.getAuthor());
+        result.setChangeDescription(source.getChangeDescription());
+        result.setContentDigest(descriptor.getContentDigest());
+        result.setCreateTime(0L);
+        result.setUpdateTime(0L);
+        return result;
+    }
+    
+    private void ensureDraftSlotAvailable(Agent agent, String version) throws NacosException {
+        String editingVersion = agent.getVersionInfo().getEditingVersion();
+        if (StringUtils.isNotBlank(editingVersion) && !version.equals(editingVersion)) {
+            throw conflict("Agent already has an editing Version: " + editingVersion, null);
+        }
+    }
+    
+    private void markEditingVersion(String namespaceId, String agentName, String version)
+        throws NacosException {
+        for (int i = 0; i < AiResourceConstants.MAX_WORKING_VERSION_RETRY; i++) {
+            AiResource meta = resourcePersistService.find(namespaceId, agentName,
+                Constants.Agent.RESOURCE_TYPE_AGENT);
+            if (!matches(meta, namespaceId, agentName)) {
+                throw notFound("Agent not found: " + agentName);
+            }
+            if (meta.getMetaVersion() == null) {
+                throw serverError("Stored Agent metaVersion is missing: " + agentName, null);
+            }
+            ResourceVersionInfo versionInfo = AiResourceManager.requireVersionInfo(meta);
+            if (version.equals(versionInfo.getEditingVersion())) {
+                return;
+            }
+            if (StringUtils.isNotBlank(versionInfo.getEditingVersion())) {
+                throw conflict("Agent already has an editing Version: "
+                    + versionInfo.getEditingVersion(), null);
+            }
+            versionInfo.setEditingVersion(version);
+            AiResource updateValue = buildMetaUpdateValue(meta, versionInfo,
+                AgentResourceExtSerializer.deserialize(meta.getExt()));
+            if (resourcePersistService.updateMetaCas(namespaceId, agentName,
+                Constants.Agent.RESOURCE_TYPE_AGENT, meta.getMetaVersion(), updateValue)) {
+                return;
+            }
+        }
+        throw conflict("Agent editing Version changed concurrently: " + agentName, null);
+    }
+    
+    private void clearEditingVersion(String namespaceId, String agentName, String version)
+        throws NacosException {
+        for (int i = 0; i < AiResourceConstants.MAX_WORKING_VERSION_RETRY; i++) {
+            AiResource meta = resourcePersistService.find(namespaceId, agentName,
+                Constants.Agent.RESOURCE_TYPE_AGENT);
+            if (!matches(meta, namespaceId, agentName)) {
+                throw notFound("Agent not found: " + agentName);
+            }
+            if (meta.getMetaVersion() == null) {
+                throw serverError("Stored Agent metaVersion is missing: " + agentName, null);
+            }
+            ResourceVersionInfo versionInfo = AiResourceManager.requireVersionInfo(meta);
+            if (!version.equals(versionInfo.getEditingVersion())) {
+                throw illegalState("Agent Version is not the current draft: " + agentName + '@'
+                    + version);
+            }
+            versionInfo.setEditingVersion(null);
+            AiResource updateValue = buildMetaUpdateValue(meta, versionInfo,
+                AgentResourceExtSerializer.deserialize(meta.getExt()));
+            if (resourcePersistService.updateMetaCas(namespaceId, agentName,
+                Constants.Agent.RESOURCE_TYPE_AGENT, meta.getMetaVersion(), updateValue)) {
+                return;
+            }
+        }
+        throw conflict("Agent editing Version changed concurrently: " + agentName, null);
+    }
+    
+    private Map<String, String> mergeRequestedLabels(ResourceVersionInfo versionInfo,
+        Map<String, String> requestedLabels) {
+        Map<String, String> result = requestedLabels == null
+            ? new LinkedHashMap<String, String>(versionInfo.getLabels())
+            : new LinkedHashMap<String, String>(requestedLabels);
+        if (requestedLabels != null) {
+            result.remove(AiResourceConstants.LABEL_LATEST);
+            String latest = versionInfo.getLabels().get(AiResourceConstants.LABEL_LATEST);
+            if (latest != null) {
+                result.put(AiResourceConstants.LABEL_LATEST, latest);
+            }
+        }
+        return result;
+    }
+    
+    private void validateLabelTargets(String namespaceId, String agentName,
+        Map<String, String> labels) throws NacosException {
+        for (Map.Entry<String, String> label : labels.entrySet()) {
+            AgentValidationUtils.validateLabel(label.getKey());
+            AgentValidationUtils.validateVersion(label.getValue());
+            if (AiResourceConstants.LABEL_LATEST.equals(label.getKey())) {
+                continue;
+            }
+            AiResourceVersion target = versionPersistService.find(namespaceId, agentName,
+                Constants.Agent.RESOURCE_TYPE_AGENT, label.getValue());
+            if (!matches(target, namespaceId, agentName, label.getValue())) {
+                throw notFound("Agent label target Version not found: " + agentName + '@'
+                    + label.getValue());
+            }
+            if (AiConstants.Agent.VERSION_STATUS_DRAFT.equals(target.getStatus())
+                || AiConstants.Agent.VERSION_STATUS_REVIEWING.equals(target.getStatus())) {
+                throw illegalState("Agent label cannot target a working Version: " + label.getKey()
+                    + '=' + label.getValue());
+            }
+        }
+    }
+    
+    private Map<String, List<String>> loadOnlineVersionProtocols(String namespaceId,
+        String agentName) throws NacosException {
+        List<AiResourceVersion> onlineRows = listAllVersionRows(namespaceId, agentName,
+            AiConstants.Agent.VERSION_STATUS_ONLINE);
+        Map<String, List<String>> result =
+            new LinkedHashMap<String, List<String>>(onlineRows.size());
+        for (AiResourceVersion row : onlineRows) {
+            AgentVersionStorageDescriptor descriptor =
+                requireStorageDescriptor(row, agentName, row.getVersion());
+            AgentVersionContent content = storageService.load(descriptor);
+            List<String> protocols =
+                new ArrayList<String>(content.getCallInterfaces().size());
+            for (AgentCallInterface callInterface : content.getCallInterfaces()) {
+                protocols.add(callInterface.getProtocol());
+            }
+            result.put(row.getVersion(), protocols);
+        }
+        return result;
+    }
+    
+    private List<AiResourceVersion> listAllVersionRows(String namespaceId, String agentName,
+        String status) {
+        List<AiResourceVersion> result = new ArrayList<AiResourceVersion>();
+        int pageNo = 1;
+        while (true) {
+            Page<AiResourceVersion> page = versionPersistService.list(namespaceId, agentName,
+                Constants.Agent.RESOURCE_TYPE_AGENT, status, pageNo, VERSION_SCAN_PAGE_SIZE);
+            if (page == null || page.getPageItems() == null || page.getPageItems().isEmpty()) {
+                return result;
+            }
+            result.addAll(page.getPageItems());
+            if (page.getPageItems().size() < VERSION_SCAN_PAGE_SIZE) {
+                return result;
+            }
+            pageNo++;
+        }
+    }
+    
+    private AiResource buildMetaUpdateValue(AiResource source, ResourceVersionInfo versionInfo,
+        AgentResourceExt resourceExt) {
+        AiResource result = new AiResource();
+        result.setStatus(source.getStatus());
+        result.setDesc(source.getDesc());
+        result.setBizTags(source.getBizTags());
+        result.setExt(AgentResourceExtSerializer.serialize(resourceExt));
+        try {
+            result.setVersionInfo(JacksonUtils.toJson(versionInfo));
+        } catch (NacosSerializationException e) {
+            throw new IllegalArgumentException("Unable to serialize Agent version info", e);
+        }
+        return result;
     }
     
     private void validateDraftUpdateInputs(String namespaceId, String agentName, String version,

--- a/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PublishPipelineResourceTypeTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/pipeline/model/PublishPipelineResourceTypeTest.java
@@ -43,9 +43,9 @@ class PublishPipelineResourceTypeTest {
     }
     
     @Test
-    void testValuesContainsAllThreeTypes() {
+    void testValuesContainsAllTypes() {
         PublishPipelineResourceType[] values = PublishPipelineResourceType.values();
-        assertEquals(3, values.length, "PublishPipelineResourceType should have exactly 3 values");
+        assertEquals(4, values.length, "PublishPipelineResourceType should have exactly 4 values");
         
         Set<PublishPipelineResourceType> valueSet =
             Arrays.stream(values).collect(Collectors.toSet());
@@ -55,5 +55,7 @@ class PublishPipelineResourceTypeTest {
             "values() should contain PROMPT");
         assertTrue(valueSet.contains(PublishPipelineResourceType.AGENTSPEC),
             "values() should contain AGENTSPEC");
+        assertTrue(valueSet.contains(PublishPipelineResourceType.AGENT),
+            "values() should contain AGENT");
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/AgentOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/AgentOperationServiceTest.java
@@ -1,0 +1,627 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.ai.pipeline.PublishPipelineExecutor;
+import com.alibaba.nacos.ai.pipeline.model.PipelineCallback;
+import com.alibaba.nacos.ai.service.VisibilityHelper;
+import com.alibaba.nacos.ai.service.resource.AiResourceManager;
+import com.alibaba.nacos.ai.service.resource.PublishPipelineInfo;
+import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
+import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.model.agent.Agent;
+import com.alibaba.nacos.api.ai.model.agent.AgentOverview;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionDetail;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionSummary;
+import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecutionResult;
+import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecutionStatus;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineContext;
+import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentOperationServiceTest {
+    
+    private static final String NAMESPACE_ID = "public";
+    
+    private static final String AGENT_NAME = "Nacos Agent";
+    
+    private static final String VERSION = "1.0.0-RC1";
+    
+    @Mock
+    private AgentPersistenceService persistenceService;
+    
+    @Mock
+    private AiResourceManager resourceManager;
+    
+    @Mock
+    private PublishPipelineExecutor publishPipelineExecutor;
+    
+    private AgentOperationService service;
+    
+    private MockedStatic<VisibilityHelper> visibilityHelper;
+    
+    private MockedStatic<AiResourceTraceService> traceService;
+    
+    @BeforeEach
+    void setUp() {
+        service =
+            new AgentOperationService(persistenceService, resourceManager,
+                publishPipelineExecutor);
+        visibilityHelper = org.mockito.Mockito.mockStatic(VisibilityHelper.class);
+        visibilityHelper.when(VisibilityHelper::resolveCurrentIdentity).thenReturn("alice");
+        visibilityHelper.when(VisibilityHelper::resolveClientIp).thenReturn("127.0.0.1");
+        traceService = org.mockito.Mockito.mockStatic(AiResourceTraceService.class);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        traceService.close();
+        visibilityHelper.close();
+    }
+    
+    @Test
+    void testCreateAndReadOperationsDelegateWithoutChangingModels() throws NacosException {
+        Agent agent = new Agent();
+        agent.setAgentName(AGENT_NAME);
+        AgentVersionDetail draft = new AgentVersionDetail();
+        draft.setVersion(VERSION);
+        AgentOverview overview = new AgentOverview();
+        Agent storedAgent = new Agent();
+        AiResource meta = meta(null, null);
+        AgentVersionDetail detail = new AgentVersionDetail();
+        Page<AgentVersionSummary> page = new Page<AgentVersionSummary>();
+        when(persistenceService.create(agent, draft)).thenReturn(overview);
+        when(resourceManager.requireMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(meta);
+        when(persistenceService.getAgent(NAMESPACE_ID, AGENT_NAME)).thenReturn(storedAgent);
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(detail);
+        when(persistenceService.listAgentVersions(NAMESPACE_ID, AGENT_NAME, null, 1, 20))
+            .thenReturn(page);
+        
+        assertSame(overview, service.create(agent, draft));
+        assertSame(storedAgent, service.getAgent(NAMESPACE_ID, AGENT_NAME));
+        assertSame(detail, service.getVersion(NAMESPACE_ID, AGENT_NAME, VERSION));
+        assertSame(page, service.listVersions(NAMESPACE_ID, AGENT_NAME, null, 1, 20));
+        
+        verify(resourceManager, org.mockito.Mockito.times(3)).ensureReadableOrNotFound(meta,
+            "Agent not found: " + AGENT_NAME);
+    }
+    
+    @Test
+    void testDraftOperationsRequireWritableResourceAndDelegate() throws NacosException {
+        AiResource meta = meta(VERSION, null);
+        AgentVersionDetail draft = new AgentVersionDetail();
+        draft.setVersion(VERSION);
+        AgentVersionDetail result = new AgentVersionDetail();
+        when(resourceManager.requireMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(meta);
+        when(persistenceService.createDraft(NAMESPACE_ID, AGENT_NAME, draft, null))
+            .thenReturn(result);
+        when(persistenceService.updateDraft(NAMESPACE_ID, AGENT_NAME, VERSION,
+            Collections.emptyList(), "change")).thenReturn(result);
+        
+        assertSame(result,
+            service.createDraft(NAMESPACE_ID, AGENT_NAME, draft, null));
+        assertSame(result, service.updateDraft(NAMESPACE_ID, AGENT_NAME, VERSION,
+            Collections.emptyList(), "change"));
+        service.deleteDraft(NAMESPACE_ID, AGENT_NAME, VERSION);
+        service.deleteAgent(NAMESPACE_ID, AGENT_NAME);
+        
+        visibilityHelper.verify(
+            () -> VisibilityHelper.checkWritableResource(meta),
+            org.mockito.Mockito.times(4));
+        verify(persistenceService).deleteDraft(NAMESPACE_ID, AGENT_NAME, VERSION);
+        verify(persistenceService).deleteAgent(NAMESPACE_ID, AGENT_NAME);
+    }
+    
+    @Test
+    void testSubmitWithoutPipelinePublishesVerifiedDraftAndClearsEditing()
+        throws NacosException {
+        AiResource meta = meta(VERSION, null);
+        AiResourceVersion draft = versionRow(AiConstants.Agent.VERSION_STATUS_DRAFT);
+        AgentVersionSummary summary = summary(AiConstants.Agent.VERSION_STATUS_ONLINE);
+        stubWritableMeta(meta);
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(draft);
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(new AgentVersionDetail());
+        when(publishPipelineExecutor.isPipelineAvailable(PublishPipelineResourceType.AGENT))
+            .thenReturn(false);
+        when(persistenceService.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(summary);
+        
+        assertSame(summary, service.submit(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        verify(persistenceService).updateVersionStatus(NAMESPACE_ID, AGENT_NAME, VERSION,
+            AiConstants.Agent.VERSION_STATUS_ONLINE);
+        verify(persistenceService).synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, VERSION, null,
+            VERSION, null);
+        verify(resourceManager, never()).moveToReviewing(anyString(), anyString(), anyString(),
+            anyString(), any(AiResource.class), any(ResourceVersionInfo.class));
+    }
+    
+    @Test
+    void testSubmitRejectsNonDraftBeforeContentOrPipelineAccess() throws NacosException {
+        stubWritableMeta(meta(VERSION, null));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWING));
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.submit(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        assertIllegalState(exception);
+        verify(persistenceService, never()).getAgentVersion(anyString(), anyString(), anyString());
+        verify(publishPipelineExecutor, never()).isPipelineAvailable(any());
+        verify(persistenceService, never()).updateVersionStatus(anyString(), anyString(),
+            anyString(), anyString());
+    }
+    
+    @Test
+    void testSubmitStartsAgentPipelineAfterMovingDraftToReviewing() throws NacosException {
+        AiResource meta = meta(VERSION, null);
+        stubWritableMeta(meta);
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_DRAFT));
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(new AgentVersionDetail());
+        when(publishPipelineExecutor.isPipelineAvailable(PublishPipelineResourceType.AGENT))
+            .thenReturn(true);
+        when(publishPipelineExecutor.execute(any(PublishPipelineContext.class),
+            any(PipelineCallback.class), anyString())).thenAnswer(
+                invocation -> invocation.getArgument(2));
+        AgentVersionSummary reviewing =
+            summary(AiConstants.Agent.VERSION_STATUS_REVIEWING);
+        when(persistenceService.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(reviewing);
+        
+        assertSame(reviewing, service.submit(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        verify(resourceManager).moveToReviewing(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(VERSION), eq(meta),
+            any(ResourceVersionInfo.class));
+        ArgumentCaptor<PublishPipelineContext> contextCaptor =
+            ArgumentCaptor.forClass(PublishPipelineContext.class);
+        verify(publishPipelineExecutor).execute(contextCaptor.capture(),
+            any(PipelineCallback.class), anyString());
+        assertEquals(PublishPipelineResourceType.AGENT,
+            contextCaptor.getValue().getResourceType());
+        assertEquals(NAMESPACE_ID, contextCaptor.getValue().getNamespaceId());
+        assertEquals(AGENT_NAME, contextCaptor.getValue().getResourceName());
+        assertEquals(VERSION, contextCaptor.getValue().getVersion());
+    }
+    
+    @Test
+    void testSubmitPipelineFallthroughPublishesAndClearsReviewing() throws NacosException {
+        AiResource meta = meta(VERSION, null);
+        stubWritableMeta(meta);
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_DRAFT),
+                versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWING));
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(new AgentVersionDetail());
+        when(publishPipelineExecutor.isPipelineAvailable(PublishPipelineResourceType.AGENT))
+            .thenReturn(true);
+        when(publishPipelineExecutor.execute(any(PublishPipelineContext.class),
+            any(PipelineCallback.class), anyString())).thenReturn("");
+        when(persistenceService.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(summary(AiConstants.Agent.VERSION_STATUS_ONLINE));
+        
+        service.submit(NAMESPACE_ID, AGENT_NAME, VERSION);
+        
+        verify(persistenceService).updatePublishPipelineInfo(eq(NAMESPACE_ID),
+            eq(AGENT_NAME), eq(VERSION), org.mockito.ArgumentMatchers.contains("IN_PROGRESS"));
+        verify(persistenceService).updatePublishPipelineInfo(NAMESPACE_ID, AGENT_NAME, VERSION,
+            null);
+        verify(persistenceService).synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, VERSION, null,
+            null, VERSION);
+    }
+    
+    @Test
+    void testSubmitStopsWhenPipelineMarkerCannotBeWritten() throws NacosException {
+        stubWritableMeta(meta(VERSION, null));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_DRAFT));
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(new AgentVersionDetail());
+        when(publishPipelineExecutor.isPipelineAvailable(PublishPipelineResourceType.AGENT))
+            .thenReturn(true);
+        doThrow(new NacosException(NacosException.SERVER_ERROR, "marker write failed"))
+            .when(persistenceService).updatePublishPipelineInfo(eq(NAMESPACE_ID),
+                eq(AGENT_NAME), eq(VERSION), anyString());
+        
+        assertThrows(NacosException.class,
+            () -> service.submit(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        verify(publishPipelineExecutor, never()).execute(any(PublishPipelineContext.class),
+            any(PipelineCallback.class), anyString());
+        verify(persistenceService, never()).synchronizeDerivedState(anyString(), anyString(),
+            anyString(), any(), any(), any());
+    }
+    
+    @Test
+    void testSubmitStopsWhenPipelineMarkerCannotBeCleared() throws NacosException {
+        stubWritableMeta(meta(VERSION, null));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_DRAFT));
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(new AgentVersionDetail());
+        when(publishPipelineExecutor.isPipelineAvailable(PublishPipelineResourceType.AGENT))
+            .thenReturn(true);
+        when(publishPipelineExecutor.execute(any(PublishPipelineContext.class),
+            any(PipelineCallback.class), anyString())).thenReturn("");
+        doAnswer(invocation -> {
+            if (invocation.getArgument(3) == null) {
+                throw new NacosException(NacosException.SERVER_ERROR, "marker clear failed");
+            }
+            return null;
+        }).when(persistenceService).updatePublishPipelineInfo(eq(NAMESPACE_ID),
+            eq(AGENT_NAME), eq(VERSION), any());
+        
+        assertThrows(NacosException.class,
+            () -> service.submit(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        verify(persistenceService, never()).synchronizeDerivedState(anyString(), anyString(),
+            anyString(), any(), any(), any());
+    }
+    
+    @Test
+    void testApprovedPipelineCallbackTransitionsOnlyMatchingReview()
+        throws NacosException {
+        AtomicReference<PipelineCallback> callback = new AtomicReference<PipelineCallback>();
+        AtomicReference<String> executionId = new AtomicReference<String>();
+        prepareAsyncSubmit(callback, executionId);
+        
+        service.submit(NAMESPACE_ID, AGENT_NAME, VERSION);
+        AiResourceVersion inProgress =
+            versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWING);
+        inProgress.setPublishPipelineInfo(pipelineInfo(executionId.get(),
+            PipelineExecutionStatus.IN_PROGRESS, false));
+        AiResourceVersion completed =
+            versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWING);
+        completed.setPublishPipelineInfo(pipelineInfo(executionId.get(),
+            PipelineExecutionStatus.APPROVED, false));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(inProgress, completed);
+        PipelineExecutionResult result = new PipelineExecutionResult();
+        result.setExecutionId(executionId.get());
+        result.setStatus(PipelineExecutionStatus.APPROVED);
+        
+        callback.get().onComplete(result);
+        
+        verify(persistenceService).updatePublishPipelineInfo(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(VERSION), org.mockito.ArgumentMatchers.contains("APPROVED"));
+        verify(persistenceService).updateVersionStatus(NAMESPACE_ID, AGENT_NAME, VERSION,
+            AiConstants.Agent.VERSION_STATUS_REVIEWED);
+    }
+    
+    @Test
+    void testPipelineCallbackIgnoresStaleExecution() throws NacosException {
+        AtomicReference<PipelineCallback> callback = new AtomicReference<PipelineCallback>();
+        AtomicReference<String> executionId = new AtomicReference<String>();
+        prepareAsyncSubmit(callback, executionId);
+        service.submit(NAMESPACE_ID, AGENT_NAME, VERSION);
+        AiResourceVersion current =
+            versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWING);
+        current.setPublishPipelineInfo(pipelineInfo("newer-execution",
+            PipelineExecutionStatus.IN_PROGRESS, false));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(current);
+        
+        callback.get().onComplete(new PipelineExecutionResult());
+        
+        verify(persistenceService, never()).updatePublishPipelineInfo(eq(NAMESPACE_ID),
+            eq(AGENT_NAME), eq(VERSION),
+            org.mockito.ArgumentMatchers.contains("APPROVED"));
+        verify(persistenceService, never()).updateVersionStatus(anyString(), anyString(),
+            anyString(), eq(AiConstants.Agent.VERSION_STATUS_REVIEWED));
+    }
+    
+    @Test
+    void testPipelineCallbackDoesNotRegressVersionThatLeftReviewing()
+        throws NacosException {
+        AtomicReference<PipelineCallback> callback = new AtomicReference<PipelineCallback>();
+        AtomicReference<String> executionId = new AtomicReference<String>();
+        prepareAsyncSubmit(callback, executionId);
+        service.submit(NAMESPACE_ID, AGENT_NAME, VERSION);
+        AiResourceVersion current =
+            versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWING);
+        current.setPublishPipelineInfo(pipelineInfo(executionId.get(),
+            PipelineExecutionStatus.IN_PROGRESS, false));
+        AiResourceVersion alreadyOnline =
+            versionRow(AiConstants.Agent.VERSION_STATUS_ONLINE);
+        alreadyOnline.setPublishPipelineInfo(pipelineInfo(executionId.get(),
+            PipelineExecutionStatus.APPROVED, false));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(current, alreadyOnline);
+        PipelineExecutionResult result = new PipelineExecutionResult();
+        result.setStatus(PipelineExecutionStatus.APPROVED);
+        
+        callback.get().onComplete(result);
+        
+        verify(persistenceService, never()).updateVersionStatus(anyString(), anyString(),
+            anyString(), eq(AiConstants.Agent.VERSION_STATUS_REVIEWED));
+    }
+    
+    @Test
+    void testPipelineCallbackFailureIsContained() throws NacosException {
+        AtomicReference<PipelineCallback> callback = new AtomicReference<PipelineCallback>();
+        AtomicReference<String> executionId = new AtomicReference<String>();
+        prepareAsyncSubmit(callback, executionId);
+        service.submit(NAMESPACE_ID, AGENT_NAME, VERSION);
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenThrow(new IllegalStateException("storage unavailable"));
+        
+        assertDoesNotThrow(() -> callback.get().onComplete(new PipelineExecutionResult()));
+        
+        verify(persistenceService, never()).updatePublishPipelineInfo(eq(NAMESPACE_ID),
+            eq(AGENT_NAME), eq(VERSION),
+            org.mockito.ArgumentMatchers.contains("APPROVED"));
+    }
+    
+    @Test
+    void testPublishRequiresReviewedApprovedCurrentReviewAndRevalidatesContent()
+        throws NacosException {
+        AiResource meta = meta(null, VERSION);
+        AiResourceVersion reviewed = versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWED);
+        reviewed.setPublishPipelineInfo(
+            pipelineInfo("execution", PipelineExecutionStatus.APPROVED, false));
+        AgentVersionSummary online =
+            summary(AiConstants.Agent.VERSION_STATUS_ONLINE);
+        stubWritableMeta(meta);
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(reviewed);
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(new AgentVersionDetail());
+        when(persistenceService.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(online);
+        
+        assertSame(online, service.publish(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        verify(persistenceService).getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION);
+        verify(persistenceService).updateVersionStatus(NAMESPACE_ID, AGENT_NAME, VERSION,
+            AiConstants.Agent.VERSION_STATUS_ONLINE);
+        verify(persistenceService).synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, VERSION, null,
+            null, VERSION);
+    }
+    
+    @Test
+    void testPublishRejectsUnapprovedOrHistoricalReview() throws NacosException {
+        AiResource meta = meta(null, VERSION);
+        AiResourceVersion reviewed = versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWED);
+        reviewed.setPublishPipelineInfo(
+            pipelineInfo("execution", PipelineExecutionStatus.APPROVED, true));
+        stubWritableMeta(meta);
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(reviewed);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.publish(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        assertIllegalState(exception);
+        verify(persistenceService, never()).updateVersionStatus(anyString(), anyString(),
+            anyString(), anyString());
+    }
+    
+    @Test
+    void testForcePublishAcceptsReviewingAndRejectsOnline() throws NacosException {
+        AiResource meta = meta(null, VERSION);
+        stubWritableMeta(meta);
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWING));
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(new AgentVersionDetail());
+        when(persistenceService.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(summary(AiConstants.Agent.VERSION_STATUS_ONLINE));
+        
+        service.forcePublish(NAMESPACE_ID, AGENT_NAME, VERSION);
+        
+        verify(persistenceService).synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, VERSION, null,
+            null, VERSION);
+        
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_ONLINE));
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.forcePublish(NAMESPACE_ID, AGENT_NAME, VERSION));
+        assertIllegalState(exception);
+    }
+    
+    @Test
+    void testRedraftRejectsAnotherEditingVersionBeforeGenericTransition()
+        throws NacosException {
+        AiResource meta = meta("2.0.0", VERSION);
+        stubWritableMeta(meta);
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWED));
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.redraft(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        assertEquals(NacosException.CONFLICT, exception.getErrCode());
+        assertEquals(ErrorCode.RESOURCE_CONFLICT.getCode(), exception.getDetailErrCode());
+        verify(resourceManager, never()).doRedraft(anyString(), anyString(), anyString(),
+            anyString());
+    }
+    
+    @Test
+    void testRedraftCurrentReviewReturnsDraftSummary() throws NacosException {
+        stubWritableMeta(meta(null, VERSION));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWED));
+        AgentVersionSummary draft = summary(AiConstants.Agent.VERSION_STATUS_DRAFT);
+        when(persistenceService.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(draft);
+        
+        assertSame(draft, service.redraft(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        verify(resourceManager).doRedraft(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION);
+    }
+    
+    @Test
+    void testPublishRejectsVersionThatIsNotCurrentReview() throws NacosException {
+        stubWritableMeta(meta(null, "2.0.0"));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_REVIEWED));
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.publish(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        assertIllegalState(exception);
+        verify(persistenceService, never()).updateVersionStatus(anyString(), anyString(),
+            anyString(), anyString());
+    }
+    
+    @Test
+    void testOnlineAndOfflineUseExactSourceStatesAndRebuildDerivedData()
+        throws NacosException {
+        stubWritableMeta(meta(null, null));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_OFFLINE),
+                versionRow(AiConstants.Agent.VERSION_STATUS_ONLINE));
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(new AgentVersionDetail());
+        when(persistenceService.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(summary(AiConstants.Agent.VERSION_STATUS_ONLINE),
+                summary(AiConstants.Agent.VERSION_STATUS_OFFLINE));
+        
+        service.online(NAMESPACE_ID, AGENT_NAME, VERSION);
+        service.offline(NAMESPACE_ID, AGENT_NAME, VERSION);
+        
+        verify(persistenceService).synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, VERSION, null,
+            null, null);
+        verify(persistenceService).synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, null, null,
+            null, null);
+    }
+    
+    @Test
+    void testUpdateLabelsDelegatesCompleteMapToDerivedStateCas() throws NacosException {
+        stubWritableMeta(meta(null, null));
+        Map<String, String> labels = new LinkedHashMap<String, String>();
+        labels.put("stable", VERSION);
+        Agent updated = new Agent();
+        when(persistenceService.synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, null, labels,
+            null, null)).thenReturn(updated);
+        
+        assertSame(updated, service.updateLabels(NAMESPACE_ID, AGENT_NAME, labels));
+    }
+    
+    private void prepareAsyncSubmit(AtomicReference<PipelineCallback> callback,
+        AtomicReference<String> executionId) throws NacosException {
+        stubWritableMeta(meta(VERSION, null));
+        when(persistenceService.requireVersionRow(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(versionRow(AiConstants.Agent.VERSION_STATUS_DRAFT));
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(new AgentVersionDetail());
+        when(publishPipelineExecutor.isPipelineAvailable(PublishPipelineResourceType.AGENT))
+            .thenReturn(true);
+        when(publishPipelineExecutor.execute(any(PublishPipelineContext.class),
+            any(PipelineCallback.class), anyString())).thenAnswer(invocation -> {
+                callback.set(invocation.getArgument(1));
+                executionId.set(invocation.getArgument(2));
+                return executionId.get();
+            });
+        when(persistenceService.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(summary(AiConstants.Agent.VERSION_STATUS_REVIEWING));
+    }
+    
+    private void stubWritableMeta(AiResource meta) throws NacosException {
+        when(resourceManager.requireMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(meta);
+    }
+    
+    private AiResource meta(String editingVersion, String reviewingVersion) {
+        ResourceVersionInfo versionInfo = new ResourceVersionInfo();
+        versionInfo.setEditingVersion(editingVersion);
+        versionInfo.setReviewingVersion(reviewingVersion);
+        versionInfo.setOnlineCnt(0);
+        versionInfo.setLabels(new LinkedHashMap<String, String>());
+        AiResource result = new AiResource();
+        result.setNamespaceId(NAMESPACE_ID);
+        result.setName(AGENT_NAME);
+        result.setType(Constants.Agent.RESOURCE_TYPE_AGENT);
+        result.setMetaVersion(1L);
+        result.setVersionInfo(JacksonUtils.toJson(versionInfo));
+        return result;
+    }
+    
+    private AiResourceVersion versionRow(String status) {
+        AiResourceVersion result = new AiResourceVersion();
+        result.setNamespaceId(NAMESPACE_ID);
+        result.setName(AGENT_NAME);
+        result.setType(Constants.Agent.RESOURCE_TYPE_AGENT);
+        result.setVersion(VERSION);
+        result.setStatus(status);
+        return result;
+    }
+    
+    private AgentVersionSummary summary(String status) {
+        AgentVersionSummary result = new AgentVersionSummary();
+        result.setVersion(VERSION);
+        result.setStatus(status);
+        return result;
+    }
+    
+    private String pipelineInfo(String executionId, PipelineExecutionStatus status,
+        boolean historical) {
+        PublishPipelineInfo result = new PublishPipelineInfo();
+        result.setExecutionId(executionId);
+        result.setStatus(status);
+        result.setHistorical(historical);
+        return JacksonUtils.toJson(result);
+    }
+    
+    private void assertIllegalState(NacosApiException exception) {
+        assertEquals(NacosException.INVALID_PARAM, exception.getErrCode());
+        assertEquals(ErrorCode.ILLEGAL_STATE.getCode(), exception.getDetailErrCode());
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/AgentPersistenceServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/AgentPersistenceServiceTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.ai.service.agent;
 
 import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.constant.AiResourceConstants;
 import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.model.AiResourceVersion;
 import com.alibaba.nacos.ai.model.agent.AgentResourceExt;
@@ -29,6 +30,7 @@ import com.alibaba.nacos.ai.service.agent.storage.AgentVersionStorageService;
 import com.alibaba.nacos.ai.service.agent.storage.PreparedAgentVersionWrite;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.agent.Agent;
@@ -37,9 +39,11 @@ import com.alibaba.nacos.api.ai.model.agent.AgentOverview;
 import com.alibaba.nacos.api.ai.model.agent.AgentProvider;
 import com.alibaba.nacos.api.ai.model.agent.AgentVersionCatalog;
 import com.alibaba.nacos.api.ai.model.agent.AgentVersionDetail;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionSummary;
 import com.alibaba.nacos.api.ai.model.agent.EndpointSource;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.sys.env.EnvUtil;
@@ -48,6 +52,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -73,6 +78,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -1237,6 +1244,889 @@ class AgentPersistenceServiceTest {
             () -> service.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION)));
     }
     
+    @Test
+    void testCreateDraftPersistsDirectContentAndClaimsEditingVersion() throws NacosException {
+        String draftVersion = "1.1.0";
+        AgentVersionDetail draft = newDraft(draftVersion, "json-rpc");
+        AgentVersionContent draftContent = new AgentVersionContent(draft.getCallInterfaces());
+        PreparedAgentVersionWrite draftWrite = prepareWrite(draftVersion, draftContent);
+        AiResourceVersion persistedDraft =
+            storedVersion(draftVersion, AiConstants.Agent.VERSION_STATUS_DRAFT, draftWrite);
+        AtomicReference<AiResource> currentResource =
+            new AtomicReference<AiResource>(resourceWithoutWorkingVersions());
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenAnswer(
+                invocation -> currentResource.get());
+        when(storageService.prepare(eq(NAMESPACE_ID), eq(AGENT_NAME), eq(draftVersion),
+            any(AgentVersionContent.class))).thenReturn(draftWrite);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, draftVersion)).thenReturn(null, persistedDraft);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(VERSION_ID + 1);
+        when(resourcePersistService.updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class)))
+            .thenAnswer(invocation -> {
+                currentResource.set(applyMetaUpdate(currentResource.get(),
+                    invocation.<AiResource>getArgument(4), 4L));
+                return true;
+            });
+        when(storageService.load(any(AgentVersionStorageDescriptor.class)))
+            .thenReturn(draftContent);
+        
+        AgentVersionDetail result =
+            service.createDraft(NAMESPACE_ID, AGENT_NAME, draft, null);
+        
+        assertEquals(draftVersion, result.getVersion());
+        assertEquals("json-rpc", result.getCallInterfaces().get(0).getProtocol());
+        assertEquals(draftWrite.getDescriptor().getContentDigest(), result.getContentDigest());
+        ResourceVersionInfo versionInfo = JacksonUtils.toObj(
+            currentResource.get().getVersionInfo(), ResourceVersionInfo.class);
+        assertEquals(draftVersion, versionInfo.getEditingVersion());
+        InOrder order = inOrder(versionPersistService, storageService, resourcePersistService);
+        order.verify(versionPersistService).insert(any(AiResourceVersion.class));
+        order.verify(storageService).save(draftWrite);
+        order.verify(resourcePersistService).updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class));
+    }
+    
+    @Test
+    void testCreateDraftCopiesExactBasedOnVersion() throws NacosException {
+        String draftVersion = "1.1.0";
+        AgentVersionDetail draft = newDraft(draftVersion, null);
+        AgentVersionContent sourceContent = new AgentVersionContent(
+            newInitialDraft().getCallInterfaces());
+        PreparedAgentVersionWrite draftWrite = prepareWrite(draftVersion, sourceContent);
+        AiResourceVersion persistedDraft =
+            storedVersion(draftVersion, AiConstants.Agent.VERSION_STATUS_DRAFT, draftWrite);
+        AtomicReference<AiResource> currentResource =
+            new AtomicReference<AiResource>(resourceWithoutWorkingVersions());
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenAnswer(
+                invocation -> currentResource.get());
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(storedVersion());
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, draftVersion)).thenReturn(null, persistedDraft);
+        when(storageService.load(any(AgentVersionStorageDescriptor.class)))
+            .thenReturn(sourceContent);
+        when(storageService.prepare(eq(NAMESPACE_ID), eq(AGENT_NAME), eq(draftVersion),
+            any(AgentVersionContent.class))).thenReturn(draftWrite);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(VERSION_ID + 1);
+        when(resourcePersistService.updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class)))
+            .thenAnswer(invocation -> {
+                currentResource.set(applyMetaUpdate(currentResource.get(),
+                    invocation.<AiResource>getArgument(4), 4L));
+                return true;
+            });
+        
+        AgentVersionDetail result =
+            service.createDraft(NAMESPACE_ID, AGENT_NAME, draft, VERSION);
+        
+        assertEquals(draftVersion, result.getVersion());
+        assertEquals(sourceContent.getCallInterfaces(), result.getCallInterfaces());
+        ArgumentCaptor<AgentVersionContent> contentCaptor =
+            ArgumentCaptor.forClass(AgentVersionContent.class);
+        verify(storageService).prepare(eq(NAMESPACE_ID), eq(AGENT_NAME), eq(draftVersion),
+            contentCaptor.capture());
+        assertEquals(sourceContent.getCallInterfaces(),
+            contentCaptor.getValue().getCallInterfaces());
+        verify(storageService, times(2)).load(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testCreateDraftRejectsAnotherWorkingDraftBeforeContentPersistence()
+        throws NacosException {
+        AgentVersionDetail draft = newDraft("1.1.0", "json-rpc");
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.createDraft(NAMESPACE_ID, AGENT_NAME, draft, null));
+        
+        assertConflict(exception);
+        verifyNoInteractions(versionPersistService, storageService);
+        verify(resourcePersistService, never()).updateMetaCas(anyString(), anyString(),
+            anyString(), anyLong(), any(AiResource.class));
+    }
+    
+    @Test
+    void testCreateDraftValidatesIdentityStatusAndReadOnlyFieldsBeforePersistence() {
+        assertInvalidCreateDraft(null, null);
+        
+        AgentVersionDetail namespaceMismatch = newDraft("1.1.0", "a2a");
+        namespaceMismatch.setNamespaceId("other");
+        assertInvalidCreateDraft(namespaceMismatch, null);
+        
+        AgentVersionDetail nameMismatch = newDraft("1.1.0", "a2a");
+        nameMismatch.setAgentName("Other Agent");
+        assertInvalidCreateDraft(nameMismatch, null);
+        
+        AgentVersionDetail invalidStatus = newDraft("1.1.0", "a2a");
+        invalidStatus.setStatus(AiConstants.Agent.VERSION_STATUS_ONLINE);
+        assertInvalidCreateDraft(invalidStatus, null);
+        
+        AgentVersionDetail contentDigest = newDraft("1.1.0", "a2a");
+        contentDigest.setContentDigest("sha256:" + repeat('a', 64));
+        assertInvalidCreateDraft(contentDigest, null);
+        
+        AgentVersionDetail createTime = newDraft("1.1.0", "a2a");
+        createTime.setCreateTime(1L);
+        assertInvalidCreateDraft(createTime, null);
+        
+        AgentVersionDetail updateTime = newDraft("1.1.0", "a2a");
+        updateTime.setUpdateTime(1L);
+        assertInvalidCreateDraft(updateTime, null);
+        
+        verifyNoInteractions(resourcePersistService, versionPersistService, storageService);
+    }
+    
+    @Test
+    void testCreateDraftRequiresExactlyOneDistinctContentSource() {
+        assertInvalidCreateDraft(newDraft("1.1.0", "a2a"), VERSION);
+        assertInvalidCreateDraft(newDraft("1.1.0", null), null);
+        assertInvalidCreateDraft(newDraft(VERSION, null), VERSION);
+        
+        verifyNoInteractions(resourcePersistService, versionPersistService, storageService);
+    }
+    
+    @Test
+    void testCreateDraftAcceptsIdempotentEditingPointer() throws NacosException {
+        String draftVersion = "1.1.0";
+        AgentVersionDetail draft = newDraft(draftVersion, "a2a");
+        AgentVersionContent draftContent = new AgentVersionContent(draft.getCallInterfaces());
+        PreparedAgentVersionWrite draftWrite = prepareWrite(draftVersion, draftContent);
+        AiResourceVersion persistedDraft =
+            storedVersion(draftVersion, AiConstants.Agent.VERSION_STATUS_DRAFT, draftWrite);
+        AiResource resource = lifecycleResource(draftVersion, null,
+            Collections.<String, String>emptyMap(), 3L);
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(resource);
+        when(storageService.prepare(eq(NAMESPACE_ID), eq(AGENT_NAME), eq(draftVersion),
+            any(AgentVersionContent.class))).thenReturn(draftWrite);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, draftVersion)).thenReturn(null, persistedDraft);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(VERSION_ID + 1);
+        when(storageService.load(any(AgentVersionStorageDescriptor.class)))
+            .thenReturn(draftContent);
+        
+        AgentVersionDetail result =
+            service.createDraft(NAMESPACE_ID, AGENT_NAME, draft, null);
+        
+        assertEquals(draftVersion, result.getVersion());
+        verify(resourcePersistService, never()).updateMetaCas(anyString(), anyString(),
+            anyString(), anyLong(), any(AiResource.class));
+    }
+    
+    @Test
+    void testCreateDraftRejectsEditingPointerClaimedAfterContentWrite() throws NacosException {
+        String draftVersion = "1.1.0";
+        AgentVersionDetail draft = newDraft(draftVersion, "a2a");
+        PreparedAgentVersionWrite draftWrite =
+            prepareWrite(draftVersion, new AgentVersionContent(draft.getCallInterfaces()));
+        AiResource unclaimed = resourceWithoutWorkingVersions();
+        AiResource claimed = lifecycleResource("2.0.0", null,
+            Collections.<String, String>emptyMap(), 4L);
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(unclaimed, claimed);
+        when(storageService.prepare(eq(NAMESPACE_ID), eq(AGENT_NAME), eq(draftVersion),
+            any(AgentVersionContent.class))).thenReturn(draftWrite);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, draftVersion)).thenReturn(null);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(VERSION_ID + 1);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.createDraft(NAMESPACE_ID, AGENT_NAME, draft, null));
+        
+        assertConflict(exception);
+        verify(storageService).save(draftWrite);
+        verify(resourcePersistService, never()).updateMetaCas(anyString(), anyString(),
+            anyString(), anyLong(), any(AiResource.class));
+    }
+    
+    @Test
+    void testCreateDraftFailsAfterEditingPointerCasRetryExhaustion()
+        throws NacosException {
+        String draftVersion = "1.1.0";
+        AgentVersionDetail draft = newDraft(draftVersion, "a2a");
+        PreparedAgentVersionWrite draftWrite =
+            prepareWrite(draftVersion, new AgentVersionContent(draft.getCallInterfaces()));
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(resourceWithoutWorkingVersions());
+        when(storageService.prepare(eq(NAMESPACE_ID), eq(AGENT_NAME), eq(draftVersion),
+            any(AgentVersionContent.class))).thenReturn(draftWrite);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, draftVersion)).thenReturn(null);
+        when(versionPersistService.insert(any(AiResourceVersion.class))).thenReturn(VERSION_ID + 1);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.createDraft(NAMESPACE_ID, AGENT_NAME, draft, null));
+        
+        assertConflict(exception);
+        verify(resourcePersistService, times(AiResourceConstants.MAX_WORKING_VERSION_RETRY))
+            .updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+                eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class));
+    }
+    
+    @Test
+    void testDeleteDraftClearsEditingPointerBeforeDeletingRowAndContent()
+        throws NacosException {
+        AiResource resource = storedResource();
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(storedVersion());
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(resource);
+        when(resourcePersistService.updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class)))
+            .thenReturn(true);
+        when(versionPersistService.delete(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(1);
+        
+        service.deleteDraft(NAMESPACE_ID, AGENT_NAME, VERSION);
+        
+        ArgumentCaptor<AiResource> updateCaptor = ArgumentCaptor.forClass(AiResource.class);
+        verify(resourcePersistService).updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), updateCaptor.capture());
+        ResourceVersionInfo versionInfo = JacksonUtils.toObj(
+            updateCaptor.getValue().getVersionInfo(), ResourceVersionInfo.class);
+        assertNull(versionInfo.getEditingVersion());
+        InOrder order = inOrder(versionPersistService, resourcePersistService, storageService);
+        order.verify(versionPersistService).find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION);
+        order.verify(resourcePersistService).find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT);
+        order.verify(resourcePersistService).updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class));
+        order.verify(versionPersistService).delete(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION);
+        order.verify(storageService).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testDeleteDraftRejectsNonDraftWithoutChangingMetadataOrStorage()
+        throws NacosException {
+        AiResourceVersion online = storedVersion();
+        online.setStatus(AiConstants.Agent.VERSION_STATUS_ONLINE);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(online);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.deleteDraft(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        assertEquals(ErrorCode.ILLEGAL_STATE.getCode(), exception.getDetailErrCode());
+        verifyNoInteractions(resourcePersistService, storageService);
+        verify(versionPersistService, never()).delete(anyString(), anyString(), anyString(),
+            anyString());
+    }
+    
+    @Test
+    void testDeleteDraftDoesNotDeleteStorageWhenVersionRowDeleteMisses()
+        throws NacosException {
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(storedVersion());
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(resourcePersistService.updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class)))
+            .thenReturn(true);
+        when(versionPersistService.delete(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(0);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.deleteDraft(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        assertServerError(exception);
+        verify(storageService, never()).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testDeleteDraftRejectsVersionThatIsNotEditingPointer() throws NacosException {
+        AiResource anotherDraft = lifecycleResource("2.0.0", null,
+            Collections.<String, String>emptyMap(), 3L);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(storedVersion());
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(anotherDraft);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.deleteDraft(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        assertEquals(ErrorCode.ILLEGAL_STATE.getCode(), exception.getDetailErrCode());
+        verify(versionPersistService, never()).delete(anyString(), anyString(), anyString(),
+            anyString());
+        verifyNoInteractions(storageService);
+    }
+    
+    @Test
+    void testDeleteDraftFailsAfterEditingPointerCasRetryExhaustion()
+        throws NacosException {
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(storedVersion());
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.deleteDraft(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        assertConflict(exception);
+        verify(resourcePersistService, times(AiResourceConstants.MAX_WORKING_VERSION_RETRY))
+            .updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+                eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class));
+        verify(versionPersistService, never()).delete(anyString(), anyString(), anyString(),
+            anyString());
+        verifyNoInteractions(storageService);
+    }
+    
+    @Test
+    void testDeleteAgentScansEveryVersionPageAndCleansEveryContentObject()
+        throws NacosException {
+        List<AiResourceVersion> firstPageRows = new ArrayList<AiResourceVersion>();
+        for (int i = 0; i < 100; i++) {
+            String version = "1.0." + i;
+            AgentVersionContent versionContent = contentWithProtocol("a2a");
+            firstPageRows.add(storedVersion(version, AiConstants.Agent.VERSION_STATUS_ONLINE,
+                prepareWrite(version, versionContent)));
+        }
+        String lastVersion = "1.0.100";
+        AiResourceVersion lastRow = storedVersion(lastVersion,
+            AiConstants.Agent.VERSION_STATUS_OFFLINE,
+            prepareWrite(lastVersion, contentWithProtocol("json-rpc")));
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 1, 100))
+            .thenReturn(versionPage(firstPageRows, 101, 2));
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 2, 100))
+            .thenReturn(versionPage(Collections.singletonList(lastRow), 101, 2));
+        when(resourcePersistService.delete(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(1);
+        when(versionPersistService.deleteByNameAndType(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(101);
+        
+        service.deleteAgent(NAMESPACE_ID, AGENT_NAME);
+        
+        verify(versionPersistService).list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 1, 100);
+        verify(versionPersistService).list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 2, 100);
+        verify(resourcePersistService).delete(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT);
+        verify(versionPersistService).deleteByNameAndType(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT);
+        InOrder order = inOrder(resourcePersistService, versionPersistService, storageService);
+        order.verify(resourcePersistService).delete(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT);
+        order.verify(versionPersistService).deleteByNameAndType(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT);
+        order.verify(storageService, times(101))
+            .delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testDeleteAgentValidatesEveryDescriptorBeforeDeletingAnyState()
+        throws NacosException {
+        AiResourceVersion valid = storedVersion();
+        AiResourceVersion invalid = storedVersion();
+        invalid.setVersion("1.1.0");
+        invalid.setStorage("{}");
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 1, 100))
+            .thenReturn(versionPage(Arrays.asList(valid, invalid), 2, 1));
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.deleteAgent(NAMESPACE_ID, AGENT_NAME));
+        
+        assertServerError(exception);
+        verify(resourcePersistService, never()).delete(anyString(), anyString(), anyString());
+        verify(versionPersistService, never()).deleteByNameAndType(anyString(), anyString(),
+            anyString());
+        verify(storageService, never()).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testDeleteAgentStopsBeforeVersionAndStorageCleanupWhenResourceDeleteMisses()
+        throws NacosException {
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 1, 100))
+            .thenReturn(versionPage(Collections.singletonList(storedVersion()), 1, 1));
+        when(resourcePersistService.delete(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(0);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.deleteAgent(NAMESPACE_ID, AGENT_NAME));
+        
+        assertServerError(exception);
+        verify(versionPersistService, never()).deleteByNameAndType(anyString(), anyString(),
+            anyString());
+        verify(storageService, never()).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testDeleteAgentDoesNotDeleteStorageWhenVersionRowsAreNotDeleted()
+        throws NacosException {
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 1, 100))
+            .thenReturn(versionPage(Collections.singletonList(storedVersion()), 1, 1));
+        when(resourcePersistService.delete(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(1);
+        when(versionPersistService.deleteByNameAndType(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(0);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.deleteAgent(NAMESPACE_ID, AGENT_NAME));
+        
+        assertServerError(exception);
+        verify(storageService, never()).delete(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testDeleteAgentReportsSingleStorageCleanupFailure() throws NacosException {
+        NacosException storageFailure =
+            new NacosException(NacosException.SERVER_ERROR, "storage delete failed");
+        stubDeleteAgentRows(Collections.singletonList(storedVersion()));
+        doThrow(storageFailure).when(storageService)
+            .delete(any(AgentVersionStorageDescriptor.class));
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.deleteAgent(NAMESPACE_ID, AGENT_NAME));
+        
+        assertServerError(exception);
+        assertSame(storageFailure, exception.getCause());
+        assertEquals(0, storageFailure.getSuppressed().length);
+    }
+    
+    @Test
+    void testDeleteAgentSuppressesAdditionalStorageCleanupFailures() throws NacosException {
+        AiResourceVersion secondVersion = storedVersion("1.1.0",
+            AiConstants.Agent.VERSION_STATUS_OFFLINE,
+            prepareWrite("1.1.0", contentWithProtocol("json-rpc")));
+        NacosException firstFailure =
+            new NacosException(NacosException.SERVER_ERROR, "first delete failed");
+        NacosException secondFailure =
+            new NacosException(NacosException.SERVER_ERROR, "second delete failed");
+        stubDeleteAgentRows(Arrays.asList(storedVersion(), secondVersion));
+        doThrow(firstFailure, secondFailure).when(storageService)
+            .delete(any(AgentVersionStorageDescriptor.class));
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.deleteAgent(NAMESPACE_ID, AGENT_NAME));
+        
+        assertServerError(exception);
+        assertSame(firstFailure, exception.getCause());
+        assertEquals(1, firstFailure.getSuppressed().length);
+        assertSame(secondFailure, firstFailure.getSuppressed()[0]);
+    }
+    
+    @Test
+    void testVersionSummaryReadsNeverLoadVersionContent() throws NacosException {
+        AiResourceVersion online = storedVersion();
+        online.setStatus(AiConstants.Agent.VERSION_STATUS_ONLINE);
+        Page<AiResourceVersion> sourcePage =
+            versionPage(Collections.singletonList(online), 1, 1);
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT,
+            AiConstants.Agent.VERSION_STATUS_ONLINE, 2, 20)).thenReturn(sourcePage);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(online);
+        
+        Page<AgentVersionSummary> result = service.listAgentVersions(NAMESPACE_ID, AGENT_NAME,
+            AiConstants.Agent.VERSION_STATUS_ONLINE, 2, 20);
+        AgentVersionSummary exact =
+            service.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION);
+        
+        assertEquals(1, result.getTotalCount());
+        assertEquals(VERSION, result.getPageItems().get(0).getVersion());
+        assertEquals(prepared.getDescriptor().getContentDigest(),
+            result.getPageItems().get(0).getContentDigest());
+        assertEquals(VERSION, exact.getVersion());
+        assertEquals(AiConstants.Agent.VERSION_STATUS_ONLINE, exact.getStatus());
+        verifyNoInteractions(storageService);
+    }
+    
+    @Test
+    void testListVersionSummariesHandlesNullPageWithoutStorageReads()
+        throws NacosException {
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 3, 20)).thenReturn(null);
+        
+        Page<AgentVersionSummary> result =
+            service.listAgentVersions(NAMESPACE_ID, AGENT_NAME, null, 3, 20);
+        
+        assertEquals(3, result.getPageNumber());
+        assertEquals(0, result.getTotalCount());
+        assertEquals(0, result.getPagesAvailable());
+        assertTrue(result.getPageItems().isEmpty());
+        verifyNoInteractions(storageService);
+    }
+    
+    @Test
+    void testListVersionSummariesRejectsInvalidStoredDescriptor() throws NacosException {
+        AiResourceVersion invalid = storedVersion();
+        invalid.setStorage("{}");
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 1, 20))
+            .thenReturn(versionPage(Collections.singletonList(invalid), 1, 1));
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.listAgentVersions(NAMESPACE_ID, AGENT_NAME, null, 1, 20));
+        
+        assertServerError(exception);
+        verifyNoInteractions(storageService);
+    }
+    
+    @Test
+    void testGetVersionSummaryRejectsInvalidStoredDescriptor() throws NacosException {
+        AiResourceVersion invalid = storedVersion();
+        invalid.setStorage("{}");
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(invalid);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.getAgentVersionSummary(NAMESPACE_ID, AGENT_NAME, VERSION));
+        
+        assertServerError(exception);
+        verifyNoInteractions(storageService);
+    }
+    
+    @Test
+    void testLifecycleRowUpdatesRequireOneAffectedVersion() throws NacosException {
+        String pipelineInfo = "{\"executionId\":\"pipeline-1\"}";
+        when(versionPersistService.updateStatus(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION,
+            AiConstants.Agent.VERSION_STATUS_REVIEWING)).thenReturn(1);
+        when(versionPersistService.updatePublishPipelineInfo(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION, pipelineInfo)).thenReturn(1);
+        
+        service.updateVersionStatus(NAMESPACE_ID, AGENT_NAME, VERSION,
+            AiConstants.Agent.VERSION_STATUS_REVIEWING);
+        service.updatePublishPipelineInfo(NAMESPACE_ID, AGENT_NAME, VERSION, pipelineInfo);
+        
+        verify(versionPersistService).updateStatus(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION,
+            AiConstants.Agent.VERSION_STATUS_REVIEWING);
+        verify(versionPersistService).updatePublishPipelineInfo(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION, pipelineInfo);
+    }
+    
+    @Test
+    void testLifecycleRowUpdatesFailWhenVersionWasNotUpdated() {
+        String pipelineInfo = "{\"executionId\":\"pipeline-1\"}";
+        when(versionPersistService.updateStatus(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION,
+            AiConstants.Agent.VERSION_STATUS_REVIEWING)).thenReturn(0);
+        when(versionPersistService.updatePublishPipelineInfo(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION, pipelineInfo)).thenReturn(0);
+        
+        assertServerError(assertThrows(NacosApiException.class,
+            () -> service.updateVersionStatus(NAMESPACE_ID, AGENT_NAME, VERSION,
+                AiConstants.Agent.VERSION_STATUS_REVIEWING)));
+        assertServerError(assertThrows(NacosApiException.class,
+            () -> service.updatePublishPipelineInfo(NAMESPACE_ID, AGENT_NAME, VERSION,
+                pipelineInfo)));
+    }
+    
+    @Test
+    void testSynchronizeDerivedStateWritesLifecycleAndCatalogInOneCas()
+        throws NacosException {
+        String reviewedVersion = "1.0.1";
+        String latestVersion = "1.1.0";
+        AiResource resource = lifecycleResource(VERSION, reviewedVersion,
+            Collections.singletonMap(AiResourceConstants.LABEL_LATEST, "0.9.0"), 3L);
+        AgentVersionContent reviewedContent = contentWithProtocol("json-rpc");
+        AgentVersionContent latestContent = contentWithProtocol("a2a");
+        AiResourceVersion reviewed = storedVersion(reviewedVersion,
+            AiConstants.Agent.VERSION_STATUS_ONLINE,
+            prepareWrite(reviewedVersion, reviewedContent));
+        AiResourceVersion latest = storedVersion(latestVersion,
+            AiConstants.Agent.VERSION_STATUS_ONLINE,
+            prepareWrite(latestVersion, latestContent));
+        AtomicReference<AiResource> currentResource =
+            new AtomicReference<AiResource>(resource);
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenAnswer(
+                invocation -> currentResource.get());
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, reviewedVersion)).thenReturn(reviewed);
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AiConstants.Agent.VERSION_STATUS_ONLINE, 1, 100))
+            .thenReturn(versionPage(Arrays.asList(reviewed, latest), 2, 1));
+        when(storageService.load(any(AgentVersionStorageDescriptor.class)))
+            .thenReturn(reviewedContent, latestContent);
+        when(resourcePersistService.updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class)))
+            .thenAnswer(invocation -> {
+                currentResource.set(applyMetaUpdate(resource,
+                    invocation.<AiResource>getArgument(4), 4L));
+                return true;
+            });
+        Map<String, String> labels =
+            Collections.singletonMap("stable", reviewedVersion);
+        
+        Agent result = service.synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME,
+            latestVersion, labels, VERSION, reviewedVersion);
+        assertEquals(2, result.getVersionInfo().getOnlineCnt());
+        assertEquals(latestVersion, result.getVersionCatalog().getLatestVersion());
+        
+        ArgumentCaptor<AiResource> updateCaptor = ArgumentCaptor.forClass(AiResource.class);
+        verify(resourcePersistService).updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), updateCaptor.capture());
+        ResourceVersionInfo versionInfo = JacksonUtils.toObj(
+            updateCaptor.getValue().getVersionInfo(), ResourceVersionInfo.class);
+        assertNull(versionInfo.getEditingVersion());
+        assertNull(versionInfo.getReviewingVersion());
+        assertEquals(2, versionInfo.getOnlineCnt());
+        assertEquals(latestVersion,
+            versionInfo.getLabels().get(AiResourceConstants.LABEL_LATEST));
+        assertEquals(reviewedVersion, versionInfo.getLabels().get("stable"));
+        AgentResourceExt resourceExt =
+            AgentResourceExtSerializer.deserialize(updateCaptor.getValue().getExt());
+        assertEquals(latestVersion, resourceExt.getVersionCatalog().getLatestVersion());
+        assertEquals(2, resourceExt.getVersionCatalog().getOnlineVersions().size());
+        assertEquals(latestVersion,
+            resourceExt.getVersionCatalog().getOnlineVersions().get(0).getVersion());
+        assertEquals(Collections.singletonList("a2a"),
+            resourceExt.getVersionCatalog().getOnlineVersions().get(0).getProtocols());
+        assertEquals(reviewedVersion,
+            resourceExt.getVersionCatalog().getOnlineVersions().get(1).getVersion());
+        assertEquals(Collections.singletonList("stable"),
+            resourceExt.getVersionCatalog().getOnlineVersions().get(1).getLabels());
+    }
+    
+    @Test
+    void testSynchronizeDerivedStateRebuildsFactsAfterCasRetry() throws NacosException {
+        String latestVersion = "1.1.0";
+        AiResource first = lifecycleResource(null, null,
+            Collections.<String, String>emptyMap(), 3L);
+        AiResource second = lifecycleResource(null, null,
+            Collections.<String, String>emptyMap(), 4L);
+        AiResource finalResource = lifecycleResource(null, null,
+            Collections.singletonMap(AiResourceConstants.LABEL_LATEST, latestVersion), 5L);
+        AgentVersionContent onlineContent = contentWithProtocol("a2a");
+        AgentVersionCatalogBuilder.Result derived = AgentVersionCatalogBuilder.build(
+            Collections.singletonMap(latestVersion, Collections.singletonList("a2a")),
+            Collections.singletonMap(AiResourceConstants.LABEL_LATEST, latestVersion));
+        ResourceVersionInfo finalVersionInfo =
+            AiResourceManager.requireVersionInfo(finalResource);
+        finalVersionInfo.setOnlineCnt(1);
+        finalVersionInfo.setLabels(
+            new LinkedHashMap<String, String>(derived.getLabels()));
+        finalResource.setVersionInfo(JacksonUtils.toJson(finalVersionInfo));
+        AgentResourceExt finalResourceExt =
+            AgentResourceExtSerializer.deserialize(finalResource.getExt());
+        finalResourceExt.setVersionCatalog(derived.getVersionCatalog());
+        finalResource.setExt(AgentResourceExtSerializer.serialize(finalResourceExt));
+        AiResourceVersion online = storedVersion(latestVersion,
+            AiConstants.Agent.VERSION_STATUS_ONLINE,
+            prepareWrite(latestVersion, onlineContent));
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(first, second, finalResource);
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AiConstants.Agent.VERSION_STATUS_ONLINE, 1, 100))
+            .thenReturn(versionPage(Collections.singletonList(online), 1, 1));
+        when(storageService.load(any(AgentVersionStorageDescriptor.class)))
+            .thenReturn(onlineContent);
+        when(resourcePersistService.updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), anyLong(), any(AiResource.class)))
+            .thenReturn(false, true);
+        
+        service.synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, latestVersion, null, null,
+            null);
+        
+        verify(resourcePersistService).updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class));
+        verify(resourcePersistService).updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+            eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(4L), any(AiResource.class));
+        verify(versionPersistService, times(2)).list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AiConstants.Agent.VERSION_STATUS_ONLINE, 1, 100);
+        verify(storageService, times(2)).load(any(AgentVersionStorageDescriptor.class));
+    }
+    
+    @Test
+    void testSynchronizeDerivedStateRejectsLabelTargetingWorkingVersion()
+        throws NacosException {
+        AiResource resource = lifecycleResource(null, null,
+            Collections.<String, String>emptyMap(), 3L);
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(resource);
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(storedVersion());
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, null,
+                Collections.singletonMap("stable", VERSION), null, null));
+        
+        assertEquals(ErrorCode.ILLEGAL_STATE.getCode(), exception.getDetailErrCode());
+        verify(versionPersistService, never()).list(anyString(), anyString(), anyString(),
+            any(), anyInt(), anyInt());
+        verify(resourcePersistService, never()).updateMetaCas(anyString(), anyString(),
+            anyString(), anyLong(), any(AiResource.class));
+        verifyNoInteractions(storageService);
+    }
+    
+    @Test
+    void testSynchronizeDerivedStateRejectsMissingResourceAndMetaVersion()
+        throws NacosException {
+        AiResource missingMetaVersion = resourceWithoutWorkingVersions();
+        missingMetaVersion.setMetaVersion(null);
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(null, missingMetaVersion);
+        
+        NacosApiException notFound = assertThrows(NacosApiException.class,
+            () -> service.synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, null, null, null,
+                null));
+        NacosApiException serverError = assertThrows(NacosApiException.class,
+            () -> service.synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, null, null, null,
+                null));
+        
+        assertEquals(NacosException.NOT_FOUND, notFound.getErrCode());
+        assertServerError(serverError);
+        verify(resourcePersistService, never()).updateMetaCas(anyString(), anyString(),
+            anyString(), anyLong(), any(AiResource.class));
+    }
+    
+    @Test
+    void testSynchronizeDerivedStateFailsAfterCasRetryExhaustion() throws NacosException {
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(resourceWithoutWorkingVersions());
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, null, null, null,
+                null));
+        
+        assertConflict(exception);
+        verify(resourcePersistService, times(AiResourceConstants.MAX_WORKING_VERSION_RETRY))
+            .updateMetaCas(eq(NAMESPACE_ID), eq(AGENT_NAME),
+                eq(Constants.Agent.RESOURCE_TYPE_AGENT), eq(3L), any(AiResource.class));
+        verify(versionPersistService, times(AiResourceConstants.MAX_WORKING_VERSION_RETRY))
+            .list(NAMESPACE_ID, AGENT_NAME, Constants.Agent.RESOURCE_TYPE_AGENT,
+                AiConstants.Agent.VERSION_STATUS_ONLINE, 1, 100);
+    }
+    
+    @Test
+    void testSynchronizeDerivedStateRejectsMissingCustomLabelTarget()
+        throws NacosException {
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(resourceWithoutWorkingVersions());
+        when(versionPersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, VERSION)).thenReturn(null);
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, null,
+                Collections.singletonMap("stable", VERSION), null, null));
+        
+        assertEquals(NacosException.NOT_FOUND, exception.getErrCode());
+        verify(resourcePersistService, never()).updateMetaCas(anyString(), anyString(),
+            anyString(), anyLong(), any(AiResource.class));
+        verifyNoInteractions(storageService);
+    }
+    
+    private AgentVersionDetail newDraft(String version, String protocol) {
+        AgentVersionDetail result = new AgentVersionDetail();
+        result.setVersion(version);
+        if (protocol != null) {
+            result.setCallInterfaces(contentWithProtocol(protocol).getCallInterfaces());
+        }
+        result.setAuthor("alice");
+        result.setChangeDescription("Create " + version);
+        return result;
+    }
+    
+    private void assertInvalidCreateDraft(AgentVersionDetail draft, String basedOnVersion) {
+        assertThrows(IllegalArgumentException.class,
+            () -> service.createDraft(NAMESPACE_ID, AGENT_NAME, draft, basedOnVersion));
+    }
+    
+    private AgentVersionContent contentWithProtocol(String protocol) {
+        AgentCallInterface callInterface = new AgentCallInterface();
+        callInterface.setProtocol(protocol);
+        callInterface.setProtocolVersion("1.0");
+        callInterface.setDescriptorMediaType("application/json");
+        callInterface.setNativeDescriptor(
+            Collections.<String, Object>singletonMap("protocol", protocol));
+        callInterface.setEndpointSourceOrder(
+            Arrays.asList(EndpointSource.RUNTIME, EndpointSource.DECLARED));
+        return new AgentVersionContent(Collections.singletonList(callInterface));
+    }
+    
+    private PreparedAgentVersionWrite prepareWrite(String version,
+        AgentVersionContent versionContent) {
+        return new AgentVersionStorageService().prepare(NAMESPACE_ID, AGENT_NAME, version,
+            versionContent);
+    }
+    
+    private AiResource resourceWithoutWorkingVersions() {
+        return lifecycleResource(null, null, Collections.<String, String>emptyMap(), 3L);
+    }
+    
+    private AiResource lifecycleResource(String editingVersion, String reviewingVersion,
+        Map<String, String> labels, long metaVersion) {
+        AiResource result = storedResource();
+        ResourceVersionInfo versionInfo = new ResourceVersionInfo();
+        versionInfo.setEditingVersion(editingVersion);
+        versionInfo.setReviewingVersion(reviewingVersion);
+        versionInfo.setOnlineCnt(0);
+        versionInfo.setLabels(new LinkedHashMap<String, String>(labels));
+        result.setVersionInfo(JacksonUtils.toJson(versionInfo));
+        result.setMetaVersion(metaVersion);
+        return result;
+    }
+    
+    private AiResource applyMetaUpdate(AiResource source, AiResource update, long metaVersion) {
+        AiResource result = lifecycleResource(null, null,
+            Collections.<String, String>emptyMap(), metaVersion);
+        result.setId(source.getId());
+        result.setGmtCreate(source.getGmtCreate());
+        result.setGmtModified(source.getGmtModified());
+        result.setNamespaceId(source.getNamespaceId());
+        result.setName(source.getName());
+        result.setType(source.getType());
+        result.setFrom(source.getFrom());
+        result.setOwner(source.getOwner());
+        result.setScope(source.getScope());
+        result.setStatus(update.getStatus());
+        result.setDesc(update.getDesc());
+        result.setBizTags(update.getBizTags());
+        result.setVersionInfo(update.getVersionInfo());
+        result.setExt(update.getExt());
+        return result;
+    }
+    
+    private Page<AiResourceVersion> versionPage(List<AiResourceVersion> rows, int totalCount,
+        int pagesAvailable) {
+        Page<AiResourceVersion> result = new Page<AiResourceVersion>();
+        result.setPageNumber(1);
+        result.setTotalCount(totalCount);
+        result.setPagesAvailable(pagesAvailable);
+        result.setPageItems(rows);
+        return result;
+    }
+    
+    private void stubDeleteAgentRows(List<AiResourceVersion> rows) {
+        when(resourcePersistService.find(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(storedResource());
+        when(versionPersistService.list(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, 1, 100))
+            .thenReturn(versionPage(rows, rows.size(), 1));
+        when(resourcePersistService.delete(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(1);
+        when(versionPersistService.deleteByNameAndType(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(rows.size());
+    }
+    
     private void stubPrepare() {
         when(storageService.prepare(anyString(), anyString(), anyString(),
             any(AgentVersionContent.class))).thenReturn(prepared);
@@ -1477,6 +2367,17 @@ class AgentPersistenceServiceTest {
         result.setDesc("Initial draft");
         result.setStorage(
             AgentVersionStorageDescriptorSerializer.serialize(prepared.getDescriptor()));
+        return result;
+    }
+    
+    private AiResourceVersion storedVersion(String version, String status,
+        PreparedAgentVersionWrite versionWrite) {
+        AiResourceVersion result = storedVersion();
+        result.setId(VERSION_ID + Math.abs(version.hashCode()));
+        result.setVersion(version);
+        result.setStatus(status);
+        result.setStorage(AgentVersionStorageDescriptorSerializer.serialize(
+            versionWrite.getDescriptor()));
         return result;
     }
     

--- a/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineResourceType.java
+++ b/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineResourceType.java
@@ -43,5 +43,10 @@ public enum PublishPipelineResourceType {
     /**
      * AgentSpec resource type.
      */
-    AGENTSPEC
+    AGENTSPEC,
+    
+    /**
+     * Agent resource type.
+     */
+    AGENT
 }

--- a/plugin/ai/src/test/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineModelTest.java
+++ b/plugin/ai/src/test/java/com/alibaba/nacos/plugin/ai/pipeline/model/PublishPipelineModelTest.java
@@ -81,6 +81,8 @@ class PublishPipelineModelTest {
             new SkillPipelineContext().getResourceType());
         assertEquals(PublishPipelineResourceType.AGENTSPEC,
             new AgentSpecPipelineContext().getResourceType());
+        assertEquals(PublishPipelineResourceType.AGENT,
+            PublishPipelineResourceType.valueOf("AGENT"));
     }
     
     @Test

--- a/specs/en/plugin/ai-pipeline-plugin-spec.md
+++ b/specs/en/plugin/ai-pipeline-plugin-spec.md
@@ -20,7 +20,7 @@
 
 The AI publish pipeline plugin type provides review or interception logic before
 AI resources are published. It is designed for generic AI resources such as
-Skill, Prompt, MCP, AgentSpec, and future AI resource types.
+Skill, Prompt, MCP, AgentSpec, Agent, and future AI resource types.
 
 This is an ordered chain plugin. Matching nodes execute serially by
 `PublishPipelineService.getPreferOrder()` in ascending order. A failed node

--- a/specs/zh-cn/plugin/ai-pipeline-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-pipeline-plugin-spec.md
@@ -19,7 +19,7 @@
 ## 范围
 
 AI 发布 Pipeline 插件用于在 AI 资源发布前提供审核或拦截逻辑。它面向 Skill、Prompt、
-MCP、AgentSpec 以及未来的通用 AI 资源类型。
+MCP、AgentSpec、Agent 以及未来的通用 AI 资源类型。
 
 这是有序链式插件。匹配节点按 `PublishPipelineService.getPreferOrder()` 升序串行执行。
 某个节点失败会停止后续 pipeline，并将本次执行标记为 rejected。通用生命周期和状态规则由


### PR DESCRIPTION
## What is the purpose of the change

Complete the persistence and orchestration layer for the unified Agent lifecycle defined by the Agent management specs.

This is the first implementation stage of the A2A-to-RAD migration. It intentionally excludes Admin APIs, Maintainer SDK APIs, and the Console facade.

For #14804

## Brief changelog

- add the internal Agent lifecycle operation service for draft creation and update, submission, publishing, redrafting, online/offline transitions, labels, and deletion
- extend Agent persistence to rebuild `versionInfo` and `versionCatalog` from persisted lifecycle state
- verify stored Agent Version content before publishing or bringing a Version online
- add Agent support to the AI publish Pipeline resource types and synchronize the English and Chinese plugin specs
- add comprehensive unit tests for lifecycle, failure, retry, concurrency-guard, and derived-state scenarios

## Verifying this change

- `mvn -pl plugin/ai,ai spotless:apply spotless:check`
- `mvn -pl plugin/ai,ai test`
  - plugin/ai: 17 tests passed
  - ai: 1714 tests passed, 2 skipped
- `mvn -pl ai -am -DskipTests compile apache-rat:check checkstyle:check spotbugs:check spotless:check`
  - all 29 reactor modules passed

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit tests to verify the implementation.
* [x] Run the relevant compile, unit-test, Apache RAT, Checkstyle, SpotBugs, and Spotless checks.
