### PR TITLE
[ISSUE #15658] Keep AI resource storage provider routing stable

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.ai.model.AiResourceVersion;
 import com.alibaba.nacos.ai.service.prompt.PromptOperationService;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.storage.AiResourceStorageUtils;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.api.ai.model.prompt.PromptUtils;
 import com.alibaba.nacos.api.ai.model.prompt.PromptVersionInfo;
@@ -475,9 +476,8 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
     }
     
     private static String resolveStorageProvider() {
-        String provider =
-            EnvUtil.getProperty(Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY,
-                STORAGE_PROVIDER_NACOS_CONFIG);
-        return StringUtils.isBlank(provider) ? STORAGE_PROVIDER_NACOS_CONFIG : provider.trim();
+        return AiResourceStorageUtils.resolveProvider(
+            Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY,
+            STORAGE_PROVIDER_NACOS_CONFIG);
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/PromptDataMigrationTask.java
@@ -348,6 +348,14 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
     
     private void migrateOneVersion(String namespace, String promptKey, String version,
         PromptLegacyDataReader reader) throws Exception {
+        AiResourceVersion existing = aiResourceVersionPersistService.find(namespace, promptKey,
+            RESOURCE_TYPE_PROMPT, version);
+        if (existing != null) {
+            LOGGER.debug("Prompt '{}' version '{}' already in DB, skip migration", promptKey,
+                version);
+            return;
+        }
+        
         PromptVersionInfo versionInfo = reader.readVersionContent(namespace, promptKey, version);
         if (versionInfo == null) {
             LOGGER.warn("No content found for prompt '{}' version '{}', skip", promptKey, version);
@@ -364,16 +372,8 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
             java.nio.charset.StandardCharsets.UTF_8.name());
         versionInfo.setMd5(md5);
         
-        // Write to typed storage FIRST (idempotent overwrite)
-        writeToTypedStorage(namespace, promptKey, version, versionInfo);
-        
-        // Then create DB record (idempotent: skip if exists)
-        AiResourceVersion existing = aiResourceVersionPersistService.find(namespace, promptKey,
-            RESOURCE_TYPE_PROMPT, version);
-        if (existing != null) {
-            LOGGER.debug("Prompt '{}' version '{}' already in DB, skip insert", promptKey, version);
-            return;
-        }
+        // Write to typed storage before publishing the matching version record.
+        String storageJson = writeToTypedStorage(namespace, promptKey, version, versionInfo);
         
         AiResourceVersion versionRecord = new AiResourceVersion();
         versionRecord.setNamespaceId(namespace);
@@ -384,7 +384,7 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
         versionRecord.setAuthor(versionInfo.getSrcUser() != null ? versionInfo.getSrcUser() : "-");
         versionRecord.setDesc(versionInfo.getCommitMsg() != null ? versionInfo.getCommitMsg()
             : "migrated from legacy config");
-        versionRecord.setStorage(buildStorageJson(namespace, promptKey, version));
+        versionRecord.setStorage(storageJson);
         
         try {
             aiResourceVersionPersistService.insert(versionRecord);
@@ -457,7 +457,7 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
         }
     }
     
-    private void writeToTypedStorage(String namespace, String promptKey, String version,
+    private String writeToTypedStorage(String namespace, String promptKey, String version,
         PromptVersionInfo versionInfo) throws NacosException {
         String provider = resolveStorageProvider();
         byte[] contentBytes = JacksonUtils.toJson(versionInfo).getBytes(StandardCharsets.UTF_8);
@@ -465,11 +465,13 @@ public class PromptDataMigrationTask implements ApplicationListener<ApplicationR
             NacosConfigAiResourceStorage.RESOURCE_TYPE_PROMPT, promptKey, version,
             PromptUtils.PROMPT_MAIN_DATA_ID);
         AiResourceStorageRouter.getInstance().route(storageKey).save(storageKey, contentBytes);
+        return buildStorageJson(namespace, promptKey, version, provider);
     }
     
-    private static String buildStorageJson(String namespace, String promptKey, String version) {
+    private static String buildStorageJson(String namespace, String promptKey, String version,
+        String provider) {
         Map<String, Object> json = new HashMap<>(4);
-        json.put("provider", resolveStorageProvider());
+        json.put("provider", provider);
         json.put("scope", namespace + ":" + promptKey + ":" + version);
         json.put("files", Collections.singletonList(PromptUtils.PROMPT_MAIN_DATA_ID));
         return JacksonUtils.toJson(json);

--- a/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/constant/Constants.java
@@ -35,6 +35,11 @@ public class Constants {
     
     public static final String ARD_ENABLED_KEY = "nacos.ai.ard.enabled";
     
+    /**
+     * Selects the default AI Resource storage provider for new writes.
+     */
+    public static final String AI_STORAGE_PROVIDER_CONFIG_KEY = "nacos.ai.storage.provider";
+    
     public static final String MCP_LIST_SEARCH_ACCURATE = "accurate";
     
     public static final String MCP_LIST_SEARCH_BLUR = "blur";
@@ -130,7 +135,7 @@ public class Constants {
         public static final String RESOURCE_TYPE_AGENT = "agent";
         
         /**
-         * Selects the AI Storage provider for Agent Version content.
+         * Compatibility override for the Agent storage provider.
          */
         public static final String AGENT_STORAGE_PROVIDER_CONFIG_KEY =
             "nacos.ai.agent.storage.provider";

--- a/ai/src/main/java/com/alibaba/nacos/ai/plugin/AiStoragePluginTypePolicy.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/plugin/AiStoragePluginTypePolicy.java
@@ -83,7 +83,8 @@ public class AiStoragePluginTypePolicy implements PluginTypePolicy {
     
     @Override
     public String getSelectionProperty() {
-        return Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY + ", "
+        return Constants.AI_STORAGE_PROVIDER_CONFIG_KEY + ", "
+            + Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY + ", "
             + Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY + ", "
             + Constants.AgentSpecs.AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY + ", "
             + Constants.Agent.AGENT_STORAGE_PROVIDER_CONFIG_KEY;
@@ -91,11 +92,14 @@ public class AiStoragePluginTypePolicy implements PluginTypePolicy {
     
     @Override
     public String getActivationDescription() {
-        return "the AI module requires the configured Prompt, Skill, AgentSpec, and Agent storage providers";
+        return "the AI module requires the configured AI Resource storage providers";
     }
     
     private String resolveProvider(PluginTypeConfiguration configuration, String property) {
         String provider = configuration.getProperty(property);
+        if (StringUtils.isBlank(provider)) {
+            provider = configuration.getProperty(Constants.AI_STORAGE_PROVIDER_CONFIG_KEY);
+        }
         return StringUtils.isBlank(provider) ? NacosConfigAiResourceStorage.TYPE : provider.trim();
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/storage/AgentVersionStorageService.java
@@ -19,13 +19,13 @@ package com.alibaba.nacos.ai.service.agent.storage;
 import com.alibaba.nacos.ai.constant.Constants;
 import com.alibaba.nacos.ai.model.agent.AgentVersionContent;
 import com.alibaba.nacos.ai.model.agent.AgentVersionStorageDescriptor;
+import com.alibaba.nacos.ai.storage.AiResourceStorageUtils;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
 import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
-import com.alibaba.nacos.sys.env.EnvUtil;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
@@ -253,8 +253,8 @@ public class AgentVersionStorageService {
     }
     
     private static String configuredProvider() {
-        return EnvUtil.getProperty(Constants.Agent.AGENT_STORAGE_PROVIDER_CONFIG_KEY,
-            DEFAULT_STORAGE_PROVIDER);
+        return AiResourceStorageUtils.resolveProvider(
+            Constants.Agent.AGENT_STORAGE_PROVIDER_CONFIG_KEY, DEFAULT_STORAGE_PROVIDER);
     }
     
     private static NacosException corruptedContent(String message, Throwable cause) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -28,6 +28,7 @@ import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
 import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
+import com.alibaba.nacos.ai.storage.AiResourceStorageUtils;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.ai.utils.AgentSpecContentDigestUtils;
 import com.alibaba.nacos.ai.utils.AgentSpecSeedArchiveReader;
@@ -52,7 +53,6 @@ import com.alibaba.nacos.plugin.ai.pipeline.model.ResourceFileContent;
 import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
 import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
-import com.alibaba.nacos.sys.env.EnvUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -1118,10 +1118,9 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
      * Resolve the storage provider from system config. Defaults to "nacos_config".
      */
     private static String resolveStorageProvider() {
-        String provider =
-            EnvUtil.getProperty(Constants.AgentSpecs.AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY,
-                STORAGE_PROVIDER_NACOS_CONFIG);
-        return StringUtils.isBlank(provider) ? STORAGE_PROVIDER_NACOS_CONFIG : provider.trim();
+        return AiResourceStorageUtils.resolveProvider(
+            Constants.AgentSpecs.AGENTSPEC_STORAGE_PROVIDER_CONFIG_KEY,
+            STORAGE_PROVIDER_NACOS_CONFIG);
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImpl.java
@@ -133,13 +133,14 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         String currentUser = VisibilityHelper.resolveCurrentIdentity();
         
         // 1) write storage for draft version (main config + resources persisted concurrently)
-        saveAgentSpecFilesConcurrently(namespaceId, agentSpec, version, uniformId);
+        String storageJson = writeAgentSpecToStorage(namespaceId, agentSpec, version, uniformId,
+            null);
         
         // 2) insert draft version row
         resourceManager.insertVersionRow(namespaceId, agentSpecName, RESOURCE_TYPE_AGENTSPEC,
             StringUtils.isBlank(currentUser) ? DEFAULT_AUTHOR : currentUser,
             AiResourceConstants.VERSION_STATUS_DRAFT, version, agentSpec.getDescription(),
-            buildStorageJson(namespaceId, agentSpecName, version));
+            storageJson);
         
         // 3) create or update meta for editingVersion
         resourceManager.initOrUpdateMetaForDraft(namespaceId, agentSpecName,
@@ -240,7 +241,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "AgentSpec version not found: " + agentSpecName + "@" + version);
         }
-        return loadAgentSpecFromStorage(namespaceId, agentSpecName, version);
+        return loadAgentSpecFromStorage(namespaceId, agentSpecName, version,
+            versionRow.getStorage());
     }
     
     /**
@@ -268,7 +270,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "AgentSpec version not found: " + agentSpecName + "@" + version);
         }
-        return loadAgentSpecMetaFromStorage(namespaceId, agentSpecName, version);
+        return loadAgentSpecMetaFromStorage(namespaceId, agentSpecName, version,
+            versionRow.getStorage());
     }
     
     /**
@@ -485,11 +488,12 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         // Step 3: Brand-new bootstrap: write to storage and directly create published meta + version (skip draft workflow)
         String version = DEFAULT_INITIAL_VERSION;
         long uniformId = System.currentTimeMillis();
-        writeAgentSpecToStorage(namespaceId, agentSpec, version, uniformId);
+        String storageJson = writeAgentSpecToStorage(namespaceId, agentSpec, version, uniformId,
+            null);
         
         resourceManager.insertBootstrapMeta(namespaceId, name, RESOURCE_TYPE_AGENTSPEC,
             agentSpec.getDescription(), agentSpec.getBizTags(), DEFAULT_AUTHOR, from, version,
-            buildStorageJson(namespaceId, name, version));
+            storageJson);
     }
     
     /**
@@ -534,8 +538,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         // Read current storage content and compare with bundled content to detect missing critical data
         AgentSpec currentAgentSpec;
         try {
-            currentAgentSpec =
-                loadAgentSpecFromStorage(namespaceId, bundledAgentSpec.getName(), latestVersion);
+            currentAgentSpec = loadAgentSpecFromStorage(namespaceId, bundledAgentSpec.getName(),
+                latestVersion, versionRow.getStorage());
         } catch (NacosException e) {
             currentAgentSpec = null;
         }
@@ -545,11 +549,10 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         
         // Content is missing: overwrite storage with bundled data and update version/meta records
         long uniformId = System.currentTimeMillis();
-        writeAgentSpecToStorage(namespaceId, bundledAgentSpec, latestVersion, uniformId);
+        String storageJson = writeAgentSpecToStorage(namespaceId, bundledAgentSpec, latestVersion,
+            uniformId, versionRow.getStorage());
         resourceManager.updateVersionStorageAndDesc(namespaceId, bundledAgentSpec.getName(),
-            RESOURCE_TYPE_AGENTSPEC, latestVersion,
-            buildStorageJson(namespaceId, bundledAgentSpec.getName(),
-                latestVersion),
+            RESOURCE_TYPE_AGENTSPEC, latestVersion, storageJson,
             bundledAgentSpec.getDescription());
         resourceManager.syncImportedMeta(namespaceId, meta, bundledAgentSpec.getDescription(),
             bundledAgentSpec.getBizTags());
@@ -593,13 +596,13 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     private void overwriteEditingDraft(String namespaceId, AgentSpec agentSpec, AiResource meta,
         String editing)
         throws NacosException {
-        resourceManager.requireDraftVersion(namespaceId, agentSpec.getName(),
-            RESOURCE_TYPE_AGENTSPEC, editing);
+        AiResourceVersion draft = resourceManager.requireDraftVersion(namespaceId,
+            agentSpec.getName(), RESOURCE_TYPE_AGENTSPEC, editing);
         long uniformId = System.currentTimeMillis();
-        writeAgentSpecToStorage(namespaceId, agentSpec, editing, uniformId);
+        String storageJson = writeAgentSpecToStorage(namespaceId, agentSpec, editing, uniformId,
+            draft.getStorage());
         resourceManager.updateVersionStorageAndDesc(namespaceId, agentSpec.getName(),
-            RESOURCE_TYPE_AGENTSPEC, editing,
-            buildStorageJson(namespaceId, agentSpec.getName(), editing),
+            RESOURCE_TYPE_AGENTSPEC, editing, storageJson,
             agentSpec.getDescription());
         resourceManager.syncImportedMeta(namespaceId, meta, agentSpec.getDescription(),
             agentSpec.getBizTags());
@@ -679,7 +682,7 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "AgentSpec version not online: " + name);
         }
-        return loadAgentSpecFromStorage(namespaceId, name, resolved);
+        return loadAgentSpecFromStorage(namespaceId, name, resolved, versionRow.getStorage());
     }
     
     /**
@@ -724,7 +727,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "AgentSpec version not online: " + name);
         }
-        AgentSpec agentSpec = loadAgentSpecFromStorage(namespaceId, name, resolved);
+        AgentSpec agentSpec = loadAgentSpecFromStorage(namespaceId, name, resolved,
+            versionRow.getStorage());
         
         // Step 5: Determine effective MD5; back-fill if missing (legacy data)
         String effectiveMd5 = storedMd5;
@@ -846,12 +850,13 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         // Step 1: Copy storage content from base version to new version path
         AgentSpec baseAgentSpec = loadAgentSpecFromStorage(namespaceId, name, base);
         long uniformId = System.currentTimeMillis();
-        writeAgentSpecToStorage(namespaceId, baseAgentSpec, newVersion, uniformId);
+        String storageJson = writeAgentSpecToStorage(namespaceId, baseAgentSpec, newVersion,
+            uniformId, null);
         
         // Step 2: Insert draft version row
         resourceManager.insertVersionRow(namespaceId, name, RESOURCE_TYPE_AGENTSPEC, DEFAULT_AUTHOR,
             AiResourceConstants.VERSION_STATUS_DRAFT, newVersion, baseAgentSpec.getDescription(),
-            buildStorageJson(namespaceId, name, newVersion));
+            storageJson);
         
         // Step 3: Update meta's editingVersion pointer
         resourceManager.markEditingVersionCas(namespaceId, meta, info, newVersion,
@@ -892,14 +897,15 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "No editing draft exists for agentspec: " + name);
         }
-        resourceManager.requireDraftVersion(namespaceId, name, RESOURCE_TYPE_AGENTSPEC, editing);
+        AiResourceVersion draft = resourceManager.requireDraftVersion(namespaceId, name,
+            RESOURCE_TYPE_AGENTSPEC, editing);
         
         // Overwrite storage files with new content, update version row and meta description
         long uniformId = System.currentTimeMillis();
-        writeAgentSpecToStorage(namespaceId, draftAgentSpec, editing, uniformId);
+        String storageJson = writeAgentSpecToStorage(namespaceId, draftAgentSpec, editing,
+            uniformId, draft.getStorage());
         resourceManager.updateVersionStorageAndDesc(namespaceId, name, RESOURCE_TYPE_AGENTSPEC,
-            editing,
-            buildStorageJson(namespaceId, name, editing), draftAgentSpec.getDescription());
+            editing, storageJson, draftAgentSpec.getDescription());
         resourceManager.bumpMetaDescription(namespaceId, meta, draftAgentSpec.getDescription());
         AiResourceTraceService.logSuccess(RESOURCE_TYPE_AGENTSPEC, name, editing,
             AiResourceTraceService.OP_UPDATE_DRAFT,
@@ -952,7 +958,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
         ctx.setVersion(finalTarget);
         ctx.setFilesLoader(() -> {
             try {
-                return buildPipelineFiles(loadAgentSpecFromStorage(namespaceId, name, finalTarget));
+                return buildPipelineFiles(loadAgentSpecFromStorage(namespaceId, name, finalTarget,
+                    v.getStorage()));
             } catch (NacosException e) {
                 throw new IllegalStateException(
                     "Failed to load AgentSpec files for pipeline execution", e);
@@ -1127,11 +1134,25 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
      * Build storage metadata JSON for version row (provider + scope).
      */
     private static String buildStorageJson(String namespaceId, String agentSpecName,
-        String version) {
+        String version, String provider) {
         Map<String, Object> json = new HashMap<>(4);
-        json.put("provider", resolveStorageProvider());
+        json.put("provider", provider);
         json.put("scope", namespaceId + ":" + agentSpecName + ":" + version);
         return JacksonUtils.toJson(json);
+    }
+    
+    private static String parseStorageProvider(String storageJson) {
+        if (StringUtils.isNotBlank(storageJson)) {
+            try {
+                Map<String, Object> storage = JacksonUtils.toObj(storageJson, Map.class);
+                Object provider = storage.get("provider");
+                if (provider instanceof String && StringUtils.isNotBlank((String) provider)) {
+                    return ((String) provider).trim();
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return STORAGE_PROVIDER_NACOS_CONFIG;
     }
     
     /**
@@ -1248,10 +1269,12 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
      * <p>Files are persisted concurrently via a dedicated IO executor to reduce latency
      * when AgentSpec contains multiple resource files. Mirrors the Skill implementation.</p>
      */
-    private void writeAgentSpecToStorage(String namespaceId, AgentSpec agentSpec, String version,
-        long uniformId)
-        throws NacosException {
-        saveAgentSpecFilesConcurrently(namespaceId, agentSpec, version, uniformId);
+    private String writeAgentSpecToStorage(String namespaceId, AgentSpec agentSpec, String version,
+        long uniformId, String persistedStorage) throws NacosException {
+        String provider = persistedStorage == null ? resolveStorageProvider()
+            : parseStorageProvider(persistedStorage);
+        saveAgentSpecFilesConcurrently(provider, namespaceId, agentSpec, version, uniformId);
+        return buildStorageJson(namespaceId, agentSpec.getName(), version, provider);
     }
     
     /**
@@ -1262,9 +1285,8 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
      * individual save tasks are unwrapped from {@link CompletionException} and rethrown to keep the
      * original exception semantics aligned with the previous serial implementation.</p>
      */
-    private void saveAgentSpecFilesConcurrently(String namespaceId, AgentSpec agentSpec,
-        String version, long uniformId) throws NacosException {
-        String provider = resolveStorageProvider();
+    private void saveAgentSpecFilesConcurrently(String provider, String namespaceId,
+        AgentSpec agentSpec, String version, long uniformId) throws NacosException {
         String agentSpecName = agentSpec.getName();
         Executor executor = ExecutorUtils.getAgentSpecStorageIoExecutor();
         List<CompletableFuture<Void>> tasks = new ArrayList<>();
@@ -1321,9 +1343,21 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
     private AgentSpec loadAgentSpecFromStorage(String namespaceId, String agentSpecName,
         String version)
         throws NacosException {
+        AiResourceVersion versionRow = resourceManager.findVersion(namespaceId, agentSpecName,
+            RESOURCE_TYPE_AGENTSPEC, version);
+        if (versionRow == null) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                "AgentSpec version not found: " + agentSpecName + "@" + version);
+        }
+        return loadAgentSpecFromStorage(namespaceId, agentSpecName, version,
+            versionRow.getStorage());
+    }
+    
+    private AgentSpec loadAgentSpecFromStorage(String namespaceId, String agentSpecName,
+        String version, String storageJson) throws NacosException {
+        String provider = parseStorageProvider(storageJson);
         // Step 1: Read main config file (manifest.json)
-        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(resolveStorageProvider(),
-            namespaceId,
+        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId,
             NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC, agentSpecName, version,
             NacosConfigAiResourceStorage.getMainFilePath(AgentSpecUtils.AGENTSPEC_MAIN_DATA_ID));
         byte[] mainBytes = storageRouter.route(mainKey).get(mainKey);
@@ -1353,10 +1387,9 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
                     NacosConfigAiResourceStorage.getAgentSpecResourceFilePath(resourceRef.getType(),
                         resourceRef.getName());
                 StorageKey resourceKey =
-                    NacosConfigAiResourceStorage.buildStorageKey(resolveStorageProvider(),
-                        namespaceId, NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC,
-                        agentSpecName, version,
-                        path);
+                    NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId,
+                        NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC, agentSpecName,
+                        version, path);
                 byte[] resourceBytes = storageRouter.route(resourceKey).get(resourceKey);
                 if (resourceBytes != null) {
                     AgentSpecResource resource = JacksonUtils.toObj(
@@ -1374,10 +1407,9 @@ public class AgentSpecOperationServiceImpl implements AgentSpecOperationService 
      * and builds resource entries with name and type from the reference list.
      */
     private AgentSpec loadAgentSpecMetaFromStorage(String namespaceId, String agentSpecName,
-        String version)
-        throws NacosException {
-        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(resolveStorageProvider(),
-            namespaceId,
+        String version, String storageJson) throws NacosException {
+        String provider = parseStorageProvider(storageJson);
+        StorageKey mainKey = NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId,
             NacosConfigAiResourceStorage.RESOURCE_TYPE_AGENTSPEC, agentSpecName, version,
             NacosConfigAiResourceStorage.getMainFilePath(AgentSpecUtils.AGENTSPEC_MAIN_DATA_ID));
         byte[] mainBytes = storageRouter.route(mainKey).get(mainKey);

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
@@ -34,6 +34,7 @@ import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
 import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.api.ai.model.pipeline.PipelineExecutionResult;
+import com.alibaba.nacos.ai.storage.AiResourceStorageUtils;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
 import com.alibaba.nacos.ai.utils.AiResourceVersionStorageJsonUtil;
@@ -60,7 +61,6 @@ import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
 import com.alibaba.nacos.plugin.ai.pipeline.model.ResourceFileContent;
 import com.alibaba.nacos.plugin.ai.pipeline.model.ResourceFilesPipelineContext;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
-import com.alibaba.nacos.sys.env.EnvUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -828,10 +828,9 @@ public class PromptOperationServiceImpl implements PromptOperationService {
     }
     
     private static String resolvePromptStorageProvider() {
-        String provider =
-            EnvUtil.getProperty(Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY,
-                NacosConfigAiResourceStorage.TYPE);
-        return StringUtils.isBlank(provider) ? NacosConfigAiResourceStorage.TYPE : provider.trim();
+        return AiResourceStorageUtils.resolveProvider(
+            Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY,
+            NacosConfigAiResourceStorage.TYPE);
     }
     
     private AiResource requireMeta(String namespaceId, String promptKey) throws NacosException {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
@@ -149,13 +149,13 @@ public class PromptOperationServiceImpl implements PromptOperationService {
                 StringUtils.isBlank(targetVersion) ? DEFAULT_INITIAL_VERSION : targetVersion;
             validateVersion(version);
             
-            writePromptToStorage(namespaceId, promptKey, version, template, variables);
+            String storageJson = writePromptToStorage(namespaceId, promptKey, version, template,
+                variables, null);
             
             String currentUser = VisibilityHelper.resolveCurrentIdentity();
             resourceManager.insertVersionRow(namespaceId, promptKey, RESOURCE_TYPE_PROMPT,
                 StringUtils.isBlank(currentUser) ? DEFAULT_AUTHOR : currentUser,
-                VERSION_STATUS_DRAFT, version, commitMsg,
-                buildStorageJson(namespaceId, promptKey, version));
+                VERSION_STATUS_DRAFT, version, commitMsg, storageJson);
             
             resourceManager.initOrUpdateMetaForDraft(namespaceId, promptKey, RESOURCE_TYPE_PROMPT,
                 description, bizTags, version, null, true);
@@ -180,21 +180,20 @@ public class PromptOperationServiceImpl implements PromptOperationService {
                 throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                     "Base version not found: " + basedOnVersion);
             }
-            PromptVersionInfo baseContent =
-                loadPromptFromStorage(namespaceId, promptKey, basedOnVersion);
+            PromptVersionInfo baseContent = loadPromptFromStorage(namespaceId, promptKey,
+                basedOnVersion, baseRow.getStorage());
             String newVersion = StringUtils.isBlank(targetVersion)
                 ? incrementVersion(basedOnVersion) : targetVersion;
             validateVersion(newVersion);
             checkVersionNotExists(namespaceId, promptKey, newVersion);
             
-            writePromptToStorage(namespaceId, promptKey, newVersion,
-                baseContent.getTemplate(), baseContent.getVariables());
+            String storageJson = writePromptToStorage(namespaceId, promptKey, newVersion,
+                baseContent.getTemplate(), baseContent.getVariables(), null);
             
             String currentUser = VisibilityHelper.resolveCurrentIdentity();
             resourceManager.insertVersionRow(namespaceId, promptKey, RESOURCE_TYPE_PROMPT,
                 StringUtils.isBlank(currentUser) ? DEFAULT_AUTHOR : currentUser,
-                VERSION_STATUS_DRAFT, newVersion, commitMsg,
-                buildStorageJson(namespaceId, promptKey, newVersion));
+                VERSION_STATUS_DRAFT, newVersion, commitMsg, storageJson);
             
             resourceManager.markEditingVersionCas(namespaceId, meta, resourceInfo, newVersion,
                 "create draft");
@@ -214,13 +213,13 @@ public class PromptOperationServiceImpl implements PromptOperationService {
         validateVersion(newVersion);
         checkVersionNotExists(namespaceId, promptKey, newVersion);
         
-        writePromptToStorage(namespaceId, promptKey, newVersion, template, variables);
+        String storageJson = writePromptToStorage(namespaceId, promptKey, newVersion, template,
+            variables, null);
         
         String currentUser = VisibilityHelper.resolveCurrentIdentity();
         resourceManager.insertVersionRow(namespaceId, promptKey, RESOURCE_TYPE_PROMPT,
             StringUtils.isBlank(currentUser) ? DEFAULT_AUTHOR : currentUser,
-            VERSION_STATUS_DRAFT, newVersion, commitMsg,
-            buildStorageJson(namespaceId, promptKey, newVersion));
+            VERSION_STATUS_DRAFT, newVersion, commitMsg, storageJson);
         
         resourceManager.markEditingVersionCas(namespaceId, meta, resourceInfo, newVersion,
             "create draft");
@@ -250,13 +249,14 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "No editing draft exists for prompt: " + promptKey);
         }
-        resourceManager.requireDraftVersion(namespaceId, promptKey, RESOURCE_TYPE_PROMPT, editing);
+        AiResourceVersion draft = resourceManager.requireDraftVersion(namespaceId, promptKey,
+            RESOURCE_TYPE_PROMPT, editing);
         
-        writePromptToStorage(namespaceId, promptKey, editing, template, variables);
+        String storageJson = writePromptToStorage(namespaceId, promptKey, editing, template,
+            variables, draft.getStorage());
         
         // Update commitMsg in DB if provided
         if (StringUtils.isNotBlank(commitMsg)) {
-            String storageJson = buildStorageJson(namespaceId, promptKey, editing);
             resourceManager.updateVersionStorageAndDesc(namespaceId, promptKey,
                 RESOURCE_TYPE_PROMPT,
                 editing, storageJson, commitMsg);
@@ -303,7 +303,8 @@ public class PromptOperationServiceImpl implements PromptOperationService {
         ctx.setResourceName(promptKey);
         ctx.setVersion(finalTarget);
         
-        PromptVersionInfo content = loadPromptFromStorage(namespaceId, promptKey, finalTarget);
+        PromptVersionInfo content = loadPromptFromStorage(namespaceId, promptKey, finalTarget,
+            submitVersion.getStorage());
         List<ResourceFileContent> pipelineFiles = new ArrayList<>();
         ResourceFileContent mainFile = new ResourceFileContent();
         mainFile.setFilePath(PromptUtils.PROMPT_MAIN_DATA_ID);
@@ -545,7 +546,8 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "Prompt version not found: " + promptKey + "@" + version);
         }
-        PromptVersionInfo result = loadPromptFromStorage(namespaceId, promptKey, version);
+        PromptVersionInfo result = loadPromptFromStorage(namespaceId, promptKey, version,
+            versionRow.getStorage());
         result.setSrcUser(versionRow.getAuthor());
         result.setCommitMsg(versionRow.getDesc());
         result.setStatus(versionRow.getStatus());
@@ -680,7 +682,8 @@ public class PromptOperationServiceImpl implements PromptOperationService {
                 "Prompt version not online: " + promptKey + "@" + resolved);
         }
         
-        PromptVersionInfo result = loadPromptFromStorage(namespaceId, promptKey, resolved);
+        PromptVersionInfo result = loadPromptFromStorage(namespaceId, promptKey, resolved,
+            versionRow.getStorage());
         result.setSrcUser(versionRow.getAuthor());
         result.setCommitMsg(versionRow.getDesc());
         return result;
@@ -747,11 +750,11 @@ public class PromptOperationServiceImpl implements PromptOperationService {
     
     // ========== Private methods ==========
     
-    private void writePromptToStorage(String namespaceId, String promptKey, String version,
-        String template,
-        List<PromptVariable> variables) throws NacosException {
-        String provider = resolvePromptStorageProvider();
-        
+    private String writePromptToStorage(String namespaceId, String promptKey, String version,
+        String template, List<PromptVariable> variables, String persistedStorage)
+        throws NacosException {
+        String provider = persistedStorage == null ? resolvePromptStorageProvider()
+            : parseStorageProvider(persistedStorage);
         PromptVersionInfo content = new PromptVersionInfo();
         content.setPromptKey(promptKey);
         content.setVersion(version);
@@ -769,12 +772,24 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             RESOURCE_TYPE_PROMPT, promptKey, version,
             PromptUtils.PROMPT_MAIN_DATA_ID);
         storageRouter.route(storageKey).save(storageKey, contentBytes);
+        return buildStorageJson(namespaceId, promptKey, version, provider);
     }
     
     private PromptVersionInfo loadPromptFromStorage(String namespaceId, String promptKey,
         String version)
         throws NacosException {
-        String provider = resolvePromptStorageProvider();
+        AiResourceVersion versionRow = resourceManager.findVersion(namespaceId, promptKey,
+            RESOURCE_TYPE_PROMPT, version);
+        if (versionRow == null) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                "Prompt version not found: " + promptKey + "@" + version);
+        }
+        return loadPromptFromStorage(namespaceId, promptKey, version, versionRow.getStorage());
+    }
+    
+    private PromptVersionInfo loadPromptFromStorage(String namespaceId, String promptKey,
+        String version, String storageJson) throws NacosException {
+        String provider = parseStorageProvider(storageJson);
         StorageKey storageKey = NacosConfigAiResourceStorage.buildStorageKey(provider, namespaceId,
             RESOURCE_TYPE_PROMPT, promptKey, version,
             PromptUtils.PROMPT_MAIN_DATA_ID);
@@ -819,12 +834,27 @@ public class PromptOperationServiceImpl implements PromptOperationService {
         }
     }
     
-    private static String buildStorageJson(String namespaceId, String promptKey, String version) {
+    private static String buildStorageJson(String namespaceId, String promptKey, String version,
+        String provider) {
         Map<String, Object> json = new HashMap<>(4);
-        json.put("provider", resolvePromptStorageProvider());
+        json.put("provider", provider);
         json.put("scope", namespaceId + ":" + promptKey + ":" + version);
         json.put("files", Collections.singletonList(PromptUtils.PROMPT_MAIN_DATA_ID));
         return JacksonUtils.toJson(json);
+    }
+    
+    private static String parseStorageProvider(String storageJson) {
+        if (StringUtils.isNotBlank(storageJson)) {
+            try {
+                Map<String, Object> storage = JacksonUtils.toObj(storageJson, Map.class);
+                Object provider = storage.get("provider");
+                if (provider instanceof String && StringUtils.isNotBlank((String) provider)) {
+                    return ((String) provider).trim();
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return NacosConfigAiResourceStorage.TYPE;
     }
     
     private static String resolvePromptStorageProvider() {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -35,6 +35,7 @@ import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
 import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
+import com.alibaba.nacos.ai.storage.AiResourceStorageUtils;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.ai.utils.AiResourceVersionStorageJsonUtil;
 import com.alibaba.nacos.ai.utils.ExecutorUtils;
@@ -1610,10 +1611,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
      * Resolve the storage provider from system config. Defaults to "nacos_config".
      */
     private static String resolveSkillStorageProvider() {
-        String provider =
-            EnvUtil.getProperty(Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY,
-                STORAGE_PROVIDER_NACOS_CONFIG);
-        return StringUtils.isBlank(provider) ? STORAGE_PROVIDER_NACOS_CONFIG : provider.trim();
+        return AiResourceStorageUtils.resolveProvider(Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY,
+            STORAGE_PROVIDER_NACOS_CONFIG);
     }
     
     /**

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -457,11 +457,12 @@ public class SkillOperationServiceImpl implements SkillOperationService {
             resolveUploadVersion(skill.getSkillMd(), null, null));
         // Normalize frontmatter before writing (bootstrap = first create)
         SkillRequestUtil.normalizeSkillFrontmatter(skill, skillName, version, true);
-        List<String> files = writeSkillToStorage(namespaceId, skill, version);
+        String provider = resolveSkillStorageProvider();
+        List<String> files = writeSkillToStorage(namespaceId, skill, version, provider);
         
         // Step 4: Insert meta + version rows with status directly set to online (published)
         String storageJson = buildStorageJson(namespaceId, skillName, version, files,
-            SkillContentDigestUtils.computeContentMd5(skill));
+            SkillContentDigestUtils.computeContentMd5(skill), provider);
         resourceManager.insertBootstrapMeta(namespaceId, skillName, RESOURCE_TYPE_SKILL,
             skill.getDescription(), null, DEFAULT_AUTHOR, from, version, storageJson);
         
@@ -913,13 +914,14 @@ public class SkillOperationServiceImpl implements SkillOperationService {
     private void overwriteEditingDraft(String namespaceId, Skill skill, AiResource meta,
         String editing, String commitMsg)
         throws NacosException {
-        resourceManager.requireDraftVersion(namespaceId, skill.getName(), RESOURCE_TYPE_SKILL,
-            editing);
+        AiResourceVersion draftVersion = resourceManager.requireDraftVersion(namespaceId,
+            skill.getName(), RESOURCE_TYPE_SKILL, editing);
         // Normalize frontmatter before writing (overwrite = existing skill, not first create)
         SkillRequestUtil.normalizeSkillFrontmatter(skill, skill.getName(), editing, false);
-        List<String> files = writeSkillToStorage(namespaceId, skill, editing);
+        String provider = parseStorageProvider(draftVersion.getStorage());
+        List<String> files = writeSkillToStorage(namespaceId, skill, editing, provider);
         String storageJson = buildStorageJson(namespaceId, skill.getName(), editing, files,
-            SkillContentDigestUtils.computeContentMd5(skill));
+            SkillContentDigestUtils.computeContentMd5(skill), provider);
         if (StringUtils.isNotBlank(commitMsg)) {
             resourceManager.updateVersionStorageAndDesc(namespaceId, skill.getName(),
                 RESOURCE_TYPE_SKILL, editing, storageJson, commitMsg);
@@ -1204,7 +1206,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
                 RESOURCE_TYPE_SKILL, base);
             Skill baseSkill = loadSkillFromStorage(namespaceId, name, base,
                 baseVersionRow != null ? baseVersionRow.getStorage() : null);
-            List<String> files = writeSkillToStorage(namespaceId, baseSkill, newVersion);
+            String provider = resolveSkillStorageProvider();
+            List<String> files = writeSkillToStorage(namespaceId, baseSkill, newVersion, provider);
             
             // Step 2: Insert draft version row
             String currentUser = VisibilityHelper.resolveCurrentIdentity();
@@ -1213,7 +1216,7 @@ public class SkillOperationServiceImpl implements SkillOperationService {
                 StringUtils.isBlank(currentUser) ? DEFAULT_AUTHOR : currentUser,
                 AiResourceConstants.VERSION_STATUS_DRAFT, newVersion, versionDesc,
                 buildStorageJson(namespaceId, name, newVersion, files,
-                    SkillContentDigestUtils.computeContentMd5(baseSkill)));
+                    SkillContentDigestUtils.computeContentMd5(baseSkill), provider));
             
             // Step 3: Update meta's editingVersion pointer
             resourceManager.markEditingVersionCas(namespaceId, meta, info, newVersion,
@@ -1252,15 +1255,17 @@ public class SkillOperationServiceImpl implements SkillOperationService {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "No editing draft exists for skill: " + name);
         }
-        resourceManager.requireDraftVersion(namespaceId, name, RESOURCE_TYPE_SKILL, editing);
+        AiResourceVersion draftVersion = resourceManager.requireDraftVersion(namespaceId, name,
+            RESOURCE_TYPE_SKILL, editing);
         
         // Normalize frontmatter before writing to storage (editing = existing skill, not first create)
         SkillRequestUtil.normalizeSkillFrontmatter(draftSkill, name, editing, false);
         
         // Step 3: Overwrite storage files with new content, update version row's storage JSON and meta description
-        List<String> files = writeSkillToStorage(namespaceId, draftSkill, editing);
+        String provider = parseStorageProvider(draftVersion.getStorage());
+        List<String> files = writeSkillToStorage(namespaceId, draftSkill, editing, provider);
         String storageJson = buildStorageJson(namespaceId, name, editing, files,
-            SkillContentDigestUtils.computeContentMd5(draftSkill));
+            SkillContentDigestUtils.computeContentMd5(draftSkill), provider);
         if (StringUtils.isNotBlank(commitMsg)) {
             resourceManager.updateVersionStorageAndDesc(namespaceId, name, RESOURCE_TYPE_SKILL,
                 editing,
@@ -1592,7 +1597,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         SkillRequestUtil.normalizeSkillFrontmatter(skill, skillName, version, existedMeta == null);
         
         // 1) write all resources (including SKILL.md) to storage
-        List<String> files = writeSkillToStorage(namespaceId, skill, version);
+        String provider = resolveSkillStorageProvider();
+        List<String> files = writeSkillToStorage(namespaceId, skill, version, provider);
         
         // 2) insert draft version row
         String versionDesc = StringUtils.isNotBlank(commitMsg) ? commitMsg : "";
@@ -1600,7 +1606,7 @@ public class SkillOperationServiceImpl implements SkillOperationService {
             StringUtils.isBlank(currentUser) ? DEFAULT_AUTHOR : currentUser,
             AiResourceConstants.VERSION_STATUS_DRAFT, version, versionDesc,
             buildStorageJson(namespaceId, skillName, version, files,
-                SkillContentDigestUtils.computeContentMd5(skill)));
+                SkillContentDigestUtils.computeContentMd5(skill), provider));
         
         // 3) create or update meta for editingVersion
         resourceManager.initOrUpdateMetaForDraft(namespaceId, skillName, RESOURCE_TYPE_SKILL,
@@ -1622,9 +1628,9 @@ public class SkillOperationServiceImpl implements SkillOperationService {
      *                   yet need to persist the listener-related fingerprint
      */
     private static String buildStorageJson(String namespaceId, String skillName, String version,
-        List<String> files, String contentMd5) {
+        List<String> files, String contentMd5, String provider) {
         Map<String, Object> json = new LinkedHashMap<>(8);
-        json.put("provider", resolveSkillStorageProvider());
+        json.put("provider", provider);
         json.put("scope", namespaceId + ":" + skillName + ":" + version);
         json.put("files", files);
         if (StringUtils.isNotBlank(contentMd5)) {
@@ -1738,9 +1744,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
      *
      * @return list of stored file paths (for use in buildStorageJson)
      */
-    private List<String> writeSkillToStorage(String namespaceId, Skill skill, String version)
-        throws NacosException {
-        String provider = resolveSkillStorageProvider();
+    private List<String> writeSkillToStorage(String namespaceId, Skill skill, String version,
+        String provider) throws NacosException {
         String skillName = skill.getName();
         List<String> files = new ArrayList<>();
         

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImpl.java
@@ -1521,7 +1521,7 @@ public class SkillOperationServiceImpl implements SkillOperationService {
     
     /**
      * Query a skill for client consumption. Resolves the target version via explicit version, label, or manifest,
-     * loads the skill content from the index manifest's file list, and publishes a download event.
+     * loads the skill content from the version's persisted storage descriptor, and publishes a download event.
      */
     @Override
     public Skill querySkill(String namespaceId, String name, String version, String label)
@@ -1548,14 +1548,20 @@ public class SkillOperationServiceImpl implements SkillOperationService {
                 "Skill version not found: " + name);
         }
         
-        // Step 4: Get file list from manifest and read storage content
+        // Step 4: Verify the version is indexed, then read using its persisted storage descriptor
         List<String> files = manifest.getVersions().get(resolved);
         if (files == null || files.isEmpty()) {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "Skill version not found: " + name + "@" + resolved);
         }
+        AiResourceVersion versionRow = resourceManager.findVersion(namespaceId, name,
+            RESOURCE_TYPE_SKILL, resolved);
+        if (versionRow == null) {
+            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
+                "Skill version not found: " + name + "@" + resolved);
+        }
         
-        Skill skill = loadSkillFromFiles(namespaceId, name, resolved, files);
+        Skill skill = loadSkillFromStorage(namespaceId, name, resolved, versionRow.getStorage());
         // Step 5: Publish download event for download count tracking
         NotifyCenter.publishEvent(
             new SkillDownloadEvent(namespaceId, name, RESOURCE_TYPE_SKILL, resolved));
@@ -1646,6 +1652,24 @@ public class SkillOperationServiceImpl implements SkillOperationService {
         } catch (Exception ignored) {
         }
         return null;
+    }
+    
+    /**
+     * Parse the provider persisted with a version. Historical descriptors without a provider belong to
+     * nacos_config, regardless of the provider selected for new writes.
+     */
+    private static String parseStorageProvider(String storageJson) {
+        if (StringUtils.isNotBlank(storageJson)) {
+            try {
+                Map<String, Object> map = JacksonUtils.toObj(storageJson, Map.class);
+                Object provider = map.get("provider");
+                if (provider instanceof String && StringUtils.isNotBlank((String) provider)) {
+                    return ((String) provider).trim();
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return STORAGE_PROVIDER_NACOS_CONFIG;
     }
     
     /**
@@ -1822,7 +1846,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "No files found in storage for skill: " + skillName + "@" + version);
         }
-        return loadSkillFromFiles(namespaceId, skillName, version, files);
+        return loadSkillFromFiles(namespaceId, skillName, version,
+            parseStorageProvider(storageJson), files);
     }
     
     /**
@@ -1830,9 +1855,8 @@ public class SkillOperationServiceImpl implements SkillOperationService {
      * SKILL.md content provides name/description and markdown body; others populate the resource map.
      */
     private Skill loadSkillFromFiles(String namespaceId, String skillName, String version,
-        List<String> files)
+        String provider, List<String> files)
         throws NacosException {
-        String provider = resolveSkillStorageProvider();
         Skill skill = new Skill();
         skill.setNamespaceId(namespaceId);
         Map<String, SkillResource> resourceMap = new HashMap<>(files.size());

--- a/ai/src/main/java/com/alibaba/nacos/ai/storage/AiResourceStorageUtils.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/storage/AiResourceStorageUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.storage;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.sys.env.EnvUtil;
+
+/**
+ * Utilities for AI resource storage.
+ *
+ * @author nacos
+ */
+public final class AiResourceStorageUtils {
+    
+    private AiResourceStorageUtils() {
+    }
+    
+    /**
+     * Resolve the storage provider for new writes. A resource-specific property takes precedence
+     * for compatibility, followed by the global AI storage property.
+     *
+     * @param resourcePropertyKey resource-specific compatibility property
+     * @param defaultProvider default provider
+     * @return resolved provider
+     */
+    public static String resolveProvider(String resourcePropertyKey, String defaultProvider) {
+        String provider = EnvUtil.getProperty(resourcePropertyKey);
+        if (StringUtils.isBlank(provider)) {
+            provider = EnvUtil.getProperty(Constants.AI_STORAGE_PROVIDER_CONFIG_KEY,
+                defaultProvider);
+        }
+        return StringUtils.isBlank(provider) ? defaultProvider : provider.trim();
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/config/PromptDataMigrationTaskTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/config/PromptDataMigrationTaskTest.java
@@ -418,28 +418,19 @@ class PromptDataMigrationTaskTest {
             return resp;
         });
         
-        // Version already exists in DB — DB insert should be skipped, but storage write still happens
+        // Version already exists in DB — both storage write and DB insert should be skipped
         AiResourceVersion existingVersion = new AiResourceVersion();
         existingVersion.setVersion("0.0.1");
         when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, RESOURCE_TYPE_PROMPT, "0.0.1"))
             .thenReturn(existingVersion);
         
-        // readVersionContent uses configInfoPersistService.findConfigAllInfo
-        PromptVersionInfo versionContent = new PromptVersionInfo();
-        versionContent.setPromptKey(PROMPT_KEY);
-        versionContent.setVersion("0.0.1");
-        versionContent.setTemplate("Hello");
-        ConfigAllInfo versionConfigAllInfo = new ConfigAllInfo();
-        versionConfigAllInfo.setContent(JacksonUtils.toJson(versionContent));
-        when(configInfoPersistService.findConfigAllInfo(any(), eq(PROMPT_GROUP), eq(NS)))
-            .thenReturn(versionConfigAllInfo);
-        
         task.onApplicationEvent(createRootContextEvent());
         
         // Meta should still be inserted
         verify(aiResourcePersistService, timeout(ASYNC_TIMEOUT)).insert(any(AiResource.class));
-        // Storage write still happens (idempotent overwrite)
-        verify(storage, timeout(ASYNC_TIMEOUT)).save(any(StorageKey.class), any(byte[].class));
+        // Existing version storage must not be redirected or overwritten by the current provider
+        verify(storage, after(ASYNC_TIMEOUT).never()).save(any(StorageKey.class),
+            any(byte[].class));
         // But version DB insert should be skipped
         verify(aiResourceVersionPersistService, after(ASYNC_TIMEOUT).never())
             .insert(any(AiResourceVersion.class));

--- a/ai/src/test/java/com/alibaba/nacos/ai/plugin/AiStoragePluginTypePolicyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/plugin/AiStoragePluginTypePolicyTest.java
@@ -39,7 +39,9 @@ class AiStoragePluginTypePolicyTest {
     void testTypeAndDiagnostics() {
         assertEquals(PluginType.AI_STORAGE, policy.getPluginType());
         assertFalse(policy.supportsPreRefreshValidation());
-        assertTrue(policy.getActivationDescription().contains("Prompt"));
+        assertTrue(policy.getActivationDescription().contains("AI Resource"));
+        assertTrue(policy.getSelectionProperty()
+            .contains(Constants.AI_STORAGE_PROVIDER_CONFIG_KEY));
         assertTrue(policy.getSelectionProperty()
             .contains(Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY));
         assertTrue(policy.getSelectionProperty()
@@ -84,8 +86,31 @@ class AiStoragePluginTypePolicyTest {
     }
     
     @Test
+    void testGlobalRequiredProvider() {
+        MapConfiguration configuration = new MapConfiguration();
+        configuration.setProperty(Constants.AI_STORAGE_PROVIDER_CONFIG_KEY, " external ");
+        policy.initialize(configuration);
+        
+        assertEquals(Set.of("external"), policy.getRequiredPluginNames(configuration));
+    }
+    
+    @Test
+    void testResourceOverrideAndGlobalFallback() {
+        MapConfiguration configuration = new MapConfiguration();
+        configuration.setProperty(Constants.AI_STORAGE_PROVIDER_CONFIG_KEY, "global-store");
+        configuration.setProperty(Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY,
+            "prompt-store");
+        policy.initialize(configuration);
+        
+        assertEquals(Set.of("global-store", "prompt-store"),
+            policy.getRequiredPluginNames(configuration));
+    }
+    
+    @Test
     void testRequiredProvidersByResourceDomain() {
         MapConfiguration configuration = new MapConfiguration();
+        configuration.setProperty(Constants.AI_STORAGE_PROVIDER_CONFIG_KEY,
+            "global-store");
         configuration.setProperty(Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY,
             " prompt-store ");
         configuration.setProperty(Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY,
@@ -102,6 +127,7 @@ class AiStoragePluginTypePolicyTest {
         assertTrue(required.contains("skill-store"));
         assertTrue(required.contains("agentspec-store"));
         assertTrue(required.contains("agent-store"));
+        assertFalse(required.contains("global-store"));
         configuration.setProperty(Constants.Prompt.PROMPT_STORAGE_PROVIDER_CONFIG_KEY,
             "changed-store");
         assertFalse(policy.getRequiredPluginNames(configuration).contains("changed-store"));

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecConcurrentSaveTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecConcurrentSaveTest.java
@@ -225,9 +225,9 @@ class AgentSpecConcurrentSaveTest {
     private void invokeConcurrentSave(String namespaceId, AgentSpec agentSpec, String version,
         long uniformId) throws Exception {
         Method method = AgentSpecOperationServiceImpl.class
-            .getDeclaredMethod("saveAgentSpecFilesConcurrently", String.class, AgentSpec.class,
-                String.class, long.class);
+            .getDeclaredMethod("saveAgentSpecFilesConcurrently", String.class, String.class,
+                AgentSpec.class, String.class, long.class);
         method.setAccessible(true);
-        method.invoke(service, namespaceId, agentSpec, version, uniformId);
+        method.invoke(service, storage.type(), namespaceId, agentSpec, version, uniformId);
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agentspecs/AgentSpecOperationServiceImplTest.java
@@ -92,6 +92,9 @@ class AgentSpecOperationServiceImplTest {
     private AiResourceStorage storage;
     
     @Mock
+    private AiResourceStorage externalStorage;
+    
+    @Mock
     private AiResourcePersistService aiResourcePersistService;
     
     @Mock
@@ -114,7 +117,9 @@ class AgentSpecOperationServiceImplTest {
         EnvUtil.setEnvironment(new StandardEnvironment());
         AiResourceStorageRouter.reset();
         lenient().when(storage.type()).thenReturn("nacos_config");
+        lenient().when(externalStorage.type()).thenReturn("external");
         AiResourceStorageRouter.join(storage);
+        AiResourceStorageRouter.join(externalStorage);
         PublishPipelineManager pipelineManager = TestAiPipelineSupport.newManager(false,
             List.of(), List.of());
         PublishPipelineExecutor publishPipelineExecutor = new PublishPipelineExecutor(
@@ -797,14 +802,17 @@ class AgentSpecOperationServiceImplTest {
         AiResourceVersion vRow = new AiResourceVersion();
         vRow.setVersion("v1");
         vRow.setStatus("online");
+        vRow.setStorage("{\"provider\":\"external\"}");
         when(aiResourceVersionPersistService.find(eq(namespaceId), eq(name), anyString(), eq("v1")))
             .thenReturn(vRow);
         String mainJson = "{\"name\":\"my-agentspec\",\"description\":\"desc\",\"resources\":[]}";
-        when(storage.get(any(StorageKey.class)))
+        when(externalStorage.get(any(StorageKey.class)))
             .thenReturn(mainJson.getBytes(StandardCharsets.UTF_8));
         AgentSpec result = service.getAgentSpecVersionDetail(namespaceId, name, "v1");
         assertNotNull(result);
         assertEquals("my-agentspec", result.getName());
+        verify(externalStorage).get(argThat(key -> "external".equals(key.getProvider())));
+        verify(storage, never()).get(any(StorageKey.class));
     }
     
     @Test
@@ -1125,7 +1133,7 @@ class AgentSpecOperationServiceImplTest {
         AiResourceVersion vRow = new AiResourceVersion();
         vRow.setVersion("v2");
         vRow.setStatus("draft");
-        vRow.setStorage("{\"provider\":\"nacos_config\","
+        vRow.setStorage("{\"provider\":\"external\","
             + "\"scope\":\"test-ns:my-agentspec:v2\"}");
         when(aiResourceVersionPersistService.find(eq(namespaceId), eq(name), anyString(), eq("v2")))
             .thenReturn(vRow);
@@ -1137,7 +1145,12 @@ class AgentSpecOperationServiceImplTest {
         draft.setDescription("updated desc");
         service.updateDraft(namespaceId, draft);
         verify(aiResourceVersionPersistService).updateStorageAndDesc(eq(namespaceId), eq(name),
-            eq("agentspec"), eq("v2"), anyString(), eq("updated desc"));
+            eq("agentspec"), eq("v2"), argThat(storageJson -> storageJson.contains(
+                "\"provider\":\"external\"")),
+            eq("updated desc"));
+        verify(externalStorage).save(argThat(key -> "external".equals(key.getProvider())),
+            any(byte[].class));
+        verify(storage, never()).save(any(StorageKey.class), any(byte[].class));
     }
     
     @Test
@@ -1183,7 +1196,7 @@ class AgentSpecOperationServiceImplTest {
         AiResourceVersion vRow = new AiResourceVersion();
         vRow.setVersion("v2");
         vRow.setStatus("draft");
-        vRow.setStorage("{\"provider\":\"nacos_config\","
+        vRow.setStorage("{\"provider\":\"external\","
             + "\"scope\":\"test-ns:my-agentspec:v2\"}");
         when(aiResourceVersionPersistService.find(eq(namespaceId), eq(name), anyString(), eq("v2")))
             .thenReturn(vRow);
@@ -1193,6 +1206,8 @@ class AgentSpecOperationServiceImplTest {
         service.deleteDraft(namespaceId, name);
         verify(aiResourceVersionPersistService).delete(eq(namespaceId), eq(name), eq("agentspec"),
             eq("v2"));
+        verify(externalStorage).delete(argThat(key -> "external".equals(key.getProvider())));
+        verify(storage, never()).delete(any(StorageKey.class));
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
@@ -71,6 +71,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -96,6 +97,9 @@ class PromptOperationServiceImplTest {
     
     @Mock
     private AiResourceStorage storage;
+    
+    @Mock
+    private AiResourceStorage externalStorage;
     
     @Mock
     private AiResourcePersistService aiResourcePersistService;
@@ -126,7 +130,9 @@ class PromptOperationServiceImplTest {
         EnvUtil.setEnvironment(new StandardEnvironment());
         AiResourceStorageRouter.reset();
         lenient().when(storage.type()).thenReturn("nacos_config");
+        lenient().when(externalStorage.type()).thenReturn("external");
         AiResourceStorageRouter.join(storage);
+        AiResourceStorageRouter.join(externalStorage);
         PublishPipelineManager pipelineManager = TestAiPipelineSupport.newManager(false,
             Collections.emptyList(), Collections.emptyList());
         PublishPipelineExecutor publishPipelineExecutor =
@@ -272,12 +278,16 @@ class PromptOperationServiceImplTest {
         AiResource meta =
             createMeta(PROMPT_KEY, 1L, "{\"labels\":{},\"editingVersion\":\"0.0.1\"}");
         when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE)).thenReturn(meta);
+        AiResourceVersion draft = createVersionRow("0.0.1", "draft");
+        draft.setStorage("{\"provider\":\"external\"}");
         when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, PROMPT_TYPE, "0.0.1"))
-            .thenReturn(createVersionRow("0.0.1", "draft"));
+            .thenReturn(draft);
         
         service.updateDraft(NS, PROMPT_KEY, "updated template", null, "update msg");
         
-        verify(storage).save(any(StorageKey.class), any(byte[].class));
+        verify(externalStorage).save(argThat(key -> "external".equals(key.getProvider())),
+            any(byte[].class));
+        verify(storage, never()).save(any(StorageKey.class), any(byte[].class));
     }
     
     @Test
@@ -308,15 +318,18 @@ class PromptOperationServiceImplTest {
         AiResource meta =
             createMeta(PROMPT_KEY, 1L, "{\"labels\":{},\"editingVersion\":\"0.0.1\"}");
         when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE)).thenReturn(meta);
+        AiResourceVersion draft = createVersionRow("0.0.1", "draft");
+        draft.setStorage("{\"provider\":\"external\"}");
         when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, PROMPT_TYPE, "0.0.1"))
-            .thenReturn(createVersionRow("0.0.1", "draft"));
+            .thenReturn(draft);
         when(aiResourcePersistService.updateMetaCas(eq(NS), eq(PROMPT_KEY), eq(PROMPT_TYPE), eq(1L),
             any(AiResource.class))).thenReturn(true);
         
         service.deleteDraft(NS, PROMPT_KEY);
         
         verify(aiResourceVersionPersistService).delete(NS, PROMPT_KEY, PROMPT_TYPE, "0.0.1");
-        verify(storage).delete(any(StorageKey.class));
+        verify(externalStorage).delete(argThat(key -> "external".equals(key.getProvider())));
+        verify(storage, never()).delete(any(StorageKey.class));
     }
     
     @Test
@@ -414,8 +427,10 @@ class PromptOperationServiceImplTest {
             createMeta(PROMPT_KEY, 1L, "{\"labels\":{},\"editingVersion\":\"0.0.1\"}");
         when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE)).thenReturn(meta);
         // Target version exists but is already online (formal version).
+        AiResourceVersion version = createVersionRow("0.0.1", "online");
+        version.setStorage("{\"provider\":\"external\"}");
         when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, PROMPT_TYPE, "0.0.1"))
-            .thenReturn(createVersionRow("0.0.1", "online"));
+            .thenReturn(version);
         
         NacosApiException ex = assertThrows(NacosApiException.class,
             () -> service.submit(NS, PROMPT_KEY, "0.0.1"));
@@ -1005,18 +1020,23 @@ class PromptOperationServiceImplTest {
     void testGetPromptVersionDetailSuccessfully() throws NacosException {
         AiResource meta = createMeta(PROMPT_KEY, 1L, "{\"labels\":{}}");
         when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE)).thenReturn(meta);
+        AiResourceVersion version = createVersionRow("0.0.1", "online");
+        version.setStorage("{\"provider\":\"external\"}");
         when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, PROMPT_TYPE, "0.0.1"))
-            .thenReturn(createVersionRow("0.0.1", "online"));
+            .thenReturn(version);
         
         PromptVersionInfo content = new PromptVersionInfo();
         content.setTemplate("hello");
-        mockStorageGet(JacksonUtils.toJson(content).getBytes(StandardCharsets.UTF_8));
+        when(externalStorage.get(any(StorageKey.class)))
+            .thenReturn(JacksonUtils.toJson(content).getBytes(StandardCharsets.UTF_8));
         
         PromptVersionInfo result = service.getPromptVersionDetail(NS, PROMPT_KEY, "0.0.1");
         
         assertNotNull(result);
         assertEquals(PROMPT_KEY, result.getPromptKey());
         assertEquals("0.0.1", result.getVersion());
+        verify(externalStorage).get(argThat(key -> "external".equals(key.getProvider())));
+        verify(storage, never()).get(any(StorageKey.class));
     }
     
     // ========== listPrompts / listPromptVersions ==========
@@ -1133,6 +1153,8 @@ class PromptOperationServiceImplTest {
     void testRefreshLatestMirrorPublishesToLegacyConfig() throws NacosException {
         AiResource meta = createMeta(PROMPT_KEY, 1L, "{\"labels\":{\"latest\":\"0.0.1\"}}");
         when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE)).thenReturn(meta);
+        when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, PROMPT_TYPE, "0.0.1"))
+            .thenReturn(createVersionRow("0.0.1", "online"));
         
         PromptVersionInfo content = new PromptVersionInfo();
         content.setTemplate("hello");

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
@@ -319,7 +319,7 @@ class PromptOperationServiceImplTest {
             createMeta(PROMPT_KEY, 1L, "{\"labels\":{},\"editingVersion\":\"0.0.1\"}");
         when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE)).thenReturn(meta);
         AiResourceVersion draft = createVersionRow("0.0.1", "draft");
-        draft.setStorage("{\"provider\":\"external\"}");
+        draft.setStorage("{\"provider\":\"external\",\"files\":[\"content.json\"]}");
         when(aiResourceVersionPersistService.find(NS, PROMPT_KEY, PROMPT_TYPE, "0.0.1"))
             .thenReturn(draft);
         when(aiResourcePersistService.updateMetaCas(eq(NS), eq(PROMPT_KEY), eq(PROMPT_TYPE), eq(1L),

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
@@ -2457,6 +2457,7 @@ class SkillOperationServiceImplTest {
             new com.alibaba.nacos.ai.model.AiResourceVersion();
         vRow.setVersion("v1");
         vRow.setStatus("draft");
+        vRow.setStorage("{\"provider\":\"external\",\"files\":[\"SKILL.md\"]}");
         when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(),
             eq("v1")))
             .thenReturn(vRow);
@@ -2471,7 +2472,11 @@ class SkillOperationServiceImplTest {
         skillOperationService.updateDraft(namespaceId, draft, null);
         verify(aiResourceVersionPersistService).updateStorage(eq(namespaceId), eq(skillName),
             anyString(),
-            eq("v1"), anyString());
+            eq("v1"), argThat(storageJson -> storageJson.contains(
+                "\"provider\":\"external\"")));
+        verify(externalStorage).save(argThat(key -> "external".equals(key.getProvider())),
+            any(byte[].class));
+        verify(storage, never()).save(any(StorageKey.class), any(byte[].class));
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/skills/SkillOperationServiceImplTest.java
@@ -115,6 +115,9 @@ class SkillOperationServiceImplTest {
     private AiResourceStorage storage;
     
     @Mock
+    private AiResourceStorage externalStorage;
+    
+    @Mock
     private AiResourcePersistService aiResourcePersistService;
     
     @Mock
@@ -140,7 +143,9 @@ class SkillOperationServiceImplTest {
         EnvUtil.setEnvironment(new StandardEnvironment());
         AiResourceStorageRouter.reset();
         lenient().when(storage.type()).thenReturn("nacos_config");
+        lenient().when(externalStorage.type()).thenReturn("external");
         AiResourceStorageRouter.join(storage);
+        AiResourceStorageRouter.join(externalStorage);
         PublishPipelineManager pipelineManager = TestAiPipelineSupport.newManager(false,
             List.of(), List.of());
         PublishPipelineExecutor publishPipelineExecutor = new PublishPipelineExecutor(
@@ -164,6 +169,8 @@ class SkillOperationServiceImplTest {
             visibilityManagerStatic.close();
         }
         System.clearProperty(AUTO_PUBLISH_AFTER_REVIEW_ENABLED_KEY);
+        System.clearProperty(
+            com.alibaba.nacos.ai.constant.Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY);
         TestAiPipelineSupport.clearStateChecker();
         EnvUtil.setEnvironment(CACHED_ENVIRONMENT);
     }
@@ -2327,15 +2334,50 @@ class SkillOperationServiceImplTest {
             new com.alibaba.nacos.ai.model.AiResourceVersion();
         vRow.setVersion(version);
         vRow.setStorage(
-            "{\"provider\":\"nacos_config\",\"scope\":\"test-ns:test-skill:v1\",\"files\":[\"SKILL.md\"]}");
+            "{\"provider\":\"external\",\"scope\":\"test-ns:test-skill:v1\",\"files\":[\"SKILL.md\"]}");
         when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(),
             eq(version)))
             .thenReturn(vRow);
-        when(storage.get(any(StorageKey.class))).thenReturn(
+        when(externalStorage.get(any(StorageKey.class))).thenReturn(
             ("---\nname: test-skill\ndescription: desc\n---\n\nbody").getBytes());
         Skill result = skillOperationService.getSkillVersionDetail(namespaceId, skillName, version);
         assertNotNull(result);
         assertEquals("test-skill", result.getName());
+        verify(externalStorage).get(argThat(key -> "external".equals(key.getProvider())));
+        verify(storage, never()).get(any(StorageKey.class));
+    }
+    
+    @Test
+    void testGetSkillVersionDetailUsesNacosConfigForLegacyStorage() throws NacosException {
+        String namespaceId = "test-ns";
+        String skillName = "test-skill";
+        String version = "v1";
+        AiResource meta = new AiResource();
+        meta.setName(skillName);
+        meta.setType("skill");
+        meta.setStatus("enable");
+        meta.setScope(VisibilityConstants.SCOPE_PUBLIC);
+        when(aiResourcePersistService.find(eq(namespaceId), eq(skillName), anyString()))
+            .thenReturn(meta);
+        com.alibaba.nacos.ai.model.AiResourceVersion vRow =
+            new com.alibaba.nacos.ai.model.AiResourceVersion();
+        vRow.setVersion(version);
+        vRow.setStorage(
+            "{\"scope\":\"test-ns:test-skill:v1\",\"files\":[\"SKILL.md\"]}");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(),
+            eq(version)))
+            .thenReturn(vRow);
+        System.setProperty(
+            com.alibaba.nacos.ai.constant.Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY,
+            "external");
+        when(storage.get(any(StorageKey.class))).thenReturn(
+            ("---\nname: test-skill\ndescription: desc\n---\n\nbody").getBytes());
+        
+        Skill result = skillOperationService.getSkillVersionDetail(namespaceId, skillName, version);
+        
+        assertNotNull(result);
+        verify(storage).get(argThat(key -> "nacos_config".equals(key.getProvider())));
+        verify(externalStorage, never()).get(any(StorageKey.class));
     }
     
     @Test
@@ -2490,7 +2532,7 @@ class SkillOperationServiceImplTest {
         vRow.setVersion("v1");
         vRow.setStatus("draft");
         vRow.setStorage(
-            "{\"provider\":\"nacos_config\",\"scope\":\"ns:s:v1\",\"files\":[\"SKILL.md\"]}");
+            "{\"provider\":\"external\",\"scope\":\"ns:s:v1\",\"files\":[\"SKILL.md\"]}");
         when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(),
             eq("v1")))
             .thenReturn(vRow);
@@ -2501,6 +2543,8 @@ class SkillOperationServiceImplTest {
         skillOperationService.deleteDraft(namespaceId, skillName);
         verify(aiResourceVersionPersistService).delete(eq(namespaceId), eq(skillName), anyString(),
             eq("v1"));
+        verify(externalStorage).delete(argThat(key -> "external".equals(key.getProvider())));
+        verify(storage, never()).delete(any(StorageKey.class));
     }
     
     @Test
@@ -2913,11 +2957,21 @@ class SkillOperationServiceImplTest {
         manifest.setVersions(new HashMap<>(Map.of("v1", List.of("SKILL.md"))));
         manifest.setLabels(new HashMap<>(Map.of("latest", "v1")));
         when(manifestService.query(eq(namespaceId), eq(skillName))).thenReturn(manifest);
-        when(storage.get(any(StorageKey.class))).thenReturn(
+        com.alibaba.nacos.ai.model.AiResourceVersion vRow =
+            new com.alibaba.nacos.ai.model.AiResourceVersion();
+        vRow.setVersion("v1");
+        vRow.setStorage(
+            "{\"provider\":\"external\",\"scope\":\"test-ns:my-skill:v1\",\"files\":[\"SKILL.md\"]}");
+        when(aiResourceVersionPersistService.find(eq(namespaceId), eq(skillName), anyString(),
+            eq("v1")))
+            .thenReturn(vRow);
+        when(externalStorage.get(any(StorageKey.class))).thenReturn(
             ("---\nname: my-skill\ndescription: desc\n---\n\nbody").getBytes());
         Skill result = skillOperationService.querySkill(namespaceId, skillName, null, null);
         assertNotNull(result);
         assertEquals("my-skill", result.getName());
+        verify(externalStorage).get(argThat(key -> "external".equals(key.getProvider())));
+        verify(storage, never()).get(any(StorageKey.class));
     }
     
     @Test

--- a/ai/src/test/java/com/alibaba/nacos/ai/storage/AiResourceStorageUtilsTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/storage/AiResourceStorageUtilsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.storage;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AiResourceStorageUtilsTest {
+    
+    private static final ConfigurableEnvironment CACHED_ENVIRONMENT = EnvUtil.getEnvironment();
+    
+    @BeforeEach
+    void setUp() {
+        EnvUtil.setEnvironment(new StandardEnvironment());
+    }
+    
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(Constants.AI_STORAGE_PROVIDER_CONFIG_KEY);
+        System.clearProperty(Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY);
+        EnvUtil.setEnvironment(CACHED_ENVIRONMENT);
+    }
+    
+    @Test
+    void testResolveProviderUsesGlobalConfiguration() {
+        System.setProperty(Constants.AI_STORAGE_PROVIDER_CONFIG_KEY, " external ");
+        
+        assertEquals("external", AiResourceStorageUtils.resolveProvider(
+            Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY,
+            NacosConfigAiResourceStorage.TYPE));
+    }
+    
+    @Test
+    void testResolveProviderPrefersResourceCompatibilityConfiguration() {
+        System.setProperty(Constants.AI_STORAGE_PROVIDER_CONFIG_KEY, "global-store");
+        System.setProperty(Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY, "skill-store");
+        
+        assertEquals("skill-store", AiResourceStorageUtils.resolveProvider(
+            Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY,
+            NacosConfigAiResourceStorage.TYPE));
+    }
+    
+    @Test
+    void testResolveProviderUsesDefault() {
+        assertEquals(NacosConfigAiResourceStorage.TYPE,
+            AiResourceStorageUtils.resolveProvider(
+                Constants.Skills.SKILL_STORAGE_PROVIDER_CONFIG_KEY,
+                NacosConfigAiResourceStorage.TYPE));
+    }
+}

--- a/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/storage/spi/AiResourceStorageBuilder.java
+++ b/plugin/ai/src/main/java/com/alibaba/nacos/plugin/ai/storage/spi/AiResourceStorageBuilder.java
@@ -38,7 +38,11 @@ public interface AiResourceStorageBuilder {
     /**
      * Build an {@link AiResourceStorage} instance.
      *
-     * @return a fully initialized {@link AiResourceStorage} instance
+     * <p>Unified plugin configuration is applied to configurable storage instances after
+     * registration. An optional provider may return {@code null} when its bootstrap properties
+     * are absent.</p>
+     *
+     * @return storage instance to register, or {@code null} to skip registration
      */
     AiResourceStorage build();
 }

--- a/specs/en/ai/agentspec-spec.md
+++ b/specs/en/ai/agentspec-spec.md
@@ -45,6 +45,11 @@ and resource references before writing a version.
 AgentSpec uses the standard `ai_resource` and `ai_resource_version` model. It
 uses AI storage for `manifest.json` and resource files.
 
+Each version descriptor persists its selected storage provider. Reads, draft
+replacements, and deletes use that persisted provider, while the effective
+provider configuration selects only new versions. A legacy descriptor without
+a provider uses `nacos_config`.
+
 Unlike Skill, AgentSpec does not maintain a separate manifest index. Version
 metadata and storage pointers are authoritative.
 

--- a/specs/en/ai/ai-resource-model-spec.md
+++ b/specs/en/ai/ai-resource-model-spec.md
@@ -105,6 +105,12 @@ The default storage implementation is Nacos Config based, but Config is only a
 storage backend here. AI resource content stored through `nacos_config` must not
 be treated as user-owned Config resources.
 
+Each version must persist its selected storage provider in
+`AiResourceVersion.storage`. The effective provider configuration selects the
+provider only when a new version is written. Reads, draft replacements, and
+deletes for an existing version must route through its persisted provider. A
+legacy storage descriptor without a provider belongs to `nacos_config`.
+
 Storage extension behavior is defined by the
 [AI Storage Plugin Spec](../plugin/ai-storage-plugin-spec.md). Database dialect
 behavior is defined by the [Data Source Dialect Plugin Spec](../plugin/datasource-dialect-plugin-spec.md).

--- a/specs/en/ai/prompt-spec.md
+++ b/specs/en/ai/prompt-spec.md
@@ -65,7 +65,14 @@ server may return a not-modified error.
 Subscriptions should report Prompt changes without exposing broad management
 listing behavior to runtime clients.
 
-## 5. Migration
+## 5. Storage
+
+Prompt persists the selected storage provider in each version descriptor.
+Operations on an existing version use that persisted provider; the effective
+provider configuration applies only to new versions. A legacy descriptor
+without a provider uses `nacos_config`.
+
+## 6. Migration
 
 Prompt has a migration task from legacy Prompt storage to
 `ai_resource + ai_resource_version + AI storage`. Migration must:
@@ -75,7 +82,7 @@ Prompt has a migration task from legacy Prompt storage to
 - preserve existing versions and latest behavior where possible;
 - keep legacy mappings as compatibility storage, not formal Config semantics.
 
-## 6. Evolution Note
+## 7. Evolution Note
 
 Prompt formats, variable schemas, tool-call conventions, and model-provider
 requirements may change quickly. Prompt spec revisions may introduce new

--- a/specs/en/ai/skill-spec.md
+++ b/specs/en/ai/skill-spec.md
@@ -168,6 +168,12 @@ Skill metadata and versions use `ai_resource` and `ai_resource_version`.
 Skill file content is stored through AI storage. The default storage is
 `nacos_config`, but that is an implementation backend.
 
+Each version must persist its storage provider in the `ai_resource_version`
+storage descriptor. Reads and deletes must route through that persisted
+provider. The configured Skill storage provider controls new writes only and
+must not redirect existing versions. A legacy descriptor without `provider`
+belongs to `nacos_config`.
+
 Skill also maintains a lightweight manifest for client-side discovery. The
 manifest is an index derived from Skill metadata and must not become the source
 of truth for lifecycle state.

--- a/specs/en/ai/skill-spec.md
+++ b/specs/en/ai/skill-spec.md
@@ -170,7 +170,7 @@ Skill file content is stored through AI storage. The default storage is
 
 Each version must persist its storage provider in the `ai_resource_version`
 storage descriptor. Reads and deletes must route through that persisted
-provider. The configured Skill storage provider controls new writes only and
+provider. The effective AI Resource storage provider controls new writes only and
 must not redirect existing versions. A legacy descriptor without `provider`
 belongs to `nacos_config`.
 

--- a/specs/en/plugin/ai-storage-plugin-spec.md
+++ b/specs/en/plugin/ai-storage-plugin-spec.md
@@ -48,7 +48,7 @@ Storage implementations are created by `AiResourceStorageBuilder`.
 | Builder method | Requirement |
 |----------------|-------------|
 | `type()` | Stable storage provider type. |
-| `build()` | Build an `AiResourceStorage`. |
+| `build()` | Build an `AiResourceStorage`, or return null when an optional provider is not statically configured for discovery. |
 
 The storage service implements:
 
@@ -143,24 +143,33 @@ built-in `ai-storage:nacos_config` provider is the default backend and a
 critical plugin required by server AI capabilities, so it cannot be disabled
 through plugin management while the server depends on it.
 
-The following properties select a provider for an AI resource domain:
+The following property selects the provider for new writes across all AI
+resource domains:
 
 ```properties
-nacos.ai.prompt.storage.provider=nacos_config
-nacos.ai.skill.storage.provider=nacos_config
-nacos.ai.agentspec.storage.provider=nacos_config
-nacos.ai.agent.storage.provider=nacos_config
+nacos.ai.storage.provider=nacos_config
 ```
 
-They are domain routing policy, not private configuration definitions owned by
+For compatibility, the following existing domain properties remain supported:
+
+```properties
+nacos.ai.prompt.storage.provider=
+nacos.ai.skill.storage.provider=
+nacos.ai.agentspec.storage.provider=
+nacos.ai.agent.storage.provider=
+```
+
+A non-blank domain property overrides the global property for that domain. If
+neither is configured, the domain uses `nacos_config`. These properties are
+domain routing policy, not private configuration definitions owned by
 `ai-storage:nacos_config`.
 
-When the AI module is active, all providers selected independently for Prompt, Skill, AgentSpec,
-and Agent are required implementations of this critical routed type. The same provider may satisfy
-multiple domains. Before startup succeeds, every distinct selected provider must be discovered and
-enabled; a different available provider is not a valid fallback. When the AI module is disabled by
-function mode or `nacos.extension.ai.enabled=false`, AI storage is inactive and does not impose a
-startup requirement.
+When the AI module is active, every effective provider selected after applying the precedence above
+is a required implementation of this critical routed type. Before startup succeeds, every distinct
+selected provider must be discovered and enabled; a different available provider is not a valid
+fallback. When the AI module is disabled by function mode or
+`nacos.extension.ai.enabled=false`, AI storage is inactive and does not impose a startup
+requirement.
 
 AI storage implementations are built from Spring-managed services during context refresh, so this
 type does not participate in pre-refresh critical validation. The unified plugin manager performs

--- a/specs/zh-cn/ai/agentspec-spec.md
+++ b/specs/zh-cn/ai/agentspec-spec.md
@@ -43,6 +43,10 @@ AgentSpec upload 接收 ZIP 包。解析器必须先校验 manifest 和资源引
 AgentSpec 使用标准 `ai_resource` 和 `ai_resource_version` 模型。它通过 AI 存储保存
 `manifest.json` 和资源文件。
 
+每个版本描述都持久化选定的存储 provider。读取、draft 覆盖和删除使用已持久化的
+provider，有效 provider 配置只选择新版本。缺少 provider 的历史描述使用
+`nacos_config`。
+
 不同于 Skill，AgentSpec 不维护独立 manifest index。版本元数据和存储指针是事实来源。
 
 ## 4. 生命周期

--- a/specs/zh-cn/ai/ai-resource-model-spec.md
+++ b/specs/zh-cn/ai/ai-resource-model-spec.md
@@ -100,6 +100,10 @@ Labels 不得指向 draft 或 reviewing 版本。运行时客户端可以通过�
 默认存储实现基于 Nacos Config，但 Config 在这里只是存储后端。通过
 `nacos_config` 保存的 AI 内容不应被视为用户拥有的 Config 资源。
 
+每个版本必须在 `AiResourceVersion.storage` 中持久化选定的存储 provider。有效 provider
+配置只在写入新版本时选择 provider；已有版本的读取、draft 覆盖和删除必须按已持久化的
+provider 路由。缺少 provider 的历史存储描述归属于 `nacos_config`。
+
 存储扩展行为由 [AI 存储插件规范](../plugin/ai-storage-plugin-spec.md)定义。数据库
 方言行为由 [数据源方言插件规范](../plugin/datasource-dialect-plugin-spec.md)定义。
 

--- a/specs/zh-cn/ai/prompt-spec.md
+++ b/specs/zh-cn/ai/prompt-spec.md
@@ -61,7 +61,13 @@ Prompt。如果 md5 与当前版本内容 md5 一致，服务端可以返回 not
 
 订阅应报告 Prompt 变更，但不应向运行时客户端暴露宽范围管理列表能力。
 
-## 5. 迁移
+## 5. 存储
+
+Prompt 在每个版本的存储描述中持久化选定的 provider。已有版本的操作使用已持久化的
+provider，有效 provider 配置仅作用于新版本。缺少 provider 的历史描述使用
+`nacos_config`。
+
+## 6. 迁移
 
 Prompt 存在从旧 Prompt 存储迁移到
 `ai_resource + ai_resource_version + AI storage` 的迁移任务。迁移必须：
@@ -71,7 +77,7 @@ Prompt 存在从旧 Prompt 存储迁移到
 - 尽可能保留已有版本和 latest 行为；
 - 将旧映射保持为兼容存储，而不是正式 Config 语义。
 
-## 6. 演进说明
+## 7. 演进说明
 
 Prompt 格式、变量 schema、tool-call 约定和模型提供方要求可能快速变化。Prompt 规范
 调整可以引入新的内容字段或校验规则，但必须为已有 Prompt 保留版本化迁移路径。

--- a/specs/zh-cn/ai/skill-spec.md
+++ b/specs/zh-cn/ai/skill-spec.md
@@ -134,7 +134,7 @@ Skill 元数据和版本使用 `ai_resource` 与 `ai_resource_version`。Skill �
 AI 存储保存。默认存储为 `nacos_config`，但它只是实现后端。
 
 每个版本必须在 `ai_resource_version` 的存储描述中持久化存储 provider。读取和删除必须
-按该版本已持久化的 provider 路由。Skill 存储 provider 配置只控制新写入，不得重定向已有
+按该版本已持久化的 provider 路由。有效 AI Resource 存储 provider 配置只控制新写入，不得重定向已有
 版本。缺少 `provider` 的历史存储描述归属于 `nacos_config`。
 
 Skill 还维护一个轻量 manifest 以支持客户端发现。Manifest 是从 Skill 元数据派生的

--- a/specs/zh-cn/ai/skill-spec.md
+++ b/specs/zh-cn/ai/skill-spec.md
@@ -133,6 +133,10 @@ Nacos 注册中心路径不得在 upload、query 或 download 过程中执行包
 Skill 元数据和版本使用 `ai_resource` 与 `ai_resource_version`。Skill 文件内容通过
 AI 存储保存。默认存储为 `nacos_config`，但它只是实现后端。
 
+每个版本必须在 `ai_resource_version` 的存储描述中持久化存储 provider。读取和删除必须
+按该版本已持久化的 provider 路由。Skill 存储 provider 配置只控制新写入，不得重定向已有
+版本。缺少 `provider` 的历史存储描述归属于 `nacos_config`。
+
 Skill 还维护一个轻量 manifest 以支持客户端发现。Manifest 是从 Skill 元数据派生的
 索引，不应成为生命周期状态的事实来源。
 

--- a/specs/zh-cn/plugin/ai-storage-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-storage-plugin-spec.md
@@ -44,7 +44,7 @@ AI 存储插件抽象 AI 资源的二进制或文本内容存储。元数据仍�
 | Builder 方法 | 要求 |
 |--------------|------|
 | `type()` | 稳定存储提供者类型。 |
-| `build()` | 构造 `AiResourceStorage`。 |
+| `build()` | 构造 `AiResourceStorage`；可选 provider 未静态配置、无需参与发现时可返回 null。 |
 
 存储服务实现：
 
@@ -117,20 +117,27 @@ AI 存储 provider 接入统一插件 state。禁用非 critical provider 后，
 插件管理查询，但 router 会拒绝该 provider 的新操作。内置 `ai-storage:nacos_config` 是默认
 后端，也是服务端 AI 能力依赖的 critical 插件；服务端仍依赖它时，不能通过插件管理将其禁用。
 
-以下属性为不同 AI 资源领域选择 provider：
+以下属性为所有 AI 资源领域的新写入选择 provider：
 
 ```properties
-nacos.ai.prompt.storage.provider=nacos_config
-nacos.ai.skill.storage.provider=nacos_config
-nacos.ai.agentspec.storage.provider=nacos_config
-nacos.ai.agent.storage.provider=nacos_config
+nacos.ai.storage.provider=nacos_config
 ```
 
-它们属于领域路由策略，不是 `ai-storage:nacos_config` 所拥有的私有配置 definitions。
+为兼容历史配置，继续支持以下领域属性：
 
-AI 模块 active 时，为 Prompt、Skill、AgentSpec、Agent 分别选择的所有 provider 都是该 critical
-路由类型的必需实现；同一 provider 可以同时满足多个领域。Nacos 启动成功前，每个去重后的
-选中 provider 都必须已被发现且处于 enabled 状态，另一个可用 provider 不能作为 fallback。
+```properties
+nacos.ai.prompt.storage.provider=
+nacos.ai.skill.storage.provider=
+nacos.ai.agentspec.storage.provider=
+nacos.ai.agent.storage.provider=
+```
+
+非空领域属性优先于全局属性；两者均未配置时使用 `nacos_config`。这些属性属于领域路由策略，
+不是 `ai-storage:nacos_config` 所拥有的私有配置 definitions。
+
+AI 模块 active 时，按上述优先级选出的每个有效 provider 都是该 critical 路由类型的必需实现。
+Nacos 启动成功前，每个去重后的选中 provider 都必须已被发现且处于 enabled 状态，另一个可用
+provider 不能作为 fallback。
 AI 模块因 function mode 或 `nacos.extension.ai.enabled=false` 关闭时，AI storage 为 inactive，
 不产生启动约束。
 


### PR DESCRIPTION
## What is the purpose of the change

Keep AI resource versions bound to the storage provider selected when they were written, while allowing operators to select one default provider for all AI resource types.

Fixes #15658.

## Brief changelog

- Add `nacos.ai.storage.provider` as the shared fallback for new Prompt, Skill, AgentSpec, and Agent writes.
- Preserve the existing resource-specific properties as higher-priority compatibility overrides.
- Route reads, draft updates, and deletes through the provider persisted in each version descriptor; legacy descriptors continue to use `nacos_config`.
- Check for an existing Prompt version before migration writes storage content.
- Allow optional `AiResourceStorageBuilder` implementations to return `null`, and update the related specifications and tests.

This PR is provider-neutral and does not include an OSS implementation.

## Verifying this change

The following focused checks passed:

```bash
mvn -q -pl ai,plugin/ai -am -DskipTests spotless:check
mvn -q -pl ai -am -Dtest=AiResourceStorageUtilsTest,AiStoragePluginTypePolicyTest,AgentVersionStorageServiceTest,PromptOperationServiceImplTest,SkillOperationServiceImplTest,AgentSpecOperationServiceImplTest,PromptDataMigrationTaskTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
