### PR TITLE
[FEATURE] Add authentication for JRaft gRPC requests

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/auth/InnerApiAuthEnabled.java
+++ b/core/src/main/java/com/alibaba/nacos/core/auth/InnerApiAuthEnabled.java
@@ -39,14 +39,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *     This class is only working during upgrading step for 2.x to 3.x. After nacos cluster upgrade to 3.x, this class will stop working.
  *     It will cause the downgrade from 3.x to 2.x is not smoothly(lossless).
  * </p>
- * <p>
- *     The support will be removed after 3.x not support upgrading from 2.x to 3.x in community.
- *     It might be 3.1.0 or 3.2.0, depend on community's decision.
- * </p>
- *
  * @author xiweng.yy
+ * @deprecated only used for a smooth rolling upgrade from 2.x to 3.x; it will be removed in
+ *     Nacos 3.4.0
  */
 @Component
+@Deprecated(since = "3.0.0", forRemoval = true)
 public class InnerApiAuthEnabled {
     
     private final ServerMemberManager serverMemberManager;

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/MemberMetaDataConstants.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/MemberMetaDataConstants.java
@@ -44,7 +44,12 @@ public class MemberMetaDataConstants {
     
     public static final String SUPPORT_GRAY_MODEL = "supportGrayModel";
     
+    /**
+     * Temporary capability flag for JRaft gRPC authentication rolling upgrades.
+     */
+    public static final String SUPPORT_JRAFT_AUTH = "supportJraftAuth";
+    
     public static final String[] BASIC_META_KEYS =
         new String[] {SITE_KEY, AD_WEIGHT, RAFT_PORT, WEIGHT, VERSION,
-            READY_TO_UPGRADE};
+            READY_TO_UPGRADE, SUPPORT_JRAFT_AUTH};
 }

