### PR TITLE
[ISSUE #14804] Implement Agent Runtime Endpoint Registry

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -112,27 +112,6 @@ public class Constants {
         
         public static final String SEARCH_ACCURATE = "accurate";
         
-        public static final String AGENT_ENDPOINT_GROUP = "agent-endpoints";
-        
-        public static final String AGENT_ENDPOINT_PATH_KEY = "__nacos.agent.endpoint.path__";
-        
-        public static final String AGENT_ENDPOINT_TRANSPORT_KEY =
-            "__nacos.agent.endpoint.transport__";
-        
-        public static final String NACOS_AGENT_ENDPOINT_SUPPORT_TLS =
-            "__nacos.agent.endpoint.supportTls__";
-        
-        public static final String NACOS_AGENT_ENDPOINT_PROTOCOL_KEY =
-            "__nacos.agent.endpoint.protocol__";
-        
-        public static final String NACOS_AGENT_ENDPOINT_QUERY_KEY =
-            "__nacos.agent.endpoint.query__";
-        
-        public static final String NACOS_AGENT_ENDPOINT_PROTOCOL_VERSION_KEY =
-            "__nacos.agent.endpoint.protocolVersion__";
-        
-        public static final String NACOS_AGENT_ENDPOINT_TENANT_KEY =
-            "__nacos.agent.endpoint.tenant__";
     }
     
     public static class Agent {
@@ -147,6 +126,40 @@ public class Constants {
          */
         public static final String AGENT_STORAGE_PROVIDER_CONFIG_KEY =
             "nacos.ai.agent.storage.provider";
+        
+        public static final String AGENT_ENDPOINT_GROUP = "agent-endpoints";
+        
+        public static final String AGENT_ENDPOINT_METADATA_PREFIX = "__nacos.agent.endpoint.";
+        
+        public static final String AGENT_ENDPOINT_PATH_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "path__";
+        
+        public static final String AGENT_ENDPOINT_TRANSPORT_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "transport__";
+        
+        public static final String AGENT_ENDPOINT_PROTOCOL_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "protocol__";
+        
+        public static final String AGENT_ENDPOINT_PROTOCOL_VERSION_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "protocolVersion__";
+        
+        public static final String AGENT_ENDPOINT_SUPPORT_TLS_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "supportTls__";
+        
+        public static final String AGENT_ENDPOINT_QUERY_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "query__";
+        
+        public static final String AGENT_ENDPOINT_TENANT_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "tenant__";
+        
+        public static final String AGENT_ENDPOINT_VERSION_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "version__";
+        
+        public static final String AGENT_ENDPOINT_VERSION_RANGE_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "versionRange__";
+        
+        public static final String AGENT_ENDPOINT_PRIORITY_KEY =
+            AGENT_ENDPOINT_METADATA_PREFIX + "priority__";
     }
     
     public static class Skills {

--- a/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/a2a/AgentEndpointRequestHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/a2a/AgentEndpointRequestHandler.java
@@ -86,7 +86,7 @@ public class AgentEndpointRequestHandler
                 agentIdCodecHolder.encode(request.getAgentName()) + "::"
                     + request.getEndpoint().getVersion();
             Service service =
-                Service.newService(request.getNamespaceId(), Constants.A2A.AGENT_ENDPOINT_GROUP,
+                Service.newService(request.getNamespaceId(), Constants.Agent.AGENT_ENDPOINT_GROUP,
                     serviceName);
             switch (request.getType()) {
                 case AiRemoteConstants.REGISTER_ENDPOINT:

--- a/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/a2a/BatchAgentEndpointRequestHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/remote/handler/a2a/BatchAgentEndpointRequestHandler.java
@@ -92,7 +92,7 @@ public class BatchAgentEndpointRequestHandler
             String version = request.getEndpoints().stream().findFirst().get().getVersion();
             String serviceName = agentIdCodecHolder.encode(request.getAgentName()) + "::" + version;
             Service service =
-                Service.newService(request.getNamespaceId(), Constants.A2A.AGENT_ENDPOINT_GROUP,
+                Service.newService(request.getNamespaceId(), Constants.Agent.AGENT_ENDPOINT_GROUP,
                     serviceName);
             clientOperationService.batchRegisterInstance(service, instances,
                 meta.getConnectionId());

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationService.java
@@ -417,7 +417,7 @@ public class A2aServerOperationService {
         String serviceName =
             agentIdCodecHolder.encode(agentCard.getName()) + "::" + agentCard.getVersion();
         Service service =
-            Service.newService(namespaceId, Constants.A2A.AGENT_ENDPOINT_GROUP, serviceName);
+            Service.newService(namespaceId, Constants.Agent.AGENT_ENDPOINT_GROUP, serviceName);
         ServiceInfo serviceInfo = serviceStorage.getData(service);
         if (serviceInfo.getHosts().isEmpty()) {
             return;

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/runtime/AgentRuntimeEndpointMapper.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/runtime/AgentRuntimeEndpointMapper.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.runtime;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.api.ai.model.agent.Endpoint;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointSnapshotItem;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointState;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeVersionBinding;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.api.ai.utils.EndpointCanonicalizer;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Converts Agent Runtime Endpoints to and from Naming instances.
+ *
+ * @author Nacos
+ */
+public final class AgentRuntimeEndpointMapper {
+    
+    private static final int MAX_HOST_LENGTH = 253;
+    
+    private static final int MAX_NAMING_METADATA_LENGTH = 1024;
+    
+    private static final Pattern URI_SCHEME_PATTERN =
+        Pattern.compile("[a-z][a-z0-9+.-]*");
+    
+    private static final Set<String> KNOWN_RESERVED_KEYS = Collections.unmodifiableSet(
+        new HashSet<String>(Arrays.asList(Constants.Agent.AGENT_ENDPOINT_PATH_KEY,
+            Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY,
+            Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY,
+            Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY,
+            Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY,
+            Constants.Agent.AGENT_ENDPOINT_QUERY_KEY,
+            Constants.Agent.AGENT_ENDPOINT_TENANT_KEY,
+            Constants.Agent.AGENT_ENDPOINT_VERSION_KEY,
+            Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY,
+            Constants.Agent.AGENT_ENDPOINT_PRIORITY_KEY)));
+    
+    private AgentRuntimeEndpointMapper() {
+    }
+    
+    /**
+     * Convert one public Runtime Endpoint into an ephemeral Naming instance.
+     *
+     * @param endpoint public Endpoint
+     * @param runtimeVersion deployed runtime Version
+     * @param versionRange canonical compatible Agent Version range
+     * @return Naming instance without a service name
+     */
+    public static Instance toInstance(Endpoint endpoint, String runtimeVersion,
+        String versionRange) {
+        Endpoint canonical = canonicalPayload(endpoint);
+        String canonicalRange = canonicalVersionRange(runtimeVersion, versionRange);
+        URI uri = parseCanonicalUri(canonical.getUri());
+        
+        Map<String, String> metadata = new LinkedHashMap<String, String>();
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PATH_KEY, valueOrEmpty(uri.getRawPath()));
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, canonical.getTransport());
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY, uri.getScheme());
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY,
+            Boolean.toString(isTlsScheme(uri.getScheme())));
+        if (uri.getRawQuery() != null) {
+            metadata.put(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY, uri.getRawQuery());
+        }
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_VERSION_KEY, runtimeVersion);
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY, canonicalRange);
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PRIORITY_KEY,
+            Integer.toString(canonical.getPriority()));
+        if (canonical.getMetadata() != null) {
+            validateNamingControlKeys(canonical.getMetadata());
+            metadata.putAll(canonical.getMetadata());
+        }
+        validateCompleteMetadata(metadata);
+        
+        String host = EndpointCanonicalizer.normalizedHost(canonical.getUri());
+        validateHost(host);
+        Instance result = new Instance();
+        result.setIp(host);
+        result.setPort(EndpointCanonicalizer.effectivePort(canonical.getUri()));
+        result.setClusterName(canonical.getTransport());
+        result.setWeight(canonical.getWeight());
+        result.setEnabled(true);
+        result.setHealthy(true);
+        result.setEphemeral(true);
+        result.setMetadata(metadata);
+        return result;
+    }
+    
+    /**
+     * Convert one Naming ServiceStorage instance into a Runtime Endpoint contribution.
+     *
+     * @param instance Naming instance with operational metadata already applied
+     * @param lastUpdatedTime Naming ServiceInfo observation time
+     * @return validated single-contribution management item
+     */
+    public static RuntimeEndpointSnapshotItem fromInstance(Instance instance,
+        long lastUpdatedTime) {
+        if (instance == null) {
+            throw new IllegalArgumentException("Naming instance must not be null");
+        }
+        validateHost(instance.getIp());
+        if (instance.getPort() < 1 || instance.getPort() > 65535) {
+            throw new IllegalArgumentException(
+                "Invalid Naming instance port: " + instance.getPort());
+        }
+        AgentValidationUtils.validateTransport(instance.getClusterName());
+        
+        Map<String, String> metadata = stringMetadata(instance.getMetadata());
+        validateCompleteMetadata(metadata);
+        validateReservedKeys(metadata);
+        
+        String transport = requiredMetadata(metadata,
+            Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY);
+        AgentValidationUtils.validateTransport(transport);
+        if (!instance.getClusterName().equals(transport)) {
+            throw new IllegalArgumentException(
+                "Naming cluster and Agent Endpoint transport must match");
+        }
+        String uriScheme = requiredMetadata(metadata,
+            Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY);
+        validateUriScheme(uriScheme);
+        String supportTls = requiredMetadata(metadata,
+            Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY);
+        if (!"true".equals(supportTls) && !"false".equals(supportTls)) {
+            throw new IllegalArgumentException("Invalid Agent Endpoint supportTls: " + supportTls);
+        }
+        if (Boolean.parseBoolean(supportTls) != isTlsScheme(uriScheme)) {
+            throw new IllegalArgumentException(
+                "Agent Endpoint URI scheme and supportTls must agree");
+        }
+        
+        String path = requiredMetadata(metadata, Constants.Agent.AGENT_ENDPOINT_PATH_KEY);
+        String query = metadata.get(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY);
+        int priority = parsePriority(requiredMetadata(metadata,
+            Constants.Agent.AGENT_ENDPOINT_PRIORITY_KEY));
+        String runtimeVersion = requiredMetadata(metadata,
+            Constants.Agent.AGENT_ENDPOINT_VERSION_KEY);
+        String persistedRange = requiredMetadata(metadata,
+            Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY);
+        String versionRange = canonicalVersionRange(runtimeVersion, persistedRange);
+        if (!persistedRange.equals(versionRange)) {
+            throw new IllegalArgumentException(
+                "Agent Endpoint Version range must be canonical");
+        }
+        validateLegacyMetadata(metadata);
+        
+        String uri = composeUri(uriScheme, instance.getIp(), instance.getPort(), path, query);
+        Endpoint endpoint = new Endpoint();
+        endpoint.setUri(uri);
+        endpoint.setTransport(transport);
+        endpoint.setPriority(priority);
+        endpoint.setWeight(instance.getWeight());
+        Map<String, String> publicMetadata = publicMetadata(metadata);
+        if (!publicMetadata.isEmpty()) {
+            endpoint.setMetadata(publicMetadata);
+        }
+        Endpoint canonical = canonicalPayload(endpoint);
+        if (!uri.equals(canonical.getUri())) {
+            throw new IllegalArgumentException(
+                "Naming instance does not contain a canonical Agent Endpoint URI");
+        }
+        RuntimeVersionBinding binding = new RuntimeVersionBinding();
+        binding.setRuntimeVersion(runtimeVersion);
+        binding.setVersionRange(versionRange);
+        RuntimeEndpointSnapshotItem result = new RuntimeEndpointSnapshotItem();
+        result.setEndpoint(canonical);
+        result.setBindings(new ArrayList<RuntimeVersionBinding>(
+            Collections.singletonList(binding)));
+        result.setEnabled(instance.isEnabled());
+        result.setHealthy(instance.isHealthy());
+        result.setState(runtimeState(instance.isEnabled(), instance.isHealthy()));
+        result.setLastUpdatedTime(lastUpdatedTime);
+        return result;
+    }
+    
+    private static Endpoint canonicalPayload(Endpoint endpoint) {
+        Endpoint canonical = EndpointCanonicalizer.canonicalize(endpoint);
+        canonical.setHealthy(null);
+        return canonical;
+    }
+    
+    private static String canonicalVersionRange(String runtimeVersion, String versionRange) {
+        AgentValidationUtils.validateVersion(runtimeVersion);
+        String result = versionRange == null
+            ? RuntimeVersionRangeSupport.exact(runtimeVersion)
+            : RuntimeVersionRangeSupport.canonicalize(versionRange);
+        if (!RuntimeVersionRangeSupport.contains(result, runtimeVersion)) {
+            throw new IllegalArgumentException("versionRange must contain runtimeVersion");
+        }
+        return result;
+    }
+    
+    private static URI parseCanonicalUri(String uri) {
+        try {
+            URI result = new URI(uri);
+            validateUriScheme(result.getScheme());
+            return result;
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid canonical Agent Endpoint URI: " + uri, e);
+        }
+    }
+    
+    private static String composeUri(String scheme, String host, int port, String path,
+        String query) {
+        String formattedHost = host.indexOf(':') >= 0 ? '[' + host + ']' : host;
+        StringBuilder result = new StringBuilder().append(scheme).append("://")
+            .append(formattedHost).append(':').append(port).append(path);
+        if (query != null) {
+            result.append('?').append(query);
+        }
+        return result.toString();
+    }
+    
+    private static Map<String, String> stringMetadata(Map<String, String> rawMetadata) {
+        if (rawMetadata == null) {
+            throw new IllegalArgumentException("Naming instance metadata must not be null");
+        }
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        for (Map.Entry<String, String> entry : rawMetadata.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                throw new IllegalArgumentException(
+                    "Agent Endpoint Naming metadata must contain only non-null strings");
+            }
+            result.put(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
+    
+    private static void validateNamingControlKeys(Map<String, String> metadata) {
+        if (metadata.containsKey(
+            com.alibaba.nacos.naming.constants.Constants.PUBLISH_INSTANCE_ENABLE)
+            || metadata.containsKey(
+                com.alibaba.nacos.naming.constants.Constants.PUBLISH_INSTANCE_WEIGHT)) {
+            throw new IllegalArgumentException(
+                "Endpoint metadata uses a reserved Naming control key");
+        }
+    }
+    
+    private static void validateReservedKeys(Map<String, String> metadata) {
+        for (String key : metadata.keySet()) {
+            if (key.startsWith(Constants.Agent.AGENT_ENDPOINT_METADATA_PREFIX)
+                && !KNOWN_RESERVED_KEYS.contains(key)) {
+                throw new IllegalArgumentException(
+                    "Unknown Agent Endpoint reserved metadata key: " + key);
+            }
+        }
+    }
+    
+    private static String requiredMetadata(Map<String, String> metadata, String key) {
+        String result = metadata.get(key);
+        if (result == null) {
+            throw new IllegalArgumentException("Missing Agent Endpoint metadata: " + key);
+        }
+        return result;
+    }
+    
+    private static void validateLegacyMetadata(Map<String, String> metadata) {
+        String protocolVersion =
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY);
+        if (protocolVersion != null && !protocolVersion.isEmpty()) {
+            AgentValidationUtils.validateProtocolVersion(protocolVersion);
+        }
+        String tenant = metadata.get(Constants.Agent.AGENT_ENDPOINT_TENANT_KEY);
+        if (tenant != null && tenant.length() > 256) {
+            throw new IllegalArgumentException("Invalid Agent Endpoint tenant");
+        }
+    }
+    
+    private static Map<String, String> publicMetadata(Map<String, String> metadata) {
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            if (!entry.getKey().startsWith(Constants.Agent.AGENT_ENDPOINT_METADATA_PREFIX)) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        AgentValidationUtils.validateEndpointMetadata(result);
+        validateNamingControlKeys(result);
+        return result;
+    }
+    
+    private static int parsePriority(String value) {
+        if (value.isEmpty() || value.length() > 10
+            || value.length() > 1 && value.charAt(0) == '0') {
+            throw new IllegalArgumentException("Invalid Agent Endpoint priority: " + value);
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) < '0' || value.charAt(i) > '9') {
+                throw new IllegalArgumentException("Invalid Agent Endpoint priority: " + value);
+            }
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid Agent Endpoint priority: " + value, e);
+        }
+    }
+    
+    private static void validateUriScheme(String value) {
+        if (value == null || !URI_SCHEME_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("Invalid Agent Endpoint URI scheme: " + value);
+        }
+    }
+    
+    private static boolean isTlsScheme(String scheme) {
+        return "https".equals(scheme) || "wss".equals(scheme);
+    }
+    
+    private static void validateHost(String host) {
+        if (host == null || host.isEmpty() || host.length() > MAX_HOST_LENGTH) {
+            throw new IllegalArgumentException("Invalid Naming instance host: " + host);
+        }
+    }
+    
+    private static void validateCompleteMetadata(Map<String, String> metadata) {
+        int length = 0;
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            length += entry.getKey().length() + entry.getValue().length();
+            if (length > MAX_NAMING_METADATA_LENGTH) {
+                throw new IllegalArgumentException(
+                    "Agent Endpoint Naming metadata exceeds "
+                        + MAX_NAMING_METADATA_LENGTH + " characters");
+            }
+        }
+    }
+    
+    private static String valueOrEmpty(String value) {
+        return value == null ? "" : value;
+    }
+    
+    private static RuntimeEndpointState runtimeState(boolean enabled, boolean healthy) {
+        if (!enabled) {
+            return RuntimeEndpointState.DISABLED;
+        }
+        if (!healthy) {
+            return RuntimeEndpointState.UNHEALTHY;
+        }
+        return RuntimeEndpointState.AVAILABLE;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/runtime/AgentRuntimeRegistryService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/runtime/AgentRuntimeRegistryService.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.runtime;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.service.agent.fingerprint.RuntimeEndpointRevision;
+import com.alibaba.nacos.ai.service.agent.identity.RadServiceNameComposer;
+import com.alibaba.nacos.ai.service.agent.metadata.AgentVersionComparator;
+import com.alibaba.nacos.api.ai.model.agent.Endpoint;
+import com.alibaba.nacos.api.ai.model.agent.EndpointSource;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointSnapshot;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointSnapshotItem;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointState;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeVersionBinding;
+import com.alibaba.nacos.api.ai.model.rad.AgentEndpointRegistrationBatch;
+import com.alibaba.nacos.api.ai.model.rad.EndpointSet;
+import com.alibaba.nacos.api.ai.utils.AgentModelValidator;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+import com.alibaba.nacos.api.ai.utils.EndpointCanonicalizer;
+import com.alibaba.nacos.api.ai.utils.EndpointNaturalKey;
+import com.alibaba.nacos.api.ai.utils.RadModelValidator;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.api.naming.utils.NamingUtils;
+import com.alibaba.nacos.naming.core.v2.index.ServiceStorage;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.core.v2.service.impl.EphemeralClientOperationServiceImpl;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Agent Runtime Registry backed directly by Naming client publications.
+ *
+ * <p>One registration is the complete batch for one publisher and Naming Service. Naming owns
+ * replacement, liveness, AP convergence, indexing, and cleanup. This service only composes the
+ * Naming identity, converts data structures, and builds public read models.</p>
+ *
+ * @author Nacos
+ */
+@Component
+public class AgentRuntimeRegistryService {
+    
+    private static final int MAX_RUNTIME_ENDPOINTS = 1000;
+    
+    private static final Comparator<RuntimeVersionBinding> BINDING_COMPARATOR =
+        new Comparator<RuntimeVersionBinding>() {
+            
+            @Override
+            public int compare(RuntimeVersionBinding left, RuntimeVersionBinding right) {
+                int result = AgentVersionComparator.compare(left.getRuntimeVersion(),
+                    right.getRuntimeVersion());
+                if (result != 0) {
+                    return result;
+                }
+                return left.getVersionRange().compareTo(right.getVersionRange());
+            }
+        };
+    
+    private final ServiceStorage serviceStorage;
+    
+    private final EphemeralClientOperationServiceImpl clientOperationService;
+    
+    public AgentRuntimeRegistryService(ServiceStorage serviceStorage,
+        EphemeralClientOperationServiceImpl clientOperationService) {
+        this.serviceStorage = serviceStorage;
+        this.clientOperationService = clientOperationService;
+    }
+    
+    /**
+     * Replace one publisher's complete Runtime Endpoint batch.
+     *
+     * @param publisherId Naming client identity
+     * @param batch complete batch for one Agent, protocol, and shared Version values
+     * @throws NacosException when Naming rejects the batch
+     */
+    public void register(String publisherId, AgentEndpointRegistrationBatch batch)
+        throws NacosException {
+        RadModelValidator.validate(batch);
+        List<Instance> instances = new ArrayList<Instance>(batch.getEndpoints().size());
+        for (Endpoint endpoint : batch.getEndpoints()) {
+            instances.add(AgentRuntimeEndpointMapper.toInstance(endpoint,
+                batch.getRuntimeVersion(), batch.getVersionRange()));
+        }
+        NamingUtils.batchCheckInstanceIsLegal(instances);
+        clientOperationService.batchRegisterInstance(composeService(batch.getNamespaceId(),
+            batch.getAgentName(), batch.getProtocol()), instances, publisherId);
+    }
+    
+    /**
+     * Remove one publisher's complete Runtime Endpoint publication.
+     *
+     * <p>Partial removal is a client-side batch operation: the client computes the retained
+     * instances and registers the replacement batch. This method is used only when no publication
+     * remains.</p>
+     *
+     * @param publisherId Naming client identity
+     * @param namespaceId namespace identifier
+     * @param agentName Agent name
+     * @param protocol Agent protocol
+     */
+    public void deregisterPublisher(String publisherId, String namespaceId, String agentName,
+        String protocol) {
+        validateReadIdentity(namespaceId, agentName, protocol, null);
+        clientOperationService.deregisterInstance(
+            composeService(namespaceId, agentName, protocol), new Instance(), publisherId);
+    }
+    
+    /**
+     * Return the management Runtime Endpoint snapshot for one Agent protocol.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName Agent name
+     * @param protocol Agent protocol
+     * @param version optional Agent Version filter
+     * @return Runtime Endpoint snapshot
+     * @throws NacosException when Naming state cannot be represented by the Agent contract
+     */
+    public RuntimeEndpointSnapshot getRuntimeEndpointSnapshot(String namespaceId,
+        String agentName,
+        String protocol, String version) throws NacosException {
+        validateReadIdentity(namespaceId, agentName, protocol, version);
+        RuntimeEndpointSnapshot result = new RuntimeEndpointSnapshot();
+        result.setNamespaceId(namespaceId);
+        result.setAgentName(agentName);
+        result.setProtocol(protocol);
+        result.setVersion(version);
+        result.setItems(loadSnapshotItems(namespaceId, agentName, protocol, version));
+        AgentModelValidator.validateRuntimeEndpointSnapshot(result);
+        return result;
+    }
+    
+    /**
+     * Return enabled Runtime Endpoints for RAD discovery.
+     *
+     * @param namespaceId namespace identifier
+     * @param agentName Agent name
+     * @param protocol Agent protocol
+     * @param version exact target Agent Version
+     * @return Runtime Endpoint set and deterministic source revision
+     * @throws NacosException when Naming state cannot be represented by the Agent contract
+     */
+    public EndpointSet getRuntimeEndpointSet(String namespaceId, String agentName,
+        String protocol, String version) throws NacosException {
+        validateReadIdentity(namespaceId, agentName, protocol, version);
+        if (version == null) {
+            throw new IllegalArgumentException("Runtime EndpointSet Version must not be null");
+        }
+        List<Endpoint> endpoints =
+            loadRuntimeEndpoints(namespaceId, agentName, protocol, version);
+        sortRuntimeEndpoints(namespaceId, agentName, protocol, endpoints);
+        EndpointSet result = new EndpointSet();
+        result.setSource(EndpointSource.RUNTIME);
+        result.setSourceRevision(
+            RuntimeEndpointRevision.compute(namespaceId, agentName, protocol, endpoints));
+        result.setEndpoints(endpoints);
+        RadModelValidator.validate(result);
+        return result;
+    }
+    
+    private List<RuntimeEndpointSnapshotItem> loadSnapshotItems(String namespaceId,
+        String agentName, String protocol,
+        String version) throws NacosException {
+        ServiceInfo serviceInfo = getServiceInfo(namespaceId, agentName, protocol);
+        Map<EndpointNaturalKey, RuntimeEndpointSnapshotItem> result =
+            new TreeMap<EndpointNaturalKey, RuntimeEndpointSnapshotItem>();
+        for (Instance instance : serviceInfo.getHosts()) {
+            RuntimeEndpointSnapshotItem contribution =
+                mapInstance(instance, serviceInfo.getLastRefTime());
+            List<RuntimeVersionBinding> matchingBindings =
+                matchingBindings(contribution.getBindings(), version);
+            if (matchingBindings.isEmpty()) {
+                continue;
+            }
+            contribution.setBindings(matchingBindings);
+            Endpoint endpoint = contribution.getEndpoint();
+            EndpointNaturalKey key =
+                EndpointNaturalKey.of(namespaceId, agentName, protocol, endpoint);
+            RuntimeEndpointSnapshotItem current = result.get(key);
+            if (current == null) {
+                result.put(key, contribution);
+            } else {
+                if (!samePayload(current.getEndpoint(), endpoint)) {
+                    throw conflict(key);
+                }
+                mergeSnapshotItem(current, contribution);
+            }
+        }
+        validateCapacity(result.size());
+        return new ArrayList<RuntimeEndpointSnapshotItem>(result.values());
+    }
+    
+    private List<Endpoint> loadRuntimeEndpoints(String namespaceId, String agentName,
+        String protocol, String version) throws NacosException {
+        ServiceInfo serviceInfo = getServiceInfo(namespaceId, agentName, protocol);
+        Map<EndpointNaturalKey, Endpoint> payloads =
+            new TreeMap<EndpointNaturalKey, Endpoint>();
+        Map<EndpointNaturalKey, Endpoint> result =
+            new TreeMap<EndpointNaturalKey, Endpoint>();
+        for (Instance instance : serviceInfo.getHosts()) {
+            RuntimeEndpointSnapshotItem contribution =
+                mapInstance(instance, serviceInfo.getLastRefTime());
+            if (matchingBindings(contribution.getBindings(), version).isEmpty()) {
+                continue;
+            }
+            Endpoint endpoint = contribution.getEndpoint();
+            EndpointNaturalKey key =
+                EndpointNaturalKey.of(namespaceId, agentName, protocol, endpoint);
+            Endpoint previous = payloads.putIfAbsent(key, endpoint);
+            if (previous != null && !samePayload(previous, endpoint)) {
+                throw conflict(key);
+            }
+            if (!contribution.getEnabled()) {
+                continue;
+            }
+            Endpoint current = result.get(key);
+            if (current == null) {
+                current = copyEndpoint(endpoint);
+                current.setHealthy(contribution.getHealthy());
+                result.put(key, current);
+            } else {
+                current.setHealthy(current.getHealthy() || contribution.getHealthy());
+            }
+        }
+        validateCapacity(payloads.size());
+        return new ArrayList<Endpoint>(result.values());
+    }
+    
+    private ServiceInfo getServiceInfo(String namespaceId, String agentName, String protocol) {
+        ServiceInfo result =
+            serviceStorage.getData(composeService(namespaceId, agentName, protocol));
+        if (result == null) {
+            throw new NacosRuntimeException(NacosException.SERVER_ERROR,
+                "Naming ServiceStorage returned no Runtime Endpoint data");
+        }
+        return result;
+    }
+    
+    private RuntimeEndpointSnapshotItem mapInstance(Instance instance, long lastUpdatedTime) {
+        try {
+            return AgentRuntimeEndpointMapper.fromInstance(instance, lastUpdatedTime);
+        } catch (IllegalArgumentException e) {
+            throw new NacosRuntimeException(NacosException.SERVER_ERROR,
+                "Invalid Agent Runtime Endpoint in Naming ServiceStorage", e);
+        }
+    }
+    
+    private List<RuntimeVersionBinding> matchingBindings(
+        List<RuntimeVersionBinding> bindings, String version) {
+        List<RuntimeVersionBinding> result = new ArrayList<RuntimeVersionBinding>();
+        for (RuntimeVersionBinding binding : bindings) {
+            if (version == null
+                || RuntimeVersionRangeSupport.contains(binding.getVersionRange(), version)) {
+                result.add(binding);
+            }
+        }
+        return result;
+    }
+    
+    private void mergeSnapshotItem(RuntimeEndpointSnapshotItem current,
+        RuntimeEndpointSnapshotItem contribution) {
+        Set<RuntimeVersionBinding> bindings =
+            new TreeSet<RuntimeVersionBinding>(BINDING_COMPARATOR);
+        bindings.addAll(current.getBindings());
+        bindings.addAll(contribution.getBindings());
+        current.setBindings(new ArrayList<RuntimeVersionBinding>(bindings));
+        current.setEnabled(current.getEnabled() || contribution.getEnabled());
+        current.setHealthy(current.getHealthy() || contribution.getHealthy());
+        current.setState(runtimeState(current.getEnabled(), current.getHealthy()));
+    }
+    
+    private RuntimeEndpointState runtimeState(boolean enabled, boolean healthy) {
+        if (!enabled) {
+            return RuntimeEndpointState.DISABLED;
+        }
+        if (!healthy) {
+            return RuntimeEndpointState.UNHEALTHY;
+        }
+        return RuntimeEndpointState.AVAILABLE;
+    }
+    
+    private void validateCapacity(int size) throws NacosException {
+        if (size > MAX_RUNTIME_ENDPOINTS) {
+            throw new NacosException(NacosException.OVER_THRESHOLD,
+                "Runtime Endpoint result exceeds " + MAX_RUNTIME_ENDPOINTS
+                    + " natural keys");
+        }
+    }
+    
+    private Service composeService(String namespaceId, String agentName, String protocol) {
+        return Service.newService(namespaceId, Constants.Agent.AGENT_ENDPOINT_GROUP,
+            RadServiceNameComposer.compose(agentName, protocol));
+    }
+    
+    private void validateReadIdentity(String namespaceId, String agentName, String protocol,
+        String version) {
+        AgentValidationUtils.validateNamespaceId(namespaceId);
+        AgentValidationUtils.validateAgentName(agentName);
+        AgentValidationUtils.validateProtocol(protocol);
+        if (version != null) {
+            AgentValidationUtils.validateVersion(version);
+        }
+    }
+    
+    private void sortRuntimeEndpoints(String namespaceId, String agentName, String protocol,
+        List<Endpoint> endpoints) {
+        Collections.sort(endpoints, new Comparator<Endpoint>() {
+            
+            @Override
+            public int compare(Endpoint left, Endpoint right) {
+                int result = Integer.compare(left.getPriority(), right.getPriority());
+                if (result != 0) {
+                    return result;
+                }
+                EndpointNaturalKey leftKey =
+                    EndpointNaturalKey.of(namespaceId, agentName, protocol, left);
+                EndpointNaturalKey rightKey =
+                    EndpointNaturalKey.of(namespaceId, agentName, protocol, right);
+                return leftKey.compareTo(rightKey);
+            }
+        });
+    }
+    
+    private NacosApiException conflict(EndpointNaturalKey key) {
+        return new NacosApiException(NacosException.CONFLICT, ErrorCode.RESOURCE_CONFLICT,
+            "Naming contains conflicting Runtime Endpoints for natural key: " + key);
+    }
+    
+    private boolean samePayload(Endpoint left, Endpoint right) {
+        Endpoint first = EndpointCanonicalizer.canonicalize(left);
+        Endpoint second = EndpointCanonicalizer.canonicalize(right);
+        return first.getUri().equals(second.getUri())
+            && first.getTransport().equals(second.getTransport())
+            && first.getPriority().equals(second.getPriority())
+            && sameWeight(first.getWeight(), second.getWeight())
+            && Objects.equals(first.getMetadata(), second.getMetadata());
+    }
+    
+    private boolean sameWeight(Double left, Double right) {
+        double first = left == 0D ? 0D : left;
+        double second = right == 0D ? 0D : right;
+        return Double.doubleToLongBits(first) == Double.doubleToLongBits(second);
+    }
+    
+    private static Endpoint copyEndpoint(Endpoint source) {
+        Endpoint result = new Endpoint();
+        result.setUri(source.getUri());
+        result.setTransport(source.getTransport());
+        result.setPriority(source.getPriority());
+        result.setWeight(source.getWeight());
+        result.setHealthy(source.getHealthy());
+        if (source.getMetadata() != null) {
+            result.setMetadata(new LinkedHashMap<String, String>(source.getMetadata()));
+        }
+        return result;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/runtime/RuntimeVersionRangeSupport.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/runtime/RuntimeVersionRangeSupport.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.runtime;
+
+import com.alibaba.nacos.ai.service.agent.metadata.AgentVersionComparator;
+import com.alibaba.nacos.api.ai.utils.AgentValidationUtils;
+
+/**
+ * Server-internal operations over the public Agent Version range grammar.
+ *
+ * @author Nacos
+ */
+final class RuntimeVersionRangeSupport {
+    
+    private RuntimeVersionRangeSupport() {
+    }
+    
+    static String exact(String version) {
+        AgentValidationUtils.validateVersion(version);
+        return '[' + version + ']';
+    }
+    
+    static String canonicalize(String versionRange) {
+        AgentValidationUtils.validateVersionRange(versionRange);
+        ParsedRange parsed = ParsedRange.parse(versionRange);
+        if (parsed.lowerBound != null && parsed.upperBound != null
+            && parsed.lowerInclusive && parsed.upperInclusive
+            && AgentVersionComparator.compare(parsed.lowerBound, parsed.upperBound) == 0) {
+            return '[' + parsed.lowerBound + ']';
+        }
+        return versionRange;
+    }
+    
+    static boolean contains(String versionRange, String version) {
+        AgentValidationUtils.validateVersionRange(versionRange);
+        AgentValidationUtils.validateVersion(version);
+        ParsedRange parsed = ParsedRange.parse(versionRange);
+        if (parsed.lowerBound != null) {
+            int comparison = AgentVersionComparator.compare(version, parsed.lowerBound);
+            if (comparison < 0 || comparison == 0 && !parsed.lowerInclusive) {
+                return false;
+            }
+        }
+        if (parsed.upperBound != null) {
+            int comparison = AgentVersionComparator.compare(version, parsed.upperBound);
+            if (comparison > 0 || comparison == 0 && !parsed.upperInclusive) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    private static final class ParsedRange {
+        
+        private final String lowerBound;
+        
+        private final String upperBound;
+        
+        private final boolean lowerInclusive;
+        
+        private final boolean upperInclusive;
+        
+        private ParsedRange(String lowerBound, String upperBound, boolean lowerInclusive,
+            boolean upperInclusive) {
+            this.lowerBound = lowerBound;
+            this.upperBound = upperBound;
+            this.lowerInclusive = lowerInclusive;
+            this.upperInclusive = upperInclusive;
+        }
+        
+        private static ParsedRange parse(String value) {
+            int comma = value.indexOf(',');
+            if (comma < 0) {
+                String exact = value.substring(1, value.length() - 1);
+                return new ParsedRange(exact, exact, true, true);
+            }
+            String lower = value.substring(1, comma);
+            String upper = value.substring(comma + 1, value.length() - 1);
+            return new ParsedRange(lower.isEmpty() ? null : lower,
+                upper.isEmpty() ? null : upper, value.charAt(0) == '[',
+                value.charAt(value.length() - 1) == ']');
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentCardUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentCardUtil.java
@@ -111,31 +111,32 @@ public class AgentCardUtil {
     public static AgentInterface buildAgentInterface(Instance instance) {
         AgentInterface agentInterface = new AgentInterface();
         String protocol =
-            instance.getMetadata().get(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_KEY);
+            instance.getMetadata().get(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY);
         if (StringUtils.isEmpty(protocol)) {
             protocol = AiConstants.A2a.A2A_ENDPOINT_DEFAULT_PROTOCOL;
         }
         boolean isSupportTls = Boolean.parseBoolean(
-            instance.getMetadata().get(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS));
+            instance.getMetadata().get(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY));
         protocol = handlerTlsIfNeeded(protocol, isSupportTls);
         String url = String.format(AGENT_INTERFACE_URL_PATTERN, protocol, instance.getIp(),
             instance.getPort());
-        String path = instance.getMetadata().get(Constants.A2A.AGENT_ENDPOINT_PATH_KEY);
+        String path = instance.getMetadata().get(Constants.Agent.AGENT_ENDPOINT_PATH_KEY);
         if (StringUtils.isNotBlank(path)) {
             url += path.startsWith("/") ? path : "/" + path;
         }
-        String query = instance.getMetadata().get(Constants.A2A.NACOS_AGENT_ENDPOINT_QUERY_KEY);
+        String query = instance.getMetadata().get(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY);
         if (StringUtils.isNotBlank(query)) {
             url += "?" + query;
         }
         agentInterface.setUrl(url);
-        String transport = instance.getMetadata().get(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY);
+        String transport =
+            instance.getMetadata().get(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY);
         agentInterface.setTransport(transport);
         agentInterface.setProtocolBinding(transport);
         agentInterface.setProtocolVersion(
-            instance.getMetadata().get(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_VERSION_KEY));
+            instance.getMetadata().get(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY));
         agentInterface
-            .setTenant(instance.getMetadata().get(Constants.A2A.NACOS_AGENT_ENDPOINT_TENANT_KEY));
+            .setTenant(instance.getMetadata().get(Constants.Agent.AGENT_ENDPOINT_TENANT_KEY));
         return agentInterface;
     }
     

--- a/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentEndpointUtil.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/utils/AgentEndpointUtil.java
@@ -72,13 +72,13 @@ public class AgentEndpointUtil {
                 : endpoint.getProtocolVersion();
         String tenant =
             StringUtils.isBlank(endpoint.getTenant()) ? StringUtils.EMPTY : endpoint.getTenant();
-        Map<String, String> metadata = Map.of(Constants.A2A.AGENT_ENDPOINT_PATH_KEY, path,
-            Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, endpoint.getTransport(),
-            Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS, String.valueOf(endpoint.isSupportTls()),
-            Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_KEY, protocol,
-            Constants.A2A.NACOS_AGENT_ENDPOINT_QUERY_KEY,
-            query, Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_VERSION_KEY, protocolVersion,
-            Constants.A2A.NACOS_AGENT_ENDPOINT_TENANT_KEY, tenant);
+        Map<String, String> metadata = Map.of(Constants.Agent.AGENT_ENDPOINT_PATH_KEY, path,
+            Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, endpoint.getTransport(),
+            Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY,
+            String.valueOf(endpoint.isSupportTls()), Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY,
+            protocol, Constants.Agent.AGENT_ENDPOINT_QUERY_KEY, query,
+            Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY, protocolVersion,
+            Constants.Agent.AGENT_ENDPOINT_TENANT_KEY, tenant);
         instance.setMetadata(metadata);
         instance.validate();
         return instance;

--- a/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/a2a/AgentEndpointRequestHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/a2a/AgentEndpointRequestHandlerTest.java
@@ -190,10 +190,10 @@ class AgentEndpointRequestHandlerTest {
     
     private void validateInstanceMetadata(Instance instance) {
         Map<String, String> metadata = instance.getMetadata();
-        assertTrue(metadata.containsKey(Constants.A2A.AGENT_ENDPOINT_PATH_KEY));
-        assertTrue(metadata.containsKey(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY));
-        assertTrue(metadata.containsKey(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS));
-        assertTrue(metadata.containsKey(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_KEY));
-        assertTrue(metadata.containsKey(Constants.A2A.NACOS_AGENT_ENDPOINT_QUERY_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_PATH_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY));
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/a2a/BatchAgentEndpointRequestHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/remote/handler/a2a/BatchAgentEndpointRequestHandlerTest.java
@@ -209,10 +209,10 @@ class BatchAgentEndpointRequestHandlerTest {
     
     private void validateInstanceMetadata(Instance instance) {
         Map<String, String> metadata = instance.getMetadata();
-        assertTrue(metadata.containsKey(Constants.A2A.AGENT_ENDPOINT_PATH_KEY));
-        assertTrue(metadata.containsKey(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY));
-        assertTrue(metadata.containsKey(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS));
-        assertTrue(metadata.containsKey(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_KEY));
-        assertTrue(metadata.containsKey(Constants.A2A.NACOS_AGENT_ENDPOINT_QUERY_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_PATH_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY));
+        assertTrue(metadata.containsKey(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY));
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/a2a/A2aServerOperationServiceTest.java
@@ -754,14 +754,14 @@ public class A2aServerOperationServiceTest {
             .thenReturn(detailResponse);
         
         final Service service =
-            Service.newService(TEST_NAMESPACE_ID, Constants.A2A.AGENT_ENDPOINT_GROUP,
+            Service.newService(TEST_NAMESPACE_ID, Constants.Agent.AGENT_ENDPOINT_GROUP,
                 ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
         final ServiceInfo serviceInfo = new ServiceInfo();
         com.alibaba.nacos.api.naming.pojo.Instance instance =
             new com.alibaba.nacos.api.naming.pojo.Instance();
         instance.setIp("127.0.0.1");
         instance.setPort(8080);
-        instance.getMetadata().put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY,
+        instance.getMetadata().put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY,
             detailInfo.getPreferredTransport());
         serviceInfo.addHost(instance);
         when(serviceStorage.getData(service)).thenReturn(serviceInfo);
@@ -817,8 +817,9 @@ public class A2aServerOperationServiceTest {
             .thenReturn(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
         when(detailResponse.getContent()).thenReturn(JacksonUtils.toJson(detailInfo));
         
-        Service service = Service.newService(TEST_NAMESPACE_ID, Constants.A2A.AGENT_ENDPOINT_GROUP,
-            ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
+        Service service =
+            Service.newService(TEST_NAMESPACE_ID, Constants.Agent.AGENT_ENDPOINT_GROUP,
+                ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
         ServiceInfo serviceInfo = new ServiceInfo();
         serviceInfo.setHosts(Collections.emptyList());
         when(serviceStorage.getData(service)).thenReturn(serviceInfo);
@@ -854,7 +855,7 @@ public class A2aServerOperationServiceTest {
         when(detailResponse.getContent()).thenReturn(JacksonUtils.toJson(detailInfo));
         
         final Service service =
-            Service.newService(TEST_NAMESPACE_ID, Constants.A2A.AGENT_ENDPOINT_GROUP,
+            Service.newService(TEST_NAMESPACE_ID, Constants.Agent.AGENT_ENDPOINT_GROUP,
                 ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
         
         // Create a service info with hosts
@@ -863,7 +864,7 @@ public class A2aServerOperationServiceTest {
             new com.alibaba.nacos.api.naming.pojo.Instance();
         instance.setIp("127.0.0.1");
         instance.setPort(8080);
-        instance.getMetadata().put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY,
+        instance.getMetadata().put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY,
             detailInfo.getPreferredTransport());
         serviceInfo.addHost(instance);
         when(serviceStorage.getData(service)).thenReturn(serviceInfo);
@@ -910,8 +911,9 @@ public class A2aServerOperationServiceTest {
             .thenReturn(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
         when(detailResponse.getContent()).thenReturn(JacksonUtils.toJson(detailInfo));
         
-        Service service = Service.newService(TEST_NAMESPACE_ID, Constants.A2A.AGENT_ENDPOINT_GROUP,
-            ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
+        Service service =
+            Service.newService(TEST_NAMESPACE_ID, Constants.Agent.AGENT_ENDPOINT_GROUP,
+                ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
         ServiceInfo serviceInfo = new ServiceInfo();
         serviceInfo.setHosts(Collections.emptyList());
         when(serviceStorage.getData(service)).thenReturn(serviceInfo);
@@ -946,14 +948,14 @@ public class A2aServerOperationServiceTest {
             .thenReturn(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
         when(detailResponse.getContent()).thenReturn(JacksonUtils.toJson(detailInfo));
         final Service service =
-            Service.newService(TEST_NAMESPACE_ID, Constants.A2A.AGENT_ENDPOINT_GROUP,
+            Service.newService(TEST_NAMESPACE_ID, Constants.Agent.AGENT_ENDPOINT_GROUP,
                 ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
         final ServiceInfo serviceInfo = new ServiceInfo();
         com.alibaba.nacos.api.naming.pojo.Instance instance =
             new com.alibaba.nacos.api.naming.pojo.Instance();
         instance.setIp("127.0.0.1");
         instance.setPort(8080);
-        instance.setMetadata(Map.of(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC"));
+        instance.setMetadata(Map.of(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC"));
         serviceInfo.addHost(instance);
         when(serviceStorage.getData(service)).thenReturn(serviceInfo);
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
@@ -983,14 +985,14 @@ public class A2aServerOperationServiceTest {
             .thenReturn(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
         when(detailResponse.getContent()).thenReturn(JacksonUtils.toJson(detailInfo));
         final Service service =
-            Service.newService(TEST_NAMESPACE_ID, Constants.A2A.AGENT_ENDPOINT_GROUP,
+            Service.newService(TEST_NAMESPACE_ID, Constants.Agent.AGENT_ENDPOINT_GROUP,
                 ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
         final ServiceInfo serviceInfo = new ServiceInfo();
         com.alibaba.nacos.api.naming.pojo.Instance instance =
             new com.alibaba.nacos.api.naming.pojo.Instance();
         instance.setIp("127.0.0.1");
         instance.setPort(8080);
-        instance.setMetadata(Map.of(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC"));
+        instance.setMetadata(Map.of(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC"));
         serviceInfo.addHost(instance);
         when(serviceStorage.getData(service)).thenReturn(serviceInfo);
         when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
@@ -1017,8 +1019,9 @@ public class A2aServerOperationServiceTest {
             .thenReturn(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
         when(detailResponse.getContent()).thenReturn(JacksonUtils.toJson(detailInfo));
         
-        Service service = Service.newService(TEST_NAMESPACE_ID, Constants.A2A.AGENT_ENDPOINT_GROUP,
-            ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
+        Service service =
+            Service.newService(TEST_NAMESPACE_ID, Constants.Agent.AGENT_ENDPOINT_GROUP,
+                ENCODED_AGENT_NAME + "::" + TEST_AGENT_VERSION);
         ServiceInfo serviceInfo = new ServiceInfo();
         serviceInfo.setHosts(Collections.emptyList());
         when(serviceStorage.getData(service)).thenReturn(serviceInfo);

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/runtime/AgentRuntimeEndpointMapperTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/runtime/AgentRuntimeEndpointMapperTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.runtime;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.api.ai.model.agent.Endpoint;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointSnapshotItem;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointState;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentRuntimeEndpointMapperTest {
+    
+    private static final String ENABLE_KEY =
+        com.alibaba.nacos.naming.constants.Constants.PUBLISH_INSTANCE_ENABLE;
+    
+    private static final String WEIGHT_KEY =
+        com.alibaba.nacos.naming.constants.Constants.PUBLISH_INSTANCE_WEIGHT;
+    
+    @Test
+    void testMapEndpointToNamingAndBack() {
+        Endpoint endpoint = endpoint("HTTPS://EXAMPLE.COM/a2a?tenant=nacos", "JSON-RPC");
+        endpoint.setPriority(3);
+        endpoint.setWeight(2.5D);
+        endpoint.setHealthy(false);
+        endpoint.setMetadata(Collections.singletonMap("region", "cn-hangzhou"));
+        
+        Instance instance = AgentRuntimeEndpointMapper.toInstance(endpoint, "1.0.0",
+            "[1.0.0,1.0.0]");
+        
+        assertNull(instance.getServiceName());
+        assertEquals("example.com", instance.getIp());
+        assertEquals(443, instance.getPort());
+        assertEquals("JSON-RPC", instance.getClusterName());
+        assertEquals(2.5D, instance.getWeight());
+        assertTrue(instance.isEnabled());
+        assertTrue(instance.isHealthy());
+        assertTrue(instance.isEphemeral());
+        Map<String, String> metadata = instance.getMetadata();
+        assertEquals("/a2a", metadata.get(Constants.Agent.AGENT_ENDPOINT_PATH_KEY));
+        assertEquals("tenant=nacos",
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY));
+        assertEquals("JSON-RPC",
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY));
+        assertEquals("https", metadata.get(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY));
+        assertEquals("true", metadata.get(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY));
+        assertEquals("3", metadata.get(Constants.Agent.AGENT_ENDPOINT_PRIORITY_KEY));
+        assertEquals("1.0.0", metadata.get(Constants.Agent.AGENT_ENDPOINT_VERSION_KEY));
+        assertEquals("[1.0.0]",
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY));
+        assertEquals("cn-hangzhou", metadata.get("region"));
+        
+        instance.setEnabled(false);
+        instance.setHealthy(false);
+        RuntimeEndpointSnapshotItem result =
+            AgentRuntimeEndpointMapper.fromInstance(instance, 1234L);
+        
+        assertEndpoint(result.getEndpoint(), "https://example.com:443/a2a?tenant=nacos",
+            "JSON-RPC", 3, 2.5D);
+        assertEquals("cn-hangzhou", result.getEndpoint().getMetadata().get("region"));
+        assertEquals("1.0.0", result.getBindings().get(0).getRuntimeVersion());
+        assertEquals("[1.0.0]", result.getBindings().get(0).getVersionRange());
+        assertFalse(result.getEnabled());
+        assertFalse(result.getHealthy());
+        assertEquals(RuntimeEndpointState.DISABLED, result.getState());
+        assertEquals(1234L, result.getLastUpdatedTime());
+    }
+    
+    @Test
+    void testMapDefaultsAndIpv6() {
+        Instance defaultInstance = AgentRuntimeEndpointMapper.toInstance(
+            endpoint("http://NACOS.EXAMPLE", "http"), "1.0.0", null);
+        
+        assertEquals("nacos.example", defaultInstance.getIp());
+        assertEquals(80, defaultInstance.getPort());
+        assertEquals("", defaultInstance.getMetadata().get(
+            Constants.Agent.AGENT_ENDPOINT_PATH_KEY));
+        assertFalse(defaultInstance.getMetadata().containsKey(
+            Constants.Agent.AGENT_ENDPOINT_QUERY_KEY));
+        assertEquals("0", defaultInstance.getMetadata().get(
+            Constants.Agent.AGENT_ENDPOINT_PRIORITY_KEY));
+        assertEquals("[1.0.0]", defaultInstance.getMetadata().get(
+            Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY));
+        assertEquals(1D, defaultInstance.getWeight());
+        
+        Instance ipv6Instance = AgentRuntimeEndpointMapper.toInstance(
+            endpoint("wss://[2001:0DB8:0:0:0:0:0:1]/rpc", "websocket"),
+            "1.0.0", "[1.0.0]");
+        RuntimeEndpointSnapshotItem result =
+            AgentRuntimeEndpointMapper.fromInstance(ipv6Instance, 1L);
+        
+        assertEquals("2001:db8::1", ipv6Instance.getIp());
+        assertEquals(443, ipv6Instance.getPort());
+        assertEquals("wss://[2001:db8::1]:443/rpc", result.getEndpoint().getUri());
+    }
+    
+    @Test
+    void testAcceptLegacyMetadataWithoutExposingIt() {
+        Instance instance = validInstance();
+        instance.getMetadata().put(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY, "1.0");
+        instance.getMetadata().put(Constants.Agent.AGENT_ENDPOINT_TENANT_KEY, "public");
+        
+        RuntimeEndpointSnapshotItem result =
+            AgentRuntimeEndpointMapper.fromInstance(instance, 1L);
+        
+        assertNull(result.getEndpoint().getMetadata());
+        assertEquals("https://example.com:443/agent", result.getEndpoint().getUri());
+        
+        instance.getMetadata().put(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY, "");
+        instance.getMetadata().put(Constants.Agent.AGENT_ENDPOINT_TENANT_KEY, "");
+        assertEquals("https://example.com:443/agent",
+            AgentRuntimeEndpointMapper.fromInstance(instance, 1L).getEndpoint().getUri());
+    }
+    
+    @Test
+    void testMappedSnapshotItemDoesNotShareNamingMetadata() {
+        Instance instance = validInstance();
+        instance.getMetadata().put("region", "cn-hangzhou");
+        
+        RuntimeEndpointSnapshotItem result =
+            AgentRuntimeEndpointMapper.fromInstance(instance, 1234L);
+        result.getEndpoint().getMetadata().put("region", "outside");
+        
+        assertEquals("cn-hangzhou", instance.getMetadata().get("region"));
+        assertEquals(RuntimeEndpointState.AVAILABLE, result.getState());
+        assertEquals(1234L, result.getLastUpdatedTime());
+    }
+    
+    @Test
+    void testRejectInvalidForwardInput() {
+        Endpoint valid = endpoint("http://127.0.0.1:8848/agent", "http");
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentRuntimeEndpointMapper.toInstance(null, "1.0.0", null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentRuntimeEndpointMapper.toInstance(valid, null, null));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentRuntimeEndpointMapper.toInstance(valid, "1.0.0", "[2.0.0]"));
+        valid.setMetadata(Collections.singletonMap(ENABLE_KEY, "false"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentRuntimeEndpointMapper.toInstance(valid, "1.0.0", null));
+        valid.setMetadata(Collections.singletonMap(WEIGHT_KEY, "2"));
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentRuntimeEndpointMapper.toInstance(valid, "1.0.0", null));
+    }
+    
+    @Test
+    void testRejectOversizedForwardMetadata() {
+        Endpoint endpoint = endpoint("http://127.0.0.1:8848/agent", "http");
+        Map<String, String> oversized = new LinkedHashMap<String, String>();
+        for (int i = 0; i < 4; i++) {
+            oversized.put(repeat((char) ('a' + i), 64), repeat('x', 256));
+        }
+        endpoint.setMetadata(oversized);
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentRuntimeEndpointMapper.toInstance(endpoint, "1.0.0", null));
+    }
+    
+    @Test
+    void testRejectInvalidNamingIdentityAndMetadataShape() {
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentRuntimeEndpointMapper.fromInstance(null, 1L));
+        assertInvalidInstance(value -> value.setMetadata(null));
+        assertInvalidInstance(value -> value.setIp(null));
+        assertInvalidInstance(value -> value.setIp(repeat('a', 254)));
+        assertInvalidInstance(value -> value.setPort(0));
+        assertInvalidInstance(value -> value.setPort(65536));
+        assertInvalidInstance(value -> value.setClusterName("bad_cluster"));
+        assertInvalidInstance(value -> value.getMetadata().put(null, "value"));
+        assertInvalidInstance(value -> value.getMetadata().put("value", null));
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_METADATA_PREFIX + "unknown__", "value"));
+    }
+    
+    @Test
+    void testRejectMissingRequiredMetadata() {
+        List<String> requiredKeys = Arrays.asList(Constants.Agent.AGENT_ENDPOINT_PATH_KEY,
+            Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY,
+            Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY,
+            Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY,
+            Constants.Agent.AGENT_ENDPOINT_VERSION_KEY,
+            Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY,
+            Constants.Agent.AGENT_ENDPOINT_PRIORITY_KEY);
+        for (String key : requiredKeys) {
+            Instance instance = validInstance();
+            instance.getMetadata().remove(key);
+            assertThrows(IllegalArgumentException.class,
+                () -> AgentRuntimeEndpointMapper.fromInstance(instance, 1L), key);
+        }
+    }
+    
+    @Test
+    void testRejectConflictingReservedMetadata() {
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "grpc"));
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY, "HTTPS"));
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "TRUE"));
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "false"));
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY, "[1.0.0,1.0.0]"));
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY, "[2.0.0]"));
+    }
+    
+    @Test
+    void testRejectInvalidPriorityAndUriProjection() {
+        for (String priority : Arrays.asList("", "01", "-1", "2147483648", "99999999999")) {
+            assertInvalidInstance(value -> value.getMetadata().put(
+                Constants.Agent.AGENT_ENDPOINT_PRIORITY_KEY, priority));
+        }
+        assertInvalidInstance(value -> value.setIp("EXAMPLE.COM"));
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_QUERY_KEY, "bad query"));
+    }
+    
+    @Test
+    void testRejectInvalidLegacyAndCapacityMetadata() {
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY, "bad version"));
+        assertInvalidInstance(value -> value.getMetadata().put(
+            Constants.Agent.AGENT_ENDPOINT_TENANT_KEY, repeat('t', 257)));
+        assertInvalidInstance(value -> {
+            for (int i = 0; i < 4; i++) {
+                value.getMetadata().put(repeat((char) ('a' + i), 64),
+                    repeat('x', 256));
+            }
+        });
+    }
+    
+    private void assertInvalidInstance(Consumer<Instance> mutation) {
+        Instance instance = validInstance();
+        mutation.accept(instance);
+        assertThrows(IllegalArgumentException.class,
+            () -> AgentRuntimeEndpointMapper.fromInstance(instance, 1L));
+    }
+    
+    private Instance validInstance() {
+        return AgentRuntimeEndpointMapper.toInstance(
+            endpoint("https://example.com:443/agent", "http"), "1.0.0", "[1.0.0]");
+    }
+    
+    private Endpoint endpoint(String uri, String transport) {
+        Endpoint result = new Endpoint();
+        result.setUri(uri);
+        result.setTransport(transport);
+        return result;
+    }
+    
+    private void assertEndpoint(Endpoint endpoint, String uri, String transport, int priority,
+        double weight) {
+        assertEquals(uri, endpoint.getUri());
+        assertEquals(transport, endpoint.getTransport());
+        assertEquals(priority, endpoint.getPriority());
+        assertEquals(weight, endpoint.getWeight());
+        assertNull(endpoint.getHealthy());
+    }
+    
+    private String repeat(char value, int count) {
+        return String.join("", Collections.nCopies(count, String.valueOf(value)));
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/runtime/AgentRuntimeRegistryServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/runtime/AgentRuntimeRegistryServiceTest.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.runtime;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.service.agent.identity.RadServiceNameComposer;
+import com.alibaba.nacos.api.ai.model.agent.Endpoint;
+import com.alibaba.nacos.api.ai.model.agent.EndpointSource;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointSnapshot;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointSnapshotItem;
+import com.alibaba.nacos.api.ai.model.agent.RuntimeEndpointState;
+import com.alibaba.nacos.api.ai.model.rad.AgentEndpointRegistrationBatch;
+import com.alibaba.nacos.api.ai.model.rad.EndpointSet;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.naming.core.v2.index.ServiceStorage;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
+import com.alibaba.nacos.naming.core.v2.service.impl.EphemeralClientOperationServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentRuntimeRegistryServiceTest {
+    
+    private static final String NAMESPACE_ID = "public";
+    
+    private static final String AGENT_NAME = "demo-agent";
+    
+    private static final String PROTOCOL = "a2a";
+    
+    private static final String PUBLISHER_ID = "connection-1";
+    
+    @Mock
+    private ServiceStorage serviceStorage;
+    
+    @Mock
+    private EphemeralClientOperationServiceImpl clientOperationService;
+    
+    private AgentRuntimeRegistryService registryService;
+    
+    @BeforeEach
+    void setUp() {
+        registryService =
+            new AgentRuntimeRegistryService(serviceStorage, clientOperationService);
+    }
+    
+    @Test
+    void testRegisterDelegatesCompleteBatchToNaming() throws NacosException {
+        AgentEndpointRegistrationBatch batch = registration("1.0.0",
+            "[1.0.0,2.0.0)", Arrays.asList(
+                endpoint("https://one.example.com/agent", "json-rpc"),
+                endpoint("https://two.example.com/agent", "json-rpc")));
+        
+        registryService.register(PUBLISHER_ID, batch);
+        
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Instance>> instancesCaptor =
+            ArgumentCaptor.forClass(List.class);
+        verify(clientOperationService).batchRegisterInstance(eq(expectedService()),
+            instancesCaptor.capture(), eq(PUBLISHER_ID));
+        List<Instance> instances = instancesCaptor.getValue();
+        assertEquals(2, instances.size());
+        assertEquals("1.0.0", instances.get(0).getMetadata().get(
+            Constants.Agent.AGENT_ENDPOINT_VERSION_KEY));
+        assertEquals("[1.0.0,2.0.0)", instances.get(0).getMetadata().get(
+            Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY));
+        assertEquals("one.example.com", instances.get(0).getIp());
+        verify(serviceStorage, never()).getData(any());
+    }
+    
+    @Test
+    void testLaterRegistrationIsAnotherCompleteReplacement() throws NacosException {
+        registryService.register(PUBLISHER_ID, registration("1.0.0", null,
+            Arrays.asList(endpoint("https://one.example.com/agent", "json-rpc"),
+                endpoint("https://two.example.com/agent", "json-rpc"))));
+        registryService.register(PUBLISHER_ID, registration("2.0.0", null,
+            Collections.singletonList(
+                endpoint("https://three.example.com/agent", "json-rpc"))));
+        
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Instance>> instancesCaptor =
+            ArgumentCaptor.forClass(List.class);
+        verify(clientOperationService, times(2)).batchRegisterInstance(eq(expectedService()),
+            instancesCaptor.capture(), eq(PUBLISHER_ID));
+        List<Instance> replacement = instancesCaptor.getAllValues().get(1);
+        assertEquals(1, replacement.size());
+        assertEquals("three.example.com", replacement.get(0).getIp());
+        assertEquals("2.0.0", replacement.get(0).getMetadata().get(
+            Constants.Agent.AGENT_ENDPOINT_VERSION_KEY));
+        assertEquals("[2.0.0]", replacement.get(0).getMetadata().get(
+            Constants.Agent.AGENT_ENDPOINT_VERSION_RANGE_KEY));
+    }
+    
+    @Test
+    void testRejectInvalidRegistrationBeforeNamingWrite() {
+        AgentEndpointRegistrationBatch invalid =
+            registration("1.0.0", null, Collections.<Endpoint>emptyList());
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> registryService.register(PUBLISHER_ID, invalid));
+        
+        verify(clientOperationService, never()).batchRegisterInstance(any(), any(), any());
+    }
+    
+    @Test
+    void testDeregisterPublisherRemovesCompleteNamingPublication() {
+        registryService.deregisterPublisher(PUBLISHER_ID, NAMESPACE_ID, AGENT_NAME, PROTOCOL);
+        
+        verify(clientOperationService).deregisterInstance(eq(expectedService()),
+            any(Instance.class), eq(PUBLISHER_ID));
+        verify(serviceStorage, never()).getData(any());
+    }
+    
+    @Test
+    void testSnapshotAggregatesBindingsOnlyWhenReading() throws NacosException {
+        Endpoint endpoint = endpoint("https://example.com/agent", "json-rpc");
+        Instance versionOne = instance(endpoint, "1.0.0", "[1.0.0]", true, false);
+        Instance versionTwo = instance(endpoint, "2.0.0", "[2.0.0]", true, true);
+        when(serviceStorage.getData(expectedService()))
+            .thenReturn(serviceInfo(1234L, versionOne, versionTwo));
+        
+        RuntimeEndpointSnapshot all =
+            registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, null);
+        RuntimeEndpointSnapshot versionOneSnapshot =
+            registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, "1.0.0");
+        
+        assertEquals(1, all.getItems().size());
+        RuntimeEndpointSnapshotItem allItem = all.getItems().get(0);
+        assertEquals(2, allItem.getBindings().size());
+        assertEquals("1.0.0", allItem.getBindings().get(0).getRuntimeVersion());
+        assertEquals("2.0.0", allItem.getBindings().get(1).getRuntimeVersion());
+        assertEquals(1234L, allItem.getLastUpdatedTime());
+        assertTrue(allItem.getHealthy());
+        assertEquals(1, versionOneSnapshot.getItems().size());
+        RuntimeEndpointSnapshotItem selected = versionOneSnapshot.getItems().get(0);
+        assertEquals(1, selected.getBindings().size());
+        assertEquals("1.0.0", selected.getBindings().get(0).getRuntimeVersion());
+        assertFalse(selected.getHealthy());
+        assertEquals(RuntimeEndpointState.UNHEALTHY, selected.getState());
+    }
+    
+    @Test
+    void testSnapshotDeduplicatesBindingsAndPreservesEndpointMetadata() throws NacosException {
+        Endpoint endpoint = endpoint("https://example.com/agent", "json-rpc");
+        endpoint.setMetadata(Collections.singletonMap("region", "cn-hangzhou"));
+        when(serviceStorage.getData(expectedService())).thenReturn(serviceInfo(1234L,
+            instance(endpoint, "1.0.0", "[1.0.0]", true, true),
+            instance(endpoint, "1.0.0", "[1.0.0]", true, true),
+            instance(endpoint, "1.0.0", "[1.0.0,2.0.0]", true, true)));
+        
+        RuntimeEndpointSnapshot snapshot =
+            registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, null);
+        EndpointSet endpointSet =
+            registryService.getRuntimeEndpointSet(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, "1.0.0");
+        
+        assertEquals(1, snapshot.getItems().size());
+        RuntimeEndpointSnapshotItem item = snapshot.getItems().get(0);
+        assertEquals(2, item.getBindings().size());
+        assertEquals("[1.0.0,2.0.0]", item.getBindings().get(0).getVersionRange());
+        assertEquals("[1.0.0]", item.getBindings().get(1).getVersionRange());
+        assertEquals("cn-hangzhou", item.getEndpoint().getMetadata().get("region"));
+        assertEquals("cn-hangzhou",
+            endpointSet.getEndpoints().get(0).getMetadata().get("region"));
+    }
+    
+    @Test
+    void testRuntimeEndpointSetUsesNamingEnabledAndHealthState() throws NacosException {
+        Endpoint disabled = endpoint("https://disabled.example.com/agent", "json-rpc");
+        disabled.setPriority(0);
+        Endpoint unhealthy = endpoint("https://unhealthy.example.com/agent", "json-rpc");
+        unhealthy.setPriority(1);
+        Endpoint healthy = endpoint("https://healthy.example.com/agent", "json-rpc");
+        healthy.setPriority(2);
+        when(serviceStorage.getData(expectedService())).thenReturn(serviceInfo(10L,
+            instance(disabled, "1.0.0", "[1.0.0]", false, true),
+            instance(unhealthy, "1.0.0", "[1.0.0]", true, false),
+            instance(healthy, "1.0.0", "[1.0.0]", true, true)));
+        
+        RuntimeEndpointSnapshot snapshot =
+            registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, "1.0.0");
+        EndpointSet result =
+            registryService.getRuntimeEndpointSet(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, "1.0.0");
+        
+        assertEquals(RuntimeEndpointState.DISABLED,
+            snapshotItem(snapshot, "https://disabled.example.com:443/agent").getState());
+        assertEquals(RuntimeEndpointState.UNHEALTHY,
+            snapshotItem(snapshot, "https://unhealthy.example.com:443/agent").getState());
+        assertEquals(RuntimeEndpointState.AVAILABLE,
+            snapshotItem(snapshot, "https://healthy.example.com:443/agent").getState());
+        assertEquals(EndpointSource.RUNTIME, result.getSource());
+        assertEquals(2, result.getEndpoints().size());
+        assertEquals("https://unhealthy.example.com:443/agent",
+            result.getEndpoints().get(0).getUri());
+        assertFalse(result.getEndpoints().get(0).getHealthy());
+        assertTrue(result.getEndpoints().get(1).getHealthy());
+    }
+    
+    @Test
+    void testRuntimeEndpointSetIgnoresDisabledContributionHealth() throws NacosException {
+        Endpoint endpoint = endpoint("https://example.com/agent", "json-rpc");
+        when(serviceStorage.getData(expectedService())).thenReturn(serviceInfo(10L,
+            instance(endpoint, "1.0.0", "[1.0.0]", false, true),
+            instance(endpoint, "1.0.0", "[1.0.0]", true, false)));
+        
+        RuntimeEndpointSnapshot snapshot =
+            registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, "1.0.0");
+        EndpointSet endpointSet =
+            registryService.getRuntimeEndpointSet(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, "1.0.0");
+        
+        assertTrue(snapshot.getItems().get(0).getEnabled());
+        assertTrue(snapshot.getItems().get(0).getHealthy());
+        assertEquals(RuntimeEndpointState.AVAILABLE, snapshot.getItems().get(0).getState());
+        assertEquals(1, endpointSet.getEndpoints().size());
+        assertFalse(endpointSet.getEndpoints().get(0).getHealthy());
+    }
+    
+    @Test
+    void testRuntimeEndpointSetOrdersAndProducesContentRevision() throws NacosException {
+        Endpoint lowPriority = endpoint("http://low.example.com/agent", "json-rpc");
+        lowPriority.setPriority(10);
+        Endpoint first = endpoint("http://a.example.com/agent", "json-rpc");
+        Endpoint second = endpoint("http://b.example.com/agent", "json-rpc");
+        when(serviceStorage.getData(expectedService())).thenReturn(serviceInfo(10L,
+            instance(lowPriority, "1.0.0", "[1.0.0]", true, true),
+            instance(second, "1.0.0", "[1.0.0]", true, true),
+            instance(first, "1.0.0", "[1.0.0]", true, true)));
+        
+        EndpointSet result =
+            registryService.getRuntimeEndpointSet(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, "1.0.0");
+        EndpointSet empty =
+            registryService.getRuntimeEndpointSet(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, "2.0.0");
+        
+        assertEquals("http://a.example.com:80/agent", result.getEndpoints().get(0).getUri());
+        assertEquals("http://b.example.com:80/agent", result.getEndpoints().get(1).getUri());
+        assertEquals("http://low.example.com:80/agent",
+            result.getEndpoints().get(2).getUri());
+        assertNotEquals(result.getSourceRevision(), empty.getSourceRevision());
+        assertTrue(empty.getEndpoints().isEmpty());
+    }
+    
+    @Test
+    void testRejectConflictingNamingProjection() {
+        Endpoint first = endpoint("https://example.com/one", "json-rpc");
+        Endpoint second = endpoint("https://example.com/two", "json-rpc");
+        when(serviceStorage.getData(expectedService())).thenReturn(serviceInfo(10L,
+            instance(first, "1.0.0", "[1.0.0]", true, true),
+            instance(second, "1.0.0", "[1.0.0]", true, true)));
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, null));
+        
+        assertEquals(NacosException.CONFLICT, exception.getErrCode());
+    }
+    
+    @Test
+    void testRejectConflictingPriorityWeightAndMetadata() {
+        Endpoint base = endpoint("https://example.com/agent", "json-rpc");
+        Endpoint differentPriority = endpoint("https://example.com/agent", "json-rpc");
+        differentPriority.setPriority(1);
+        assertConflictingProjection(base, differentPriority);
+        
+        Endpoint differentWeight = endpoint("https://example.com/agent", "json-rpc");
+        differentWeight.setWeight(2D);
+        assertConflictingProjection(base, differentWeight);
+        
+        Endpoint differentMetadata = endpoint("https://example.com/agent", "json-rpc");
+        differentMetadata.setMetadata(Collections.singletonMap("region", "cn-hangzhou"));
+        assertConflictingProjection(base, differentMetadata);
+    }
+    
+    @Test
+    void testRejectOversizedNamingProjection() {
+        List<Instance> instances = new ArrayList<Instance>();
+        for (int i = 0; i <= 1000; i++) {
+            instances.add(instance(
+                endpoint("https://host-" + i + ".example.com/agent", "json-rpc"),
+                "1.0.0", "[1.0.0]", true, true));
+        }
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setHosts(instances);
+        serviceInfo.setLastRefTime(10L);
+        when(serviceStorage.getData(expectedService())).thenReturn(serviceInfo);
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, null));
+        
+        assertEquals(NacosException.OVER_THRESHOLD, exception.getErrCode());
+    }
+    
+    @Test
+    void testRejectInvalidNamingProjection() {
+        Instance invalid = instance(endpoint("https://example.com/agent", "json-rpc"),
+            "1.0.0", "[1.0.0]", true, true);
+        invalid.getMetadata().remove(Constants.Agent.AGENT_ENDPOINT_VERSION_KEY);
+        when(serviceStorage.getData(expectedService())).thenReturn(serviceInfo(10L, invalid));
+        
+        assertThrows(NacosRuntimeException.class,
+            () -> registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, null));
+        
+        when(serviceStorage.getData(expectedService())).thenReturn(null);
+        assertThrows(NacosRuntimeException.class,
+            () -> registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, null));
+    }
+    
+    @Test
+    void testReturnEmptySnapshotFromEmptyNamingService() throws NacosException {
+        when(serviceStorage.getData(expectedService())).thenReturn(serviceInfo(99L));
+        
+        RuntimeEndpointSnapshot result =
+            registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, null);
+        
+        assertTrue(result.getItems().isEmpty());
+        assertEquals(NAMESPACE_ID, result.getNamespaceId());
+        assertEquals(AGENT_NAME, result.getAgentName());
+        assertEquals(PROTOCOL, result.getProtocol());
+    }
+    
+    @Test
+    void testRejectNullRuntimeEndpointSetVersion() {
+        assertThrows(IllegalArgumentException.class,
+            () -> registryService.getRuntimeEndpointSet(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, null));
+    }
+    
+    private AgentEndpointRegistrationBatch registration(String runtimeVersion,
+        String versionRange, List<Endpoint> endpoints) {
+        AgentEndpointRegistrationBatch result = new AgentEndpointRegistrationBatch();
+        result.setNamespaceId(NAMESPACE_ID);
+        result.setAgentName(AGENT_NAME);
+        result.setProtocol(PROTOCOL);
+        result.setRuntimeVersion(runtimeVersion);
+        result.setVersionRange(versionRange);
+        result.setEndpoints(endpoints);
+        return result;
+    }
+    
+    private Instance instance(Endpoint endpoint, String runtimeVersion, String versionRange,
+        boolean enabled, boolean healthy) {
+        Instance result =
+            AgentRuntimeEndpointMapper.toInstance(endpoint, runtimeVersion, versionRange);
+        result.setEnabled(enabled);
+        result.setHealthy(healthy);
+        return result;
+    }
+    
+    private ServiceInfo serviceInfo(long lastRefTime, Instance... instances) {
+        ServiceInfo result = new ServiceInfo();
+        result.setHosts(Arrays.asList(instances));
+        result.setLastRefTime(lastRefTime);
+        return result;
+    }
+    
+    private Endpoint endpoint(String uri, String transport) {
+        Endpoint result = new Endpoint();
+        result.setUri(uri);
+        result.setTransport(transport);
+        return result;
+    }
+    
+    private Service expectedService() {
+        return Service.newService(NAMESPACE_ID, Constants.Agent.AGENT_ENDPOINT_GROUP,
+            RadServiceNameComposer.compose(AGENT_NAME, PROTOCOL));
+    }
+    
+    private void assertConflictingProjection(Endpoint first, Endpoint second) {
+        when(serviceStorage.getData(expectedService())).thenReturn(serviceInfo(10L,
+            instance(first, "1.0.0", "[1.0.0]", true, true),
+            instance(second, "1.0.0", "[1.0.0]", true, true)));
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> registryService.getRuntimeEndpointSnapshot(
+                NAMESPACE_ID, AGENT_NAME, PROTOCOL, null));
+        assertEquals(NacosException.CONFLICT, exception.getErrCode());
+    }
+    
+    private RuntimeEndpointSnapshotItem snapshotItem(RuntimeEndpointSnapshot snapshot,
+        String uri) {
+        for (RuntimeEndpointSnapshotItem item : snapshot.getItems()) {
+            if (uri.equals(item.getEndpoint().getUri())) {
+                return item;
+            }
+        }
+        throw new AssertionError("Missing Runtime Endpoint snapshot item: " + uri);
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/runtime/RuntimeVersionRangeSupportTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/runtime/RuntimeVersionRangeSupportTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.agent.runtime;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RuntimeVersionRangeSupportTest {
+    
+    @Test
+    void testExactAndCanonicalForms() {
+        assertEquals("[1.0.0-RC1]", RuntimeVersionRangeSupport.exact("1.0.0-RC1"));
+        assertEquals("[1.0.0]",
+            RuntimeVersionRangeSupport.canonicalize("[1.0.0,1.0.0]"));
+        assertEquals("[1.0.0,2.0.0)",
+            RuntimeVersionRangeSupport.canonicalize("[1.0.0,2.0.0)"));
+        assertEquals("[1.0.0,2.0.0]",
+            RuntimeVersionRangeSupport.canonicalize("[1.0.0,2.0.0]"));
+        assertEquals("(,2.0.0]",
+            RuntimeVersionRangeSupport.canonicalize("(,2.0.0]"));
+        assertEquals("[1.0.0,)",
+            RuntimeVersionRangeSupport.canonicalize("[1.0.0,)"));
+    }
+    
+    @Test
+    void testContainsClosedOpenAndUnboundedRanges() {
+        assertTrue(RuntimeVersionRangeSupport.contains("[1.0.0]", "1.0.0"));
+        assertFalse(RuntimeVersionRangeSupport.contains("[1.0.0]", "1.0.1"));
+        assertTrue(RuntimeVersionRangeSupport.contains("[1.0.0,2.0.0)", "1.0.0"));
+        assertTrue(RuntimeVersionRangeSupport.contains("[1.0.0,2.0.0)", "2.0.0-RC1"));
+        assertFalse(RuntimeVersionRangeSupport.contains("[1.0.0,2.0.0)", "2.0.0"));
+        assertTrue(RuntimeVersionRangeSupport.contains("(,1.0.0]", "0.0.0"));
+        assertTrue(RuntimeVersionRangeSupport.contains("[1.0.0,)", "100.0.0"));
+        assertFalse(RuntimeVersionRangeSupport.contains("(1.0.0,)", "1.0.0"));
+    }
+    
+    @Test
+    void testCaseSensitivePrereleasePrecedence() {
+        assertTrue(RuntimeVersionRangeSupport.contains("[1.0.0-RC1,1.0.0)",
+            "1.0.0-rc1"));
+        assertFalse(RuntimeVersionRangeSupport.contains("[1.0.0-rc1,1.0.0)",
+            "1.0.0-RC1"));
+    }
+    
+    @Test
+    void testRejectInvalidInputs() {
+        assertThrows(IllegalArgumentException.class,
+            () -> RuntimeVersionRangeSupport.exact(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> RuntimeVersionRangeSupport.canonicalize("[2.0.0,1.0.0]"));
+        assertThrows(IllegalArgumentException.class,
+            () -> RuntimeVersionRangeSupport.contains("[1.0.0]", "1.0"));
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentCardUtilTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentCardUtilTest.java
@@ -143,9 +143,9 @@ class AgentCardUtilTest {
         instance.setPort(8080);
         
         Map<String, String> metadata = new HashMap<>();
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS, "true");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_PATH_KEY, "/agent");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "true");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PATH_KEY, "/agent");
         instance.setMetadata(metadata);
         
         // When
@@ -166,9 +166,9 @@ class AgentCardUtilTest {
         instance.setPort(8080);
         
         Map<String, String> metadata = new HashMap<>();
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS, "false");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_PATH_KEY, "/agent");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "false");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PATH_KEY, "/agent");
         instance.setMetadata(metadata);
         
         // When
@@ -189,8 +189,8 @@ class AgentCardUtilTest {
         instance.setPort(8080);
         
         Map<String, String> metadata = new HashMap<>();
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS, "false");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "false");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
         instance.setMetadata(metadata);
         
         // When
@@ -211,9 +211,9 @@ class AgentCardUtilTest {
         instance.setPort(8080);
         
         Map<String, String> metadata = new HashMap<>();
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS, "false");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_PATH_KEY, "agent");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "false");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PATH_KEY, "agent");
         instance.setMetadata(metadata);
         
         // When
@@ -234,10 +234,10 @@ class AgentCardUtilTest {
         instance.setPort(8080);
         
         Map<String, String> metadata = new HashMap<>();
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS, "false");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "GRPC");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_PATH_KEY, "/agent");
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_KEY, "grpc");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "false");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "GRPC");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PATH_KEY, "/agent");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY, "grpc");
         instance.setMetadata(metadata);
         
         // When
