### PR TITLE
[Bugfix] Fix legacy controller context path URI parsing

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
+++ b/core/src/main/java/com/alibaba/nacos/core/code/ControllerMethodsCache.java
@@ -197,8 +197,9 @@ public class ControllerMethodsCache {
     
     private String resolveContextPath(HttpServletRequest request) {
         String requestContextPath = request.getContextPath();
-        return StringUtils.isEmpty(requestContextPath) ? EnvUtil.getContextPath()
+        String contextPath = StringUtils.isEmpty(requestContextPath) ? EnvUtil.getContextPath()
             : requestContextPath;
+        return StringUtils.isEmpty(contextPath) ? contextPath : getPath(contextPath);
     }
     
     private String stripContextPath(String path, String contextPath) {
@@ -213,8 +214,12 @@ public class ControllerMethodsCache {
     }
     
     private String getPath(HttpServletRequest request) {
+        return getPath(request.getRequestURI());
+    }
+    
+    private String getPath(String uri) {
         try {
-            return new URI(request.getRequestURI()).getPath();
+            return new URI(uri).getPath();
         } catch (URISyntaxException e) {
             LOGGER.error("parse request to path error", e);
             throw new NacosRuntimeException(NacosException.NOT_FOUND, "Invalid URI");

--- a/core/src/test/java/com/alibaba/nacos/core/code/ControllerMethodsCacheTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/code/ControllerMethodsCacheTest.java
@@ -122,6 +122,20 @@ class ControllerMethodsCacheTest {
     }
     
     @Test
+    void getMethodFromLegacyResolverWithEncodedContextPath() throws Exception {
+        ObjectProvider<RequestMappingHandlerMapping> provider = mock(ObjectProvider.class);
+        ControllerMethodsCache springCache = new ControllerMethodsCache(provider);
+        springCache.initClassMethod(Collections.singleton(TestController.class));
+        System.setProperty(ControllerMethodsCache.LEGACY_RESOLVER_ENABLED, "true");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/n%61cos/api/get");
+        request.setContextPath("/n%61cos");
+        request.setRequestURI("/n%61cos/api/get");
+        request.setParameter("required", "yes");
+        
+        assertEquals("get", springCache.getMethod(request).getName());
+    }
+    
+    @Test
     void getMethodReturnsNullWhenNoMapping() {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/nacos/v1/cs/configs");
         request.setRequestURI("/nacos/v1/cs/configs");

--- a/specs/en/design/foundation-request-context-spec.md
+++ b/specs/en/design/foundation-request-context-spec.md
@@ -113,7 +113,9 @@ HTTP controller-method resolution rules:
 - `nacos.core.auth.controller-method-cache.legacy-enabled=true` may temporarily downgrade method
   resolution to the legacy annotation cache. The legacy resolver is deprecated since 3.3.0,
   scheduled for removal in 3.4.0, and can differ from Spring MVC path matching, so it must remain
-  disabled by default.
+  disabled by default. While enabled, it must parse the request URI and context path consistently
+  before removing the context path, including when either value contains percent-encoded
+  characters.
 
 ## 4. gRPC Request Filter Model
 

--- a/specs/zh-cn/design/foundation-request-context-spec.md
+++ b/specs/zh-cn/design/foundation-request-context-spec.md
@@ -91,7 +91,8 @@ HTTP Controller 方法解析规则：
 - query parameter 不参与 Controller 路径匹配。
 - 可通过 `nacos.core.auth.controller-method-cache.legacy-enabled=true` 临时降级到旧注解缓存
   解析器。旧解析器从 3.3.0 起废弃，计划在 3.4.0 移除，且可能与 Spring MVC 路径匹配结果
-  不一致，因此默认必须关闭。
+  不一致，因此默认必须关闭。启用旧解析器时，必须在移除 context path 前使用一致的方式解析
+  request URI 和 context path，包括任一值包含百分号编码字符的情况。
 
 ## 4. gRPC 请求过滤模型
 


### PR DESCRIPTION
## What is the purpose of the change

Keep the deprecated controller-method cache safe when
`nacos.core.auth.controller-method-cache.legacy-enabled=true` is used as an emergency downgrade.
The default Spring MVC handler-mapping resolver is not affected, but the legacy resolver decoded
the request URI without parsing the request-specific context path the same way. For an encoded
context path such as `/n%61cos`, it therefore failed to remove the context path and could not
resolve controller metadata.

No public issue is linked because this follow-up concerns request authorization path handling and
aligns the develop fallback with the protection already merged in #15688 for v3.2.4.

## Brief changelog

- Parse request-specific and configured context paths with the same `URI.getPath()` logic used for
  request URIs in the legacy resolver.
- Add a regression unit test that explicitly enables the legacy resolver and resolves
  `/n%61cos/api/get`.
- Document consistent request URI and context-path parsing for the temporary legacy downgrade in
  the English and Chinese request-context specifications.

## Verifying this change

- `mvn -pl core spotless:apply`
- `mvn -pl core spotless:check`
- `mvn -pl core -Dtest=ControllerMethodsCacheTest test` (24 tests passed)
- `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e
  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn`
  (62 modules passed)

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (not linked publicly for this
  request-authorization follow-up).
* [x] Format the pull request title according to the project convention used by #15686 and #15688.
* [x] Write a pull request description that is detailed enough to understand what the pull request
  does, how, and why.
* [x] Write necessary unit tests to verify the logic correction.
* [x] Run the relevant Maven compile, RAT, Checkstyle, SpotBugs, Spotless, and unit-test checks.
