### PR TITLE
[ISSUE #15640] Support Nacos on Linux RISC-V with RocksDB

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRocksDbDiskService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigRocksDbDiskService.java
@@ -51,6 +51,10 @@ public class ConfigRocksDbDiskService implements ConfigDiskService {
     
     private static final long DEFAULT_WRITE_BUFFER_MB = 32;
     
+    static {
+        RocksDB.loadLibrary();
+    }
+    
     Map<String, RocksDB> rocksDbMap = new HashMap<>();
     
     private void createDirIfNotExist(String dir) {

--- a/distribution/bin/startup.sh
+++ b/distribution/bin/startup.sh
@@ -27,6 +27,42 @@ error_exit ()
     exit 1
 }
 
+configure_riscv64_libatomic() {
+    if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "riscv64" ]; then
+        return
+    fi
+
+    if [[ "${LD_PRELOAD:-}" == *"libatomic.so.1"* ]]; then
+        return
+    fi
+
+    local libatomic_path=""
+    if command -v ldconfig > /dev/null 2>&1 && command -v awk > /dev/null 2>&1; then
+        libatomic_path=$(ldconfig -p 2> /dev/null | awk '/libatomic\.so\.1 .*=>/ {print $NF; exit}')
+    fi
+
+    if [ -z "${libatomic_path}" ] || [ ! -r "${libatomic_path}" ]; then
+        local candidate
+        for candidate in /lib/riscv64-linux-gnu/libatomic.so.1 \
+                         /usr/lib/riscv64-linux-gnu/libatomic.so.1 \
+                         /lib64/lp64d/libatomic.so.1 \
+                         /usr/lib64/lp64d/libatomic.so.1 \
+                         /lib64/libatomic.so.1 \
+                         /usr/lib64/libatomic.so.1; do
+            if [ -r "${candidate}" ]; then
+                libatomic_path="${candidate}"
+                break
+            fi
+        done
+    fi
+
+    if [ -z "${libatomic_path}" ] || [ ! -r "${libatomic_path}" ]; then
+        return
+    fi
+
+    export LD_PRELOAD="${LD_PRELOAD:+${LD_PRELOAD}:}${libatomic_path}"
+}
+
 validate_base64() {
     decode_cmd=""
     if command -v base64 > /dev/null 2>&1; then
@@ -293,6 +329,8 @@ if [ ! -f "$logfile" ]; then
 fi
 
 echo "$JAVA $JAVA_OPT_EXT_FIX ${JAVA_OPT}" > "$logfile"
+
+configure_riscv64_libatomic
 
 if [ "$JAVA_OPT_EXT_FIX" = "" ]; then
   nohup "$JAVA" ${JAVA_OPT} nacos.nacos >> "$logfile" 2>&1 &

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
         <HikariCP.version>3.4.2</HikariCP.version>
         <jraft-core.version>1.4.0</jraft-core.version>
         <rpc-grpc-impl.version>${jraft-core.version}</rpc-grpc-impl.version>
+        <rocksdb.version>8.10.2</rocksdb.version>
         <!-- gson version should follow grcp-core dependency -->
         <!-- TODO try to remove direct dependency on gson -->
         <gson.version>2.11.0</gson.version>
@@ -1021,6 +1022,12 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.rocksdb</groupId>
+                <artifactId>rocksdbjni</artifactId>
+                <version>${rocksdb.version}</version>
             </dependency>
             
             <!-- Third-party libs -->


### PR DESCRIPTION
## What is the purpose of the change

Support Nacos startup on Linux RISC-V systems by using a RocksDB JNI release that contains a `riscv64` native library and loading its required `libatomic.so.1` dependency before Java starts.

For #15640

The startup change is strictly gated to Linux `riscv64`. Other operating systems and architectures keep the existing behavior. Linux RISC-V also keeps the existing behavior when no readable `libatomic.so.1` can be found.

## Brief changelog

- Manage `org.rocksdb:rocksdbjni` at version 8.10.2, overriding the 8.8.1 version brought by `jraft-core`.
- Explicitly call `RocksDB.loadLibrary()` for the Config RocksDB dump backend because RocksDB 8.10.2 no longer loads JNI from the `RocksDB` class initializer.
- Detect Linux `riscv64` in `startup.sh` and append a readable `libatomic.so.1` path to `LD_PRELOAD`, while preserving any existing preload value.

## Verifying this change

- `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check ...`: all 61 reactor modules passed.
- `mvn -pl config -Dtest=ConfigRocksDbDiskServiceTest -DskipITs test`: 15 tests passed.
- Core and distribution dependency trees resolve `rocksdbjni:8.10.2`; the artifact contains `librocksdbjni-linux-riscv64.so`.
- `bash -n distribution/bin/startup.sh` passed.
- Startup gating was exercised for non-Linux, non-RISC-V, missing/unreadable `libatomic.so.1`, readable `libatomic.so.1`, existing `LD_PRELOAD`, and already-preloaded `libatomic.so.1` scenarios.
- A native RISC-V end-to-end Nacos startup was not available in the local environment and remains for CI or native-environment validation.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
