### PR TITLE
[Security] Harden distributed database query result resolution

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourceRowMappers.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/repository/AiResourceRowMappers.java
@@ -18,52 +18,80 @@ package com.alibaba.nacos.ai.service.repository;
 
 import com.alibaba.nacos.ai.model.AiResource;
 import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.persistence.repository.RowMapperManager;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 /**
  * Row mappers for ai_resource and ai_resource_version.
  */
-final class AiResourceRowMappers {
+@Component
+public final class AiResourceRowMappers {
     
-    private AiResourceRowMappers() {
+    static final RowMapper<AiResource> AI_RESOURCE_ROW_MAPPER = new AiResourceRowMapper();
+    
+    static final RowMapper<AiResourceVersion> AI_RESOURCE_VERSION_ROW_MAPPER =
+        new AiResourceVersionRowMapper();
+    
+    static {
+        RowMapperManager.registerRowMapper(
+            AI_RESOURCE_ROW_MAPPER.getClass().getCanonicalName(), AI_RESOURCE_ROW_MAPPER);
+        RowMapperManager.registerRowMapper(
+            AI_RESOURCE_VERSION_ROW_MAPPER.getClass().getCanonicalName(),
+            AI_RESOURCE_VERSION_ROW_MAPPER);
     }
     
-    static final RowMapper<AiResource> AI_RESOURCE_ROW_MAPPER = (rs, rowNum) -> {
-        AiResource r = new AiResource();
-        r.setId(rs.getLong("id"));
-        r.setGmtCreate(rs.getTimestamp("gmt_create"));
-        r.setGmtModified(rs.getTimestamp("gmt_modified"));
-        r.setName(rs.getString("name"));
-        r.setType(rs.getString("type"));
-        r.setDesc(rs.getString("c_desc"));
-        r.setStatus(rs.getString("status"));
-        r.setNamespaceId(rs.getString("namespace_id"));
-        r.setBizTags(rs.getString("biz_tags"));
-        r.setExt(rs.getString("ext"));
-        r.setFrom(rs.getString("c_from"));
-        r.setVersionInfo(rs.getString("version_info"));
-        r.setMetaVersion(rs.getLong("meta_version"));
-        r.setScope(rs.getString("scope"));
-        r.setOwner(rs.getString("owner"));
-        r.setDownloadCount(rs.getLong("download_count"));
-        return r;
-    };
+    public AiResourceRowMappers() {
+    }
     
-    static final RowMapper<AiResourceVersion> AI_RESOURCE_VERSION_ROW_MAPPER = (rs, rowNum) -> {
-        AiResourceVersion v = new AiResourceVersion();
-        v.setId(rs.getLong("id"));
-        v.setGmtCreate(rs.getTimestamp("gmt_create"));
-        v.setGmtModified(rs.getTimestamp("gmt_modified"));
-        v.setType(rs.getString("type"));
-        v.setAuthor(rs.getString("author"));
-        v.setName(rs.getString("name"));
-        v.setDesc(rs.getString("c_desc"));
-        v.setStatus(rs.getString("status"));
-        v.setVersion(rs.getString("version"));
-        v.setNamespaceId(rs.getString("namespace_id"));
-        v.setStorage(rs.getString("storage"));
-        v.setPublishPipelineInfo(rs.getString("publish_pipeline_info"));
-        v.setDownloadCount(rs.getLong("download_count"));
-        return v;
-    };
+    private static final class AiResourceRowMapper implements RowMapper<AiResource> {
+        
+        @Override
+        public AiResource mapRow(ResultSet resultSet, int rowNum) throws SQLException {
+            AiResource result = new AiResource();
+            result.setId(resultSet.getLong("id"));
+            result.setGmtCreate(resultSet.getTimestamp("gmt_create"));
+            result.setGmtModified(resultSet.getTimestamp("gmt_modified"));
+            result.setName(resultSet.getString("name"));
+            result.setType(resultSet.getString("type"));
+            result.setDesc(resultSet.getString("c_desc"));
+            result.setStatus(resultSet.getString("status"));
+            result.setNamespaceId(resultSet.getString("namespace_id"));
+            result.setBizTags(resultSet.getString("biz_tags"));
+            result.setExt(resultSet.getString("ext"));
+            result.setFrom(resultSet.getString("c_from"));
+            result.setVersionInfo(resultSet.getString("version_info"));
+            result.setMetaVersion(resultSet.getLong("meta_version"));
+            result.setScope(resultSet.getString("scope"));
+            result.setOwner(resultSet.getString("owner"));
+            result.setDownloadCount(resultSet.getLong("download_count"));
+            return result;
+        }
+    }
+    
+    private static final class AiResourceVersionRowMapper
+        implements RowMapper<AiResourceVersion> {
+        
+        @Override
+        public AiResourceVersion mapRow(ResultSet resultSet, int rowNum) throws SQLException {
+            AiResourceVersion result = new AiResourceVersion();
+            result.setId(resultSet.getLong("id"));
+            result.setGmtCreate(resultSet.getTimestamp("gmt_create"));
+            result.setGmtModified(resultSet.getTimestamp("gmt_modified"));
+            result.setType(resultSet.getString("type"));
+            result.setAuthor(resultSet.getString("author"));
+            result.setName(resultSet.getString("name"));
+            result.setDesc(resultSet.getString("c_desc"));
+            result.setStatus(resultSet.getString("status"));
+            result.setVersion(resultSet.getString("version"));
+            result.setNamespaceId(resultSet.getString("namespace_id"));
+            result.setStorage(resultSet.getString("storage"));
+            result.setPublishPipelineInfo(resultSet.getString("publish_pipeline_info"));
+            result.setDownloadCount(resultSet.getLong("download_count"));
+            return result;
+        }
+    }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/repository/AiResourceRowMappersTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/repository/AiResourceRowMappersTest.java
@@ -17,6 +17,8 @@
 package com.alibaba.nacos.ai.service.repository;
 
 import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.AiResourceVersion;
+import com.alibaba.nacos.persistence.repository.RowMapperManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -28,6 +30,8 @@ import java.sql.Timestamp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 /**
@@ -40,6 +44,21 @@ class AiResourceRowMappersTest {
     
     @Mock
     private ResultSet resultSet;
+    
+    @Test
+    void testAiResourceRowMappersAreRegistered() {
+        String resourceMapperName =
+            AiResourceRowMappers.AI_RESOURCE_ROW_MAPPER.getClass().getCanonicalName();
+        String versionMapperName =
+            AiResourceRowMappers.AI_RESOURCE_VERSION_ROW_MAPPER.getClass().getCanonicalName();
+        
+        assertNotNull(resourceMapperName);
+        assertNotNull(versionMapperName);
+        assertSame(AiResourceRowMappers.AI_RESOURCE_ROW_MAPPER,
+            RowMapperManager.getRowMapper(resourceMapperName));
+        assertSame(AiResourceRowMappers.AI_RESOURCE_VERSION_ROW_MAPPER,
+            RowMapperManager.getRowMapper(versionMapperName));
+    }
     
     @Test
     void testAiResourceRowMapperIncludesScopeAndOwner() throws SQLException {
@@ -95,5 +114,30 @@ class AiResourceRowMappersTest {
         assertEquals("local", resource.getFrom());
         assertEquals("PRIVATE", resource.getScope());
         assertEquals("bob", resource.getOwner());
+    }
+    
+    @Test
+    void testAiResourceVersionRowMapper() throws SQLException {
+        when(resultSet.getString(anyString())).thenAnswer(invocation -> {
+            String columnName = invocation.getArgument(0);
+            if ("name".equals(columnName)) {
+                return "test-skill";
+            }
+            if ("version".equals(columnName)) {
+                return "1.0.0";
+            }
+            if ("storage".equals(columnName)) {
+                return "local";
+            }
+            return null;
+        });
+        
+        AiResourceVersion version =
+            AiResourceRowMappers.AI_RESOURCE_VERSION_ROW_MAPPER.mapRow(resultSet, 0);
+        
+        assertNotNull(version);
+        assertEquals("test-skill", version.getName());
+        assertEquals("1.0.0", version.getVersion());
+        assertEquals("local", version.getStorage());
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/persistence/DistributedDatabaseOperateImpl.java
+++ b/core/src/main/java/com/alibaba/nacos/core/persistence/DistributedDatabaseOperateImpl.java
@@ -157,6 +157,11 @@ public class DistributedDatabaseOperateImpl extends RequestProcessor4CP
      */
     private static final String DATA_IMPORT_KEY = "00--0-data_import-0--00";
     
+    private static final Map<String, Class<?>> BASIC_RESULT_TYPES = Map.of(
+        Integer.class.getCanonicalName(), Integer.class,
+        Long.class.getCanonicalName(), Long.class,
+        String.class.getCanonicalName(), String.class);
+    
     private final ServerMemberManager memberManager;
     
     private CPProtocol protocol;
@@ -509,32 +514,30 @@ public class DistributedDatabaseOperateImpl extends RequestProcessor4CP
             LoggerUtils.printIfDebugEnabled(LOGGER, "getData info : selectRequest : {}",
                 selectRequest);
             sqlLimiter.doLimitForSelectRequest(selectRequest);
-            final RowMapper<Object> mapper =
-                RowMapperManager.getRowMapper(selectRequest.getClassName());
             final byte type = selectRequest.getQueryType();
             switch (type) {
                 case QueryType.QUERY_ONE_WITH_MAPPER_WITH_ARGS:
                     data = queryOne(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(),
-                        mapper);
+                        getRequiredRowMapper(selectRequest.getClassName()));
                     break;
                 case QueryType.QUERY_ONE_NO_MAPPER_NO_ARGS:
                     data = queryOne(jdbcTemplate, selectRequest.getSql(),
-                        ClassUtils.findClassByName(selectRequest.getClassName()));
+                        getBasicResultType(selectRequest.getClassName()));
                     break;
                 case QueryType.QUERY_ONE_NO_MAPPER_WITH_ARGS:
                     data = queryOne(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(),
-                        ClassUtils.findClassByName(selectRequest.getClassName()));
+                        getBasicResultType(selectRequest.getClassName()));
                     break;
                 case QueryType.QUERY_MANY_WITH_MAPPER_WITH_ARGS:
                     data = queryMany(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(),
-                        mapper);
+                        getRequiredRowMapper(selectRequest.getClassName()));
                     break;
                 case QueryType.QUERY_MANY_WITH_LIST_WITH_ARGS:
                     data = queryMany(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs());
                     break;
                 case QueryType.QUERY_MANY_NO_MAPPER_WITH_ARGS:
                     data = queryMany(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(),
-                        ClassUtils.findClassByName(selectRequest.getClassName()));
+                        getBasicResultType(selectRequest.getClassName()));
                     break;
                 default:
                     throw new IllegalArgumentException("Unsupported data query categories");