@@ -258,10 +258,10 @@ class AgentCardUtilTest {
         instance.setPort(8080);
         
         Map<String, String> metadata = new HashMap<>();
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS, "false");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_PATH_KEY, "/agent");
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_QUERY_KEY, "param1=value1&param2=value2");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "false");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PATH_KEY, "/agent");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY, "param1=value1&param2=value2");
         instance.setMetadata(metadata);
         
         // When
@@ -282,11 +282,11 @@ class AgentCardUtilTest {
         instance.setPort(8080);
         
         Map<String, String> metadata = new HashMap<>();
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS, "true");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_PATH_KEY, "/agent");
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_KEY, "https");
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_QUERY_KEY, "token=abc123");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "true");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PATH_KEY, "/agent");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY, "https");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY, "token=abc123");
         instance.setMetadata(metadata);
         
         // When
@@ -322,10 +322,10 @@ class AgentCardUtilTest {
         instance.setIp("127.0.0.1");
         instance.setPort(8080);
         Map<String, String> metadata = new HashMap<>();
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS, "false");
-        metadata.put(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_VERSION_KEY, "1.0");
-        metadata.put(Constants.A2A.NACOS_AGENT_ENDPOINT_TENANT_KEY, "public");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY, "false");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY, "JSONRPC");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY, "1.0");
+        metadata.put(Constants.Agent.AGENT_ENDPOINT_TENANT_KEY, "public");
         instance.setMetadata(metadata);
         AgentInterface result = AgentCardUtil.buildAgentInterface(instance);
         assertEquals("1.0", result.getProtocolVersion());

