### PR TITLE
[ISSUE #14008] Mirror relocated grpc native image metadata in shaded nacos-client

### DIFF
--- a/client/src/main/resources/META-INF/native-image/com.alibaba.nacos/nacos-client/native-image.properties
+++ b/client/src/main/resources/META-INF/native-image/com.alibaba.nacos/nacos-client/native-image.properties
@@ -1,0 +1,41 @@
+# Copyright 1999-2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# nacos-client is published as a shaded jar: maven-shade-plugin relocates io.grpc.**
+# (which embeds netty as io.grpc.netty.shaded.io.netty.**) under
+# com.alibaba.nacos.shaded.**, see the relocations section of client/pom.xml.
+#
+# The shade plugin rewrites class files but not the textual content of
+# META-INF/native-image/**, so the class initialization directives that
+# io.grpc:grpc-netty-shaded ships in its own native-image.properties files no longer
+# match any class of the published jar and are silently dropped by GraalVM. Without the
+# mirrored directives below, netty is initialized at build time where it must be
+# initialized at run time, and the resulting native image fails while the gRPC channel
+# performs protocol negotiation.
+#
+# Keep this file in sync with the metadata of the resolved grpc-netty-shaded version;
+# NativeImageMetadataConsistencyTest fails when a directive has no mirror here.
+
+Args = --initialize-at-build-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.buffer.ByteBufAllocator,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.buffer.ByteBufUtil,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.buffer.AbstractReferenceCountedByteBuf \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.util.AbstractReferenceCounted,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.util.concurrent.GlobalEventExecutor,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.util.concurrent.ImmediateEventExecutor,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.util.concurrent.ScheduledFutureTask,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.util.internal.ThreadLocalRandom \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.util.NetUtilSubstitutions$NetUtilLocalhost4LazyHolder \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.util.NetUtilSubstitutions$NetUtilLocalhost6LazyHolder \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.util.NetUtilSubstitutions$NetUtilLocalhostLazyHolder \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.util.NetUtilSubstitutions$NetUtilNetworkInterfacesLazyHolder \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.ssl.util.ThreadLocalInsecureRandom \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.codec.compression.BrotliDecoder \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.codec.http.HttpObjectEncoder,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2CodecUtil,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2ClientUpgradeCodec,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2ConnectionHandler,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2FrameWriter \
+       --initialize-at-run-time=com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.channel.epoll,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.channel.unix.Limits,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.channel.unix.IovArray,com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.channel.unix.Errors

--- a/client/src/main/resources/META-INF/native-image/com.alibaba.nacos/nacos-client/reflect-config.json
+++ b/client/src/main/resources/META-INF/native-image/com.alibaba.nacos/nacos-client/reflect-config.json
@@ -1354,6 +1354,10 @@
     "name":"com.alibaba.nacos.shaded.io.grpc.internal.DnsNameResolverProvider"
   },
   {
+    "name":"com.alibaba.nacos.shaded.io.grpc.internal.JndiResourceResolverFactory",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
     "name":"com.alibaba.nacos.shaded.io.grpc.internal.PickFirstLoadBalancerProvider"
   },
   {
@@ -1467,8 +1471,17 @@
     ]
   },
   {
+    "name":"com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.channel.DefaultFileRegion"
+  },
+  {
+    "name":"com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket"
+  },
+  {
     "name":"com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel",
     "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "name":"com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.channel.unix.PeerCredentials"
   },
   {
     "name":"com.alibaba.nacos.shaded.io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder",

--- a/client/src/test/java/com/alibaba/nacos/client/nativeimage/NativeImageMetadataConsistencyTest.java
+++ b/client/src/test/java/com/alibaba/nacos/client/nativeimage/NativeImageMetadataConsistencyTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 1999-2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.client.nativeimage;
+
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Consistency tests for the GraalVM native image metadata shipped by nacos-client.
+ *
+ * <p>{@code nacos-client} is published as a shaded jar: {@code maven-shade-plugin} relocates
+ * {@code io.grpc.**}, {@code com.google.**} and friends under {@code com.alibaba.nacos.shaded.**},
+ * see the {@code relocations} section of {@code client/pom.xml}. The shade plugin rewrites class
+ * files, but it does not rewrite the textual content of {@code META-INF/native-image/**} metadata.
+ * So every reachability entry inherited from a relocated dependency must also be declared under the
+ * {@code com.alibaba.nacos.shaded.} prefix, otherwise GraalVM silently drops it and the resulting
+ * native image fails at runtime.</p>
+ *
+ * @author wushiyuanmaimob
+ */
+class NativeImageMetadataConsistencyTest {
+    
+    /**
+     * Prefix applied by {@code maven-shade-plugin} to all relocated packages.
+     */
+    private static final String SHADED_PREFIX = "com.alibaba.nacos.shaded.";
+    
+    private static final String NACOS_METADATA_DIR =
+        "META-INF/native-image/com.alibaba.nacos/nacos-client/";
+    
+    private static final String NATIVE_IMAGE_PROPERTIES = "native-image.properties";
+    
+    private static final String REFLECT_CONFIG = "reflect-config.json";
+    
+    private static final String NATIVE_IMAGE_METADATA_ROOT = "META-INF/native-image/";
+    
+    private static final String INIT_AT_BUILD_TIME = "--initialize-at-build-time=";
+    
+    private static final String INIT_AT_RUN_TIME = "--initialize-at-run-time=";
+    
+    private static final String NAME_FIELD = "name";
+    
+    /**
+     * Source prefixes of the relocations declared in {@code client/pom.xml}. Any metadata entry
+     * starting with one of them is repackaged in the shaded jar and needs a mirrored entry.
+     */
+    private static final List<String> RELOCATED_PREFIXES = Arrays.asList("io.grpc.", "io.netty.",
+        "com.google.", "io.perfmark.", "io.opencensus.", "javax.annotation.",
+        "org.checkerframework.", "android.annotation.");
+    
+    @Test
+    void testEveryInheritedInitializationArgHasShadedMirror()
+        throws IOException, URISyntaxException {
+        Set<String> inherited = readInitializationTargets(readRelocatedDependencyProperties());
+        Set<String> mirrored = readInitializationTargets(readNacosClientProperties());
+        Set<String> missing = new TreeSet<>();
+        for (String each : inherited) {
+            if (!mirrored.contains(SHADED_PREFIX + each)) {
+                missing.add(each);
+            }
+        }
+        assertTrue(missing.isEmpty(),
+            "nacos-client is shaded, so these class initialization directives inherited from "
+                + "io.grpc:grpc-netty-shaded match no class in the published jar and must be "
+                + "mirrored under " + SHADED_PREFIX + " in " + NACOS_METADATA_DIR
+                + NATIVE_IMAGE_PROPERTIES + ": " + missing);
+    }
+    
+    @Test
+    void testEveryRelocatedReflectConfigEntryHasShadedMirror() throws IOException {
+        Set<String> names = readReflectConfigNames();
+        assertFalse(names.isEmpty(), REFLECT_CONFIG + " should not be empty");
+        Set<String> missing = new TreeSet<>();
+        for (String each : names) {
+            if (isRelocated(each) && !names.contains(SHADED_PREFIX + each)) {
+                missing.add(each);
+            }
+        }
+        assertTrue(missing.isEmpty(),
+            "these " + REFLECT_CONFIG + " entries are relocated by the shade plugin and need a "
+                + SHADED_PREFIX + " twin, otherwise they are dead in the published jar: "
+                + missing);
+    }
+    
+    private boolean isRelocated(String className) {
+        if (className.startsWith(SHADED_PREFIX)) {
+            return false;
+        }
+        for (String each : RELOCATED_PREFIXES) {
+            if (className.startsWith(each)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    private Set<String> readReflectConfigNames() throws IOException {
+        Set<String> result = new LinkedHashSet<>();
+        try (InputStream inputStream = openNacosMetadata(REFLECT_CONFIG)) {
+            JsonNode root = JacksonUtils.toObj(inputStream, JsonNode.class);
+            for (JsonNode each : root) {
+                JsonNode name = each.get(NAME_FIELD);
+                if (null != name) {
+                    result.add(name.asText());
+                }
+            }
+        }
+        return result;
+    }
+    
+    private InputStream openNacosMetadata(String fileName) {
+        InputStream result = Thread.currentThread().getContextClassLoader()
+            .getResourceAsStream(NACOS_METADATA_DIR + fileName);
+        assertNotNull(result, "missing native image metadata " + NACOS_METADATA_DIR + fileName);
+        return result;
+    }
+    
+    private List<String> readNacosClientProperties() throws IOException {
+        List<String> result = new ArrayList<>();
+        Enumeration<URL> urls = Thread.currentThread().getContextClassLoader()
+            .getResources(NACOS_METADATA_DIR + NATIVE_IMAGE_PROPERTIES);
+        while (urls.hasMoreElements()) {
+            try (InputStream inputStream = urls.nextElement().openStream()) {
+                result.add(readAll(inputStream));
+            }
+        }
+        assertEquals(1, result.size(),
+            "nacos-client must ship exactly one " + NACOS_METADATA_DIR + NATIVE_IMAGE_PROPERTIES
+                + " mirroring the class initialization directives of its relocated dependencies");
+        return result;
+    }
+    
+    /**
+     * Read every {@code native-image.properties} shipped by the relocated grpc dependency, taken
+     * from the jar actually resolved on the test classpath so that a grpc upgrade is detected.
+     *
+     * @return raw content of each inherited {@code native-image.properties}
+     * @throws IOException        if the dependency jar can not be read
+     * @throws URISyntaxException if the dependency location is not a valid file URI
+     */
+    private List<String> readRelocatedDependencyProperties()
+        throws IOException, URISyntaxException {
+        URL location =
+            NettyChannelBuilder.class.getProtectionDomain().getCodeSource().getLocation();
+        assertNotNull(location, "cannot locate io.grpc:grpc-netty-shaded on the test classpath");
+        List<String> result = new ArrayList<>();
+        try (JarFile jarFile = new JarFile(new File(location.toURI()))) {
+            Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if (name.startsWith(NATIVE_IMAGE_METADATA_ROOT)
+                    && name.endsWith(NATIVE_IMAGE_PROPERTIES)) {
+                    try (InputStream inputStream = jarFile.getInputStream(entry)) {
+                        result.add(readAll(inputStream));
+                    }
+                }
+            }
+        }
+        assertFalse(result.isEmpty(),
+            "io.grpc:grpc-netty-shaded is expected to ship native image metadata");
+        return result;
+    }
+    
+    /**
+     * Extract the class or package names referenced by {@code --initialize-at-build-time} and
+     * {@code --initialize-at-run-time} directives, joining the backslash continued lines first.
+     */
+    private Set<String> readInitializationTargets(List<String> contents) {
+        Set<String> result = new TreeSet<>();
+        for (String content : contents) {
+            String joined = content.replace("\\\r\n", " ").replace("\\\n", " ");
+            for (String token : joined.split("\\s+")) {
+                String values = null;
+                if (token.startsWith(INIT_AT_BUILD_TIME)) {
+                    values = token.substring(INIT_AT_BUILD_TIME.length());
+                } else if (token.startsWith(INIT_AT_RUN_TIME)) {
+                    values = token.substring(INIT_AT_RUN_TIME.length());
+                }
+                if (null == values) {
+                    continue;
+                }
+                for (String each : values.split(",")) {
+                    if (!each.isEmpty()) {
+                        result.add(each);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+    
+    private String readAll(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int length = inputStream.read(buffer);
+        while (length > 0) {
+            output.write(buffer, 0, length);
+            length = inputStream.read(buffer);
+        }
+        return new String(output.toByteArray(), StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix #14008: a native image built with `nacos-client` compiles successfully but dies at runtime as soon as the gRPC channel is established:

```
UNAVAILABLE: Connection closing while performing protocol negotiation for
[NettyClientHandler#0, WriteBufferingAndExceptionHandler#0, DefaultChannelPipeline$TailContext#0]
```

Root cause is in the packaged GraalVM reachability metadata, not in the client logic.

`nacos-client` is published as a shaded jar. `maven-shade-plugin` relocates `io.grpc.**` — which itself embeds netty as `io.grpc.netty.shaded.io.netty.**` — under `com.alibaba.nacos.shaded.**` (see the `relocations` section of `client/pom.xml`). The shade plugin rewrites class files, but it does **not** rewrite the textual content of `META-INF/native-image/**`. So every reachability directive inherited from `io.grpc:grpc-netty-shaded` still names `io.grpc.netty.shaded.io.netty.*`, a package that does not exist in the published jar, and GraalVM silently drops it.

`reflect-config.json` already handles this by declaring both the original and the relocated name for most entries, but two gaps remain:

1. **There is no mirrored `native-image.properties` at all.** `nacos-client` ships `reflect-config.json`, `resource-config.json`, `jni-config.json`, `proxy-config.json`, `serialization-config.json` and `predefined-classes-config.json`, but no `native-image.properties`. The 7 files that `grpc-netty-shaded:1.78.0` contributes all target `io.grpc.netty.shaded.io.netty.*`, so the **entire netty class-initialization policy is lost** in the shaded jar. Classes that netty requires to be initialized at run time — `PooledByteBufAllocator`, `ByteBufUtil`, `GlobalEventExecutor`, `ScheduledFutureTask`, `Http2ConnectionHandler`, `Http2CodecUtil`, `ThreadLocalInsecureRandom`, the `NetUtilSubstitutions` holders, … — end up initialized at build time instead, which is exactly what breaks the channel during protocol negotiation.

2. **Four `reflect-config.json` entries have no relocated counterpart**: `io.grpc.internal.JndiResourceResolverFactory`, `io.grpc.netty.shaded.io.netty.channel.DefaultFileRegion`, `io.grpc.netty.shaded.io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket` and `io.grpc.netty.shaded.io.netty.channel.unix.PeerCredentials`.

This is consistent with the workaround the reporter found — regenerating the whole configuration with `native-image-agent` against the running application produces the relocated names and makes the image work.

## Brief changelog

* Add `client/src/main/resources/META-INF/native-image/com.alibaba.nacos/nacos-client/native-image.properties`, mirroring under the `com.alibaba.nacos.shaded.` prefix every `--initialize-at-build-time` / `--initialize-at-run-time` directive that `io.grpc:grpc-netty-shaded` ships.
* Add the four missing `com.alibaba.nacos.shaded.` twins to `reflect-config.json`.
* Add `NativeImageMetadataConsistencyTest`, which reads the inherited `native-image.properties` from the grpc jar **actually resolved on the test classpath** and asserts that every directive, and every relocatable `reflect-config.json` entry, has a `com.alibaba.nacos.shaded.` mirror. A future grpc upgrade that adds or renames a directive turns this test red instead of silently degrading the native image again.

No production code and no runtime behaviour on the JVM is touched; the change is additive metadata only.

## Verifying this change

* `NativeImageMetadataConsistencyTest` was confirmed **red before the fix** — `testEveryInheritedInitializationArgHasShadedMirror` failed with `native-image.properties … expected: <1> but was: <0>`, and `testEveryRelocatedReflectConfigEntryHasShadedMirror` listed exactly the four unpaired entries above — and green after it.
* `mvn -pl client test` → **1157 tests, 0 failures, 0 errors**.
* `mvn -pl client spotless:check checkstyle:check spotbugs:check apache-rat:check` → BUILD SUCCESS, 0 Checkstyle violations, RAT `Unapproved: 0`. The new `native-image.properties` carries the Apache header as `#` comments, so no RAT exclusion is needed.
* `mvn -pl client -Prelease-nacos package` → the shaded jar contains the new `native-image.properties` unmodified, and the mirrored targets resolve against the relocated classes actually present in the jar, e.g. `com/alibaba/nacos/shaded/io/grpc/netty/shaded/io/netty/buffer/PooledByteBufAllocator.class` and `.../util/concurrent/GlobalEventExecutor.class`.

One note for reviewers: 10 of the 27 mirrored targets (`channel.epoll`, `channel.unix.IovArray`, `BrotliDecoder`, the `websocketx` encoders, `ThreadLocalInsecureRandom` and the four `NetUtilSubstitutions` holders) are stripped from the shaded jar by `minimizeJar=true`. GraalVM only warns about directives whose class is absent, exactly as it does today for all of them under the unrelocated names, and mirroring the upstream metadata faithfully keeps the file correct if the `minimizeJar` set or the grpc version changes later. I kept the mirror complete rather than pruning it to the currently reachable subset; happy to prune if you prefer the narrower list.

I do not have a GraalVM toolchain to attach an end-to-end native build, so the runtime fix itself is argued from the metadata, not measured. If you would like an end-to-end reproduction before merging, I can put together a minimal Spring Cloud Gateway sample matching the issue.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
