### PR TITLE
fix(config): guard NPE in getGrayLastModifiedTs and add volatile to DCL

### DIFF
--- a/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/ConfigCacheService.java
@@ -493,7 +493,7 @@ public class ConfigCacheService {
     
     public static long getGrayLastModifiedTs(String groupKey, String grayName) {
         CacheItem item = CACHE.get(groupKey);
-        if (item.getConfigCacheGray() == null || !item.getConfigCacheGray().containsKey(grayName)) {
+        if (item == null || item.getConfigCacheGray() == null || !item.getConfigCacheGray().containsKey(grayName)) {
             return 0;
         }
         ConfigCache configCacheGray = item.getConfigCacheGray().get(grayName);

--- a/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigDiskServiceFactory.java
+++ b/config/src/main/java/com/alibaba/nacos/config/server/service/dump/disk/ConfigDiskServiceFactory.java
@@ -23,7 +23,7 @@ package com.alibaba.nacos.config.server.service.dump.disk;
  */
 public class ConfigDiskServiceFactory {
     
-    static ConfigDiskService configDiskService;
+    static volatile ConfigDiskService configDiskService;
     
     private static final String TYPE_RAW_DISK = "rawdisk";
     

--- a/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigCacheServiceTest.java
+++ b/config/src/test/java/com/alibaba/nacos/config/server/service/ConfigCacheServiceTest.java
@@ -401,6 +401,9 @@ class ConfigCacheServiceTest {
             ConfigCacheService.getGrayLastModifiedTs(groupKey, grayName));
         assertEquals(0,
             ConfigCacheService.getGrayLastModifiedTs(groupKey, "noGray"));
+        // Non-existent group key must not throw NPE; should return 0 like siblings.
+        assertEquals(0,
+            ConfigCacheService.getGrayLastModifiedTs("noKey", grayName));
         
         ConfigCacheService.remove(dataId, group, tenant);
     }


### PR DESCRIPTION
## What is the purpose of the change

Fixes #15625

Two targeted correctness fixes in the `config` module.

### 1. NPE in `ConfigCacheService.getGrayLastModifiedTs`

The method dereferenced the `CacheItem` returned by `CACHE.get(groupKey)` without a null check, even though that lookup can return `null`. Every sibling method (`getContentGrayMd5`, `getGrayRule`) already guards `item == null`. A query for a non-existent group key would throw a `NullPointerException` instead of returning `0`.

```diff
-        if (item.getConfigCacheGray() == null || !item.getConfigCacheGray().containsKey(grayName)) {
+        if (item == null || item.getConfigCacheGray() == null || !item.getConfigCacheGray().containsKey(grayName)) {
```

### 2. Broken double-checked locking in `ConfigDiskServiceFactory`

The singleton used double-checked locking but the static field was not `volatile`. Without `volatile`, the JMM permits a thread to observe a non-null reference to a partially-constructed object (classic broken DCL). Declared the field `volatile` for safe publication.

```diff
-    static ConfigDiskService configDiskService;
+    static volatile ConfigDiskService configDiskService;
```

## Brief changelog

- `ConfigCacheService.getGrayLastModifiedTs`: add `item == null` guard consistent with sibling methods.
- `ConfigDiskServiceFactory.configDiskService`: mark `volatile`.
- `ConfigCacheServiceTest.testGetGrayLastModifiedTs`: add regression assertion for the non-existent group-key path.

## Verifying this change

- Existing `testGetGrayLastModifiedTs` extended to assert `getGrayLastModifiedTs("noKey", grayName) == 0` (previously would NPE).
- No behavior change for existing valid-key callers.