--- a/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentEndpointUtilTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/utils/AgentEndpointUtilTest.java
@@ -50,19 +50,19 @@ class AgentEndpointUtilTest {
         
         Map<String, String> metadata = instance.getMetadata();
         assertNotNull(metadata);
-        assertEquals(endpoint.getPath(), metadata.get(Constants.A2A.AGENT_ENDPOINT_PATH_KEY));
+        assertEquals(endpoint.getPath(), metadata.get(Constants.Agent.AGENT_ENDPOINT_PATH_KEY));
         assertEquals(endpoint.getTransport(),
-            metadata.get(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY));
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY));
         assertEquals(String.valueOf(endpoint.isSupportTls()),
-            metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_SUPPORT_TLS));
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_SUPPORT_TLS_KEY));
         assertEquals(endpoint.getProtocol(),
-            metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_KEY));
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY));
         assertEquals(endpoint.getQuery(),
-            metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_QUERY_KEY));
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY));
         assertEquals(endpoint.getProtocolVersion(),
-            metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_VERSION_KEY));
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY));
         assertEquals(endpoint.getTenant(),
-            metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_TENANT_KEY));
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_TENANT_KEY));
         
         assertDoesNotThrow(instance::validate);
     }
@@ -86,11 +86,11 @@ class AgentEndpointUtilTest {
         
         Map<String, String> metadata = instance.getMetadata();
         assertNotNull(metadata);
-        assertEquals("", metadata.get(Constants.A2A.AGENT_ENDPOINT_PATH_KEY));
-        assertEquals("", metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_KEY));
-        assertEquals("", metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_QUERY_KEY));
-        assertEquals("", metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_VERSION_KEY));
-        assertEquals("", metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_TENANT_KEY));
+        assertEquals("", metadata.get(Constants.Agent.AGENT_ENDPOINT_PATH_KEY));
+        assertEquals("", metadata.get(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY));
+        assertEquals("", metadata.get(Constants.Agent.AGENT_ENDPOINT_QUERY_KEY));
+        assertEquals("", metadata.get(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_VERSION_KEY));
+        assertEquals("", metadata.get(Constants.Agent.AGENT_ENDPOINT_TENANT_KEY));
         
         assertDoesNotThrow(instance::validate);
     }
