### PR TITLE
[ISSUE #11890] Check instance existence before removing expired instance metadata

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/core/v2/cleaner/ExpiredMetadataCleaner.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/core/v2/cleaner/ExpiredMetadataCleaner.java
@@ -16,9 +16,14 @@
 
 package com.alibaba.nacos.naming.core.v2.cleaner;
 
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
+import com.alibaba.nacos.naming.core.v2.index.ServiceStorage;
 import com.alibaba.nacos.naming.core.v2.metadata.ExpiredMetadataInfo;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataOperateService;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.misc.GlobalConfig;
 import com.alibaba.nacos.naming.misc.GlobalExecutor;
 import com.alibaba.nacos.naming.misc.Loggers;
@@ -42,10 +47,13 @@ public class ExpiredMetadataCleaner extends AbstractNamingCleaner {
     
     private final NamingMetadataOperateService metadataOperateService;
     
+    private final ServiceStorage serviceStorage;
+    
     public ExpiredMetadataCleaner(NamingMetadataManager metadataManager,
-        NamingMetadataOperateService metadataOperateService) {
+        NamingMetadataOperateService metadataOperateService, ServiceStorage serviceStorage) {
         this.metadataManager = metadataManager;
         this.metadataOperateService = metadataOperateService;
+        this.serviceStorage = serviceStorage;
         GlobalExecutor.scheduleExpiredClientCleaner(this, INITIAL_DELAY,
             GlobalConfig.getExpiredMetadataCleanInterval(),
             TimeUnit.MILLISECONDS);
@@ -67,17 +75,52 @@ public class ExpiredMetadataCleaner extends AbstractNamingCleaner {
     }
     
     private void removeExpiredMetadata(ExpiredMetadataInfo expiredInfo) {
-        Loggers.SRV_LOG.info("Remove expired metadata {}", expiredInfo);
         if (null == expiredInfo.getMetadataId()) {
+            Loggers.SRV_LOG.info("Remove expired metadata {}", expiredInfo);
             if (metadataManager.containServiceMetadata(expiredInfo.getService())) {
                 metadataOperateService.deleteServiceMetadata(expiredInfo.getService());
             }
         } else {
+            if (isInstanceStillRegistered(expiredInfo)) {
+                // The metadata id is derived from ip:port:cluster rather than from the client id,
+                // so the same instance can be re-registered by another client after the original
+                // client is expired. In that case the metadata is still in use, keep it and stop
+                // tracking this expired record.
+                Loggers.SRV_LOG.info("Instance is still registered, keep metadata {}", expiredInfo);
+                metadataManager.getExpiredMetadataInfos().remove(expiredInfo);
+                return;
+            }
+            Loggers.SRV_LOG.info("Remove expired metadata {}", expiredInfo);
             if (metadataManager.containInstanceMetadata(expiredInfo.getService(),
                 expiredInfo.getMetadataId())) {
                 metadataOperateService.deleteInstanceMetadata(expiredInfo.getService(),
                     expiredInfo.getMetadataId());
             }
         }
+    }
+    
+    /**
+     * Check whether the instance owning the expired metadata is still registered in its service.
+     *
+     * <p>The metadata id is rebuilt from each published instance instead of being parsed back from
+     * the expired metadata id, so that IPv6 addresses containing colons are handled correctly.</p>
+     *
+     * @param expiredInfo expired instance metadata info
+     * @return {@code true} if the instance is still registered
+     */
+    private boolean isInstanceStillRegistered(ExpiredMetadataInfo expiredInfo) {
+        Service service = expiredInfo.getService();
+        ServiceInfo serviceInfo = serviceStorage.getPushData(service);
+        if (null == serviceInfo || null == serviceInfo.getHosts()) {
+            return false;
+        }
+        for (Instance each : serviceInfo.getHosts()) {
+            String metadataId = InstancePublishInfo
+                .genMetadataId(each.getIp(), each.getPort(), each.getClusterName());
+            if (metadataId.equals(expiredInfo.getMetadataId())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/core/v2/cleaner/ExpiredMetadataCleanerTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/core/v2/cleaner/ExpiredMetadataCleanerTest.java
@@ -16,10 +16,15 @@
 
 package com.alibaba.nacos.naming.core.v2.cleaner;
 
+import com.alibaba.nacos.api.naming.pojo.Instance;
+import com.alibaba.nacos.api.naming.pojo.ServiceInfo;
 import com.alibaba.nacos.common.utils.ConcurrentHashSet;
+import com.alibaba.nacos.naming.core.v2.index.ServiceStorage;
 import com.alibaba.nacos.naming.core.v2.metadata.ExpiredMetadataInfo;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataManager;
 import com.alibaba.nacos.naming.core.v2.metadata.NamingMetadataOperateService;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
+import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,9 +34,13 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,6 +48,16 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ExpiredMetadataCleanerTest {
+    
+    private static final String IP = "1.1.1.1";
+    
+    private static final int PORT = 8848;
+    
+    private static final String CLUSTER = "DEFAULT";
+    
+    private static final String METADATA_ID = InstancePublishInfo.genMetadataId(IP, PORT, CLUSTER);
+    
+    private static final Service SERVICE = Service.newService("public", "DEFAULT_GROUP", "test.1");
     
     private ExpiredMetadataCleaner expiredMetadataCleaner;
     
@@ -53,11 +72,14 @@ class ExpiredMetadataCleanerTest {
     @Mock
     private ExpiredMetadataInfo expiredMetadataInfoMock;
     
+    @Mock
+    private ServiceStorage serviceStorageMock;
+    
     @BeforeEach
     void setUp() throws Exception {
         EnvUtil.setEnvironment(new MockEnvironment());
-        expiredMetadataCleaner =
-            new ExpiredMetadataCleaner(metadataManagerMock, metadataOperateServiceMock);
+        expiredMetadataCleaner = new ExpiredMetadataCleaner(metadataManagerMock,
+            metadataOperateServiceMock, serviceStorageMock);
         
         set.add(expiredMetadataInfoMock);
         
@@ -94,13 +116,73 @@ class ExpiredMetadataCleanerTest {
     
     @Test
     void testDoCleanRemovesInstanceMetadata() {
-        when(expiredMetadataInfoMock.getMetadataId()).thenReturn("1.1.1.1:8848");
+        when(expiredMetadataInfoMock.getMetadataId()).thenReturn(METADATA_ID);
+        when(serviceStorageMock.getPushData(any())).thenReturn(serviceInfoWithHosts());
         when(metadataManagerMock.containInstanceMetadata(expiredMetadataInfoMock.getService(),
-            "1.1.1.1:8848")).thenReturn(true);
+            METADATA_ID)).thenReturn(true);
         
         expiredMetadataCleaner.doClean();
         
         verify(metadataOperateServiceMock)
-            .deleteInstanceMetadata(expiredMetadataInfoMock.getService(), "1.1.1.1:8848");
+            .deleteInstanceMetadata(expiredMetadataInfoMock.getService(), METADATA_ID);
+    }
+    
+    @Test
+    void testDoCleanKeepsInstanceMetadataWhenInstanceStillRegistered() {
+        // Arrange: the owning client disconnected, but the same instance was
+        // re-registered by another client, so it is still present in the service.
+        when(expiredMetadataInfoMock.getService()).thenReturn(SERVICE);
+        when(expiredMetadataInfoMock.getMetadataId()).thenReturn(METADATA_ID);
+        when(serviceStorageMock.getPushData(SERVICE))
+            .thenReturn(serviceInfoWithHosts(instance(IP, PORT, CLUSTER)));
+        Mockito.lenient()
+            .when(metadataManagerMock.containInstanceMetadata(SERVICE, METADATA_ID))
+            .thenReturn(true);
+        
+        // Act
+        expiredMetadataCleaner.doClean();
+        
+        // Assert
+        verify(metadataOperateServiceMock, never()).deleteInstanceMetadata(any(), any());
+    }
+    
+    @Test
+    void testDoCleanUntracksExpiredInfoWhenInstanceStillRegistered() {
+        when(expiredMetadataInfoMock.getService()).thenReturn(SERVICE);
+        when(expiredMetadataInfoMock.getMetadataId()).thenReturn(METADATA_ID);
+        when(serviceStorageMock.getPushData(SERVICE))
+            .thenReturn(serviceInfoWithHosts(instance(IP, PORT, CLUSTER)));
+        assertTrue(set.contains(expiredMetadataInfoMock));
+        
+        expiredMetadataCleaner.doClean();
+        
+        assertFalse(set.contains(expiredMetadataInfoMock));
+    }
+    
+    @Test
+    void testDoCleanRemovesInstanceMetadataWhenOnlyAnotherInstanceRemains() {
+        when(expiredMetadataInfoMock.getService()).thenReturn(SERVICE);
+        when(expiredMetadataInfoMock.getMetadataId()).thenReturn(METADATA_ID);
+        when(serviceStorageMock.getPushData(SERVICE))
+            .thenReturn(serviceInfoWithHosts(instance(IP, PORT + 1, CLUSTER)));
+        when(metadataManagerMock.containInstanceMetadata(SERVICE, METADATA_ID)).thenReturn(true);
+        
+        expiredMetadataCleaner.doClean();
+        
+        verify(metadataOperateServiceMock).deleteInstanceMetadata(SERVICE, METADATA_ID);
+    }
+    
+    private static ServiceInfo serviceInfoWithHosts(Instance... hosts) {
+        ServiceInfo serviceInfo = new ServiceInfo();
+        serviceInfo.setHosts(hosts.length == 0 ? Collections.emptyList() : List.of(hosts));
+        return serviceInfo;
+    }
+    
+    private static Instance instance(String ip, int port, String cluster) {
+        Instance instance = new Instance();
+        instance.setIp(ip);
+        instance.setPort(port);
+        instance.setClusterName(cluster);
+        return instance;
     }
 }

--- a/specs/en/naming/naming-metadata-selector-spec.md
+++ b/specs/en/naming/naming-metadata-selector-spec.md
@@ -155,6 +155,13 @@ through the CP metadata path. Metadata may outlive runtime clients temporarily.
 Expired metadata cleanup removes metadata after its owning service or instance
 becomes detached for the configured expiration window.
 
+Instance metadata is identified by the instance identity, not by the publishing
+client. The disconnection of a client does not by itself detach the instance:
+the same instance may have been re-registered by another client. Cleanup must
+therefore confirm that the instance is no longer registered in its service
+before the metadata is removed, and must stop tracking the expired record when
+the instance is still registered.
+
 Runtime metadata follows the lifecycle of the runtime publisher. Operational
 metadata follows the metadata persistence path and may overlay runtime metadata
 after recovery.

--- a/specs/zh-cn/naming/naming-metadata-selector-spec.md
+++ b/specs/zh-cn/naming/naming-metadata-selector-spec.md
@@ -136,6 +136,10 @@ Service metadata、cluster metadata 和 instance metadata 操作通过 CP metada
 可能在运行时 client 消失后临时存活。过期元数据清理会在所属 service 或 instance 脱离达到配置
 过期窗口后移除元数据。
 
+instance metadata 由 instance identity 标识，而非由发布它的 client 标识。client 断开本身并不
+代表 instance 脱离：同一个 instance 可能已被另一个 client 重新注册。因此清理前必须确认该
+instance 已不再注册于其 service，若 instance 仍在注册中，则应保留元数据并停止跟踪该过期记录。
+
 运行时元数据跟随运行时 publisher 生命周期。运维态元数据跟随元数据持久化路径，并可以在恢复后
 覆盖运行时元数据。
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes #11890.

Instance metadata (for example the "offline" state set from the console) is
silently lost after restarting one node of a Nacos cluster.

The metadata id of an instance is `ip:port:cluster` and does not contain the
client id, so the same instance can be re-registered by a different client:

1. Client connects to Nacos1 as `client_1`; the instance is set offline.
2. Nacos1 is restarted. The client reconnects to Nacos2 as `client_2` and
   re-registers the same instance, so the instance is still registered.
3. Nacos2/Nacos3 still hold the stale `client_1`. When it expires,
   `ExpiredClientCleaner` publishes `ClientDisconnectEvent`, and
   `NamingMetadataManager` marks the instance metadata expired — the same
   metadata id that `client_2` is now using.
4. After `nacos.naming.expired-metadata.expired-time` (60s by default),
   `ExpiredMetadataCleaner` deletes the metadata and the offline state is gone.

This also aligns the code with the Naming Metadata And Selector Spec, which
already states that expired metadata cleanup happens after the owning instance
"becomes detached" — the disconnection of one client is not by itself a detach.

The approach follows the direction agreed by maintainers in the issue: do the
check in the cleaner, and use `ServiceStorage.getPushData(...)` to read the real
data.

## Brief changelog

- `ExpiredMetadataCleaner` now confirms the instance is no longer registered in
  its service before deleting instance metadata.
- When the instance is still registered, the expired record is dropped from
  `NamingMetadataManager#getExpiredMetadataInfos()` so it is not re-checked on
  every clean cycle (default interval 5s). A later genuine detach re-adds it
  with a fresh create time.
- The instance is matched by rebuilding the metadata id from each published
  instance via `InstancePublishInfo#genMetadataId`, instead of parsing the
  expired metadata id back into ip/port/cluster. Splitting on `:` would be wrong
  for IPv6 addresses, and this keeps `InstancePublishInfo` unchanged.
- Service metadata cleanup is unchanged; the extra lookup only runs for instance
  metadata that has already passed the expiration window.
- Spec clarification added to `naming-metadata-selector-spec.md` (en + zh-cn).

No HTTP API, gRPC API or Java SDK contract is changed, so `test/openapi-test`
and `test/java-sdk-test` coverage is not affected.

## Verifying this change

`ExpiredMetadataCleanerTest` — 3 new cases, verified to fail before the fix:

- instance still registered -> metadata is kept (previously deleted);
- instance still registered -> expired record is untracked;
- only a different instance remains -> metadata is still deleted (regression
  guard for the existing behaviour).

Local verification:

- `mvn -pl naming test` — 982 tests, 0 failures.
- `mvn -pl naming spotless:check checkstyle:check spotbugs:check apache-rat:check`
  — all pass, 0 Checkstyle violations.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
