### PR TITLE
[PR #nacos-plugin/pull/167] Fix legacy skills.sh importer state key migration

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/plugin/AiResourceImportPluginTypePolicy.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/plugin/AiResourceImportPluginTypePolicy.java
@@ -130,6 +130,8 @@ public class AiResourceImportPluginTypePolicy implements PluginTypePolicy {
         result.put("skills-well-known",
             "nacos.plugin.ai.importer.skills.well-known.enabled");
         result.put("skills-sh", "nacos.plugin.ai.importer.skills.skills-sh.enabled");
+        result.put("skills-sh-authenticated",
+            "nacos.plugin.ai.importer.skills.skills-sh.enabled");
         return Collections.unmodifiableMap(result);
     }
     

--- a/ai/src/test/java/com/alibaba/nacos/ai/plugin/AiResourceImportPluginTypePolicyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/plugin/AiResourceImportPluginTypePolicyTest.java
@@ -95,30 +95,30 @@ class AiResourceImportPluginTypePolicyTest {
     void testLegacySkillsShStateEnablesAuthenticatedImporter() {
         MapConfiguration configuration = new MapConfiguration();
         configuration.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "true");
-
+        
         assertTrue(policy.isPluginEnabledByDefault("skills-sh-authenticated", configuration));
     }
-
+    
     @Test
     void testCanonicalAuthenticatedImporterStateOverridesLegacyState() {
         MapConfiguration configuration = new MapConfiguration();
         configuration.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "false");
         configuration.setProperty(
             "nacos.plugin.ai-resource-import.skills-sh-authenticated.enabled", "true");
-
+        
         assertTrue(policy.isPluginEnabledByDefault("skills-sh-authenticated", configuration));
     }
-
+    
     @Test
     void testCanonicalAuthenticatedImporterFalseIsNotOverriddenByLegacyTrue() {
         MapConfiguration configuration = new MapConfiguration();
         configuration.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "true");
         configuration.setProperty(
             "nacos.plugin.ai-resource-import.skills-sh-authenticated.enabled", "false");
-
+        
         assertFalse(policy.isPluginEnabledByDefault("skills-sh-authenticated", configuration));
     }