@@ -115,9 +115,9 @@ class AgentEndpointUtilTest {
         Map<String, String> metadata = instance.getMetadata();
         assertNotNull(metadata);
         assertEquals(endpoint.getProtocol(),
-            metadata.get(Constants.A2A.NACOS_AGENT_ENDPOINT_PROTOCOL_KEY));
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_PROTOCOL_KEY));
         assertEquals(endpoint.getTransport(),
-            metadata.get(Constants.A2A.AGENT_ENDPOINT_TRANSPORT_KEY));
+            metadata.get(Constants.Agent.AGENT_ENDPOINT_TRANSPORT_KEY));
         
         assertDoesNotThrow(instance::validate);
     }

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/rad/AgentEndpointDeregistrationBatch.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/rad/AgentEndpointDeregistrationBatch.java
@@ -23,7 +23,10 @@ import java.io.Serializable;
 import java.util.List;
 
 /**
- * Batch command that deregisters runtime Agent endpoints by natural key.
+ * Client-side intent that deregisters Runtime Endpoints by natural key.
+ *
+ * <p>The SDK applies this intent to its complete publisher batch and registers the retained
+ * replacement. When no Endpoint remains, it deregisters the complete publisher service.</p>
  *
  * @author Nacos
  */

--- a/api/src/main/java/com/alibaba/nacos/api/ai/model/rad/AgentEndpointRegistrationBatch.java
+++ b/api/src/main/java/com/alibaba/nacos/api/ai/model/rad/AgentEndpointRegistrationBatch.java
@@ -23,7 +23,9 @@ import java.io.Serializable;
 import java.util.List;
 
 /**
- * Batch command that registers or updates runtime Agent endpoints.
+ * Complete Runtime Endpoint batch for one publisher, Agent, protocol, and Version binding.
+ *
+ * <p>A later batch replaces the previous batch for the same publisher and Naming service.</p>
  *
  * @author Nacos
  */

--- a/specs/en/ai/a2a-agent-spec.md
+++ b/specs/en/ai/a2a-agent-spec.md
@@ -98,24 +98,28 @@ records without logging the complete descriptor or sensitive endpoint metadata.
 
 ## 4. Legacy Runtime Endpoint Writes
 
-Legacy single and batch endpoint operations retain replacement semantics under
-this compatibility scope:
+Legacy single and batch endpoint operations remain on the existing
+Version-specific Naming layout during the first compatibility phase:
 
 ```text
 publisher + namespaceId + agentName + exactVersion + protocol=a2a
+
+group=agent-endpoints
+serviceName=<legacyEncodedAgentName>::<exactVersion>
 ```
 
-Single register replaces the scope with one endpoint; batch register replaces
-it with the submitted set. The adapter maps the exact version to
-`runtimeVersion=version` and `versionRange=[version]` and writes through the
-canonical Runtime Endpoint Registry.
+Single register delegates to the existing Naming single-instance operation and
+replaces the publication with one endpoint. Batch register delegates to Naming
+batch registration and replaces the complete submitted batch. Legacy
+deregister removes the complete publication for the exact-Version service.
 
-The Registry stores separate publisher contribution groups for different exact
-versions even when they use the same public endpoint natural key. Legacy
-deregister removes only the requested exact-version contribution group. This
-internal compatibility operation is intentionally narrower than RAD
-`Deregister`, which removes the current publisher's bindings for the submitted
-natural endpoint keys.
+The compatibility handler does not redirect these writes to the new
+Version-neutral RAD Runtime Service, does not write `runtimeVersion` or
+`versionRange` metadata, and does not enter the new RAD Runtime write path. An
+old A2A client cannot submit the complete cross-Version publisher batch
+required by that Service; redirecting it would allow one Version registration
+to overwrite another. Migration, dual read or write, cutover, rollback, and
+old-service cleanup require a separate rolling-upgrade contract.
 
 Endpoint publication may precede Agent or Version creation. It never creates an
 Agent definition implicitly.

--- a/specs/en/ai/agent-api-spec.md
+++ b/specs/en/ai/agent-api-spec.md
@@ -79,8 +79,9 @@ complete, non-paged snapshot.
 |---|---|
 | Missing or invalid field, invalid URI/range, or duplicate endpoint natural key | Standard parameter error |
 | Invisible or absent Discover target | `RESOURCE_NOT_FOUND`; no visibility distinction |
-| Endpoint pre-registration when no Agent definition exists | Accepted after structural, authorization, quota, and conflict validation |
-| Metadata CAS or publisher-payload conflict | `RESOURCE_CONFLICT` |
+| Endpoint pre-registration when no Agent definition exists | Accepted after structural, authorization, and per-batch quota validation |
+| Metadata CAS conflict | `RESOURCE_CONFLICT` |
+| Converged runtime projection contains conflicting publisher payloads | `RESOURCE_CONFLICT` |
 | Invalid Version lifecycle transition | `ILLEGAL_STATE` |
 | HTTP heartbeat for unknown client | HTTP 404 and the distinct `HTTP_CLIENT_NOT_FOUND` application code |
 | Unsupported negotiated transport capability | Local `FEATURE_NOT_SUPPORTED`; no remote request |
@@ -119,8 +120,15 @@ complete replacement results. `getAll`, `selectOneHealthy`, protocol choice,
 priority/weight selection, and actual Agent calling are local SDK helpers, not
 additional remote operations.
 
-Register is a natural-key upsert and does not replace omitted endpoints. The
-SDK stores registration batches as redo intent. The initial implementation may
+One registration batch is the complete desired state for the SDK publisher and
+`(namespaceId, agentName, protocol)`. Register replaces the previous batch,
+including its single `runtimeVersion` and `versionRange`; omitted Endpoints are
+removed. The SDK stores that complete batch as redo intent.
+
+`deregisterAgentEndpoints` remains a convenience method over natural keys. The
+SDK removes those keys from its expected batch and sends the complete remaining
+batch through Register. When no Endpoint remains, it sends a whole-publication
+deregistration. The initial implementation may
 omit a new generic Agent-definition publish method, but existing
 `A2aService.releaseAgentCard` remains functional through the compatibility
 adapter. A later Client SDK revision will provide an optional code-first Agent
@@ -149,8 +157,8 @@ blindly repeated through HTTP.
 |---|---|---|---|
 | GET | `/v3/client/ai/agents/search` | RAD search query | `Result<Page<AgentCatalogEntry>>` |
 | GET | `/v3/client/ai/agents` | RAD reference and optional filter query | `Result<AgentDiscoveryResult>` |
-| POST | `/v3/client/ai/agents/endpoints` | `AgentEndpointRegistrationBatch` | `Result<ClientLivenessInfo>` |
-| DELETE | `/v3/client/ai/agents/endpoints` | JSON `AgentEndpointDeregistrationBatch` | `Result<Void>` |
+| POST | `/v3/client/ai/agents/endpoints` | Complete `AgentEndpointRegistrationBatch` | `Result<ClientLivenessInfo>` |
+| DELETE | `/v3/client/ai/agents/endpoints` | JSON `namespaceId + agentName + protocol` publication identity | `Result<Void>` |
 | PUT | `/v3/client/ai/agents/endpoints/heartbeat` | No body | `Result<ClientLivenessInfo>` |
 
 Search query names equal RAD field names. Repeated `tagsAll` values use AND;
@@ -162,11 +170,18 @@ parameters are `protocol`, `transport`, and `endpointSource`.
 `protocolVersion` is singular. `metadataSelector` is one URL-encoded JSON
 object rather than dynamic `metadata.<key>` parameter names.
 
-The Endpoint path deliberately uses only POST and DELETE. POST already upserts
-complete endpoint values, so a general PUT would introduce ambiguous partial
-update semantics. GET is unnecessary because consumers use Discover and
-maintainers use `RuntimeEndpointSnapshot`. DELETE with a JSON body is the only
-0.1 binding and requires clients and gateways that preserve that body.
+The Endpoint path deliberately uses only POST and DELETE. POST replaces the
+current publisher's complete batch for one Agent and protocol, so a general
+PUT would duplicate the same replacement operation. GET is unnecessary because
+consumers use Discover and maintainers use `RuntimeEndpointSnapshot`.
+
+DELETE removes the current HTTP publisher's whole publication for the supplied
+Agent and protocol. It does not accept endpoint keys. The official SDK
+implements partial deregistration by updating its local expected batch and
+POSTing the complete remainder; it uses DELETE only when that remainder is
+empty. A direct HTTP caller likewise owns its complete desired batch. The
+three-field DELETE body is a binding object, not a replacement for the
+application-facing `AgentEndpointDeregistrationBatch` RAD model.
 
 ### 2.4 HTTP Publisher Identity And Liveness
 
@@ -207,7 +222,8 @@ The server routes HTTP publisher state by `clientId` through Distro type
 `lastActiveTime`, and timeout task. Peers receive complete client state needed
 to rebuild the Naming/RAD projection. A new owner starts its failover grace
 period only after receiving a complete snapshot; otherwise it returns
-`HTTP_CLIENT_NOT_FOUND`, and the client redoes every expected endpoint group.
+`HTTP_CLIENT_NOT_FOUND`, and the client redoes every expected complete service
+batch.
 The first accepted write binds the client id to authenticated identity and
 namespace. Later mismatches are rejected. The same string in another module
 does not share liveness or cleanup state.
@@ -220,13 +236,26 @@ does not share liveness or cleanup state.
 | `AgentDiscoveryRequest` | `AgentDiscoveryResponse` | One Discover |
 | `AgentSubscribeRequest` | `AgentSubscribeResponse` | Subscribe or unsubscribe; a successful subscription returns an opaque `watchKey` and the current complete result |
 | `AgentDiscoveryNotifyRequest` | `AgentDiscoveryNotifyResponse` | Push a `SNAPSHOT` or `TERMINATED` event for one `watchKey` and receive an acknowledgement |
-| `AgentEndpointRegisterRequest` | `AgentEndpointOperationResponse` | Register one RAD batch |
-| `AgentEndpointDeregisterRequest` | `AgentEndpointOperationResponse` | Deregister one RAD batch |
+| `AgentEndpointRegisterRequest` | `AgentEndpointOperationResponse` | Replace one complete RAD batch for the connection, Agent, and protocol |
+| `AgentEndpointDeregisterRequest` | `AgentEndpointOperationResponse` | Remove the connection's whole publication for one Agent and protocol |
 
 All requests report module `ai`. gRPC endpoint contributions belong to
 `RequestMeta.connectionId`; no client id or heartbeat payload is added.
 Disconnect removes that connection's contributions. Reconnect obtains a new
 connection id and redoes endpoints and subscriptions.
+
+The endpoint handlers are Naming adapters. Register validates and converts the
+submitted complete Endpoint batch to Naming Instances, then invokes Naming
+batch registration. Deregister invokes Naming whole-publication deregistration.
+They do not read or merge the previous publisher batch, add an Agent service
+lock, directly query Naming's client index, or scan other publishers during a
+write.
+
+Runtime Snapshot, Discover, and Watch read the complete internal Naming
+`ServiceStorage` projection. They construct one binding from each Instance's
+singular runtime Version and Version-range metadata, retain ranges matching the
+requested Version, and aggregate the resulting `bindings[]` and health by
+public Endpoint natural key.
 
 `AgentSubscribeResponse.watchKey` is the binding-defined opaque identity for
 the accepted wire subscription. The SDK maps it to the canonical local Watch
@@ -265,18 +294,21 @@ does not authorize sending a RAD payload through a legacy fallback.
 | Event | Required behavior |
 |---|---|
 | Repeat identical Register | Success without semantic change |
-| Register changed non-identity fields | Upsert that publisher contribution |
+| Register changed content, runtime Version, or range | Replace that publisher's complete service batch |
 | Duplicate natural key in one batch | Reject the complete batch |
-| Repeat Deregister | Success without change |
+| Partial SDK Deregister | Remove keys from local expected state and Register the complete remainder |
+| Last SDK Deregister or direct remote Deregister | Remove the publisher's whole service publication |
+| Repeat whole-publication Deregister | Success without change |
 | Repeat heartbeat | Refresh only client liveness |
 | HTTP timeout | Retry with the same client id and identical payload using backoff |
-| `HTTP_CLIENT_NOT_FOUND` | Mark all local endpoint intent unregistered and redo by complete group |
-| gRPC reconnect | Redo endpoints and subscriptions under the new connection id |
+| `HTTP_CLIENT_NOT_FOUND` | Mark local endpoint intent unregistered and redo each complete service batch |
+| gRPC reconnect | Redo complete endpoint batches and subscriptions under the new connection id |
 | Cross-transport deregistration | Forbidden; one publisher identity cannot remove another transport's contribution |
 
-The SDK records expected state before the first write. Shutdown performs a
-best-effort deregistration; expiry remains the cleanup fallback. Parameter,
-authorization, and publisher-conflict errors do not enter infinite redo.
+The SDK records expected state before the first write and serializes desired
+batch changes per Agent and protocol. Shutdown performs a best-effort
+whole-publication deregistration; expiry remains the cleanup fallback.
+Parameter and authorization errors do not enter infinite redo.
 
 ## 3. Admin API And Maintainer SDK
 
