### PR TITLE
fix: add @Secured to /v3/console/server/state and /guide endpoints

### DIFF
--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ConsoleServerStateController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ConsoleServerStateController.java
@@ -19,12 +19,16 @@ package com.alibaba.nacos.console.controller.v3;
 
 import com.alibaba.nacos.api.annotation.Since;
 import com.alibaba.nacos.api.annotation.NacosApi;
+import com.alibaba.nacos.api.common.ApiType;
 import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.model.v2.SupportedLanguage;
+import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.console.paramcheck.ConsoleDefaultHttpParamExtractor;
 import com.alibaba.nacos.console.proxy.ServerStateProxy;
 import com.alibaba.nacos.core.paramcheck.ExtractorManager;
+import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,6 +61,8 @@ public class ConsoleServerStateController {
      */
     @Since("3.0.0")
     @GetMapping("/state")
+    @Secured(resource = "/v3/console/server/state", action = ActionTypes.READ,
+        signType = SignType.CONSOLE, apiType = ApiType.CONSOLE_API)
     public ResponseEntity<Map<String, String>> serverState() throws NacosException {
         Map<String, String> serverState = serverStateProxy.getServerState();
         return ResponseEntity.ok().body(serverState);
@@ -88,6 +94,8 @@ public class ConsoleServerStateController {
      */
     @Since("3.0.0")
     @GetMapping("/guide")
+    @Secured(resource = "/v3/console/server/guide", action = ActionTypes.READ,
+        signType = SignType.CONSOLE, apiType = ApiType.CONSOLE_API)
     public Result<String> getConsoleUiGuide() {
         String guideInformation = serverStateProxy.getConsoleUiGuide();
         return Result.success(guideInformation);


### PR DESCRIPTION
## What

Add `@Secured` authentication annotation to `/v3/console/server/state` and `/v3/console/server/guide` endpoints in `ConsoleServerStateController`.

## Why

These two console API endpoints currently return sensitive server configuration data **without any authentication**:

- `/v3/console/server/state` — exposes nacos version, `auth_enabled` status, startup mode, server port, auth system type, quota parameters, config retention days, and other sensitive configuration items.
- `/v3/console/server/guide` — exposes configuration parameter metadata, leaking application.properties configuration key names.

Unauthenticated remote attackers can obtain service fingerprint, authentication switch status, and server configuration details, which facilitates further targeted attacks.

## How

Added `@Secured(resource = "...", action = ActionTypes.READ, signType = SignType.CONSOLE, apiType = ApiType.CONSOLE_API)` to both `serverState()` and `getConsoleUiGuide()` methods, matching the same security pattern used by other v3 console endpoints (e.g., `ConsoleClusterController.getNodeList()`).

## Testing

- Security: Unauthenticated requests to `/v3/console/server/state` and `/v3/console/server/guide` now return `401 Unauthorized` instead of leaking configuration data.
- Backward compatibility: Authenticated admin requests continue to work as before.
- Follows existing `@Secured` conventions in the codebase.

Closes #15683
