### PR TITLE
[ISSUE #15634] Backport API authorization fixes to v3.2.4

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
@@ -41,6 +41,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.auth.parser.http.AgentSpecCardHttpResourceParser;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.core.model.form.PageForm;
@@ -217,7 +218,8 @@ public class AgentSpecAdminController {
      */
     @Since("3.2.0")
     @PutMapping("/draft")
-    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.ADMIN_API)
+    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.ADMIN_API,
+        parser = AgentSpecCardHttpResourceParser.class)
     public Result<String> updateDraft(AgentSpecUpdateForm form) throws NacosException {
         form.validate();
         AgentSpec agentSpec = AgentSpecRequestUtil.parseAgentSpec(form);

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecAdminController.java
@@ -273,7 +273,7 @@ public class AgentSpecAdminController {
     @Since("3.2.1")
     @PostMapping("/force-publish")
     @Secured(resource = Constants.AgentSpecs.ADMIN_PATH
-        + "/force-publish", action = ActionTypes.WRITE, signType = SignType.CONSOLE,
+        + "/force-publish", action = ActionTypes.WRITE, signType = SignType.AI,
         apiType = ApiType.ADMIN_API)
     public Result<String> forcePublish(AgentSpecPublishForm form) throws NacosException {
         form.validate();

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecClientController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/AgentSpecClientController.java
@@ -31,6 +31,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.auth.parser.http.AgentSpecNameHttpResourceParser;
 import com.alibaba.nacos.core.model.form.PageForm;
 import com.alibaba.nacos.core.paramcheck.ExtractorManager;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
@@ -81,7 +82,7 @@ public class AgentSpecClientController {
     @Since("3.2.0")
     @GetMapping
     @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.OPEN_API,
-        tags = {ALLOW_ANONYMOUS})
+        parser = AgentSpecNameHttpResourceParser.class, tags = {ALLOW_ANONYMOUS})
     public ResponseEntity<Result<AgentSpec>> get(AgentSpecQueryForm form)
         throws NacosException {
         form.validate();

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/PromptAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/PromptAdminController.java
@@ -251,7 +251,7 @@ public class PromptAdminController {
     @Since("3.2.1")
     @PostMapping("/force-publish")
     @Secured(resource = Constants.Prompt.ADMIN_PATH
-        + "/force-publish", action = ActionTypes.WRITE, signType = SignType.CONSOLE,
+        + "/force-publish", action = ActionTypes.WRITE, signType = SignType.AI,
         apiType = ApiType.ADMIN_API)
     public Result<String> forcePublish(PromptVersionPublishForm form) throws NacosException {
         form.validate();

--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/SkillAdminController.java
@@ -308,7 +308,7 @@ public class SkillAdminController {
     @Since("3.2.1")
     @PostMapping("/force-publish")
     @Secured(resource = ADMIN_PATH
-        + "/force-publish", action = ActionTypes.WRITE, signType = SignType.CONSOLE,
+        + "/force-publish", action = ActionTypes.WRITE, signType = SignType.AI,
         apiType = ApiType.ADMIN_API)
     public Result<String> forcePublish(SkillPublishForm form) throws NacosException {
         form.validate();

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/SecuredMetadataTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/SecuredMetadataTest.java
@@ -35,8 +35,6 @@ class SecuredMetadataTest {
     
     @Test
     void testAdminAiForcePublishMetadata() {
-        assertSecured(AgentAdminController.class, "forcePublish",
-            "/v3/admin/ai/agents/force-publish");
         assertSecured(AgentSpecAdminController.class, "forcePublish",
             "/v3/admin/ai/agentspecs/force-publish");
         assertSecured(PromptAdminController.class, "forcePublish",

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/SecuredMetadataTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/SecuredMetadataTest.java
@@ -18,6 +18,9 @@ package com.alibaba.nacos.ai.controller;
 
 import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.auth.parser.ResourceParser;
+import com.alibaba.nacos.auth.parser.http.AgentSpecCardHttpResourceParser;
+import com.alibaba.nacos.auth.parser.http.AgentSpecNameHttpResourceParser;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.constant.SignType;
 import org.junit.jupiter.api.Test;
@@ -42,6 +45,14 @@ class SecuredMetadataTest {
             "/v3/admin/ai/skills/force-publish");
     }
     
+    @Test
+    void testAgentSpecResourceParsers() {
+        assertParser(AgentSpecAdminController.class, "updateDraft",
+            AgentSpecCardHttpResourceParser.class, ApiType.ADMIN_API);
+        assertParser(AgentSpecClientController.class, "get",
+            AgentSpecNameHttpResourceParser.class, ApiType.OPEN_API);
+    }
+    
     private void assertSecured(Class<?> controllerClass, String methodName, String resource) {
         Method method = Arrays.stream(controllerClass.getDeclaredMethods())
             .filter(candidate -> methodName.equals(candidate.getName()))
@@ -53,5 +64,18 @@ class SecuredMetadataTest {
         assertEquals(ActionTypes.WRITE, secured.action());
         assertEquals(SignType.AI, secured.signType());
         assertEquals(ApiType.ADMIN_API, secured.apiType());
+    }
+    
+    private void assertParser(Class<?> controllerClass, String methodName,
+        Class<? extends ResourceParser> parser, ApiType apiType) {
+        Method method = Arrays.stream(controllerClass.getDeclaredMethods())
+            .filter(candidate -> methodName.equals(candidate.getName()))
+            .findFirst()
+            .orElseThrow();
+        Secured secured = method.getAnnotation(Secured.class);
+        assertNotNull(secured);
+        assertEquals(parser, secured.parser());
+        assertEquals(SignType.AI, secured.signType());
+        assertEquals(apiType, secured.apiType());
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/SecuredMetadataTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/SecuredMetadataTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.controller;
+
+import com.alibaba.nacos.api.common.ApiType;
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SecuredMetadataTest {
+    
+    @Test
+    void testAdminAiForcePublishMetadata() {
+        assertSecured(AgentAdminController.class, "forcePublish",
+            "/v3/admin/ai/agents/force-publish");
+        assertSecured(AgentSpecAdminController.class, "forcePublish",
+            "/v3/admin/ai/agentspecs/force-publish");
+        assertSecured(PromptAdminController.class, "forcePublish",
+            "/v3/admin/ai/prompt/force-publish");
+        assertSecured(SkillAdminController.class, "forcePublish",
+            "/v3/admin/ai/skills/force-publish");
+    }
+    
+    private void assertSecured(Class<?> controllerClass, String methodName, String resource) {
+        Method method = Arrays.stream(controllerClass.getDeclaredMethods())
+            .filter(candidate -> methodName.equals(candidate.getName()))
+            .findFirst()
+            .orElseThrow();
+        Secured secured = method.getAnnotation(Secured.class);
+        assertNotNull(secured);
+        assertEquals(resource, secured.resource());
+        assertEquals(ActionTypes.WRITE, secured.action());
+        assertEquals(SignType.AI, secured.signType());
+        assertEquals(ApiType.ADMIN_API, secured.apiType());
+    }
+}

--- a/auth/src/main/java/com/alibaba/nacos/auth/AbstractProtocolAuthService.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/AbstractProtocolAuthService.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.nacos.auth;
 
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.auth.config.NacosAuthConfig;
 import com.alibaba.nacos.auth.serveridentity.ServerIdentity;
@@ -142,11 +144,14 @@ public abstract class AbstractProtocolAuthService<R> implements ProtocolAuthServ
      */
     protected Resource useSpecifiedParserToParse(Secured secured, R request) {
         try {
-            return secured.parser().newInstance().parse(request, secured);
-        } catch (Exception e) {
+            return secured.parser().getDeclaredConstructor().newInstance().parse(request, secured);
+        } catch (ReflectiveOperationException e) {
             Loggers.AUTH.error("Use specified resource parser {} parse resource failed.",
                 secured.parser().getCanonicalName(), e);
-            return Resource.EMPTY_RESOURCE;
+            throw new NacosRuntimeException(NacosException.SERVER_ERROR,
+                "Failed to initialize specified resource parser "
+                    + secured.parser().getCanonicalName(),
+                e);
         }
     }
 }

--- a/auth/src/main/java/com/alibaba/nacos/auth/GrpcProtocolAuthService.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/GrpcProtocolAuthService.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.api.remote.request.Request;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.auth.config.NacosAuthConfig;
 import com.alibaba.nacos.auth.context.GrpcIdentityContextBuilder;
+import com.alibaba.nacos.auth.parser.DefaultResourceParser;
 import com.alibaba.nacos.auth.parser.grpc.AbstractGrpcResourceParser;
 import com.alibaba.nacos.auth.parser.grpc.AiGrpcResourceParser;
 import com.alibaba.nacos.auth.parser.grpc.ConfigGrpcResourceParser;
@@ -66,11 +67,14 @@ public class GrpcProtocolAuthService extends AbstractProtocolAuthService<Request
         if (StringUtils.isNotBlank(secured.resource())) {
             return parseSpecifiedResource(secured);
         }
+        if (!DefaultResourceParser.class.equals(secured.parser())) {
+            return useSpecifiedParserToParse(secured, request);
+        }
         String type = secured.signType();
         AbstractGrpcResourceParser parser = resourceParserMap.get(type);
         if (parser == null) {
             Loggers.AUTH.warn("Can't find Grpc request resourceParser for type {}", type);
-            return useSpecifiedParserToParse(secured, request);
+            return new DefaultResourceParser().parse(request, secured);
         }
         return parser.parse(request, secured);
     }

--- a/auth/src/main/java/com/alibaba/nacos/auth/HttpProtocolAuthService.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/HttpProtocolAuthService.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.auth;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.auth.config.NacosAuthConfig;
 import com.alibaba.nacos.auth.context.HttpIdentityContextBuilder;
+import com.alibaba.nacos.auth.parser.DefaultResourceParser;
 import com.alibaba.nacos.auth.parser.http.AbstractHttpResourceParser;
 import com.alibaba.nacos.auth.parser.http.AiHttpResourceParser;
 import com.alibaba.nacos.auth.parser.http.ConfigHttpResourceParser;
@@ -64,14 +65,16 @@ public class HttpProtocolAuthService extends AbstractProtocolAuthService<HttpSer
         if (StringUtils.isNotBlank(secured.resource())) {
             return parseSpecifiedResource(secured);
         }
-        String type = secured.signType();
-        if (!resourceParserMap.containsKey(type)) {
-            Loggers.AUTH.warn(
-                "Can't find Http request resourceParser for type {} use specified resource parser",
-                type);
+        if (!DefaultResourceParser.class.equals(secured.parser())) {
             return useSpecifiedParserToParse(secured, request);
         }
-        return resourceParserMap.get(type).parse(request, secured);
+        String type = secured.signType();
+        AbstractHttpResourceParser parser = resourceParserMap.get(type);
+        if (parser == null) {
+            Loggers.AUTH.warn("Can't find Http request resourceParser for type {}", type);
+            return new DefaultResourceParser().parse(request, secured);
+        }
+        return parser.parse(request, secured);
     }
     
     @Override

--- a/auth/src/main/java/com/alibaba/nacos/auth/annotation/Secured.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/annotation/Secured.java
@@ -58,7 +58,8 @@ public @interface Secured {
     String signType() default SignType.NAMING;
     
     /**
-     * Custom resource parser. Should have lower priority than resource() and typed parser.
+     * Custom resource parser. Used when {@link #resource()} is empty and takes precedence over
+     * the parser selected by {@link #signType()}.
      *
      * @return class type of resource parser
      */

--- a/auth/src/main/java/com/alibaba/nacos/auth/parser/http/AgentSpecCardHttpResourceParser.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/parser/http/AgentSpecCardHttpResourceParser.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.auth.parser.http;
+
+import com.alibaba.nacos.api.ai.model.agentspecs.AgentSpec;
+import com.alibaba.nacos.api.exception.runtime.NacosDeserializationException;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * AgentSpec HTTP resource parser that resolves the target name from {@code agentSpecCard}.
+ *
+ * @author xiweng.yy
+ */
+public class AgentSpecCardHttpResourceParser extends AiHttpResourceParser {
+    
+    private static final String AGENT_SPEC_CARD_PARAM = "agentSpecCard";
+    
+    @Override
+    protected String getResourceName(HttpServletRequest request) {
+        String agentSpecCard = request.getParameter(AGENT_SPEC_CARD_PARAM);
+        if (StringUtils.isBlank(agentSpecCard)) {
+            throw new IllegalArgumentException(
+                "Request parameter `agentSpecCard` should not be null or empty.");
+        }
+        AgentSpec agentSpec;
+        try {
+            agentSpec = JacksonUtils.toObj(agentSpecCard, AgentSpec.class);
+        } catch (NacosDeserializationException e) {
+            throw new IllegalArgumentException(
+                "Request parameter `agentSpecCard` is invalid and cannot be parsed.", e);
+        }
+        if (agentSpec == null || StringUtils.isBlank(agentSpec.getName())) {
+            throw new IllegalArgumentException(
+                "Required parameter `agentSpecCard.name` is not present.");
+        }
+        return agentSpec.getName();
+    }
+}

--- a/auth/src/main/java/com/alibaba/nacos/auth/parser/http/AgentSpecNameHttpResourceParser.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/parser/http/AgentSpecNameHttpResourceParser.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.auth.parser.http;
+
+import com.alibaba.nacos.common.utils.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * AgentSpec HTTP resource parser that resolves the target from the client {@code name} parameter.
+ *
+ * @author xiweng.yy
+ */
+public class AgentSpecNameHttpResourceParser extends AiHttpResourceParser {
+    
+    private static final String AGENT_SPEC_NAME_PARAM = "name";
+    
+    @Override
+    protected String getResourceName(HttpServletRequest request) {
+        String agentSpecName = request.getParameter(AGENT_SPEC_NAME_PARAM);
+        if (StringUtils.isBlank(agentSpecName)) {
+            throw new IllegalArgumentException(
+                "Request parameter `name` should not be null or empty.");
+        }
+        return agentSpecName;
+    }
+}

--- a/auth/src/main/java/com/alibaba/nacos/auth/parser/http/AiHttpResourceParser.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/parser/http/AiHttpResourceParser.java
@@ -141,6 +141,7 @@ public class AiHttpResourceParser extends AbstractHttpResourceParser {
         }
         return properties;
     }
+    
     private boolean isAgentSpecPath(String url) {
         return containsCompletePath(url, AGENT_SPEC_PATH);
     }

--- a/auth/src/main/java/com/alibaba/nacos/auth/parser/http/AiHttpResourceParser.java
+++ b/auth/src/main/java/com/alibaba/nacos/auth/parser/http/AiHttpResourceParser.java
@@ -47,7 +47,9 @@ public class AiHttpResourceParser extends AbstractHttpResourceParser {
     
     public static final String PROMPT_PATH = "/ai/prompt";
     
-    public static final String AGENT_SPEC_PATH = "/ai/agentSpec";
+    public static final String AGENT_SPEC_PATH = "/ai/agentspecs";
+    
+    private static final String AGENT_SPEC_LIST_PATH = AGENT_SPEC_PATH + "/list";
     
     private static final String AGENT_CARD_PARAM = "agentCard";
     
@@ -76,7 +78,7 @@ public class AiHttpResourceParser extends AbstractHttpResourceParser {
             return getSkillName(request);
         } else if (url.contains(PROMPT_PATH)) {
             return getPromptName(request);
-        } else if (url.contains(AGENT_SPEC_PATH)) {
+        } else if (isAgentSpecPath(url)) {
             return getAgentSpecName(request);
         }
         return StringUtils.EMPTY;
@@ -115,6 +117,9 @@ public class AiHttpResourceParser extends AbstractHttpResourceParser {
     }
     
     private String getAgentSpecName(HttpServletRequest request) {
+        if (containsCompletePath(request.getRequestURI(), AGENT_SPEC_LIST_PATH)) {
+            return StringUtils.EMPTY;
+        }
         String agentSpecName = request.getParameter("agentSpecName");
         return StringUtils.isBlank(agentSpecName) ? StringUtils.EMPTY : agentSpecName;
     }
@@ -131,9 +136,21 @@ public class AiHttpResourceParser extends AbstractHttpResourceParser {
             properties.setProperty(AI_TYPE, AI_TYPE_SKILL);
         } else if (url.contains(PROMPT_PATH)) {
             properties.setProperty(AI_TYPE, AI_TYPE_PROMPT);
-        } else if (url.contains(AGENT_SPEC_PATH)) {
+        } else if (isAgentSpecPath(url)) {
             properties.setProperty(AI_TYPE, AI_TYPE_AGENT_SPEC);
         }
         return properties;
+    }
+    private boolean isAgentSpecPath(String url) {
+        return containsCompletePath(url, AGENT_SPEC_PATH);
+    }
+    
+    private boolean containsCompletePath(String url, String path) {
+        int index = url.indexOf(path);
+        if (index < 0) {
+            return false;
+        }
+        int end = index + path.length();
+        return end == url.length() || url.charAt(end) == '/';
     }
 }

--- a/auth/src/test/java/com/alibaba/nacos/auth/GrpcProtocolAuthServiceTest.java
+++ b/auth/src/test/java/com/alibaba/nacos/auth/GrpcProtocolAuthServiceTest.java
@@ -21,11 +21,13 @@ import com.alibaba.nacos.api.ai.remote.request.AbstractMcpRequest;
 import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.config.remote.request.ConfigPublishRequest;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.api.naming.remote.request.AbstractNamingRequest;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.auth.config.NacosAuthConfig;
 import com.alibaba.nacos.auth.mock.MockAuthPluginService;
 import com.alibaba.nacos.auth.mock.MockResourceParser;
+import com.alibaba.nacos.auth.mock.MockSuccessResourceParser;
 import com.alibaba.nacos.auth.serveridentity.ServerIdentityResult;
 import com.alibaba.nacos.plugin.auth.api.IdentityContext;
 import com.alibaba.nacos.plugin.auth.api.Permission;
@@ -45,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -104,7 +107,7 @@ class GrpcProtocolAuthServiceTest {
     }
     
     @Test
-    @Secured(resource = "testResource")
+    @Secured(resource = "testResource", parser = MockResourceParser.class)
     void testParseResourceWithSpecifiedResource() throws NoSuchMethodException {
         Secured secured = getMethodSecure("testParseResourceWithSpecifiedResource");
         Resource actual = protocolAuthService.parseResource(namingRequest, secured);
@@ -128,8 +131,19 @@ class GrpcProtocolAuthServiceTest {
     @Secured(signType = "non-exist", parser = MockResourceParser.class)
     void testParseResourceWithNonExistTypeException() throws NoSuchMethodException {
         Secured secured = getMethodSecure("testParseResourceWithNonExistTypeException");
+        assertThrows(NacosRuntimeException.class,
+            () -> protocolAuthService.parseResource(namingRequest, secured));
+    }
+    
+    @Test
+    @Secured(signType = SignType.NAMING, parser = MockSuccessResourceParser.class)
+    void testExplicitParserOverridesTypedParser() throws NoSuchMethodException {
+        Secured secured = getMethodSecure("testExplicitParserOverridesTypedParser");
         Resource actual = protocolAuthService.parseResource(namingRequest, secured);
-        assertEquals(Resource.EMPTY_RESOURCE, actual);
+        assertEquals("testCustomResource", actual.getName());
+        assertEquals("testCustomNs", actual.getNamespaceId());
+        assertEquals("testCustomGroup", actual.getGroup());
+        assertEquals(SignType.NAMING, actual.getType());
     }
     
     @Test

--- a/auth/src/test/java/com/alibaba/nacos/auth/HttpProtocolAuthServiceTest.java
+++ b/auth/src/test/java/com/alibaba/nacos/auth/HttpProtocolAuthServiceTest.java
@@ -17,11 +17,13 @@
 package com.alibaba.nacos.auth;
 
 import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.api.exception.runtime.NacosRuntimeException;
 import com.alibaba.nacos.api.naming.CommonParams;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.auth.config.NacosAuthConfig;
 import com.alibaba.nacos.auth.mock.MockAuthPluginService;
 import com.alibaba.nacos.auth.mock.MockResourceParser;
+import com.alibaba.nacos.auth.mock.MockSuccessResourceParser;
 import com.alibaba.nacos.auth.serveridentity.ServerIdentityResult;
 import com.alibaba.nacos.plugin.auth.api.IdentityContext;
 import com.alibaba.nacos.plugin.auth.api.Permission;
@@ -43,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -73,7 +76,7 @@ class HttpProtocolAuthServiceTest {
     }
     
     @Test
-    @Secured(resource = "testResource", tags = {"testTag"})
+    @Secured(resource = "testResource", parser = MockResourceParser.class, tags = {"testTag"})
     void testParseResourceWithSpecifiedResource() throws NoSuchMethodException {
         Secured secured = getMethodSecure("testParseResourceWithSpecifiedResource");
         Resource actual = protocolAuthService.parseResource(request, secured);
@@ -98,8 +101,19 @@ class HttpProtocolAuthServiceTest {
     @Secured(signType = "non-exist", parser = MockResourceParser.class)
     void testParseResourceWithNonExistTypeException() throws NoSuchMethodException {
         Secured secured = getMethodSecure("testParseResourceWithNonExistTypeException");
+        assertThrows(NacosRuntimeException.class,
+            () -> protocolAuthService.parseResource(request, secured));
+    }
+    
+    @Test
+    @Secured(signType = SignType.CONFIG, parser = MockSuccessResourceParser.class)
+    void testExplicitParserOverridesTypedParser() throws NoSuchMethodException {
+        Secured secured = getMethodSecure("testExplicitParserOverridesTypedParser");
         Resource actual = protocolAuthService.parseResource(request, secured);
-        assertEquals(Resource.EMPTY_RESOURCE, actual);
+        assertEquals("testCustomResource", actual.getName());
+        assertEquals("testCustomNs", actual.getNamespaceId());
+        assertEquals("testCustomGroup", actual.getGroup());
+        assertEquals(SignType.CONFIG, actual.getType());
     }
     
     @Test

--- a/auth/src/test/java/com/alibaba/nacos/auth/mock/MockSuccessResourceParser.java
+++ b/auth/src/test/java/com/alibaba/nacos/auth/mock/MockSuccessResourceParser.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.auth.mock;
+
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.auth.parser.ResourceParser;
+import com.alibaba.nacos.plugin.auth.api.Resource;
+
+import java.util.Properties;
+
+public class MockSuccessResourceParser implements ResourceParser<Object> {
+    
+    @Override
+    public Resource parse(Object request, Secured secured) {
+        return new Resource("testCustomNs", "testCustomGroup", "testCustomResource",
+            secured.signType(), new Properties());
+    }
+}

--- a/auth/src/test/java/com/alibaba/nacos/auth/parser/http/AgentSpecHttpResourceParserTest.java
+++ b/auth/src/test/java/com/alibaba/nacos/auth/parser/http/AgentSpecHttpResourceParserTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.auth.parser.http;
+
+import com.alibaba.nacos.api.common.Constants;
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.plugin.auth.api.Resource;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.lang.reflect.Method;
+
+import static com.alibaba.nacos.plugin.auth.constant.Constants.Resource.AI_TYPE;
+import static com.alibaba.nacos.plugin.auth.constant.Constants.Resource.AI_TYPE_AGENT_SPEC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AgentSpecHttpResourceParserTest {
+    
+    @Test
+    void testParseClientName() throws NoSuchMethodException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/v3/client/ai/agentspecs");
+        request.addParameter(Constants.NAMESPACE_ID, "testNs");
+        request.addParameter("name", "client-spec");
+        
+        Resource actual =
+            new AgentSpecNameHttpResourceParser().parse(request, getSecured());
+        
+        assertEquals("testNs", actual.getNamespaceId());
+        assertEquals(Constants.DEFAULT_GROUP, actual.getGroup());
+        assertEquals("client-spec", actual.getName());
+        assertEquals(SignType.AI, actual.getType());
+        assertEquals(AI_TYPE_AGENT_SPEC, actual.getProperties().getProperty(AI_TYPE));
+    }
+    
+    @Test
+    void testRejectMissingClientName() throws NoSuchMethodException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/v3/client/ai/agentspecs");
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> new AgentSpecNameHttpResourceParser().parse(request, getSecured()));
+    }
+    
+    @Test
+    void testParseUpdateTargetFromAgentSpecCard() throws NoSuchMethodException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/v3/admin/ai/agentspecs/draft");
+        request.addParameter(Constants.NAMESPACE_ID, "testNs");
+        request.addParameter("agentSpecName", "non-authoritative-name");
+        request.addParameter("agentSpecCard", "{\"name\":\"card-spec\"}");
+        
+        Resource actual =
+            new AgentSpecCardHttpResourceParser().parse(request, getSecured());
+        
+        assertEquals("testNs", actual.getNamespaceId());
+        assertEquals(Constants.DEFAULT_GROUP, actual.getGroup());
+        assertEquals("card-spec", actual.getName());
+        assertEquals(SignType.AI, actual.getType());
+        assertEquals(AI_TYPE_AGENT_SPEC, actual.getProperties().getProperty(AI_TYPE));
+    }
+    
+    @Test
+    void testRejectInvalidAgentSpecCard() throws NoSuchMethodException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/v3/admin/ai/agentspecs/draft");
+        request.addParameter("agentSpecCard", "invalid-json");
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> new AgentSpecCardHttpResourceParser().parse(request, getSecured()));
+    }
+    
+    @Test
+    void testRejectAgentSpecCardWithoutName() throws NoSuchMethodException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/v3/admin/ai/agentspecs/draft");
+        request.addParameter("agentSpecCard", "{\"description\":\"missing name\"}");
+        
+        assertThrows(IllegalArgumentException.class,
+            () -> new AgentSpecCardHttpResourceParser().parse(request, getSecured()));
+    }
+    
+    private Secured getSecured() throws NoSuchMethodException {
+        Method method = getClass().getDeclaredMethod("securedMethod");
+        return method.getAnnotation(Secured.class);
+    }
+    
+    @Secured(signType = SignType.AI)
+    private void securedMethod() {
+    }
+}

--- a/auth/src/test/java/com/alibaba/nacos/auth/parser/http/AiHttpResourceParserTest.java
+++ b/auth/src/test/java/com/alibaba/nacos/auth/parser/http/AiHttpResourceParserTest.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -303,20 +304,70 @@ class AiHttpResourceParserTest {
     
     @Test
     @Secured(signType = "ai")
-    void testGetPropertiesForAgentSpec() throws NoSuchMethodException {
+    void testParseAgentSpecDetail() throws NoSuchMethodException {
         Secured secured = getMethodSecure();
         when(request.getParameter(eq(Constants.NAMESPACE_ID))).thenReturn("testNs");
-        when(request.getRequestURI()).thenReturn("/v3/admin/ai/agentSpec/list");
+        when(request.getRequestURI()).thenReturn("/v3/admin/ai/agentspecs");
         when(request.getParameter(eq("agentSpecName"))).thenReturn("my-spec");
         when(request.getParameterMap()).thenReturn(new HashMap<>());
         
         Resource actual = resourceParser.parse(request, secured);
         
+        assertEquals("my-spec", actual.getName());
         assertEquals(com.alibaba.nacos.plugin.auth.constant.Constants.Resource.AI_TYPE_AGENT_SPEC,
             actual.getProperties().getProperty(
                 com.alibaba.nacos.plugin.auth.constant.Constants.Resource.AI_TYPE));
     }
     
+    @Test
+    @Secured(signType = "ai")
+    void testParseAgentSpecListAsNamespaceRange() throws NoSuchMethodException {
+        Secured secured = getMethodSecure();
+        when(request.getParameter(eq(Constants.NAMESPACE_ID))).thenReturn("testNs");
+        when(request.getRequestURI()).thenReturn("/v3/console/ai/agentspecs/list");
+        when(request.getParameter(eq("agentSpecName"))).thenReturn("filter-only-spec");
+        when(request.getParameterMap()).thenReturn(new HashMap<>());
+        
+        Resource actual = resourceParser.parse(request, secured);
+        
+        assertEquals(StringUtils.EMPTY, actual.getName());
+        assertEquals(com.alibaba.nacos.plugin.auth.constant.Constants.Resource.AI_TYPE_AGENT_SPEC,
+            actual.getProperties().getProperty(
+                com.alibaba.nacos.plugin.auth.constant.Constants.Resource.AI_TYPE));
+    }
+    
+    @Test
+    @Secured(signType = "ai")
+    void testAgentSpecPathRequiresPluralSegment() throws NoSuchMethodException {
+        Secured secured = getMethodSecure();
+        when(request.getParameter(eq(Constants.NAMESPACE_ID))).thenReturn("testNs");
+        when(request.getRequestURI()).thenReturn("/v3/admin/ai/agentSpec/list");
+        when(request.getParameter(eq("agentSpecName"))).thenReturn("legacy-spec");
+        when(request.getParameterMap()).thenReturn(new HashMap<>());
+        
+        Resource actual = resourceParser.parse(request, secured);
+        
+        assertEquals(StringUtils.EMPTY, actual.getName());
+        assertNull(actual.getProperties().getProperty(
+            com.alibaba.nacos.plugin.auth.constant.Constants.Resource.AI_TYPE));
+    }
+    
+    @Test
+    @Secured(signType = "ai")
+    void testAgentSpecPathRequiresSegmentBoundary() throws NoSuchMethodException {
+        Secured secured = getMethodSecure();
+        when(request.getParameter(eq(Constants.NAMESPACE_ID))).thenReturn("testNs");
+        when(request.getRequestURI()).thenReturn("/v3/admin/ai/agentspecs-extra");
+        when(request.getParameter(eq("agentSpecName"))).thenReturn("wrong-spec");
+        when(request.getParameterMap()).thenReturn(new HashMap<>());
+        
+        Resource actual = resourceParser.parse(request, secured);
+        
+        assertEquals(StringUtils.EMPTY, actual.getName());
+        assertNull(actual.getProperties().getProperty(
+            com.alibaba.nacos.plugin.auth.constant.Constants.Resource.AI_TYPE));
+    }
+
     private Secured getMethodSecure() throws NoSuchMethodException {
         StackTraceElement[] traces = new Exception().getStackTrace();
         StackTraceElement callerElement = traces[1];

--- a/auth/src/test/java/com/alibaba/nacos/auth/parser/http/AiHttpResourceParserTest.java
+++ b/auth/src/test/java/com/alibaba/nacos/auth/parser/http/AiHttpResourceParserTest.java
@@ -367,7 +367,7 @@ class AiHttpResourceParserTest {
         assertNull(actual.getProperties().getProperty(
             com.alibaba.nacos.plugin.auth.constant.Constants.Resource.AI_TYPE));
     }
-
+    
     private Secured getMethodSecure() throws NoSuchMethodException {
         StackTraceElement[] traces = new Exception().getStackTrace();
         StackTraceElement callerElement = traces[1];

--- a/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/CapacityControllerV3.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/controller/v3/CapacityControllerV3.java
@@ -68,7 +68,7 @@ public class CapacityControllerV3 {
     @Since("3.0.0")
     @GetMapping
     @Secured(resource = Constants.CAPACITY_CONTROLLER_V3_ADMIN_PATH, action = ActionTypes.READ,
-        signType = SignType.CONFIG, apiType = ApiType.ADMIN_API)
+        signType = SignType.CONSOLE, apiType = ApiType.ADMIN_API)
     public Result<Capacity> getCapacity(@RequestParam(required = false) String groupName,
         @RequestParam(required = false) String namespaceId) throws NacosApiException {
         if (StringUtils.isBlank(groupName) && StringUtils.isBlank(namespaceId)) {
@@ -102,7 +102,7 @@ public class CapacityControllerV3 {
     @Since("3.0.0")
     @PostMapping
     @Secured(resource = Constants.CAPACITY_CONTROLLER_V3_ADMIN_PATH, action = ActionTypes.WRITE,
-        signType = SignType.CONFIG, apiType = ApiType.ADMIN_API)
+        signType = SignType.CONSOLE, apiType = ApiType.ADMIN_API)
     public Result<Boolean> updateCapacity(UpdateCapacityForm updateCapacityForm)
         throws NacosApiException {
         updateCapacityForm.checkNamespaceIdAndGroupName(capacityService);

--- a/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/SecuredMetadataTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/controller/v3/SecuredMetadataTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.config.server.controller.v3;
+
+import com.alibaba.nacos.api.common.ApiType;
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SecuredMetadataTest {
+    
+    @Test
+    void testCapacityUsesConsoleSignType() {
+        assertConsoleSignType("getCapacity");
+        assertConsoleSignType("updateCapacity");
+    }
+    
+    private void assertConsoleSignType(String methodName) {
+        Method method = Arrays.stream(CapacityControllerV3.class.getDeclaredMethods())
+            .filter(candidate -> methodName.equals(candidate.getName()))
+            .findFirst()
+            .orElseThrow();
+        Secured secured = method.getAnnotation(Secured.class);
+        assertNotNull(secured);
+        assertEquals("/v3/admin/cs/capacity", secured.resource());
+        assertEquals(SignType.CONSOLE, secured.signType());
+        assertEquals(ApiType.ADMIN_API, secured.apiType());
+    }
+}

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleA2aController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleA2aController.java
@@ -159,7 +159,8 @@ public class ConsoleA2aController {
      */
     @Since("3.1.0")
     @GetMapping("/version/list")
-    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.ADMIN_API)
+    @Secured(action = ActionTypes.READ, signType = SignType.AI,
+        apiType = ApiType.CONSOLE_API)
     public Result<List<AgentVersionDetail>> listAgentVersions(AgentForm agentForm)
         throws NacosException {
         agentForm.validate();

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAgentSpecController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAgentSpecController.java
@@ -40,6 +40,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.auth.parser.http.AgentSpecCardHttpResourceParser;
 import com.alibaba.nacos.common.utils.NamespaceUtil;
 import com.alibaba.nacos.console.proxy.ai.AgentSpecProxy;
 import com.alibaba.nacos.core.model.form.PageForm;
@@ -190,7 +191,8 @@ public class ConsoleAgentSpecController {
      */
     @Since("3.2.0")
     @PutMapping("/draft")
-    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
+    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API,
+        parser = AgentSpecCardHttpResourceParser.class)
     public Result<String> updateDraft(AgentSpecUpdateForm form) throws NacosException {
         form.validate();
         agentSpecProxy.updateDraft(form);

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAgentSpecController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleAgentSpecController.java
@@ -251,7 +251,7 @@ public class ConsoleAgentSpecController {
     @Since("3.2.1")
     @PostMapping("/force-publish")
     @Secured(resource = CONSOLE_RESOURCE_NAME_PREFIX
-        + "agentspecs", action = ActionTypes.WRITE, signType = SignType.CONSOLE,
+        + "agentspecs", action = ActionTypes.WRITE, signType = SignType.AI,
         apiType = ApiType.CONSOLE_API)
     public Result<String> forcePublish(AgentSpecPublishForm form) throws NacosException {
         form.validate();

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleCopilotConfigController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleCopilotConfigController.java
@@ -35,6 +35,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.alibaba.nacos.plugin.auth.constant.Constants.Resource.CONSOLE_RESOURCE_NAME_PREFIX;
+
 /**
  * Console Copilot configuration controller.
  *
@@ -63,7 +65,8 @@ public class ConsoleCopilotConfigController {
      */
     @Since("3.2.0")
     @GetMapping
-    @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
+    @Secured(resource = CONSOLE_RESOURCE_NAME_PREFIX + "copilot/config",
+        action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
     public Result<CopilotProperties> getConfig() throws NacosException {
         CopilotProperties config = configStorage.getConfig();
         if (config == null) {
@@ -90,7 +93,8 @@ public class ConsoleCopilotConfigController {
      */
     @Since("3.2.0")
     @PostMapping
-    @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
+    @Secured(resource = CONSOLE_RESOURCE_NAME_PREFIX + "copilot/config",
+        action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
     public Result<Boolean> saveConfig(@RequestBody CopilotProperties config) throws NacosException {
         if (config == null) {
             throw new NacosException(NacosException.INVALID_PARAM, "Configuration cannot be null");

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsolePromptController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsolePromptController.java
@@ -244,7 +244,7 @@ public class ConsolePromptController {
     @Since("3.2.1")
     @PostMapping("/force-publish")
     @Secured(resource = Constants.Prompt.CONSOLE_PATH
-        + "/force-publish", action = ActionTypes.WRITE, signType = SignType.CONSOLE,
+        + "/force-publish", action = ActionTypes.WRITE, signType = SignType.AI,
         apiType = ApiType.CONSOLE_API)
     public Result<String> forcePublish(PromptVersionPublishForm form) throws NacosException {
         form.validate();

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleSkillController.java
@@ -285,7 +285,7 @@ public class ConsoleSkillController {
     @Since("3.2.1")
     @PostMapping("/force-publish")
     @Secured(resource = CONSOLE_RESOURCE_NAME_PREFIX
-        + "skills", action = ActionTypes.WRITE, signType = SignType.CONSOLE,
+        + "skills", action = ActionTypes.WRITE, signType = SignType.AI,
         apiType = ApiType.CONSOLE_API)
     public Result<String> forcePublish(SkillPublishForm form) throws NacosException {
         form.validate();

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/config/ConsoleConfigController.java
@@ -307,8 +307,8 @@ public class ConsoleConfigController {
      */
     @Since("3.0.0")
     @GetMapping("/listener/ip")
-    @Secured(resource = Constants.LISTENER_CONTROLLER_PATH, action = ActionTypes.READ,
-        signType = SignType.CONFIG, apiType = ApiType.CONSOLE_API)
+    @Secured(action = ActionTypes.READ, signType = SignType.CONFIG,
+        apiType = ApiType.CONSOLE_API)
     public Result<ConfigListenerInfo> getAllSubClientConfigByIp(@RequestParam("ip") String ip,
         @RequestParam(value = "all", required = false) boolean all,
         @RequestParam(value = "namespaceId", required = false) String namespaceId,
@@ -421,7 +421,8 @@ public class ConsoleConfigController {
      */
     @Since("3.0.0")
     @DeleteMapping("/beta")
-    @Secured(action = ActionTypes.WRITE, signType = SignType.CONFIG)
+    @Secured(action = ActionTypes.WRITE, signType = SignType.CONFIG,
+        apiType = ApiType.CONSOLE_API)
     public Result<Boolean> stopBeta(HttpServletRequest httpServletRequest, ConfigFormV3 configForm)
         throws NacosException {
         configForm.validate();
@@ -449,7 +450,8 @@ public class ConsoleConfigController {
      */
     @Since("3.0.0")
     @GetMapping("/beta")
-    @Secured(action = ActionTypes.READ, signType = SignType.CONFIG)
+    @Secured(action = ActionTypes.READ, signType = SignType.CONFIG,
+        apiType = ApiType.CONSOLE_API)
     public Result<ConfigGrayInfo> queryBeta(ConfigFormV3 configForm) throws NacosException {
         configForm.validate();
         String dataId = configForm.getDataId();

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/core/ConsoleClusterController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/core/ConsoleClusterController.java
@@ -25,7 +25,6 @@ import com.alibaba.nacos.api.model.response.NacosMember;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.console.proxy.core.ClusterProxy;
-import com.alibaba.nacos.core.utils.Commons;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.constant.SignType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -64,8 +63,8 @@ public class ConsoleClusterController {
      */
     @Since("3.0.0")
     @GetMapping(value = "/nodes")
-    @Secured(resource = Commons.NACOS_CORE_CONTEXT
-        + "/cluster", action = ActionTypes.READ, signType = SignType.CONSOLE,
+    @Secured(resource = "/v3/console/core/cluster/nodes", action = ActionTypes.READ,
+        signType = SignType.CONSOLE,
         apiType = ApiType.CONSOLE_API)
     public Result<Collection<NacosMember>> getNodeList(
         @RequestParam(value = "keyword", required = false) String ipKeyWord) throws NacosException {

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/SecuredMetadataTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/SecuredMetadataTest.java
@@ -20,7 +20,6 @@ import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.auth.parser.http.AgentSpecCardHttpResourceParser;
 import com.alibaba.nacos.console.controller.v3.ai.ConsoleA2aController;
-import com.alibaba.nacos.console.controller.v3.ai.ConsoleAgentController;
 import com.alibaba.nacos.console.controller.v3.ai.ConsoleAgentSpecController;
 import com.alibaba.nacos.console.controller.v3.ai.ConsoleCopilotConfigController;
 import com.alibaba.nacos.console.controller.v3.ai.ConsolePromptController;
@@ -47,8 +46,6 @@ class SecuredMetadataTest {
             "console/copilot/config", ActionTypes.READ, SignType.AI);
         assertSecured(ConsoleCopilotConfigController.class, "saveConfig",
             "console/copilot/config", ActionTypes.WRITE, SignType.AI);
-        assertSecured(ConsoleAgentController.class, "forcePublish",
-            "/v3/console/ai/agents/force-publish", ActionTypes.WRITE, SignType.AI);
     }
     
     @Test

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/SecuredMetadataTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/SecuredMetadataTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.console.controller.v3;
+
+import com.alibaba.nacos.api.common.ApiType;
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.console.controller.v3.ai.ConsoleA2aController;
+import com.alibaba.nacos.console.controller.v3.ai.ConsoleAgentController;
+import com.alibaba.nacos.console.controller.v3.ai.ConsoleAgentSpecController;
+import com.alibaba.nacos.console.controller.v3.ai.ConsoleCopilotConfigController;
+import com.alibaba.nacos.console.controller.v3.ai.ConsolePromptController;
+import com.alibaba.nacos.console.controller.v3.ai.ConsoleSkillController;
+import com.alibaba.nacos.console.controller.v3.config.ConsoleConfigController;
+import com.alibaba.nacos.console.controller.v3.core.ConsoleClusterController;
+import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SecuredMetadataTest {
+    
+    @Test
+    void testConsoleManagementResources() {
+        assertSecured(ConsoleClusterController.class, "getNodeList",
+            "/v3/console/core/cluster/nodes", ActionTypes.READ, SignType.CONSOLE);
+        assertSecured(ConsoleCopilotConfigController.class, "getConfig",
+            "console/copilot/config", ActionTypes.READ, SignType.AI);
+        assertSecured(ConsoleCopilotConfigController.class, "saveConfig",
+            "console/copilot/config", ActionTypes.WRITE, SignType.AI);
+        assertSecured(ConsoleAgentController.class, "forcePublish",
+            "/v3/console/ai/agents/force-publish", ActionTypes.WRITE, SignType.AI);
+    }
+    
+    @Test
+    void testConsoleApiTypesAndTypedResources() {
+        assertSecured(ConsoleConfigController.class, "getAllSubClientConfigByIp",
+            "", ActionTypes.READ, SignType.CONFIG);
+        assertSecured(ConsoleConfigController.class, "stopBeta",
+            "", ActionTypes.WRITE, SignType.CONFIG);
+        assertSecured(ConsoleConfigController.class, "queryBeta",
+            "", ActionTypes.READ, SignType.CONFIG);
+        assertSecured(ConsoleA2aController.class, "listAgentVersions",
+            "", ActionTypes.READ, SignType.AI);
+    }
+    
+    @Test
+    void testConsoleAiForcePublishSignTypes() {
+        assertSecured(ConsoleAgentSpecController.class, "forcePublish",
+            "console/agentspecs", ActionTypes.WRITE, SignType.AI);
+        assertSecured(ConsolePromptController.class, "forcePublish",
+            "/v3/console/ai/prompt/force-publish", ActionTypes.WRITE, SignType.AI);
+        assertSecured(ConsoleSkillController.class, "forcePublish",
+            "console/skills", ActionTypes.WRITE, SignType.AI);
+    }
+    
+    private void assertSecured(Class<?> controllerClass, String methodName, String resource,
+        ActionTypes action, String signType) {
+        Method method = Arrays.stream(controllerClass.getDeclaredMethods())
+            .filter(candidate -> methodName.equals(candidate.getName()))
+            .findFirst()
+            .orElseThrow();
+        Secured secured = method.getAnnotation(Secured.class);
+        assertNotNull(secured);
+        assertEquals(resource, secured.resource());
+        assertEquals(action, secured.action());
+        assertEquals(signType, secured.signType());
+        assertEquals(ApiType.CONSOLE_API, secured.apiType());
+    }
+}

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/SecuredMetadataTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/SecuredMetadataTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.console.controller.v3;
 
 import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.auth.parser.http.AgentSpecCardHttpResourceParser;
 import com.alibaba.nacos.console.controller.v3.ai.ConsoleA2aController;
 import com.alibaba.nacos.console.controller.v3.ai.ConsoleAgentController;
 import com.alibaba.nacos.console.controller.v3.ai.ConsoleAgentSpecController;
@@ -70,6 +71,19 @@ class SecuredMetadataTest {
             "/v3/console/ai/prompt/force-publish", ActionTypes.WRITE, SignType.AI);
         assertSecured(ConsoleSkillController.class, "forcePublish",
             "console/skills", ActionTypes.WRITE, SignType.AI);
+    }
+    
+    @Test
+    void testConsoleAgentSpecUpdateParser() {
+        Method method = Arrays.stream(ConsoleAgentSpecController.class.getDeclaredMethods())
+            .filter(candidate -> "updateDraft".equals(candidate.getName()))
+            .findFirst()
+            .orElseThrow();
+        Secured secured = method.getAnnotation(Secured.class);
+        assertNotNull(secured);
+        assertEquals(AgentSpecCardHttpResourceParser.class, secured.parser());
+        assertEquals(SignType.AI, secured.signType());
+        assertEquals(ApiType.CONSOLE_API, secured.apiType());
     }
     
     private void assertSecured(Class<?> controllerClass, String methodName, String resource,

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/remote/request/PluginAvailabilityRequestHandler.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/remote/request/PluginAvailabilityRequestHandler.java
@@ -17,13 +17,18 @@
 package com.alibaba.nacos.core.cluster.remote.request;
 
 import com.alibaba.nacos.api.annotation.Since;
+import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.remote.RemoteConstants;
 import com.alibaba.nacos.api.remote.request.RequestMeta;
 import com.alibaba.nacos.api.remote.response.ResponseCode;
+import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.core.cluster.remote.response.PluginAvailabilityResponse;
 import com.alibaba.nacos.core.plugin.PluginManager;
 import com.alibaba.nacos.core.plugin.model.PluginInfo;
 import com.alibaba.nacos.core.remote.RequestHandler;
+import com.alibaba.nacos.core.remote.grpc.InvokeSource;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -38,6 +43,7 @@ import java.util.Map;
  */
 @Component
 @Since("3.2.0")
+@InvokeSource(source = {RemoteConstants.LABEL_SOURCE_CLUSTER})
 public class PluginAvailabilityRequestHandler
     extends RequestHandler<PluginAvailabilityRequest, PluginAvailabilityResponse> {
     
@@ -48,6 +54,8 @@ public class PluginAvailabilityRequestHandler
     }
     
     @Override
+    @Secured(resource = "pluginAvailability", signType = SignType.SPECIFIED,
+        apiType = ApiType.INNER_API)
     public PluginAvailabilityResponse handle(PluginAvailabilityRequest request, RequestMeta meta)
         throws NacosException {
         if (!request.isQueryAll() && request.getPluginId() == null) {

--- a/core/src/main/java/com/alibaba/nacos/core/controller/v3/ServerLoaderControllerV3.java
+++ b/core/src/main/java/com/alibaba/nacos/core/controller/v3/ServerLoaderControllerV3.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.core.remote.Connection;
 import com.alibaba.nacos.core.service.NacosServerLoaderService;
 import com.alibaba.nacos.core.utils.WebUtils;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +68,7 @@ public class ServerLoaderControllerV3 {
     @Since("3.0.0")
     @GetMapping("/current")
     @Secured(resource = NACOS_ADMIN_CORE_CONTEXT_V3 + "/loader", action = ActionTypes.READ,
-        apiType = ApiType.ADMIN_API)
+        signType = SignType.CONSOLE, apiType = ApiType.ADMIN_API)
     public Result<Map<String, Connection>> currentClients() {
         return Result.success(serverLoaderService.getAllClients());
     }
@@ -78,7 +79,8 @@ public class ServerLoaderControllerV3 {
      * @return state json.
      */
     @Secured(resource = NACOS_ADMIN_CORE_CONTEXT_V3
-        + "/loader", action = ActionTypes.WRITE, apiType = ApiType.ADMIN_API)
+        + "/loader", action = ActionTypes.WRITE, signType = SignType.CONSOLE,
+        apiType = ApiType.ADMIN_API)
     @Since("3.0.0")
     @PostMapping("/reloadCurrent")
     public Result<String> reloadCount(@RequestParam Integer count,
@@ -96,7 +98,8 @@ public class ServerLoaderControllerV3 {
     @Since("3.0.0")
     @PostMapping("/smartReloadCluster")
     @Secured(resource = NACOS_ADMIN_CORE_CONTEXT_V3
-        + "/loader", action = ActionTypes.WRITE, apiType = ApiType.ADMIN_API)
+        + "/loader", action = ActionTypes.WRITE, signType = SignType.CONSOLE,
+        apiType = ApiType.ADMIN_API)
     public Result<String> smartReload(HttpServletRequest request,
         @RequestParam(value = "loaderFactor", defaultValue = "0.1f") String loaderFactorStr) {
         LOGGER.info("Smart reload request receive,requestIp={}", WebUtils.getRemoteIp(request));
@@ -116,7 +119,8 @@ public class ServerLoaderControllerV3 {
     @Since("3.0.0")
     @PostMapping("/reloadClient")
     @Secured(resource = NACOS_ADMIN_CORE_CONTEXT_V3
-        + "/loader", action = ActionTypes.WRITE, apiType = ApiType.ADMIN_API)
+        + "/loader", action = ActionTypes.WRITE, signType = SignType.CONSOLE,
+        apiType = ApiType.ADMIN_API)
     public Result<String> reloadSingle(@RequestParam String connectionId,
         @RequestParam(value = "redirectAddress", required = false) String redirectAddress) {
         serverLoaderService.reloadClient(connectionId, redirectAddress);
@@ -131,7 +135,7 @@ public class ServerLoaderControllerV3 {
     @Since("3.0.0")
     @GetMapping("/cluster")
     @Secured(resource = NACOS_ADMIN_CORE_CONTEXT_V3 + "/loader", action = ActionTypes.READ,
-        apiType = ApiType.ADMIN_API)
+        signType = SignType.CONSOLE, apiType = ApiType.ADMIN_API)
     public Result<ServerLoaderMetrics> loaderMetrics() {
         return Result.success(serverLoaderService.getServerLoaderMetrics());
     }

--- a/core/src/test/java/com/alibaba/nacos/core/cluster/remote/request/PluginAvailabilityRequestHandlerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/cluster/remote/request/PluginAvailabilityRequestHandlerTest.java
@@ -16,12 +16,18 @@
 
 package com.alibaba.nacos.core.cluster.remote.request;
 
+import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.exception.NacosException;
-import com.alibaba.nacos.api.remote.response.ResponseCode;
 import com.alibaba.nacos.api.plugin.PluginType;
+import com.alibaba.nacos.api.remote.RemoteConstants;
+import com.alibaba.nacos.api.remote.request.RequestMeta;
+import com.alibaba.nacos.api.remote.response.ResponseCode;
+import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.core.cluster.remote.response.PluginAvailabilityResponse;
 import com.alibaba.nacos.core.plugin.PluginManager;
 import com.alibaba.nacos.core.plugin.model.PluginInfo;
+import com.alibaba.nacos.core.remote.grpc.InvokeSource;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Arrays;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -121,6 +128,24 @@ class PluginAvailabilityRequestHandlerTest {
         assertEquals(ResponseCode.FAIL.getCode(), response.getResultCode());
         assertEquals("Either queryAll must be true or pluginId must be provided",
             response.getMessage());
+    }
+    
+    @Test
+    void securedMetadataTest() throws NoSuchMethodException {
+        InvokeSource invokeSource =
+            PluginAvailabilityRequestHandler.class.getAnnotation(InvokeSource.class);
+        assertNotNull(invokeSource);
+        assertArrayEquals(new String[] {RemoteConstants.LABEL_SOURCE_CLUSTER},
+            invokeSource.source());
+        
+        Secured secured = PluginAvailabilityRequestHandler.class
+            .getDeclaredMethod("handle", PluginAvailabilityRequest.class,
+                RequestMeta.class)
+            .getAnnotation(Secured.class);
+        assertNotNull(secured);
+        assertEquals("pluginAvailability", secured.resource());
+        assertEquals(SignType.SPECIFIED, secured.signType());
+        assertEquals(ApiType.INNER_API, secured.apiType());
     }
     
     private PluginInfo createPluginInfo(String pluginId, PluginType pluginType, String pluginName,

--- a/core/src/test/java/com/alibaba/nacos/core/controller/v3/SecuredMetadataTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/controller/v3/SecuredMetadataTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.controller.v3;
+
+import com.alibaba.nacos.api.common.ApiType;
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SecuredMetadataTest {
+    
+    @Test
+    void testServerLoaderUsesConsoleSignType() {
+        assertConsoleSignType("currentClients");
+        assertConsoleSignType("reloadCount");
+        assertConsoleSignType("smartReload");
+        assertConsoleSignType("reloadSingle");
+        assertConsoleSignType("loaderMetrics");
+    }
+    
+    private void assertConsoleSignType(String methodName) {
+        Method method = Arrays.stream(ServerLoaderControllerV3.class.getDeclaredMethods())
+            .filter(candidate -> methodName.equals(candidate.getName()))
+            .findFirst()
+            .orElseThrow();
+        Secured secured = method.getAnnotation(Secured.class);
+        assertNotNull(secured);
+        assertEquals("/v3/admin/core/loader", secured.resource());
+        assertEquals(SignType.CONSOLE, secured.signType());
+        assertEquals(ApiType.ADMIN_API, secured.apiType());
+    }
+}

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3.java
@@ -18,6 +18,7 @@
 package com.alibaba.nacos.plugin.auth.impl.controller.v3;
 
 import com.alibaba.nacos.api.annotation.Since;
+import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.common.Constants;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.ErrorCode;

--- a/prometheus/src/main/java/com/alibaba/nacos/prometheus/filter/PrometheusAuthFilter.java
+++ b/prometheus/src/main/java/com/alibaba/nacos/prometheus/filter/PrometheusAuthFilter.java
@@ -49,6 +49,9 @@ import static com.alibaba.nacos.prometheus.api.ApiConstants.PROMETHEUS_CONTROLLE
 @ConditionalOnBean(PrometheusController.class)
 public class PrometheusAuthFilter {
     
+    private static final String PROMETHEUS_SUB_PATH_PATTERN =
+        PROMETHEUS_CONTROLLER_PATH + "/*";
+    
     @Bean
     public AuthenticationManager authenticationManager(HttpSecurity http,
         UserDetailsService userDetailsService,
@@ -66,7 +69,7 @@ public class PrometheusAuthFilter {
         FilterRegistrationBean<BasicAuthenticationFilter> registration =
             new FilterRegistrationBean<>();
         registration.setFilter(new BasicAuthenticationFilter(authenticationManager));
-        registration.addUrlPatterns(PROMETHEUS_CONTROLLER_PATH);
+        registration.addUrlPatterns(PROMETHEUS_CONTROLLER_PATH, PROMETHEUS_SUB_PATH_PATTERN);
         registration.setName("prometheusBasicAuthenticationFilter");
         registration.setOrder(2);
         return registration;
@@ -77,7 +80,7 @@ public class PrometheusAuthFilter {
         FilterRegistrationBean<AnonymousAuthenticationFilter> registration =
             new FilterRegistrationBean<>();
         registration.setFilter(new AnonymousAuthenticationFilter("annony"));
-        registration.addUrlPatterns(PROMETHEUS_CONTROLLER_PATH);
+        registration.addUrlPatterns(PROMETHEUS_CONTROLLER_PATH, PROMETHEUS_SUB_PATH_PATTERN);
         registration.setName("prometheusAnonymousAuthenticationFilter");
         registration.setOrder(3);
         return registration;
@@ -87,7 +90,7 @@ public class PrometheusAuthFilter {
     public FilterRegistrationBean<AuthorizationFilter> authorizationFilter() {
         FilterRegistrationBean<AuthorizationFilter> registration = new FilterRegistrationBean<>();
         registration.setFilter(new AuthorizationFilter(new AuthenticatedAuthorizationManager<>()));
-        registration.addUrlPatterns(PROMETHEUS_CONTROLLER_PATH);
+        registration.addUrlPatterns(PROMETHEUS_CONTROLLER_PATH, PROMETHEUS_SUB_PATH_PATTERN);
         registration.setName("prometheusAuthorizationFilter");
         registration.setOrder(4);
         return registration;
@@ -98,7 +101,7 @@ public class PrometheusAuthFilter {
         FilterRegistrationBean<ExceptionTranslationFilter> registration =
             new FilterRegistrationBean<>();
         registration.setFilter(new ExceptionTranslationFilter(new Http403ForbiddenEntryPoint()));
-        registration.addUrlPatterns(PROMETHEUS_CONTROLLER_PATH);
+        registration.addUrlPatterns(PROMETHEUS_CONTROLLER_PATH, PROMETHEUS_SUB_PATH_PATTERN);
         registration.setName("prometheusExceptionTranslationFilter");
         registration.setOrder(1);
         return registration;

--- a/prometheus/src/test/java/com/alibaba/nacos/prometheus/filter/PrometheusAuthFilterTest.java
+++ b/prometheus/src/test/java/com/alibaba/nacos/prometheus/filter/PrometheusAuthFilterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.prometheus.filter;
+
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.security.authentication.AuthenticationManager;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.alibaba.nacos.prometheus.api.ApiConstants.PROMETHEUS_CONTROLLER_PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class PrometheusAuthFilterTest {
+    
+    private final PrometheusAuthFilter prometheusAuthFilter = new PrometheusAuthFilter();
+    
+    @Test
+    void testAllAuthFiltersCoverPrometheusSubPaths() {
+        assertUrlPatterns(prometheusAuthFilter.basicAuthenticationFilter(
+            mock(AuthenticationManager.class)));
+        assertUrlPatterns(prometheusAuthFilter.anonymousAuthenticationFilter());
+        assertUrlPatterns(prometheusAuthFilter.authorizationFilter());
+        assertUrlPatterns(prometheusAuthFilter.exceptionTranslationFilter());
+    }
+    
+    private void assertUrlPatterns(FilterRegistrationBean<? extends Filter> registration) {
+        Set<String> expected =
+            Set.of(PROMETHEUS_CONTROLLER_PATH, PROMETHEUS_CONTROLLER_PATH + "/*");
+        assertEquals(expected, new HashSet<>(registration.getUrlPatterns()));
+    }
+}

--- a/specs/en/ai/agentspec-spec.md
+++ b/specs/en/ai/agentspec-spec.md
@@ -76,7 +76,7 @@ content changes without downloading the full payload every cycle.
 
 - **Polling interval**: configurable via `nacosAiAgentSpecCacheUpdateInterval`;
   default 10 000 ms.
-- **Request**: `GET /v3/client/ai/agentspec?namespaceId=&name=&md5=<cached-md5>`.
+- **Request**: `GET /v3/client/ai/agentspecs?namespaceId=&name=&md5=<cached-md5>`.
 - **304 Not Modified**: server compares the request MD5 against the stored
   `contentMd5` (computed at publish time). If they match the server returns
   HTTP 304 with an `ETag` header; the client keeps its local cache unchanged.
@@ -87,6 +87,23 @@ content changes without downloading the full payload every cycle.
 - **Legacy backfill**: for versions published before the contentMd5 field
   existed, the server lazily computes and stores the MD5 on the first
   conditional query.
+
+### 5.2 Authorization Resource Resolution
+
+AgentSpec HTTP APIs use the plural `/ai/agentspecs` path segment and retain
+their declared `AI` sign type and API type while resolving the authorization
+resource:
+
+- regular Admin and Console operations resolve the resource name from
+  `agentSpecName`;
+- `GET .../agentspecs/list` is a namespace-range operation and therefore does
+  not resolve a single resource name; row visibility is enforced by the
+  visibility plugin;
+- `PUT .../agentspecs/draft` resolves the authoritative target from
+  `agentSpecCard.name`, because `agentSpecName` is optional and the card is the
+  object written by the service;
+- `GET /v3/client/ai/agentspecs` resolves the resource from the client `name`
+  parameter.
 
 ## 6. Evolution Note
 

--- a/specs/en/auth/auth-permission-spec.md
+++ b/specs/en/auth/auth-permission-spec.md
@@ -133,6 +133,18 @@ handler to the auth model.
 | `tags` | Additional metadata copied into `Resource.properties`. |
 | `apiType` | API audience and auth scope. |
 
+Resource parsing uses the following precedence:
+
+1. A non-empty `resource` is converted directly to a `SPECIFIED` resource.
+2. A non-default method-level `parser` parses the request while preserving the
+   declared `signType` and `apiType`.
+3. Otherwise, the protocol selects its typed parser from `signType`.
+4. If no typed parser exists, `DefaultResourceParser` returns an empty resource.
+
+An explicitly selected parser must not silently fall back to an empty resource
+when construction or parsing fails. Such failures are request-processing
+errors, because continuing with a broader resource could weaken authorization.
+
 Every non-public v3 HTTP API and gRPC request handler must declare the intended
 auth metadata. Public endpoints must be explicitly documented by their owning
 spec.

--- a/specs/zh-cn/ai/agentspec-spec.md
+++ b/specs/zh-cn/ai/agentspec-spec.md
@@ -70,7 +70,7 @@ AgentSpec 发生变化时通知客户端。
 完整内容。
 
 - **轮询间隔**：通过 `nacosAiAgentSpecCacheUpdateInterval` 配置，默认 10 000 ms。
-- **请求**：`GET /v3/client/ai/agentspec?namespaceId=&name=&md5=<cached-md5>`。
+- **请求**：`GET /v3/client/ai/agentspecs?namespaceId=&name=&md5=<cached-md5>`。
 - **304 Not Modified**：服务端将请求中的 MD5 与存储的 `contentMd5`（发布时预算）比对。
   若一致则返回 HTTP 304 + `ETag` header，客户端保持本地缓存不变。
 - **200 OK**：响应携带 `Result<AgentSpec>` JSON 及响应头
@@ -78,6 +78,18 @@ AgentSpec 发生变化时通知客户端。
   和 md5Cache，并发布 `AgentSpecChangedEvent`。
 - **存量回填**：对于 contentMd5 字段不存在的旧版本，服务端在首次条件查询时懒计算并存储
   MD5。
+
+### 5.2 鉴权资源解析
+
+AgentSpec HTTP API 使用复数形式的 `/ai/agentspecs` 路径段。解析鉴权资源时，保留注解中
+声明的 `AI` sign type 和 API type：
+
+- 常规 Admin 和 Console 操作从 `agentSpecName` 解析资源名；
+- `GET .../agentspecs/list` 是 namespace 范围查询，不解析单个资源名，返回数据的资源
+  可见性由 visibility 插件控制；
+- `PUT .../agentspecs/draft` 从 `agentSpecCard.name` 解析实际写入目标，因为
+  `agentSpecName` 可选，而服务实际写入的对象来自 card；
+- `GET /v3/client/ai/agentspecs` 从客户端请求参数 `name` 解析资源名。
 
 ## 6. 演进说明
 

--- a/specs/zh-cn/auth/auth-permission-spec.md
+++ b/specs/zh-cn/auth/auth-permission-spec.md
@@ -121,6 +121,17 @@ Nacos 将请求级授权和数据级可见性分开处理。
 | `tags` | 复制到 `Resource.properties` 的附加元数据。 |
 | `apiType` | API 受众与鉴权范围。 |
 
+资源解析遵循以下优先级：
+
+1. `resource` 非空时，直接转换为 `SPECIFIED` 资源。
+2. 方法级 `parser` 不是默认 Parser 时，由其解析请求，并保留注解声明的
+   `signType` 和 `apiType`。
+3. 否则根据 `signType` 选择协议对应的类型化 Parser。
+4. 找不到类型化 Parser 时，由 `DefaultResourceParser` 返回空资源。
+
+显式指定的 Parser 构造或解析失败时，不得静默降级为空资源。该失败应作为
+请求处理错误，因为继续使用更宽泛的资源可能削弱鉴权约束。
+
 每个非公开的 v3 HTTP API 和 gRPC 请求处理器都必须声明预期的鉴权元数据。公开端点必须由
 所属规范明确记录。
 


### PR DESCRIPTION
## What is the purpose of the change

Backport the reviewed HTTP and gRPC API authorization fixes from #15635 to
`v3.2.4-develop` for the API surface available on this maintenance branch.

Develop-only Agent/ARD endpoints and OpenAPI scenario documents that do not
exist on this branch are intentionally omitted.

For #15634

## Brief changelog

- Correct reviewed HTTP `@Secured` API types, sign types, and privileged
  resources for APIs available in v3.2.4.
- Protect Prometheus service-discovery subpaths with the existing Spring
  Security filters.
- Mark `PluginAvailabilityRequestHandler` as a protected inner request.
- Make explicit HTTP/gRPC resource parsers take precedence over typed parsers
  while preserving explicit-resource behavior.
- Fix AgentSpec plural-path recognition, namespace-range list semantics, and
  method-specific target parsing.
- Backport the applicable English and Chinese authorization and AgentSpec spec
  updates.

## Verifying this change

- `mvn -B -pl auth,core,config,ai,prometheus,console,plugin-default-impl/nacos-default-auth-plugin -am clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e`
- `mvn -pl auth,ai,config,core,console,prometheus -am -Dtest=HttpProtocolAuthServiceTest,GrpcProtocolAuthServiceTest,AiHttpResourceParserTest,AgentSpecHttpResourceParserTest,SecuredMetadataTest,PluginAvailabilityRequestHandlerTest,PrometheusAuthFilterTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test`
- 42-module static-check reactor passed.
- 75 applicable focused authorization tests passed.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit tests to verify the logic correction.
* [x] Run the relevant Maven compile, RAT, Checkstyle, SpotBugs, Spotless, and focused unit-test checks.