@@ -382,5 +414,9 @@ RAD ability:
 
 Legacy Console A2A APIs are supported through the Nacos 3.4 line. Legacy Admin
 and Maintainer A2A APIs remain through the Nacos 4.0 compatibility boundary.
+During this compatibility window, legacy A2A Endpoint APIs keep their existing
+version-qualified Naming layout and replacement scopes. They are not rewritten
+onto the new version-neutral Agent Naming service, because an old client cannot
+construct the complete cross-Version publisher batch required by that service.
 Historical data migration and mixed-version rolling-upgrade behavior are a
 separate specification and must not be inferred from this API-only contract.

--- a/specs/en/ai/agent-management-spec.md
+++ b/specs/en/ai/agent-management-spec.md
@@ -324,8 +324,12 @@ state = AVAILABLE | DISABLED | UNHEALTHY
 
 State evaluation is ordered: `enabled=false` is `DISABLED`; otherwise
 `healthy=false` is `UNHEALTHY`; all other items are `AVAILABLE`.
-`lastUpdatedTime` changes only when public Endpoint content, enabled state, or
-aggregate health changes. A heartbeat alone does not change it.
+`lastUpdatedTime` is the `lastRefTime` of the Naming `ServiceInfo` projection
+from which the snapshot was built. All items from one snapshot therefore share
+the same projection observation time. It is not a per-Endpoint distributed
+fact or a cache validator and may change whenever Naming rebuilds that Service
+projection. Cross-node equality and watch deduplication use the content-derived
+`sourceRevision` instead.
 
 `protocol` is required. Without `version`, the snapshot contains one effective
 item per natural Endpoint key for that protocol and all of its Version

--- a/specs/en/ai/agent-storage-spec.md
+++ b/specs/en/ai/agent-storage-spec.md
@@ -45,7 +45,7 @@ RUNTIME publisher contributions ------> Naming Client runtime state
 | `ai_resource` | Agent identity, catalog, governance, version summary, and derived online catalog. | Version payload or runtime health. |
 | `ai_resource_version` | Exact Version identity, lifecycle status, author, storage pointer, and pipeline state. | CallInterface payload or runtime endpoint. |
 | AI Storage | Canonical `AgentVersionContent` bytes for one Version. | Resource identity, lifecycle, labels, or visibility. |
-| Naming Client state | Live publisher contributions, health, enabled state, and version bindings. | Agent definition or Version lifecycle. |
+| Naming Client state | Live publisher contributions, health, enabled state, and singular runtime Version/range facts. | Agent definition or Version lifecycle. |
 
 The service must not persist a merged `AgentDiscoveryResult`. Summary,
 management detail, catalog, discovery, and watch objects are read projections
@@ -293,91 +293,83 @@ namespaceId / agentName / runtimeVersion / versionRange? / protocol
 endpoints[1..1000]
 ```
 
-All Endpoints in a batch share the Version binding and protocol. A one-item
-array is the generic single-Endpoint form. The command itself is not persisted.
-The server validates the complete batch before applying it atomically. A
-duplicate natural key rejects the batch. Registration upserts only listed
-contributions and does not remove omitted Endpoints; repeating identical
-content succeeds without a semantic change.
+All Endpoints in a batch share one `runtimeVersion`/`versionRange` pair and
+protocol. A one-item array is the generic single-Endpoint form. The command
+itself is not persisted.
+The batch is the publisher's complete desired state for the composed Naming
+Service. The server validates the complete batch and delegates it to Naming
+`batchRegisterInstance`. Naming atomically replaces the previous batch for the
+same Client and Service; omitted Endpoints are removed. A duplicate natural key
+rejects the batch. Repeating identical content is idempotent.
 
 `AgentEndpointDeregistrationBatch` contains only `namespaceId`, `agentName`,
-`protocol`, and `endpoints[] {uri, transport}`. For the current publisher, each
-natural Endpoint key removes all of that publisher's Version-binding groups.
-The caller does not submit or cache endpoint ids, runtime Versions, ranges,
-metadata, priority, or weight.
+`protocol`, and `endpoints[] {uri, transport}`. It is an SDK-side intent model,
+not a server-side partial-delete command. The SDK removes the listed natural
+keys from its redo state and submits the retained complete batch through the
+same registration path. When no Endpoint remains, it deregisters the complete
+Client and Service publication. The server never reads and merges the previous
+batch for a partial deregistration.
 
 ### 4.3 Internal Publisher Contributions
 
-The internal publication-group identity is:
+The Naming publication identity is:
 
 ```text
 publisherIdentity
 + namespaceId + agentName + protocol
-+ runtimeVersion + canonicalVersionRange
 ```
 
-An Endpoint contribution identity appends the public Endpoint natural key.
-This distinction is mandatory:
+Naming stores exactly one `BatchInstancePublishInfo` for that Client and
+Service. Its Instances carry one shared `runtimeVersion` and canonical
+`versionRange`. A later registration replaces that complete record, including
+the shared Version fields. The first release therefore allows one singular
+`runtimeVersion` and `versionRange` pair per publisher, Agent, and protocol.
+Supporting multiple pairs requires a future complete-snapshot wire model, not
+a server-side read-merge-write loop.
 
-- one publisher may bind the same host, port, and transport through multiple
-  runtime-Version/range groups;
-- Version bindings do not create version-specific Naming services or duplicate
-  the public Endpoint in a target discovery result;
-- registering the same contribution identity is an upsert; and
-- the new generic deregistration command removes every matching group for that
-  publisher and natural Endpoint.
+The Agent layer does not inspect the previous publisher record, depend directly
+on `ClientServiceIndexesManager`, add a service lock, or scan other publishers
+before a write. Naming owns replacement, connection cleanup, indexes, events,
+and Distro AP convergence. The Agent layer only validates and converts the
+complete batch.
 
-The compatibility adapter may use an internal group-delete operation. It
-deletes only one exact publication group and is not part of the public RAD
-command set. The old A2A exact-Version deregistration uses this operation so it
-does not remove the same publisher's contributions for another Version.
-
-Across all live contributions, the same public natural Endpoint key must have
-one canonical public Endpoint payload, regardless of publisher identity or
-whether their Version ranges overlap. A registration whose URI scheme, path,
-query, priority, weight, or public metadata differs from the existing payload is
-rejected as a contribution conflict. Contributions may add distinct Version
-bindings only when their canonical Endpoint payload is identical.
+Different publishers may contribute Instances that converge to the same public
+natural Endpoint key. The read projection aggregates identical canonical
+payloads. If converged Naming state contains different URI payload fields,
+priority, weight, or public metadata for the same natural key, the read fails
+with `RESOURCE_CONFLICT` instead of selecting an arbitrary value. This is a
+projection-safety check, not a write-time reservation or CP constraint.
 
 ### 4.4 Bindings Aggregation
 
-Naming publisher contributions are aggregated into an Endpoint projection
-with a canonical `bindings[]` array:
-
-```json
-[
-  {"runtimeVersion":"1.0.6","versionRange":"[1.0.0,2.0.0)"}
-]
-```
-
-The array is deduplicated and sorted in ascending Agent SemVer order by
-`runtimeVersion`, then in ascending case-sensitive string order by
-`versionRange`. This exact array is the Version-matching fact.
-
-Each effective publisher record stores it under
-`__nacos.agent.endpoint.bindings__`. When the array contains exactly one item,
-the record also writes these diagnostic and initial-release compatibility
-mirrors:
+Each Naming Instance stores one canonical binding in the singular metadata
+keys:
 
 ```text
 __nacos.agent.endpoint.version__       = runtimeVersion
-__nacos.agent.endpoint.versionRange__  = versionRange
+__nacos.agent.endpoint.versionRange__  = canonicalVersionRange
 ```
 
-When the array contains more than one item, both singular keys are removed.
-Readers always use `bindings` when present and must not merge stale singular
-keys into it.
+There is no serialized `bindings` metadata value. `RuntimeVersionBinding`
+objects and public `bindings[]` arrays are created only while reading the
+Naming Service projection. Bindings are deduplicated and sorted in ascending
+Agent SemVer order by `runtimeVersion`, then in ascending case-sensitive string
+order by `versionRange`.
 
-`RuntimeEndpointSnapshot` aggregates publisher contributions without exposing
+`RuntimeEndpointSnapshot` reads the complete internal Naming Service projection
+from `ServiceStorage`, then aggregates projected Instances without exposing
 publisher identity. It contains exactly one item per public natural Endpoint
 key, with the canonical Endpoint payload and all effective `bindings[]`. A
 Version-filtered snapshot retains only matching bindings and omits an item when
-none remain.
+none remain. `ServiceStorage` may deduplicate completely identical Instances;
+this does not alter the public projection because identical Instance payload,
+bindings, enabled state, and health would aggregate into the same public item.
 
 RAD discovery first filters bindings for the target Version, then aggregates
-equal natural keys into one public Endpoint. Because every inconsistent payload
-is rejected at write time, one target Version never produces two
-different public payloads for the same natural key.
+equal natural keys into one public Endpoint. A projection rebuild rejects
+inconsistent payloads visible after AP convergence. Therefore one successful
+target-Version projection never contains two different public payloads for the
+same natural key.
 
 ### 4.5 Pre-registration And Lifecycle
 
@@ -387,8 +379,8 @@ Version, or CallInterface does not exist. Registration success means runtime
 intent was accepted; it does not imply current discoverability.
 
 Registration validates AgentName, runtime Version, range, protocol, Endpoint,
-authorization, capacity, and contribution conflicts. It does not validate
-definition existence or Version lifecycle status.
+authorization, and batch capacity. It does not validate definition existence,
+Version lifecycle status, or other publishers' current values.
 
 Publisher identity is internal:
 
@@ -475,8 +467,8 @@ metadata and must agree on read.
 | HTTPS state | `__nacos.agent.endpoint.supportTls__`. |
 | raw URI query | `__nacos.agent.endpoint.query__`. |
 | native tenant, when present | `__nacos.agent.endpoint.tenant__`. |
-| canonical bindings | `__nacos.agent.endpoint.bindings__`. |
-| single-binding diagnostic mirrors | `__nacos.agent.endpoint.version__`, `__nacos.agent.endpoint.versionRange__`. |
+| runtime Version | `__nacos.agent.endpoint.version__`. |
+| canonical Version range | `__nacos.agent.endpoint.versionRange__`. |
 | priority | `__nacos.agent.endpoint.priority__`. |
 | weight | `Instance.weight`. |
 | public Endpoint metadata | Remaining `Instance.metadata`. |
@@ -484,17 +476,14 @@ metadata and must agree on read.
 
 User metadata must not override any `__nacos.agent.endpoint.*__` key. The server
 constructs and validates the complete Naming metadata before accepting a
-publication. Missing range input is canonicalized before writing `bindings`.
+publication. Missing range input is canonicalized before writing
+`versionRange`.
 
 `__nacos.agent.endpoint.protocolVersion__` is a legacy-only compatibility fact.
-Only the A2A compatibility adapter writes it. It is excluded from public RAD
-Endpoint metadata and Runtime revision input. When projecting an old A2A
-response, the adapter prefers this value and falls back to the target
-CallInterface `protocolVersion` when it is absent. The aggregate writes this
-singular key only while every represented A2A contribution reports the same
-value; if values differ, it removes the key and each exact-Version projection
-uses its target CallInterface fallback. A disagreement is not a public Endpoint
-payload conflict.
+It is excluded from public RAD Endpoint metadata and Runtime revision input.
+When projecting an old A2A response, the compatibility adapter prefers this
+value and falls back to the target CallInterface `protocolVersion` when it is
+absent.
 
 The public natural key maps to service, cluster, IP, and port. Path and query
 remain payload metadata. No Version appears in serviceName or clusterName, so
@@ -502,14 +491,28 @@ the service count does not grow with compatible Agent Versions.
 
 ### 5.3 Naming Fact Boundary
 
-Naming Client publisher contributions, including their canonical bindings, are
-the RUNTIME fact source. Ordinary Naming `ServiceInfo` may collapse equal IP and
-port entries, apply selector or health-protection behavior, and cannot preserve
-all Agent publication groups. It is not a RAD fact source.
+Naming Client state remains the RUNTIME write fact and owns publisher identity,
+connection or heartbeat liveness, cleanup, complete-batch replacement, indexes,
+events, and AP convergence. Registration converts a complete Agent Endpoint
+batch to Naming Instances and invokes Naming once. Complete deregistration
+removes the Client and Service publication. The Agent server does not read or
+merge the old publisher record.
 
-Agent runtime reads aggregate raw publisher contributions from the Naming
-Client/index path, then apply binding and enabled filters. They must not forward
-a standard Naming Java SDK subscription result as a RAD watch snapshot.
+Runtime Snapshot and Discover reads use the complete internal Service
+projection cached by Naming `ServiceStorage`. That projection is built from the
+service-scoped Client index and includes operational Instance metadata. The
+Agent layer parses each Instance's singular binding, applies an optional
+target-Version filter, validates payload consistency, and aggregates by the
+public natural Endpoint key.
+Deduplication of completely identical Instances inside `ServiceStorage` is safe
+because redundant identical publications do not change any public aggregate
+field.
+
+The internal `ServiceInfo` container returned by `ServiceStorage` is not the
+same contract as a Naming result exposed through an SDK, HTTP API, selector, or
+health-protection path. An external or post-processed Naming `ServiceInfo` must
+not be treated as the Runtime fact source or forwarded directly as a RAD Watch
+snapshot.
 
 Operational Naming metadata for `enabled` and `weight` has its normal
 precedence over runtime publication values. The Agent projection still retains
@@ -542,7 +545,7 @@ For each
 `(namespaceId, agentName, targetVersion, protocol, source=RUNTIME)`, the server
 generates an opaque `sourceRevision` after it:
 
-1. aggregates live publisher contributions;
+1. reads the complete internal Naming Service projection from `ServiceStorage`;
 2. selects bindings that contain the target Version;
 3. canonicalizes each Endpoint URI, validates and preserves transport,
    materializes effective `priority=0` and `weight=1`, and requires `healthy`;
@@ -595,8 +598,9 @@ by `h2`, each as an unsigned eight-byte big-endian value, and then lowercase
 hexadecimal. These rules are also machine-readable in internal storage schema
 version 1.
 
-Implementations mark semantic projections dirty, coalesce bursts, and cache
-the result. They must not hash every heartbeat or every discovery read.
+Naming `ServiceStorage` supplies the current cached Service projection. The
+Agent read path derives the public Endpoint set and its revision from that
+result without maintaining another projection cache.
 
 Persistent AgentVersion content continues to use SHA-256. A DECLARED endpoint
 set uses the Version `contentDigest` as its opaque source revision.
@@ -608,7 +612,7 @@ set uses the Version `contentDigest` as its opaque source revision.
 | Management Agent list or RAD Search | `ai_resource` page. | No |
 | Agent overview | Resource plus bounded Version-row page. | No |
 | Exact Version detail | One Version row. | One |
-| Runtime Endpoint snapshot | Raw Naming publisher contributions for one protocol; optional binding filter. | No |
+| Runtime Endpoint snapshot | Complete internal `ServiceStorage` projection for one protocol; optional binding filter. | No |
 | RAD Discover | Resource, online Version, cached content, and eligible runtime projection. | Once on digest miss |
 
 | Change | Write target | Consistency rule |
@@ -625,6 +629,11 @@ Cache validators follow facts:
 | Agent metadata | `metaVersion`. |
 | Agent Version content | `contentDigest`. |
 | Target runtime projection | `sourceRevision`. |
+
+Naming `ServiceStorage` owns the complete per-Service projection cache. The
+Agent layer does not maintain another Runtime registry or projection cache; it
+derives the requested Agent projection from the current `ServiceStorage`
+result. `sourceRevision` is computed from the resulting public Endpoint set.
 
 An AI Storage provider guarantees atomic bytes for one StorageKey and the read
 consistency it declares. Agent Registry owns orchestration across Resource,
@@ -682,20 +691,12 @@ The A2A adapter is the first consumer of this storage contract:
 | Runtime calling protocol | Canonical Agent protocol token `a2a`. |
 | Legacy endpoint transport and URI parts | Common Endpoint and reserved Naming metadata. |
 
-Old single and batch registrations keep an exact-Version replacement scope:
+During the initial compatibility phase, old A2A runtime registration keeps its
+existing version-specific Naming layout. It must not be redirected to the new
+version-neutral Service until the A2A client or adapter can maintain and submit
+the complete desired batch for that Service. This prevents one legacy Version
+registration from overwriting another.
 
-```text
-(publisherIdentity, namespaceId, agentName, protocol=a2a,
- runtimeVersion=version, versionRange=[version])
-```
-
-The compatibility adapter replaces that internal group. Old deregistration
-deletes only that exact group, even when the same publisher and physical
-Endpoint have bindings for other Versions. New RAD deregistration instead
-deletes all bindings for the supplied natural Endpoint under the current
-publisher.
-
-After cutover, compatibility writes use the new AI Resource, AI Storage, and
-Naming layouts. Historical Config rows, historical Naming services, mixed
-cluster dual-read or dual-write, cutover, rollback, and malformed historical
+The later cutover to the common Naming layout, historical Naming services,
+mixed-cluster dual-read or dual-write, rollback, and malformed historical
 identity handling belong to a separate rolling-upgrade and migration contract.

--- a/specs/en/ai/rad-protocol-spec.md
+++ b/specs/en/ai/rad-protocol-spec.md
@@ -48,8 +48,8 @@ RAD 0.1.0 defines five operations:
 | `Search` | `AgentSearchRequest` | `AgentCatalogPage` | Search candidate Agents with pagination |
 | `Discover` | `AgentDiscoveryRequest` | `AgentDiscoveryResult` | Return one complete calling snapshot for an Agent version |
 | `Watch` | `AgentDiscoveryRequest` | `AgentDiscoveryResult` stream | Return the initial and subsequent complete replacement snapshots |
-| `Register` | `AgentEndpointRegistrationBatch` | Success or error | Register or update runtime endpoints |
-| `Deregister` | `AgentEndpointDeregistrationBatch` | Success or error | Deregister runtime endpoints |
+| `Register` | `AgentEndpointRegistrationBatch` | Success or error | Replace the current publisher's complete runtime endpoint batch |
+| `Deregister` | `AgentEndpointDeregistrationBatch` | Success or error | Remove endpoint keys from the publisher's desired batch |
 
 `Watch` reuses the `Discover` request and result. RAD does not add an event
 envelope around watched snapshots.
@@ -152,8 +152,8 @@ The schema exposes exactly six root messages:
 | `AgentCatalogPage` | `Search` result |
 | `AgentDiscoveryRequest` | `Discover` and `Watch` request |
 | `AgentDiscoveryResult` | `Discover` and `Watch` complete snapshot |
-| `AgentEndpointRegistrationBatch` | `Register` request |
-| `AgentEndpointDeregistrationBatch` | `Deregister` request |
+| `AgentEndpointRegistrationBatch` | Complete desired batch for `Register` |
+| `AgentEndpointDeregistrationBatch` | Publisher-client desired-state command for `Deregister` |
 
 A language binding may reuse an exactly equivalent native type. For example,
 Java may implement `AgentCatalogPage` as `Page<AgentCatalogEntry>` rather than
@@ -271,7 +271,9 @@ Context rules:
 - A `DECLARED` endpoint MUST NOT contain `healthy`.
 - A `RUNTIME` discovery endpoint MUST contain `healthy`.
 - Deregister submits only `uri` and `transport`, the endpoint natural-key
-  fields represented by the public object.
+  fields represented by the public object. It is a publisher-client convenience
+  command; a Nacos binding applies it to local desired state before sending a
+  complete replacement batch.
 
 Runtime endpoints do not use `endpointId`.
 
@@ -391,6 +393,12 @@ describes Agent versions that the deployment can serve. When absent, the
 server canonicalizes it to `[runtimeVersion]`. `runtimeVersion` MUST be
 contained in the effective range.
 
+For one publisher and `(namespaceId, agentName, protocol)`, this array is the
+complete desired Endpoint batch. Register replaces the previous batch in full;
+an omitted Endpoint is removed. One publisher therefore has one effective
+`runtimeVersion` and `versionRange` for this scope at a time. Changing either
+value is a complete replacement, not an internal group update.
+
 `AgentEndpointDeregistrationBatch` contains:
 
 ```text
@@ -398,9 +406,12 @@ namespaceId / agentName / protocol
 endpoints[] { uri, transport }
 ```
 
-For every supplied natural key, Deregister removes all bindings contributed by
-the current publisher, including bindings from different internal
-`runtimeVersion` and `versionRange` groups.
+`AgentEndpointDeregistrationBatch` is retained as an application-facing
+convenience object. The publisher client removes the supplied natural keys
+from its locally cached registration batch and registers the complete
+remaining batch. When no Endpoint remains, it deregisters the whole publisher
+publication for `(namespaceId, agentName, protocol)`. A Nacos server does not
+perform a partial read-merge-write for this object.
 
 ## 4. Search
 
@@ -491,9 +502,11 @@ Register verifies:
 - request structure, endpoint constraints, authorization, and capacity;
 - valid `runtimeVersion` and `versionRange`, with the runtime version contained
   in the range;
-- no duplicate natural key in one batch and no publication conflict described
-  in Section 7.3;
+- no duplicate natural key in one batch;
 - the request does not submit or overwrite `protocolVersion`.
+
+Register validation is limited to the submitted complete batch. It does not
+scan other publishers or reserve a natural Endpoint key before writing.
 
 Register does not require the Agent, the runtime version, a range boundary, a
 version within the range, or a corresponding calling interface to exist. It
@@ -512,44 +525,64 @@ publication itself.
 
 ### 7.2 Batch, Idempotency, And Atomicity
 
-One registration batch belongs to one:
+One registration batch is the complete desired publication for one publisher
+and:
 
 ```text
-(namespaceId, agentName, protocol, runtimeVersion, versionRange)
+(namespaceId, agentName, protocol)
 ```
+
+`runtimeVersion` and `versionRange` are shared content of that batch, not an
+additional publication identity or a server-managed binding group.
 
 Rules:
 
-- The Registry validates all endpoints before atomically applying one batch.
-- Register adds or updates only listed natural keys and does not replace
-  omitted endpoints.
+- The binding validates all endpoints before atomically applying one complete
+  batch for the current publisher and publication identity.
+- Register replaces the previous batch; omitted endpoints are removed.
 - Repeating identical content for the same publisher succeeds without a
   change.
-- A changed non-identity field performs an upsert.
+- A changed Endpoint field, runtime Version, or range is expressed by replacing
+  the complete batch.
 - A duplicate natural key within one batch rejects the whole batch.
-- Deregister removes only the current publisher's contributions.
-- Deregistering a missing contribution succeeds without a change.
-- Transactions across batches are not guaranteed.
+- The publisher client serializes changes to its local desired batch. Partial
+  Deregister and Version replacement calculate the new batch locally and use
+  Register for the replacement.
+- When the desired batch becomes empty, the binding removes the current
+  publisher's whole publication for the service.
+- Deregistering a missing local contribution succeeds without a remote change.
 
 A single-endpoint operation uses an `endpoints[]` of length one; RAD does not
 define separate single-item commands.
 
-### 7.3 Publication Groups And Multiple Publishers
+The Nacos server path is a data-structure adapter over Naming. It transforms
+the complete Endpoint batch into Naming Instances and invokes Naming batch
+registration or whole-publication deregistration. It does not read the prior
+publisher batch, incrementally merge it, add an Agent service lock, directly
+query the Naming client index, or scan other publishers during a write.
 
-A binding supplies an opaque publisher identity and liveness semantics. The
-identity does not enter discovery results.
+### 7.3 Naming Publication And Multiple Publishers
 
-The Registry may keep multiple internal publication groups for one public
-endpoint natural key, distinguished by `runtimeVersion` and canonical
-`versionRange`. A publisher may therefore contribute the same public endpoint
-through more than one compatible-version declaration. Discover first retains
-groups matching its target version and then aggregates them to one public
-endpoint.
+The publisher transport supplies an opaque identity and liveness semantics.
+The identity does not enter discovery results.
 
-Contributions that can project to the same public endpoint MUST agree on the
-canonical URI, transport, priority, weight, and metadata. A conflicting
-registration returns `CONFLICT`. Health is aggregated across matching active
-contributions:
+Each publisher contributes at most one complete batch, with one singular
+`runtimeVersion` and `versionRange` pair, to one
+`(namespaceId, agentName, protocol)` Naming service. Different publishers may
+contribute different pairs. The Nacos read path loads the complete internal
+Service projection from Naming `ServiceStorage`, retains contributions whose
+range matches the target Version, and aggregates query-time bindings by public
+Endpoint natural key. Agent code does not directly walk the Naming client
+index.
+
+Contributions visible after AP convergence that project to the same public
+Endpoint MUST agree on canonical URI, transport, priority, weight, and
+metadata. Registration does not perform a cross-publisher write-time scan.
+When a converged `ServiceStorage` projection contains conflicting payloads, the
+affected read or Watch reports `CONFLICT` rather than selecting an
+arbitrary value. Removing either conflicting publication restores the
+projection after normal Naming convergence. Health is aggregated across
+matching active contributions:
 
 - at least one healthy contribution produces `healthy=true`;
 - all contributions unhealthy produces `healthy=false`;
@@ -594,9 +627,9 @@ A binding maps these abstract categories to its concrete response model:
 | `NOT_FOUND` | Discover target is absent, invisible, disabled, or not online; watched target later disappears |
 | `PERMISSION_DENIED` | Caller cannot operate in the target namespace |
 | `RESOURCE_EXHAUSTED` | Endpoint or publication capacity is full, or a complete response exceeds a binding limit |
-| `CONFLICT` | Publication contents conflict or a concurrent state conflicts |
+| `CONFLICT` | Converged runtime contributions contain incompatible payloads for one natural Endpoint key |
 | `UNSUPPORTED_CAPABILITY` | Binding does not support the requested operation |
-| `UNAVAILABLE` | Registry cannot currently form a trustworthy snapshot or apply a write |
+| `UNAVAILABLE` | Registry cannot currently read Naming state or apply a write |
 
 An invisible resource and a nonexistent resource both appear as `NOT_FOUND`
 to prevent visibility side channels. An empty filter result is not an error and
@@ -709,3 +742,8 @@ coarse syntax of a version-range string and does not replace domain validation.
   }]
 }
 ```