--- a/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
+++ b/core/src/main/java/com/alibaba/nacos/core/cluster/ServerMemberManager.java
@@ -158,6 +158,8 @@ public class ServerMemberManager implements NacosMemberManager {
         this.self.setExtendVal(MemberMetaDataConstants.VERSION, VersionUtils.version);
         //works  for gray model upgrade,can delete after compatibility period.
         this.self.setExtendVal(MemberMetaDataConstants.SUPPORT_GRAY_MODEL, true);
+        // Temporary capability used to finish the JRaft authentication rolling upgrade.
+        this.self.setExtendVal(MemberMetaDataConstants.SUPPORT_JRAFT_AUTH, true);
         this.self.setGrpcReportEnabled(true);
         
         // init abilities.

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/ConsistencyConfiguration.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/ConsistencyConfiguration.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.common.spi.NacosServiceLoader;
 import com.alibaba.nacos.consistency.cp.CPProtocol;
 import com.alibaba.nacos.core.cluster.ServerMemberManager;
 import com.alibaba.nacos.core.distributed.raft.JRaftProtocol;
+import com.alibaba.nacos.core.distributed.raft.auth.JRaftAuthUpgradeCoordinator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,9 +37,11 @@ import java.util.concurrent.Callable;
 public class ConsistencyConfiguration {
     
     @Bean(value = "strongAgreementProtocol")
-    public CPProtocol strongAgreementProtocol(ServerMemberManager memberManager) throws Exception {
+    public CPProtocol strongAgreementProtocol(ServerMemberManager memberManager,
+        JRaftAuthUpgradeCoordinator jRaftAuthUpgradeCoordinator) throws Exception {
         final CPProtocol protocol =
-            getProtocol(CPProtocol.class, () -> new JRaftProtocol(memberManager));
+            getProtocol(CPProtocol.class,
+                () -> new JRaftProtocol(memberManager, jRaftAuthUpgradeCoordinator));
         return protocol;
     }
     

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftProtocol.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftProtocol.java
@@ -31,6 +31,7 @@ import com.alibaba.nacos.consistency.entity.Response;
 import com.alibaba.nacos.consistency.entity.WriteRequest;
 import com.alibaba.nacos.core.cluster.Member;
 import com.alibaba.nacos.core.cluster.ServerMemberManager;
+import com.alibaba.nacos.core.distributed.raft.auth.JRaftAuthUpgradeCoordinator;
 import com.alibaba.nacos.core.distributed.AbstractConsistencyProtocol;
 import com.alibaba.nacos.core.distributed.raft.exception.NoSuchRaftGroupException;
 import com.alibaba.nacos.core.monitor.MetricsMonitor;
@@ -104,9 +105,10 @@ public class JRaftProtocol extends AbstractConsistencyProtocol<RaftConfig, Reque
     
     private ServerMemberManager memberManager;
     
-    public JRaftProtocol(ServerMemberManager memberManager) throws Exception {
+    public JRaftProtocol(ServerMemberManager memberManager,
+        JRaftAuthUpgradeCoordinator jRaftAuthUpgradeCoordinator) throws Exception {
         this.memberManager = memberManager;
-        this.raftServer = new JRaftServer();
+        this.raftServer = new JRaftServer(jRaftAuthUpgradeCoordinator);
         this.jRaftMaintainService = new JRaftMaintainService(raftServer);
     }
     

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
@@ -33,6 +33,7 @@ import com.alibaba.nacos.consistency.entity.Response;
 import com.alibaba.nacos.consistency.exception.ConsistencyException;
 import com.alibaba.nacos.core.distributed.raft.exception.DuplicateRaftGroupException;
 import com.alibaba.nacos.core.distributed.raft.exception.JRaftException;
+import com.alibaba.nacos.core.distributed.raft.auth.JRaftAuthUpgradeCoordinator;
 import com.alibaba.nacos.core.distributed.raft.exception.NoLeaderException;
 import com.alibaba.nacos.core.distributed.raft.exception.NoSuchRaftGroupException;
 import com.alibaba.nacos.core.distributed.raft.utils.FailoverClosure;
@@ -140,7 +141,10 @@ public class JRaftServer {
     
     private int rpcRequestTimeoutMs;
     
-    public JRaftServer() {
+    private final JRaftAuthUpgradeCoordinator jRaftAuthUpgradeCoordinator;
+    
+    public JRaftServer(JRaftAuthUpgradeCoordinator jRaftAuthUpgradeCoordinator) {
+        this.jRaftAuthUpgradeCoordinator = jRaftAuthUpgradeCoordinator;
         this.conf = new Configuration();
     }
     
@@ -203,7 +207,8 @@ public class JRaftServer {
                 }
                 nodeOptions.setInitialConf(conf);
                 
-                rpcServer = JRaftUtils.initRpcServer(this, localPeerId);
+                rpcServer = JRaftUtils.initRpcServer(this, localPeerId,
+                    jRaftAuthUpgradeCoordinator);
                 
                 if (!this.rpcServer.init(null)) {
                     Loggers.RAFT.error("Fail to init [BaseRpcServer].");

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/auth/JRaftAuthMetadata.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/auth/JRaftAuthMetadata.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.auth;
+
+import io.grpc.Metadata;
+
+/**
+ * Metadata keys used to transport Nacos server identity over JRaft gRPC.
+ *
+ * @author xiweng.yy
+ */
+final class JRaftAuthMetadata {
+    
+    static final Metadata.Key<String> IDENTITY_KEY = Metadata.Key.of(
+        "nacos-server-identity-key", Metadata.ASCII_STRING_MARSHALLER);
+    
+    static final Metadata.Key<String> IDENTITY_VALUE = Metadata.Key.of(
+        "nacos-server-identity-value", Metadata.ASCII_STRING_MARSHALLER);
+    
+    private JRaftAuthMetadata() {
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/auth/JRaftAuthUpgradeCoordinator.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/auth/JRaftAuthUpgradeCoordinator.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.auth;
+
+import com.alibaba.nacos.core.cluster.Member;
+import com.alibaba.nacos.core.cluster.MemberMetaDataConstants;
+import com.alibaba.nacos.core.cluster.ServerMemberManager;
+import com.alibaba.nacos.core.utils.Loggers;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Coordinates the temporary rolling-upgrade compatibility window for JRaft gRPC authentication.
+ *
+ * <p>This component is deliberately isolated from the permanent credential transport and validation
+ * code. It allows requests with invalid credentials only until every member reports JRaft auth
+ * support, persists the irreversible enforcement decision, and restores that decision after a
+ * restart. It will be removed in Nacos 4.0.0, when JRaft authentication is always enforced.</p>
+ *
+ * @author xiweng.yy
+ * @deprecated only used for a smooth rolling upgrade; it will be removed in Nacos 4.0.0
+ */
+@Component
+@Deprecated(since = "3.3.0", forRemoval = true)
+public class JRaftAuthUpgradeCoordinator {
+    
+    static final String STATE_FILE_NAME = "jraft-auth-enforced.state";
+    
+    private static final String STATE_FILE_VERSION = "version=1";
+    
+    private static final String ENFORCED_STATE = "state=ENFORCED";
+    
+    private static final long WARNING_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(1);
+    
+    private final ServerMemberManager serverMemberManager;
+    
+    private final Path stateFile;
+    
+    private final AtomicBoolean enforced = new AtomicBoolean(false);
+    
+    private final AtomicBoolean statePersisted = new AtomicBoolean(false);
+    
+    private final AtomicLong nextWarningTime = new AtomicLong(0L);
+    
+    @Autowired
+    public JRaftAuthUpgradeCoordinator(ServerMemberManager serverMemberManager) {
+        this(serverMemberManager,
+            Path.of(EnvUtil.getNacosHome(), "data", STATE_FILE_NAME));
+    }
+    
+    JRaftAuthUpgradeCoordinator(ServerMemberManager serverMemberManager, Path stateFile) {
+        this.serverMemberManager = serverMemberManager;
+        this.stateFile = stateFile;
+        loadState();
+    }
+    
+    /**
+     * Returns whether invalid JRaft credentials must be rejected.
+     *
+     * @return {@code true} if authentication enforcement has been latched
+     */
+    public boolean isEnforced() {
+        return enforced.get();
+    }
+    
+    /**
+     * Handles an invalid credential according to the temporary rolling-upgrade state.
+     *
+     * @return {@code true} only while the compatibility window still allows the request
+     */
+    public boolean allowInvalidCredential() {
+        if (enforced.get()) {
+            return false;
+        }
+        warnInvalidCredential();
+        return true;
+    }
+    
+    /**
+     * Checks the complete member view and irreversibly enables JRaft authentication when every
+     * member reports support. In-memory enforcement is enabled immediately, while state-file
+     * persistence is retried independently until it succeeds.
+     */
+    @Scheduled(fixedRate = 3000)
+    public synchronized void doCheck() {
+        if (enforced.get()) {
+            persistStateIfNecessary();
+            return;
+        }
+        Collection<Member> members = serverMemberManager.allMembers();
+        if (members == null || members.isEmpty()) {
+            return;
+        }
+        for (Member each : members) {
+            if (!Boolean.TRUE.equals(
+                each.getExtendVal(MemberMetaDataConstants.SUPPORT_JRAFT_AUTH))) {
+                return;
+            }
+        }
+        enforced.set(true);
+        Loggers.RAFT.info(
+            "All Nacos servers support JRaft authentication; enforcement is enabled");
+        persistStateIfNecessary();
+    }
+    
+    private void loadState() {
+        if (!Files.isRegularFile(stateFile)) {
+            return;
+        }
+        try {
+            List<String> lines = Files.readAllLines(stateFile, StandardCharsets.UTF_8);
+            if (lines.contains(STATE_FILE_VERSION) && lines.contains(ENFORCED_STATE)) {
+                enforced.set(true);
+                statePersisted.set(true);
+                Loggers.RAFT.info(
+                    "Restored enforced JRaft authentication state from persistent marker");
+            } else {
+                Loggers.RAFT.warn("Ignored invalid JRaft authentication state file at {}",
+                    stateFile);
+            }
+        } catch (IOException e) {
+            Loggers.RAFT.warn("Failed to read JRaft authentication state file at {}", stateFile,
+                e);
+        }
+    }
+    
+    private void persistStateIfNecessary() {
+        if (statePersisted.get()) {
+            return;
+        }
+        try {
+            persistState();
+            statePersisted.set(true);
+        } catch (IOException e) {
+            Loggers.RAFT.error(
+                "Failed to persist JRaft authentication enforcement state; will retry", e);
+        }
+    }
+    
+    private void persistState() throws IOException {
+        Path parent = stateFile.getParent();
+        Files.createDirectories(parent);
+        Path temporaryFile = parent.resolve(STATE_FILE_NAME + ".tmp");
+        Files.write(temporaryFile, Arrays.asList(STATE_FILE_VERSION, ENFORCED_STATE),
+            StandardCharsets.UTF_8, StandardOpenOption.CREATE,
+            StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        try {
+            Files.move(temporaryFile, stateFile, StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(temporaryFile, stateFile, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+    
+    private void warnInvalidCredential() {
+        long now = System.currentTimeMillis();
+        long next = nextWarningTime.get();
+        if (now >= next && nextWarningTime.compareAndSet(next,
+            now + WARNING_INTERVAL_MILLIS)) {
+            Loggers.RAFT.warn(
+                "Allowed a JRaft request with missing or invalid server identity during "
+                    + "the rolling-upgrade compatibility window");
+        }
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/auth/NacosJRaftCallCredentials.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/auth/NacosJRaftCallCredentials.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.auth;
+
+import com.alibaba.nacos.auth.config.NacosAuthConfig;
+import com.alibaba.nacos.auth.config.NacosAuthConfigHolder;
+import com.alibaba.nacos.core.auth.NacosServerAuthConfig;
+import io.grpc.CallCredentials;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+/**
+ * Supplies the configured Nacos server identity to every JRaft gRPC request.
+ *
+ * @author xiweng.yy
+ */
+public class NacosJRaftCallCredentials extends CallCredentials {
+    
+    private final Supplier<NacosAuthConfig> authConfigSupplier;
+    
+    public NacosJRaftCallCredentials() {
+        this(() -> NacosAuthConfigHolder.getInstance()
+            .getNacosAuthConfigByScope(NacosServerAuthConfig.NACOS_SERVER_AUTH_SCOPE));
+    }
+    
+    NacosJRaftCallCredentials(Supplier<NacosAuthConfig> authConfigSupplier) {
+        this.authConfigSupplier = authConfigSupplier;
+    }
+    
+    @Override
+    public void applyRequestMetadata(RequestInfo requestInfo, Executor appExecutor,
+        MetadataApplier applier) {
+        appExecutor.execute(() -> {
+            try {
+                NacosAuthConfig authConfig = Objects.requireNonNull(authConfigSupplier.get(),
+                    "Nacos server auth config");
+                Metadata metadata = new Metadata();
+                metadata.put(JRaftAuthMetadata.IDENTITY_KEY,
+                    Objects.toString(authConfig.getServerIdentityKey(), ""));
+                metadata.put(JRaftAuthMetadata.IDENTITY_VALUE,
+                    Objects.toString(authConfig.getServerIdentityValue(), ""));
+                applier.apply(metadata);
+            } catch (Exception e) {
+                applier.fail(Status.UNAUTHENTICATED.withDescription(
+                    "Failed to obtain Nacos server identity").withCause(e));
+            }
+        });
+    }
+    
+    @Override
+    public void thisUsesUnstableApi() {
+        // Required by the gRPC CallCredentials contract.
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/auth/NacosJRaftServerInterceptor.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/auth/NacosJRaftServerInterceptor.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.auth;
+
+import com.alibaba.nacos.api.common.ApiType;
+import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.auth.config.NacosAuthConfig;
+import com.alibaba.nacos.auth.config.NacosAuthConfigHolder;
+import com.alibaba.nacos.auth.serveridentity.ServerIdentity;
+import com.alibaba.nacos.auth.serveridentity.ServerIdentityChecker;
+import com.alibaba.nacos.auth.serveridentity.ServerIdentityCheckerHolder;
+import com.alibaba.nacos.auth.serveridentity.ServerIdentityResult;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.core.auth.NacosServerAuthConfig;
+import com.alibaba.nacos.plugin.auth.constant.SignType;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+
+/**
+ * Validates Nacos server identity before dispatching a native JRaft gRPC request.
+ *
+ * @author xiweng.yy
+ */
+@Secured(resource = "jraft", signType = SignType.SPECIFIED, apiType = ApiType.INNER_API)
+public class NacosJRaftServerInterceptor implements ServerInterceptor {
+    
+    private static final Secured JRAFT_SECURED =
+        NacosJRaftServerInterceptor.class.getAnnotation(Secured.class);
+    
+    private final JRaftAuthUpgradeCoordinator upgradeCoordinator;
+    
+    private final NacosAuthConfig authConfig;
+    
+    private final ServerIdentityChecker identityChecker;
+    
+    public NacosJRaftServerInterceptor(JRaftAuthUpgradeCoordinator upgradeCoordinator) {
+        this(upgradeCoordinator, NacosAuthConfigHolder.getInstance()
+            .getNacosAuthConfigByScope(NacosServerAuthConfig.NACOS_SERVER_AUTH_SCOPE),
+            ServerIdentityCheckerHolder.getInstance().newChecker());
+    }
+    
+    NacosJRaftServerInterceptor(JRaftAuthUpgradeCoordinator upgradeCoordinator,
+        NacosAuthConfig authConfig, ServerIdentityChecker identityChecker) {
+        this.upgradeCoordinator = upgradeCoordinator;
+        this.authConfig = authConfig;
+        this.identityChecker = identityChecker;
+        this.identityChecker.init(authConfig);
+    }
+    
+    @Override
+    public <T, R> ServerCall.Listener<T> interceptCall(
+        ServerCall<T, R> call, Metadata headers,
+        ServerCallHandler<T, R> next) {
+        if (isCredentialValid(headers) || upgradeCoordinator.allowInvalidCredential()) {
+            return next.startCall(call, headers);
+        }
+        call.close(Status.UNAUTHENTICATED.withDescription("Nacos server identity not matched"),
+            new Metadata());
+        return new ServerCall.Listener<T>() {
+        };
+    }
+    
+    private boolean isCredentialValid(Metadata headers) {
+        if (authConfig == null || StringUtils.isBlank(authConfig.getServerIdentityKey())
+            || StringUtils.isBlank(authConfig.getServerIdentityValue())) {
+            return false;
+        }
+        String identityKey = headers.get(JRaftAuthMetadata.IDENTITY_KEY);
+        String identityValue = headers.get(JRaftAuthMetadata.IDENTITY_VALUE);
+        if (!authConfig.getServerIdentityKey().equals(identityKey)) {
+            return false;
+        }
+        try {
+            ServerIdentityResult result = identityChecker.check(
+                new ServerIdentity(identityKey, identityValue), JRAFT_SECURED);
+            return ServerIdentityResult.ResultStatus.MATCHED == result.getStatus();
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/grpc/NacosGrpcClient.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/grpc/NacosGrpcClient.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ * Copyright (c) 2018, The SOFAStack Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.grpc;
+
+import com.alibaba.nacos.core.distributed.raft.auth.NacosJRaftCallCredentials;
+import com.alipay.sofa.jraft.ReplicatorGroup;
+import com.alipay.sofa.jraft.entity.PeerId;
+import com.alipay.sofa.jraft.error.InvokeTimeoutException;
+import com.alipay.sofa.jraft.error.RemotingException;
+import com.alipay.sofa.jraft.option.RpcOptions;
+import com.alipay.sofa.jraft.rpc.InvokeCallback;
+import com.alipay.sofa.jraft.rpc.InvokeContext;
+import com.alipay.sofa.jraft.rpc.RpcClient;
+import com.alipay.sofa.jraft.rpc.RpcUtils;
+import com.alipay.sofa.jraft.rpc.impl.ManagedChannelHelper;
+import com.alipay.sofa.jraft.rpc.impl.MarshallerRegistry;
+import com.alipay.sofa.jraft.util.DirectExecutor;
+import com.alipay.sofa.jraft.util.Endpoint;
+import com.alipay.sofa.jraft.util.Requires;
+import com.alipay.sofa.jraft.util.SystemPropertyUtil;
+import com.google.protobuf.Message;
+import io.grpc.CallCredentials;
+import io.grpc.CallOptions;
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Nacos JRaft gRPC client that attaches Nacos server identity credentials to every request.
+ *
+ * <p>This class follows the SOFA-JRaft 1.4.0 {@code GrpcClient} implementation because that
+ * version does not expose the channel and call-option construction points needed by Nacos. It
+ * should extend the upstream client after the required protected extension point is released.</p>
+ *
+ * @author xiweng.yy
+ */
+public class NacosGrpcClient implements RpcClient {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(NacosGrpcClient.class);
+    
+    private static final String FIXED_METHOD_NAME = "_call";
+    
+    private static final int RESET_CONN_THRESHOLD =
+        SystemPropertyUtil.getInt("jraft.grpc.max.conn.failures.to_reset", 2);
+    
+    private static final int RPC_MAX_INBOUND_MESSAGE_SIZE = SystemPropertyUtil.getInt(
+        "jraft.grpc.max_inbound_message_size.bytes", 4 * 1024 * 1024);
+    
+    private final Map<Endpoint, ManagedChannel> managedChannelPool = new ConcurrentHashMap<>();
+    
+    private final Map<Endpoint, AtomicInteger> transientFailures = new ConcurrentHashMap<>();
+    
+    private final Map<String, Message> parserClasses;
+    
+    private final MarshallerRegistry marshallerRegistry;
+    
+    private final CallCredentials callCredentials;
+    
+    private volatile ReplicatorGroup replicatorGroup;
+    
+    public NacosGrpcClient(Map<String, Message> parserClasses,
+        MarshallerRegistry marshallerRegistry) {
+        this(parserClasses, marshallerRegistry, new NacosJRaftCallCredentials());
+    }
+    
+    NacosGrpcClient(Map<String, Message> parserClasses, MarshallerRegistry marshallerRegistry,
+        CallCredentials callCredentials) {
+        this.parserClasses = parserClasses;
+        this.marshallerRegistry = marshallerRegistry;
+        this.callCredentials = callCredentials;
+    }
+    
+    @Override
+    public boolean init(RpcOptions rpcOptions) {
+        return true;
+    }
+    
+    @Override
+    public void shutdown() {
+        closeAllChannels();
+        transientFailures.clear();
+    }
+    
+    @Override
+    public boolean checkConnection(Endpoint endpoint) {
+        return checkConnection(endpoint, false);
+    }
+    
+    @Override
+    public boolean checkConnection(Endpoint endpoint, boolean createIfAbsent) {
+        Requires.requireNonNull(endpoint, "endpoint");
+        return checkChannel(endpoint, createIfAbsent);
+    }
+    
+    @Override
+    public void closeConnection(Endpoint endpoint) {
+        Requires.requireNonNull(endpoint, "endpoint");
+        closeChannel(endpoint);
+    }
+    
+    @Override
+    public void registerConnectEventListener(ReplicatorGroup replicatorGroup) {
+        this.replicatorGroup = replicatorGroup;
+    }
+    
+    @Override
+    public Object invokeSync(Endpoint endpoint, Object request, InvokeContext invokeContext,
+        long timeoutMillis) throws RemotingException {
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        invokeAsync(endpoint, request, invokeContext, (result, error) -> {
+            if (error == null) {
+                future.complete(result);
+            } else {
+                future.completeExceptionally(error);
+            }
+        }, timeoutMillis);
+        try {
+            return future.get(timeoutMillis, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw new InvokeTimeoutException(e);
+        } catch (Throwable e) {
+            future.cancel(true);
+            throw new RemotingException(e);
+        }
+    }
+    
+    @Override
+    public void invokeAsync(Endpoint endpoint, Object request, InvokeContext invokeContext,
+        InvokeCallback callback, long timeoutMillis) {
+        Requires.requireNonNull(endpoint, "endpoint");
+        Requires.requireNonNull(request, "request");
+        Executor executor = callback.executor() == null ? DirectExecutor.INSTANCE
+            : callback.executor();
+        ManagedChannel channel = getCheckedChannel(endpoint);
+        if (channel == null) {
+            executor.execute(() -> callback.complete(null,
+                new RemotingException("Fail to connect: " + endpoint)));
+            return;
+        }
+        MethodDescriptor<Message, Message> callMethod = getCallMethod(request);
+        CallOptions callOptions = CallOptions.DEFAULT
+            .withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS)
+            .withCallCredentials(callCredentials);
+        ClientCalls.asyncUnaryCall(channel.newCall(callMethod, callOptions), (Message) request,
+            new StreamObserver<Message>() {
+                
+                @Override
+                public void onNext(Message value) {
+                    executor.execute(() -> callback.complete(value, null));
+                }
+                
+                @Override
+                public void onError(Throwable throwable) {
+                    executor.execute(() -> callback.complete(null, throwable));
+                }
+                
+                @Override
+                public void onCompleted() {
+                }
+            });
+    }
+    
+    private MethodDescriptor<Message, Message> getCallMethod(Object request) {
+        String requestClassName = request.getClass().getName();
+        Message requestInstance = Requires.requireNonNull(parserClasses.get(requestClassName),
+            "null default instance: " + requestClassName);
+        return MethodDescriptor.<Message, Message>newBuilder()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName(MethodDescriptor.generateFullMethodName(requestClassName,
+                FIXED_METHOD_NAME))
+            .setRequestMarshaller(ProtoUtils.marshaller(requestInstance))
+            .setResponseMarshaller(ProtoUtils.marshaller(
+                marshallerRegistry.findResponseInstanceByRequest(requestClassName)))
+            .build();
+    }
+    
+    private ManagedChannel getCheckedChannel(Endpoint endpoint) {
+        ManagedChannel channel = getChannel(endpoint, true);
+        return checkConnectivity(endpoint, channel) ? channel : null;
+    }
+    
+    private ManagedChannel getChannel(Endpoint endpoint, boolean createIfAbsent) {
+        if (createIfAbsent) {
+            return managedChannelPool.computeIfAbsent(endpoint, this::newChannel);
+        }
+        return managedChannelPool.get(endpoint);
+    }
+    
+    private ManagedChannel newChannel(Endpoint endpoint) {
+        ManagedChannel channel = ManagedChannelBuilder.forAddress(endpoint.getIp(),
+            endpoint.getPort())
+            .usePlaintext()
+            .directExecutor()
+            .maxInboundMessageSize(RPC_MAX_INBOUND_MESSAGE_SIZE)
+            .build();
+        LOGGER.info("Creating new channel to: {}.", endpoint);
+        notifyWhenStateChanged(ConnectivityState.IDLE, endpoint, channel);
+        return channel;
+    }
+    
+    private ManagedChannel removeChannel(Endpoint endpoint) {
+        return managedChannelPool.remove(endpoint);
+    }
+    
+    private void notifyWhenStateChanged(ConnectivityState state, Endpoint endpoint,
+        ManagedChannel channel) {
+        channel.notifyWhenStateChanged(state, () -> onStateChanged(endpoint, channel));
+    }
+    
+    private void onStateChanged(Endpoint endpoint, ManagedChannel channel) {
+        ConnectivityState state = channel.getState(false);
+        LOGGER.info("The channel {} is in state: {}.", endpoint, state);
+        switch (state) {
+            case READY:
+                notifyReady(endpoint);
+                notifyWhenStateChanged(ConnectivityState.READY, endpoint, channel);
+                break;
+            case TRANSIENT_FAILURE:
+                notifyFailure(endpoint);
+                notifyWhenStateChanged(ConnectivityState.TRANSIENT_FAILURE, endpoint, channel);
+                break;
+            case SHUTDOWN:
+                notifyShutdown(endpoint);
+                break;
+            case CONNECTING:
+                notifyWhenStateChanged(ConnectivityState.CONNECTING, endpoint, channel);
+                break;
+            case IDLE:
+                notifyWhenStateChanged(ConnectivityState.IDLE, endpoint, channel);
+                break;
+            default:
+                break;
+        }
+    }
+    
+    private void notifyReady(Endpoint endpoint) {
+        LOGGER.info("The channel {} has successfully established.", endpoint);
+        clearConnFailuresCount(endpoint);
+        ReplicatorGroup currentReplicatorGroup = replicatorGroup;
+        if (currentReplicatorGroup == null) {
+            return;
+        }
+        try {
+            RpcUtils.runInThread(() -> {
+                PeerId peer = new PeerId();
+                if (peer.parse(endpoint.toString())) {
+                    LOGGER.info("Peer {} is connected.", peer);
+                    currentReplicatorGroup.checkReplicator(peer, true);
+                } else {
+                    LOGGER.error("Fail to parse peer: {}.", endpoint);
+                }
+            });
+        } catch (Throwable e) {
+            LOGGER.error("Fail to check replicator {}.", endpoint, e);
+        }
+    }
+    
+    private void notifyFailure(Endpoint endpoint) {
+        LOGGER.warn("There has been some transient failure on this channel {}.", endpoint);
+    }
+    
+    private void notifyShutdown(Endpoint endpoint) {
+        LOGGER.warn("This channel {} has started shutting down. Any new RPCs should fail "
+            + "immediately.", endpoint);
+    }
+    
+    private void closeAllChannels() {
+        for (Map.Entry<Endpoint, ManagedChannel> entry : managedChannelPool.entrySet()) {
+            ManagedChannel channel = entry.getValue();
+            LOGGER.info("Shutdown managed channel: {}, {}.", entry.getKey(), channel);
+            ManagedChannelHelper.shutdownAndAwaitTermination(channel);
+        }
+        managedChannelPool.clear();
+    }
+    
+    private void closeChannel(Endpoint endpoint) {
+        ManagedChannel channel = removeChannel(endpoint);
+        LOGGER.info("Close connection: {}, {}.", endpoint, channel);
+        if (channel != null) {
+            ManagedChannelHelper.shutdownAndAwaitTermination(channel);
+        }
+    }
+    
+    private boolean checkChannel(Endpoint endpoint, boolean createIfAbsent) {
+        ManagedChannel channel = getChannel(endpoint, createIfAbsent);
+        return channel != null && checkConnectivity(endpoint, channel);
+    }
+    
+    private int incConnFailuresCount(Endpoint endpoint) {
+        return transientFailures.computeIfAbsent(endpoint, key -> new AtomicInteger())
+            .incrementAndGet();
+    }
+    
+    private void clearConnFailuresCount(Endpoint endpoint) {
+        transientFailures.remove(endpoint);
+    }
+    
+    private boolean checkConnectivity(Endpoint endpoint, ManagedChannel channel) {
+        ConnectivityState state = channel.getState(false);
+        if (state != ConnectivityState.TRANSIENT_FAILURE
+            && state != ConnectivityState.SHUTDOWN) {
+            return true;
+        }
+        int failures = incConnFailuresCount(endpoint);
+        if (failures < RESET_CONN_THRESHOLD) {
+            if (failures == RESET_CONN_THRESHOLD - 1) {
+                channel.resetConnectBackoff();
+            }
+            return true;
+        }
+        clearConnFailuresCount(endpoint);
+        ManagedChannel removedChannel = removeChannel(endpoint);
+        if (removedChannel == null) {
+            return false;
+        }
+        LOGGER.warn("Channel[{}] in [INACTIVE] state {} times, it has been removed from the "
+            + "pool.", endpoint, failures);
+        if (removedChannel != channel) {
+            ManagedChannelHelper.shutdownAndAwaitTermination(removedChannel, 100L);
+        }
+        ManagedChannelHelper.shutdownAndAwaitTermination(channel, 100L);
+        return false;
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/grpc/NacosGrpcRaftRpcFactory.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/grpc/NacosGrpcRaftRpcFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.grpc;
+
+import com.alipay.sofa.jraft.rpc.RaftRpcFactory;
+import com.alipay.sofa.jraft.rpc.RpcClient;
+import com.alipay.sofa.jraft.rpc.impl.GrpcRaftRpcFactory;
+import com.alipay.sofa.jraft.util.SPI;
+import com.google.protobuf.Message;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Nacos JRaft gRPC factory that installs {@link NacosGrpcClient} with a higher SPI priority.
+ *
+ * @author xiweng.yy
+ */
+@SPI(priority = 100)
+public class NacosGrpcRaftRpcFactory extends GrpcRaftRpcFactory {
+    
+    private final Map<String, Message> parserClasses = new ConcurrentHashMap<>();
+    
+    @Override
+    public void registerProtobufSerializer(String className, Object... args) {
+        super.registerProtobufSerializer(className, args);
+        parserClasses.put(className, (Message) args[0]);
+    }
+    
+    @Override
+    public RpcClient createRpcClient(RaftRpcFactory.ConfigHelper<RpcClient> helper) {
+        RpcClient rpcClient = new NacosGrpcClient(parserClasses, getMarshallerRegistry());
+        if (helper != null) {
+            helper.config(rpcClient);
+        }
+        return rpcClient;
+    }
+}

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftUtils.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftUtils.java
@@ -24,6 +24,8 @@ import com.alibaba.nacos.consistency.entity.Response;
 import com.alibaba.nacos.consistency.entity.WriteRequest;
 import com.alibaba.nacos.core.cluster.ServerMemberManager;
 import com.alibaba.nacos.core.distributed.raft.JRaftServer;
+import com.alibaba.nacos.core.distributed.raft.auth.JRaftAuthUpgradeCoordinator;
+import com.alibaba.nacos.core.distributed.raft.auth.NacosJRaftServerInterceptor;
 import com.alibaba.nacos.core.distributed.raft.processor.NacosReadRequestProcessor;
 import com.alibaba.nacos.core.distributed.raft.processor.NacosWriteRequestProcessor;
 import com.alibaba.nacos.core.utils.Loggers;
@@ -38,6 +40,7 @@ import com.alipay.sofa.jraft.option.NodeOptions;
 import com.alipay.sofa.jraft.rpc.RaftRpcServerFactory;
 import com.alipay.sofa.jraft.rpc.RpcServer;
 import com.alipay.sofa.jraft.rpc.impl.GrpcRaftRpcFactory;
+import com.alipay.sofa.jraft.rpc.impl.GrpcServer;
 import com.alipay.sofa.jraft.rpc.impl.MarshallerRegistry;
 import com.alipay.sofa.jraft.util.RpcFactoryHelper;
 
@@ -58,7 +61,8 @@ import java.util.stream.Collectors;
 @SuppressWarnings("all")
 public class JRaftUtils {
     
-    public static RpcServer initRpcServer(JRaftServer server, PeerId peerId) {
+    public static RpcServer initRpcServer(JRaftServer server, PeerId peerId,
+        JRaftAuthUpgradeCoordinator jRaftAuthUpgradeCoordinator) {
         GrpcRaftRpcFactory raftRpcFactory = (GrpcRaftRpcFactory) RpcFactoryHelper.rpcFactory();
         raftRpcFactory.registerProtobufSerializer(Log.class.getName(), Log.getDefaultInstance());
         raftRpcFactory.registerProtobufSerializer(GetRequest.class.getName(),
@@ -81,6 +85,11 @@ public class JRaftUtils {
             Response.getDefaultInstance());
         
         final RpcServer rpcServer = raftRpcFactory.createRpcServer(peerId.getEndpoint());
+        boolean interceptorAdded = ((GrpcServer) rpcServer).addServerInterceptor(
+            new NacosJRaftServerInterceptor(jRaftAuthUpgradeCoordinator));
+        if (!interceptorAdded) {
+            throw new IllegalStateException("Failed to install JRaft authentication interceptor");
+        }
         RaftRpcServerFactory.addRaftRequestProcessors(rpcServer, RaftExecutor.getRaftCoreExecutor(),
             RaftExecutor.getRaftCliServiceExecutor());
         

--- a/core/src/main/resources/META-INF/services/com.alipay.sofa.jraft.rpc.RaftRpcFactory
+++ b/core/src/main/resources/META-INF/services/com.alipay.sofa.jraft.rpc.RaftRpcFactory
@@ -1,0 +1,17 @@
+#
+# Copyright 1999-2026 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.nacos.core.distributed.raft.grpc.NacosGrpcRaftRpcFactory

--- a/core/src/test/java/com/alibaba/nacos/core/auth/InnerApiAuthEnabledTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/auth/InnerApiAuthEnabledTest.java
@@ -32,6 +32,7 @@ import org.springframework.mock.env.MockEnvironment;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -63,6 +64,14 @@ class InnerApiAuthEnabledTest {
     @Test
     void testIsEnabledInitiallyFalse() {
         assertFalse(innerApiAuthEnabled.isEnabled());
+    }
+    
+    @Test
+    void testDeprecatedForRemoval() {
+        assertTrue(InnerApiAuthEnabled.class.isAnnotationPresent(Deprecated.class));
+        Deprecated deprecated = InnerApiAuthEnabled.class.getAnnotation(Deprecated.class);
+        assertTrue(deprecated.forRemoval());
+        assertEquals("3.0.0", deprecated.since());
     }
     
     @Test

--- a/core/src/test/java/com/alibaba/nacos/core/cluster/MemberMetaDataConstantsTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/cluster/MemberMetaDataConstantsTest.java
@@ -34,6 +34,7 @@ class MemberMetaDataConstantsTest {
         assertEquals("remoteConnectType", MemberMetaDataConstants.SUPPORT_REMOTE_C_TYPE);
         assertEquals("readyToUpgrade", MemberMetaDataConstants.READY_TO_UPGRADE);
         assertEquals("supportGrayModel", MemberMetaDataConstants.SUPPORT_GRAY_MODEL);
+        assertEquals("supportJraftAuth", MemberMetaDataConstants.SUPPORT_JRAFT_AUTH);
     }
     
     @Test
@@ -45,18 +46,20 @@ class MemberMetaDataConstantsTest {
         assertNotNull(MemberMetaDataConstants.RAFT_PORT);
         assertNotNull(MemberMetaDataConstants.LAST_REFRESH_TIME);
         assertNotNull(MemberMetaDataConstants.SUPPORT_GRAY_MODEL);
+        assertNotNull(MemberMetaDataConstants.SUPPORT_JRAFT_AUTH);
     }
     
     @Test
     void testBasicMetaKeys() {
         String[] keys = MemberMetaDataConstants.BASIC_META_KEYS;
         assertNotNull(keys);
-        assertEquals(6, keys.length);
+        assertEquals(7, keys.length);
         assertEquals(MemberMetaDataConstants.SITE_KEY, keys[0]);
         assertEquals(MemberMetaDataConstants.AD_WEIGHT, keys[1]);
         assertEquals(MemberMetaDataConstants.RAFT_PORT, keys[2]);
         assertEquals(MemberMetaDataConstants.WEIGHT, keys[3]);
         assertEquals(MemberMetaDataConstants.VERSION, keys[4]);
         assertEquals(MemberMetaDataConstants.READY_TO_UPGRADE, keys[5]);
+        assertEquals(MemberMetaDataConstants.SUPPORT_JRAFT_AUTH, keys[6]);
     }
 }

--- a/core/src/test/java/com/alibaba/nacos/core/cluster/ServerMemberManagerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/cluster/ServerMemberManagerTest.java
@@ -143,6 +143,12 @@ class ServerMemberManagerTest {
     }
     
     @Test
+    void testSelfReportsJRaftAuthenticationCapability() {
+        assertEquals(Boolean.TRUE, serverMemberManager.getSelf()
+            .getExtendVal(MemberMetaDataConstants.SUPPORT_JRAFT_AUTH));
+    }
+    
+    @Test
     void testUpdateNonBasicExtendInfoMember() {
         Member newMember = Member.builder().ip("1.1.1.1").port(8848).state(NodeState.UP).build();
         newMember.setExtendVal("naming", "test");

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/ConsistencyConfigurationTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/ConsistencyConfigurationTest.java
@@ -18,6 +18,7 @@ package com.alibaba.nacos.core.distributed;
 
 import com.alibaba.nacos.consistency.cp.CPProtocol;
 import com.alibaba.nacos.core.cluster.ServerMemberManager;
+import com.alibaba.nacos.core.distributed.raft.auth.JRaftAuthUpgradeCoordinator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -42,7 +43,8 @@ class ConsistencyConfigurationTest {
     @Test
     void testStrongAgreementProtocolReturnsProtocol() throws Exception {
         ConsistencyConfiguration config = new ConsistencyConfiguration();
-        CPProtocol protocol = config.strongAgreementProtocol(memberManager);
+        CPProtocol protocol = config.strongAgreementProtocol(memberManager,
+            mock(JRaftAuthUpgradeCoordinator.class));
         assertNotNull(protocol);
     }
     

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/raft/JRaftProtocolTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/raft/JRaftProtocolTest.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.consistency.entity.ReadRequest;
 import com.alibaba.nacos.consistency.entity.Response;
 import com.alibaba.nacos.consistency.entity.WriteRequest;
 import com.alibaba.nacos.core.cluster.ServerMemberManager;
+import com.alibaba.nacos.core.distributed.raft.auth.JRaftAuthUpgradeCoordinator;
 import com.alibaba.nacos.core.distributed.raft.exception.NoSuchRaftGroupException;
 import com.alipay.sofa.jraft.Node;
 import com.google.protobuf.Message;
@@ -65,6 +66,9 @@ class JRaftProtocolTest {
     @Mock
     private ServerMemberManager memberManager;
     
+    @Mock
+    private JRaftAuthUpgradeCoordinator jRaftAuthUpgradeCoordinator;
+    
     private ReadRequest readRequest;
     
     private WriteRequest writeRequest;
@@ -79,7 +83,7 @@ class JRaftProtocolTest {
     
     @BeforeEach
     void setUp() throws Exception {
-        raftProtocol = new JRaftProtocol(memberManager);
+        raftProtocol = new JRaftProtocol(memberManager, jRaftAuthUpgradeCoordinator);
         ReadRequest.Builder readRequestBuilder = ReadRequest.newBuilder();
         readRequest = readRequestBuilder.build();
         

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/raft/JRaftServerTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/raft/JRaftServerTest.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.consistency.entity.Response;
 import com.alibaba.nacos.consistency.entity.WriteRequest;
 import com.alibaba.nacos.core.cluster.Member;
 import com.alibaba.nacos.core.distributed.ProtocolManager;
+import com.alibaba.nacos.core.distributed.raft.auth.JRaftAuthUpgradeCoordinator;
 import com.alibaba.nacos.core.distributed.raft.exception.DuplicateRaftGroupException;
 import com.alibaba.nacos.core.distributed.raft.exception.JRaftException;
 import com.alibaba.nacos.core.distributed.raft.exception.NoLeaderException;
@@ -54,10 +55,12 @@ import com.alipay.sofa.jraft.rpc.impl.cli.CliClientServiceImpl;
 import com.alipay.sofa.jraft.util.Endpoint;
 import com.google.protobuf.Message;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -69,6 +72,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -106,6 +110,9 @@ import static org.mockito.Mockito.when;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class JRaftServerTest {
     
+    @TempDir
+    private static Path temporaryDirectory;
+    
     private final String groupId = "test_group";
     
     private PeerId peerId1;
@@ -122,6 +129,9 @@ class JRaftServerTest {
     
     @Mock
     private RequestProcessor4CP mockProcessor4CP;
+    
+    @Mock
+    private JRaftAuthUpgradeCoordinator jRaftAuthUpgradeCoordinator;
     
     @Mock
     private CliClientServiceImpl cliClientServiceMock;
@@ -152,6 +162,13 @@ class JRaftServerTest {
     @BeforeAll
     static void beforeClass() {
         EnvUtil.setEnvironment(new MockEnvironment());
+        EnvUtil.setNacosHomePath(temporaryDirectory.toString());
+    }
+    
+    @AfterAll
+    static void afterClass() {
+        EnvUtil.setNacosHomePath(null);
+        EnvUtil.setEnvironment(null);
     }
     
     @BeforeEach
@@ -162,7 +179,7 @@ class JRaftServerTest {
             Collections.singletonList(Member.builder().ip("1.1.1.1").port(7848).build());
         config.setMembers("1.1.1.1:7848", ProtocolManager.toCPMembersInfo(initEvent));
         
-        server = new JRaftServer() {
+        server = new JRaftServer(jRaftAuthUpgradeCoordinator) {
             
             @Override
             boolean peerChange(JRaftMaintainService maintainService, Set<String> newPeers) {
@@ -593,7 +610,7 @@ class JRaftServerTest {
     /** When isStarted is false, createMultiRaftGroup only adds to processors and returns. */
     @Test
     void testCreateMultiRaftGroupWhenNotStartedOnlyAddsProcessors() throws Exception {
-        JRaftServer notStartedServer = new JRaftServer();
+        JRaftServer notStartedServer = new JRaftServer(jRaftAuthUpgradeCoordinator);
         notStartedServer.init(config);
         Field multiRaftGroupField = JRaftServer.class.getDeclaredField("multiRaftGroup");
         multiRaftGroupField.setAccessible(true);
@@ -637,13 +654,15 @@ class JRaftServerTest {
             MockedStatic<JRaftUtils> jraftUtilsMock = mockStatic(JRaftUtils.class)) {
             nodeManagerMock.when(NodeManager::getInstance).thenReturn(mockNodeManager);
             jraftUtilsMock
-                .when(() -> JRaftUtils.initRpcServer(any(JRaftServer.class), any(PeerId.class)))
+                .when(() -> JRaftUtils.initRpcServer(any(JRaftServer.class), any(PeerId.class),
+                    any(JRaftAuthUpgradeCoordinator.class)))
                 .thenReturn(mockRpcServer);
             serverSpy.start();
             assertTrue((Boolean) ReflectionTestUtils.getField(serverSpy, "isStarted"));
             verify(serverSpy).createMultiRaftGroup(anyCollection());
             jraftUtilsMock
-                .verify(() -> JRaftUtils.initRpcServer(any(JRaftServer.class), any(PeerId.class)));
+                .verify(() -> JRaftUtils.initRpcServer(any(JRaftServer.class),
+                    any(PeerId.class), any(JRaftAuthUpgradeCoordinator.class)));
         }
     }
     
@@ -657,7 +676,8 @@ class JRaftServerTest {
             MockedStatic<JRaftUtils> jraftUtilsMock = mockStatic(JRaftUtils.class)) {
             nodeManagerMock.when(NodeManager::getInstance).thenReturn(mockNodeManager);
             jraftUtilsMock
-                .when(() -> JRaftUtils.initRpcServer(any(JRaftServer.class), any(PeerId.class)))
+                .when(() -> JRaftUtils.initRpcServer(any(JRaftServer.class), any(PeerId.class),
+                    any(JRaftAuthUpgradeCoordinator.class)))
                 .thenThrow(cause);
             JRaftException ex = assertThrows(JRaftException.class, () -> server.start());
             assertTrue(ex.getCause() == cause);
@@ -676,7 +696,8 @@ class JRaftServerTest {
             MockedStatic<JRaftUtils> jraftUtilsMock = mockStatic(JRaftUtils.class)) {
             nodeManagerMock.when(NodeManager::getInstance).thenReturn(mockNodeManager);
             jraftUtilsMock
-                .when(() -> JRaftUtils.initRpcServer(any(JRaftServer.class), any(PeerId.class)))
+                .when(() -> JRaftUtils.initRpcServer(any(JRaftServer.class), any(PeerId.class),
+                    any(JRaftAuthUpgradeCoordinator.class)))
                 .thenReturn(mockRpcServer);
             assertThrows(RuntimeException.class, () -> server.start());
             assertFalse((Boolean) ReflectionTestUtils.getField(server, "isStarted"));
@@ -737,7 +758,7 @@ class JRaftServerTest {
     /** invokeToLeader when no leader throws NoLeaderException. */
     @Test
     void testInvokeToLeaderWhenNoLeaderThrowsNoLeaderException() throws Exception {
-        JRaftServer serverWithNoLeader = new JRaftServer() {
+        JRaftServer serverWithNoLeader = new JRaftServer(jRaftAuthUpgradeCoordinator) {
             
             @Override
             protected PeerId getLeader(String raftGroupId) {

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/raft/auth/JRaftAuthUpgradeCoordinatorTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/raft/auth/JRaftAuthUpgradeCoordinatorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.auth;
+
+import com.alibaba.nacos.core.cluster.Member;
+import com.alibaba.nacos.core.cluster.MemberMetaDataConstants;
+import com.alibaba.nacos.core.cluster.ServerMemberManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JRaftAuthUpgradeCoordinatorTest {
+    
+    @TempDir
+    private Path temporaryDirectory;
+    
+    @Mock
+    private ServerMemberManager serverMemberManager;
+    
+    @Test
+    void testInitialStateAllowsInvalidCredential() {
+        JRaftAuthUpgradeCoordinator coordinator = newCoordinator();
+        
+        assertFalse(coordinator.isEnforced());
+        assertTrue(coordinator.allowInvalidCredential());
+    }
+    
+    @Test
+    void testDoesNotEnforceUntilEveryMemberSupportsAuthentication() {
+        Member supported = memberWithCapability(true);
+        Member unsupported = memberWithCapability(false);
+        when(serverMemberManager.allMembers()).thenReturn(Arrays.asList(supported, unsupported));
+        JRaftAuthUpgradeCoordinator coordinator = newCoordinator();
+        
+        coordinator.doCheck();
+        
+        assertFalse(coordinator.isEnforced());
+        assertFalse(Files.exists(stateFile()));
+    }
+    
+    @Test
+    void testPersistsAfterEnforcingAndRemainsEnforced() {
+        Member supported = memberWithCapability(true);
+        List<Member> members = new ArrayList<>(Collections.singletonList(supported));
+        when(serverMemberManager.allMembers()).thenReturn(members);
+        JRaftAuthUpgradeCoordinator coordinator = newCoordinator();
+        
+        coordinator.doCheck();
+        
+        assertTrue(coordinator.isEnforced());
+        assertTrue(Files.isRegularFile(stateFile()));
+        assertFalse(coordinator.allowInvalidCredential());
+        
+        members.clear();
+        members.add(memberWithCapability(false));
+        coordinator.doCheck();
+        assertTrue(coordinator.isEnforced());
+    }
+    
+    @Test
+    void testRestoresEnforcedStateFromMarker() throws Exception {
+        Files.write(stateFile(), Arrays.asList("version=1", "state=ENFORCED"),
+            StandardCharsets.UTF_8);
+        
+        JRaftAuthUpgradeCoordinator coordinator = newCoordinator();
+        
+        assertTrue(coordinator.isEnforced());
+        assertFalse(coordinator.allowInvalidCredential());
+    }
+    
+    @Test
+    void testInvalidMarkerDoesNotEnableEnforcement() throws Exception {
+        Files.write(stateFile(), Collections.singletonList("state=COMPATIBLE"),
+            StandardCharsets.UTF_8);
+        
+        JRaftAuthUpgradeCoordinator coordinator = newCoordinator();
+        
+        assertFalse(coordinator.isEnforced());
+    }
+    
+    @Test
+    void testPersistenceFailureDoesNotBlockEnforcementAndRetries() throws Exception {
+        Path parentFile = temporaryDirectory.resolve("not-a-directory");
+        Files.write(parentFile, Collections.singletonList("content"), StandardCharsets.UTF_8);
+        Path stateFile = parentFile.resolve(JRaftAuthUpgradeCoordinator.STATE_FILE_NAME);
+        Member supported = memberWithCapability(true);
+        when(serverMemberManager.allMembers()).thenReturn(Collections.singletonList(supported));
+        JRaftAuthUpgradeCoordinator coordinator =
+            new JRaftAuthUpgradeCoordinator(serverMemberManager, stateFile);
+        
+        coordinator.doCheck();
+        
+        assertTrue(coordinator.isEnforced());
+        assertFalse(coordinator.allowInvalidCredential());
+        assertFalse(Files.exists(stateFile));
+        
+        Files.delete(parentFile);
+        Files.createDirectories(parentFile);
+        coordinator.doCheck();
+        
+        assertTrue(Files.isRegularFile(stateFile));
+    }
+    
+    private JRaftAuthUpgradeCoordinator newCoordinator() {
+        return new JRaftAuthUpgradeCoordinator(serverMemberManager, stateFile());
+    }
+    
+    private Path stateFile() {
+        return temporaryDirectory.resolve(JRaftAuthUpgradeCoordinator.STATE_FILE_NAME);
+    }
+    
+    private Member memberWithCapability(boolean supported) {
+        Member member = mock(Member.class);
+        lenient().when(member.getExtendVal(MemberMetaDataConstants.SUPPORT_JRAFT_AUTH))
+            .thenReturn(supported);
+        return member;
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/raft/auth/NacosJRaftCallCredentialsTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/raft/auth/NacosJRaftCallCredentialsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.auth;
+
+import com.alibaba.nacos.auth.config.NacosAuthConfig;
+import io.grpc.CallCredentials;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NacosJRaftCallCredentialsTest {
+    
+    @Test
+    void testAppliesCurrentServerIdentity() {
+        NacosAuthConfig authConfig = mock(NacosAuthConfig.class);
+        when(authConfig.getServerIdentityKey()).thenReturn("identity-key");
+        when(authConfig.getServerIdentityValue()).thenReturn("identity-value");
+        NacosJRaftCallCredentials credentials = new NacosJRaftCallCredentials(() -> authConfig);
+        AtomicReference<Metadata> result = new AtomicReference<>();
+        
+        credentials.applyRequestMetadata(mock(CallCredentials.RequestInfo.class), Runnable::run,
+            new CallCredentials.MetadataApplier() {
+                
+                @Override
+                public void apply(Metadata headers) {
+                    result.set(headers);
+                }
+                
+                @Override
+                public void fail(Status status) {
+                }
+            });
+        
+        assertNotNull(result.get());
+        assertEquals("identity-key", result.get().get(JRaftAuthMetadata.IDENTITY_KEY));
+        assertEquals("identity-value", result.get().get(JRaftAuthMetadata.IDENTITY_VALUE));
+    }
+    
+    @Test
+    void testFailsWhenAuthConfigIsUnavailable() {
+        NacosJRaftCallCredentials credentials = new NacosJRaftCallCredentials(() -> null);
+        AtomicReference<Status> result = new AtomicReference<>();
+        
+        credentials.applyRequestMetadata(mock(CallCredentials.RequestInfo.class), Runnable::run,
+            new CallCredentials.MetadataApplier() {
+                
+                @Override
+                public void apply(Metadata headers) {
+                }
+                
+                @Override
+                public void fail(Status status) {
+                    result.set(status);
+                }
+            });
+        
+        assertNotNull(result.get());
+        assertEquals(Status.Code.UNAUTHENTICATED, result.get().getCode());
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/raft/auth/NacosJRaftServerInterceptorTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/raft/auth/NacosJRaftServerInterceptorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.auth;
+
+import com.alibaba.nacos.auth.config.NacosAuthConfig;
+import com.alibaba.nacos.auth.serveridentity.ServerIdentityChecker;
+import com.alibaba.nacos.auth.serveridentity.ServerIdentityResult;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NacosJRaftServerInterceptorTest {
+    
+    @Mock
+    private JRaftAuthUpgradeCoordinator upgradeCoordinator;
+    
+    @Mock
+    private NacosAuthConfig authConfig;
+    
+    @Mock
+    private ServerIdentityChecker identityChecker;
+    
+    @Mock
+    private ServerCall<Object, Object> serverCall;
+    
+    @Mock
+    private ServerCallHandler<Object, Object> next;
+    
+    @Mock
+    private ServerCall.Listener<Object> listener;
+    
+    private NacosJRaftServerInterceptor interceptor;
+    
+    @BeforeEach
+    void setUp() {
+        when(authConfig.getServerIdentityKey()).thenReturn("identity-key");
+        when(authConfig.getServerIdentityValue()).thenReturn("identity-value");
+        interceptor = new NacosJRaftServerInterceptor(upgradeCoordinator, authConfig,
+            identityChecker);
+    }
+    
+    @Test
+    void testValidCredentialContinuesRequest() {
+        Metadata headers = validHeaders();
+        when(identityChecker.check(any(), any())).thenReturn(ServerIdentityResult.success());
+        when(next.startCall(serverCall, headers)).thenReturn(listener);
+        
+        ServerCall.Listener<Object> result = interceptor.interceptCall(serverCall, headers, next);
+        
+        assertSame(listener, result);
+        verify(upgradeCoordinator, never()).allowInvalidCredential();
+    }
+    
+    @Test
+    void testInvalidCredentialContinuesDuringCompatibilityWindow() {
+        Metadata headers = new Metadata();
+        when(upgradeCoordinator.allowInvalidCredential()).thenReturn(true);
+        when(next.startCall(serverCall, headers)).thenReturn(listener);
+        
+        ServerCall.Listener<Object> result = interceptor.interceptCall(serverCall, headers, next);
+        
+        assertSame(listener, result);
+        verify(next).startCall(serverCall, headers);
+    }
+    
+    @Test
+    void testInvalidCredentialRejectedAfterEnforcement() {
+        Metadata headers = new Metadata();
+        when(upgradeCoordinator.allowInvalidCredential()).thenReturn(false);
+        ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+        
+        interceptor.interceptCall(serverCall, headers, next);
+        
+        verify(serverCall).close(statusCaptor.capture(), any(Metadata.class));
+        verify(next, never()).startCall(any(), any());
+        org.junit.jupiter.api.Assertions.assertEquals(Status.Code.UNAUTHENTICATED,
+            statusCaptor.getValue().getCode());
+    }
+    
+    @Test
+    void testMismatchedIdentityKeyIsRejected() {
+        Metadata headers = validHeaders();
+        headers.discardAll(JRaftAuthMetadata.IDENTITY_KEY);
+        headers.put(JRaftAuthMetadata.IDENTITY_KEY, "different-key");
+        when(upgradeCoordinator.allowInvalidCredential()).thenReturn(false);
+        
+        interceptor.interceptCall(serverCall, headers, next);
+        
+        verify(identityChecker, never()).check(any(), any());
+        verify(serverCall).close(any(Status.class), any(Metadata.class));
+    }
+    
+    private Metadata validHeaders() {
+        Metadata result = new Metadata();
+        result.put(JRaftAuthMetadata.IDENTITY_KEY, "identity-key");
+        result.put(JRaftAuthMetadata.IDENTITY_VALUE, "identity-value");
+        return result;
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/raft/grpc/NacosGrpcClientTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/raft/grpc/NacosGrpcClientTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.grpc;
+
+import com.alibaba.nacos.consistency.entity.ReadRequest;
+import com.alibaba.nacos.consistency.entity.Response;
+import com.alipay.sofa.jraft.rpc.InvokeCallback;
+import com.alipay.sofa.jraft.rpc.impl.MarshallerRegistry;
+import com.alipay.sofa.jraft.util.Endpoint;
+import com.google.protobuf.Message;
+import io.grpc.CallCredentials;
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NacosGrpcClientTest {
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    void testInvokeAsyncAttachesCallCredentials() {
+        MarshallerRegistry marshallerRegistry = mock(MarshallerRegistry.class);
+        when(marshallerRegistry.findResponseInstanceByRequest(ReadRequest.class.getName()))
+            .thenReturn(Response.getDefaultInstance());
+        CallCredentials credentials = mock(CallCredentials.class);
+        NacosGrpcClient client = new NacosGrpcClient(
+            Collections.singletonMap(ReadRequest.class.getName(),
+                ReadRequest.getDefaultInstance()),
+            marshallerRegistry, credentials);
+        Endpoint endpoint = new Endpoint("127.0.0.1", 7848);
+        ManagedChannel channel = mock(ManagedChannel.class);
+        when(channel.getState(false)).thenReturn(ConnectivityState.READY);
+        ClientCall<Message, Message> call = mock(ClientCall.class);
+        when(channel.newCall(any(MethodDescriptor.class), any(CallOptions.class))).thenReturn(call);
+        Map<Endpoint, ManagedChannel> channelPool =
+            (Map<Endpoint, ManagedChannel>) ReflectionTestUtils.getField(client,
+                "managedChannelPool");
+        channelPool.put(endpoint, channel);
+        InvokeCallback callback = mock(InvokeCallback.class);
+        ArgumentCaptor<CallOptions> callOptionsCaptor = ArgumentCaptor.forClass(CallOptions.class);
+        
+        client.invokeAsync(endpoint, ReadRequest.getDefaultInstance(), null, callback, 1000L);
+        
+        verify(channel).newCall(any(MethodDescriptor.class), callOptionsCaptor.capture());
+        assertSame(credentials, callOptionsCaptor.getValue().getCredentials());
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/raft/grpc/NacosGrpcRaftRpcFactoryTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/raft/grpc/NacosGrpcRaftRpcFactoryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.distributed.raft.grpc;
+
+import com.alibaba.nacos.consistency.entity.ReadRequest;
+import com.alibaba.nacos.consistency.entity.Response;
+import com.alipay.sofa.jraft.rpc.RaftRpcFactory;
+import com.alipay.sofa.jraft.rpc.RpcClient;
+import com.alipay.sofa.jraft.util.JRaftServiceLoader;
+import com.alipay.sofa.jraft.util.RpcFactoryHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NacosGrpcRaftRpcFactoryTest {
+    
+    @Test
+    void testCreatesNacosGrpcClientAndAppliesHelper() {
+        NacosGrpcRaftRpcFactory factory = new NacosGrpcRaftRpcFactory();
+        factory.registerProtobufSerializer(ReadRequest.class.getName(),
+            ReadRequest.getDefaultInstance());
+        factory.getMarshallerRegistry().registerResponseInstance(ReadRequest.class.getName(),
+            Response.getDefaultInstance());
+        AtomicBoolean helperCalled = new AtomicBoolean(false);
+        
+        RpcClient rpcClient = factory.createRpcClient(client -> helperCalled.set(true));
+        
+        assertInstanceOf(NacosGrpcClient.class, rpcClient);
+        assertTrue(helperCalled.get());
+    }
+    
+    @Test
+    void testNacosFactoryHasHighestSpiPriority() {
+        RaftRpcFactory factory = JRaftServiceLoader.load(RaftRpcFactory.class).first();
+        
+        assertInstanceOf(NacosGrpcRaftRpcFactory.class, factory);
+        assertInstanceOf(NacosGrpcRaftRpcFactory.class, RpcFactoryHelper.rpcFactory());
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/raft/processor/AbstractProcessorTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/raft/processor/AbstractProcessorTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.core.distributed.raft.processor;
 import com.alibaba.nacos.consistency.entity.Response;
 import com.alibaba.nacos.consistency.entity.WriteRequest;
 import com.alibaba.nacos.core.distributed.raft.JRaftServer;
+import com.alibaba.nacos.core.distributed.raft.auth.JRaftAuthUpgradeCoordinator;
 import com.alibaba.nacos.core.distributed.raft.utils.FailoverClosure;
 import com.alipay.sofa.jraft.Node;
 import com.alipay.sofa.jraft.Status;
@@ -40,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,7 +56,7 @@ class AbstractProcessorTest {
     @Mock
     private Node followerNode;
     
-    private JRaftServer server = new JRaftServer() {
+    private JRaftServer server = new JRaftServer(mock(JRaftAuthUpgradeCoordinator.class)) {
         
         @Override
         public void applyOperation(Node node, Message data, FailoverClosure closure) {

--- a/core/src/test/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftUtilsTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/distributed/raft/utils/JRaftUtilsTest.java
@@ -20,6 +20,7 @@ import com.alibaba.nacos.core.cluster.ServerMemberManager;
 import com.alibaba.nacos.core.distributed.raft.JRaftServer;
 import com.alibaba.nacos.core.distributed.raft.RaftConfig;
 import com.alibaba.nacos.core.distributed.raft.RaftSysConstants;
+import com.alibaba.nacos.core.distributed.raft.auth.JRaftAuthUpgradeCoordinator;
 import com.alibaba.nacos.sys.utils.ApplicationUtils;
 import com.alipay.sofa.jraft.CliService;
 import com.alipay.sofa.jraft.RouteTable;
@@ -70,6 +71,9 @@ class JRaftUtilsTest {
     
     @Mock
     private JRaftServer server;
+    
+    @Mock
+    private JRaftAuthUpgradeCoordinator jRaftAuthUpgradeCoordinator;
     
     private MockedStatic<ApplicationUtils> applicationUtilsMock;
     private MockedStatic<RouteTable> routeTableMock;
@@ -270,7 +274,8 @@ class JRaftUtilsTest {
         RpcServer rpcServer = null;
         try {
             PeerId peerId = PeerId.parsePeer("127.0.0.1:18080");
-            rpcServer = JRaftUtils.initRpcServer(server, peerId);
+            rpcServer = JRaftUtils.initRpcServer(server, peerId,
+                jRaftAuthUpgradeCoordinator);
             assertNotNull(rpcServer);
         } finally {
             shutdownRpcServerQuietly(rpcServer);

--- a/specs/en/auth/auth-permission-spec.md
+++ b/specs/en/auth/auth-permission-spec.md
@@ -166,6 +166,12 @@ The common auth flow is:
 Server-internal requests may also require the configured server identity key and
 value before normal request handling continues.
 
+JRaft native gRPC is such a server-internal transport even though it does not
+use a Nacos `RequestHandler`. Its client transports server identity through
+gRPC `CallCredentials`, and its server validates the identity in a
+`ServerInterceptor`. Public Open API auth being disabled must not bypass JRaft
+server identity after the cluster has entered enforced mode.
+
 ## Resource Permission Names
 
 Nacos permissions are evaluated against resources derived from the

--- a/specs/en/design/foundation-cluster-membership-spec.md
+++ b/specs/en/design/foundation-cluster-membership-spec.md
@@ -58,6 +58,7 @@ A Nacos server member is represented by `Member`, which extends the public
 | `abilities` | Server ability table reported by the member, including remote, config, and naming abilities. |
 | `failAccessCnt` | Local transient failure counter used to move a member from suspicious to down. |
 | `grpcReportEnabled` | Compatibility flag for mixed-version member reporting. It is not a new semantic capability. |
+| `supportJraftAuth` | Temporary rolling-upgrade capability indicating that the member can send and validate JRaft server identity credentials. It is not an identity proof. |
 
 Member identity rules:
 
@@ -122,6 +123,13 @@ existing member. It must not add an unknown member. If the update changes basic
 metadata, it publishes a `MembersChangeEvent` with the changed member as the
 trigger.
 
+The temporary `supportJraftAuth` metadata is set only by the local member that
+implements the capability. Address lookup must not infer it for a remote member.
+It participates in basic metadata change detection so authenticated member
+reports can converge the capability view. Consumers may use the all-member view
+to finish a rolling-upgrade transition, but they must not use the field as
+request identity or authorization evidence.
+
 ## 5. Member Readiness And Health Observation
 
 Local readiness is set by `ServerMemberManager.setSelfReady`. It marks the local
@@ -184,6 +192,8 @@ Consumers of cluster membership must follow these rules:
 - do not treat member ordering as a domain sharding rule unless the domain spec
   explicitly defines that behavior;
 - do not write domain ownership into `Member.extendInfo`.
+- an upgrade consumer that latches a security capability must not disable it
+  because a member is later added, removed, or updated.
 
 ## 8. Related Specs
 

--- a/specs/en/design/foundation-cp-consistency-spec.md
+++ b/specs/en/design/foundation-cp-consistency-spec.md
@@ -120,6 +120,47 @@ Implementation timeouts are operational defaults, not public API guarantees.
 Domain specs must not expose JRaft timeout values as user-visible correctness
 contracts unless a domain API explicitly defines them.
 
+### JRaft Transport Authentication
+
+JRaft native gRPC is an inner server-to-server transport. New JRaft clients
+always attach the configured Nacos server identity through gRPC
+`CallCredentials`, and the server always validates it in a
+`ServerInterceptor` before dispatching to a JRaft processor.
+
+Rolling upgrade uses a temporary two-state transition:
+
+```text
+COMPATIBLE -> ENFORCED
+```
+
+In `COMPATIBLE`, missing or invalid credentials are rate-limited and logged but
+the request continues, because an old member cannot attach credentials. Each
+new member publishes the temporary `supportJraftAuth=true` capability. After
+every member in the complete membership view reports the capability, the local
+server automatically and irreversibly enters `ENFORCED`. In `ENFORCED`, a
+missing or invalid credential is rejected with gRPC `UNAUTHENTICATED` before
+processor execution.
+
+The transition is monotonic. Member additions, removals, or metadata updates
+must not return an enforced process to compatibility. Runtime enforcement is
+latched before writing `{nacos.home}/data/jraft-auth-enforced.state`; a marker
+write failure must not delay enforcement and must be retried by later scheduled
+checks. A server that finds the state file on restart enforces authentication
+immediately. The state file contains no server identity or member data and is
+not an operator rollback switch.
+
+Capability discovery, compatible admission, transition, and state-file handling
+belong to one isolated compatibility component. That component is deprecated
+from its introduction, documents removal in Nacos 4.0.0, and must not own the
+permanent credential parser or validator. Nacos 4.0.0 removes the component and
+always enforces JRaft server identity.
+
+After enforcement, a mixed-version rolling downgrade to members without JRaft
+credentials is not lossless or guaranteed available. Old clients cannot call
+new enforced servers, so leader election, replication, ReadIndex, leader
+forwarding, snapshots, and CLI operations may fail depending on group leader
+and quorum placement.
+
 ## 6. Current CP Consumers
 
 | Group | Owner | Purpose |

--- a/specs/en/design/foundation-internal-rpc-spec.md
+++ b/specs/en/design/foundation-internal-rpc-spec.md
@@ -59,8 +59,12 @@ clients created by `ClusterRpcClientProxy` also carry the label:
 RemoteConstants.LABEL_SOURCE = RemoteConstants.LABEL_SOURCE_CLUSTER
 ```
 
-Internal RPC is therefore not a separate protocol family. It is a restricted
-source, auth, and handler discipline on top of the remote layer.
+Most internal RPC is therefore not a separate protocol family. It is a
+restricted source, auth, and handler discipline on top of the remote layer.
+The built-in JRaft CP transport is the exception: it uses JRaft's native gRPC
+messages and processors instead of the Nacos `Payload` and `RequestHandler`
+model, but it remains an inner server-to-server API and follows the server
+identity rules in this spec.
 
 The model is:
 
@@ -138,6 +142,10 @@ Rules:
 - namespace validation, parameter extraction, TPS control, and other request
   filters should be declared on handlers when the domain requires them.
 
+`InnerApiAuthEnabled` is only a compatibility gate for rolling upgrades from
+2.x to 3.x. It is deprecated for removal in Nacos 3.4.0; permanent inner API
+server-identity validation must not depend on this temporary component.
+
 Known request filter concerns include:
 
 | Filter concern | Typical annotation or path | Rule |
@@ -146,6 +154,27 @@ Known request filter concerns include:
 | Parameter validation | `@ExtractorManager.Extractor` | Reuse shared parameter extraction and validation. |
 | Namespace validation | `@NamespaceValidation` | Validate namespace existence where resource identity contains namespace. |
 | TPS control | `@TpsControl` | Register and enforce stable control points for cluster traffic. |
+
+JRaft native gRPC authentication follows transport-specific rules:
+
+- every new JRaft client attaches the configured Nacos server identity through
+  gRPC `CallCredentials`;
+- a gRPC `ServerInterceptor` validates the credentials before any Raft, CLI,
+  snapshot, read, or write processor executes;
+- this path does not introduce a Nacos `RequestHandler` or payload wrapper;
+- the credential reuses `nacos.core.auth.server.identity.key` and
+  `nacos.core.auth.server.identity.value` and is required independently of the
+  public API auth switch;
+- fixed lowercase metadata names `nacos-server-identity-key` and
+  `nacos-server-identity-value` carry the configured key and value, so an
+  operator-defined identity key is not interpreted as a gRPC metadata name;
+- logs must never print the identity value;
+- rolling-upgrade compatibility and enforcement transition rules are owned by
+  the [CP Consistency Spec](foundation-cp-consistency-spec.md).
+
+The credential is request authentication, not transport confidentiality. A
+plaintext JRaft channel remains observable and replayable to an on-path actor;
+deployments that require those protections must secure the transport boundary.
 
 ## 6. Payload Registration
 
@@ -212,6 +241,9 @@ Those retry rules belong to the Config and Naming consistency specs.
   spec explicitly says so.
 - Source labels, connection existence, or member membership alone are not
   authorization. Inner requests must use server identity and the auth filter.
+- JRaft member capability metadata is an upgrade signal, not an identity or
+  authorization proof. JRaft request admission depends on the credential
+  validated by the server interceptor.
 - `ClusterRpcClientProxy` must remain transport-oriented. It must not own
   Config, Naming, AI, or plugin payload semantics.
 - Domain payloads must not depend on unbounded request body size, blocking

--- a/specs/zh-cn/auth/auth-permission-spec.md
+++ b/specs/zh-cn/auth/auth-permission-spec.md
@@ -148,6 +148,10 @@ Nacos 将请求级授权和数据级可见性分开处理。
 
 服务端内部请求在继续处理前，还可能要求配置的服务端身份 key 和 value 校验通过。
 
+JRaft 原生 gRPC 虽然不使用 Nacos `RequestHandler`，仍属于服务端内部传输。客户端通过 gRPC
+`CallCredentials` 传输 server identity，服务端通过 `ServerInterceptor` 校验。集群进入强制状态后，
+关闭公开 Open API 鉴权不得绕过 JRaft server identity。
+
 ## 资源权限名
 
 Nacos 权限基于[资源模型](../design/resource-model-spec.md)派生的资源进行评估：

--- a/specs/zh-cn/design/foundation-cluster-membership-spec.md
+++ b/specs/zh-cn/design/foundation-cluster-membership-spec.md
@@ -55,6 +55,7 @@ Nacos Server member 由 `Member` 表示。`Member` 继承公开的 `NacosMember`
 | `abilities` | 由 member 上报的服务端能力表，包括 remote、config 和 naming 能力。 |
 | `failAccessCnt` | 本地临时失败计数，用于把 member 从 suspicious 推进到 down。 |
 | `grpcReportEnabled` | 混合版本 member 上报的兼容标记，不是新的语义能力。 |
+| `supportJraftAuth` | 临时滚动升级能力，表示 member 能发送和校验 JRaft server identity credential；它不是身份凭据。 |
 
 Member 身份规则：
 
@@ -106,6 +107,10 @@ Lookup 选择规则：
 `ServerMemberManager.update(Member)` 用于更新已存在 member 的元数据/状态。它不得新增未知 member。
 如果更新改变基础元数据，则发布以该 member 为 trigger 的 `MembersChangeEvent`。
 
+临时 `supportJraftAuth` 元数据只能由真正实现该能力的本机 member 设置，address lookup 不得为远端
+member 推断该值。它需要参与基础元数据变化检测，使经过鉴权的 member report 能收敛能力视图。
+使用方可以通过全量 member 视图完成滚动升级迁移，但不得把该字段作为请求身份或授权证据。
+
 ## 5. Member Ready 与健康观测
 
 本机 ready 由 `ServerMemberManager.setSelfReady` 设置。它会将本机 member 标记为 `UP`，把本机
@@ -155,6 +160,7 @@ Member 健康是本地对服务端 peer 的观测。它不能替代 AP/CP 协议
 - 除非通过 `MembersChangeEvent` 刷新，否则不要长期缓存 member list；
 - 除非领域规范明确声明，否则不要把 member 顺序视为领域分片规则；
 - 不要把领域归属写入 `Member.extendInfo`。
+- 升级使用方一旦锁存某项安全能力，不得因为后续 member 新增、删除或更新而关闭该能力。
 
 ## 8. 相关规范
 

--- a/specs/zh-cn/design/foundation-cp-consistency-spec.md
+++ b/specs/zh-cn/design/foundation-cp-consistency-spec.md
@@ -104,6 +104,36 @@ JRaft 是当前使用的多 group CP 运行时。
 实现中的超时是运维默认值，不是公开 API 保证。除非领域 API 明确声明，领域规范不得把 JRaft
 超时值暴露为用户可见正确性契约。
 
+### JRaft 传输鉴权
+
+JRaft 原生 gRPC 是服务端间 inner transport。新版本 JRaft client 始终通过 gRPC
+`CallCredentials` 携带配置的 Nacos server identity，服务端始终在分发给 JRaft processor 前通过
+`ServerInterceptor` 校验。
+
+滚动升级使用临时两态迁移：
+
+```text
+COMPATIBLE -> ENFORCED
+```
+
+`COMPATIBLE` 状态下，缺失或错误 credential 会被限频记录，但请求继续执行，因为旧 member 无法携带
+credential。每个新 member 发布临时能力 `supportJraftAuth=true`。完整 member 视图中的所有 member
+都上报该能力后，本机自动且不可逆地进入 `ENFORCED`。在 `ENFORCED` 中，缺失或错误 credential
+会在 processor 执行前以 gRPC `UNAUTHENTICATED` 拒绝。
+
+状态迁移是单向的。Member 新增、删除或元数据更新不得使已强制的进程回到兼容状态。运行态必须先锁存
+强制鉴权，再写入 `{nacos.home}/data/jraft-auth-enforced.state`；状态文件写入失败不得延迟强制鉴权，
+后续定时检查必须持续重试。服务端重启发现该文件时必须立即强制鉴权。状态文件不包含 server identity
+或 member 数据，也不是运维回退开关。
+
+能力发现、兼容放行、状态迁移和状态文件处理必须由一个独立兼容组件拥有。该组件从引入时即标记废弃，
+Javadoc 明确在 Nacos 4.0.0 删除，并且不得拥有永久 credential 解析或校验逻辑。Nacos 4.0.0 删除该
+组件后始终强制 JRaft server identity。
+
+进入强制状态后，向不携带 JRaft credential 的旧版本做混合滚动降级不保证无损或可用。旧 client
+不能调用已强制的新 server，leader 所在位置和 group quorum 分布可能导致选主、复制、ReadIndex、
+leader 转发、snapshot 和 CLI 操作失败。
+
 ## 6. 当前 CP 使用方
 
 | Group | 归属 | 用途 |

--- a/specs/zh-cn/design/foundation-internal-rpc-spec.md
+++ b/specs/zh-cn/design/foundation-internal-rpc-spec.md
@@ -53,7 +53,10 @@ Cluster gRPC Server 使用 `cluster` 来源标签。`ClusterRpcClientProxy` 创�
 RemoteConstants.LABEL_SOURCE = RemoteConstants.LABEL_SOURCE_CLUSTER
 ```
 
-因此内部 RPC 不是独立的协议族，而是在远程层之上施加来源、鉴权和 handler 约束的一类调用纪律。
+大部分内部 RPC 不是独立的协议族，而是在远程层之上施加来源、鉴权和 handler 约束的一类调用纪律。
+内置 JRaft CP 传输是例外：它使用 JRaft 原生 gRPC message 和 processor，而不是 Nacos
+`Payload` 与 `RequestHandler` 模型，但仍属于服务端间 inner API，并遵循本文的 server identity
+规则。
 
 模型如下：
 
@@ -113,6 +116,9 @@ Handler 拥有请求语义。远程基础层拥有 dispatch、来源检查、请
 - 公开 API 鉴权关闭，不代表可以跳过必要的 inner server identity 校验；
 - 领域需要 namespace 校验、参数提取、TPS control 等能力时，应在 handler 上声明对应 filter。
 
+`InnerApiAuthEnabled` 只用于从 2.x 滚动升级至 3.x 的兼容窗口，并标记为在 Nacos 3.4.0 删除；
+永久的 inner API server identity 校验不得依赖该临时组件。
+
 已知请求 filter 关注点包括：
 
 | Filter 关注点 | 典型注解或路径 | 规则 |
@@ -121,6 +127,23 @@ Handler 拥有请求语义。远程基础层拥有 dispatch、来源检查、请
 | 参数校验 | `@ExtractorManager.Extractor` | 复用共享参数提取和校验。 |
 | Namespace 校验 | `@NamespaceValidation` | 当资源身份包含 namespace 时校验 namespace 存在性。 |
 | TPS Control | `@TpsControl` | 为集群流量注册并执行稳定 control 点。 |
+
+JRaft 原生 gRPC 鉴权遵循以下传输规则：
+
+- 所有新版本 JRaft client 都通过 gRPC `CallCredentials` 携带配置的 Nacos server identity；
+- gRPC `ServerInterceptor` 在任何 Raft、CLI、snapshot、read 或 write processor 执行前校验
+  credential；
+- 该路径不引入 Nacos `RequestHandler` 或 payload 包裹；
+- credential 复用 `nacos.core.auth.server.identity.key` 和
+  `nacos.core.auth.server.identity.value`，且不受公开 API 鉴权开关影响；
+- 使用固定的小写 metadata 名称 `nacos-server-identity-key` 和
+  `nacos-server-identity-value` 承载配置的 key 与 value，避免将用户配置的 identity key
+  直接解释为 gRPC metadata 名称；
+- 日志不得输出 identity value；
+- 滚动升级兼容和强制状态迁移规则由[CP 一致性规范](foundation-cp-consistency-spec.md)定义。
+
+该 credential 只提供请求身份校验，不提供传输机密性。明文 JRaft 链路仍可能被链路中间方观察或
+重放；需要相应保护的部署必须同时保护传输边界。
 
 ## 6. Payload 注册
 
@@ -174,6 +197,8 @@ Cluster RPC 调用方必须定义自己的重试或补偿行为。
 
 - 除非接口规范显式声明，内部 RPC 不是公开 HTTP、SDK 或 open gRPC API。
 - 来源标签、连接存在性或 member 关系本身不是鉴权。Inner request 必须使用服务端身份和 auth filter。
+- JRaft member 能力元数据只是升级信号，不是身份或授权证明。JRaft 请求准入取决于 server
+  interceptor 校验的 credential。
 - `ClusterRpcClientProxy` 必须保持传输职责，不应拥有 Config、Naming、AI 或插件 payload 语义。
 - 领域 payload 不应依赖无限制 request body、阻塞 callback，或在关键 remote 线程上执行慢速远端 IO。
 - 当内部 payload 的兼容字段影响滚动升级行为时，应在领域层记录。


### PR DESCRIPTION
## What is the purpose of the change

Add Nacos server identity authentication to native JRaft gRPC traffic while preserving rolling-upgrade compatibility.

## Brief changelog

- Attach the configured Nacos server identity to every JRaft gRPC client request through `CallCredentials`.
- Validate the identity in a JRaft `ServerInterceptor` before request dispatch.
- Automatically enable enforcement after every member advertises JRaft authentication support, then persist the irreversible state under `${nacos.home}/data`.
- Isolate and deprecate the rolling-upgrade coordinator for removal in Nacos 4.0.0.
- Document the transport, membership capability, rolling-upgrade, downgrade, and persistence behavior in the English and Chinese specifications.

## Verifying this change

- Passed the full 61-module compile, Apache RAT, Checkstyle, SpotBugs, and Spotless checks.
- Passed 15 focused unit tests for the JRaft credentials, interceptor, upgrade coordinator, and gRPC factory/client.
- Started Nacos in cluster mode with embedded storage and exercised native JRaft `PingRequest` calls on port 7848:
  - missing identity: `UNAUTHENTICATED`
  - invalid identity: `UNAUTHENTICATED`
  - valid identity: `OK`
- Restarted with the persisted enforcement marker and confirmed authentication enforcement did not roll back.

## Checklist

- [x] The title and description are meaningful.
- [x] Unit tests cover the new behavior.
- [x] Local formatting and static checks pass.