@@ -552,6 +555,22 @@ public class DistributedDatabaseOperateImpl extends RequestProcessor4CP
         } finally {
             readLock.unlock();
         }
+    }
+    
+    private RowMapper<Object> getRequiredRowMapper(String className) {
+        RowMapper<Object> result = RowMapperManager.getRowMapper(className);
+        if (result == null) {
+            throw new IllegalArgumentException("Unregistered row mapper");
+        }
+        return result;
+    }
+    
+    private Class<?> getBasicResultType(String className) {
+        Class<?> result = className == null ? null : BASIC_RESULT_TYPES.get(className);
+        if (result == null) {
+            throw new IllegalArgumentException("Unsupported basic result type");
+        }
+        return result;
     }
     
     @Override

--- a/core/src/test/java/com/alibaba/nacos/core/persistence/DistributedDatabaseOperateImplTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/persistence/DistributedDatabaseOperateImplTest.java
@@ -30,6 +30,7 @@ import com.alibaba.nacos.persistence.datasource.DynamicDataSource;
 import com.alibaba.nacos.persistence.datasource.LocalDataSourceServiceImpl;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.persistence.model.event.RaftDbErrorEvent;
+import com.alibaba.nacos.persistence.repository.RowMapperManager;
 import com.alibaba.nacos.persistence.repository.embedded.EmbeddedStorageContextHolder;
 import com.alibaba.nacos.persistence.repository.embedded.sql.ModifyRequest;
 import com.alibaba.nacos.persistence.repository.embedded.sql.QueryType;