+
+This is the application-facing SDK command. The SDK removes the natural key
+from its cached batch and sends the complete remaining Register request. If
+the remaining batch is empty, the Nacos binding sends a whole-publication
+deregistration for `namespaceId`, `agentName`, and `protocol`.

--- a/specs/en/grpc-api/api-spec.md
+++ b/specs/en/grpc-api/api-spec.md
@@ -247,8 +247,8 @@ registrations, and negotiated abilities are present in the runtime.
 | `AgentDiscoveryRequest` | `AgentDiscoveryResponse` | read | Discover one Agent and return one complete `AgentDiscoveryResult`. |
 | `AgentSubscribeRequest` | `AgentSubscribeResponse` | read | Subscribe or unsubscribe an Agent reference and optional filter; subscribe returns an opaque `watchKey` and the current complete result. |
 | `AgentDiscoveryNotifyRequest` | `AgentDiscoveryNotifyResponse` | server push | Push one `SNAPSHOT` or `TERMINATED` event for a `watchKey` and receive an acknowledgement. |
-| `AgentEndpointRegisterRequest` | `AgentEndpointOperationResponse` | write | Upsert one runtime Endpoint registration batch owned by the current connection. |
-| `AgentEndpointDeregisterRequest` | `AgentEndpointOperationResponse` | write | Idempotently remove one runtime Endpoint deregistration batch owned by the current connection. |
+| `AgentEndpointRegisterRequest` | `AgentEndpointOperationResponse` | write | Replace the complete runtime Endpoint batch owned by the current connection for one Agent and protocol. |
+| `AgentEndpointDeregisterRequest` | `AgentEndpointOperationResponse` | write | Idempotently remove the current connection's whole runtime Endpoint publication for one Agent and protocol. |
 
 For this target binding, `AgentDiscoveryNotifyRequest` contains `watchKey` and
 `eventType`. `SNAPSHOT` requires a complete `AgentDiscoveryResult` and no

--- a/specs/en/http-api/v3-api-surface.md
+++ b/specs/en/http-api/v3-api-surface.md
@@ -200,8 +200,8 @@ Client target paths:
 | --- | --- | --- |
 | GET | `/v3/client/ai/agents/search` | Search the Agent catalog. |
 | GET | `/v3/client/ai/agents` | Discover one Agent, with an optional discovery filter. |
-| POST | `/v3/client/ai/agents/endpoints` | Upsert a runtime Endpoint registration batch. |
-| DELETE | `/v3/client/ai/agents/endpoints` | Deregister a runtime Endpoint batch using a JSON body. |
+| POST | `/v3/client/ai/agents/endpoints` | Replace the current publisher's complete runtime Endpoint batch. |
+| DELETE | `/v3/client/ai/agents/endpoints` | Remove the current publisher's whole runtime Endpoint publication identified by a JSON body. |
 | PUT | `/v3/client/ai/agents/endpoints/heartbeat` | Refresh one HTTP publisher client's liveness. |
 
 Admin and Console target paths use the prefixes

--- a/specs/en/naming/naming-metadata-selector-spec.md
+++ b/specs/en/naming/naming-metadata-selector-spec.md
@@ -75,27 +75,41 @@ Runtime Endpoint projection. Its version-1 keys are:
 | `__nacos.agent.endpoint.supportTls__` | Whether the projected URI uses TLS. |
 | `__nacos.agent.endpoint.query__` | Raw URI query. |
 | `__nacos.agent.endpoint.tenant__` | Protocol-native tenant when present. |
-| `__nacos.agent.endpoint.version__` | Single-binding runtime Version compatibility and diagnostic mirror. |
-| `__nacos.agent.endpoint.versionRange__` | Single-binding canonical Version range compatibility and diagnostic mirror. |
-| `__nacos.agent.endpoint.bindings__` | Canonical JSON array of runtime Version and Version-range bindings. |
+| `__nacos.agent.endpoint.version__` | Runtime Version of this Instance contribution. |
+| `__nacos.agent.endpoint.versionRange__` | Canonical Version range of this Instance contribution. |
 | `__nacos.agent.endpoint.priority__` | Endpoint priority; a lower number has higher priority. |
 
-Only the Agent Runtime Registry may write keys under this prefix. Public
-runtime and operational metadata writes must reject them, so the ordinary
-operational-over-runtime priority rule does not override Agent projection
-facts. Endpoint weight, enabled state, and health continue to use their native
-Naming Instance fields rather than reserved metadata keys.
+Only the Agent Endpoint Naming adapter may write keys under this prefix.
+Public runtime and operational metadata writes must reject them, so the
+ordinary operational-over-runtime priority rule does not override Agent
+projection facts. Endpoint weight, enabled state, and health continue to use
+their native Naming Instance fields rather than reserved metadata keys.
 
-Only the A2A compatibility adapter writes `protocolVersion`. Public RAD
-Endpoint metadata and Runtime revision exclude it. The old A2A response
-projection prefers this value and falls back to the target Agent CallInterface
-`protocolVersion` when it is absent.
+The current Version-specific A2A compatibility layout may write
+`protocolVersion`; new RAD registration does not. Public RAD Endpoint metadata
+and Runtime revision exclude it. The old A2A response projection prefers this
+value and falls back to the target Agent CallInterface `protocolVersion` when
+it is absent.
 
-`bindings` is the Version-matching fact. When it has exactly one item, the
-Registry also writes `version` and `versionRange` as mirrors. When it has more
-than one item, the Registry removes both singular keys. Readers use `bindings`
-when present and must not merge stale singular values. The exact canonical
-array and Runtime projection rules are defined by the
+Every new Version-neutral RAD Runtime Naming Instance carries exactly one
+`version` and `versionRange` pair. The range must be canonical and contain the
+runtime Version. Naming metadata does not store a serialized bindings array.
+The current Version-specific A2A Naming layout is outside this requirement.
+
+Registration follows Naming complete-batch replacement semantics. The client
+maintains the complete Endpoint batch published by one connection for one
+Agent protocol service, removes or replaces entries locally, and submits the
+remaining complete batch through Naming batch registration. If the resulting
+desired batch is empty, the client invokes whole-publication deregistration
+instead of submitting an empty batch. The server-side Agent adapter maps the
+submitted batch to Naming Instances and must not read and merge the publisher's
+previous batch.
+
+On a new RAD Runtime query, readers construct one `RuntimeVersionBinding` from
+each Instance's singular pair, apply Version-range matching, and aggregate the
+resulting `bindings[]` by natural Endpoint key. `RuntimeVersionBinding` and
+`bindings[]` are query projections rather than Naming registration metadata.
+The exact Runtime projection rules are defined by the
 [Agent Storage Spec](../ai/agent-storage-spec.md).
 
 New core behavior must not be bound to arbitrary user metadata keys. If a

--- a/specs/schemas/ai/agent/internal/v1/agent-storage.schema.json
+++ b/specs/schemas/ai/agent/internal/v1/agent-storage.schema.json
@@ -30,7 +30,6 @@
       "tenant": "__nacos.agent.endpoint.tenant__",
       "version": "__nacos.agent.endpoint.version__",
       "versionRange": "__nacos.agent.endpoint.versionRange__",
-      "bindings": "__nacos.agent.endpoint.bindings__",
       "priority": "__nacos.agent.endpoint.priority__"
     }
   },
@@ -638,41 +637,16 @@
       },
       "$comment": "Version 1 favors a concise readable value and accepts the low-probability tuple collision caused by hyphens in both components; for example, (A, B-C) and (A-B, C) both compose to rad-A-B-C. A collision-free rule requires a new composer id and explicit migration. The value contains only [A-Za-z0-9-], starts with a letter or digit, may end with a letter, digit, or hyphen, and does not claim to be a DNS name."
     },
-    "RuntimeVersionBinding": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "runtimeVersion",
-        "versionRange"
-      ],
-      "properties": {
-        "runtimeVersion": {
-          "$ref": "#/$defs/AgentVersion"
-        },
-        "versionRange": {
-          "$ref": "#/$defs/VersionRange"
-        }
-      },
-      "description": "runtimeVersion must be contained by versionRange."
-    },
-    "RuntimeVersionBindings": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "$ref": "#/$defs/RuntimeVersionBinding"
-      },
-      "description": "Canonical order and semantic deduplication use runtimeVersion then canonical versionRange with case-sensitive Agent version ordering; JSON Schema only enforces exact JSON-value uniqueness."
-    },
     "NamingRuntimeMetadata": {
       "type": "object",
-      "maxProperties": 43,
+      "maxProperties": 42,
       "required": [
         "__nacos.agent.endpoint.path__",
         "__nacos.agent.endpoint.transport__",
         "__nacos.agent.endpoint.protocol__",
         "__nacos.agent.endpoint.supportTls__",
-        "__nacos.agent.endpoint.bindings__",
+        "__nacos.agent.endpoint.version__",
+        "__nacos.agent.endpoint.versionRange__",
         "__nacos.agent.endpoint.priority__"
       ],
       "properties": {
@@ -691,7 +665,7 @@
         },
         "__nacos.agent.endpoint.protocolVersion__": {
           "$ref": "#/$defs/ProtocolVersion",
-          "description": "Optional legacy A2A compatibility fact. Only the compatibility adapter writes it, and only while all represented A2A contributions agree on one value. Public RAD projection and Runtime revision exclude it; differing values remove this singular key and use the target CallInterface fallback."
+          "description": "Optional compatibility fact reserved for a future A2A migration adapter that writes the new RAD layout. The current version-specific legacy A2A publication is outside this definition. Public RAD projection and Runtime revision exclude this value."
         },
         "__nacos.agent.endpoint.supportTls__": {
           "type": "string",
@@ -710,17 +684,12 @@
           "maxLength": 256
         },
         "__nacos.agent.endpoint.version__": {
-          "$ref": "#/$defs/AgentVersion"
+          "$ref": "#/$defs/AgentVersion",
+          "description": "Runtime Version for this single Naming Instance contribution."
         },
         "__nacos.agent.endpoint.versionRange__": {
-          "$ref": "#/$defs/VersionRange"
-        },
-        "__nacos.agent.endpoint.bindings__": {
-          "type": "string",
-          "minLength": 2,
-          "maxLength": 1024,
-          "pattern": "^\\[.*\\]$",
-          "description": "Canonical JSON array of RuntimeVersionBinding objects, sorted and deduplicated. Parsing and equality to NamingRuntimePublication.bindings require domain validation."
+          "$ref": "#/$defs/VersionRange",
+          "description": "Canonical Version range for this single Naming Instance contribution. It must contain the singular runtime Version."
         },
         "__nacos.agent.endpoint.priority__": {
           "type": "string",
@@ -741,7 +710,6 @@
               "__nacos.agent.endpoint.tenant__",
               "__nacos.agent.endpoint.version__",
               "__nacos.agent.endpoint.versionRange__",
-              "__nacos.agent.endpoint.bindings__",
               "__nacos.agent.endpoint.priority__"
             ]
           },
@@ -754,7 +722,7 @@
         "type": "string",
         "maxLength": 256
       },
-      "description": "The sum of Java String.length() for all keys and values must not exceed 1024. At most 32 properties may be public Endpoint metadata; these encoded-size and category-count constraints require domain validation."
+      "description": "Each Naming Instance stores exactly one singular runtime Version and canonical Version range pair; no serialized bindings array is stored. The range must contain the runtime Version. The sum of Java String.length() for all keys and values must not exceed 1024. At most 32 properties may be public Endpoint metadata; these semantic, encoded-size, and category-count constraints require domain validation."
     },
     "NamingRuntimePublication": {
       "type": "object",
@@ -772,7 +740,6 @@
         "ephemeral",
         "enabled",
         "healthy",
-        "bindings",
         "metadata"
       ],
       "properties": {
@@ -822,54 +789,11 @@
         "healthy": {
           "type": "boolean"
         },
-        "bindings": {
-          "$ref": "#/$defs/RuntimeVersionBindings"
-        },
         "metadata": {
           "$ref": "#/$defs/NamingRuntimeMetadata"
         }
       },
-      "oneOf": [
-        {
-          "properties": {
-            "bindings": {
-              "maxItems": 1
-            },
-            "metadata": {
-              "required": [
-                "__nacos.agent.endpoint.version__",
-                "__nacos.agent.endpoint.versionRange__"
-              ]
-            }
-          }
-        },
-        {
-          "properties": {
-            "bindings": {
-              "minItems": 2
-            },
-            "metadata": {
-              "allOf": [
-                {
-                  "not": {
-                    "required": [
-                      "__nacos.agent.endpoint.version__"
-                    ]
-                  }
-                },
-                {
-                  "not": {
-                    "required": [
-                      "__nacos.agent.endpoint.versionRange__"
-                    ]
-                  }
-                }
-              ]
-            }
-          }
-        }
-      ],
-      "$comment": "clusterName must equal the reserved transport metadata. One binding mirrors its runtimeVersion and versionRange into the singular keys. Two or more bindings remove both singular keys. The bindings metadata string must be the canonical JSON serialization of bindings. Across all live contributions, one natural Endpoint key must have one canonical public payload; identical payloads aggregate all bindings into this Naming instance. IP, port, path, query, scheme, and TLS metadata must reconstruct that canonical Endpoint. The optional reserved protocolVersion is written only by the legacy A2A adapter and is excluded from public RAD Endpoint metadata and Runtime revision."
+      "$comment": "This definition covers only the new Version-neutral RAD Naming layout. Current legacy A2A services named <legacyEncodedAgentName>::<exactVersion> and their Instance metadata are outside its scope. clusterName must equal the reserved transport metadata. Each Naming Runtime publication carries exactly one runtime Version and canonical Version range pair in metadata, and the range must contain the runtime Version. A publisher submits the complete Instance batch for one Agent protocol service; a new batch replaces that publisher's previous batch. If the client's desired batch becomes empty, it invokes whole-publication deregistration instead of submitting an empty batch. The server adapter maps the submitted batch without reading and merging old publisher state. Query projections construct one RuntimeVersionBinding per Instance, apply range matching, and aggregate bindings by natural Endpoint key. IP, port, path, query, scheme, and TLS metadata must reconstruct the canonical Endpoint. The optional reserved protocolVersion is excluded from public RAD Endpoint metadata and Runtime revision."
     },
     "RuntimeRevisionContract": {
       "type": "object",
@@ -1080,7 +1004,7 @@
           "const": "murmur3-x64-128-v1:"
         }
       },
-      "$comment": "For one namespaceId/agentName/targetVersion/protocol projection, aggregate publishers by natural Endpoint key, retain bindings matching targetVersion, remove enabled=false, retain both healthy values, canonicalize URI, validate and preserve transport, materialize default priority=0 and weight=1.0, and require healthy. Sort Endpoints by normalizedHost UTF-16 ordinal, effectivePort numeric, then transport UTF-16 ordinal; sort public metadata keys by UTF-16 ordinal. The legacy-only reserved protocolVersion metadata is not public metadata and is excluded from the revision. Revision bytes start with a four-byte unsigned big-endian Endpoint count. For every Endpoint, encode URI and transport as uint32be length-prefixed UTF-8, priority as int32be, weight as big-endian IEEE-754 binary64 with negative zero normalized to positive zero, metadata as uint32be entry count followed by ordered length-prefixed key/value strings, and healthy as one byte 0 or 1. The empty projection is exactly uint32be(0). Hash the bytes with Apache Commons Codec MurmurHash3.hash128x64(byte[], 0, length, 0). Emit h1 followed by h2, each as eight unsigned big-endian bytes, then encode the 16 bytes as 32 lowercase hexadecimal characters. Membership changes caused by bindings or enabled state change the input set; those control fields are not serialized into an included Endpoint."
+      "$comment": "For one namespaceId/agentName/targetVersion/protocol projection, construct a RuntimeVersionBinding from each Naming Instance's singular runtime Version and Version range metadata, retain contributions whose range matches targetVersion, aggregate publishers and query-time bindings by natural Endpoint key, remove enabled=false, retain both healthy values, canonicalize URI, validate and preserve transport, materialize default priority=0 and weight=1.0, and require healthy. Sort Endpoints by normalizedHost UTF-16 ordinal, effectivePort numeric, then transport UTF-16 ordinal; sort public metadata keys by UTF-16 ordinal. The legacy-only reserved protocolVersion metadata is not public metadata and is excluded from the revision. Revision bytes start with a four-byte unsigned big-endian Endpoint count. For every Endpoint, encode URI and transport as uint32be length-prefixed UTF-8, priority as int32be, weight as big-endian IEEE-754 binary64 with negative zero normalized to positive zero, metadata as uint32be entry count followed by ordered length-prefixed key/value strings, and healthy as one byte 0 or 1. The empty projection is exactly uint32be(0). Hash the bytes with Apache Commons Codec MurmurHash3.hash128x64(byte[], 0, length, 0). Emit h1 followed by h2, each as eight unsigned big-endian bytes, then encode the 16 bytes as 32 lowercase hexadecimal characters. Membership changes caused by Version-range matching or enabled state change the input set; those query control fields are not serialized into an included Endpoint."
     }
   }
 }

--- a/specs/zh-cn/ai/a2a-agent-spec.md
+++ b/specs/zh-cn/ai/a2a-agent-spec.md
@@ -83,18 +83,24 @@ A2A Binding 是一个 `AgentCallInterface`：
 
 ## 4. 旧 Runtime Endpoint 写入
 
-旧单条和批量 Endpoint 操作在以下兼容 scope 内保持全量替换语义：
+首个兼容阶段中，旧单条和批量 Endpoint 操作继续使用现有的按 Version 划分 Naming layout：
 
 ```text
 publisher + namespaceId + agentName + exactVersion + protocol=a2a
+
+group=agent-endpoints
+serviceName=<legacyEncodedAgentName>::<exactVersion>
 ```
 
-单条注册将 scope 替换为一个 Endpoint，批量注册替换为提交的集合。Adapter 将精确版本映射为
-`runtimeVersion=version` 和 `versionRange=[version]`，并写入标准 Runtime Endpoint Registry。
+单条注册委托 Naming 现有的单实例操作，将该 publication 替换为一个 Endpoint；批量注册委托
+Naming Batch 注册，以提交的完整 Batch 覆盖旧 Batch。旧 deregister 删除该精确 Version
+Service 对应的完整 publication。
 
-即使不同精确版本使用相同的公开 Endpoint 自然键，Registry 也会保存不同的 publisher contribution
-分组。旧 deregister 只删除请求精确版本的 contribution group。该内部兼容操作有意窄于 RAD
-`Deregister`；后者会删除当前 publisher 对所提交自然键的全部 bindings。
+兼容 Handler 不把这些写入重定向到新的无 Version RAD Runtime Service，不写入
+`runtimeVersion` 或 `versionRange` metadata，也不进入新的 RAD Runtime 写入路径。旧 A2A
+Client 无法提交该 Service 要求的完整跨 Version Publisher Batch；直接重定向会导致一个
+Version 注册覆盖另一个 Version。历史 Service 的迁移、双读或双写、切流、回滚和清理必须由
+独立的滚动升级契约定义。
 
 Endpoint 可以先于 Agent 或 Version 定义发布，但不得隐式创建 Agent 定义。
 

--- a/specs/zh-cn/ai/agent-api-spec.md
+++ b/specs/zh-cn/ai/agent-api-spec.md
@@ -73,8 +73,9 @@ Agent 元数据更新使用 `expectedMetaVersion`；draft 内容只允许在目�
 |---|---|
 | 字段缺失或非法、URI/range 非法、Endpoint 自然键重复 | 标准参数错误 |
 | Discover 目标不可见或不存在 | `RESOURCE_NOT_FOUND`，不区分可见性 |
-| 不存在 Agent 定义时 Endpoint 预注册 | 完成结构、鉴权、配额和冲突校验后接受 |
-| 元数据 CAS 或 Publisher payload 冲突 | `RESOURCE_CONFLICT` |
+| 不存在 Agent 定义时 Endpoint 预注册 | 完成结构、鉴权和单 Batch 配额校验后接受 |
+| 元数据 CAS 冲突 | `RESOURCE_CONFLICT` |
+| 收敛后的 Runtime 投影包含 Publisher Payload 冲突 | `RESOURCE_CONFLICT` |
 | Version 生命周期转换非法 | `ILLEGAL_STATE` |
 | HTTP heartbeat 找不到 Client | HTTP 404 和独立应用码 `HTTP_CLIENT_NOT_FOUND` |
 | 协商后的传输不支持能力 | 本地 `FEATURE_NOT_SUPPORTED`，不发送远程请求 |
@@ -110,8 +111,15 @@ AiService extends AgentDiscoveryService, A2aService
 `selectOneHealthy`、协议选择、priority/weight 选址和实际 Agent Calling 是 SDK 本地
 helper，不增加远程操作。
 
-注册是按自然键 upsert，不替换未提交 Endpoint。SDK 将注册 Batch 保存为 redo 意图。
-首个实现可以不增加通用 Agent 定义发布方法，但现有 `A2aService.releaseAgentCard`
+一个 Registration Batch 是该 SDK Publisher 在
+`(namespaceId, agentName, protocol)` 下的完整期望状态。Register 完整替换此前
+Batch 及其唯一的 `runtimeVersion` 和 `versionRange`，未提交的 Endpoint 会被删除。
+SDK 将该完整 Batch 保存为 redo 意图。
+
+`deregisterAgentEndpoints` 保留为按自然键操作的便利方法。SDK 从期望 Batch 中删除
+这些自然键，再通过 Register 发送完整的剩余 Batch；没有 Endpoint 剩余时发送整份
+Publication 注销。首个实现可以不增加通用 Agent 定义发布方法，但现有
+`A2aService.releaseAgentCard`
 必须通过兼容 Adapter 保持可用。后续 Client SDK 提供可选的代码式 Agent 发布：
 `autoSubmit=false` 创建 draft，`autoSubmit=true` 执行普通 submit Pipeline；它不是
 force-publish，注册 Endpoint 也不会隐式创建定义。
@@ -135,8 +143,8 @@ HTTP-only SDK 在本地拒绝 Watch，不得通过轮询伪装 Watch。写入超
 |---|---|---|---|
 | GET | `/v3/client/ai/agents/search` | RAD Search query | `Result<Page<AgentCatalogEntry>>` |
 | GET | `/v3/client/ai/agents` | RAD Reference 和可选 Filter query | `Result<AgentDiscoveryResult>` |
