### PR TITLE
Fix active health check target address validation for v2.x (#15712)

### DIFF
--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckAddressValidator.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckAddressValidator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.v2.processor;
+
+import com.alibaba.nacos.common.utils.InternetAddressUtil;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Validator for active health check target addresses.
+ *
+ * @author xiweng.yy
+ */
+final class HealthCheckAddressValidator {
+
+    private static final String URL_PREFIX = "http://";
+
+    private HealthCheckAddressValidator() {
+    }
+
+    /**
+     * Returns whether the address is a plain host without URL components controlled by the
+     * instance IP field.
+     *
+     * @param address instance address
+     * @return {@code true} if the address can be used as an active health check host
+     */
+    static boolean isValid(String address) {
+        if (address == null || address.isEmpty()) {
+            return false;
+        }
+        boolean ipv6Host = isIpv6Host(address);
+        if (containsUnsafeCharacter(address, ipv6Host)) {
+            return false;
+        }
+        if (ipv6Host) {
+            return true;
+        }
+        try {
+            URL parsed = new URL(URL_PREFIX + address);
+            return address.equals(parsed.getHost()) && parsed.getUserInfo() == null
+                    && parsed.getPort() == -1 && parsed.getPath().isEmpty()
+                    && parsed.getQuery() == null && parsed.getRef() == null;
+        } catch (MalformedURLException e) {
+            return false;
+        }
+    }
+
+    private static boolean isIpv6Host(String address) {
+        boolean startsWithBracket = address.startsWith(InternetAddressUtil.IPV6_START_MARK);
+        boolean endsWithBracket = address.endsWith(InternetAddressUtil.IPV6_END_MARK);
+        if (startsWithBracket || endsWithBracket) {
+            if (!startsWithBracket || !endsWithBracket || address.length() < 3) {
+                return false;
+            }
+            return InternetAddressUtil.isIPv6(address.substring(1, address.length() - 1));
+        }
+        return InternetAddressUtil.isIPv6(address);
+    }
+
+    private static boolean containsUnsafeCharacter(String address, boolean ipv6Host) {
+        for (int index = 0; index < address.length(); index++) {
+            char each = address.charAt(index);
+            if (Character.isWhitespace(each) || Character.isISOControl(each) || each == '/'
+                    || each == '?' || each == '#' || each == '@' || each == '\\') {
+                return true;
+            }
+            if (each == '%' && !ipv6Host) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckProcessorV2Delegate.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckProcessorV2Delegate.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.naming.healthcheck.v2.processor;
 
 import com.alibaba.nacos.naming.core.v2.metadata.ClusterMetadata;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.healthcheck.extend.HealthCheckExtendProvider;
 import com.alibaba.nacos.naming.healthcheck.extend.HealthCheckProcessorExtendV2;
@@ -37,12 +38,17 @@ import java.util.stream.Collectors;
 @Component("healthCheckDelegateV2")
 public class HealthCheckProcessorV2Delegate implements HealthCheckProcessorV2 {
     
+    static final String INVALID_ADDRESS_MESSAGE = "active health check address is invalid";
+
     private final Map<String, HealthCheckProcessorV2> healthCheckProcessorMap = new HashMap<>();
     
+    private final HealthCheckCommonV2 healthCheckCommon;
+
     public HealthCheckProcessorV2Delegate(HealthCheckExtendProvider provider,
-            HealthCheckProcessorExtendV2 healthCheckProcessorExtend) {
+            HealthCheckProcessorExtendV2 healthCheckProcessorExtend, HealthCheckCommonV2 healthCheckCommon) {
         provider.setHealthCheckProcessorExtend(healthCheckProcessorExtend);
         provider.init();
+        this.healthCheckCommon = healthCheckCommon;
     }
     
     @Autowired
@@ -58,9 +64,22 @@ public class HealthCheckProcessorV2Delegate implements HealthCheckProcessorV2 {
         if (processor == null) {
             processor = healthCheckProcessorMap.get(NoneHealthCheckProcessor.TYPE);
         }
+        if (isInvalidActiveCheckAddress(task, service, processor)) {
+            healthCheckCommon.checkFailNow(task, service, INVALID_ADDRESS_MESSAGE);
+            return;
+        }
         processor.process(task, service, metadata);
     }
     
+    private boolean isInvalidActiveCheckAddress(HealthCheckTaskV2 task, Service service,
+            HealthCheckProcessorV2 processor) {
+        if (NoneHealthCheckProcessor.TYPE.equals(processor.getType())) {
+            return false;
+        }
+        InstancePublishInfo instance = task.getClient().getInstancePublishInfo(service);
+        return instance != null && !HealthCheckAddressValidator.isValid(instance.getIp());
+    }
+
     @Override
     public String getType() {
         return null;

--- a/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/MysqlHealthCheckProcessor.java
+++ b/naming/src/main/java/com/alibaba/nacos/naming/healthcheck/v2/processor/MysqlHealthCheckProcessor.java
@@ -35,6 +35,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeoutException;
@@ -64,6 +65,18 @@ public class MysqlHealthCheckProcessor implements HealthCheckProcessorV2 {
     
     private static final String MYSQL_SLAVE_READONLY = "ON";
     
+    private static final String CONNECT_TIMEOUT_PROPERTY = "connectTimeout";
+
+    private static final String SOCKET_TIMEOUT_PROPERTY = "socketTimeout";
+
+    private static final String LOGIN_TIMEOUT_PROPERTY = "loginTimeout";
+
+    private static final String ALLOW_LOAD_LOCAL_INFILE_PROPERTY = "allowLoadLocalInfile";
+
+    private static final String ALLOW_URL_IN_LOCAL_INFILE_PROPERTY = "allowUrlInLocalInfile";
+
+    private static final String ALLOW_MULTI_QUERIES_PROPERTY = "allowMultiQueries";
+
     private static final ConcurrentMap<String, Connection> CONNECTION_POOL = new ConcurrentHashMap<String, Connection>();
     
     public MysqlHealthCheckProcessor(HealthCheckCommonV2 healthCheckCommon, SwitchDomain switchDomain) {
@@ -138,9 +151,7 @@ public class MysqlHealthCheckProcessor implements HealthCheckProcessorV2 {
                 Mysql config = (Mysql) metadata.getHealthChecker();
                 
                 if (connection == null || connection.isClosed()) {
-                    String url = "jdbc:mysql://" + instance.getIp() + ":" + instance.getPort() + "?connectTimeout="
-                            + CONNECT_TIMEOUT_MS + "&socketTimeout=" + CONNECT_TIMEOUT_MS + "&loginTimeout=" + 1;
-                    connection = DriverManager.getConnection(url, config.getUser(), config.getPwd());
+                    connection = DriverManager.getConnection(buildJdbcUrl(instance), buildConnectionProperties(config));
                     CONNECTION_POOL.put(key, connection);
                 }
                 
@@ -203,5 +214,26 @@ public class MysqlHealthCheckProcessor implements HealthCheckProcessorV2 {
                 }
             }
         }
+    }
+
+    static String buildJdbcUrl(HealthCheckInstancePublishInfo instance) {
+        return "jdbc:mysql://" + instance.getIp() + ":" + instance.getPort();
+    }
+
+    static Properties buildConnectionProperties(Mysql config) {
+        Properties properties = new Properties();
+        if (config.getUser() != null) {
+            properties.setProperty("user", config.getUser());
+        }
+        if (config.getPwd() != null) {
+            properties.setProperty("password", config.getPwd());
+        }
+        properties.setProperty(CONNECT_TIMEOUT_PROPERTY, String.valueOf(CONNECT_TIMEOUT_MS));
+        properties.setProperty(SOCKET_TIMEOUT_PROPERTY, String.valueOf(CONNECT_TIMEOUT_MS));
+        properties.setProperty(LOGIN_TIMEOUT_PROPERTY, "1");
+        properties.setProperty(ALLOW_LOAD_LOCAL_INFILE_PROPERTY, Boolean.FALSE.toString());
+        properties.setProperty(ALLOW_URL_IN_LOCAL_INFILE_PROPERTY, Boolean.FALSE.toString());
+        properties.setProperty(ALLOW_MULTI_QUERIES_PROPERTY, Boolean.FALSE.toString());
+        return properties;
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckAddressValidatorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckAddressValidatorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.v2.processor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HealthCheckAddressValidatorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"localhost", "127.0.0.1", "mysql-service.internal",
+            "mysql_service", "[::1]", "::1", "fe80::1%eth0"})
+    void testValidAddress(String address) {
+        assertTrue(HealthCheckAddressValidator.isValid(address));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "host:3306", "host/path", "host?query=true", "host#fragment",
+            "user@host", "host\\path", "host%3Fquery=true", "[::1]:3306", "[::1]suffix",
+            "rogue-mysql:3306?allowLoadLocalInfile=true#", "host\nquery=true"})
+    void testInvalidAddress(String address) {
+        assertFalse(HealthCheckAddressValidator.isValid(address));
+    }
+
+    @Test
+    void testNullAddress() {
+        assertFalse(HealthCheckAddressValidator.isValid(null));
+    }
+}

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckProcessorV2DelegateTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/HealthCheckProcessorV2DelegateTest.java
@@ -19,6 +19,7 @@ package com.alibaba.nacos.naming.healthcheck.v2.processor;
 import com.alibaba.nacos.api.naming.pojo.healthcheck.HealthCheckType;
 import com.alibaba.nacos.naming.core.v2.client.impl.IpPortBasedClient;
 import com.alibaba.nacos.naming.core.v2.metadata.ClusterMetadata;
+import com.alibaba.nacos.naming.core.v2.pojo.InstancePublishInfo;
 import com.alibaba.nacos.naming.core.v2.pojo.Service;
 import com.alibaba.nacos.naming.healthcheck.extend.HealthCheckExtendProvider;
 import com.alibaba.nacos.naming.healthcheck.extend.HealthCheckProcessorExtendV2;
@@ -33,13 +34,16 @@ import org.springframework.mock.env.MockEnvironment;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class HealthCheckProcessorV2DelegateTest {
@@ -51,6 +55,9 @@ class HealthCheckProcessorV2DelegateTest {
     private HealthCheckProcessorExtendV2 healthCheckProcessorExtendV2;
     
     @Mock
+    private HealthCheckCommonV2 healthCheckCommonV2;
+
+    @Mock
     private HealthCheckTaskV2 healthCheckTaskV2;
     
     @Mock
@@ -59,11 +66,24 @@ class HealthCheckProcessorV2DelegateTest {
     @Mock
     private ClusterMetadata clusterMetadata;
     
+    @Mock
+    private HealthCheckProcessorV2 noneHealthCheckProcessor;
+
+    @Mock
+    private HealthCheckProcessorV2 activeHealthCheckProcessor;
+
+    @Mock
+    private IpPortBasedClient client;
+
+    @Mock
+    private InstancePublishInfo instance;
+
     private HealthCheckProcessorV2Delegate healthCheckProcessorV2Delegate;
     
     @BeforeEach
     void setUp() {
-        healthCheckProcessorV2Delegate = new HealthCheckProcessorV2Delegate(healthCheckExtendProvider, healthCheckProcessorExtendV2);
+        healthCheckProcessorV2Delegate = new HealthCheckProcessorV2Delegate(healthCheckExtendProvider,
+                healthCheckProcessorExtendV2, healthCheckCommonV2);
         verify(healthCheckExtendProvider).init();
         EnvUtil.setEnvironment(new MockEnvironment());
     }
@@ -91,11 +111,53 @@ class HealthCheckProcessorV2DelegateTest {
         healthCheckProcessorV2Delegate.process(healthCheckTaskV2, service, clusterMetadata);
         
         verify(clusterMetadata).getHealthyCheckType();
-        verify(healthCheckTaskV2).getClient();
+        verify(healthCheckTaskV2, times(2)).getClient();
+    }
+
+    @Test
+    void testProcessValidAddress() {
+        mockActiveHealthCheck("127.0.0.1");
+
+        healthCheckProcessorV2Delegate.process(healthCheckTaskV2, service, clusterMetadata);
+
+        verify(activeHealthCheckProcessor).process(healthCheckTaskV2, service, clusterMetadata);
+        verify(healthCheckCommonV2, never()).checkFailNow(healthCheckTaskV2, service,
+                HealthCheckProcessorV2Delegate.INVALID_ADDRESS_MESSAGE);
+    }
+
+    @Test
+    void testProcessInvalidAddress() {
+        mockActiveHealthCheck("rogue-mysql:3306?allowLoadLocalInfile=true#");
+
+        healthCheckProcessorV2Delegate.process(healthCheckTaskV2, service, clusterMetadata);
+
+        verify(activeHealthCheckProcessor, never()).process(healthCheckTaskV2, service, clusterMetadata);
+        verify(healthCheckCommonV2).checkFailNow(healthCheckTaskV2, service,
+                HealthCheckProcessorV2Delegate.INVALID_ADDRESS_MESSAGE);
+    }
+
+    @Test
+    void testProcessFallbackToNoneProcessor() {
+        when(noneHealthCheckProcessor.getType()).thenReturn(NoneHealthCheckProcessor.TYPE);
+        when(clusterMetadata.getHealthyCheckType()).thenReturn("UNKNOWN");
+        healthCheckProcessorV2Delegate.addProcessor(Collections.singletonList(noneHealthCheckProcessor));
+
+        healthCheckProcessorV2Delegate.process(healthCheckTaskV2, service, clusterMetadata);
+
+        verify(noneHealthCheckProcessor).process(healthCheckTaskV2, service, clusterMetadata);
     }
     
     @Test
     void testGetType() {
         assertNull(healthCheckProcessorV2Delegate.getType());
+    }
+
+    private void mockActiveHealthCheck(String address) {
+        when(activeHealthCheckProcessor.getType()).thenReturn(HealthCheckType.TCP.name());
+        when(clusterMetadata.getHealthyCheckType()).thenReturn(HealthCheckType.TCP.name());
+        when(healthCheckTaskV2.getClient()).thenReturn(client);
+        when(client.getInstancePublishInfo(service)).thenReturn(instance);
+        when(instance.getIp()).thenReturn(address);
+        healthCheckProcessorV2Delegate.addProcessor(Collections.singletonList(activeHealthCheckProcessor));
     }
 }

--- a/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/MysqlHealthCheckProcessorTest.java
+++ b/naming/src/test/java/com/alibaba/nacos/naming/healthcheck/v2/processor/MysqlHealthCheckProcessorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.naming.healthcheck.v2.processor;
+
+import com.alibaba.nacos.api.naming.pojo.healthcheck.impl.Mysql;
+import com.alibaba.nacos.naming.core.v2.pojo.HealthCheckInstancePublishInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class MysqlHealthCheckProcessorTest {
+
+    @Test
+    void testBuildJdbcUrlWithoutConnectionProperties() {
+        HealthCheckInstancePublishInfo instance = new HealthCheckInstancePublishInfo("127.0.0.1", 3306);
+
+        String actual = MysqlHealthCheckProcessor.buildJdbcUrl(instance);
+
+        assertEquals("jdbc:mysql://127.0.0.1:3306", actual);
+    }
+
+    @Test
+    void testBuildConnectionProperties() {
+        Mysql config = new Mysql();
+        config.setUser("nacos");
+        config.setPwd("nacos-password");
+
+        Properties actual = MysqlHealthCheckProcessor.buildConnectionProperties(config);
+
+        assertEquals("nacos", actual.getProperty("user"));
+        assertEquals("nacos-password", actual.getProperty("password"));
+        assertEquals("500", actual.getProperty("connectTimeout"));
+        assertEquals("500", actual.getProperty("socketTimeout"));
+        assertEquals("1", actual.getProperty("loginTimeout"));
+        assertEquals("false", actual.getProperty("allowLoadLocalInfile"));
+        assertEquals("false", actual.getProperty("allowUrlInLocalInfile"));
+        assertEquals("false", actual.getProperty("allowMultiQueries"));
+    }
+
+    @Test
+    void testBuildConnectionPropertiesWithoutCredentials() {
+        Properties actual = MysqlHealthCheckProcessor.buildConnectionProperties(new Mysql());
+
+        assertFalse(actual.containsKey("user"));
+        assertFalse(actual.containsKey("password"));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Port the active health check target validation from #15712 to the v2.x codebase. The v2.x health check implementation has the same risk, but its code and tests have diverged enough that the develop commit cannot be cherry-picked directly.

This change validates instance addresses before dispatching active health checks and prevents instance-controlled text from becoming part of a MySQL JDBC URL.

## Brief changelog

* Validate active health check target hosts centrally before processor dispatch.
* Mark invalid targets as failed without invoking the configured health check processor.
* Build the MySQL JDBC URL from only the validated host and port, and pass connection options through `Properties`.
* Explicitly disable MySQL local infile URL options and multi-query support.
* Add unit tests for valid/invalid host forms, dispatch behavior, and JDBC URL/properties construction.

## Verifying this change

* JDK 8 full reactor build: `clean package apache-rat:check findbugs:findbugs -DskipTests` (37 modules passed; the build was resumed after removing ignored artifacts left by newer branches).
* Focused tests: 29 tests passed across `HealthCheckAddressValidatorTest`, `HealthCheckProcessorV2DelegateTest`, and `MysqlHealthCheckProcessorTest`.
* `git diff --check upstream/v2.x-develop...HEAD` passed.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [ ] Make sure there is a Github issue filed for the change (usually before you start working on it). This is the v2.x port of the already reviewed fix in #15712 and does not create a public security issue.
* [x] Each commit in the pull request has a meaningful subject line and body.
* [x] The pull request description explains what the pull request does, how, and why.
* [x] Unit tests verify the logic correction.
* [x] The relevant JDK 8 build, Checkstyle, RAT, FindBugs, and focused unit tests pass.
