### PR TITLE
fix: unify login failure responses to prevent username enumeration

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/UserController.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/UserController.java
@@ -93,18 +93,21 @@ public class UserController {
         String authSystemType = getServerAuthConfig().getNacosAuthSystemType();
         if (AuthSystemTypes.NACOS.name().equalsIgnoreCase(authSystemType)
             || AuthSystemTypes.LDAP.name().equalsIgnoreCase(authSystemType)) {
-            
-            NacosUser user = iAuthenticationManager.authenticate(request);
-            
-            response.addHeader(AuthConstants.AUTHORIZATION_HEADER,
-                AuthConstants.TOKEN_PREFIX + user.getToken());
-            
-            Map<String, Object> result = new HashMap<>();
-            result.put(Constants.ACCESS_TOKEN, user.getToken());
-            result.put(Constants.TOKEN_TTL, jwtTokenManager.getTokenTtlInSeconds(user.getToken()));
-            result.put(Constants.GLOBAL_ADMIN, iAuthenticationManager.hasGlobalAdminRole(user));
-            result.put(Constants.USERNAME, user.getUserName());
-            return result;
+            try {
+                NacosUser user = iAuthenticationManager.authenticate(request);
+
+                response.addHeader(AuthConstants.AUTHORIZATION_HEADER,
+                    AuthConstants.TOKEN_PREFIX + user.getToken());
+
+                Map<String, Object> result = new HashMap<>();
+                result.put(Constants.ACCESS_TOKEN, user.getToken());
+                result.put(Constants.TOKEN_TTL, jwtTokenManager.getTokenTtlInSeconds(user.getToken()));
+                result.put(Constants.GLOBAL_ADMIN, iAuthenticationManager.hasGlobalAdminRole(user));
+                result.put(Constants.USERNAME, user.getUserName());
+                return result;
+            } catch (AccessException | RuntimeException e) {
+                return RestResultUtils.failed(HttpStatus.UNAUTHORIZED.value(), null, "Login failed");
+            }
         }
         
         UsernamePasswordAuthenticationToken authenticationToken =

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3.java
@@ -302,18 +302,21 @@ public class UserControllerV3 {
         String authSystemType = getServerAuthConfig().getNacosAuthSystemType();
         if (AuthSystemTypes.NACOS.name().equalsIgnoreCase(authSystemType)
             || AuthSystemTypes.LDAP.name().equalsIgnoreCase(authSystemType)) {
-            
-            NacosUser user = iAuthenticationManager.authenticate(request);
-            
-            response.addHeader(AuthConstants.AUTHORIZATION_HEADER,
-                AuthConstants.TOKEN_PREFIX + user.getToken());
-            
-            Map<String, Object> result = new HashMap<>();
-            result.put(Constants.ACCESS_TOKEN, user.getToken());
-            result.put(Constants.TOKEN_TTL, jwtTokenManager.getTokenTtlInSeconds(user.getToken()));
-            result.put(Constants.GLOBAL_ADMIN, iAuthenticationManager.hasGlobalAdminRole(user));
-            result.put(Constants.USERNAME, user.getUserName());
-            return result;
+            try {
+                NacosUser user = iAuthenticationManager.authenticate(request);
+
+                response.addHeader(AuthConstants.AUTHORIZATION_HEADER,
+                    AuthConstants.TOKEN_PREFIX + user.getToken());
+
+                Map<String, Object> result = new HashMap<>();
+                result.put(Constants.ACCESS_TOKEN, user.getToken());
+                result.put(Constants.TOKEN_TTL, jwtTokenManager.getTokenTtlInSeconds(user.getToken()));
+                result.put(Constants.GLOBAL_ADMIN, iAuthenticationManager.hasGlobalAdminRole(user));
+                result.put(Constants.USERNAME, user.getUserName());
+                return result;
+            } catch (AccessException | RuntimeException e) {
+                return Result.failure(HttpStatus.UNAUTHORIZED.value(), "Login failed", null);
+            }
         }
         return Result.failure(ErrorCode.ILLEGAL_STATE.getCode(),
             "Current Nacos auth plugin type is not `nacos` or `nacos-ldap`, don't support login API.",


### PR DESCRIPTION
## What

Wrap the `IAuthenticationManager.authenticate()` call in the NACOS/LDAP login branch with a try-catch that returns a unified `401 Unauthorized` response on any authentication failure.

## Why

The `/v1/auth/login` and `/v3/auth/user/login` endpoints leak whether a username exists by returning different HTTP status codes:

- **Non-existent user**: returns `HTTP 500` with body `caused: User xxx not found`
- **Existing user + wrong password**: returns `HTTP 403` with body `User not found! Please check user exist or password is right!`

This side-channel allows unauthenticated attackers to enumerate valid system accounts (username enumeration vulnerability).

## Fix

Catch `AccessException | RuntimeException` (which covers both `AccessException` from wrong-password and `UsernameNotFoundException` as a `RuntimeException` from non-existent users) and return a unified `HTTP 401` with the generic message `"Login failed"` for both cases.

Apply the same fix to both:
- `UserController.java` (v1 endpoint `/v1/auth/login`)
- `UserControllerV3.java` (v3 endpoint `/v3/auth/user/login`)

Fixes #15682