### PR TITLE
[ISSUE #15701] Fix history config next-record query for Derby and gray configs

### DIFF
--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/HistoryConfigInfoMapperByDerby.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/main/java/com/alibaba/nacos/plugin/datasource/impl/derby/HistoryConfigInfoMapperByDerby.java
@@ -17,11 +17,15 @@
 package com.alibaba.nacos.plugin.datasource.impl.derby;
 
 import com.alibaba.nacos.common.utils.CollectionUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.plugin.datasource.constants.DataSourceConstant;
 import com.alibaba.nacos.plugin.datasource.constants.FieldConstant;
 import com.alibaba.nacos.plugin.datasource.mapper.HistoryConfigInfoMapper;
 import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
+
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The derby implementation of ConfigInfoMapper.
@@ -58,6 +62,30 @@ public class HistoryConfigInfoMapperByDerby extends AbstractMapperByDerby
     @Override
     public String getDataSource() {
         return DataSourceConstant.DERBY;
+    }
+    
+    @Override
+    public MapperResult getNextHistoryInfo(MapperContext context) {
+        Object grayName = context.getWhereParameter(FieldConstant.GRAY_NAME);
+        boolean filterByGrayName = StringUtils.isNotBlank(Objects.toString(grayName, null));
+        String sql =
+            "SELECT nid,data_id,group_id,tenant_id,app_name,content,md5,src_user,src_ip,op_type,publish_type,"
+                + "gray_name,ext_info,gmt_create,gmt_modified,encrypted_data_key FROM his_config_info "
+                + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND publish_type = ? "
+                + (filterByGrayName ? "AND gray_name = ? " : "")
+                + "AND nid > ? ORDER BY nid FETCH FIRST 1 ROWS ONLY";
+        
+        List<Object> paramList = CollectionUtils.list(
+            context.getWhereParameter(FieldConstant.DATA_ID),
+            context.getWhereParameter(FieldConstant.GROUP_ID),
+            context.getWhereParameter(FieldConstant.TENANT_ID),
+            context.getWhereParameter(FieldConstant.PUBLISH_TYPE),
+            context.getWhereParameter(FieldConstant.NID));
+        if (filterByGrayName) {
+            paramList.add(4, grayName);
+        }
+        
+        return new MapperResult(sql, paramList);
     }
     
     @Override

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/HistoryConfigInfoMapperByDerbyTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-derby/src/test/java/com/alibaba/nacos/plugin/datasource/impl/derby/HistoryConfigInfoMapperByDerbyTest.java
@@ -127,6 +127,54 @@ class HistoryConfigInfoMapperByDerbyTest {
     }
     
     @Test
+    void testGetNextHistoryInfo() {
+        Object dataId = "dataId";
+        Object groupId = "groupId";
+        Object tenantId = "tenantId";
+        Object nid = 100L;
+        
+        context.putWhereParameter(FieldConstant.DATA_ID, dataId);
+        context.putWhereParameter(FieldConstant.GROUP_ID, groupId);
+        context.putWhereParameter(FieldConstant.TENANT_ID, tenantId);
+        context.putWhereParameter(FieldConstant.NID, nid);
+        
+        MapperResult mapperResult = historyConfigInfoMapperByDerby.getNextHistoryInfo(context);
+        assertEquals(
+            "SELECT nid,data_id,group_id,tenant_id,app_name,content,md5,src_user,src_ip,op_type,publish_type,"
+                + "gray_name,ext_info,gmt_create,gmt_modified,encrypted_data_key FROM his_config_info "
+                + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND publish_type = ? "
+                + "AND nid > ? ORDER BY nid FETCH FIRST 1 ROWS ONLY",
+            mapperResult.getSql());
+        assertArrayEquals(new Object[] {dataId, groupId, tenantId, publishType, nid},
+            mapperResult.getParamList().toArray());
+    }
+    
+    @Test
+    void testGetNextHistoryInfoWithGrayName() {
+        Object dataId = "dataId";
+        Object groupId = "groupId";
+        Object tenantId = "tenantId";
+        Object grayName = "beta";
+        Object nid = 100L;
+        
+        context.putWhereParameter(FieldConstant.DATA_ID, dataId);
+        context.putWhereParameter(FieldConstant.GROUP_ID, groupId);
+        context.putWhereParameter(FieldConstant.TENANT_ID, tenantId);
+        context.putWhereParameter(FieldConstant.GRAY_NAME, grayName);
+        context.putWhereParameter(FieldConstant.NID, nid);
+        
+        MapperResult mapperResult = historyConfigInfoMapperByDerby.getNextHistoryInfo(context);
+        assertEquals(
+            "SELECT nid,data_id,group_id,tenant_id,app_name,content,md5,src_user,src_ip,op_type,publish_type,"
+                + "gray_name,ext_info,gmt_create,gmt_modified,encrypted_data_key FROM his_config_info "
+                + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND publish_type = ? "
+                + "AND gray_name = ? AND nid > ? ORDER BY nid FETCH FIRST 1 ROWS ONLY",
+            mapperResult.getSql());
+        assertArrayEquals(new Object[] {dataId, groupId, tenantId, publishType, grayName, nid},
+            mapperResult.getParamList().toArray());
+    }
+    
+    @Test
     void testGetTableName() {
         String tableName = historyConfigInfoMapperByDerby.getTableName();
         assertEquals(TableConstant.HIS_CONFIG_INFO, tableName);

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/HistoryConfigInfoMapperByOracle.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/main/java/com/alibaba/nacos/plugin/datasource/impl/oracle/HistoryConfigInfoMapperByOracle.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.plugin.datasource.model.MapperContext;
 import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The oracle implementation of HistoryConfigInfoMapper.
@@ -71,12 +72,13 @@ public class HistoryConfigInfoMapperByOracle extends AbstractMapperByOracle
     
     @Override
     public MapperResult getNextHistoryInfo(MapperContext context) {
+        Object grayName = context.getWhereParameter(FieldConstant.GRAY_NAME);
+        boolean filterByGrayName = StringUtils.isNotBlank(Objects.toString(grayName, null));
         String sql =
             "SELECT nid,data_id,group_id,tenant_id,app_name,content,md5,src_user,src_ip,op_type,publish_type,"
                 + "gray_name,ext_info,gmt_create,gmt_modified,encrypted_data_key FROM his_config_info "
                 + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND publish_type = ? "
-                + (StringUtils.isBlank(context.getContextParameter(FieldConstant.GRAY_NAME)) ? ""
-                    : "AND gray_name = ? ")
+                + (filterByGrayName ? "AND gray_name = ? " : "")
                 + "AND nid > ? ORDER BY nid FETCH FIRST 1 ROWS ONLY";
         
         List<Object> paramList = CollectionUtils.list(
@@ -85,8 +87,8 @@ public class HistoryConfigInfoMapperByOracle extends AbstractMapperByOracle
             context.getWhereParameter(FieldConstant.TENANT_ID),
             context.getWhereParameter(FieldConstant.PUBLISH_TYPE),
             context.getWhereParameter(FieldConstant.NID));
-        if (!StringUtils.isEmpty(context.getContextParameter(FieldConstant.GRAY_NAME))) {
-            paramList.add(4, context.getWhereParameter(FieldConstant.GRAY_NAME));
+        if (filterByGrayName) {
+            paramList.add(4, grayName);
         }
         
         return new MapperResult(sql, paramList);

--- a/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/test/java/com/alibaba/nacos/plugin/datasource/impl/oracle/HistoryConfigInfoMapperByOracleTest.java
+++ b/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-oracle/src/test/java/com/alibaba/nacos/plugin/datasource/impl/oracle/HistoryConfigInfoMapperByOracleTest.java
@@ -128,6 +128,31 @@ class HistoryConfigInfoMapperByOracleTest {
     }
     
     @Test
+    void testGetNextHistoryInfoWithGrayName() {
+        Object dataId = "dataId";
+        Object groupId = "groupId";
+        Object tenantId = "tenantId";
+        Object grayName = "beta";
+        Object nid = 100L;
+        
+        context.putWhereParameter(FieldConstant.DATA_ID, dataId);
+        context.putWhereParameter(FieldConstant.GROUP_ID, groupId);
+        context.putWhereParameter(FieldConstant.TENANT_ID, tenantId);
+        context.putWhereParameter(FieldConstant.GRAY_NAME, grayName);
+        context.putWhereParameter(FieldConstant.NID, nid);
+        
+        MapperResult mapperResult = historyConfigInfoMapperByOracle.getNextHistoryInfo(context);
+        assertEquals(
+            "SELECT nid,data_id,group_id,tenant_id,app_name,content,md5,src_user,src_ip,op_type,publish_type,"
+                + "gray_name,ext_info,gmt_create,gmt_modified,encrypted_data_key FROM his_config_info "
+                + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND publish_type = ? "
+                + "AND gray_name = ? AND nid > ? ORDER BY nid FETCH FIRST 1 ROWS ONLY",
+            mapperResult.getSql());
+        assertArrayEquals(new Object[] {dataId, groupId, tenantId, publishType, grayName, nid},
+            mapperResult.getParamList().toArray());
+    }
+    
+    @Test
     void testGetTableName() {
         String tableName = historyConfigInfoMapperByOracle.getTableName();
         assertEquals(TableConstant.HIS_CONFIG_INFO, tableName);

--- a/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/HistoryConfigInfoMapper.java
+++ b/plugin/datasource/src/main/java/com/alibaba/nacos/plugin/datasource/mapper/HistoryConfigInfoMapper.java
@@ -25,6 +25,7 @@ import com.alibaba.nacos.plugin.datasource.model.MapperResult;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The history config info mapper.
@@ -136,12 +137,13 @@ public interface HistoryConfigInfoMapper extends Mapper {
      * @return The sql of getting the next history config detail of the history config.
      */
     default MapperResult getNextHistoryInfo(MapperContext context) {
+        Object grayName = context.getWhereParameter(FieldConstant.GRAY_NAME);
+        boolean filterByGrayName = StringUtils.isNotBlank(Objects.toString(grayName, null));
         String sql =
             "SELECT nid,data_id,group_id,tenant_id,app_name,content,md5,src_user,src_ip,op_type,publish_type,"
                 + "gray_name,ext_info,gmt_create,gmt_modified,encrypted_data_key FROM his_config_info "
                 + "WHERE data_id = ? AND group_id = ? AND tenant_id = ? AND publish_type = ? "
-                + (StringUtils.isBlank(context.getContextParameter(FieldConstant.GRAY_NAME)) ? ""
-                    : "AND gray_name = ? ")
+                + (filterByGrayName ? "AND gray_name = ? " : "")
                 + "AND nid > ? ORDER BY nid LIMIT 1";
         
         List<Object> paramList = CollectionUtils.list(
@@ -150,8 +152,8 @@ public interface HistoryConfigInfoMapper extends Mapper {
             context.getWhereParameter(FieldConstant.TENANT_ID),
             context.getWhereParameter(FieldConstant.PUBLISH_TYPE),
             context.getWhereParameter(FieldConstant.NID));
-        if (!StringUtils.isEmpty(context.getContextParameter(FieldConstant.GRAY_NAME))) {
-            paramList.add(4, context.getWhereParameter(FieldConstant.GRAY_NAME));
+        if (filterByGrayName) {
+            paramList.add(4, grayName);
         }
         
         return new MapperResult(sql, paramList);

--- a/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/DatasourceMapperDefaultMethodTest.java
+++ b/plugin/datasource/src/test/java/com/alibaba/nacos/plugin/datasource/mapper/DatasourceMapperDefaultMethodTest.java
@@ -341,8 +341,9 @@ class DatasourceMapperDefaultMethodTest {
         assertEquals(Arrays.asList("data", "group", "tenant", "formal", 5L),
             blankGray.getParamList());
         
+        // Repository implementations publish grayName only through the where parameters,
+        // so the gray filter must be driven by that map alone.
         context.putWhereParameter(FieldConstant.GRAY_NAME, "gray");
-        context.putContextParameter(FieldConstant.GRAY_NAME, "gray");
         MapperResult withGray = mapper.getNextHistoryInfo(context);
         assertTrue(withGray.getSql().contains("gray_name = ?"));
         assertEquals(Arrays.asList("data", "group", "tenant", "formal", "gray", 5L),

--- a/specs/en/plugin/datasource-dialect-plugin-spec.md
+++ b/specs/en/plugin/datasource-dialect-plugin-spec.md
@@ -108,6 +108,15 @@ duplicates or legacy beta/tag gray tables. Such migration, if needed for a
 pre-3.0 deployment, is an upgrade prerequisite rather than a server runtime
 mapper responsibility.
 
+Mapper interfaces may supply `default` SQL for an operation. Such defaults are
+written in MySQL-compatible syntax, including row-limiting clauses such as
+`LIMIT`. A dialect whose database does not accept that syntax must override
+every affected operation; inheriting the default produces a syntax error at
+query time rather than a startup failure. Mapper defaults must also read
+optional filter values from the same `MapperContext` map the repository writes
+them to, so an optional predicate and its bound parameter are always emitted
+together.
+
 `MapperManager` loads mapper SPI implementations and indexes them by
 `dataSource + tableName`. Missing data source or table mapper is a startup or
 operation error, not an empty result.

--- a/specs/zh-cn/plugin/datasource-dialect-plugin-spec.md
+++ b/specs/zh-cn/plugin/datasource-dialect-plugin-spec.md
@@ -91,6 +91,12 @@ Mapper 实现必须提供 repository 操作需要的基础 CRUD SQL 和表级专
 legacy beta/tag 灰度表的运行时 Config 迁移查询。如果 pre-3.0 部署仍需要这些迁移，应作为升级
 前置动作完成，而不是服务端运行时 mapper 的职责。
 
+mapper 接口可以为某个操作提供 `default` SQL。这些 default 实现使用 MySQL 兼容语法编写，
+包括 `LIMIT` 之类的行数限制子句。如果某个方言对应的数据库不接受该语法，必须覆写所有受影响
+的操作；直接继承 default 不会导致启动失败，而是在查询时报语法错误。default 实现读取可选
+过滤值时，必须从 repository 实际写入的那个 `MapperContext` map 中读取，从而保证可选谓词与
+其绑定参数始终成对出现。
+
 `MapperManager` 通过 SPI 加载 mapper，并按 `dataSource + tableName` 建立索引。
 缺少数据源或表 mapper 是启动或操作错误，而不是空结果。
 


### PR DESCRIPTION
Fixes #15701

## What is the purpose of the change

`HistoryConfigInfoMapper#getNextHistoryInfo` backs the "next history record" lookup that
`HistoryService` performs when rendering the detail/diff of an `UPDATE` config history record. It
had two independent defects.

**1. The interface `default` SQL uses `LIMIT`, which Derby rejects.** The default ends with
`... ORDER BY nid LIMIT 1`. `HistoryConfigInfoMapperByDerby` already overrides
`removeConfigHistory`, `pageFindConfigHistoryFetchRows` and `findDeletedConfig` with Derby
row-limiting syntax, but not `getNextHistoryInfo`, so Derby inherited the `LIMIT` version. Derby is
the standalone-mode default datasource, so this path fails there. `HistoryConfigInfoMapperByOracle`
already overrides the method with `FETCH FIRST 1 ROWS ONLY`; MySQL and PostgreSQL accept `LIMIT`.
Only Derby was affected.

**2. The `grayName` filter never applied, on every datasource.** Whether to append
`AND gray_name = ?` was decided from `context.getContextParameter(FieldConstant.GRAY_NAME)`.
`MapperContext` keeps `whereParamMap` and `contextParamMap` as two separate maps, and both
repository implementations (`EmbeddedHistoryConfigInfoPersistServiceImpl`,
`ExternalHistoryConfigInfoPersistServiceImpl`) publish `grayName` with `putWhereParameter`.
Repo-wide, `GRAY_NAME` is never written with `putContextParameter` — the only legitimate
`contextParamMap` key is `ContextConstant.NEED_CONTENT` — and sibling code such as
`ConfigInfoGrayMapper` reads `GRAY_NAME` with `getWhereParameter`. The predicate was therefore
never generated, so for `publish_type = 'gray'` the history records of every gray version of one
config competed for "next record" and another gray version's content could be attributed to the
record being inspected. Because the SQL and its parameter list stayed consistent, this failed
silently.

The two guards were also inconsistent (`isBlank` for the SQL fragment, `isEmpty` for the
parameter), so a whitespace-only `grayName` would have emitted a bound parameter without its
predicate.

## Brief changelog

- Add the missing `getNextHistoryInfo` override to `HistoryConfigInfoMapperByDerby`, using
  `FETCH FIRST 1 ROWS ONLY` to match the existing Oracle override.
- Read `grayName` from the where parameters in `HistoryConfigInfoMapper#getNextHistoryInfo` and in
  the Oracle override, and derive both the predicate and its bound parameter from one guard.
- Add mapper tests for `getNextHistoryInfo` on Derby (formal and gray) and for the gray branch on
  Oracle; correct the default-mapper test to feed `grayName` the way production does.
- Document in the datasource dialect plugin spec (en + zh-cn) that mapper `default` SQL is
  MySQL-compatible and must be overridden by dialects that reject it, and that defaults must read
  optional filters from the map the repository writes them to.

No API signature, request/response model or HTTP contract changes, so `test/openapi-test` scenario
coverage is unchanged; this restores the documented behaviour of an existing endpoint rather than
altering its contract.

## Verifying this change

**Derby syntax, verified empirically.** Apache Derby 10.14.2.0 (the version in the root pom) was
driven over a real JDBC connection against a `his_config_info` table, preparing exactly the SQL
each variant emits:

```
DEFAULT (current code)   -> FAILED: SQLSyntaxErrorException: Syntax error: Encountered "LIMIT" at line 1, column 279.
FETCH FIRST (proposed)   -> PREPARED OK
```

The Derby module has no Derby dependency, not even in test scope, so this probe was run separately
rather than added to the build; the committed tests assert the emitted SQL, matching the style of
the existing mapper tests.

**Red before green.** Both new Derby tests failed on the pre-fix code with the actual SQL showing
`ORDER BY nid LIMIT 1`, and the gray test additionally showed the missing `AND gray_name = ?`. The
existing default-mapper assertion `assertTrue(withGray.getSql().contains("gray_name = ?"))` turned
red as soon as the test stopped writing `grayName` into `contextParamMap` — it had only ever passed
because it wrote the value into both maps:

```java
context.putWhereParameter(FieldConstant.GRAY_NAME, "gray");
context.putContextParameter(FieldConstant.GRAY_NAME, "gray");   // production never does this
```

**Test runs, all green after the fix.**

- `nacos-datasource-plugin` 39 tests, `-base` 17, `-mysql` 78, `-derby` 76, `-postgresql`,
  `-oracle` 77 — all pass, confirming MySQL and PostgreSQL are unaffected.
- `config` module: `HistoryServiceTest`, `EmbeddedHistoryConfigInfoPersistServiceImplTest`,
  `ExternalHistoryConfigInfoPersistServiceImplTest` — 33 tests pass.
- `mvn spotless:apply` then `spotless:check checkstyle:check spotbugs:check apache-rat:check` on
  the three changed modules: 0 Checkstyle violations, RAT unapproved 0, BUILD SUCCESS.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