-| POST | `/v3/client/ai/agents/endpoints` | `AgentEndpointRegistrationBatch` | `Result<ClientLivenessInfo>` |
-| DELETE | `/v3/client/ai/agents/endpoints` | JSON `AgentEndpointDeregistrationBatch` | `Result<Void>` |
+| POST | `/v3/client/ai/agents/endpoints` | 完整 `AgentEndpointRegistrationBatch` | `Result<ClientLivenessInfo>` |
+| DELETE | `/v3/client/ai/agents/endpoints` | JSON `namespaceId + agentName + protocol` Publication Identity | `Result<Void>` |
 | PUT | `/v3/client/ai/agents/endpoints/heartbeat` | 无 body | `Result<ClientLivenessInfo>` |
 
 Search query 名称与 RAD 字段相同。重复 `tagsAll` 取 AND，重复 `protocolsAny` 取 OR；
@@ -146,10 +154,15 @@ Discover 直接映射 `agentName`、`version` 和 `label`。重复 Filter 参数
 `transport` 和 `endpointSource`，`protocolVersion` 为单值。`metadataSelector` 使用一个
 URL encoded JSON object，而不是动态 `metadata.<key>` 参数名。
 
-Endpoint 路径只使用 POST 和 DELETE。POST 已经 upsert 完整 Endpoint 值，通用 PUT 会
-引入不明确的局部更新语义。GET 也没有必要：消费者使用 Discover，管理员使用
-`RuntimeEndpointSnapshot`。0.1 Binding 只定义带 JSON body 的 DELETE，并要求 Client
-和 Gateway 保留该 body。
+Endpoint 路径只使用 POST 和 DELETE。POST 完整替换当前 Publisher 对一个 Agent 和
+Protocol 的 Batch，因此通用 PUT 只会重复相同替换操作。GET 也没有必要：消费者使用
+Discover，管理员使用 `RuntimeEndpointSnapshot`。
+
+DELETE 删除当前 HTTP Publisher 对给定 Agent 和 Protocol 的整份 Publication，不接受
+Endpoint 自然键。官方 SDK 的部分注销先更新本地期望 Batch，再通过 POST 提交完整
+剩余内容；只有剩余 Batch 为空时才调用 DELETE。直接 HTTP 调用方同样自行维护完整
+期望 Batch。该三字段 DELETE Body 是 Binding 对象，不替代面向应用的
+`AgentEndpointDeregistrationBatch` RAD 模型。
 
 ### 2.4 HTTP Publisher Identity 与活性
 
@@ -183,8 +196,9 @@ heartbeatIntervalMillis < unhealthyTimeoutMillis < expireTimeoutMillis
 服务端根据 `clientId`，使用 Distro type `AI_AGENT_HTTP_CLIENT` 路由 HTTP Publisher
 状态。只有责任节点持有 native Client、`lastActiveTime` 和超时任务；Peer 接收重建
 Naming/RAD 投影所需的完整 Client state。新 Owner 只有在收到完整 Snapshot 后才启动
-故障转移宽限，否则返回 `HTTP_CLIENT_NOT_FOUND`，Client 随后 redo 全部期望 Endpoint
-分组。首次写入把 Client id 绑定到鉴权主体和 namespace；后续不匹配时拒绝。同一字符串
+故障转移宽限，否则返回 `HTTP_CLIENT_NOT_FOUND`，Client 随后 redo 每个完整的
+Endpoint Service Batch。首次写入把 Client id 绑定到鉴权主体和 namespace；后续
+不匹配时拒绝。同一字符串
 在其他模块不共享活性和清理状态。
 
 ### 2.5 gRPC Payload 与能力位
@@ -195,12 +209,21 @@ Naming/RAD 投影所需的完整 Client state。新 Owner 只有在收到完整 
 | `AgentDiscoveryRequest` | `AgentDiscoveryResponse` | 一次 Discover |
 | `AgentSubscribeRequest` | `AgentSubscribeResponse` | 订阅或取消；订阅成功时返回不透明 `watchKey` 和当前完整结果 |
 | `AgentDiscoveryNotifyRequest` | `AgentDiscoveryNotifyResponse` | 为一个 `watchKey` Push `SNAPSHOT` 或 `TERMINATED` 事件并接收 ACK |
-| `AgentEndpointRegisterRequest` | `AgentEndpointOperationResponse` | 注册一个 RAD Batch |
-| `AgentEndpointDeregisterRequest` | `AgentEndpointOperationResponse` | 注销一个 RAD Batch |
+| `AgentEndpointRegisterRequest` | `AgentEndpointOperationResponse` | 完整替换该 Connection 对一个 Agent 和 Protocol 的 RAD Batch |
+| `AgentEndpointDeregisterRequest` | `AgentEndpointOperationResponse` | 删除该 Connection 对一个 Agent 和 Protocol 的整份 Publication |
 
 所有 Request 的 module 为 `ai`。gRPC Endpoint Contribution 归属于
 `RequestMeta.connectionId`，不增加 Client id 或 heartbeat Payload。连接断开后删除该
 Connection 的 Contribution；重连取得新 connection id，并 redo Endpoint 和订阅。
+
+Endpoint Handler 是 Naming Adapter。Register 校验完整 Endpoint Batch，将其转换为
+Naming Instance，再调用 Naming Batch Register；Deregister 调用 Naming 的整份
+Publication 注销。写入时不读取或合并此前 Publisher Batch、不增加 Agent Service
+Lock、不直接查询 Naming Client Index，也不扫描其他 Publisher。
+
+Runtime Snapshot、Discover 和 Watch 从 Naming `ServiceStorage` 读取完整内部投影，
+根据每个 Instance 的 singular runtime Version 和 Version-range metadata 构造一个 Binding，
+保留 Range 命中目标 Version 的项，再按公开 Endpoint 自然键聚合 `bindings[]` 和健康状态。
 
 `AgentSubscribeResponse.watchKey` 是 Binding 为已接受 Wire Subscription 定义的不透明
 身份。SDK 将它映射到规范化本地 Watch 身份，不解析其内容。
@@ -234,17 +257,20 @@ Watch 及其 Redo State，再发送 ACK。Reconnect 后，SDK 丢弃旧 Connecti
 | 事件 | 必须行为 |
 |---|---|
 | 重复相同 Register | 成功且语义不变 |
-| Register 修改非身份字段 | Upsert 当前 Publisher Contribution |
+| Register 修改内容、Runtime Version 或 Range | 替换该 Publisher 的完整 Service Batch |
 | 同一 Batch 出现重复自然键 | 拒绝整个 Batch |
-| 重复 Deregister | 成功且语义不变 |
+| SDK 部分 Deregister | 从本地期望状态删除自然键，再 Register 完整剩余 Batch |
+| SDK 注销最后一项或直接远程 Deregister | 删除该 Publisher 的整份 Service Publication |
+| 重复整份 Publication Deregister | 成功且语义不变 |
 | 重复 heartbeat | 只刷新 Client 活性 |
 | HTTP timeout | 保持 Client id 和 payload，退避重试 |
-| `HTTP_CLIENT_NOT_FOUND` | 将全部本地 Endpoint 意图标记为未注册，并按完整分组 redo |
-| gRPC reconnect | 使用新 connection id redo Endpoint 和订阅 |
+| `HTTP_CLIENT_NOT_FOUND` | 将本地 Endpoint 意图标记为未注册，并 redo 每个完整 Service Batch |
+| gRPC reconnect | 使用新 connection id redo 完整 Endpoint Batch 和订阅 |
 | 跨传输注销 | 禁止；一个 Publisher identity 不能删除另一传输的 Contribution |
 
-SDK 在第一次写入前记录期望状态。Shutdown 执行 best-effort 注销，expire 作为清理兜底。
-参数、鉴权和 Publisher 冲突错误不进入无限 redo。
+SDK 在第一次写入前记录期望状态，并按 Agent 和 Protocol 串行修改期望 Batch。
+Shutdown 执行 best-effort 整份 Publication 注销，expire 作为清理兜底。参数和鉴权
+错误不进入无限 redo。
 
 ## 3. Admin API 与 Maintainer SDK
 
@@ -264,7 +290,8 @@ Admin 读取不隐式执行数据面 Discover，也不把 Runtime Endpoint 注�
 | GET | `/v3/admin/ai/agents/runtime-endpoints` | 读取一个 Protocol 的完整 Runtime Snapshot，可按 Version 过滤 | `Result<RuntimeEndpointSnapshot>` |
 
 Runtime 查询输入为 `namespaceId + agentName + protocol + version?`；`protocol` 必填。
-省略 `version` 时，对该 Protocol 的每个 Endpoint 自然键返回一项及其全部 Binding；提交时只保留匹配 Binding。
+省略 `version` 时，对该 Protocol 的每个 Endpoint 自然键返回一项及其全部 Binding；指定
+`version` 时只保留匹配 Binding。
 查询不应用 `endpointSourceOrder`，不要求定义存在，没有 Instance 时返回空 items。
 
 Create 包含 Agent 可写字段和必填 `initialDraft`。Agent、Version row 与 Storage 写入
@@ -333,5 +360,7 @@ Console 不提供 RAD Search、Discover、Watch、Endpoint Publication 或远程
 7. OpenAPI、Java SDK 和 Maintainer SDK 集成测试场景矩阵与 coverage registry。
 
 旧 Console A2A API 支持到 Nacos 3.4 版本线；旧 Admin 和 Maintainer A2A API 保留到
-Nacos 4.0 兼容边界。历史数据迁移和混合版本滚动升级属于独立规范，不得从本 API-only
-契约推断。
+Nacos 4.0 兼容边界。兼容期内，旧 A2A Endpoint API 保持当前带 Version 的 Naming
+Layout 和替换范围，不改写到新的无 Version Agent Naming Service；旧 Client 无法构造
+该 Service 要求的完整跨 Version Publisher Batch。历史数据迁移和混合版本滚动升级
+属于独立规范，不得从本 API-only 契约推断。

--- a/specs/zh-cn/ai/agent-management-spec.md
+++ b/specs/zh-cn/ai/agent-management-spec.md
@@ -289,8 +289,10 @@ state = AVAILABLE | DISABLED | UNHEALTHY
 ```
 
 状态按顺序判定：`enabled=false` 为 `DISABLED`；否则 `healthy=false` 为 `UNHEALTHY`；
-其他项为 `AVAILABLE`。只有公开 Endpoint 内容、enabled 或聚合健康状态变化时，
-`lastUpdatedTime` 才变化；单纯 heartbeat 不改变它。
+其他项为 `AVAILABLE`。`lastUpdatedTime` 使用本次构建 Snapshot 的 Naming `ServiceInfo.lastRefTime`，
+因此同一 Snapshot 的全部 item 共享同一个 Service 投影观察时间。它不是单个 Endpoint 的分布式事实或
+缓存校验器；Naming 每次重建该 Service 投影时都可能改变它。跨节点相等性和 Watch 去重使用由内容
+派生的 `sourceRevision`。
 
 `protocol` 必填。没有 `version` 时，Snapshot 对该 protocol 下每个 Endpoint 自然键返回一个有效项
 及其全部 Version binding；指定 `version` 时，只保留命中该 Version 的 binding，并在没有

--- a/specs/zh-cn/ai/agent-storage-spec.md
+++ b/specs/zh-cn/ai/agent-storage-spec.md
@@ -42,7 +42,7 @@ RUNTIME publisher contributions ------> Naming Client runtime state
 | `ai_resource` | Agent 身份、目录、治理、Version 摘要和派生的 online 目录。 | Version payload 或运行时健康状态。 |
 | `ai_resource_version` | 精确 Version 身份、生命周期状态、作者、Storage pointer 和 Pipeline 状态。 | CallInterface payload 或 Runtime Endpoint。 |
 | AI Storage | 一个 Version 的 canonical `AgentVersionContent` bytes。 | 资源身份、生命周期、label 或可见性。 |
-| Naming Client 状态 | 活跃 publisher contribution、健康、enabled 状态和 Version binding。 | Agent 定义或 Version 生命周期。 |
+| Naming Client 状态 | 活跃 publisher contribution、健康、enabled 状态和 singular runtime Version/range 事实。 | Agent 定义或 Version 生命周期。 |
 
 服务端不得持久化合并后的 `AgentDiscoveryResult`。Summary、管控详情、Catalog、Discover 和
 Watch 对象都是上述事实的读取投影。
@@ -263,82 +263,70 @@ namespaceId / agentName / runtimeVersion / versionRange? / protocol
 endpoints[1..1000]
 ```
 
-批次中全部 Endpoint 共享 Version binding 和 protocol。单元素数组就是通用单 Endpoint 形式。
-命令本身不持久化。服务端在原子应用前校验完整批次。批次包含重复自然键时整体拒绝。
-注册只 upsert 列出的 contribution，不删除未列出的 Endpoint；重复提交相同内容成功且不产生
-语义变化。
+批次中全部 Endpoint 共享一组 `runtimeVersion`/`versionRange` 和 protocol。单元素数组就是通用
+单 Endpoint 形式。命令本身不持久化。该批次是当前 publisher 对组合后 Naming Service 的完整期望状态。服务端校验
+完整批次后委托 Naming `batchRegisterInstance`；Naming 原子替换同一 Client 和 Service 的旧批次，
+未列出的 Endpoint 会被删除。批次包含重复自然键时整体拒绝；重复提交相同内容具有幂等性。
 
 `AgentEndpointDeregistrationBatch` 只包含 `namespaceId`、`agentName`、`protocol` 和
-`endpoints[] {uri, transport}`。对于当前 publisher，每个自然 Endpoint key 会删除该 publisher
-的全部 Version binding group。调用方不提交或缓存 endpoint id、runtime Version、range、
-metadata、priority 或 weight。
+`endpoints[] {uri, transport}`。它是 SDK 侧的操作意图，不是服务端局部删除命令。SDK 从 redo
+状态移除这些自然键，再通过同一注册路径提交保留后的完整批次；没有 Endpoint 时注销整个
+Client 和 Service publication。服务端不会为局部注销读取并合并旧批次。
 
 ### 4.3 内部 Publisher Contribution
 
-内部 publication group 身份为：
+Naming publication 身份为：
 
 ```text
 publisherIdentity
 + namespaceId + agentName + protocol
-+ runtimeVersion + canonicalVersionRange
 ```
 
-Endpoint contribution 身份在此基础上追加公开 Endpoint 自然键。必须保持以下区分：
+Naming 为该 Client 和 Service 只保存一份 `BatchInstancePublishInfo`。其中 Instance 共享一组
+`runtimeVersion` 和 canonical `versionRange`。后续注册完整替换该记录及这两个共享字段。
+因此首版同一 publisher、Agent 和 protocol 只能保存一组 singular
+`runtimeVersion`/`versionRange`。如果未来需要同时保存多组，应由客户端提供完整快照 wire model，
+而不是由服务端执行 read-merge-write。
 
-- 同一 publisher 可以通过多个 runtime-Version/range group 绑定相同 host、port 和 transport；
-- Version binding 不创建按 Version 划分的 Naming Service，也不在目标发现结果中复制公开
-  Endpoint；
-- 注册相同 contribution 身份执行 upsert；
-- 新的通用注销命令删除当前 publisher 下与该自然 Endpoint 匹配的全部 group。
+Agent 层不会读取旧 publisher 记录，不直接依赖 `ClientServiceIndexesManager`，不增加 Service 锁，
+也不在写入前扫描其他 publisher。Naming 负责完整替换、连接清理、索引、事件和 Distro AP 收敛；
+Agent 层只校验和转换完整批次。
 
-兼容 Adapter 可以使用内部 group-delete 操作。该操作只删除一个精确 publication group，
-不属于公开 RAD 命令集。旧 A2A 精确 Version 注销使用该操作，因此不会误删同一 publisher
-在其他 Version 上的 contribution。
-
-全部活跃 contribution 中，相同公开自然 Endpoint key 必须具有唯一的 canonical 公开 Endpoint
-payload，不受 publisher identity 或 Version range 是否相交影响。如果 URI scheme、path、query、priority、
-weight 或公开 metadata 与已有 payload 不同，则以 contribution 冲突拒绝注册。只有 canonical
-Endpoint payload 完全相同时，contribution 才能为同一自然键增加不同 Version binding。
+不同 publisher 的 Instance 可能在收敛后映射到同一公开自然 Endpoint key。读取投影聚合 canonical
+payload 完全相同的 contribution。如果收敛后的 Naming 状态对同一自然键包含不同 URI payload 字段、
+priority、weight 或公开 metadata，读取返回 `RESOURCE_CONFLICT`，不得任意选择。该检查用于保证
+投影安全，不是写时 reservation 或 CP 约束。
 
 ### 4.4 Binding 聚合
 
-Naming publisher contribution 聚合为包含 canonical `bindings[]` 数组的 Endpoint 投影：
-
-```json
-[
-  {"runtimeVersion":"1.0.6","versionRange":"[1.0.0,2.0.0)"}
-]
-```
-
-数组去重，并先按 `runtimeVersion` 的 Agent SemVer 升序排序，再按 `versionRange` 的
-大小写敏感字符串升序排序。该精确数组是 Version 匹配事实。
-
-每条有效 publisher record 使用 `__nacos.agent.endpoint.bindings__` 保存该数组。数组恰好
-包含一项时，同时写入以下诊断和首版兼容镜像：
+每条 Naming Instance 使用以下 singular metadata 保存一个 canonical binding：
 
 ```text
 __nacos.agent.endpoint.version__       = runtimeVersion
-__nacos.agent.endpoint.versionRange__  = versionRange
+__nacos.agent.endpoint.versionRange__  = canonicalVersionRange
 ```
 
-数组包含多项时移除两个 singular key。读取方在 `bindings` 存在时始终以其为准，不得将
-过期 singular key 合并进去。
+Naming metadata 中没有序列化的 `bindings` 值。只有读取 Naming Service 投影时才创建
+`RuntimeVersionBinding` 对象和公开 `bindings[]`。Binding 去重后先按 `runtimeVersion` 的
+Agent SemVer 升序排序，再按 `versionRange` 的大小写敏感字符串升序排序。
 
-`RuntimeEndpointSnapshot` 聚合 publisher contribution，但不暴露 publisher identity。每个公开
-自然 Endpoint key 恰好对应一项，包含 canonical Endpoint payload 和全部有效 `bindings[]`。
-按 Version 过滤的 Snapshot 只保留命中的 binding，并在没有剩余 binding 时删除该项。
+`RuntimeEndpointSnapshot` 从 `ServiceStorage` 读取完整的 Naming 内部 Service 投影，再聚合其中的
+Instance，但不暴露 publisher identity。每个公开自然 Endpoint key 恰好对应一项，包含 canonical
+Endpoint payload 和全部有效 `bindings[]`。按 Version 过滤的 Snapshot 只保留命中的 binding，并在没有
+剩余 binding 时删除该项。`ServiceStorage` 可以去重完全相同的 Instance；由于相同 Instance 的 payload、
+bindings、enabled 和 healthy 最终本就聚合为同一公开项，这不会改变公开投影。
 
-RAD Discover 先按目标 Version 过滤 binding，再将相同自然键聚合为一个公开 Endpoint。由于写入
-阶段会拒绝任何内容不一致的 payload，因此同一目标 Version 不会为同一自然键生成两个
-不同公开 payload。
+RAD Discover 先按目标 Version 过滤 binding，再将相同自然键聚合为一个公开 Endpoint。投影重建时
+拒绝 AP 收敛后可见的不一致 payload。因此成功生成的同一目标 Version 投影不会为同一自然键包含
+两个不同公开 payload。
 
 ### 4.5 预注册与生命周期
 
 Runtime 发布与 Agent 定义创建解耦。即使 Agent、Version 或 CallInterface 不存在，服务端也
 接受结构合法且鉴权通过的发布。注册成功表示运行时意图已接受，不表示当前可发现。
 
-注册校验 AgentName、runtime Version、range、protocol、Endpoint、鉴权、容量和 contribution
-冲突。它不校验定义是否存在或 Version 生命周期状态。
+注册校验 AgentName、runtime Version、range、protocol、Endpoint、鉴权和批次容量。它不校验
+定义是否存在、Version 生命周期状态或其他 publisher 的当前值。
 
 Publisher identity 是内部状态：
 
@@ -413,33 +401,38 @@ Cluster identity 和保留 metadata，读取时必须一致。
 | HTTPS 状态 | `__nacos.agent.endpoint.supportTls__`。 |
 | 原始 URI query | `__nacos.agent.endpoint.query__`。 |
 | native tenant，非空时 | `__nacos.agent.endpoint.tenant__`。 |
-| canonical binding | `__nacos.agent.endpoint.bindings__`。 |
-| 单 binding 诊断镜像 | `__nacos.agent.endpoint.version__`、`__nacos.agent.endpoint.versionRange__`。 |
+| runtime Version | `__nacos.agent.endpoint.version__`。 |
+| canonical Version range | `__nacos.agent.endpoint.versionRange__`。 |
 | priority | `__nacos.agent.endpoint.priority__`。 |
 | weight | `Instance.weight`。 |
 | 公开 Endpoint metadata | 其余 `Instance.metadata`。 |
 | 运行状态 | `Instance.enabled`、`Instance.healthy`、`ephemeral=true`。 |
 
 用户 metadata 不得覆盖任何 `__nacos.agent.endpoint.*__` key。服务端在接受 publication 前
-构造并校验完整 Naming metadata。缺失的 range 输入在写 `bindings` 前完成 canonicalize。
+构造并校验完整 Naming metadata。缺失的 range 输入在写 `versionRange` 前完成 canonicalize。
 
 `__nacos.agent.endpoint.protocolVersion__` 仅用于旧 A2A 兼容。只有 A2A 兼容 Adapter 可以写入；
-它不属于公开 RAD Endpoint metadata，也不进入 Runtime revision。反向投影旧 A2A 响应时，Adapter
-优先使用该值；缺失时回退到目标 CallInterface 的 `protocolVersion`。只有当一个聚合实例
-中全部 A2A contribution 的该值相同时才写入这个单值 key；值不同时移除 key，并由每个精确
-Version 投影使用目标 CallInterface fallback。该差异不构成公开 Endpoint payload 冲突。
+它不属于公开 RAD Endpoint metadata，也不进入 Runtime revision。反向投影旧 A2A 响应时，
+兼容 Adapter 优先使用该值；缺失时回退到目标 CallInterface 的 `protocolVersion`。
 
 公开自然键映射为 Service、Cluster、IP 和 port。Path 和 query 仍然是 payload metadata。
 ServiceName 和 clusterName 都不包含 Version，因此 Service 数量不会随兼容 Agent Version 增长。
 
 ### 5.3 Naming 事实边界
 
-包含 canonical binding 的 Naming Client publisher contribution 是 RUNTIME 事实源。普通 Naming
-`ServiceInfo` 可能合并相同 IP 和 port、应用 selector 或健康保护行为，并且不能保留所有 Agent
-publication group，因此不是 RAD 事实源。
+Naming Client 状态仍是 RUNTIME 写入事实，负责 publisher identity、连接或 heartbeat 活性、失活清理，
+完整批次替换、索引、事件和 AP 收敛。注册把完整 Agent Endpoint 批次转换为 Naming Instance 并调用
+Naming 一次；完整注销移除 Client 和 Service publication。Agent 服务端不读取或合并旧 publisher 记录。
 
-Agent 运行时读取从 Naming Client/index 路径聚合原始 publisher contribution，再应用 binding 和
-enabled filter。它们不得把标准 Naming Java SDK subscription 结果直接转发为 RAD Watch 快照。
+Runtime Snapshot 和 Discover 从 Naming `ServiceStorage` 缓存读取完整的内部 Service 投影。该投影由
+service-scoped Client index 构建，并包含运维 Instance metadata。Agent 层随后解析每条 Instance 的
+singular binding、应用可选的目标 Version filter、校验 payload 一致性，并按公开 Endpoint 自然键聚合。
+`ServiceStorage` 内部对完全相同 Instance 的去重是安全的，因为冗余且完全相同的 publication 不会
+改变任何公开聚合字段。
+
+`ServiceStorage` 返回的内部 `ServiceInfo` 容器与通过 Naming SDK、HTTP API、selector 或健康保护链路
+对外返回的 Naming 结果不是同一契约。不得把外部或已经过后处理的 Naming `ServiceInfo` 作为 Runtime
+事实源，也不得将其直接转发为 RAD Watch 快照。
 
 `enabled` 和 `weight` 的 Naming 运维 metadata 按普通规则优先于运行时 publication 值。Agent
 投影仍然保留 unhealthy Instance 并暴露其原始聚合健康状态，不应用 Naming 健康保护回退。