-
+    
     @Test
     void testLegacySkillsShStateEmitsMigrationWarningForAuthenticatedImporter() {
         Logger logger =
@@ -130,22 +130,22 @@ class AiResourceImportPluginTypePolicyTest {
             MapConfiguration configuration = new MapConfiguration();
             configuration.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled",
                 "true");
-
+            
             assertTrue(policy.isPluginEnabledByDefault("skills-sh-authenticated", configuration));
-            assertTrue(appender.list.stream().anyMatch(event ->
-                event.getFormattedMessage().contains("Legacy AI resource import plugin state key")
-                    && event.getFormattedMessage()
+            assertTrue(appender.list.stream().anyMatch(event -> event.getFormattedMessage()
+                .contains("Legacy AI resource import plugin state key")
+                && event.getFormattedMessage()
                     .contains("nacos.plugin.ai-resource-import.skills-sh-authenticated.enabled")));
         } finally {
             logger.detachAppender(appender);
             appender.stop();
         }
     }
-
+    
     private static class MapConfiguration implements PluginTypeConfiguration {
-
+        
         private final Map<String, String> properties = new HashMap<>();
-
+        
         void setProperty(String key, String value) {
             properties.put(key, value);
         }

--- a/ai/src/test/java/com/alibaba/nacos/ai/plugin/AiResourceImportPluginTypePolicyTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/plugin/AiResourceImportPluginTypePolicyTest.java
@@ -16,11 +16,15 @@
 
 package com.alibaba.nacos.ai.plugin;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.alibaba.nacos.ai.config.AiEnabledFilter;
 import com.alibaba.nacos.ai.importer.config.AiResourceImportProperties;
 import com.alibaba.nacos.api.plugin.PluginType;
 import com.alibaba.nacos.api.plugin.PluginTypeConfiguration;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -87,10 +91,61 @@ class AiResourceImportPluginTypePolicyTest {
         assertTrue(policy.isPluginEnabledByDefault("mcp-registry-protocol", configuration));
     }
     
+    @Test
+    void testLegacySkillsShStateEnablesAuthenticatedImporter() {
+        MapConfiguration configuration = new MapConfiguration();
+        configuration.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "true");
+
+        assertTrue(policy.isPluginEnabledByDefault("skills-sh-authenticated", configuration));
+    }
+
+    @Test
+    void testCanonicalAuthenticatedImporterStateOverridesLegacyState() {
+        MapConfiguration configuration = new MapConfiguration();
+        configuration.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "false");
+        configuration.setProperty(
+            "nacos.plugin.ai-resource-import.skills-sh-authenticated.enabled", "true");
+
+        assertTrue(policy.isPluginEnabledByDefault("skills-sh-authenticated", configuration));
+    }
+
+    @Test
+    void testCanonicalAuthenticatedImporterFalseIsNotOverriddenByLegacyTrue() {
+        MapConfiguration configuration = new MapConfiguration();
+        configuration.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled", "true");
+        configuration.setProperty(
+            "nacos.plugin.ai-resource-import.skills-sh-authenticated.enabled", "false");
+
+        assertFalse(policy.isPluginEnabledByDefault("skills-sh-authenticated", configuration));
+    }
+
+    @Test
+    void testLegacySkillsShStateEmitsMigrationWarningForAuthenticatedImporter() {
+        Logger logger =
+            (Logger) LoggerFactory.getLogger(AiResourceImportPluginTypePolicy.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            MapConfiguration configuration = new MapConfiguration();
+            configuration.setProperty("nacos.plugin.ai.importer.skills.skills-sh.enabled",
+                "true");
+
+            assertTrue(policy.isPluginEnabledByDefault("skills-sh-authenticated", configuration));
+            assertTrue(appender.list.stream().anyMatch(event ->
+                event.getFormattedMessage().contains("Legacy AI resource import plugin state key")
+                    && event.getFormattedMessage()
+                    .contains("nacos.plugin.ai-resource-import.skills-sh-authenticated.enabled")));
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+    }
+
     private static class MapConfiguration implements PluginTypeConfiguration {
-        
+
         private final Map<String, String> properties = new HashMap<>();
-        
+
         void setProperty(String key, String value) {
             properties.put(key, value);
         }


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the Nacos-side compatibility migration for the external authenticated skills.sh AI resource importer.

linked nacos-group/nacos-plugin#167

After the authenticated skills.sh importer is migrated to the Nacos 3.3 `AiResourceImportServiceBuilder` SPI, its managed plugin name becomes `skills-sh-authenticated`. The canonical plugin state key is therefore `nacos.plugin.ai-resource-import.skills-sh-authenticated.enabled=true`.

However, existing deployments may still use the legacy state key `nacos.plugin.ai.importer.skills.skills-sh.enabled=true`.

Without this companion change, the legacy key only enables the built-in public `skills-sh` importer, while the external authenticated importer remains disabled.

This PR maps the legacy state key to `skills-sh-authenticated` during the migration window, while keeping the canonical state key as the higher-priority source when both are configured.

## Brief changelog

- Add legacy state-key compatibility for `skills-sh-authenticated`.
- Preserve canonical state-key precedence over the legacy key.
- Add tests for:
  - legacy key enabling `skills-sh-authenticated`
  - canonical key overriding legacy key
  - canonical `false` not being overridden by legacy `true`
  - legacy key emitting a migration warning

## Verifying this change

Passed:

`mvn -pl ai -am -Dtest=AiResourceImportPluginTypePolicyTest -Dsurefire.failIfNoSpecifiedTests=false test`

`git diff --check`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction.
* [ ] Run full project verification commands.