@@ -406,6 +407,62 @@ class DistributedDatabaseOperateImplTest {
         assertTrue(response.getSuccess());
         assertEquals(42, SerializeFactory.getDefault().deserialize(response.getData().toByteArray(),
             Integer.class));
+    }
+    
+    @Test
+    void testOnRequestRejectsUnsupportedBasicResultType() throws Exception {
+        SelectRequest selectRequest = SelectRequest.builder()
+            .queryType(QueryType.QUERY_ONE_NO_MAPPER_NO_ARGS)
+            .sql("SELECT 1")
+            .className(Runtime.class.getCanonicalName())
+            .build();
+        ReadRequest readRequest = ReadRequest.newBuilder().setGroup("nacos_config")
+            .setData(ByteString.copyFrom(SerializeFactory.getDefault().serialize(selectRequest)))
+            .build();
+        
+        Response response = impl.onRequest(readRequest);
+        
+        assertFalse(response.getSuccess());
+        assertTrue(response.getErrMsg().contains("Unsupported basic result type"));
+        Mockito.verifyNoInteractions(jdbcTemplate);
+    }
+    
+    @Test
+    void testOnRequestAcceptsRegisteredRowMapper() throws Exception {
+        SelectRequest selectRequest = SelectRequest.builder()
+            .queryType(QueryType.QUERY_ONE_WITH_MAPPER_WITH_ARGS)
+            .sql("SELECT 1")
+            .args(new Object[0])
+            .className(RowMapperManager.MAP_ROW_MAPPER.getClass().getCanonicalName())
+            .build();
+        ReadRequest readRequest = ReadRequest.newBuilder().setGroup("nacos_config")
+            .setData(ByteString.copyFrom(SerializeFactory.getDefault().serialize(selectRequest)))
+            .build();
+        
+        Response response = impl.onRequest(readRequest);
+        
+        assertTrue(response.getSuccess());
+        Mockito.verify(jdbcTemplate).queryForObject(Mockito.eq("SELECT 1"),
+            Mockito.<Object[]>any(), Mockito.same(RowMapperManager.MAP_ROW_MAPPER));
+    }
+    
+    @Test
+    void testOnRequestRejectsUnregisteredRowMapper() throws Exception {
+        SelectRequest selectRequest = SelectRequest.builder()
+            .queryType(QueryType.QUERY_ONE_WITH_MAPPER_WITH_ARGS)
+            .sql("SELECT 1")
+            .args(new Object[0])
+            .className("com.alibaba.nacos.UnknownRowMapper")
+            .build();
+        ReadRequest readRequest = ReadRequest.newBuilder().setGroup("nacos_config")
+            .setData(ByteString.copyFrom(SerializeFactory.getDefault().serialize(selectRequest)))
+            .build();
+        
+        Response response = impl.onRequest(readRequest);
+        
+        assertFalse(response.getSuccess());
+        assertTrue(response.getErrMsg().contains("Unregistered row mapper"));
+        Mockito.verifyNoInteractions(jdbcTemplate);
     }
     
     @Test

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/persistence/NacosAuthPluginEmbeddedStorageConfig.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/configuration/persistence/NacosAuthPluginEmbeddedStorageConfig.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.plugin.auth.impl.configuration.persistence;
 import com.alibaba.nacos.persistence.configuration.condition.ConditionOnEmbeddedStorage;
 import com.alibaba.nacos.persistence.repository.embedded.operate.DatabaseOperate;
 import com.alibaba.nacos.plugin.auth.impl.condition.ConditionOnInnerDatasource;
