### PR TITLE
[ISSUE #15682] Backport login enumeration fix to 3.2.4

### DIFF
--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/authenticate/AbstractAuthenticationManager.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/authenticate/AbstractAuthenticationManager.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.plugin.auth.impl.users.NacosUserDetails;
 import com.alibaba.nacos.plugin.auth.impl.users.NacosUserService;
 import com.alibaba.nacos.plugin.auth.impl.utils.PasswordEncoderUtil;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 /**
  * AbstractAuthenticationManager.
@@ -37,9 +38,6 @@ import jakarta.servlet.http.HttpServletRequest;
  * @date 2023/1/13 12:48
  */
 public class AbstractAuthenticationManager implements IAuthenticationManager {
-    
-    private static final String USER_NOT_FOUND_MESSAGE =
-        "User not found! Please check user exist or password is right!";
     
     protected NacosUserService userDetailsService;
     
@@ -58,13 +56,18 @@ public class AbstractAuthenticationManager implements IAuthenticationManager {
     @Override
     public NacosUser authenticate(String username, String rawPassword) throws AccessException {
         if (StringUtils.isBlank(username) || StringUtils.isBlank(rawPassword)) {
-            throw new AccessException(USER_NOT_FOUND_MESSAGE);
+            throw new AccessException(AuthConstants.INVALID_CREDENTIALS_MESSAGE);
         }
-        NacosUserDetails nacosUserDetails =
-            (NacosUserDetails) userDetailsService.loadUserByUsername(username);
+        NacosUserDetails nacosUserDetails;
+        try {
+            nacosUserDetails =
+                (NacosUserDetails) userDetailsService.loadUserByUsername(username);
+        } catch (UsernameNotFoundException ignored) {
+            throw new AccessException(AuthConstants.INVALID_CREDENTIALS_MESSAGE);
+        }
         if (nacosUserDetails == null
             || !PasswordEncoderUtil.matches(rawPassword, nacosUserDetails.getPassword())) {
-            throw new AccessException(USER_NOT_FOUND_MESSAGE);
+            throw new AccessException(AuthConstants.INVALID_CREDENTIALS_MESSAGE);
         }
         return new NacosUser(nacosUserDetails.getUsername(), jwtTokenManager.createToken(username));
     }
@@ -72,7 +75,7 @@ public class AbstractAuthenticationManager implements IAuthenticationManager {
     @Override
     public NacosUser authenticate(String token) throws AccessException {
         if (StringUtils.isBlank(token)) {
-            throw new AccessException(USER_NOT_FOUND_MESSAGE);
+            throw new AccessException(AuthConstants.INVALID_CREDENTIALS_MESSAGE);
         }
         return jwtTokenManager.parseToken(token);
     }

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/constant/AuthConstants.java
@@ -42,6 +42,9 @@ public class AuthConstants {
     
     public static final String PARAM_PASSWORD = "password";
     
+    public static final String INVALID_CREDENTIALS_MESSAGE =
+        "User not found! Please check user exist or password is right!";
+    
     /**
      * Console resource name prefix.
      *

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/UserController.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/UserController.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -94,8 +95,13 @@ public class UserController {
         
         if (AuthSystemTypes.NACOS.name().equalsIgnoreCase(authConfigs.getNacosAuthSystemType())
             || AuthSystemTypes.LDAP.name().equalsIgnoreCase(authConfigs.getNacosAuthSystemType())) {
-            
-            NacosUser user = iAuthenticationManager.authenticate(request);
+            NacosUser user;
+            try {
+                user = iAuthenticationManager.authenticate(request);
+            } catch (AccessException ignored) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(AuthConstants.INVALID_CREDENTIALS_MESSAGE);
+            }
             
             response.addHeader(AuthConstants.AUTHORIZATION_HEADER,
                 AuthConstants.TOKEN_PREFIX + user.getToken());

--- a/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/main/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3.java
@@ -46,6 +46,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpSessionRequiredException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -305,8 +306,13 @@ public class UserControllerV3 {
         throws AccessException, IOException {
         if (AuthSystemTypes.NACOS.name().equalsIgnoreCase(authConfigs.getNacosAuthSystemType())
             || AuthSystemTypes.LDAP.name().equalsIgnoreCase(authConfigs.getNacosAuthSystemType())) {
-            
-            NacosUser user = iAuthenticationManager.authenticate(request);
+            NacosUser user;
+            try {
+                user = iAuthenticationManager.authenticate(request);
+            } catch (AccessException ignored) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(AuthConstants.INVALID_CREDENTIALS_MESSAGE);
+            }
             
             response.addHeader(AuthConstants.AUTHORIZATION_HEADER,
                 AuthConstants.TOKEN_PREFIX + user.getToken());

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/authenticate/AbstractAuthenticationManagerTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/authenticate/AbstractAuthenticationManagerTest.java
@@ -34,6 +34,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -102,6 +103,33 @@ public class AbstractAuthenticationManagerTest {
         assertThrows(AccessException.class, () -> {
             abstractAuthenticationManager.authenticate("nacos", "test");
         });
+    }
+    
+    @Test
+    void testUnknownUserAndWrongPasswordReturnSameFailure() {
+        NacosUserDetails nacosUserDetails = new NacosUserDetails(user);
+        when(userDetailsService.loadUserByUsername("missing"))
+            .thenThrow(new UsernameNotFoundException("User missing not found"));
+        when(userDetailsService.loadUserByUsername("nacos")).thenReturn(nacosUserDetails);
+        
+        AccessException unknownUser = assertThrows(AccessException.class,
+            () -> abstractAuthenticationManager.authenticate("missing", "test"));
+        AccessException wrongPassword = assertThrows(AccessException.class,
+            () -> abstractAuthenticationManager.authenticate("nacos", "wrong"));
+        
+        assertEquals(AuthConstants.INVALID_CREDENTIALS_MESSAGE, unknownUser.getErrMsg());
+        assertEquals(unknownUser.getErrMsg(), wrongPassword.getErrMsg());
+    }
+    
+    @Test
+    void testUnexpectedUserLookupFailureIsNotConvertedToAuthenticationFailure() {
+        when(userDetailsService.loadUserByUsername("nacos"))
+            .thenThrow(new IllegalStateException("database unavailable"));
+        
+        IllegalStateException actual = assertThrows(IllegalStateException.class,
+            () -> abstractAuthenticationManager.authenticate("nacos", "test"));
+        
+        assertEquals("database unavailable", actual.getMessage());
     }
     
     @Test

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/controller/UserControllerTest.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/controller/UserControllerTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.nacos.plugin.auth.impl.controller;
 
 import com.alibaba.nacos.common.model.RestResult;
+import com.alibaba.nacos.plugin.auth.exception.AccessException;
 import com.alibaba.nacos.plugin.auth.impl.authenticate.IAuthenticationManager;
 import com.alibaba.nacos.plugin.auth.impl.configuration.AuthConfigs;
 import com.alibaba.nacos.plugin.auth.impl.constant.AuthConstants;
@@ -34,6 +35,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -134,6 +137,20 @@ class UserControllerTest {
         String actualString = actual.toString();
         assertTrue(actualString.contains("\"accessToken\":\"1234567890\""));
         assertTrue(actualString.contains("\"globalAdmin\":false"));
+    }
+    
+    @Test
+    void testLoginWithInvalidCredentials() throws Exception {
+        when(authConfigs.getNacosAuthSystemType()).thenReturn(AuthSystemTypes.NACOS.name());
+        when(authenticationManager.authenticate(request))
+            .thenThrow(new AccessException("authentication detail"));
+        
+        Object actual = userController.login("nacos", "bad", response, request);
+        
+        assertTrue(actual instanceof ResponseEntity);
+        ResponseEntity<?> result = (ResponseEntity<?>) actual;
+        assertEquals(HttpStatus.FORBIDDEN, result.getStatusCode());
+        assertEquals(AuthConstants.INVALID_CREDENTIALS_MESSAGE, result.getBody());
     }
     
     @Test

--- a/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3Test.java
+++ b/plugin-default-impl/nacos-default-auth-plugin/src/test/java/com/alibaba/nacos/plugin/auth/impl/controller/v3/UserControllerV3Test.java
@@ -49,6 +49,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -473,6 +474,21 @@ class UserControllerV3Test {
         assertTrue(actualString.contains("\"globalAdmin\":false"));
         assertEquals(AuthConstants.TOKEN_PREFIX + "ldap-token",
             response.getHeader(AuthConstants.AUTHORIZATION_HEADER));
+    }
+    
+    @Test
+    void testLoginWithInvalidCredentials() throws AccessException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        when(authConfigs.getNacosAuthSystemType()).thenReturn(AuthSystemTypes.NACOS.name());
+        when(iAuthenticationManager.authenticate(request))
+            .thenThrow(new AccessException("authentication detail"));
+        
+        Object actual = userControllerV3.login(new MockHttpServletResponse(), request);
+        
+        assertTrue(actual instanceof ResponseEntity);
+        ResponseEntity<?> result = (ResponseEntity<?>) actual;
+        assertEquals(HttpStatus.FORBIDDEN, result.getStatusCode());
+        assertEquals(AuthConstants.INVALID_CREDENTIALS_MESSAGE, result.getBody());
     }
     
     @Test

--- a/specs/en/auth/default-auth-plugin-spec.md
+++ b/specs/en/auth/default-auth-plugin-spec.md
@@ -102,6 +102,22 @@ auth implementations, including [RAM](ram-auth-plugin-spec.md) and
 [OIDC](oidc-auth-plugin-spec.md), are documented as Java Client SDK extensions
 in the [Java SDK Implementation Spec](../sdk/sdk-java-impl-spec.md).
 
+### Login Response Compatibility
+
+Successful default-auth login responses from `/v3/auth/user/login` and the
+legacy v1 login routes remain a flat token object containing `accessToken`,
+`tokenTtl`, `globalAdmin`, and `username`. They are not wrapped in `Result<T>`
+because released Java clients parse this flat shape directly.
+
+An unknown username, an incorrect password, or blank credentials must produce
+the same HTTP 403 status and the same generic
+`User not found! Please check user exist or password is right!` response body.
+The HTTP status and response body must not disclose whether the username exists.
+Unknown-user authentication does not perform a password hash comparison, so
+arbitrary usernames cannot force the server to execute the CPU-intensive
+password encoder. Unexpected user storage or token issuance failures are
+operational errors and must not be converted into credential failures.
+
 ## RBAC Storage Model
 
 The default plugin stores:

--- a/specs/en/http-api/response-error-spec.md
+++ b/specs/en/http-api/response-error-spec.md
@@ -44,6 +44,8 @@ Current intentional response-shape exceptions:
 - Streaming copilot endpoints return Server-Sent Events.
 - Health readiness may return HTTP 500 with a `Result<String>` body when not
   ready.
+- Default-auth v1 and v3 login success returns the legacy flat token object,
+  while credential failures return HTTP 403 with a generic plain-text body.
 - Some legacy or operational endpoints may return plain text. These should be
   kept only when confirmed as compatibility behavior.
 

--- a/specs/zh-cn/auth/default-auth-plugin-spec.md
+++ b/specs/zh-cn/auth/default-auth-plugin-spec.md
@@ -87,6 +87,17 @@ token 密钥和服务端身份值必须由部署环境独立配置。使用默�
 [RAM](ram-auth-plugin-spec.md)、[OIDC](oidc-auth-plugin-spec.md) 等其他客户端鉴权实现作为
 Java Client SDK 扩展在 [Java SDK 实现规范](../sdk/sdk-java-impl-spec.md)中描述。
 
+### 登录响应兼容性
+
+`/v3/auth/user/login` 和遗留 v1 登录路由的默认鉴权登录成功响应保持为平铺 token 对象，
+包含 `accessToken`、`tokenTtl`、`globalAdmin` 和 `username`。该响应不使用 `Result<T>`
+包装，因为已发布的 Java 客户端会直接解析这一平铺结构。
+
+用户名不存在、密码错误或凭据为空时，必须返回相同的 HTTP 403 状态和相同的通用
+`User not found! Please check user exist or password is right!` 响应体，HTTP 状态和响应体不得
+泄露用户名是否存在。未知用户认证不执行密码哈希比对，避免攻击者使用任意用户名迫使服务端执行高 CPU
+开销的密码编码操作。用户存储或 token 签发的非预期故障属于运行异常，不得转换为凭据错误。
+
 ## RBAC 存储模型
 
 默认插件存储：

--- a/specs/zh-cn/http-api/response-error-spec.md
+++ b/specs/zh-cn/http-api/response-error-spec.md
@@ -42,6 +42,8 @@ V3 JSON 响应默认使用 `com.alibaba.nacos.api.model.v2.Result<T>`：
 - Copilot 流式端点返回 Server-Sent Events。
 - 健康检查 readiness 在未就绪时可以返回 HTTP 500，并携带
   `Result<String>` 响应体。
+- 默认鉴权 v1 和 v3 登录成功时返回遗留的平铺 token 对象，凭据错误时返回 HTTP 403
+  和通用纯文本响应体。
 - 部分遗留或运维端点可以返回纯文本。只有在确认属于兼容行为后，才应保留。
 
 ## 3. 错误处理

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/auth/UserLoginAuthApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/adminapi/auth/UserLoginAuthApiITCase.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.adminapi.auth;
+
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.http.client.NacosRestTemplate;
+import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
+import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the default auth login APIs.
+ *
+ * <p>Scenario coverage:
+ * <ul>
+ *     <li>Expected capability: v1 and v3 login preserve the legacy flat token response.</li>
+ *     <li>Boundary/validation: blank passwords produce the generic authentication failure.</li>
+ *     <li>Error handling: unknown users and wrong passwords return the same status and body.</li>
+ * </ul>
+ *
+ * @author xiweng.yy
+ */
+public class UserLoginAuthApiITCase {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserLoginAuthApiITCase.class);
+    
+    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
+    
+    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
+    
+    private static final String BASE_URL = "http://" + NACOS_HOST + ":" + NACOS_PORT;
+    
+    private static final String AUTH_USER_PATH = "/nacos/v3/auth/user";
+    
+    private static final String V3_LOGIN_PATH = AUTH_USER_PATH + "/login";
+    
+    private static final String V1_LOGIN_PATH = "/nacos/v1/auth/users/login";
+    
+    private static final String PASSWORD = "Nacos-login-it-123";
+    
+    private static final String LOGIN_FAILURE_MESSAGE =
+        "User not found! Please check user exist or password is right!";
+    
+    private CloseableHttpClient httpClient;
+    
+    private NacosRestTemplate nacosRestTemplate;
+    
+    @BeforeEach
+    public void setUp() {
+        httpClient = HttpClientBuilder.create().build();
+        nacosRestTemplate = new NacosRestTemplate(LOGGER,
+            new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
+    }
+    
+    @AfterEach
+    public void tearDown() throws Exception {
+        nacosRestTemplate.close();
+    }
+    
+    @Test
+    public void testLoginResponseCompatibility() throws Exception {
+        String username = "login_it_" + UUID.randomUUID();
+        try {
+            createUser(username);
+            
+            HttpRestResult<String> v3Success = waitForLoginSuccess(V3_LOGIN_PATH, username);
+            assertEquals(200, v3Success.getCode(), responseBody(v3Success));
+            assertFlatTokenResponse(v3Success.getData(), username);
+            
+            HttpRestResult<String> v1Success = postLogin(V1_LOGIN_PATH, username, PASSWORD);
+            assertEquals(200, v1Success.getCode(), responseBody(v1Success));
+            assertFlatTokenResponse(v1Success.getData(), username);
+            
+            HttpRestResult<String> v3Failure = verifyLoginFailures(V3_LOGIN_PATH, username);
+            HttpRestResult<String> v1Failure = verifyLoginFailures(V1_LOGIN_PATH, username);
+            assertEquals(v3Failure.getCode(), v1Failure.getCode());
+            assertEquals(responseBody(v3Failure), responseBody(v1Failure));
+        } finally {
+            deleteUser(username);
+        }
+    }
+    
+    private void createUser(String username) throws Exception {
+        HttpRestResult<String> response = nacosRestTemplate.postForm(BASE_URL + AUTH_USER_PATH,
+            Header.EMPTY, credentials(username, PASSWORD), String.class);
+        assertTrue(response.ok(), "create user failed: " + responseBody(response));
+        JsonNode result = JacksonUtils.toObj(response.getData());
+        assertEquals(0, result.get("code").asInt(), response.getData());
+        assertEquals("create user ok!", result.get("data").asText(), response.getData());
+    }
+    
+    private HttpRestResult<String> verifyLoginFailures(String path, String username)
+        throws Exception {
+        HttpRestResult<String> wrongPassword = postLogin(path, username, "wrong-password");
+        HttpRestResult<String> unknownUser = postLogin(path,
+            "missing_" + UUID.randomUUID(), "wrong-password");
+        HttpRestResult<String> blankPassword = postLogin(path, username, "");
+        
+        assertLoginFailure(wrongPassword);
+        assertEquals(wrongPassword.getCode(), unknownUser.getCode());
+        assertEquals(responseBody(wrongPassword), responseBody(unknownUser));
+        assertEquals(wrongPassword.getCode(), blankPassword.getCode());
+        assertEquals(responseBody(wrongPassword), responseBody(blankPassword));
+        return wrongPassword;
+    }
+    
+    private HttpRestResult<String> waitForLoginSuccess(String path, String username)
+        throws Exception {
+        HttpRestResult<String> response = null;
+        for (int attempt = 0; attempt < 20; attempt++) {
+            response = postLogin(path, username, PASSWORD);
+            if (response.ok()) {
+                return response;
+            }
+            Thread.sleep(1000L);
+        }
+        return response;
+    }
+    
+    private HttpRestResult<String> postLogin(String path, String username, String password)
+        throws Exception {
+        return nacosRestTemplate.postForm(BASE_URL + path, Header.EMPTY,
+            credentials(username, password), String.class);
+    }
+    
+    private Map<String, String> credentials(String username, String password) {
+        Map<String, String> credentials = new LinkedHashMap<>();
+        credentials.put("username", username);
+        credentials.put("password", password);
+        return credentials;
+    }
+    
+    private void assertFlatTokenResponse(String body, String username) throws Exception {
+        JsonNode root = JacksonUtils.toObj(body);
+        assertNotNull(root, body);
+        assertFalse(root.has("code"), body);
+        assertTrue(root.hasNonNull("accessToken"), body);
+        assertTrue(root.get("tokenTtl").asLong() > 0, body);
+        assertFalse(root.get("globalAdmin").asBoolean(), body);
+        assertEquals(username, root.get("username").asText(), body);
+    }
+    
+    private void assertLoginFailure(HttpRestResult<String> response) {
+        assertEquals(403, response.getCode(), responseBody(response));
+        assertEquals(LOGIN_FAILURE_MESSAGE, responseBody(response));
+    }
+    
+    private String responseBody(HttpRestResult<String> response) {
+        return response.getData() == null ? response.getMessage() : response.getData();
+    }
+    
+    private void deleteUser(String username) throws Exception {
+        Query query = Query.newInstance().addParam("username", username);
+        HttpRestResult<String> response = nacosRestTemplate.delete(BASE_URL + AUTH_USER_PATH,
+            Header.EMPTY, query, String.class);
+        if (!response.ok()) {
+            LOGGER.warn("delete user non-OK: code={} body={}", response.getCode(),
+                responseBody(response));
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Backport the fix for #15682 to the v3.2.4 maintenance branch.

Login failures previously exposed different HTTP responses for an unknown username and an incorrect password, which allowed username enumeration. This change preserves the established login response contract while making invalid-credential responses indistinguishable.

This is the v3.2.4-targeted counterpart of #15717 and is implemented directly against the latest v3.2.4-develop branch because cherry-picking the develop change caused broad conflicts.

## Brief changelog

* Return HTTP 403 with the existing generic message for unknown users, incorrect passwords, and blank credentials on both v1 and v3 login APIs.
* Skip the CPU-intensive password hash comparison when the username does not exist.
* Preserve unexpected user-storage and token failures as operational errors.
* Keep successful v1 and v3 login responses as the legacy flat token object so released clients can continue parsing them.
* Add unit tests, standalone OpenAPI integration coverage, and English/Chinese compatibility specifications.

## Verifying this change

Passed locally:

* mvn -pl plugin-default-impl/nacos-default-auth-plugin,test/openapi-test spotless:apply
* mvn -pl plugin-default-impl/nacos-default-auth-plugin,test/openapi-test spotless:check
* mvn -B -pl plugin-default-impl/nacos-default-auth-plugin,test/openapi-test clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -DskipTests
* mvn -pl plugin-default-impl/nacos-default-auth-plugin test (348 tests passed)
* mvn -pl test/openapi-test -DskipTests test-compile

The full release-profile reactor build was also attempted. It reaches nacos-console and then fails on the unmodified v3.2.4-develop baseline because ConsoleDeploymentConfig references ConfigCloneSourceReadPermissionChecker, while that class is absent from the maintenance branch. The reference was backported in commit 96d5ce3cf from #15676, but its prerequisite from #15498 was not backported. No console/config changes are included here because that is unrelated to #15682 and should be corrected separately.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like [ISSUE #123] Fix UnknownException when host config not exist. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in test module.
* [ ] Run the complete repository build and integration-test suite. The affected-module checks pass; the complete build is currently blocked by the unrelated v3.2.4-develop baseline problem described above.