@@ -466,7 +459,7 @@ metadata。
 针对每个 `(namespaceId, agentName, targetVersion, protocol, source=RUNTIME)`，服务端在完成
 以下步骤后生成 opaque `sourceRevision`：
 
-1. 聚合活跃 publisher contribution；
+1. 从 `ServiceStorage` 读取完整的 Naming 内部 Service 投影；
 2. 选择包含目标 Version 的 binding；
 3. 规范每个 Endpoint URI，校验并保持 transport，显式写入有效默认值 `priority=0` 和
    `weight=1`，并要求 `healthy` 存在；
@@ -511,8 +504,8 @@ Watch 去重，不用于身份、鉴权、CAS 或防篡改。
 八字节 big-endian 值，最后编码为小写十六进制。内部 Storage Schema version 1 同时以
 机器可读形式记录这些规则。
 
-实现对语义投影标脏、合并突发变化并缓存结果，不得对每次 heartbeat 或每次 Discover 读取都
-执行 hash。
+Naming `ServiceStorage` 提供当前已缓存的 Service 投影。Agent 读取路径直接从该结果派生公开
+Endpoint set 及其 revision，不维护第二份投影缓存。
 
 持久化 AgentVersion 内容继续使用 SHA-256。DECLARED Endpoint set 使用 Version
 `contentDigest` 作为 opaque source revision。
@@ -524,7 +517,7 @@ Watch 去重，不用于身份、鉴权、CAS 或防篡改。
 | 管控 Agent 列表或 RAD Search | `ai_resource` page。 | 否 |
 | Agent overview | Resource 和有界 Version-row page。 | 否 |
 | 精确 Version detail | 一行 Version。 | 一次 |
-| Runtime Endpoint Snapshot | 一个 protocol 的原始 Naming publisher contribution；可选 binding filter。 | 否 |
+| Runtime Endpoint Snapshot | 一个 protocol 的完整内部 `ServiceStorage` 投影；可选 binding filter。 | 否 |
 | RAD Discover | Resource、online Version、缓存内容和符合条件的 runtime 投影。 | Digest 未命中时一次 |
 
 | 变化 | 写入目标 | 一致性规则 |
@@ -541,6 +534,10 @@ Watch 去重，不用于身份、鉴权、CAS 或防篡改。
 | Agent 元数据 | `metaVersion`。 |
 | Agent Version 内容 | `contentDigest`。 |
 | 目标 Runtime 投影 | `sourceRevision`。 |
+
+Naming `ServiceStorage` 负责完整的 per-Service 投影缓存。Agent 层不维护额外 Runtime registry 或
+投影缓存；每次从当前 `ServiceStorage` 结果派生所需 Agent 投影，并根据最终公开 Endpoint set 计算
+`sourceRevision`。
 
 AI Storage provider 保证单个 StorageKey 的原子 bytes 和它声明的读取一致性。Agent Registry
 负责跨 Resource、Version、Storage pointer、digest 和派生目录的编排，并执行校验、幂等重试
@@ -589,17 +586,9 @@ A2A Adapter 是本存储契约的首个使用方：
 | Runtime 调用 protocol | 规范 Agent protocol token `a2a`。 |
 | 旧 Endpoint transport 和 URI 部分 | 通用 Endpoint 和 Naming 保留 metadata。 |
 
-旧 single 和 batch 注册保留精确 Version replacement scope：
+首个兼容阶段中，旧 A2A Runtime 注册继续使用现有的按 Version 划分 Naming layout。在 A2A 客户端
+或 Adapter 能够维护并提交新 Service 的完整期望批次之前，不得把旧注册直接重定向到新的
+Version-neutral Service，否则一个旧 Version 的注册会覆盖另一个 Version。
 
-```text
-(publisherIdentity, namespaceId, agentName, protocol=a2a,
- runtimeVersion=version, versionRange=[version])
-```
-
-兼容 Adapter 替换该内部 group。旧注销只删除该精确 group，即使同一 publisher 和物理
-Endpoint 还存在其他 Version binding 也不会误删。新的 RAD 注销则删除当前 publisher 下所提交
-自然 Endpoint 的全部 binding。
-
-切换后，兼容写入使用新的 AI Resource、AI Storage 和 Naming layout。历史 Config row、历史
-Naming Service、混合集群双读或双写、切换、回滚和异常历史身份处理属于独立的滚动升级与
-迁移契约。
+后续切换到公共 Naming layout、历史 Naming Service、混合集群双读或双写、回滚和异常历史身份处理
+属于独立的滚动升级与迁移契约。

--- a/specs/zh-cn/ai/rad-protocol-spec.md
+++ b/specs/zh-cn/ai/rad-protocol-spec.md
@@ -46,8 +46,8 @@ RAD 0.1.0 定义五个操作：
 | `Search` | `AgentSearchRequest` | `AgentCatalogPage` | 分页搜索候选 Agent |
 | `Discover` | `AgentDiscoveryRequest` | `AgentDiscoveryResult` | 返回一个 Agent 版本的完整调用快照 |
 | `Watch` | `AgentDiscoveryRequest` | `AgentDiscoveryResult` 流 | 返回初始和后续的完整替换快照 |
-| `Register` | `AgentEndpointRegistrationBatch` | 成功或错误 | 注册或更新运行时端点 |
-| `Deregister` | `AgentEndpointDeregistrationBatch` | 成功或错误 | 注销运行时端点 |
+| `Register` | `AgentEndpointRegistrationBatch` | 成功或错误 | 完整替换当前发布者的运行时 Endpoint Batch |
+| `Deregister` | `AgentEndpointDeregistrationBatch` | 成功或错误 | 从发布者期望 Batch 中移除 Endpoint 自然键 |
 
 `Watch` 复用 `Discover` 的请求和结果。RAD 不在订阅快照外增加事件信封对象。
 
@@ -137,8 +137,8 @@ Schema 只暴露以下六个根消息：
 | `AgentCatalogPage` | `Search` 结果 |
 | `AgentDiscoveryRequest` | `Discover` 和 `Watch` 请求 |
 | `AgentDiscoveryResult` | `Discover` 和 `Watch` 完整快照 |
-| `AgentEndpointRegistrationBatch` | `Register` 请求 |
-| `AgentEndpointDeregistrationBatch` | `Deregister` 请求 |
+| `AgentEndpointRegistrationBatch` | `Register` 的完整期望 Batch |
+| `AgentEndpointDeregistrationBatch` | `Deregister` 的 Publisher Client 期望状态命令 |
 
 语言 Binding 可以复用字段完全等价的本地类型。例如 Java 可以使用
 `Page<AgentCatalogEntry>` 实现 `AgentCatalogPage`，不必再引入一个分页类。
@@ -245,7 +245,8 @@ Filter 的全部字段都是可选字段：
 - `DECLARED` Endpoint 不得包含 `healthy`。
 - `RUNTIME` 发现结果中的 Endpoint 必须包含 `healthy`。
 - Deregister 只提交 `uri` 和 `transport`，它们是公开对象中代表 Endpoint
-  自然键的字段。
+  自然键的字段。它是 Publisher Client 的便利命令；Nacos Binding 先将其应用到
+  本地期望状态，再发送完整替换 Batch。
 
 运行时 Endpoint 不使用 `endpointId`。
 
@@ -353,6 +354,11 @@ endpoints[]              # 1..1000
 版本。字段缺失时，服务端将其规范化为 `[runtimeVersion]`。`runtimeVersion` 必须包含
 在生效范围内。
 
+对于同一 Publisher 和 `(namespaceId, agentName, protocol)`，该数组是完整的期望
+Endpoint Batch。Register 完整替换此前 Batch，未提交的 Endpoint 会被删除。因此同一
+Publisher 在该范围内同时只有一个有效 `runtimeVersion` 和 `versionRange`；修改其中
+任一值都是完整替换，不是内部 Group 更新。
+
 `AgentEndpointDeregistrationBatch` 包含：
 
 ```text
@@ -360,8 +366,10 @@ namespaceId / agentName / protocol
 endpoints[] { uri, transport }
 ```
 
-对于每个给定自然键，Deregister 删除当前发布者贡献的全部 Binding，包括不同内部
-`runtimeVersion` 和 `versionRange` 分组中的 Binding。
+`AgentEndpointDeregistrationBatch` 继续作为面向应用的便利对象。Publisher Client
+从本地缓存的 Registration Batch 中删除给定自然键，再注册完整的剩余 Batch。没有
+Endpoint 剩余时，注销 `(namespaceId, agentName, protocol)` 下该 Publisher 的整份
+Publication。Nacos Server 不针对该对象执行局部 read-merge-write。
 
 ## 4. Search
 
@@ -438,8 +446,11 @@ Register 校验：
 
 - 请求结构、Endpoint 约束、权限和容量；
 - `runtimeVersion` 和 `versionRange` 合法，并且范围包含 Runtime Version；
-- 同一 Batch 不存在重复自然键，也不存在第 7.3 节的 Publication 冲突；
+- 同一 Batch 不存在重复自然键；
 - 请求不提交或覆盖 `protocolVersion`。
+
+Register 校验只面向本次提交的完整 Batch，不扫描其他 Publisher，也不在写入前为
+Endpoint 自然键建立 Reservation。
 
 Register 不要求 Agent、Runtime Version、范围边界、范围内 Version 或对应调用接口
 已经存在，因此支持 Endpoint 预注册。
@@ -453,37 +464,49 @@ Agent 和 Version 定义不拥有 Publication 生命周期。定义的创建、�
 
 ### 7.2 Batch、幂等与原子性
 
-一个注册 Batch 属于同一个：
+一个注册 Batch 是当前 Publisher 对以下身份提交的完整期望 Publication：
 
 ```text
-(namespaceId, agentName, protocol, runtimeVersion, versionRange)
+(namespaceId, agentName, protocol)
 ```
+
+`runtimeVersion` 和 `versionRange` 是整份 Batch 共享的内容，不属于额外的 Publication
+身份，也不形成服务端管理的 Binding Group。
 
 规则：
 
-- Registry 先校验全部 Endpoint，再原子应用一个 Batch。
-- Register 只新增或更新列出的自然键，不替换未提交的 Endpoint。
+- Binding 先校验全部 Endpoint，再为当前 Publisher 和 Publication 身份原子应用一个完整 Batch。
+- Register 替换此前 Batch，未提交的 Endpoint 会被删除。
 - 同一发布者重复提交相同内容时成功但不产生变化。
-- 非身份字段变化时执行 Upsert。
+- Endpoint 字段、Runtime Version 或 Range 的变化通过完整 Batch 替换表达。
 - 同一 Batch 出现重复自然键时整体拒绝。
-- Deregister 只删除当前发布者的贡献。
-- Deregister 不存在的贡献时成功但不产生变化。
-- 跨 Batch 不承诺事务。
+- Publisher Client 串行修改本地期望 Batch。部分 Deregister 和 Version 替换都在
+  本地计算新 Batch，再使用 Register 完整覆盖。
+- 期望 Batch 变空时，Binding 删除当前 Publisher 在该 Service 下的整份 Publication。
+- 注销本地不存在的 Contribution 成功且不发起远程变更。
 
 单 Endpoint 操作使用长度为 1 的 `endpoints[]`；RAD 不定义单独的单条命令。
 
-### 7.3 Publication 分组与多发布者
+Nacos Server 路径只是 Naming 上的数据结构 Adapter：它把完整 Endpoint Batch
+转换成 Naming Instance，再调用 Naming Batch Register 或整份 Publication
+Deregister。它不读取此前 Publisher Batch、不做增量 Merge、不增加 Agent Service
+Lock、不直接查询 Naming Client Index，也不在写入时扫描其他 Publisher。
 
-Binding 提供不透明的发布者身份和存活语义，发布者身份不进入发现结果。
+### 7.3 Naming Publication 与多发布者
 
-Registry 可以为一个公开 Endpoint 自然键保存多个内部 Publication 分组，并使用
-`runtimeVersion` 和规范化后的 `versionRange` 区分分组。因此，一个发布者可以通过
-多个兼容版本声明贡献同一个公开 Endpoint。Discover 先保留与目标版本匹配的分组，
-再将其聚合为一个公开 Endpoint。
+Publisher Transport 提供不透明的发布者身份和存活语义，发布者身份不进入发现结果。
 
-能够投影为同一个公开 Endpoint 的贡献必须具有相同的规范化 URI、Transport、
-Priority、Weight 和 Metadata；冲突注册返回 `CONFLICT`。健康状态在匹配的有效贡献间
-聚合：
+每个 Publisher 对一个 `(namespaceId, agentName, protocol)` Naming Service 最多
+贡献一份完整 Batch，并且该 Batch 只有一组 singular `runtimeVersion` 和 `versionRange`。
+不同 Publisher 可以贡献不同 pair。Nacos 读取路径从 Naming `ServiceStorage` 加载完整内部
+Service 投影，保留 Range 命中目标 Version 的 Contribution，再按公开 Endpoint 自然键聚合
+查询时 Binding。Agent 代码不直接遍历 Naming Client Index。
+
+AP 收敛后能够投影为同一个公开 Endpoint 的 Contribution 必须具有相同的规范化 URI、
+Transport、Priority、Weight 和 Metadata。Register 不执行跨 Publisher 的写前扫描。
+当收敛后的 `ServiceStorage` 投影包含冲突 Payload 时，受影响的读取或 Watch 返回
+`CONFLICT`，不得任意选择一个值。移除任一冲突 Publication 后，投影随 Naming
+正常收敛恢复。健康状态在匹配的有效 Contribution 间聚合：
 
 - 至少一个健康贡献时得到 `healthy=true`；
 - 全部贡献都不健康时得到 `healthy=false`；
@@ -523,9 +546,9 @@ Binding 将以下抽象类别映射到具体响应模型：
 | `NOT_FOUND` | Discover 目标不存在、不可见、禁用或未上线；已订阅目标之后消失 |
 | `PERMISSION_DENIED` | 调用方无权操作目标命名空间 |
 | `RESOURCE_EXHAUSTED` | Endpoint 或 Publication 容量已满，或完整响应超过 Binding 限制 |
-| `CONFLICT` | Publication 内容冲突或并发状态冲突 |
+| `CONFLICT` | 收敛后的 Runtime Contribution 对同一 Endpoint 自然键包含不兼容 Payload |
 | `UNSUPPORTED_CAPABILITY` | Binding 不支持请求的操作 |
-| `UNAVAILABLE` | Registry 当前无法形成可信快照或应用写入 |
+| `UNAVAILABLE` | Registry 当前无法读取 Naming 状态或应用写入 |
 
 不可见资源与不存在资源都表现为 `NOT_FOUND`，避免可见性侧信道。Filter 无匹配不是
 错误，必须使用第 5 节规定的空结果形态。
@@ -632,3 +655,7 @@ JSON Schema 只校验 Version Range 字符串的粗略语法，不能替代领�
   }]
 }
 ```
+
+这是面向应用的 SDK 命令。SDK 从缓存 Batch 中删除该自然键，并发送完整的剩余
+Register 请求；剩余 Batch 为空时，Nacos Binding 按 `namespaceId`、`agentName` 和
+`protocol` 发送整份 Publication 注销。

--- a/specs/zh-cn/grpc-api/api-spec.md
+++ b/specs/zh-cn/grpc-api/api-spec.md
@@ -229,8 +229,8 @@ Payload 清单。
 | `AgentDiscoveryRequest` | `AgentDiscoveryResponse` | read | 发现一个 Agent 并返回完整的 `AgentDiscoveryResult`。 |
 | `AgentSubscribeRequest` | `AgentSubscribeResponse` | read | 订阅或取消订阅 Agent Reference 和可选 Filter；订阅时返回不透明 `watchKey` 和当前完整结果。 |
 | `AgentDiscoveryNotifyRequest` | `AgentDiscoveryNotifyResponse` | server push | 为一个 `watchKey` 推送 `SNAPSHOT` 或 `TERMINATED` 事件并接收 ACK。 |
-| `AgentEndpointRegisterRequest` | `AgentEndpointOperationResponse` | write | Upsert 归当前 Connection 所有的一批 Runtime Endpoint 注册。 |
-| `AgentEndpointDeregisterRequest` | `AgentEndpointOperationResponse` | write | 幂等删除归当前 Connection 所有的一批 Runtime Endpoint 注册。 |
+| `AgentEndpointRegisterRequest` | `AgentEndpointOperationResponse` | write | 完整替换当前 Connection 对一个 Agent 和 Protocol 的 Runtime Endpoint Batch。 |
+| `AgentEndpointDeregisterRequest` | `AgentEndpointOperationResponse` | write | 幂等移除当前 Connection 对一个 Agent 和 Protocol 的整份 Runtime Endpoint Publication。 |
 
 在该目标 Binding 中，`AgentDiscoveryNotifyRequest` 包含 `watchKey` 和
 `eventType`。`SNAPSHOT` 必须携带完整 `AgentDiscoveryResult` 且不携带错误；

--- a/specs/zh-cn/http-api/v3-api-surface.md
+++ b/specs/zh-cn/http-api/v3-api-surface.md
@@ -184,8 +184,8 @@ Client 目标路径：
 | --- | --- | --- |
 | GET | `/v3/client/ai/agents/search` | 搜索 Agent 目录。 |
 | GET | `/v3/client/ai/agents` | 发现一个 Agent，可附带 Discovery Filter。 |
-| POST | `/v3/client/ai/agents/endpoints` | Upsert 一批 Runtime Endpoint 注册。 |
-| DELETE | `/v3/client/ai/agents/endpoints` | 使用 JSON body 注销一批 Runtime Endpoint。 |
+| POST | `/v3/client/ai/agents/endpoints` | 完整替换当前 Publisher 的 Runtime Endpoint Batch。 |
+| DELETE | `/v3/client/ai/agents/endpoints` | 使用 JSON body 标识并移除当前 Publisher 的整份 Runtime Endpoint Publication。 |
 | PUT | `/v3/client/ai/agents/endpoints/heartbeat` | 刷新一个 HTTP Publisher Client 的活性。 |
 
 Admin 和 Console 目标路径分别使用 `/v3/admin/ai/agents` 和

--- a/specs/zh-cn/naming/naming-metadata-selector-spec.md
+++ b/specs/zh-cn/naming/naming-metadata-selector-spec.md
@@ -69,23 +69,33 @@ Version 1 使用以下 key：
 | `__nacos.agent.endpoint.supportTls__` | 投影 URI 是否使用 TLS。 |
 | `__nacos.agent.endpoint.query__` | 原始 URI query。 |
 | `__nacos.agent.endpoint.tenant__` | 存在时保存 protocol native tenant。 |
-| `__nacos.agent.endpoint.version__` | 单 binding runtime Version 兼容和诊断镜像。 |
-| `__nacos.agent.endpoint.versionRange__` | 单 binding canonical Version range 兼容和诊断镜像。 |
-| `__nacos.agent.endpoint.bindings__` | Runtime Version 和 Version range binding 的 canonical JSON 数组。 |
+| `__nacos.agent.endpoint.version__` | 该 Instance contribution 的 runtime Version。 |
+| `__nacos.agent.endpoint.versionRange__` | 该 Instance contribution 的 canonical Version range。 |
 | `__nacos.agent.endpoint.priority__` | Endpoint priority；数值越小优先级越高。 |
 
-只有 Agent Runtime Registry 可以写入该前缀下的 key。公开 runtime 和 operational metadata
+只有 Agent Endpoint Naming Adapter 可以写入该前缀下的 key。公开 runtime 和 operational metadata
 写入必须拒绝这些 key，因此普通 operational-over-runtime 优先级规则不覆盖 Agent 投影事实。
 Endpoint weight、enabled 状态和健康状态继续使用 Naming Instance 原生字段，不使用保留
 metadata key。
 
-只有 A2A 兼容 Adapter 可以写入 `protocolVersion`。公开 RAD Endpoint metadata 和 Runtime
-revision 都排除该值。反向投影旧 A2A 响应时优先使用该值；缺失时回退到目标 Agent
-CallInterface 的 `protocolVersion`。
+当前按 Version 划分的 A2A 兼容 Layout 可以写入 `protocolVersion`，新的 RAD 注册不写该值。
+公开 RAD Endpoint metadata 和 Runtime revision 都排除该值。反向投影旧 A2A 响应时优先使用
+该值；缺失时回退到目标 Agent CallInterface 的 `protocolVersion`。
 
-`bindings` 是 Version 匹配事实。数组恰好包含一项时，Registry 同时写入 `version` 和
-`versionRange` 镜像；数组包含多项时移除两个 singular key。读取方在 `bindings` 存在时以其
-为准，不得合并过期 singular 值。精确 canonical 数组和 Runtime 投影规则由
+新的无 Version RAD Runtime Naming Instance 只携带一组 `version` 和 `versionRange`。
+Version range 必须是 canonical 形式，并且必须包含该 runtime Version。Naming metadata
+不存储序列化后的 bindings 数组。当前按 Version 划分的 A2A Naming Layout 不受此要求约束。
+
+注册遵循 Naming 完整 batch 覆盖语义。客户端维护同一连接对一个 Agent protocol service
+发布的完整 Endpoint batch，在本地移除或替换条目后，通过 Naming batch registration 提交剩余的
+完整 batch；如果本地计算后的期望 batch 为空，客户端调用整份 publication 注销，不向 Naming
+提交空 batch。服务端 Agent adapter 只把提交的 batch 映射为 Naming Instance，不读取和合并该
+publisher 的旧 batch。
+
+查询新的 RAD Runtime 时，读取方根据每个 Instance 的 singular pair 构造一个
+`RuntimeVersionBinding`，执行 Version range 匹配，并按 Endpoint natural key 聚合查询结果中的 `bindings[]`。
+`RuntimeVersionBinding` 和 `bindings[]` 属于查询投影，不属于 Naming 注册 metadata。精确的
+Runtime 投影规则由
 [Agent 存储规范](../ai/agent-storage-spec.md)定义。
 
 新的核心行为不得绑定到任意用户元数据 key。如果某个元数据 key 会改变 Naming 行为，必须被保留并


### PR DESCRIPTION
For #14804

## What is the purpose of the change

Implement the Agent Runtime Endpoint Registry kernel on top of Naming's existing
ephemeral AP publication path.

The Agent layer only adapts complete Endpoint batches to Naming Instances and
derives management and discovery read models from `ServiceStorage`. It does not
introduce a second registry, an additional lock or client index scan, or CP state.

## Brief changelog

* Add bidirectional conversion between Agent Endpoints and Naming Instances.
* Reuse Naming complete-batch replacement and whole-publication deregistration
  semantics.
* Build the management `RuntimeEndpointSnapshot` and data-plane `EndpointSet`
  directly from Naming storage, including version filtering, natural-key
  aggregation, health/state projection, conflict checks, capacity limits, and a
  deterministic source revision.
* Consolidate legacy A2A Endpoint constants under `Constants.Agent` while
  preserving the legacy version-specific A2A Naming layout.
* Align the English and Chinese Agent, RAD, Naming, HTTP, and gRPC specifications
  and the internal storage schema.
* Add unit tests for mapping, version-range matching, Runtime Registry behavior,
  and A2A compatibility.

## Verifying this change

* `mvn -pl ai spotless:apply spotless:check`
* `mvn -pl ai -am -Dtest=AgentRuntimeEndpointMapperTest,AgentRuntimeRegistryServiceTest,RuntimeVersionRangeSupportTest,RuntimeEndpointRevisionTest,AgentEndpointRequestHandlerTest,BatchAgentEndpointRequestHandlerTest,A2aServerOperationServiceTest,AgentCardUtilTest,AgentEndpointUtilTest -Dsurefire.failIfNoSpecifiedTests=false test`
  (106 tests passed)
* `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`
* Parsed `specs/schemas/ai/agent/internal/v1/agent-storage.schema.json` as JSON.

This change does not expose or modify an HTTP API, Java SDK, Maintainer SDK, or
Console endpoint. Their integration-test suites are therefore not applicable to
this Runtime Registry kernel PR.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run the required local formatting, unit-test, compilation, license, checkstyle, SpotBugs, and Spotless verification for this scope; the exact commands and integration-test applicability are listed above.
