### PR TITLE
fix: use NONE health check when cluster metadata not loaded yet

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/HealthCheckTaskV2.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/HealthCheckTaskV2.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.nacos.naming.healthcheck.v2;
 
+import com.alibaba.nacos.api.naming.pojo.healthcheck.HealthCheckType;
 import com.alibaba.nacos.common.task.AbstractExecuteTask;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.metadata.ClusterMetadata;
@@ -177,7 +178,9 @@ public class HealthCheckTaskV2 extends AbstractExecuteTask implements NacosHealt
         InstancePublishInfo instancePublishInfo) {
         Optional<ServiceMetadata> serviceMetadata = metadataManager.getServiceMetadata(service);
         if (!serviceMetadata.isPresent()) {
-            return new ClusterMetadata();
+            ClusterMetadata metadata = new ClusterMetadata();
+            metadata.setHealthyCheckType(HealthCheckType.NONE.name());
+            return metadata;
         }
         String cluster = instancePublishInfo.getCluster();
         ClusterMetadata result = serviceMetadata.get().getClusters().get(cluster);


### PR DESCRIPTION
## Description

When service metadata snapshot is not yet loaded (e.g., during startup before the naming module finishes loading), `getClusterMetadata()` returns a default `ClusterMetadata()` with `healthyCheckType=Tcp.TYPE`. This causes MCP Direct Endpoint instances (which should have NONE health check) to be incorrectly checked via TCP, making them appear unhealthy.

## Root Cause

`ClusterMetadata` defaults to `healthyCheckType = Tcp.TYPE`. `HealthCheckTaskV2.getClusterMetadata()` returns `new ClusterMetadata()` when the metadata snapshot is not yet loaded, bypassing the actual NONE health check type configured for the MCP Direct Endpoint cluster. The `HealthCheckProcessorV2Delegate` then dispatches the health check to `TcpHealthCheckProcessor` instead of `NoneHealthCheckProcessor`.

## Fix

When metadata is not present, return a `ClusterMetadata` with `NONE` health check type so the health check is a no-op until the correct metadata is loaded.

## Impact

MCP Direct Endpoint instances in Nacos 3.2.2 cluster mode will no longer randomly appear unhealthy during the window between instance registration and metadata snapshot loading.

Closes #15477