### PR TITLE
[ISSUE #15477] Skip health check before service metadata is visible

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/HealthCheckTaskV2.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/HealthCheckTaskV2.java
@@ -114,9 +114,13 @@ public class HealthCheckTaskV2 extends AbstractExecuteTask implements NacosHealt
             for (Service each : client.getAllPublishedService()) {
                 if (switchDomain.isHealthCheckEnabled(each.getGroupedServiceName())) {
                     InstancePublishInfo instancePublishInfo = client.getInstancePublishInfo(each);
-                    ClusterMetadata metadata = getClusterMetadata(each, instancePublishInfo);
+                    Optional<ClusterMetadata> metadata =
+                        getClusterMetadata(each, instancePublishInfo);
+                    if (!metadata.isPresent()) {
+                        continue;
+                    }
                     ApplicationUtils.getBean(HealthCheckProcessorV2Delegate.class).process(this,
-                        each, metadata);
+                        each, metadata.get());
                     if (Loggers.EVT_LOG.isDebugEnabled()) {
                         Loggers.EVT_LOG.debug("[HEALTH-CHECK] schedule health check task: {}",
                             client.getClientId());
@@ -173,15 +177,15 @@ public class HealthCheckTaskV2 extends AbstractExecuteTask implements NacosHealt
         doHealthCheck();
     }
     
-    private ClusterMetadata getClusterMetadata(Service service,
+    private Optional<ClusterMetadata> getClusterMetadata(Service service,
         InstancePublishInfo instancePublishInfo) {
         Optional<ServiceMetadata> serviceMetadata = metadataManager.getServiceMetadata(service);
         if (!serviceMetadata.isPresent()) {
-            return new ClusterMetadata();
+            return Optional.empty();
         }
         String cluster = instancePublishInfo.getCluster();
         ClusterMetadata result = serviceMetadata.get().getClusters().get(cluster);
-        return null == result ? new ClusterMetadata() : result;
+        return Optional.of(null == result ? new ClusterMetadata() : result);
     }
     
     public long getCheckRtNormalized() {

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/HealthCheckTaskV2Test.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/HealthCheckTaskV2Test.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.naming.healthcheck.v2;
 
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
+import com.alibaba.nacos.naming.core.v2.metadata.ServiceMetadata;
 import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.healthcheck.HealthCheckReactor;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,6 +78,8 @@ class HealthCheckTaskV2Test {
     @Mock
     private HealthCheckProcessorV2Delegate processorDelegate;
     
+    private NamingMetadataManager metadataManager;
+    
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(HealthCheckTaskV2.class, "switchDomain", null);
@@ -83,8 +87,10 @@ class HealthCheckTaskV2Test {
         ApplicationUtils.injectContext(context);
         when(context.getBean(SwitchDomain.class)).thenReturn(switchDomain);
         when(switchDomain.getTcpHealthParams()).thenReturn(new SwitchDomain.TcpHealthParams());
-        when(context.getBean(NamingMetadataManager.class)).thenReturn(new NamingMetadataManager());
+        metadataManager = new NamingMetadataManager();
+        when(context.getBean(NamingMetadataManager.class)).thenReturn(metadataManager);
         when(context.getBean(HealthCheckProcessorV2Delegate.class)).thenReturn(processorDelegate);
+        when(instancePublishInfo.getCluster()).thenReturn("cluster");
         healthCheckTaskV2 = new HealthCheckTaskV2(ipPortBasedClient);
         EnvUtil.setEnvironment(new MockEnvironment());
     }
@@ -145,23 +151,45 @@ class HealthCheckTaskV2Test {
     
     @Test
     void testDoHealthCheckProcessesEnabledService() {
-        when(ipPortBasedClient.getAllPublishedService()).thenReturn(returnService());
-        when(service.getGroupedServiceName()).thenReturn("group@@service");
+        Service publishedService = Service.newService("public", "group", "service", false);
+        metadataManager.updateServiceMetadata(publishedService, new ServiceMetadata());
+        when(ipPortBasedClient.getAllPublishedService())
+            .thenReturn(Collections.singletonList(publishedService));
         when(switchDomain.isHealthCheckEnabled("group@@service")).thenReturn(true);
-        when(ipPortBasedClient.getInstancePublishInfo(service)).thenReturn(instancePublishInfo);
+        when(ipPortBasedClient.getInstancePublishInfo(publishedService))
+            .thenReturn(instancePublishInfo);
         healthCheckTaskV2.setCancelled(true);
         
         healthCheckTaskV2.doHealthCheck();
         
-        verify(processorDelegate).process(eq(healthCheckTaskV2), eq(service), any());
+        verify(processorDelegate).process(eq(healthCheckTaskV2), eq(publishedService), any());
+    }
+    
+    @Test
+    void testDoHealthCheckSkipsServiceWithoutMetadata() {
+        Service publishedService = Service.newService("public", "group", "service", false);
+        when(ipPortBasedClient.getAllPublishedService())
+            .thenReturn(Collections.singletonList(publishedService));
+        when(switchDomain.isHealthCheckEnabled("group@@service")).thenReturn(true);
+        when(ipPortBasedClient.getInstancePublishInfo(publishedService))
+            .thenReturn(instancePublishInfo);
+        healthCheckTaskV2.setCancelled(true);
+        
+        healthCheckTaskV2.doHealthCheck();
+        
+        verify(processorDelegate, never()).process(eq(healthCheckTaskV2),
+            eq(publishedService), any());
     }
     
     @Test
     void testDoHealthCheckCatchesProcessorFailure() {
-        when(ipPortBasedClient.getAllPublishedService()).thenReturn(returnService());
-        when(service.getGroupedServiceName()).thenReturn("group@@service");
+        Service publishedService = Service.newService("public", "group", "service", false);
+        metadataManager.updateServiceMetadata(publishedService, new ServiceMetadata());
+        when(ipPortBasedClient.getAllPublishedService())
+            .thenReturn(Collections.singletonList(publishedService));
         when(switchDomain.isHealthCheckEnabled("group@@service")).thenReturn(true);
-        when(ipPortBasedClient.getInstancePublishInfo(service)).thenReturn(instancePublishInfo);
+        when(ipPortBasedClient.getInstancePublishInfo(publishedService))
+            .thenReturn(instancePublishInfo);
         when(context.getBean(HealthCheckProcessorV2Delegate.class))
             .thenThrow(new RuntimeException("failed"));
         healthCheckTaskV2.setCancelled(true);


### PR DESCRIPTION
## What is the purpose of the change

Fixes #15477.

This change avoids running active health checks for persistent instances before their service metadata is visible in `NamingMetadataManager`. Without this guard, `HealthCheckTaskV2` may fall back to a default `ClusterMetadata`, whose default checker is TCP, and can incorrectly mark MCP direct endpoint instances unhealthy before their intended `NONE` checker metadata is visible.

## Brief changelog

- Skip the current health-check round when service metadata is absent.
- Preserve the existing default `ClusterMetadata` behavior when service metadata exists but the specific cluster metadata is absent.
- Add regression coverage for the no-service-metadata path.

## Verifying this change

- `mvn -pl naming spotless:apply`
- `mvn -pl naming spotless:check`
- `mvn -pl naming -Dtest=HealthCheckTaskV2Test test`
- `mvn -pl naming -Dtest=HealthCheckTaskV2Test,HealthCheckProcessorV2DelegateTest test`


Checklist:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction.
* [ ] Run full project pre-submission checks.