### PR TITLE
Harden distributed database query result resolution for v2.x (#15661)

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/persistence/DistributedDatabaseOperateImpl.java
+++ b/core/src/main/java/com/alibaba/nacos/core/persistence/DistributedDatabaseOperateImpl.java
@@ -76,6 +76,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -154,6 +155,16 @@ public class DistributedDatabaseOperateImpl extends RequestProcessor4CP implemen
      * The data import operation is dedicated key, which ACTS as an identifier.
      */
     private static final String DATA_IMPORT_KEY = "00--0-data_import-0--00";
+
+    private static final Map<String, Class<?>> BASIC_RESULT_TYPES;
+
+    static {
+        Map<String, Class<?>> resultTypes = new HashMap<>(3);
+        resultTypes.put(Integer.class.getCanonicalName(), Integer.class);
+        resultTypes.put(Long.class.getCanonicalName(), Long.class);
+        resultTypes.put(String.class.getCanonicalName(), String.class);
+        BASIC_RESULT_TYPES = Collections.unmodifiableMap(resultTypes);
+    }
     
     private final ServerMemberManager memberManager;
     
@@ -477,29 +488,30 @@ public class DistributedDatabaseOperateImpl extends RequestProcessor4CP implemen
             selectRequest = serializer.deserialize(request.getData().toByteArray(), SelectRequest.class);
             LoggerUtils.printIfDebugEnabled(LOGGER, "getData info : selectRequest : {}", selectRequest);
             sqlLimiter.doLimitForSelectRequest(selectRequest);
-            final RowMapper<Object> mapper = RowMapperManager.getRowMapper(selectRequest.getClassName());
             final byte type = selectRequest.getQueryType();
             switch (type) {
                 case QueryType.QUERY_ONE_WITH_MAPPER_WITH_ARGS:
-                    data = queryOne(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(), mapper);
+                    data = queryOne(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(),
+                            getRequiredRowMapper(selectRequest.getClassName()));
                     break;
                 case QueryType.QUERY_ONE_NO_MAPPER_NO_ARGS:
                     data = queryOne(jdbcTemplate, selectRequest.getSql(),
-                            ClassUtils.findClassByName(selectRequest.getClassName()));
+                            getBasicResultType(selectRequest.getClassName()));
                     break;
                 case QueryType.QUERY_ONE_NO_MAPPER_WITH_ARGS:
                     data = queryOne(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(),
-                            ClassUtils.findClassByName(selectRequest.getClassName()));
+                            getBasicResultType(selectRequest.getClassName()));
                     break;
                 case QueryType.QUERY_MANY_WITH_MAPPER_WITH_ARGS:
-                    data = queryMany(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(), mapper);
+                    data = queryMany(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(),
+                            getRequiredRowMapper(selectRequest.getClassName()));
                     break;
                 case QueryType.QUERY_MANY_WITH_LIST_WITH_ARGS:
                     data = queryMany(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs());
                     break;
                 case QueryType.QUERY_MANY_NO_MAPPER_WITH_ARGS:
                     data = queryMany(jdbcTemplate, selectRequest.getSql(), selectRequest.getArgs(),
-                            ClassUtils.findClassByName(selectRequest.getClassName()));
+                            getBasicResultType(selectRequest.getClassName()));
                     break;
                 default:
                     throw new IllegalArgumentException("Unsupported data query categories");
@@ -513,6 +525,22 @@ public class DistributedDatabaseOperateImpl extends RequestProcessor4CP implemen
         } finally {
             readLock.unlock();
         }
+    }
+
+    static RowMapper<Object> getRequiredRowMapper(String className) {
+        RowMapper<Object> result = RowMapperManager.getRowMapper(className);
+        if (result == null) {
+            throw new IllegalArgumentException("Unregistered row mapper");
+        }
+        return result;
+    }
+
+    static Class<?> getBasicResultType(String className) {
+        Class<?> result = className == null ? null : BASIC_RESULT_TYPES.get(className);
+        if (result == null) {
+            throw new IllegalArgumentException("Unsupported basic result type");
+        }
+        return result;
     }
     
     @Override

--- a/core/src/test/java/com/alibaba/nacos/core/persistence/DistributedDatabaseOperateImplTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/persistence/DistributedDatabaseOperateImplTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.persistence;
+
+import com.alibaba.nacos.persistence.repository.RowMapperManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DistributedDatabaseOperateImplTest {
+
+    @Test
+    void testGetBasicResultType() {
+        assertSame(Integer.class,
+                DistributedDatabaseOperateImpl.getBasicResultType(Integer.class.getCanonicalName()));
+        assertSame(Long.class, DistributedDatabaseOperateImpl.getBasicResultType(Long.class.getCanonicalName()));
+        assertSame(String.class, DistributedDatabaseOperateImpl.getBasicResultType(String.class.getCanonicalName()));
+    }
+
+    @Test
+    void testRejectUnsupportedBasicResultType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> DistributedDatabaseOperateImpl.getBasicResultType(Runtime.class.getCanonicalName()));
+        assertThrows(IllegalArgumentException.class,
+                () -> DistributedDatabaseOperateImpl.getBasicResultType(null));
+    }
+
+    @Test
+    void testGetRegisteredRowMapper() {
+        assertSame(RowMapperManager.MAP_ROW_MAPPER, DistributedDatabaseOperateImpl.getRequiredRowMapper(
+                RowMapperManager.MAP_ROW_MAPPER.getClass().getCanonicalName()));
+    }
+
+    @Test
+    void testRejectUnregisteredRowMapper() {
+        assertThrows(IllegalArgumentException.class,
+                () -> DistributedDatabaseOperateImpl.getRequiredRowMapper("com.alibaba.nacos.UnknownRowMapper"));
+        assertThrows(IllegalArgumentException.class,
+                () -> DistributedDatabaseOperateImpl.getRequiredRowMapper(null));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Port the distributed embedded query result validation from #15661 to `v2.x-develop` with the smallest change compatible with the v2.x codebase.

The v2.x branch has no AI module or persistence specs. Its distributed Config, Namespace, and Auth row mappers are already initialized through existing Spring components, so this PR only constrains result resolution in `DistributedDatabaseOperateImpl`.

## Brief changelog

* Resolve scalar query targets only from the exact supported types: `Integer`, `Long`, and `String`.
* Require mapper queries to use a `RowMapper` registered in `RowMapperManager`.
* Add unit tests for allowed and rejected result targets.

## Verifying this change

* Java 8: `mvn -pl core -am -Dtest=DistributedDatabaseOperateImplTest -Dsurefire.failIfNoSpecifiedTests=false test` (14 modules, 4 tests).
* Java 8: `mvn -pl core -DskipTests compile apache-rat:check checkstyle:check findbugs:findbugs`.
* `git diff --check upstream/v2.x-develop...HEAD`.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] This is a v2.x port of the already reviewed and merged #15661.
* [x] Each commit in the pull request has a meaningful subject line and body.
* [x] The pull request description explains what the pull request does, how, and why.
* [x] Unit tests cover the result type allowlist and registered row mapper requirement.
* [x] Relevant Java 8 build, test, RAT, Checkstyle, and FindBugs checks pass locally.
