### PR TITLE
[ISSUE #15625] Fix NPE risk in getGrayLastModifiedTs and missing volatile in ConfigDiskServiceFactory

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
@@ -493,7 +493,8 @@ public class ConfigCacheService {
     
     public static long getGrayLastModifiedTs(String groupKey, String grayName) {
         CacheItem item = CACHE.get(groupKey);
-        if (item.getConfigCacheGray() == null || !item.getConfigCacheGray().containsKey(grayName)) {
+        if (item == null || item.getConfigCacheGray() == null
+            || !item.getConfigCacheGray().containsKey(grayName)) {
             return 0;
         }
         ConfigCache configCacheGray = item.getConfigCacheGray().get(grayName);

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigDiskServiceFactory.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigDiskServiceFactory.java
@@ -23,7 +23,7 @@ package com.alibaba.nacos.config.server.service.dump.disk;
  */
 public class ConfigDiskServiceFactory {
     
-    static ConfigDiskService configDiskService;
+    static volatile ConfigDiskService configDiskService;
     
     private static final String TYPE_RAW_DISK = "rawdisk";
     


### PR DESCRIPTION
## What is the purpose of the change

Fixes two bugs in the `config` module:

1. **NPE risk in `ConfigCacheService.getGrayLastModifiedTs`** — The method calls `item.getConfigCacheGray()` without null-checking `item`, even though `item` comes from `CACHE.get(groupKey)` which can return `null`. Every sibling method in the same class correctly guards `item` (`getContentGrayMd5`, `getGrayRule`, `getLastModifiedTs`), making this a clear copy-patch oversight. Now returns `0` consistently when `item` is null.

2. **Broken double-checked locking in `ConfigDiskServiceFactory`** — The singleton field `configDiskService` was not declared `volatile`. Without `volatile`, the Java Memory Model permits a thread to see a non-null reference to an object whose constructor has not finished running (textbook broken DCL anti-pattern since Java 5). Added `volatile` to ensure safe publication.

## Brief changelog

- `ConfigCacheService.java`: added `item == null ||` guard in `getGrayLastModifiedTs`.
- `ConfigDiskServiceFactory.java`: added `volatile` to `configDiskService` field.

## Verifying this change

- `mvn compile -pl config -am` ✅ BUILD SUCCESS
- `mvn test -pl config -am -Dtest="ConfigCacheServiceTest,ConfigDiskServiceFactoryTest"` ✅ 38 tests passed, 0 failures
- `mvn spotless:check -pl config` ✅ formatting compliant

Both fixes are minimal, localized, and match existing patterns in the codebase.

Assisted-by: Claude Code