+import com.alibaba.nacos.plugin.auth.impl.persistence.AuthRowMapperManager;
 import com.alibaba.nacos.plugin.auth.impl.persistence.EmbeddedPermissionPersistServiceImpl;
 import com.alibaba.nacos.plugin.auth.impl.persistence.EmbeddedRolePersistServiceImpl;
 import com.alibaba.nacos.plugin.auth.impl.persistence.EmbeddedUserPersistServiceImpl;
@@ -35,6 +36,11 @@ import org.springframework.context.annotation.Conditional;
  */
 @Conditional(value = {ConditionOnEmbeddedStorage.class, ConditionOnInnerDatasource.class})
 public class NacosAuthPluginEmbeddedStorageConfig {
+    
+    @Bean
+    public AuthRowMapperManager authRowMapperManager() {
+        return new AuthRowMapperManager();
+    }
     
     @Bean
     public PermissionPersistService permissionPersistService(DatabaseOperate databaseOperate) {

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/configuration/persistence/NacosAuthPluginPersistenceConfigTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/configuration/persistence/NacosAuthPluginPersistenceConfigTest.java
@@ -41,6 +41,7 @@ class NacosAuthPluginPersistenceConfigTest {
         NacosAuthPluginEmbeddedStorageConfig config = new NacosAuthPluginEmbeddedStorageConfig();
         DatabaseOperate databaseOperate = mock(DatabaseOperate.class);
         
+        assertNotNull(config.authRowMapperManager());
         assertTrue(config.permissionPersistService(
             databaseOperate) instanceof EmbeddedPermissionPersistServiceImpl);
         assertTrue(

--- a/specs/en/design/foundation-persistence-dump-spec.md
+++ b/specs/en/design/foundation-persistence-dump-spec.md
@@ -176,6 +176,13 @@ Reads use the CP read path when distributed embedded storage is active. Startup
 dump may set a blocking read context so the node waits until readable data
 exists before rebuilding serving cache.
 
+Distributed embedded read requests must validate their declared result target
+before JDBC execution. Mapper-based queries may use only row mapper class names
+registered with the persistence row mapper registry. Scalar queries may use only
+explicitly allowlisted basic result types, resolved from fixed class constants
+instead of request-driven class loading. A missing, unknown, or target
+incompatible with the query type must fail the read request.
+
 Snapshot rules are defined by the
 [CP Consistency Spec](foundation-cp-consistency-spec.md). Embedded storage must
 provide enough snapshot data to rebuild local Derby state after restart or

--- a/specs/zh-cn/design/foundation-persistence-dump-spec.md
+++ b/specs/zh-cn/design/foundation-persistence-dump-spec.md
@@ -142,6 +142,10 @@ Repository operation
 启用分布式嵌入式存储时，读路径使用 CP read。启动 dump 可以设置阻塞读上下文，让节点等到已有可读数据
 后再重建服务缓存。
 
+分布式嵌入式读请求必须在执行 JDBC 前校验其声明的结果目标。基于 mapper 的查询只能使用已注册到
+持久化 RowMapper 注册表中的类名；标量查询只能使用显式白名单中的基础结果类型，并从固定 Class 常量
+解析，禁止根据请求内容动态加载类。结果目标缺失、未知或与 query type 不匹配时，必须使读请求失败。
+
 Snapshot 规则由[CP 一致性规范](foundation-cp-consistency-spec.md)定义。嵌入式存储必须提供足够
 snapshot 数据，使本地 Derby state 可以在重启或成员变化后重建。
 


### PR DESCRIPTION
## What is the purpose of the change

Distributed embedded database read requests carry a result `className`. The receiver previously resolved scalar result classes from the request through dynamic class loading and did not reject unknown row mapper names before JDBC execution.

This change constrains result resolution to known targets and makes every distributed row mapper available on receiving nodes before requests are served.

No public GitHub issue is linked because this is a security-hardening change, and the Nacos contribution guidance directs security reports away from public issues.

## Brief changelog

* Resolve scalar query results only from the exact supported basic types: `Integer`, `Long`, and `String`.
* Accept mapper query results only when their class name is registered in `RowMapperManager`.
* Replace the two AI resource lambda mappers with named implementations and register them eagerly.
* Initialize the existing Auth row mapper registrations during embedded-storage startup.
* Document the distributed embedded read-target validation contract in the English and Chinese persistence specs.

## Verifying this change

* `mvn -B -pl core,ai,plugin-default-impl/nacos-default-auth-plugin clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`
* `mvn -pl core -Dtest=DistributedDatabaseOperateImplTest test` (30 tests)
* `mvn -pl ai -Dtest=AiResourceRowMappersTest,EmbeddedAiResourcePersistServiceImplTest,EmbeddedAiResourceVersionPersistServiceImplTest test` (15 tests)
* `mvn -pl plugin-default-impl/nacos-default-auth-plugin -Dtest=AuthRowMapperManagerTest,NacosAuthPluginPersistenceConfigTest test` (7 tests)

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change. Not applicable: this PR is a security-hardening change and intentionally has no public issue.
* [x] Each commit in the pull request has a meaningful subject line and body.
* [x] The pull request description explains what the change does, how, and why.
* [x] Necessary unit tests cover valid registered targets and rejected unknown targets.
* [x] The affected-module compile, RAT, Checkstyle, SpotBugs, Spotless, and unit-test checks pass locally.
