### PR TITLE
[Refactor] Align controller context path URI parsing

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
+++ b/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
@@ -99,8 +99,9 @@ public class ControllerMethodsCache {
     
     private String resolveContextPath(HttpServletRequest request) {
         String requestContextPath = request.getContextPath();
-        return StringUtils.isEmpty(requestContextPath) ? EnvUtil.getContextPath()
+        String contextPath = StringUtils.isEmpty(requestContextPath) ? EnvUtil.getContextPath()
             : requestContextPath;
+        return StringUtils.isEmpty(contextPath) ? contextPath : getPath(contextPath);
     }
     
     private String stripContextPath(String path, String contextPath) {
@@ -115,8 +116,12 @@ public class ControllerMethodsCache {
     }
     
     private String getPath(HttpServletRequest request) {
+        return getPath(request.getRequestURI());
+    }
+    
+    private String getPath(String uri) {
         try {
-            return new URI(request.getRequestURI()).getPath();
+            return new URI(uri).getPath();
         } catch (URISyntaxException e) {
             LOGGER.error("parse request to path error", e);
             throw new NacosRuntimeException(NacosException.NOT_FOUND, "Invalid URI");

--- a/core/src/test/java/com/alibaba/nacos/core/code/ControllerMethodsCacheTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/code/ControllerMethodsCacheTest.java
@@ -148,6 +148,18 @@ class ControllerMethodsCacheTest {
     }
     
     @Test
+    void getMethodWithEncodedRequestSpecificContextPath() throws Exception {
+        cache.initClassMethod(Collections.singleton(TestController.class));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/n%61cos/api/get");
+        request.setContextPath("/n%61cos");
+        request.setRequestURI("/n%61cos/api/get");
+        request.setParameter("required", "yes");
+        Method method = cache.getMethod(request);
+        assertNotNull(method);
+        assertEquals("get", method.getName());
+    }
+    
+    @Test
     void ambiguousMappingThrowsIllegalStateException() {
         cache.initClassMethod(Collections.singleton(AmbiguousController.class));
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/ambig/same");

--- a/specs/en/design/foundation-request-context-spec.md
+++ b/specs/en/design/foundation-request-context-spec.md
@@ -79,6 +79,9 @@ Core HTTP filter responsibilities:
 - `HttpRequestContextFilter` initializes and clears `RequestContext`.
 - `AuthFilter`, `AuthAdminFilter`, and console auth filters process
   `@Secured` APIs and write `AuthContext` when auth is evaluated.
+- Filters that resolve controller metadata from a request path must parse the
+  request URI and context path consistently before removing the context path,
+  including when either value contains percent-encoded characters.
 - `NacosHttpTpsFilter` checks `@TpsControl` points through the Control plugin
   manager for HTTP v1/v2 Config and Naming paths.
 - `ParamCheckerFilter` extracts structured parameters through

--- a/specs/zh-cn/design/foundation-request-context-spec.md
+++ b/specs/zh-cn/design/foundation-request-context-spec.md
@@ -65,6 +65,8 @@ HTTP filter 是由 Nacos web 配置和领域模块注册的 servlet filter。
 - `HttpRequestContextFilter` 初始化并清理 `RequestContext`。
 - `AuthFilter`、`AuthAdminFilter` 和控制台鉴权 filter 处理 `@Secured` API，并在执行鉴权时写入
   `AuthContext`。
+- filter 根据请求路径定位 controller 元数据时，必须在移除 context path 前使用一致的方式解析
+  request URI 和 context path，包括任一值包含百分号编码字符的情况。
 - `NacosHttpTpsFilter` 对 HTTP v1/v2 Config 和 Naming 路径，通过 Control 插件 manager 检查
   `@TpsControl` 点位。
 - `ParamCheckerFilter` 通过 `ExtractorManager` 提取结构化参数，并使用当前激活的 `ParamChecker`


### PR DESCRIPTION
## What is the purpose of the change

Align `ControllerMethodsCache` context-path handling with request URI handling on the v3.2.4 line. The request URI is parsed with `URI.getPath()`, while a request-specific context path was previously compared without equivalent parsing. For percent-encoded context paths such as `/n%61cos/...`, the decoded request path and raw context path did not match, so controller metadata could not be resolved.

## Brief changelog

- Parse request-specific and configured context paths with the same `URI.getPath()` logic used for request URIs.
- Add a regression unit test for `/n%61cos/api/get`.
- Document consistent request URI and context-path processing in the request filtering specs.

## Verifying this change

- `mvn -pl core spotless:apply`
- `mvn -pl core spotless:check`
- `mvn -pl core -Dtest=ControllerMethodsCacheTest -DfailIfNoTests=false test` (21 tests passed)
- `AmbiguousUriAuthITCase` from `develop` against the v3.2.4 standalone server (60 tests passed)
- Full `clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check` validation (60 modules passed)
- `mvn -B clean install -Prelease-nacos -DskipTests=true` (60 modules passed)

## Checklist

- [ ] Make sure there is a GitHub issue filed for the change (usually before you start working on it).
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side). If you are opening from a fork, please target the branch on the left side of the maintainer repository.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main/master/develop branch!
- [x] Make sure you have added or run the tests that verify your changes.
- [x] If your change contains code, make sure you have written and run tests for it.

