### PR TITLE
[ISSUE #15475] Integrate environment plugin pre-context configuration

### DIFF
--- a/api/src/main/java/com/alibaba/nacos/api/plugin/PluginInitializationPhase.java
+++ b/api/src/main/java/com/alibaba/nacos/api/plugin/PluginInitializationPhase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.api.plugin;
+
+/**
+ * Plugin initialization phase.
+ *
+ * @author Nacos
+ */
+public enum PluginInitializationPhase {
+    
+    /**
+     * Initialize before custom environment values are applied to the Spring context.
+     */
+    PRE_CONTEXT,
+    
+    /**
+     * Initialize through the standard plugin manager after the Spring context is refreshed.
+     */
+    STANDARD
+}

--- a/api/src/main/java/com/alibaba/nacos/api/plugin/PluginType.java
+++ b/api/src/main/java/com/alibaba/nacos/api/plugin/PluginType.java
@@ -53,7 +53,8 @@ public enum PluginType {
     /**
      * Environment plugin.
      */
-    ENVIRONMENT("environment", "Environment plugin", PluginExecutionMode.CHAIN, false),
+    ENVIRONMENT("environment", "Environment plugin", PluginExecutionMode.CHAIN, false,
+        PluginInitializationPhase.PRE_CONTEXT),
     
     /**
      * Control plugin.
@@ -89,12 +90,20 @@ public enum PluginType {
     
     private final boolean critical;
     
+    private final PluginInitializationPhase initializationPhase;
+    
     PluginType(String type, String description, PluginExecutionMode executionMode,
         boolean critical) {
+        this(type, description, executionMode, critical, PluginInitializationPhase.STANDARD);
+    }
+    
+    PluginType(String type, String description, PluginExecutionMode executionMode,
+        boolean critical, PluginInitializationPhase initializationPhase) {
         this.type = type;
         this.description = description;
         this.executionMode = executionMode;
         this.critical = critical;
+        this.initializationPhase = initializationPhase;
     }
     
     public String getType() {
@@ -130,6 +139,15 @@ public enum PluginType {
      */
     public boolean isCritical() {
         return critical;
+    }
+    
+    /**
+     * Get the initialization phase shared by implementations of this plugin type.
+     *
+     * @return initialization phase
+     */
+    public PluginInitializationPhase getInitializationPhase() {
+        return initializationPhase;
     }
     
 }

--- a/api/src/test/java/com/alibaba/nacos/api/plugin/PluginTypeTest.java
+++ b/api/src/test/java/com/alibaba/nacos/api/plugin/PluginTypeTest.java
@@ -75,6 +75,8 @@ class PluginTypeTest {
         assertEquals("environment", PluginType.ENVIRONMENT.getType());
         assertEquals("Environment plugin", PluginType.ENVIRONMENT.getDescription());
         assertEquals(PluginExecutionMode.CHAIN, PluginType.ENVIRONMENT.getExecutionMode());
+        assertEquals(PluginInitializationPhase.PRE_CONTEXT,
+            PluginType.ENVIRONMENT.getInitializationPhase());
     }
     
     @Test
@@ -152,5 +154,18 @@ class PluginTypeTest {
         assertEquals(PluginExecutionMode.CHAIN, PluginExecutionMode.valueOf("CHAIN"));
         assertEquals(PluginExecutionMode.ROUTED, PluginExecutionMode.valueOf("ROUTED"));
         assertEquals(PluginExecutionMode.BROADCAST, PluginExecutionMode.valueOf("BROADCAST"));
+    }
+    
+    @Test
+    void testInitializationPhaseValues() {
+        assertEquals(2, PluginInitializationPhase.values().length);
+        assertEquals(PluginInitializationPhase.PRE_CONTEXT,
+            PluginInitializationPhase.valueOf("PRE_CONTEXT"));
+        for (PluginType type : PluginType.values()) {
+            if (PluginType.ENVIRONMENT != type) {
+                assertEquals(PluginInitializationPhase.STANDARD,
+                    type.getInitializationPhase());
+            }
+        }
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/listener/StartingApplicationListener.java
+++ b/core/src/main/java/com/alibaba/nacos/core/listener/StartingApplicationListener.java
@@ -19,7 +19,8 @@ package com.alibaba.nacos.core.listener;
 import com.alibaba.nacos.core.listener.startup.NacosStartUp;
 import com.alibaba.nacos.core.listener.startup.NacosStartUpManager;
 import com.alibaba.nacos.core.plugin.PluginCriticalBootstrapValidator;
-import com.alibaba.nacos.core.plugin.PluginManager;
+import com.alibaba.nacos.core.plugin.PreContextPluginInitializer;
+import com.alibaba.nacos.core.plugin.StandardPluginInitializer;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,21 +62,24 @@ public class StartingApplicationListener implements NacosApplicationListener {
     @Override
     public void contextLoaded(ConfigurableApplicationContext context) {
         NacosStartUp currentStartUp = NacosStartUpManager.getCurrentStartUp();
-        currentStartUp.customEnvironment();
         if (NacosStartUp.CORE_START_UP_PHASE.equals(currentStartUp.startUpPhase())
             && EnvUtil.getDeploymentType() != null) {
+            new PreContextPluginInitializer(context).initialize();
+            currentStartUp.customEnvironment();
             PluginCriticalBootstrapValidator.validate();
+            return;
         }
+        currentStartUp.customEnvironment();
     }
     
     @Override
     public void started(ConfigurableApplicationContext context) {
         NacosStartUp currentStartUp = NacosStartUpManager.getCurrentStartUp();
-        ObjectProvider<PluginManager> pluginManagerProvider =
-            context.getBeanProvider(PluginManager.class);
-        PluginManager pluginManager = pluginManagerProvider.getIfAvailable();
-        if (pluginManager != null) {
-            pluginManager.initialize();
+        ObjectProvider<StandardPluginInitializer> initializerProvider =
+            context.getBeanProvider(StandardPluginInitializer.class);
+        StandardPluginInitializer initializer = initializerProvider.getIfAvailable();
+        if (initializer != null) {
+            initializer.initialize();
         }
         currentStartUp.started();
         currentStartUp.logStarted(LOGGER);

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PluginInitializer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PluginInitializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin;
+
+import com.alibaba.nacos.api.plugin.PluginInitializationPhase;
+
+/**
+ * Orchestrates one plugin initialization phase.
+ *
+ * @author Nacos
+ */
+public interface PluginInitializer {
+    
+    /**
+     * Get the phase handled by this initializer.
+     *
+     * @return initialization phase
+     */
+    PluginInitializationPhase getInitializationPhase();
+    
+    /**
+     * Initialize plugins for the handled phase.
+     */
+    void initialize();
+}

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PluginManager.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.exception.api.NacosApiException;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.plugin.PluginConfigSpec;
+import com.alibaba.nacos.api.plugin.PluginInitializationPhase;
 import com.alibaba.nacos.api.plugin.PluginProvider;
 import com.alibaba.nacos.api.plugin.PluginStartupLifecycle;
 import com.alibaba.nacos.api.plugin.PluginStateChecker;
@@ -37,8 +38,7 @@ import com.alibaba.nacos.core.plugin.sync.PluginStateSynchronizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.ApplicationListener;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -47,6 +47,7 @@ import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,8 +62,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 3.2.0
  */
 @Component
-public class PluginManager
-    implements PluginStateChecker, PluginStateApplier, ApplicationListener<ApplicationReadyEvent> {
+public class PluginManager implements PluginStateChecker, PluginStateApplier {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(PluginManager.class);
     
@@ -85,6 +85,12 @@ public class PluginManager
      * Plugin instances: pluginId -> instance.
      */
     private final Map<String, Object> pluginInstances = new ConcurrentHashMap<>();
+    
+    /**
+     * Accepted masked configuration snapshots for pre-context plugins.
+     */
+    private final Map<String, PluginConfigResolution> preContextConfigResolutions =
+        new ConcurrentHashMap<>();
     
     /**
      * Discovered lightweight providers grouped by plugin type.
@@ -113,6 +119,8 @@ public class PluginManager
     
     private final PluginTypePolicyRegistry policyRegistry;
     
+    private final PreContextPluginInitializationResult preContextInitializationResult;
+    
     /**
      * Plugin state synchronizer for cluster synchronization.
      */
@@ -122,21 +130,33 @@ public class PluginManager
     
     @Autowired
     public PluginManager(PluginStatePersistenceService persistence,
-        @Lazy PluginStateSynchronizer synchronizer) {
-        this(persistence, synchronizer, new PluginTypePolicyRegistry());
+        @Lazy PluginStateSynchronizer synchronizer,
+        ObjectProvider<PreContextPluginInitializationResult> preContextResultProvider) {
+        this(persistence, synchronizer, new PluginTypePolicyRegistry(),
+            preContextResultProvider.getIfAvailable(
+                PreContextPluginInitializationResult::empty));
+    }
+    
+    public PluginManager(PluginStatePersistenceService persistence,
+        PluginStateSynchronizer synchronizer) {
+        this(persistence, synchronizer, new PluginTypePolicyRegistry(),
+            PreContextPluginInitializationResult.empty());
     }
     
     PluginManager(PluginStatePersistenceService persistence,
         PluginStateSynchronizer synchronizer, PluginTypePolicyRegistry policyRegistry) {
+        this(persistence, synchronizer, policyRegistry,
+            PreContextPluginInitializationResult.empty());
+    }
+    
+    PluginManager(PluginStatePersistenceService persistence,
+        PluginStateSynchronizer synchronizer, PluginTypePolicyRegistry policyRegistry,
+        PreContextPluginInitializationResult preContextInitializationResult) {
         this.persistence = persistence;
         this.synchronizer = synchronizer;
         this.policyRegistry = policyRegistry;
+        this.preContextInitializationResult = preContextInitializationResult;
         this.pluginConfigService = new PluginConfigService(persistence);
-    }
-    
-    @Override
-    public void onApplicationEvent(ApplicationReadyEvent event) {
-        initialize();
     }
     
     /**
@@ -151,6 +171,8 @@ public class PluginManager
         // Register to static holder
         PluginStateCheckerHolder.setInstance(this);
         policyRegistry.initialize();
+        
+        importPreContextPlugins();
         
         // Discover lightweight providers, then load only currently required plugin types.
         discoverPluginProviders();
@@ -208,6 +230,7 @@ public class PluginManager
         }
         
         try {
+            validateRuntimeChangeSupported(info, "state");
             validateStateChangeInternal(info, enabled);
         } catch (IllegalArgumentException e) {
             throw new NacosApiException(NacosException.INVALID_PARAM,
@@ -265,6 +288,13 @@ public class PluginManager
         if (info == null) {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "Plugin not found: " + pluginId);
+        }
+        
+        try {
+            validateRuntimeChangeSupported(info, "configuration");
+        } catch (IllegalArgumentException e) {
+            throw new NacosApiException(NacosException.INVALID_PARAM,
+                ErrorCode.PARAMETER_VALIDATE_ERROR, e.getMessage());
         }
         
         if (!info.isConfigurable()) {
@@ -336,6 +366,9 @@ public class PluginManager
      * @return plugin config resolution with masked sensitive values
      */
     public PluginConfigResolution resolvePluginConfig(PluginInfo pluginInfo) {
+        if (isPreContextPlugin(pluginInfo)) {
+            return preContextConfigResolutions.get(pluginInfo.getPluginId());
+        }
         return pluginConfigService.resolve(pluginInfo, true);
     }
     
@@ -345,7 +378,7 @@ public class PluginManager
     public void refreshStaticPluginConfigs() {
         for (Map.Entry<String, PluginInfo> entry : pluginRegistry.entrySet()) {
             PluginInfo pluginInfo = entry.getValue();
-            if (!pluginInfo.isConfigurable()) {
+            if (!pluginInfo.isConfigurable() || isPreContextPlugin(pluginInfo)) {
                 continue;
             }
             try {
@@ -379,6 +412,22 @@ public class PluginManager
         return new HashSet<>(pluginRegistry.keySet());
     }
     
+    private void importPreContextPlugins() {
+        preContextInitializationResult.getPluginInfos().forEach((pluginId, pluginInfo) -> {
+            if (pluginRegistry.putIfAbsent(pluginId, pluginInfo) != null) {
+                throw new IllegalStateException("Duplicate plugin imported from pre-context: "
+                    + pluginId);
+            }
+            Object instance =
+                preContextInitializationResult.getPluginInstances().get(pluginId);
+            pluginInstances.put(pluginId, instance);
+            pluginDefaultStates.put(pluginId, pluginInfo.isEnabled());
+            pluginStates.put(pluginId, pluginInfo.isEnabled());
+        });
+        preContextConfigResolutions.putAll(
+            preContextInitializationResult.getConfigResolutions());
+    }
+    
     /**
      * Discover lightweight plugin providers without loading their implementation instances.
      */
@@ -392,6 +441,9 @@ public class PluginManager
                 if (pluginType == null) {
                     LOGGER.warn("[PluginManager] Ignore plugin provider without type: {}",
                         provider.getClass().getName());
+                    continue;
+                }
+                if (PluginInitializationPhase.STANDARD != pluginType.getInitializationPhase()) {
                     continue;
                 }
                 pluginProviders.computeIfAbsent(pluginType, key -> new ArrayList<>()).add(provider);
@@ -486,13 +538,14 @@ public class PluginManager
     }
     
     private void loadPersistedData() {
-        loadPersistedStates(pluginRegistry.keySet());
+        Set<String> standardPluginIds = getStandardPluginIds();
+        loadPersistedStates(standardPluginIds);
         ensureCriticalTypesAvailable();
         refreshAllCriticalFlags();
         
         // Load configs
         pluginConfigService.initializeRuntimePersistedConfigs();
-        initializePluginConfigs(pluginRegistry.keySet());
+        initializePluginConfigs(standardPluginIds);
         initializePluginLifecycles(pendingStartupInitializationPluginIds);
     }
     
@@ -530,7 +583,7 @@ public class PluginManager
     private void initializePluginConfigs(Collection<String> pluginIds) {
         for (String pluginId : new HashSet<>(pluginIds)) {
             PluginInfo info = pluginRegistry.get(pluginId);
-            if (info.isConfigurable()) {
+            if (info.isConfigurable() && !isPreContextPlugin(info)) {
                 pluginConfigService.initializePluginConfig(info, pluginInstances.get(pluginId));
                 pendingConfigInitializationPluginIds.remove(pluginId);
             }
@@ -540,7 +593,7 @@ public class PluginManager
     private void initializePluginLifecycles(Collection<String> pluginIds) {
         for (String pluginId : new HashSet<>(pluginIds)) {
             PluginInfo info = pluginRegistry.get(pluginId);
-            if (!info.isEnabled()) {
+            if (!info.isEnabled() || isPreContextPlugin(info)) {
                 continue;
             }
             PluginStartupLifecycle lifecycle =
@@ -571,7 +624,11 @@ public class PluginManager
     public synchronized void validateStateChange(String pluginId, boolean enabled) {
         PluginInfo info = pluginRegistry.get(pluginId);
         if (info != null) {
+            validateRuntimeChangeSupported(info, "state");
             validateStateChangeInternal(info, enabled);
+        } else if (isPreContextPluginId(pluginId)) {
+            throw new IllegalArgumentException(
+                "Pre-context plugin state requires restart: " + pluginId);
         }
     }
     
@@ -599,20 +656,23 @@ public class PluginManager
      * @param states restored plugin states
      */
     public synchronized void restorePluginStates(Map<String, Boolean> states) {
-        for (Map.Entry<String, Boolean> entry : states.entrySet()) {
+        Map<String, Boolean> applicableStates = filterStandardEntries(states,
+            "persisted plugin state");
+        for (Map.Entry<String, Boolean> entry : applicableStates.entrySet()) {
             if (entry.getValue() == null) {
                 throw new IllegalArgumentException(
                     "Enabled state cannot be null for plugin: " + entry.getKey());
             }
         }
         if (!initialized) {
-            persistence.replaceAllStates(states);
+            persistence.replaceAllStates(applicableStates);
             LOGGER.info("[PluginManager] Staged {} plugin states restored before plugin "
-                + "discovery; critical validation will run during initialization.", states.size());
+                + "discovery; critical validation will run during initialization.",
+                applicableStates.size());
             return;
         }
         Map<String, Boolean> targetStates = new HashMap<>(pluginDefaultStates);
-        states.forEach((pluginId, enabled) -> {
+        applicableStates.forEach((pluginId, enabled) -> {
             PluginInfo info = pluginRegistry.get(pluginId);
             if (info == null) {
                 return;
@@ -628,9 +688,9 @@ public class PluginManager
             targetStates.put(pluginId, enabled);
         });
         validateCriticalStates(targetStates);
-        persistence.replaceAllStates(states);
+        persistence.replaceAllStates(applicableStates);
         pluginRegistry.forEach((pluginId, info) -> {
-            if (info.getPluginType().isExclusive()) {
+            if (info.getPluginType().isExclusive() || isPreContextPlugin(info)) {
                 return;
             }
             boolean targetEnabled = targetStates.get(pluginId);
@@ -641,6 +701,7 @@ public class PluginManager
     }
     
     private void validateStateChangeInternal(PluginInfo info, boolean enabled) {
+        validateRuntimeChangeSupported(info, "state");
         if (info.isEnabled() == enabled) {
             return;
         }
@@ -718,6 +779,63 @@ public class PluginManager
             implementations);
     }
     
+    private Set<String> getStandardPluginIds() {
+        Set<String> result = new HashSet<>();
+        pluginRegistry.forEach((pluginId, pluginInfo) -> {
+            if (!isPreContextPlugin(pluginInfo)) {
+                result.add(pluginId);
+            }
+        });
+        return result;
+    }
+    
+    private boolean isPreContextPlugin(PluginInfo pluginInfo) {
+        return pluginInfo != null && PluginInitializationPhase.PRE_CONTEXT == pluginInfo
+            .getPluginType().getInitializationPhase();
+    }
+    
+    private boolean isPreContextPluginId(String pluginId) {
+        if (pluginId == null) {
+            return false;
+        }
+        PluginInfo pluginInfo = pluginRegistry.get(pluginId);
+        if (pluginInfo != null) {
+            return isPreContextPlugin(pluginInfo);
+        }
+        int separator = pluginId.indexOf(':');
+        String typeName = separator < 0 ? pluginId : pluginId.substring(0, separator);
+        for (PluginType type : PluginType.values()) {
+            if (type.getType().equals(typeName)) {
+                return PluginInitializationPhase.PRE_CONTEXT == type.getInitializationPhase();
+            }
+        }
+        return false;
+    }
+    
+    private void validateRuntimeChangeSupported(PluginInfo pluginInfo, String operation) {
+        if (isPreContextPlugin(pluginInfo)) {
+            throw new IllegalArgumentException("Pre-context plugin " + operation
+                + " requires restart: " + pluginInfo.getPluginId());
+        }
+    }
+    
+    private <T> Map<String, T> filterStandardEntries(Map<String, T> source,
+        String sourceDescription) {
+        Map<String, T> result = new LinkedHashMap<>();
+        if (source == null) {
+            return result;
+        }
+        source.forEach((pluginId, value) -> {
+            if (isPreContextPluginId(pluginId)) {
+                LOGGER.warn("[PluginManager] Ignore {} for pre-context plugin {}.",
+                    sourceDescription, pluginId);
+            } else {
+                result.put(pluginId, value);
+            }
+        });
+        return result;
+    }
+    
     /**
      * Apply config change.
      * Called by synchronizers after successful synchronization.
@@ -727,6 +845,10 @@ public class PluginManager
      */
     @Override
     public void applyConfigChange(String pluginId, Map<String, String> config) {
+        if (isPreContextPluginId(pluginId)) {
+            throw new IllegalArgumentException(
+                "Pre-context plugin configuration requires restart: " + pluginId);
+        }
         PluginInfo info = pluginRegistry.get(pluginId);
         pluginConfigService.applyRuntimePersistedConfig(pluginId, info,
             pluginInstances.get(pluginId), config);
@@ -738,7 +860,8 @@ public class PluginManager
      * @return complete runtime persisted config snapshot
      */
     public Map<String, Map<String, String>> getRuntimePersistedConfigs() {
-        return pluginConfigService.getAllRuntimePersistedConfigs();
+        return filterStandardEntries(pluginConfigService.getAllRuntimePersistedConfigs(),
+            "runtime persisted plugin config");
     }
     
     /**
@@ -747,13 +870,19 @@ public class PluginManager
      * @param configs complete runtime persisted config snapshot
      */
     public synchronized void restorePluginConfigs(Map<String, Map<String, String>> configs) {
-        pluginConfigService.restoreRuntimePersistedConfigs(configs);
+        Map<String, Map<String, String>> applicableConfigs =
+            filterStandardEntries(configs, "runtime persisted plugin config");
+        pluginConfigService.restoreRuntimePersistedConfigs(applicableConfigs);
         pluginRegistry.forEach((pluginId, info) -> {
-            if (info.isConfigurable()) {
+            if (info.isConfigurable() && !isPreContextPlugin(info)) {
                 pluginConfigService.applyRestoredPluginConfig(info,
                     pluginInstances.get(pluginId));
             }
         });
+    }
+    
+    Map<String, Boolean> getPersistedPluginStates() {
+        return filterStandardEntries(persistence.loadAllStates(), "persisted plugin state");
     }
     
     /**

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PluginStateProcessor.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PluginStateProcessor.java
@@ -166,6 +166,6 @@ public class PluginStateProcessor extends RequestProcessor4CP {
     @Override
     public List<SnapshotOperation> loadSnapshotOperate() {
         return Collections.singletonList(
-            new PluginStateSnapshotOperation(persistence, pluginManager, lock));
+            new PluginStateSnapshotOperation(pluginManager, lock));
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PluginStateSnapshotOperation.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PluginStateSnapshotOperation.java
@@ -23,7 +23,6 @@ import com.alibaba.nacos.consistency.snapshot.Reader;
 import com.alibaba.nacos.consistency.snapshot.SnapshotOperation;
 import com.alibaba.nacos.consistency.snapshot.Writer;
 import com.alibaba.nacos.core.plugin.model.PluginStateSnapshot;
-import com.alibaba.nacos.core.plugin.storage.PluginStatePersistenceService;
 import com.alibaba.nacos.sys.utils.DiskUtils;
 import com.alipay.sofa.jraft.util.CRC64;
 import org.slf4j.Logger;
@@ -55,18 +54,14 @@ public class PluginStateSnapshotOperation implements SnapshotOperation {
     
     private static final String CHECK_SUM_KEY = "checksum";
     
-    private final PluginStatePersistenceService persistence;
-    
     private final PluginManager pluginManager;
     
     private final Serializer serializer;
     
     private final ReentrantReadWriteLock lock;
     
-    public PluginStateSnapshotOperation(PluginStatePersistenceService persistence,
-        PluginManager pluginManager,
+    public PluginStateSnapshotOperation(PluginManager pluginManager,
         ReentrantReadWriteLock lock) {
-        this.persistence = persistence;
         this.pluginManager = pluginManager;
         this.serializer = SerializeFactory.getDefault();
         this.lock = lock;
@@ -77,7 +72,7 @@ public class PluginStateSnapshotOperation implements SnapshotOperation {
         lock.writeLock().lock();
         try {
             // Load all states and configs
-            Map<String, Boolean> states = persistence.loadAllStates();
+            Map<String, Boolean> states = pluginManager.getPersistedPluginStates();
             Map<String, Map<String, String>> configs =
                 pluginManager.getRuntimePersistedConfigs();
             

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PreContextPluginInitializationResult.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PreContextPluginInitializationResult.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin;
+
+import com.alibaba.nacos.core.plugin.config.PluginConfigResolution;
+import com.alibaba.nacos.core.plugin.model.PluginInfo;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Immutable handoff from pre-context initialization to the standard plugin manager.
+ *
+ * @author Nacos
+ */
+public final class PreContextPluginInitializationResult {
+    
+    public static final String BEAN_NAME = "preContextPluginInitializationResult";
+    
+    private static final PreContextPluginInitializationResult EMPTY =
+        new PreContextPluginInitializationResult(Collections.emptyMap(), Collections.emptyMap(),
+            Collections.emptyMap());
+    
+    private final Map<String, PluginInfo> pluginInfos;
+    
+    private final Map<String, Object> pluginInstances;
+    
+    private final Map<String, PluginConfigResolution> configResolutions;
+    
+    PreContextPluginInitializationResult(Map<String, PluginInfo> pluginInfos,
+        Map<String, Object> pluginInstances,
+        Map<String, PluginConfigResolution> configResolutions) {
+        this.pluginInfos = immutableCopy(pluginInfos);
+        this.pluginInstances = immutableCopy(pluginInstances);
+        this.configResolutions = immutableCopy(configResolutions);
+    }
+    
+    public static PreContextPluginInitializationResult empty() {
+        return EMPTY;
+    }
+    
+    Map<String, PluginInfo> getPluginInfos() {
+        return pluginInfos;
+    }
+    
+    Map<String, Object> getPluginInstances() {
+        return pluginInstances;
+    }
+    
+    Map<String, PluginConfigResolution> getConfigResolutions() {
+        return configResolutions;
+    }
+    
+    private static <T> Map<String, T> immutableCopy(Map<String, T> source) {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/PreContextPluginInitializer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/PreContextPluginInitializer.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin;
+
+import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
+import com.alibaba.nacos.api.plugin.ConfigItemEffectMode;
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
+import com.alibaba.nacos.api.plugin.PluginInitializationPhase;
+import com.alibaba.nacos.api.plugin.PluginProvider;
+import com.alibaba.nacos.api.plugin.PluginStartupLifecycle;
+import com.alibaba.nacos.api.plugin.PluginType;
+import com.alibaba.nacos.common.spi.NacosServiceLoader;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.core.plugin.config.PluginConfigApplier;
+import com.alibaba.nacos.core.plugin.config.PluginConfigBasicChecker;
+import com.alibaba.nacos.core.plugin.config.PluginConfigResolution;
+import com.alibaba.nacos.core.plugin.config.PluginConfigResolver;
+import com.alibaba.nacos.core.plugin.model.PluginInfo;
+import com.alibaba.nacos.plugin.environment.CustomEnvironmentPluginManager;
+import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Initializes startup-only plugins before custom environment processing.
+ *
+ * @author Nacos
+ */
+public class PreContextPluginInitializer implements PluginInitializer {
+    
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(PreContextPluginInitializer.class);
+    
+    private final ConfigurableListableBeanFactory beanFactory;
+    
+    private final PluginTypePolicyRegistry policyRegistry;
+    
+    private final Collection<PluginProvider<?>> providers;
+    
+    private final PluginConfigResolver configResolver;
+    
+    private final PluginConfigBasicChecker configChecker;
+    
+    private final PluginConfigApplier configApplier;
+    
+    public PreContextPluginInitializer(ConfigurableApplicationContext context) {
+        this(context.getBeanFactory(), new PluginTypePolicyRegistry(), loadProviders(),
+            new PluginConfigResolver(), new PluginConfigBasicChecker(),
+            new PluginConfigApplier());
+    }
+    
+    PreContextPluginInitializer(ConfigurableListableBeanFactory beanFactory,
+        PluginTypePolicyRegistry policyRegistry, Collection<PluginProvider<?>> providers,
+        PluginConfigResolver configResolver, PluginConfigBasicChecker configChecker,
+        PluginConfigApplier configApplier) {
+        this.beanFactory = beanFactory;
+        this.policyRegistry = policyRegistry;
+        this.providers = providers;
+        this.configResolver = configResolver;
+        this.configChecker = configChecker;
+        this.configApplier = configApplier;
+    }
+    
+    @Override
+    public PluginInitializationPhase getInitializationPhase() {
+        return PluginInitializationPhase.PRE_CONTEXT;
+    }
+    
+    @Override
+    public void initialize() {
+        if (beanFactory.containsSingleton(PreContextPluginInitializationResult.BEAN_NAME)) {
+            return;
+        }
+        policyRegistry.initialize();
+        Map<String, PluginInfo> pluginInfos = new LinkedHashMap<>();
+        Map<String, Object> pluginInstances = new LinkedHashMap<>();
+        Map<String, PluginConfigResolution> configResolutions = new LinkedHashMap<>();
+        for (PluginProvider<?> provider : providers) {
+            initializeProvider(provider, pluginInfos, pluginInstances, configResolutions);
+        }
+        initializeEnvironmentManager(pluginInfos, pluginInstances);
+        PreContextPluginInitializationResult result =
+            new PreContextPluginInitializationResult(pluginInfos, pluginInstances,
+                configResolutions);
+        beanFactory.registerSingleton(PreContextPluginInitializationResult.BEAN_NAME, result);
+        LOGGER.info("[PreContextPluginInitializer] Initialized {} plugins", pluginInfos.size());
+    }
+    
+    private void initializeProvider(PluginProvider<?> provider,
+        Map<String, PluginInfo> pluginInfos, Map<String, Object> pluginInstances,
+        Map<String, PluginConfigResolution> configResolutions) {
+        PluginType pluginType;
+        try {
+            pluginType = provider.getPluginType();
+        } catch (RuntimeException e) {
+            LOGGER.warn("[PreContextPluginInitializer] Failed to identify plugin provider: {}",
+                provider.getClass().getName(), e);
+            return;
+        }
+        if (pluginType == null
+            || PluginInitializationPhase.PRE_CONTEXT != pluginType.getInitializationPhase()
+            || !policyRegistry.shouldLoad(pluginType)) {
+            return;
+        }
+        Map<String, ?> plugins;
+        try {
+            plugins = provider.getAllPlugins();
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Failed to discover pre-context plugins from provider: "
+                + provider.getClass().getName(), e);
+        }
+        if (plugins == null) {
+            return;
+        }
+        plugins.forEach((name, instance) -> initializePlugin(pluginType, name, instance,
+            pluginInfos, pluginInstances, configResolutions));
+    }
+    
+    private void initializePlugin(PluginType pluginType, String pluginName, Object instance,
+        Map<String, PluginInfo> pluginInfos, Map<String, Object> pluginInstances,
+        Map<String, PluginConfigResolution> configResolutions) {
+        if (StringUtils.isBlank(pluginName) || instance == null) {
+            LOGGER.warn("[PreContextPluginInitializer] Ignore invalid {} plugin, name={}, "
+                + "instancePresent={}", pluginType.getType(), pluginName, instance != null);
+            return;
+        }
+        String pluginId = pluginType.getType() + ":" + pluginName;
+        if (pluginInfos.containsKey(pluginId)) {
+            throw new IllegalStateException("Duplicate pre-context plugin: " + pluginId);
+        }
+        PluginInfo pluginInfo = createPluginInfo(pluginType, pluginName, pluginId, instance);
+        PluginConfigResolution resolution = initializePluginConfig(pluginInfo, instance);
+        initializePluginLifecycle(pluginInfo, instance);
+        pluginInfos.put(pluginId, pluginInfo);
+        pluginInstances.put(pluginId, instance);
+        configResolutions.put(pluginId, resolution);
+    }
+    
+    private PluginInfo createPluginInfo(PluginType pluginType, String pluginName, String pluginId,
+        Object instance) {
+        PluginInfo result = new PluginInfo();
+        result.setPluginId(pluginId);
+        result.setPluginName(pluginName);
+        result.setPluginType(pluginType);
+        result.setClassName(instance.getClass().getName());
+        result.setLoadTimestamp(System.currentTimeMillis());
+        result.setEnabled(
+            policyRegistry.isPluginEnabledByDefault(pluginType, pluginName));
+        if (instance instanceof PluginConfigSpec) {
+            PluginConfigSpec configSpec = (PluginConfigSpec) instance;
+            result.setConfigurable(configSpec.isConfigurable());
+            if (result.isConfigurable()) {
+                result.setConfigDefinitions(
+                    normalizeDefinitions(pluginId, configSpec.getConfigDefinitions()));
+                result.setConfig(copyConfig(configSpec.getCurrentConfig()));
+            }
+        }
+        return result;
+    }
+    
+    private PluginConfigResolution initializePluginConfig(PluginInfo pluginInfo, Object instance) {
+        configResolver.initializeStaticConfig(pluginInfo);
+        PluginConfigResolution resolution = configResolver.resolve(pluginInfo, false);
+        if (pluginInfo.isConfigurable()) {
+            try {
+                configChecker.validateEffectiveConfig(pluginInfo, resolution.getConfig());
+                configApplier.apply(pluginInfo.getPluginId(), instance, resolution.getConfig());
+            } catch (RuntimeException e) {
+                throw new IllegalStateException(
+                    "Failed to initialize pre-context plugin config: "
+                        + pluginInfo.getPluginId(),
+                    e);
+            }
+            pluginInfo.setConfig(copyConfig(resolution.getConfig()));
+        }
+        return configResolver.resolve(pluginInfo, true);
+    }
+    
+    private void initializePluginLifecycle(PluginInfo pluginInfo, Object instance) {
+        if (!pluginInfo.isEnabled() || !(instance instanceof PluginStartupLifecycle)) {
+            return;
+        }
+        try {
+            ((PluginStartupLifecycle) instance).initialize();
+        } catch (RuntimeException e) {
+            throw new IllegalStateException(
+                "Failed to initialize pre-context plugin lifecycle: "
+                    + pluginInfo.getPluginId(),
+                e);
+        }
+    }
+    
+    private List<ConfigItemDefinition> normalizeDefinitions(String pluginId,
+        List<ConfigItemDefinition> definitions) {
+        if (definitions == null || definitions.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<ConfigItemDefinition> result = new ArrayList<>(definitions.size());
+        for (ConfigItemDefinition definition : definitions) {
+            ConfigItemDefinition copy = copyDefinition(definition);
+            if (ConfigItemEffectMode.RUNTIME == copy.getEffectMode()) {
+                LOGGER.warn("[PreContextPluginInitializer] Treat runtime config as restart-only, "
+                    + "pluginId={}, key={}", pluginId, copy.getKey());
+                copy.setEffectMode(ConfigItemEffectMode.RESTART);
+            }
+            result.add(copy);
+        }
+        return Collections.unmodifiableList(result);
+    }
+    
+    private ConfigItemDefinition copyDefinition(ConfigItemDefinition source) {
+        ConfigItemDefinition result =
+            new ConfigItemDefinition(source.getKey(), source.getName(), source.getType());
+        result.setDescription(source.getDescription());
+        result.setDefaultValue(source.getDefaultValue());
+        result.setRequired(source.isRequired());
+        result.setEnumValues(copyList(source.getEnumValues()));
+        result.setAliases(copyList(source.getAliases()));
+        result.setSensitive(source.isSensitive());
+        result.setEffectMode(source.getEffectMode());
+        return result;
+    }
+    
+    private List<String> copyList(List<String> source) {
+        return source == null ? null : new ArrayList<>(source);
+    }
+    
+    private Map<String, String> copyConfig(Map<String, String> config) {
+        return config == null ? new LinkedHashMap<>() : new LinkedHashMap<>(config);
+    }
+    
+    private void initializeEnvironmentManager(Map<String, PluginInfo> pluginInfos,
+        Map<String, Object> pluginInstances) {
+        List<CustomEnvironmentPluginService> services = new ArrayList<>();
+        pluginInfos.forEach((pluginId, pluginInfo) -> {
+            Object instance = pluginInstances.get(pluginId);
+            if (PluginType.ENVIRONMENT == pluginInfo.getPluginType() && pluginInfo.isEnabled()
+                && instance instanceof CustomEnvironmentPluginService) {
+                services.add((CustomEnvironmentPluginService) instance);
+            }
+        });
+        CustomEnvironmentPluginManager.getInstance().initialize(services);
+    }
+    
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static Collection<PluginProvider<?>> loadProviders() {
+        return (Collection) NacosServiceLoader.load(PluginProvider.class);
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/plugin/StandardPluginInitializer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/plugin/StandardPluginInitializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin;
+
+import com.alibaba.nacos.api.plugin.PluginInitializationPhase;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Standard post-context plugin initializer.
+ *
+ * @author Nacos
+ */
+@Component
+public class StandardPluginInitializer
+    implements PluginInitializer, ApplicationListener<ApplicationReadyEvent> {
+    
+    private final PluginManager pluginManager;
+    
+    public StandardPluginInitializer(PluginManager pluginManager) {
+        this.pluginManager = pluginManager;
+    }
+    
+    @Override
+    public PluginInitializationPhase getInitializationPhase() {
+        return PluginInitializationPhase.STANDARD;
+    }
+    
+    @Override
+    public void initialize() {
+        pluginManager.initialize();
+    }
+    
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        initialize();
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/listener/StartingApplicationListenerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/listener/StartingApplicationListenerTest.java
@@ -19,12 +19,14 @@ package com.alibaba.nacos.core.listener;
 import com.alibaba.nacos.core.listener.startup.NacosStartUp;
 import com.alibaba.nacos.core.listener.startup.NacosStartUpManager;
 import com.alibaba.nacos.core.plugin.PluginCriticalBootstrapValidator;
-import com.alibaba.nacos.core.plugin.PluginManager;
+import com.alibaba.nacos.core.plugin.PreContextPluginInitializer;
+import com.alibaba.nacos.core.plugin.StandardPluginInitializer;
 import com.alibaba.nacos.sys.env.DeploymentType;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
+import org.mockito.MockedConstruction;
 import org.mockito.InOrder;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
@@ -32,6 +34,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -39,6 +42,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockConstruction;
 
 /**
  * {@link StartingApplicationListener} unit test.
@@ -97,10 +101,13 @@ class StartingApplicationListenerTest {
             MockedStatic<NacosStartUpManager> managerMock = mockStatic(NacosStartUpManager.class);
             MockedStatic<EnvUtil> envUtilMock = mockStatic(EnvUtil.class);
             MockedStatic<PluginCriticalBootstrapValidator> validatorMock =
-                mockStatic(PluginCriticalBootstrapValidator.class)) {
+                mockStatic(PluginCriticalBootstrapValidator.class);
+            MockedConstruction<PreContextPluginInitializer> initializerMock =
+                mockConstruction(PreContextPluginInitializer.class)) {
             managerMock.when(NacosStartUpManager::getCurrentStartUp).thenReturn(mockStartUp);
             envUtilMock.when(EnvUtil::getDeploymentType).thenReturn(DeploymentType.MERGED);
             listener.contextLoaded(context);
+            verify(initializerMock.constructed().get(0)).initialize();
             verify(mockStartUp).customEnvironment();
             validatorMock.verify(PluginCriticalBootstrapValidator::validate);
         }
@@ -116,12 +123,15 @@ class StartingApplicationListenerTest {
             MockedStatic<NacosStartUpManager> managerMock = mockStatic(NacosStartUpManager.class);
             MockedStatic<EnvUtil> envUtilMock = mockStatic(EnvUtil.class);
             MockedStatic<PluginCriticalBootstrapValidator> validatorMock =
-                mockStatic(PluginCriticalBootstrapValidator.class)) {
+                mockStatic(PluginCriticalBootstrapValidator.class);
+            MockedConstruction<PreContextPluginInitializer> initializerMock =
+                mockConstruction(PreContextPluginInitializer.class)) {
             managerMock.when(NacosStartUpManager::getCurrentStartUp).thenReturn(mockStartUp);
             envUtilMock.when(EnvUtil::getDeploymentType).thenReturn(null);
             listener.contextLoaded(context);
             verify(mockStartUp).customEnvironment();
             validatorMock.verifyNoInteractions();
+            assertTrue(initializerMock.constructed().isEmpty());
         }
     }
     
@@ -135,12 +145,15 @@ class StartingApplicationListenerTest {
             MockedStatic<NacosStartUpManager> managerMock = mockStatic(NacosStartUpManager.class);
             MockedStatic<EnvUtil> envUtilMock = mockStatic(EnvUtil.class);
             MockedStatic<PluginCriticalBootstrapValidator> validatorMock =
-                mockStatic(PluginCriticalBootstrapValidator.class)) {
+                mockStatic(PluginCriticalBootstrapValidator.class);
+            MockedConstruction<PreContextPluginInitializer> initializerMock =
+                mockConstruction(PreContextPluginInitializer.class)) {
             managerMock.when(NacosStartUpManager::getCurrentStartUp).thenReturn(mockStartUp);
             envUtilMock.when(EnvUtil::getDeploymentType).thenReturn(DeploymentType.MERGED);
             listener.contextLoaded(context);
             verify(mockStartUp).customEnvironment();
             validatorMock.verifyNoInteractions();
+            assertTrue(initializerMock.constructed().isEmpty());
         }
     }
     
@@ -148,18 +161,20 @@ class StartingApplicationListenerTest {
     void startedDelegatesToCurrentStartUp() {
         StartingApplicationListener listener = new StartingApplicationListener();
         NacosStartUp mockStartUp = mock(NacosStartUp.class);
-        PluginManager pluginManager = mock(PluginManager.class);
+        StandardPluginInitializer initializer = mock(StandardPluginInitializer.class);
         @SuppressWarnings("unchecked")
-        ObjectProvider<PluginManager> pluginManagerProvider = mock(ObjectProvider.class);
+        ObjectProvider<StandardPluginInitializer> initializerProvider =
+            mock(ObjectProvider.class);
         ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
-        when(context.getBeanProvider(PluginManager.class)).thenReturn(pluginManagerProvider);
-        when(pluginManagerProvider.getIfAvailable()).thenReturn(pluginManager);
+        when(context.getBeanProvider(StandardPluginInitializer.class))
+            .thenReturn(initializerProvider);
+        when(initializerProvider.getIfAvailable()).thenReturn(initializer);
         try (
             MockedStatic<NacosStartUpManager> managerMock = mockStatic(NacosStartUpManager.class)) {
             managerMock.when(NacosStartUpManager::getCurrentStartUp).thenReturn(mockStartUp);
             listener.started(context);
-            InOrder inOrder = inOrder(pluginManager, mockStartUp);
-            inOrder.verify(pluginManager).initialize();
+            InOrder inOrder = inOrder(initializer, mockStartUp);
+            inOrder.verify(initializer).initialize();
             inOrder.verify(mockStartUp).started();
             verify(mockStartUp).logStarted(any());
         }
@@ -170,9 +185,11 @@ class StartingApplicationListenerTest {
         StartingApplicationListener listener = new StartingApplicationListener();
         NacosStartUp mockStartUp = mock(NacosStartUp.class);
         @SuppressWarnings("unchecked")
-        ObjectProvider<PluginManager> pluginManagerProvider = mock(ObjectProvider.class);
+        ObjectProvider<StandardPluginInitializer> initializerProvider =
+            mock(ObjectProvider.class);
         ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
-        when(context.getBeanProvider(PluginManager.class)).thenReturn(pluginManagerProvider);
+        when(context.getBeanProvider(StandardPluginInitializer.class))
+            .thenReturn(initializerProvider);
         try (
             MockedStatic<NacosStartUpManager> managerMock = mockStatic(NacosStartUpManager.class)) {
             managerMock.when(NacosStartUpManager::getCurrentStartUp).thenReturn(mockStartUp);

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/PluginManagerTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -54,11 +54,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -92,9 +94,6 @@ class PluginManagerTest {
     
     @Mock
     private PluginTypePolicyRegistry policyRegistry;
-    
-    @Mock
-    private ApplicationReadyEvent applicationReadyEvent;
     
     private PluginManager manager;
     
@@ -144,6 +143,12 @@ class PluginManagerTest {
     @Test
     void publicConstructorCreatesManagerWithServiceLoadedPoliciesTest() {
         assertNotNull(new PluginManager(persistence, synchronizer));
+        @SuppressWarnings("unchecked")
+        ObjectProvider<PreContextPluginInitializationResult> resultProvider =
+            mock(ObjectProvider.class);
+        when(resultProvider.getIfAvailable(any(Supplier.class)))
+            .thenReturn(PreContextPluginInitializationResult.empty());
+        assertNotNull(new PluginManager(persistence, synchronizer, resultProvider));
     }
     
     @Test
@@ -405,9 +410,9 @@ class PluginManagerTest {
     }
     
     @Test
-    void onApplicationEventTest() {
+    void initializeTest() {
         registerSelectedAuthPlugin();
-        manager.onApplicationEvent(applicationReadyEvent);
+        manager.initialize();
         
         verify(persistence, times(1)).loadAllStates();
         verify(persistence, times(1)).loadAllConfigs();
@@ -418,7 +423,7 @@ class PluginManagerTest {
         registerSelectedAuthPlugin();
         
         manager.initialize();
-        manager.onApplicationEvent(applicationReadyEvent);
+        manager.initialize();
         
         verify(persistence).loadAllStates();
         verify(persistence).loadAllConfigs();
@@ -433,7 +438,7 @@ class PluginManagerTest {
         states.put("trace:test", false);
         when(persistence.loadAllStates()).thenReturn(states);
         
-        manager.onApplicationEvent(applicationReadyEvent);
+        manager.initialize();
         
         assertFalse(manager.isPluginEnabled("trace", "test"));
     }
@@ -549,7 +554,7 @@ class PluginManagerTest {
         when(persistence.loadAllStates()).thenReturn(
             Collections.singletonMap("visibility:nacos", true));
         
-        manager.onApplicationEvent(applicationReadyEvent);
+        manager.initialize();
         
         assertTrue(manager.isPluginEnabled("visibility", "nacos"));
     }
@@ -818,7 +823,7 @@ class PluginManagerTest {
         configs.put("trace:test", config);
         when(persistence.loadAllConfigs()).thenReturn(configs);
         
-        manager.onApplicationEvent(applicationReadyEvent);
+        manager.initialize();
         
         assertEquals("value", plugin.getCurrentConfig().get("key"));
         verify(persistence, never()).saveConfig(any(), anyMap());
@@ -834,7 +839,7 @@ class PluginManagerTest {
         registerConfigurablePlugin("trace", "test", plugin);
         registerSelectedAuthPlugin();
         
-        manager.onApplicationEvent(applicationReadyEvent);
+        manager.initialize();
         
         assertEquals("default", plugin.getCurrentConfig().get("endpoint"));
     }
@@ -1343,9 +1348,192 @@ class PluginManagerTest {
     }
     
     @Test
+    void initializeImportsPreContextPluginWithoutReloadingProviderTest() {
+        Object instance = new Object();
+        PluginInfo info = createPreContextPluginInfo(true);
+        PluginConfigResolution resolution = new PluginConfigResolution(
+            Collections.singletonMap("key", "ma******ue"), Collections.emptyMap());
+        PreContextPluginInitializationResult result = new PreContextPluginInitializationResult(
+            Collections.singletonMap(info.getPluginId(), info),
+            Collections.singletonMap(info.getPluginId(), instance),
+            Collections.singletonMap(info.getPluginId(), resolution));
+        manager = new PluginManager(persistence, synchronizer, policyRegistry, result);
+        PluginProvider<Object> provider = mock(PluginProvider.class);
+        when(provider.getPluginType()).thenReturn(PluginType.ENVIRONMENT);
+        
+        try (MockedStatic<NacosServiceLoader> loader = mockStatic(NacosServiceLoader.class)) {
+            loader.when(() -> NacosServiceLoader.load(PluginProvider.class))
+                .thenReturn(Collections.singletonList(provider));
+            
+            manager.initialize();
+        }
+        
+        assertSame(info, manager.getPlugin("environment:test").get());
+        assertSame(instance, getPluginInstances().get("environment:test"));
+        assertSame(resolution, manager.resolvePluginConfig(info));
+        assertTrue(manager.isPluginEnabled("environment", "test"));
+        verify(provider, never()).getAllPlugins();
+    }
+    
+    @Test
+    void initializeRejectsDuplicatePreContextPluginTest() {
+        PluginInfo info = createPreContextPluginInfo(true);
+        manager = managerWithPreContextPlugin(info);
+        ReflectionTestUtils.invokeMethod(manager, "registerPlugin", PluginType.ENVIRONMENT,
+            info.getPluginName(), new Object());
+        
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> ReflectionTestUtils.invokeMethod(manager, "importPreContextPlugins"));
+        
+        assertTrue(exception.getMessage().contains(info.getPluginId()));
+    }
+    
+    @Test
+    void initializeSkipsPreContextStartupLifecycleTest() {
+        PluginInfo info = createPreContextPluginInfo(true);
+        TestStartupPlugin instance = new TestStartupPlugin();
+        PreContextPluginInitializationResult result = new PreContextPluginInitializationResult(
+            Collections.singletonMap(info.getPluginId(), info),
+            Collections.singletonMap(info.getPluginId(), instance),
+            Collections.emptyMap());
+        manager = new PluginManager(persistence, synchronizer, policyRegistry, result);
+        ReflectionTestUtils.invokeMethod(manager, "importPreContextPlugins");
+        
+        ReflectionTestUtils.invokeMethod(manager, "initializePluginLifecycles",
+            Collections.singleton(info.getPluginId()));
+        
+        assertTrue(instance.getOperations().isEmpty());
+    }
+    
+    @Test
+    void preContextPluginRejectsRuntimeStateAndConfigChangesTest() throws NacosApiException {
+        PluginInfo info = createPreContextPluginInfo(true);
+        manager = managerWithPreContextPlugin(info);
+        try (MockedStatic<NacosServiceLoader> loader = mockStatic(NacosServiceLoader.class)) {
+            loader.when(() -> NacosServiceLoader.load(PluginProvider.class))
+                .thenReturn(Collections.emptyList());
+            manager.initialize();
+        }
+        
+        NacosApiException stateException = assertThrows(NacosApiException.class,
+            () -> manager.setPluginEnabled(info.getPluginId(), info.isEnabled()));
+        NacosApiException configException = assertThrows(NacosApiException.class,
+            () -> manager.updatePluginConfig(info.getPluginId(),
+                Collections.singletonMap("key", "value")));
+        
+        assertTrue(stateException.getErrMsg().contains("requires restart"),
+            stateException::getErrMsg);
+        assertTrue(configException.getErrMsg().contains("requires restart"),
+            configException::getErrMsg);
+        assertThrows(IllegalArgumentException.class,
+            () -> manager.validateStateChange("environment:missing", false));
+        assertThrows(IllegalArgumentException.class,
+            () -> manager.applyStateChange(info.getPluginId(), false));
+        assertThrows(IllegalArgumentException.class,
+            () -> manager.applyConfigChange(info.getPluginId(),
+                Collections.singletonMap("key", "value")));
+        verify(synchronizer, never()).syncStateChange(any(), anyBoolean());
+        verify(synchronizer, never()).syncConfigChange(any(), anyMap());
+    }
+    
+    @Test
+    void preContextPluginIsSkippedByRefreshAndSnapshotRestoreTest() {
+        PluginInfo info = createPreContextPluginInfo(true);
+        manager = managerWithPreContextPlugin(info);
+        try (MockedStatic<NacosServiceLoader> loader = mockStatic(NacosServiceLoader.class)) {
+            loader.when(() -> NacosServiceLoader.load(PluginProvider.class))
+                .thenReturn(Collections.emptyList());
+            manager.initialize();
+        }
+        PluginConfigService configService = mock(PluginConfigService.class);
+        ReflectionTestUtils.setField(manager, "pluginConfigService", configService);
+        
+        manager.refreshStaticPluginConfigs();
+        Map<String, Boolean> states = new HashMap<>();
+        states.put(info.getPluginId(), false);
+        states.put("trace:test", false);
+        manager.restorePluginStates(states);
+        
+        Map<String, Map<String, String>> configs = new HashMap<>();
+        configs.put(info.getPluginId(), Collections.singletonMap("key", "ignored"));
+        configs.put("trace:test", Collections.singletonMap("key", "restored"));
+        manager.restorePluginConfigs(configs);
+        
+        verify(configService, never()).refreshStaticConfig(any(), any());
+        verify(configService).restoreRuntimePersistedConfigs(Collections.singletonMap(
+            "trace:test", Collections.singletonMap("key", "restored")));
+        verify(configService, never()).applyRestoredPluginConfig(eq(info), any());
+        verify(persistence).replaceAllStates(
+            Collections.singletonMap("trace:test", false));
+        assertTrue(manager.isPluginEnabled("environment", "test"));
+    }
+    
+    @Test
+    void persistedSnapshotsExcludePreContextEntriesTest() {
+        PluginInfo info = createPreContextPluginInfo(true);
+        manager = managerWithPreContextPlugin(info);
+        Map<String, Boolean> persistedStates = new HashMap<>();
+        persistedStates.put(info.getPluginId(), false);
+        persistedStates.put("trace:test", true);
+        persistedStates.put("unknown", false);
+        persistedStates.put(null, true);
+        when(persistence.loadAllStates()).thenReturn(persistedStates);
+        PluginConfigService configService = mock(PluginConfigService.class);
+        Map<String, Map<String, String>> persistedConfigs = new HashMap<>();
+        persistedConfigs.put(info.getPluginId(), Collections.singletonMap("key", "ignored"));
+        persistedConfigs.put("trace:test", Collections.singletonMap("key", "value"));
+        when(configService.getAllRuntimePersistedConfigs()).thenReturn(persistedConfigs);
+        ReflectionTestUtils.setField(manager, "pluginConfigService", configService);
+        
+        Map<String, Boolean> filteredStates = manager.getPersistedPluginStates();
+        Map<String, Map<String, String>> filteredConfigs =
+            manager.getRuntimePersistedConfigs();
+        
+        assertFalse(filteredStates.containsKey(info.getPluginId()));
+        assertTrue(filteredStates.containsKey("trace:test"));
+        assertTrue(filteredStates.containsKey("unknown"));
+        assertTrue(filteredStates.containsKey(null));
+        assertFalse(filteredConfigs.containsKey(info.getPluginId()));
+        assertTrue(filteredConfigs.containsKey("trace:test"));
+    }
+    
+    @Test
+    void restoreNullPluginConfigSnapshotUsesEmptyMapTest() {
+        manager.restorePluginConfigs(null);
+        
+        verify(persistence).replaceAllConfigs(Collections.emptyMap());
+    }
+    
+    @Test
     void applyStateChangeWithUnknownPluginIdTest() {
         manager.applyStateChange("unknown:plugin", true);
         assertTrue(manager.isPluginEnabled("unknown", "plugin"));
+    }
+    
+    private PluginManager managerWithPreContextPlugin(PluginInfo info) {
+        Object instance = new TestConfigurablePlugin();
+        PluginConfigResolution resolution = new PluginConfigResolution(
+            info.getConfig(), Collections.emptyMap());
+        PreContextPluginInitializationResult result = new PreContextPluginInitializationResult(
+            Collections.singletonMap(info.getPluginId(), info),
+            Collections.singletonMap(info.getPluginId(), instance),
+            Collections.singletonMap(info.getPluginId(), resolution));
+        return new PluginManager(persistence, synchronizer, policyRegistry, result);
+    }
+    
+    private PluginInfo createPreContextPluginInfo(boolean configurable) {
+        ConfigItemDefinition definition =
+            new ConfigItemDefinition("key", "Key", null);
+        PluginInfo result = new PluginInfo();
+        result.setPluginId("environment:test");
+        result.setPluginName("test");
+        result.setPluginType(PluginType.ENVIRONMENT);
+        result.setClassName(Object.class.getName());
+        result.setEnabled(true);
+        result.setConfigurable(configurable);
+        result.setConfigDefinitions(Collections.singletonList(definition));
+        result.setConfig(Collections.singletonMap("key", "masked-value"));
+        return result;
     }
     
     private void registerTestPlugin(String type, String name, boolean configurable,

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/PluginStateSnapshotOperationTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/PluginStateSnapshotOperationTest.java
@@ -22,7 +22,6 @@ import com.alibaba.nacos.consistency.snapshot.LocalFileMeta;
 import com.alibaba.nacos.consistency.snapshot.Reader;
 import com.alibaba.nacos.consistency.snapshot.Writer;
 import com.alibaba.nacos.core.plugin.model.PluginStateSnapshot;
-import com.alibaba.nacos.core.plugin.storage.PluginStatePersistenceService;
 import com.alibaba.nacos.sys.utils.DiskUtils;
 import com.alipay.sofa.jraft.util.CRC64;
 import org.junit.jupiter.api.AfterEach;
@@ -62,9 +61,6 @@ import static org.mockito.Mockito.when;
 class PluginStateSnapshotOperationTest {
     
     @Mock
-    private PluginStatePersistenceService persistence;
-    
-    @Mock
     private PluginManager pluginManager;
     
     @Mock
@@ -82,8 +78,8 @@ class PluginStateSnapshotOperationTest {
     
     @BeforeEach
     void setUp() {
-        snapshotOperation = new PluginStateSnapshotOperation(
-            persistence, pluginManager, new ReentrantReadWriteLock());
+        snapshotOperation =
+            new PluginStateSnapshotOperation(pluginManager, new ReentrantReadWriteLock());
         serializer = SerializeFactory.getDefault();
     }
     
@@ -104,7 +100,7 @@ class PluginStateSnapshotOperationTest {
         otelConfig.put("endpoint", "http://localhost:8080");
         configs.put("trace:otel", otelConfig);
         
-        when(persistence.loadAllStates()).thenReturn(states);
+        when(pluginManager.getPersistedPluginStates()).thenReturn(states);
         when(pluginManager.getRuntimePersistedConfigs()).thenReturn(configs);
         when(writer.getPath()).thenReturn(tempDir.toString());
         when(writer.addFile(eq("plugin_state.zip"), any(LocalFileMeta.class))).thenReturn(true);
@@ -124,7 +120,7 @@ class PluginStateSnapshotOperationTest {
     
     @Test
     void onSnapshotSaveEmptyDataTest() throws Exception {
-        when(persistence.loadAllStates()).thenReturn(new HashMap<>());
+        when(pluginManager.getPersistedPluginStates()).thenReturn(new HashMap<>());
         when(pluginManager.getRuntimePersistedConfigs()).thenReturn(new HashMap<>());
         when(writer.getPath()).thenReturn(tempDir.toString());
         when(writer.addFile(eq("plugin_state.zip"), any(LocalFileMeta.class))).thenReturn(true);
@@ -140,7 +136,7 @@ class PluginStateSnapshotOperationTest {
     
     @Test
     void onSnapshotSaveFailureTest() throws Exception {
-        when(persistence.loadAllStates()).thenReturn(new HashMap<>());
+        when(pluginManager.getPersistedPluginStates()).thenReturn(new HashMap<>());
         when(pluginManager.getRuntimePersistedConfigs()).thenReturn(new HashMap<>());
         when(writer.getPath()).thenReturn(tempDir.toString());
         when(writer.addFile(eq("plugin_state.zip"), any(LocalFileMeta.class))).thenReturn(false);
@@ -157,7 +153,7 @@ class PluginStateSnapshotOperationTest {
     @Test
     void onSnapshotSaveExceptionTest() {
         IllegalStateException failure = new IllegalStateException("load failed");
-        when(persistence.loadAllStates()).thenThrow(failure);
+        when(pluginManager.getPersistedPluginStates()).thenThrow(failure);
         AtomicBoolean callbackSuccess = new AtomicBoolean(true);
         AtomicReference<Throwable> callbackError = new AtomicReference<>();
         

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/PreContextPluginInitializerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/PreContextPluginInitializerTest.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin;
+
+import com.alibaba.nacos.api.plugin.ConfigItemDefinition;
+import com.alibaba.nacos.api.plugin.ConfigItemEffectMode;
+import com.alibaba.nacos.api.plugin.ConfigItemType;
+import com.alibaba.nacos.api.plugin.PluginInitializationPhase;
+import com.alibaba.nacos.api.plugin.PluginProvider;
+import com.alibaba.nacos.api.plugin.PluginStartupLifecycle;
+import com.alibaba.nacos.api.plugin.PluginType;
+import com.alibaba.nacos.api.plugin.PluginTypeConfiguration;
+import com.alibaba.nacos.core.plugin.config.PluginConfigApplier;
+import com.alibaba.nacos.core.plugin.config.PluginConfigBasicChecker;
+import com.alibaba.nacos.core.plugin.config.PluginConfigResolution;
+import com.alibaba.nacos.core.plugin.config.PluginConfigResolver;
+import com.alibaba.nacos.core.plugin.model.PluginInfo;
+import com.alibaba.nacos.plugin.environment.CustomEnvironmentPluginManager;
+import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
+import com.alibaba.nacos.plugin.environment.spi.EnvironmentPluginTypePolicy;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PreContextPluginInitializerTest {
+    
+    private ConfigurableEnvironment cachedEnvironment;
+    
+    private MockEnvironment environment;
+    
+    private DefaultListableBeanFactory beanFactory;
+    
+    private MapConfiguration configuration;
+    
+    @BeforeEach
+    void setUp() {
+        cachedEnvironment = EnvUtil.getEnvironment();
+        environment = new MockEnvironment();
+        EnvUtil.setEnvironment(environment);
+        beanFactory = new DefaultListableBeanFactory();
+        configuration = new MapConfiguration();
+        configuration.setProperty(
+            EnvironmentPluginTypePolicy.ENVIRONMENT_ENABLED_PROPERTY, "true");
+        CustomEnvironmentPluginManager.getInstance().initialize(Collections.emptyList());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        CustomEnvironmentPluginManager.getInstance().initialize(Collections.emptyList());
+        EnvUtil.setEnvironment(cachedEnvironment);
+    }
+    
+    @Test
+    void testConfigurablePluginUsesSameInitializedInstance() {
+        TestEnvironmentPlugin plugin = new TestEnvironmentPlugin();
+        environment.setProperty(
+            "nacos.plugin.environment.test.prefix", "configured-prefix");
+        PreContextPluginInitializer initializer =
+            newInitializer(Collections.singletonList(provider("test", plugin)));
+        
+        initializer.initialize();
+        initializer.initialize();
+        
+        assertEquals(PluginInitializationPhase.PRE_CONTEXT,
+            initializer.getInitializationPhase());
+        PreContextPluginInitializationResult result = getResult();
+        PluginInfo info = result.getPluginInfos().get("environment:test");
+        assertSame(plugin, result.getPluginInstances().get("environment:test"));
+        assertTrue(info.isConfigurable());
+        assertTrue(info.isEnabled());
+        assertEquals("configured-prefix", plugin.currentConfig.get("prefix"));
+        assertEquals("fallback", plugin.currentConfig.get("optional"));
+        assertEquals(1, plugin.applyCount);
+        assertEquals(1, plugin.initializeCount);
+        assertEquals(ConfigItemEffectMode.RUNTIME,
+            plugin.definitions.get(0).getEffectMode());
+        assertEquals(ConfigItemEffectMode.RESTART,
+            info.getConfigDefinitions().get(0).getEffectMode());
+        assertEquals("Prefix description",
+            info.getConfigDefinitions().get(0).getDescription());
+        assertEquals(Collections.singletonList("legacy.prefix"),
+            info.getConfigDefinitions().get(0).getAliases());
+        assertEquals(Collections.singletonList("unused"),
+            info.getConfigDefinitions().get(0).getEnumValues());
+        assertTrue(info.getConfigDefinitions().get(0).isRequired());
+        assertTrue(info.getConfigDefinitions().get(0).isSensitive());
+        assertThrows(UnsupportedOperationException.class,
+            () -> info.getConfigDefinitions().add(new ConfigItemDefinition()));
+        
+        PluginConfigResolution resolution =
+            result.getConfigResolutions().get("environment:test");
+        assertEquals("co******ix", resolution.getConfig().get("prefix"));
+        assertEquals("configured-prefix-value",
+            CustomEnvironmentPluginManager.getInstance().getCustomValues(
+                Collections.singletonMap("fixture.key", "value")).get("fixture.key"));
+    }
+    
+    @Test
+    void testDisabledPluginIsVisibleButDoesNotTransformOrStartLifecycle() {
+        configuration.setProperty("nacos.plugin.environment.test.enabled", "false");
+        TestEnvironmentPlugin plugin = new TestEnvironmentPlugin();
+        
+        newInitializer(Collections.singletonList(provider("test", plugin))).initialize();
+        
+        PluginInfo info = getResult().getPluginInfos().get("environment:test");
+        assertFalse(info.isEnabled());
+        assertEquals(1, plugin.applyCount);
+        assertEquals(0, plugin.initializeCount);
+        assertTrue(CustomEnvironmentPluginManager.getInstance().getPropertyKeys().isEmpty());
+    }
+    
+    @Test
+    void testDisabledTypeSkipsProvider() {
+        configuration.setProperty(
+            EnvironmentPluginTypePolicy.ENVIRONMENT_ENABLED_PROPERTY, "false");
+        CountingProvider provider = new CountingProvider(Collections.emptyMap());
+        
+        newInitializer(Collections.singletonList(provider)).initialize();
+        
+        assertEquals(0, provider.loadCount);
+        assertTrue(getResult().getPluginInfos().isEmpty());
+    }
+    
+    @Test
+    void testProviderFilteringAndInvalidPlugins() {
+        PluginProvider<Object> failedTypeProvider = new PluginProvider<>() {
+            
+            @Override
+            public PluginType getPluginType() {
+                throw new IllegalStateException("type");
+            }
+            
+            @Override
+            public Map<String, Object> getAllPlugins() {
+                return Collections.emptyMap();
+            }
+        };
+        PluginProvider<Object> nullTypeProvider =
+            provider((PluginType) null, Collections.emptyMap());
+        PluginProvider<Object> standardProvider =
+            provider(PluginType.TRACE, Collections.emptyMap());
+        PluginProvider<Object> nullPluginsProvider = provider(PluginType.ENVIRONMENT, null);
+        Map<String, Object> invalidPlugins = new LinkedHashMap<>();
+        invalidPlugins.put("", new TestEnvironmentPlugin());
+        invalidPlugins.put("null", null);
+        
+        newInitializer(Arrays.asList(failedTypeProvider, nullTypeProvider, standardProvider,
+            nullPluginsProvider, provider(PluginType.ENVIRONMENT, invalidPlugins))).initialize();
+        
+        assertTrue(getResult().getPluginInfos().isEmpty());
+    }
+    
+    @Test
+    void testProviderDiscoveryFailureStopsInitialization() {
+        PluginProvider<Object> provider = new PluginProvider<>() {
+            
+            @Override
+            public PluginType getPluginType() {
+                return PluginType.ENVIRONMENT;
+            }
+            
+            @Override
+            public Map<String, Object> getAllPlugins() {
+                throw new IllegalStateException("load");
+            }
+        };
+        
+        assertThrows(IllegalStateException.class,
+            () -> newInitializer(Collections.singletonList(provider)).initialize());
+    }
+    
+    @Test
+    void testDuplicatePluginStopsInitialization() {
+        TestEnvironmentPlugin first = new TestEnvironmentPlugin();
+        TestEnvironmentPlugin second = new TestEnvironmentPlugin();
+        
+        assertThrows(IllegalStateException.class,
+            () -> newInitializer(Arrays.asList(provider("test", first),
+                provider("test", second))).initialize());
+    }
+    
+    @Test
+    void testConfigApplyFailureStopsInitialization() {
+        TestEnvironmentPlugin plugin = new TestEnvironmentPlugin();
+        plugin.failApply = true;
+        
+        assertThrows(IllegalStateException.class,
+            () -> newInitializer(Collections.singletonList(provider("test", plugin)))
+                .initialize());
+    }
+    
+    @Test
+    void testLifecycleFailureStopsInitialization() {
+        TestEnvironmentPlugin plugin = new TestEnvironmentPlugin();
+        plugin.failInitialize = true;
+        
+        assertThrows(IllegalStateException.class,
+            () -> newInitializer(Collections.singletonList(provider("test", plugin)))
+                .initialize());
+    }
+    
+    @Test
+    void testNullDefinitionsAndConfigAreAccepted() {
+        NullConfigEnvironmentPlugin plugin = new NullConfigEnvironmentPlugin();
+        
+        newInitializer(Collections.singletonList(provider("null-config", plugin))).initialize();
+        
+        PluginInfo info = getResult().getPluginInfos().get("environment:null-config");
+        assertTrue(info.isConfigurable());
+        assertTrue(info.getConfigDefinitions().isEmpty());
+        assertTrue(info.getConfig().isEmpty());
+        assertTrue(plugin.applied);
+    }
+    
+    @Test
+    void testPublicConstructorRegistersEmptyResultWhenTypeDisabled() {
+        environment.setProperty(
+            EnvironmentPluginTypePolicy.ENVIRONMENT_ENABLED_PROPERTY, "false");
+        try (GenericApplicationContext context = new GenericApplicationContext()) {
+            PreContextPluginInitializer initializer = new PreContextPluginInitializer(context);
+            
+            initializer.initialize();
+            
+            assertTrue(context.getBeanFactory()
+                .getBean(PreContextPluginInitializationResult.class)
+                .getPluginInfos().isEmpty());
+        }
+    }
+    
+    @Test
+    void testInitializationResultIsImmutableAndEmptySingletonIsUsable() {
+        PreContextPluginInitializationResult result =
+            PreContextPluginInitializationResult.empty();
+        
+        assertTrue(result.getPluginInfos().isEmpty());
+        assertTrue(result.getPluginInstances().isEmpty());
+        assertTrue(result.getConfigResolutions().isEmpty());
+        assertThrows(UnsupportedOperationException.class,
+            () -> result.getPluginInfos().put("id", new PluginInfo()));
+    }
+    
+    private PreContextPluginInitializer newInitializer(
+        List<PluginProvider<?>> providers) {
+        PluginTypePolicyRegistry policyRegistry = new PluginTypePolicyRegistry(
+            Collections.singletonList(new EnvironmentPluginTypePolicy()), configuration);
+        return new PreContextPluginInitializer(beanFactory, policyRegistry, providers,
+            new PluginConfigResolver(), new PluginConfigBasicChecker(),
+            new PluginConfigApplier());
+    }
+    
+    private PreContextPluginInitializationResult getResult() {
+        return beanFactory.getBean(PreContextPluginInitializationResult.class);
+    }
+    
+    private PluginProvider<?> provider(String name, Object plugin) {
+        return provider(PluginType.ENVIRONMENT, Collections.singletonMap(name, plugin));
+    }
+    
+    private <T> PluginProvider<T> provider(PluginType type, Map<String, T> plugins) {
+        return new PluginProvider<>() {
+            
+            @Override
+            public PluginType getPluginType() {
+                return type;
+            }
+            
+            @Override
+            public Map<String, T> getAllPlugins() {
+                return plugins;
+            }
+        };
+    }
+    
+    private static class CountingProvider implements PluginProvider<Object> {
+        
+        private final Map<String, Object> plugins;
+        
+        private int loadCount;
+        
+        private CountingProvider(Map<String, Object> plugins) {
+            this.plugins = plugins;
+        }
+        
+        @Override
+        public PluginType getPluginType() {
+            return PluginType.ENVIRONMENT;
+        }
+        
+        @Override
+        public Map<String, Object> getAllPlugins() {
+            loadCount++;
+            return plugins;
+        }
+    }
+    
+    private static class TestEnvironmentPlugin
+        implements CustomEnvironmentPluginService, PluginStartupLifecycle {
+        
+        private final List<ConfigItemDefinition> definitions = createDefinitions();
+        
+        private Map<String, String> currentConfig = Collections.emptyMap();
+        
+        private int applyCount;
+        
+        private int initializeCount;
+        
+        private boolean failApply;
+        
+        private boolean failInitialize;
+        
+        @Override
+        public Map<String, Object> customValue(Map<String, Object> property) {
+            Map<String, Object> result = new HashMap<>(property);
+            result.computeIfPresent("fixture.key",
+                (key, value) -> currentConfig.get("prefix") + "-" + value);
+            return result;
+        }
+        
+        @Override
+        public Set<String> propertyKey() {
+            return Collections.singleton("fixture.key");
+        }
+        
+        @Override
+        public Integer order() {
+            return 1;
+        }
+        
+        @Override
+        public String pluginName() {
+            return "test";
+        }
+        
+        @Override
+        public List<ConfigItemDefinition> getConfigDefinitions() {
+            return definitions;
+        }
+        
+        @Override
+        public void applyConfig(Map<String, String> config) {
+            applyCount++;
+            if (failApply) {
+                throw new IllegalStateException("apply");
+            }
+            currentConfig = new LinkedHashMap<>(config);
+        }
+        
+        @Override
+        public Map<String, String> getCurrentConfig() {
+            return currentConfig;
+        }
+        
+        @Override
+        public void initialize() {
+            initializeCount++;
+            if (failInitialize) {
+                throw new IllegalStateException("initialize");
+            }
+        }
+        
+        private static List<ConfigItemDefinition> createDefinitions() {
+            ConfigItemDefinition prefix =
+                new ConfigItemDefinition("prefix", "Prefix", ConfigItemType.STRING);
+            prefix.setDescription("Prefix description");
+            prefix.setDefaultValue("default-prefix");
+            prefix.setRequired(true);
+            prefix.setEnumValues(Collections.singletonList("unused"));
+            prefix.setAliases(Collections.singletonList("legacy.prefix"));
+            prefix.setSensitive(true);
+            prefix.setEffectMode(ConfigItemEffectMode.RUNTIME);
+            ConfigItemDefinition optional =
+                new ConfigItemDefinition("optional", "Optional", ConfigItemType.STRING);
+            optional.setDefaultValue("fallback");
+            optional.setAliases(null);
+            optional.setEnumValues(null);
+            return Arrays.asList(prefix, optional);
+        }
+    }
+    
+    private static class NullConfigEnvironmentPlugin implements CustomEnvironmentPluginService {
+        
+        private boolean applied;
+        
+        @Override
+        public boolean isConfigurable() {
+            return true;
+        }
+        
+        @Override
+        public List<ConfigItemDefinition> getConfigDefinitions() {
+            return null;
+        }
+        
+        @Override
+        public Map<String, String> getCurrentConfig() {
+            return null;
+        }
+        
+        @Override
+        public void applyConfig(Map<String, String> config) {
+            applied = true;
+        }
+        
+        @Override
+        public Map<String, Object> customValue(Map<String, Object> property) {
+            return property;
+        }
+        
+        @Override
+        public Set<String> propertyKey() {
+            return Collections.emptySet();
+        }
+        
+        @Override
+        public Integer order() {
+            return 0;
+        }
+        
+        @Override
+        public String pluginName() {
+            return "null-config";
+        }
+    }
+    
+    private static class MapConfiguration implements PluginTypeConfiguration {
+        
+        private final Map<String, String> properties = new HashMap<>();
+        
+        void setProperty(String key, String value) {
+            properties.put(key, value);
+        }
+        
+        @Override
+        public String getProperty(String key) {
+            return properties.get(key);
+        }
+        
+        @Override
+        public boolean containsProperty(String key) {
+            return properties.containsKey(key);
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/plugin/StandardPluginInitializerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/plugin/StandardPluginInitializerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.plugin;
+
+import com.alibaba.nacos.api.plugin.PluginInitializationPhase;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class StandardPluginInitializerTest {
+    
+    @Test
+    void testInitializeAndReadyFallbackUseSameFlow() {
+        PluginManager pluginManager = mock(PluginManager.class);
+        StandardPluginInitializer initializer = new StandardPluginInitializer(pluginManager);
+        
+        initializer.initialize();
+        initializer.onApplicationEvent(mock(ApplicationReadyEvent.class));
+        
+        assertEquals(PluginInitializationPhase.STANDARD,
+            initializer.getInitializationPhase());
+        verify(pluginManager, times(2)).initialize();
+    }
+}

--- a/plugin/environment/src/main/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManager.java
+++ b/plugin/environment/src/main/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManager.java
@@ -16,22 +16,21 @@
 
 package com.alibaba.nacos.plugin.environment;
 
-import com.alibaba.nacos.common.spi.NacosServiceLoader;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Objects;
-import java.util.HashSet;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
-import java.util.LinkedList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * CustomEnvironment Plugin Management.
@@ -43,35 +42,40 @@ public class CustomEnvironmentPluginManager {
     private static final Logger LOGGER =
         LoggerFactory.getLogger(CustomEnvironmentPluginManager.class);
     
-    private static final List<CustomEnvironmentPluginService> SERVICE_LIST = new LinkedList<>();
-    
     private static final CustomEnvironmentPluginManager INSTANCE =
         new CustomEnvironmentPluginManager();
     
-    public CustomEnvironmentPluginManager() {
-        loadInitial();
-    }
+    private volatile List<CustomEnvironmentPluginService> services = Collections.emptyList();
     
-    private void loadInitial() {
-        Collection<CustomEnvironmentPluginService> customEnvironmentPluginServices =
-            NacosServiceLoader.load(
-                CustomEnvironmentPluginService.class);
-        for (CustomEnvironmentPluginService customEnvironmentPluginService : customEnvironmentPluginServices) {
-            if (StringUtils.isBlank(customEnvironmentPluginService.pluginName())) {
-                LOGGER.warn(
-                    "[customEnvironmentPluginService] Load customEnvironmentPluginService({}) customEnvironmentPluginName(null/empty) fail."
-                        + " Please Add customEnvironmentPluginName to resolve.",
-                    customEnvironmentPluginService.getClass());
-                continue;
+    /**
+     * Replace the services with instances initialized by the pre-context plugin flow.
+     *
+     * @param customEnvironmentPluginServices initialized services
+     */
+    public synchronized void initialize(
+        Collection<CustomEnvironmentPluginService> customEnvironmentPluginServices) {
+        List<CustomEnvironmentPluginService> initializedServices = new ArrayList<>();
+        if (customEnvironmentPluginServices != null) {
+            for (CustomEnvironmentPluginService service : customEnvironmentPluginServices) {
+                if (service == null) {
+                    continue;
+                }
+                if (StringUtils.isBlank(service.pluginName())) {
+                    LOGGER.warn(
+                        "[CustomEnvironmentPluginManager] Ignore environment plugin {} with "
+                            + "blank plugin name.",
+                        service.getClass().getName());
+                    continue;
+                }
+                LOGGER.info(
+                    "[CustomEnvironmentPluginManager] Load environment plugin '{}' ({})",
+                    service.pluginName(), service.getClass().getName());
+                initializedServices.add(service);
             }
-            LOGGER.info(
-                "[CustomEnvironmentPluginManager] Load customEnvironmentPluginService({}) customEnvironmentPluginName({}) successfully.",
-                customEnvironmentPluginService.getClass(),
-                customEnvironmentPluginService.pluginName());
         }
-        SERVICE_LIST.addAll(customEnvironmentPluginServices.stream()
-            .sorted(Comparator.comparingInt(CustomEnvironmentPluginService::order))
-            .collect(Collectors.toList()));
+        initializedServices.sort(
+            Comparator.comparingInt(CustomEnvironmentPluginService::order));
+        services = Collections.unmodifiableList(initializedServices);
     }
     
     public static CustomEnvironmentPluginManager getInstance() {
@@ -80,7 +84,7 @@ public class CustomEnvironmentPluginManager {
     
     public Set<String> getPropertyKeys() {
         Set<String> keys = new HashSet<>();
-        for (CustomEnvironmentPluginService customEnvironmentPluginService : SERVICE_LIST) {
+        for (CustomEnvironmentPluginService customEnvironmentPluginService : services) {
             keys.addAll(customEnvironmentPluginService.propertyKey());
         }
         return keys;
@@ -88,7 +92,7 @@ public class CustomEnvironmentPluginManager {
     
     public Map<String, Object> getCustomValues(Map<String, Object> sourceProperty) {
         Map<String, Object> customValuesMap = new HashMap<>(1);
-        for (CustomEnvironmentPluginService customEnvironmentPluginService : SERVICE_LIST) {
+        for (CustomEnvironmentPluginService customEnvironmentPluginService : services) {
             Set<String> keys = customEnvironmentPluginService.propertyKey();
             Map<String, Object> propertyMap = new HashMap<>(keys.size());
             for (String key : keys) {
@@ -113,13 +117,18 @@ public class CustomEnvironmentPluginManager {
      * Injection realization.
      *
      * @param customEnvironmentPluginService customEnvironmentPluginService implementation
+     * @deprecated environment services are initialized by the pre-context plugin flow
      */
+    @Deprecated
     public static synchronized void join(
         CustomEnvironmentPluginService customEnvironmentPluginService) {
         if (Objects.isNull(customEnvironmentPluginService)) {
             return;
         }
-        SERVICE_LIST.add(customEnvironmentPluginService);
+        List<CustomEnvironmentPluginService> updatedServices =
+            new ArrayList<>(INSTANCE.services);
+        updatedServices.add(customEnvironmentPluginService);
+        INSTANCE.initialize(updatedServices);
         LOGGER.info("[CustomEnvironmentPluginService] join successfully.");
     }
 }

--- a/plugin/environment/src/main/java/com/alibaba/nacos/plugin/environment/spi/CustomEnvironmentPluginService.java
+++ b/plugin/environment/src/main/java/com/alibaba/nacos/plugin/environment/spi/CustomEnvironmentPluginService.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.plugin.environment.spi;
 
+import com.alibaba.nacos.api.plugin.PluginConfigSpec;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -24,7 +26,7 @@ import java.util.Set;
  *
  * @author : huangtianhui
  */
-public interface CustomEnvironmentPluginService {
+public interface CustomEnvironmentPluginService extends PluginConfigSpec {
     
     /**
      * customValue interface.

--- a/plugin/environment/src/main/java/com/alibaba/nacos/plugin/environment/spi/EnvironmentPluginTypePolicy.java
+++ b/plugin/environment/src/main/java/com/alibaba/nacos/plugin/environment/spi/EnvironmentPluginTypePolicy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.environment.spi;
+
+import com.alibaba.nacos.api.plugin.PluginType;
+import com.alibaba.nacos.api.plugin.PluginTypeConfiguration;
+import com.alibaba.nacos.api.plugin.PluginTypePolicy;
+
+/**
+ * Environment plugin type policy.
+ *
+ * @author Nacos
+ */
+public class EnvironmentPluginTypePolicy implements PluginTypePolicy {
+    
+    public static final String ENVIRONMENT_ENABLED_PROPERTY =
+        "nacos.custom.environment.enabled";
+    
+    @Override
+    public PluginType getPluginType() {
+        return PluginType.ENVIRONMENT;
+    }
+    
+    @Override
+    public boolean isLoadingEnabled(PluginTypeConfiguration configuration) {
+        return configuration.getBooleanProperty(ENVIRONMENT_ENABLED_PROPERTY, false);
+    }
+}

--- a/plugin/environment/src/main/resources/META-INF/services/com.alibaba.nacos.api.plugin.PluginTypePolicy
+++ b/plugin/environment/src/main/resources/META-INF/services/com.alibaba.nacos.api.plugin.PluginTypePolicy
@@ -1,0 +1,16 @@
+#
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.alibaba.nacos.plugin.environment.spi.EnvironmentPluginTypePolicy

--- a/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManagerTest.java
+++ b/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/CustomEnvironmentPluginManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,13 @@ package com.alibaba.nacos.plugin.environment;
 import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.plugin.environment.spi.CustomEnvironmentPluginService;
 import com.alibaba.nacos.plugin.environment.spi.EnvironmentPluginProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,34 +41,49 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class CustomEnvironmentPluginManagerTest {
     
-    @Test
-    void testInstance() {
-        CustomEnvironmentPluginManager instance = CustomEnvironmentPluginManager.getInstance();
-        assertNotNull(instance);
+    private final CustomEnvironmentPluginManager manager =
+        CustomEnvironmentPluginManager.getInstance();
+    
+    @BeforeEach
+    @AfterEach
+    void resetManager() {
+        manager.initialize(Collections.emptyList());
     }
     
     @Test
-    void testJoin() {
+    void testInstance() {
+        assertNotNull(manager);
+    }
+    
+    @Test
+    void testInitializeFiltersInvalidServicesAndUsesOrder() {
+        TestEnvironmentPlugin low = new TestEnvironmentPlugin("low", 1, "-low");
+        TestEnvironmentPlugin high = new TestEnvironmentPlugin("high", 10, "-high");
+        TestEnvironmentPlugin blank = new TestEnvironmentPlugin("", 20, "-blank");
+        
+        manager.initialize(Arrays.asList(high, null, blank, low));
+        
+        assertEquals(Collections.singleton("key"), manager.getPropertyKeys());
+        Map<String, Object> source = Collections.singletonMap("key", "value");
+        assertEquals("value-high", manager.getCustomValues(source).get("key"));
+    }
+    
+    @Test
+    @SuppressWarnings("deprecation")
+    void testJoinFiltersReturnedValues() {
         CustomEnvironmentPluginManager.join(new CustomEnvironmentPluginService() {
             
             @Override
             public Map<String, Object> customValue(Map<String, Object> property) {
-                String pwd = (String) property.get("db.password.0");
-                property.put("db.password.0", "test" + pwd);
-                // [issue 13367] check property remove
-                property.put("db.password.1", null);
-                property.put("db.password.2", null);
-                property.put("db.password.extra", "extra");
+                property.put("key", "changed");
+                property.put("null-key", null);
+                property.put("unknown", "ignored");
                 return property;
             }
             
             @Override
             public Set<String> propertyKey() {
-                Set<String> propertyKey = new HashSet<>();
-                propertyKey.add("db.password.0");
-                propertyKey.add("db.password.1");
-                propertyKey.add("db.password.2");
-                return propertyKey;
+                return Set.of("key", "null-key");
             }
             
             @Override
@@ -80,73 +93,28 @@ class CustomEnvironmentPluginManagerTest {
             
             @Override
             public String pluginName() {
-                return "test";
+                return "joined";
             }
         });
-        assertNotNull(CustomEnvironmentPluginManager.getInstance().getPropertyKeys());
-        Map<String, Object> sourcePropertyMap = new HashMap<>();
-        sourcePropertyMap.put("db.password.0", "nacos");
-        Map<String, Object> customValues =
-            CustomEnvironmentPluginManager.getInstance().getCustomValues(sourcePropertyMap);
-        assertNotNull(customValues);
-        // [issue 13367] check property remove
-        assertFalse(customValues.containsKey("db.password.1"));
-        assertFalse(customValues.containsKey("db.password.2"));
-        assertFalse(customValues.containsKey("db.password.extra"));
-        
         CustomEnvironmentPluginManager.join(null);
+        
+        Map<String, Object> result = manager.getCustomValues(
+            Collections.singletonMap("key", "value"));
+        
+        assertEquals("changed", result.get("key"));
+        assertFalse(result.containsKey("null-key"));
+        assertFalse(result.containsKey("unknown"));
     }
     
     @Test
-    void testCustomEnvironmentPluginServiceMethods() {
-        CustomEnvironmentPluginService service = new CustomEnvironmentPluginService() {
-            
-            @Override
-            public Map<String, Object> customValue(Map<String, Object> property) {
-                property.put("key", "value");
-                return property;
-            }
-            
-            @Override
-            public Set<String> propertyKey() {
-                return Collections.singleton("key");
-            }
-            
-            @Override
-            public Integer order() {
-                return 1;
-            }
-            
-            @Override
-            public String pluginName() {
-                return "test";
-            }
-        };
+    void testPluginConfigCompatibilityDefaults() {
+        CustomEnvironmentPluginService service =
+            new TestEnvironmentPlugin("test", 1, "-value");
         
-        Map<String, Object> property = new HashMap<>();
-        assertEquals(property, service.customValue(property));
-        assertEquals(Collections.singleton("key"), service.propertyKey());
-        assertEquals(1, service.order());
-        assertEquals("test", service.pluginName());
-    }
-    
-    @Test
-    void testLoadInitialFromSpiSkipsBlankPluginName() throws Exception {
-        List<CustomEnvironmentPluginService> services = getServices();
-        List<CustomEnvironmentPluginService> snapshot = new ArrayList<>(services);
-        services.clear();
-        Method method = CustomEnvironmentPluginManager.class.getDeclaredMethod("loadInitial");
-        method.setAccessible(true);
-        
-        try {
-            method.invoke(CustomEnvironmentPluginManager.getInstance());
-            
-            assertTrue(CustomEnvironmentPluginManager.getInstance().getPropertyKeys()
-                .contains("spi.key"));
-        } finally {
-            services.clear();
-            services.addAll(snapshot);
-        }
+        assertFalse(service.isConfigurable());
+        assertTrue(service.getConfigDefinitions().isEmpty());
+        assertTrue(service.getCurrentConfig().isEmpty());
+        service.applyConfig(Collections.singletonMap("key", "value"));
     }
     
     @Test
@@ -154,13 +122,44 @@ class CustomEnvironmentPluginManagerTest {
         EnvironmentPluginProvider provider = new EnvironmentPluginProvider();
         
         assertEquals(PluginType.ENVIRONMENT, provider.getPluginType());
-        assertNotNull(provider.getAllPlugins());
+        assertTrue(provider.getAllPlugins().containsKey("spi-environment"));
+        assertFalse(provider.getAllPlugins().containsKey(""));
     }
     
-    @SuppressWarnings("unchecked")
-    private List<CustomEnvironmentPluginService> getServices() throws Exception {
-        Field field = CustomEnvironmentPluginManager.class.getDeclaredField("SERVICE_LIST");
-        field.setAccessible(true);
-        return (List<CustomEnvironmentPluginService>) field.get(null);
+    private static class TestEnvironmentPlugin implements CustomEnvironmentPluginService {
+        
+        private final String name;
+        
+        private final int order;
+        
+        private final String suffix;
+        
+        private TestEnvironmentPlugin(String name, int order, String suffix) {
+            this.name = name;
+            this.order = order;
+            this.suffix = suffix;
+        }
+        
+        @Override
+        public Map<String, Object> customValue(Map<String, Object> property) {
+            Map<String, Object> result = new HashMap<>(property);
+            result.computeIfPresent("key", (key, value) -> value + suffix);
+            return result;
+        }
+        
+        @Override
+        public Set<String> propertyKey() {
+            return Collections.singleton("key");
+        }
+        
+        @Override
+        public Integer order() {
+            return order;
+        }
+        
+        @Override
+        public String pluginName() {
+            return name;
+        }
     }
 }

--- a/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/spi/EnvironmentPluginTypePolicyTest.java
+++ b/plugin/environment/src/test/java/com/alibaba/nacos/plugin/environment/spi/EnvironmentPluginTypePolicyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.plugin.environment.spi;
+
+import com.alibaba.nacos.api.plugin.PluginType;
+import com.alibaba.nacos.api.plugin.PluginTypeConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EnvironmentPluginTypePolicyTest {
+    
+    private final EnvironmentPluginTypePolicy policy = new EnvironmentPluginTypePolicy();
+    
+    @Test
+    void testTypeAndLoadingSwitch() {
+        MapConfiguration configuration = new MapConfiguration();
+        
+        assertEquals(PluginType.ENVIRONMENT, policy.getPluginType());
+        assertFalse(policy.isLoadingEnabled(configuration));
+        
+        configuration.setProperty(
+            EnvironmentPluginTypePolicy.ENVIRONMENT_ENABLED_PROPERTY, "true");
+        assertTrue(policy.isLoadingEnabled(configuration));
+    }
+    
+    private static class MapConfiguration implements PluginTypeConfiguration {
+        
+        private final Map<String, String> properties = new HashMap<>();
+        
+        void setProperty(String key, String value) {
+            properties.put(key, value);
+        }
+        
+        @Override
+        public String getProperty(String key) {
+            return properties.get(key);
+        }
+        
+        @Override
+        public boolean containsProperty(String key) {
+            return properties.containsKey(key);
+        }
+    }
+}

--- a/specs/en/design/foundation-server-lifecycle-env-spec.md
+++ b/specs/en/design/foundation-server-lifecycle-env-spec.md
@@ -75,7 +75,8 @@ Startup phase rules:
 - `environmentPrepared` creates required work directories, injects the Spring
   environment, loads pre-properties, and initializes system properties.
 - `contextPrepared` starts periodic startup logging.
-- `contextLoaded` may run custom environment processing.
+- During core `contextLoaded`, the pre-context plugin initializer must run
+  before custom environment processing.
 - `started` marks the phase started and logs startup result.
 - `failed` must run started phases in reverse order so resources are closed in
   the opposite order from startup.
@@ -145,6 +146,12 @@ Custom environment rules:
 
 - Custom environment processing belongs to startup/environment preparation,
   not to domain request handling.
+- Before processing begins, the pre-context plugin initializer loads enabled
+  environment implementations, resolves `STATIC > DEFAULT`, applies each
+  configurable implementation, and installs the same initialized instances in
+  `CustomEnvironmentPluginManager`.
+- The immutable initialization result is handed to the standard core plugin
+  manager for inventory and detail queries. The SPI must not be loaded again.
 - A custom environment plugin may transform configured keys into runtime
   values, but must not mutate domain state or perform business writes.
 - Because the custom property source is added first, custom values may override
@@ -152,6 +159,9 @@ Custom environment rules:
   constrain the keys they control.
 - Custom environment processing must happen before components that rely on the
   overridden values start serving requests.
+- Pre-context configuration and implementation state are restart-only. Runtime
+  plugin updates, persisted runtime overrides, local-only overrides, and later
+  static refreshes must not alter the accepted startup result.
 
 ## 7. Application Context And Started State
 

--- a/specs/en/plugin/environment-plugin-spec.md
+++ b/specs/en/plugin/environment-plugin-spec.md
@@ -44,7 +44,8 @@ general runtime configuration mutation mechanism.
 
 ## SPI
 
-Plugins implement `CustomEnvironmentPluginService`.
+Plugins implement `CustomEnvironmentPluginService`, which inherits
+`PluginConfigSpec` with compatibility defaults.
 
 | Method | Requirement |
 |--------|-------------|
@@ -54,6 +55,11 @@ Plugins implement `CustomEnvironmentPluginService`.
 | `customValue(property)` | Return transformed values for the declared keys. |
 
 The plugin is exposed to the core plugin manager as type `environment`.
+
+The type uses the `PRE_CONTEXT` initialization phase. Core loads each SPI
+implementation once, resolves and applies its startup configuration, and then
+hands the same instance to `CustomEnvironmentPluginManager`. The environment
+manager must not independently load the SPI.
 
 ## Execution Rules
 
@@ -80,10 +86,20 @@ The deployment switch documented for environment plugins is:
 nacos.custom.environment.enabled=true
 ```
 
-The current environment manager loads SPI services directly and uses the
-deployment switch above. When this plugin type is routed through the core plugin
-manager, runtime availability should converge on unified plugin state for
-`environment:{pluginName}`.
+The switch is a static module/ability switch. When false, environment
+implementations are not loaded. Each implementation may additionally use its
+standard startup-state key:
+
+```properties
+nacos.plugin.environment.{pluginName}.enabled=true
+```
+
+Configuration definitions use the standard
+`nacos.plugin.environment.{pluginName}.{itemKey}` key and only
+`STATIC > DEFAULT` is resolved. All values are startup-only. A definition
+declared as `RUNTIME` is exposed as `RESTART` with a warning. Runtime state and
+configuration updates are rejected, and later static refreshes do not reapply
+the plugin. Plugin detail reports the accepted startup snapshot.
 
 Plugins should document:
 

--- a/specs/en/plugin/plugin-spec.md
+++ b/specs/en/plugin/plugin-spec.md
@@ -115,6 +115,21 @@ compatibility. Whether an implementation is configurable is derived from
 `PluginConfigSpec.isConfigurable()`; configurable and zero-config implementations may coexist under
 the same plugin type.
 
+## Initialization Phases
+
+Initialization phase is a plugin-type capability declared by `PluginType`, not a choice made by an
+individual implementation.
+
+| Phase | Meaning |
+|-------|---------|
+| `PRE_CONTEXT` | Discover, resolve, and apply the plugin before custom environment values are added to the Spring environment. |
+| `STANDARD` | Initialize the plugin through the regular core plugin manager after the Spring context is refreshed. |
+
+`environment` is the built-in `PRE_CONTEXT` type. All other built-in types use `STANDARD`.
+Both phases use the common `PluginInitializer` orchestration contract. A pre-context initializer
+must hand the exact initialized instances and their accepted configuration snapshots to the later
+core manager; the provider must not be loaded a second time.
+
 ## SPI Layers
 
 Nacos plugins have two related SPI layers:
@@ -129,8 +144,8 @@ Unified domain plugin SPIs extend `PluginConfigSpec`. Its compatibility defaults
 definitions, an empty current map, and a no-op apply callback, so an implementation compiled against
 an older domain SPI and a new zero-config implementation both remain `configurable=false`. A plugin
 that declares at least one `ConfigItemDefinition` is configurable and must implement the current-map
-and apply callbacks. `environment` remains a bootstrap exception until its unified configuration
-lifecycle is designed. `control` participates through its stable managed configuration adapter.
+and apply callbacks. The environment SPI inherits this contract and is initialized through the
+pre-context phase. `control` participates through its stable managed configuration adapter.
 For `ai-resource-import`, the stable request-service Builder itself implements
 `PluginConfigSpec`; the request-scoped service does not register as a second plugin. A plugin
 category that supports enable or disable checks must use
@@ -148,14 +163,17 @@ Plugin implementations are discovered with the Nacos SPI loader. Deployments may
 provide plugins from the classpath or from the server plugin directory. The
 plugin implementation must be loadable without changing Nacos server code.
 
-After the Spring context is refreshed, the core `PluginManager` discovers lightweight
-`PluginProvider` implementations. It invokes `getAllPlugins` immediately only for plugin types
-whose domain policy enables loading. Active critical types always load regardless of the optional
-loading predicate. For a deferred non-critical type, a later server configuration refresh that
-enables loading must discover its implementations, restore persisted implementation state,
-resolve effective configuration, and invoke `applyConfig` before those implementations are
-exposed for execution. A loaded type is retained when its loading predicate later becomes false;
-the owning domain entry switch continues to gate execution.
+The pre-context initializer discovers enabled `PRE_CONTEXT` providers before custom environment
+processing. It resolves only `STATIC > DEFAULT`, applies configurable implementations, and makes
+the resulting instances available to the owning domain manager. After the Spring context is
+refreshed, the standard initializer discovers lightweight `STANDARD` `PluginProvider`
+implementations. It invokes `getAllPlugins` immediately only for plugin types whose domain policy
+enables loading. Active critical types always load regardless of the optional loading predicate.
+For a deferred non-critical type, a later server configuration refresh that enables loading must
+discover its implementations, restore persisted implementation state, resolve effective
+configuration, and invoke `applyConfig` before those implementations are exposed for execution.
+A loaded type is retained when its loading predicate later becomes false; the owning domain entry
+switch continues to gate execution.
 
 The loading predicate does not replace implementation state. Its default is `true` for binary
 compatibility and a domain should override it only when it owns a type-wide module or capability
@@ -365,6 +383,10 @@ priority is:
 LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
 ```
 
+This full priority applies to `STANDARD` plugins. `PRE_CONTEXT` plugins resolve
+only `STATIC > DEFAULT`; runtime persisted and local-only sources are not loaded
+or accepted for them.
+
 | Source | Meaning |
 |--------|---------|
 | `DEFAULT` | Value from `ConfigItemDefinition.defaultValue`. |
@@ -421,11 +443,9 @@ critical implementation lists.
 Bootstrap or build-time types cannot satisfy this contract with a late runtime
 check. `control` completes unified config apply before building and installing
 its startup manager bundle, and rejects runtime selection changes.
-`environment` still transforms Spring properties before the core plugin manager
-is ready; its status capability and restart/bootstrap semantics must be defined
-before management APIs can report a state update as effective.
-`ai-resource-import` is not currently exposed through `PluginProvider` and is
-outside unified state management.
+`environment` is initialized in the pre-context phase and only its startup
+state may participate in property transformation. Runtime state changes are
+rejected. `ai-resource-import` is managed through its stable Builder.
 
 ### Config Update Compatibility
 
@@ -471,6 +491,15 @@ calculation:
 3. A runtime request replaces one complete `RUNTIME_PERSISTED` or `LOCAL_ONLY`
    source map. The server resolves all sources again and invokes the plugin for
    each accepted request, including a same-map request used as a manual retry.
+
+`PRE_CONTEXT` plugins are an explicit startup-only variant of this flow. Before
+custom environment processing, core captures their static source, resolves
+`STATIC > DEFAULT`, validates and applies the result, and records that accepted
+snapshot for later plugin detail queries. A `RUNTIME` definition declared by a
+pre-context implementation is defensively copied and exposed as `RESTART`, with
+a warning containing only the plugin ID and item key. Runtime config APIs,
+persisted or local-only restoration, and `ServerConfigChangeEvent` refresh must
+not update pre-context plugins.
 
 The `STATIC` resolver keeps an accepted per-plugin snapshot instead of reading
 live environment values independently for every detail query. Startup captures

--- a/specs/zh-cn/design/foundation-server-lifecycle-env-spec.md
+++ b/specs/zh-cn/design/foundation-server-lifecycle-env-spec.md
@@ -61,7 +61,7 @@ Nacos 启动阶段由 `NacosStartUp` 实现表示，并通过 `NacosStartUpManag
 - `starting` 创建阶段级启动跟踪和周期性启动日志。
 - `environmentPrepared` 创建必要工作目录、注入 Spring environment、加载预置属性并初始化系统属性。
 - `contextPrepared` 启动周期性启动日志。
-- `contextLoaded` 可以执行自定义环境处理。
+- Core `contextLoaded` 中必须先执行 pre-context 插件初始化，再执行自定义环境处理。
 - `started` 标记阶段启动完成并记录启动结果。
 - `failed` 必须按已启动阶段的逆序执行，以便资源按启动相反顺序关闭。
 
@@ -114,10 +114,17 @@ Core 启动会从配置好的 application 配置资源加载 `application.proper
 自定义环境规则：
 
 - 自定义环境处理属于启动/环境准备阶段，不属于领域请求处理。
+- 开始处理前，pre-context plugin initializer 会加载 enabled environment 实现，解析
+  `STATIC > DEFAULT`，对可配置实现执行 apply，并把同一批已初始化实例安装到
+  `CustomEnvironmentPluginManager`。
+- 不可变初始化结果会继续交给 standard 核心插件管理器，用于 inventory 和 detail 查询；
+  后续流程不得再次加载 SPI。
 - 自定义环境插件可以把配置 key 转换为运行时值，但不得修改领域状态或执行业务写入。
 - 因为自定义 property source 会被放到第一位，自定义值可以覆盖低优先级 property source。插件
   实现必须文档化并约束自己控制的 key。
 - 自定义环境处理必须发生在依赖被覆盖值的组件开始服务请求之前。
+- Pre-context 配置和实现状态均为 restart-only。运行时插件更新、runtime persisted override、
+  local-only override 和后续静态刷新均不得改变启动时已接受结果。
 
 ## 7. Application Context 与 Started 状态
 

--- a/specs/zh-cn/plugin/environment-plugin-spec.md
+++ b/specs/zh-cn/plugin/environment-plugin-spec.md
@@ -39,7 +39,8 @@
 
 ## SPI
 
-插件实现 `CustomEnvironmentPluginService`。
+插件实现 `CustomEnvironmentPluginService`，该接口通过兼容默认方法继承
+`PluginConfigSpec`。
 
 | 方法 | 要求 |
 |------|------|
@@ -49,6 +50,10 @@
 | `customValue(property)` | 返回声明 key 的转换结果。 |
 
 该插件以 `environment` 类型暴露给核心插件管理器。
+
+该类型使用 `PRE_CONTEXT` 初始化阶段。Core 对每个 SPI 实现只加载一次，解析并应用启动配置，
+随后把同一个实例交给 `CustomEnvironmentPluginManager`。Environment manager 不得再次独立
+加载 SPI。
 
 ## 执行规则
 
@@ -71,8 +76,18 @@
 nacos.custom.environment.enabled=true
 ```
 
-当前 environment manager 直接加载 SPI 服务，并使用上面的部署开关。该插件类型通过核心
-插件管理器路由时，运行时可用性应收敛到 `environment:{pluginName}` 的统一插件状态。
+该开关属于静态模块/能力开关；为 false 时不加载 environment 实现。每个实现还可以使用标准
+启动状态 key：
+
+```properties
+nacos.plugin.environment.{pluginName}.enabled=true
+```
+
+配置 definition 使用标准
+`nacos.plugin.environment.{pluginName}.{itemKey}` key，且只解析
+`STATIC > DEFAULT`。所有配置均为启动期配置；声明为 `RUNTIME` 的 definition 会输出 WARN
+并按 `RESTART` 暴露。运行时状态和配置更新必须拒绝，后续静态刷新不得再次 apply。
+插件 detail 返回已接受的启动快照。
 
 插件应记录：
 

--- a/specs/zh-cn/plugin/plugin-spec.md
+++ b/specs/zh-cn/plugin/plugin-spec.md
@@ -103,6 +103,19 @@ Nacos 资源身份、鉴权和 payload 语义，因为它们会影响 SDK 发出
 `executionMode == EXCLUSIVE` 推导，以保持 API 兼容。插件实现是否可配置由
 `PluginConfigSpec.isConfigurable()` 决定，同一插件类型下允许同时存在可配置和零配置实现。
 
+## 初始化阶段
+
+初始化阶段是由 `PluginType` 声明的插件类型能力，不允许插件实现自行选择。
+
+| 阶段 | 含义 |
+|------|------|
+| `PRE_CONTEXT` | 在自定义环境值写入 Spring environment 之前完成发现、配置解析和 apply。 |
+| `STANDARD` | Spring context refresh 后，通过常规核心插件管理器完成初始化。 |
+
+`environment` 是内置的 `PRE_CONTEXT` 类型，其余内置类型均为 `STANDARD`。两个阶段共享
+`PluginInitializer` 编排契约。pre-context initializer 必须把已初始化的原始实例及其已接受
+配置快照交给后续核心管理器，后续流程不得再次加载 provider。
+
 ## SPI 层次
 
 Nacos 插件包含两个相关的 SPI 层次：
@@ -114,8 +127,8 @@ Nacos 插件包含两个相关的 SPI 层次：
 已接入统一配置的领域插件 SPI 统一继承 `PluginConfigSpec`。该契约的兼容默认实现返回空
 definitions、空 current map，并提供空 apply 回调，因此按旧版领域 SPI 编译的实现和新版
 零配置实现都会保持 `configurable=false`。声明至少一个 `ConfigItemDefinition` 的插件属于
-可配置实现，必须实现 current-map 和 apply 回调。`environment` 在统一 bootstrap 配置生命周期
-完成设计前继续作为例外；`control` 通过稳定的 managed configuration adapter 接入。
+可配置实现，必须实现 current-map 和 apply 回调。environment SPI 继承该契约，并通过
+pre-context 阶段初始化；`control` 通过稳定的 managed configuration adapter 接入。
 `ai-resource-import` 的稳定请求 Service Builder 本身实现 `PluginConfigSpec`，请求级
 Service 不再注册为第二个插件。
 支持启停状态判断的插件类别，应通过 `PluginStateCheckerHolder` 获取状态，而不是维护一套
@@ -130,9 +143,11 @@ Service 不再注册为第二个插件。
 插件实现通过 Nacos SPI 加载。部署时可以从 classpath 或服务端插件目录提供插件。
 插件实现必须能在不修改 Nacos 服务端代码的情况下被加载。
 
-核心 `PluginManager` 会在 Spring 上下文刷新完成后先发现轻量 `PluginProvider` 实现。
-只有领域 policy 当前允许加载的插件类型才会立即调用 `getAllPlugins`；active critical 类型
-不受可选加载判据影响，必须加载。对于被延迟的非 critical 类型，后续服务配置刷新使加载
+pre-context initializer 会在自定义环境处理前发现 policy 允许加载的 `PRE_CONTEXT`
+provider，只解析 `STATIC > DEFAULT`，对可配置实现执行 apply，并把实例交给领域 manager。
+Spring context refresh 后，standard initializer 再发现轻量 `STANDARD` `PluginProvider`
+实现。只有领域 policy 当前允许加载的插件类型才会立即调用 `getAllPlugins`；active critical
+类型不受可选加载判据影响，必须加载。对于被延迟的非 critical 类型，后续服务配置刷新使加载
 判据变为 true 时，必须先发现实现、恢复持久化实现 state、解析 effective config 并调用
 `applyConfig`，然后才能让这些实现参与执行。类型一旦加载，加载判据再次变为 false 时不卸载
 实例，仍由所属领域入口总开关阻止执行。
@@ -314,6 +329,9 @@ alias，则按定义中的声明顺序取第一个生效，并由服务端记录
 LOCAL_ONLY > RUNTIME_PERSISTED > STATIC > DEFAULT
 ```
 
+完整优先级只适用于 `STANDARD` 插件。`PRE_CONTEXT` 插件只解析 `STATIC > DEFAULT`，
+不加载也不接受 runtime persisted 或 local-only source。
+
 | 来源 | 含义 |
 |------|------|
 | `DEFAULT` | 来自 `ConfigItemDefinition.defaultValue`。 |
@@ -357,10 +375,9 @@ core source registry 统一持有已启用 resolver 及其固定顺序。四个�
 的 API 适配层不得分别维护硬编码的互斥类型或关键实现列表。
 
 启动期或构建期插件不能通过较晚的运行时检查满足该契约。`control` 会先完成统一配置 apply，
-再构建并安装启动期 manager bundle，同时拒绝运行时切换实现。`environment` 仍会在 core
-插件管理器就绪前转换 Spring 属性；管理 API 能够把它的状态更新报告为已生效之前，必须先
-定义其状态能力和重启/bootstrap 语义。
-`ai-resource-import` 当前没有通过 `PluginProvider` 暴露，不属于统一状态管理范围。
+再构建并安装启动期 manager bundle，同时拒绝运行时切换实现。`environment` 在 pre-context
+阶段初始化，只有启动时接受的状态可以参与属性转换，运行时状态修改必须拒绝。
+`ai-resource-import` 通过稳定的 Builder 纳入统一管理。
 
 ### 配置更新兼容性
 
@@ -397,6 +414,13 @@ source 的 effective value 复制成 runtime override。服务端应记录 WARN 
 3. 运行时请求完整替换一个 `RUNTIME_PERSISTED` 或 `LOCAL_ONLY` source map，随后
    重新解析全部来源；每次接受的请求都调用插件实现，包括使用相同完整 map 发起的
    手动重试。
+
+`PRE_CONTEXT` 插件是该流程显式定义的启动期变体。Core 在自定义环境处理前捕获其静态
+source，解析 `STATIC > DEFAULT`，校验并应用结果，同时保存已接受快照供后续插件 detail
+查询。若 pre-context 实现声明 `RUNTIME` definition，Core 必须复制该 definition 并按
+`RESTART` 暴露，同时输出只包含 plugin ID 和 item key 的 WARN，不得修改插件持有的原对象。
+运行时配置 API、持久化或 local-only 恢复及 `ServerConfigChangeEvent` 刷新均不得更新
+pre-context 插件。
 
 `STATIC` resolver 应维护每个插件的已接受快照，而不是让每次 detail 查询独立读取实时
 环境值。启动时捕获全部已定义静态字段，并允许应用两种 effect mode。启动完成后，

--- a/sys/src/test/java/com/alibaba/nacos/sys/env/EnvUtilTest.java
+++ b/sys/src/test/java/com/alibaba/nacos/sys/env/EnvUtilTest.java
@@ -82,16 +82,14 @@ class EnvUtilTest {
         if (!systemBeanManagerMocked.isClosed()) {
             systemBeanManagerMocked.close();
         }
+        CustomEnvironmentPluginManager.getInstance().initialize(Collections.emptyList());
         EnvUtil.setEnvironment(null);
     }
     
     @Test
     void testCustomEnvironment() {
         environment.setProperty("nacos.custom.environment.enabled", "true");
-        List<CustomEnvironmentPluginService> pluginServices =
-            (List<CustomEnvironmentPluginService>) ReflectionTestUtils.getField(
-                CustomEnvironmentPluginManager.getInstance(), "SERVICE_LIST");
-        pluginServices.add(new CustomEnvironmentPluginService() {
+        CustomEnvironmentPluginService pluginService = new CustomEnvironmentPluginService() {
             
             @Override
             public Map<String, Object> customValue(Map<String, Object> property) {
@@ -110,9 +108,11 @@ class EnvUtilTest {
             
             @Override
             public String pluginName() {
-                return "";
+                return "test";
             }
-        });
+        };
+        CustomEnvironmentPluginManager.getInstance()
+            .initialize(Collections.singletonList(pluginService));
         MutablePropertySources mock = Mockito.mock(MutablePropertySources.class);
         ReflectionTestUtils.setField(environment, "propertySources", mock);
         EnvUtil.customEnvironment();


### PR DESCRIPTION
For #15475

## What is the purpose of the change

Environment plugins transform properties before the Spring context is refreshed, while the
standard plugin manager is initialized later. Previously the environment manager loaded the SPI
independently, so unified plugin configuration could be applied to a different instance after the
environment transformation had already run.

This change introduces a type-level pre-context initialization phase so environment plugins can
use the unified configuration model without losing their required startup timing.

## Brief changelog

* Add `PluginInitializationPhase` and use `PRE_CONTEXT` for the environment plugin type.
* Split plugin startup orchestration into pre-context and standard initializers.
* Resolve `STATIC > DEFAULT`, validate, and apply environment plugin configuration before custom
  environment processing, then hand the same initialized instances to `PluginManager`.
* Treat runtime definitions from pre-context plugins as restart-only and reject runtime state or
  configuration updates.
* Exclude pre-context plugins from persisted runtime/local-only restore, static refresh, and CP
  plugin-state snapshots.
* Make the environment SPI inherit `PluginConfigSpec`, retain compatibility defaults, and stop
  `CustomEnvironmentPluginManager` from independently loading the SPI.
* Update the English and Chinese plugin and server lifecycle specifications.

## Verifying this change

* `mvn -B -pl api,plugin/environment,core -am spotless:check`
* `mvn -B -pl api test` (1167 tests)
* `mvn -B -pl plugin/environment test` (6 tests)
* `mvn -B -pl core test` (1573 tests)
* `mvn -B -pl api,plugin/environment,core -am compile apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests`
* `mvn '-Prelease-nacos,!dev' -Dmaven.test.skip=true clean install -U`
* Verified modified/new executable classes have 100% line coverage.
* Ran a standalone server with a temporary environment SPI fixture before and after the refactor:
  configuration is now applied before transformation on the same instance, plugin detail reports
  the accepted `STATIC` snapshot with `RESTART` effect mode, and runtime config/state PUT requests
  are rejected with a restart-required error.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
