### PR TITLE
[ISSUE #12557] Add spin retry to config dump write lock acquisition

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
@@ -28,7 +28,6 @@ import com.alibaba.nacos.config.server.model.gray.GrayRule;
 import com.alibaba.nacos.config.server.model.gray.GrayRuleManager;
 import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskServiceFactory;
 import com.alibaba.nacos.config.server.utils.GroupKey2;
-import com.alibaba.nacos.config.server.utils.LogUtil;
 import com.alibaba.nacos.sys.env.EnvUtil;
 
 import java.io.IOException;
@@ -87,7 +86,7 @@ public class ConfigCacheService {
         String groupKey = GroupKey2.getKey(dataId, group, tenant);
         CacheItem ci = makeSure(groupKey, encryptedDataKey);
         ci.setType(type);
-        final int lockResult = tryWriteLock(groupKey);
+        final int lockResult = tryConfigWriteLock(groupKey);
         
         if (lockResult < 0) {
             DUMP_LOG.warn("[dump-error] write lock failed. {}", groupKey);
@@ -200,7 +199,7 @@ public class ConfigCacheService {
         final String groupKey = GroupKey2.getKey(dataId, group, tenant);
         
         makeSure(groupKey, null);
-        final int lockResult = tryWriteLock(groupKey);
+        final int lockResult = tryConfigWriteLock(groupKey);
         
         if (lockResult < 0) {
             DUMP_LOG.warn("[dump-gray-error] write lock failed. {}", groupKey);
@@ -626,43 +625,106 @@ public class ConfigCacheService {
         cache.getConfigCache().setLastModifiedTs(lastModifiedTs);
     }
     
-    private static final int TRY_GET_LOCK_TIMES = 9;
+    /**
+     * Maximum number of attempts used by {@link #tryConfigReadLock(String)} / {@link #tryConfigWriteLock(String)} when
+     * the lock is contended. The implementation performs exactly {@code MAX_LOCK_ATTEMPTS} attempts, sleeping for
+     * {@link #LOCK_RETRY_INTERVAL_MILLIS} between two consecutive attempts.
+     */
+    private static final int MAX_LOCK_ATTEMPTS = 10;
     
     /**
-     * try config read lock with spin of try get lock times.
+     * Sleep interval between two consecutive lock attempts of {@link #tryConfigReadLock(String)} /
+     * {@link #tryConfigWriteLock(String)}.
+     */
+    private static final int LOCK_RETRY_INTERVAL_MILLIS = 1;
+    
+    /**
+     * Try config read lock with retry of {@link #MAX_LOCK_ATTEMPTS} times.
      *
      * @param groupKey group key of config.
      * @return 0 - No data and failed. Positive number - lock succeeded. Negative number - lock failed.
      */
     public static int tryConfigReadLock(String groupKey) {
-        
+        return tryLockWithRetry(groupKey, true);
+    }
+    
+    /**
+     * Try config write lock with retry of {@link #MAX_LOCK_ATTEMPTS} times.
+     *
+     * @param groupKey group key of config.
+     * @return 0 - No data and failed. Positive number - lock succeeded. Negative number - lock failed.
+     */
+    static int tryConfigWriteLock(String groupKey) {
+        return tryLockWithRetry(groupKey, false);
+    }
+    
+    /**
+     * Acquire the read or write lock with a bounded retry loop.
+     *
+     * <p>Both {@link #tryConfigReadLock(String)} and {@link #tryConfigWriteLock(String)} share this helper so that the
+     * retry count, the delay between attempts, the interruption handling and any future backoff behavior cannot drift
+     * between the two paths.</p>
+     *
+     * <p>The retry loop performs at most {@link #MAX_LOCK_ATTEMPTS} attempts. The underlying {@link #tryReadLock} /
+     * {@link #tryWriteLock} already emits a warning on each failed attempt, so this helper does not log per attempt.
+     * Instead, it logs a single aggregated warning once all attempts are exhausted, including the attempt count and the
+     * elapsed time. If the sleeping thread is interrupted, the interrupt flag is restored and the loop stops
+     * retrying.</p>
+     *
+     * @param groupKey group key of config.
+     * @param readLock {@code true} to acquire the read lock, {@code false} to acquire the write lock.
+     * @return 0 - No data and failed. Positive number - lock succeeded. Negative number - lock failed.
+     */
+    private static int tryLockWithRetry(String groupKey, boolean readLock) {
         // Lock failed by default.
         int lockResult = -1;
-        
-        // Try to get lock times, max value: 10;
-        for (int i = TRY_GET_LOCK_TIMES; i >= 0; --i) {
-            lockResult = ConfigCacheService.tryReadLock(groupKey);
-            
-            // The data is non-existent.
-            if (0 == lockResult) {
-                break;
-            }
-            
-            // Success
-            if (lockResult > 0) {
-                break;
-            }
-            
-            // Retry.
-            if (i > 0) {
-                try {
-                    Thread.sleep(1);
-                } catch (Exception e) {
-                    LogUtil.PULL_CHECK_LOG.error("An Exception occurred while thread sleep", e);
+        long startNanos = System.nanoTime();
+        int attempts = 0;
+        boolean interrupted = false;
+        try {
+            for (int i = 0; i < MAX_LOCK_ATTEMPTS; i++) {
+                attempts++;
+                lockResult = readLock ? ConfigCacheService.tryReadLock(groupKey)
+                    : ConfigCacheService.tryWriteLock(groupKey);
+                
+                // The data is non-existent.
+                if (0 == lockResult) {
+                    return lockResult;
                 }
+                
+                // Success
+                if (lockResult > 0) {
+                    return lockResult;
+                }
+                
+                // No more attempts.
+                if (i == MAX_LOCK_ATTEMPTS - 1) {
+                    break;
+                }
+                
+                try {
+                    Thread.sleep(LOCK_RETRY_INTERVAL_MILLIS);
+                } catch (InterruptedException e) {
+                    // Stop retrying but keep the interrupt status for callers and restore it before returning.
+                    interrupted = true;
+                    DUMP_LOG.warn("[{}-lock] retry interrupted, groupKey={}",
+                        readLock ? "read" : "write",
+                        groupKey);
+                    break;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
             }
         }
         
+        // All attempts exhausted: log a single aggregated warning including attempt count and elapsed time.
+        if (lockResult < 0) {
+            DUMP_LOG.warn("[{}-lock] failed after {} attempts, cost={}ms, groupKey={}",
+                readLock ? "read" : "write",
+                attempts, (System.nanoTime() - startNanos) / 1000000L, groupKey);
+        }
         return lockResult;
     }
 }

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpConfigHandler.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/DumpConfigHandler.java
@@ -32,6 +32,17 @@ import com.alibaba.nacos.config.server.service.trace.ConfigTraceService;
  */
 public class DumpConfigHandler extends Subscriber<ConfigDumpEvent> {
     
+    private final DumpService dumpService;
+    
+    /**
+     * Creates a dump event handler.
+     *
+     * @param dumpService dump service used to enqueue keyed dump tasks
+     */
+    public DumpConfigHandler(DumpService dumpService) {
+        this.dumpService = dumpService;
+    }
+    
     /**
      * trigger config dump event.
      *
@@ -108,7 +119,11 @@ public class DumpConfigHandler extends Subscriber<ConfigDumpEvent> {
     
     @Override
     public void onEvent(ConfigDumpEvent event) {
-        configDump(event);
+        DumpRequest dumpRequest =
+            DumpRequest.create(event.getDataId(), event.getGroup(), event.getNamespaceId(),
+                event.getLastModifiedTs(), event.getHandleIp());
+        dumpRequest.setGrayName(event.getGrayName());
+        dumpService.dump(dumpRequest);
     }
     
     @Override

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigDumpApplyHook.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigDumpApplyHook.java
@@ -22,9 +22,11 @@ import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.model.event.ConfigDumpEvent;
 import com.alibaba.nacos.config.server.service.dump.DumpConfigHandler;
+import com.alibaba.nacos.config.server.service.dump.DumpService;
 import com.alibaba.nacos.consistency.entity.WriteRequest;
 import com.alibaba.nacos.core.utils.GenericType;
 import com.alibaba.nacos.persistence.repository.embedded.hook.EmbeddedApplyHook;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -39,9 +41,9 @@ import java.util.Objects;
 @Component
 public class EmbeddedConfigDumpApplyHook extends EmbeddedApplyHook {
     
-    public EmbeddedConfigDumpApplyHook() {
+    public EmbeddedConfigDumpApplyHook(@Lazy DumpService dumpService) {
         NotifyCenter.registerToPublisher(ConfigDumpEvent.class, NotifyCenter.ringBufferSize);
-        NotifyCenter.registerSubscriber(new DumpConfigHandler());
+        NotifyCenter.registerSubscriber(new DumpConfigHandler(dumpService));
     }
     
     @Override

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigCacheServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigCacheServiceTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.config.server.service;
 
 import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.model.CacheItem;
+import com.alibaba.nacos.config.server.model.ConfigCache;
 import com.alibaba.nacos.config.server.model.ConfigCacheGray;
 import com.alibaba.nacos.config.server.model.gray.GrayRuleManager;
 import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskService;
@@ -636,6 +637,88 @@ class ConfigCacheServiceTest {
     }
     
     @Test
+    void testDumpWithMd5RetriesAndUpdatesCacheAfterTransientContention() throws Exception {
+        String dataId = "retryDumpD";
+        String group = "retryDumpG";
+        String tenant = "retryDumpT";
+        String content = "retryContent";
+        String md5 = "retryMd5";
+        long ts = System.currentTimeMillis();
+        String encryptedDataKey = "retryKey";
+        String groupKey = GroupKey2.getKey(dataId, group, tenant);
+        
+        // Simulate transient write-lock contention: fail the first few attempts, then succeed.
+        SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
+        OngoingStubbing<Boolean> when = Mockito.when(lock.tryWriteLock());
+        for (int i = 0; i < 5; i++) {
+            when = when.thenReturn(false);
+        }
+        when.thenReturn(true);
+        // A real ConfigCache is required so dumpWithMd5 can read/write the cached md5.
+        ConfigCache configCache = new ConfigCache();
+        CacheItem cacheItem = Mockito.mock(CacheItem.class);
+        Mockito.when(cacheItem.getRwLock()).thenReturn(lock);
+        Mockito.when(cacheItem.getConfigCache()).thenReturn(configCache);
+        cache().put(groupKey, cacheItem);
+        
+        boolean result = ConfigCacheService.dumpWithMd5(dataId, group, tenant, content, md5, ts,
+            "text", encryptedDataKey);
+        
+        // dumpWithMd5 must eventually succeed through the retry path and update the cache.
+        assertTrue(result);
+        assertEquals(md5, configCache.getMd5());
+        assertEquals(ts, configCache.getLastModifiedTs());
+        assertEquals(encryptedDataKey, configCache.getEncryptedDataKey());
+        Mockito.verify(configDiskService, times(1)).saveToDisk(eq(dataId), eq(group), eq(tenant),
+            eq(content));
+        cache().remove(groupKey);
+    }
+    
+    @Test
+    void testDumpGrayRetriesAndUpdatesCacheAfterTransientContention() throws Exception {
+        String dataId = "retryGrayD";
+        String group = "retryGrayG";
+        String tenant = "retryGrayT";
+        String grayName = "grayRetry";
+        String grayRule = "{\"type\":\"tag\",\"version\":\"1.0.0\",\"expr\":\"retry\","
+            + "\"priority\":1}";
+        String content = "retryGrayContent";
+        String expectedMd5 = MD5Utils.md5Hex(content, "UTF-8");
+        long ts = System.currentTimeMillis();
+        String encryptedDataKey = "retryGrayKey";
+        String groupKey = GroupKey2.getKey(dataId, group, tenant);
+        
+        // Simulate transient write-lock contention: fail the first few attempts, then succeed.
+        SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
+        OngoingStubbing<Boolean> when = Mockito.when(lock.tryWriteLock());
+        for (int i = 0; i < 4; i++) {
+            when = when.thenReturn(false);
+        }
+        when.thenReturn(true);
+        // A real gray cache is required so dumpGray can read/write the cached md5 / gray rule.
+        ConfigCacheGray grayCache = new ConfigCacheGray(grayName);
+        Map<String, ConfigCacheGray> grayMap = new ConcurrentHashMap<>();
+        grayMap.put(grayName, grayCache);
+        CacheItem cacheItem = Mockito.mock(CacheItem.class);
+        Mockito.when(cacheItem.getRwLock()).thenReturn(lock);
+        Mockito.when(cacheItem.getConfigCacheGray()).thenReturn(grayMap);
+        cache().put(groupKey, cacheItem);
+        
+        boolean result = ConfigCacheService.dumpGray(dataId, group, tenant, grayName, grayRule,
+            content, ts, encryptedDataKey);
+        
+        // dumpGray must eventually succeed through the retry path and update the gray cache.
+        assertTrue(result);
+        assertEquals(expectedMd5, grayCache.getMd5());
+        assertEquals(ts, grayCache.getLastModifiedTs());
+        assertEquals(encryptedDataKey, grayCache.getEncryptedDataKey());
+        Mockito.verify(configDiskService, times(1)).saveGrayToDisk(eq(dataId), eq(group),
+            eq(tenant),
+            eq(grayName), eq(content));
+        cache().remove(groupKey);
+    }
+    
+    @Test
     void testRemoveWriteLockFailed() throws Exception {
         String dataId = "rmLockD";
         String group = "rmLockG";
@@ -701,6 +784,45 @@ class ConfigCacheServiceTest {
     }
     
     @Test
+    void testTryConfigWriteLock() throws Exception {
+        String dataId = "123testTryConfigWriteLock";
+        String group = "1234";
+        String tenant = "1234";
+        CacheItem cacheItem = Mockito.mock(CacheItem.class);
+        SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
+        Mockito.when(cacheItem.getRwLock()).thenReturn(lock);
+        String groupKey = GroupKey2.getKey(dataId, group, tenant);
+        ConcurrentHashMap<String, CacheItem> cache = cache();
+        cache.put(groupKey, cacheItem);
+        
+        // lock ==0,not exist
+        int writeLock = ConfigCacheService.tryConfigWriteLock(groupKey + "3245");
+        assertEquals(0, writeLock);
+        
+        //lock == 1 , success get lock
+        Mockito.when(lock.tryWriteLock()).thenReturn(true);
+        int writeLockSuccess = ConfigCacheService.tryConfigWriteLock(groupKey);
+        assertEquals(1, writeLockSuccess);
+        
+        //lock ==-1 fail after spin all times;
+        OngoingStubbing<Boolean> when = Mockito.when(lock.tryWriteLock());
+        for (int i = 0; i < 10; i++) {
+            when = when.thenReturn(false);
+        }
+        int writeLockFail = ConfigCacheService.tryConfigWriteLock(groupKey);
+        assertEquals(-1, writeLockFail);
+        
+        //lock ==1 success after serval spin  times;
+        OngoingStubbing<Boolean> when2 = Mockito.when(lock.tryWriteLock());
+        for (int i = 0; i < 5; i++) {
+            when2 = when2.thenReturn(false);
+        }
+        when2.thenReturn(true);
+        int writeLockSuccessAfterRetry = ConfigCacheService.tryConfigWriteLock(groupKey);
+        assertEquals(1, writeLockSuccessAfterRetry);
+    }
+    
+    @Test
     void testTryConfigReadLockWhenSleepInterrupted() throws Exception {
         String dataId = "interruptReadLockD";
         String group = "interruptReadLockG";
@@ -710,8 +832,33 @@ class ConfigCacheServiceTest {
         String groupKey = putMockCacheItem(dataId, group, tenant, lock);
         
         Thread.currentThread().interrupt();
-        assertEquals(-1, ConfigCacheService.tryConfigReadLock(groupKey));
-        assertFalse(Thread.currentThread().isInterrupted());
+        try {
+            assertEquals(-1, ConfigCacheService.tryConfigReadLock(groupKey));
+            // The interrupt flag must be restored so callers higher up the stack can react to it.
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+        cache().remove(groupKey);
+    }
+    
+    @Test
+    void testTryConfigWriteLockWhenSleepInterrupted() throws Exception {
+        String dataId = "interruptWriteLockD";
+        String group = "interruptWriteLockG";
+        String tenant = "interruptWriteLockT";
+        SimpleReadWriteLock lock = Mockito.mock(SimpleReadWriteLock.class);
+        Mockito.when(lock.tryWriteLock()).thenReturn(false);
+        String groupKey = putMockCacheItem(dataId, group, tenant, lock);
+        
+        Thread.currentThread().interrupt();
+        try {
+            assertEquals(-1, ConfigCacheService.tryConfigWriteLock(groupKey));
+            // The interrupt flag must be restored so callers higher up the stack can react to it.
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
         cache().remove(groupKey);
     }
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpConfigHandlerTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpConfigHandlerTest.java
@@ -24,6 +24,7 @@ import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -37,6 +38,8 @@ class DumpConfigHandlerTest {
     
     private MockedStatic<EnvUtil> envUtilMockedStatic;
     
+    private DumpService dumpService;
+    
     @BeforeEach
     void setUp() {
         configCacheServiceMockedStatic =
@@ -45,6 +48,7 @@ class DumpConfigHandlerTest {
         envUtilMockedStatic.when(() -> EnvUtil.getProperty(
             "nacos.config.cache.type", "nacos"))
             .thenReturn("nacos");
+        dumpService = Mockito.mock(DumpService.class);
     }
     
     @AfterEach
@@ -162,22 +166,43 @@ class DumpConfigHandlerTest {
     }
     
     @Test
-    void testOnEvent() {
-        configCacheServiceMockedStatic.when(() -> ConfigCacheService.remove("d", "g", "ns"))
-            .thenReturn(true);
-        
+    void testOnEventQueuesFormalDumpByKey() {
         ConfigDumpEvent event = ConfigDumpEvent.builder()
             .dataId("d").group("g").namespaceId("ns")
             .lastModifiedTs(100L).handleIp("1.1.1.1")
             .remove(true).build();
         
-        DumpConfigHandler handler = new DumpConfigHandler();
-        handler.onEvent(event);
+        new DumpConfigHandler(dumpService).onEvent(event);
+        
+        ArgumentCaptor<DumpRequest> requestCaptor = ArgumentCaptor.forClass(DumpRequest.class);
+        Mockito.verify(dumpService).dump(requestCaptor.capture());
+        DumpRequest request = requestCaptor.getValue();
+        assertEquals("d", request.getDataId());
+        assertEquals("g", request.getGroup());
+        assertEquals("ns", request.getTenant());
+        assertEquals(100L, request.getLastModifiedTs());
+        assertEquals("1.1.1.1", request.getSourceIp());
+    }
+    
+    @Test
+    void testOnEventQueuesGrayDumpByKey() {
+        ConfigDumpEvent event = ConfigDumpEvent.builder()
+            .dataId("d").group("g").namespaceId("ns")
+            .grayName("gray1").grayRule("rule")
+            .content("content").lastModifiedTs(100L)
+            .encryptedDataKey("edk").handleIp("1.1.1.1")
+            .remove(false).build();
+        
+        new DumpConfigHandler(dumpService).onEvent(event);
+        
+        ArgumentCaptor<DumpRequest> requestCaptor = ArgumentCaptor.forClass(DumpRequest.class);
+        Mockito.verify(dumpService).dump(requestCaptor.capture());
+        assertEquals("gray1", requestCaptor.getValue().getGrayName());
     }
     
     @Test
     void testSubscribeType() {
-        DumpConfigHandler handler = new DumpConfigHandler();
+        DumpConfigHandler handler = new DumpConfigHandler(dumpService);
         assertEquals(ConfigDumpEvent.class, handler.subscribeType());
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpProcessorTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/dump/DumpProcessorTest.java
@@ -17,8 +17,10 @@
 package com.alibaba.nacos.config.server.service.dump;
 
 import com.alibaba.nacos.common.utils.MD5Utils;
+import com.alibaba.nacos.config.server.manager.TaskManager;
 import com.alibaba.nacos.config.server.model.CacheItem;
 import com.alibaba.nacos.config.server.model.ConfigInfoWrapper;
+import com.alibaba.nacos.config.server.model.event.ConfigDumpEvent;
 import com.alibaba.nacos.config.server.service.ConfigCacheService;
 import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskService;
 import com.alibaba.nacos.config.server.service.dump.disk.ConfigDiskServiceFactory;
@@ -40,9 +42,11 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -108,6 +112,8 @@ class DumpProcessorTest {
     
     @AfterEach
     void after() throws Exception {
+        ((TaskManager) ReflectionTestUtils.getField(dumpService, "dumpTaskMgr")).close();
+        ((TaskManager) ReflectionTestUtils.getField(dumpService, "dumpAllTaskMgr")).close();
         dynamicDataSourceMockedStatic.close();
         envUtilMockedStatic.close();
         ConfigDiskServiceFactory.getInstance().clearAll();
@@ -172,5 +178,49 @@ class DumpProcessorTest {
             ConfigDiskServiceFactory.getInstance().getContent(dataId, group, tenant);
         assertNull(contentFromDiskAfterRemove);
         
+    }
+    
+    @Test
+    void testStaleRemoveEventReloadsLatestPersistedConfig() throws Exception {
+        String dataId = "staleRemoveDataId";
+        String group = "staleRemoveGroup";
+        String tenant = "staleRemoveTenant";
+        String content = "latestContent";
+        long latestModified = 200L;
+        String groupKey = GroupKey2.getKey(dataId, group, tenant);
+        
+        try {
+            assertTrue(ConfigCacheService.dump(dataId, group, tenant, content, latestModified,
+                "text", "encryptedKey"));
+            ConfigInfoWrapper latestConfig = new ConfigInfoWrapper();
+            latestConfig.setDataId(dataId);
+            latestConfig.setGroup(group);
+            latestConfig.setTenant(tenant);
+            latestConfig.setContent(content);
+            latestConfig.setType("text");
+            latestConfig.setEncryptedDataKey("encryptedKey");
+            latestConfig.setLastModified(latestModified);
+            Mockito.when(configInfoPersistService.findConfigInfo(dataId, group, tenant))
+                .thenReturn(latestConfig);
+            
+            DumpConfigHandler handler = new DumpConfigHandler(dumpService);
+            handler.onEvent(ConfigDumpEvent.builder().dataId(dataId).group(group)
+                .namespaceId(tenant).lastModifiedTs(100L).handleIp("127.0.0.1").remove(true)
+                .build());
+            handler.onEvent(ConfigDumpEvent.builder().dataId(dataId).group(group)
+                .namespaceId(tenant).content(content).lastModifiedTs(latestModified)
+                .handleIp("127.0.0.1").remove(false).build());
+            
+            TaskManager taskManager =
+                (TaskManager) ReflectionTestUtils.getField(dumpService, "dumpTaskMgr");
+            assertEquals(1, taskManager.size());
+            assertTrue(taskManager.await(5, TimeUnit.SECONDS));
+            
+            CacheItem cacheItem = ConfigCacheService.getContentCache(groupKey);
+            assertEquals(MD5Utils.md5Hex(content, "UTF-8"), cacheItem.getConfigCache().getMd5());
+            assertEquals(latestModified, cacheItem.getConfigCache().getLastModifiedTs());
+        } finally {
+            ConfigCacheService.remove(dataId, group, tenant);
+        }
     }
 }

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigDumpApplyHookTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/repository/embedded/EmbeddedConfigDumpApplyHookTest.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.config.server.constant.Constants;
 import com.alibaba.nacos.config.server.model.event.ConfigDumpEvent;
+import com.alibaba.nacos.config.server.service.dump.DumpService;
 import com.alibaba.nacos.consistency.entity.WriteRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,7 @@ class EmbeddedConfigDumpApplyHookTest {
     @BeforeEach
     void setUp() {
         notifyCenterMockedStatic = Mockito.mockStatic(NotifyCenter.class);
-        hook = new EmbeddedConfigDumpApplyHook();
+        hook = new EmbeddedConfigDumpApplyHook(Mockito.mock(DumpService.class));
     }
     
     @org.junit.jupiter.api.AfterEach


### PR DESCRIPTION
## What
This replaces #15582, which was accidentally closed while correcting the shallow-clone branch history after addressing the latest review.

Makes config dump reliably update the cache even when the write lock is transiently contended, fully addressing #12557. The fix has two complementary parts:

1. **Write-lock spin retry** (`ConfigCacheService`) — mirrors the existing read-lock retry and avoids giving up on the first collision.
2. **Keyed dump-task pipeline** (`DumpConfigHandler` / `DumpService`) — raft/apply events are converted to keyed `DumpTask`s. The existing processor reloads the latest persisted state when the task executes and requeues a failed attempt, instead of replaying a captured event snapshot.

Previously, `DumpConfigHandler.onEvent` invoked `configDump(event)` directly and discarded its boolean result. A failed dump left the JVM md5 cache stale until periodic full reconciliation.

## Root cause
- `ConfigCacheService.dumpWithMd5` / `dumpGray` acquired the write lock with a single `tryWriteLock(groupKey)`; a collision with a concurrent reader immediately returned `false`. The read path already retried via `tryConfigReadLock`.
- The raft/apply path treated a `false` result as success and had no task-level retry.
- Replaying a captured event is unsafe: an old remove event can run after a newer publish and delete the newer cache value.

## Fix

### Layer 1 — write-lock retry (`ConfigCacheService`)
- Add `tryConfigWriteLock(groupKey)` mirroring `tryConfigReadLock`, used by `dumpWithMd5` and `dumpGray`.
- Back both paths with one private `tryLockWithRetry(groupKey, readLock)` helper so retry count, delay, interruption handling, and logging cannot drift.
- Rename `TRY_GET_LOCK_TIMES` to `MAX_LOCK_ATTEMPTS = 10` and extract `LOCK_RETRY_INTERVAL_MILLIS = 1`.
- Catch `InterruptedException` specifically, restore the interrupt flag, and stop retrying.
- Log one aggregate warning after attempts are exhausted and use `DUMP_LOG`.
- Keep `tryConfigWriteLock` package-private.

### Layer 2 — latest-state keyed task retry (`DumpConfigHandler`)
- Inject `DumpService` into `DumpConfigHandler` and convert each `ConfigDumpEvent` into a `DumpRequest` containing only the config identity, timestamp, source IP, and optional gray name.
- Enqueue through the existing `DumpService.dump` / `TaskManager` path. Tasks are keyed by config identity, so pending work for the same key is coalesced.
- `DumpProcessor` reads the current config from persistence on every execution. Therefore, even if a stale remove event is delivered after a newer publish, the task applies the latest persisted config rather than the stale event payload.
- A processor `false` result uses the existing `TaskManager` requeue behavior; no custom scheduler, retry counter, or captured-event replay is introduced.
- Use lazy `DumpService` injection in `EmbeddedConfigDumpApplyHook` to preserve Spring initialization order.

## Tests
- `ConfigCacheServiceTest`: lock retry behavior, dump success after transient contention, and interrupt-flag restoration without leaking the interrupt state to later tests.
- `DumpConfigHandlerTest`: formal and gray events are translated to the correct keyed dump requests.
- `DumpProcessorTest`: executes the real asynchronous `TaskManager`; a stale remove followed by a newer publish coalesces to one keyed task and leaves the cache at the latest persisted content and timestamp.
- `EmbeddedConfigDumpApplyHookTest`: updated constructor wiring.

Validation on JDK 21:
- 56 tests: 0 failures, 0 errors, 0 skipped.
- `clean compile`, Apache RAT, Checkstyle, SpotBugs, and Spotless all pass; SpotBugs reports 0 issues.

Fixes #12557
