### PR TITLE
fix: remove deprecated mockito-inline dependency

### DIFF
--- a/ai/pom.xml
+++ b/ai/pom.xml
@@ -84,11 +84,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -654,11 +654,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Motivation

The mockito-inline dependency has been deprecated and is no longer needed. Modern versions of Mockito include inline mocking capabilities by default.

## Changes

### Dependency Cleanup
- Removed deprecated mockito-inline dependency from pom.xml
- Mockito core already provides the required functionality

## Testing

- Verified that all tests continue to pass without mockito-inline
- Confirmed that mocking functionality works with standard Mockito

## Checklist

- [x] Code follows project coding standards
- [x] Changes are minimal and focused
- [x] No breaking changes introduced
- [x] Commit messages follow conventional format