### PR TITLE
[ISSUE #14804] Define shared RAD and AI resource search contracts

### DIFF
--- a/specs/en/ai/a2a-agent-spec.md
+++ b/specs/en/ai/a2a-agent-spec.md
@@ -78,6 +78,14 @@ The current descriptor baseline supports A2A 1.0 fields and the existing 0.x
 compatibility fields. Adapter normalization must not replace the stored native
 descriptor with a synthetic generic Agent object.
 
+An A2A call interface in the exact common-latest Version declares the ARD
+representation `application/a2a-agent-card+json` only when it passes complete
+AgentCard validation for that baseline. The artifact returns the stored native
+descriptor directly and must not disguise a multi-protocol Nacos Agent wrapper
+as an AgentCard. A2A support only on an older online Version affects RAD
+`protocolsAny=a2a`; it does not create a current A2A ARD representation when
+common latest has no valid AgentCard.
+
 `registrationType=URL` maps to `[DECLARED,RUNTIME]` and
 `registrationType=SERVICE` maps to `[RUNTIME,DECLARED]`. Registration type is a
 legacy projection field, not part of Agent identity or the new APIs.
@@ -219,4 +227,7 @@ of those capabilities.
 
 Changes in upstream AgentCard fields or A2A protocol versions are handled by the
 A2A adapter and versioned Agent call interface. They must not redefine the
-canonical Agent identity or the protocol-neutral RAD result.
+canonical Agent identity or the protocol-neutral RAD result. The AgentCard
+media type and pinned upstream schema baseline used by ARD are versioned with
+the [AI Registry Adaptor Spec](ai-registry-adaptor-spec.md); a change updates
+the adaptor fixtures, validator, specification, and conformance tests together.

--- a/specs/en/ai/agent-api-spec.md
+++ b/specs/en/ai/agent-api-spec.md
@@ -200,6 +200,21 @@ Search query names equal RAD field names. Repeated `tagsAll` values use AND;
 repeated `protocolsAny` values use OR. `agentNameContains` is a literal,
 case-sensitive substring.
 
+Agent Search is a resource-specific facade over shared Search Core with
+`resourceType=agent` fixed. It maintains no second index and performs no
+secondary business filtering after index pagination. `agentNameContains`,
+`tagsAll`, and `protocolsAny` are converted to typed predicates from the
+[AI Resource Search Spec](ai-resource-search-spec.md) before totals and page
+truncation. When generic AI Resource Search queries only Agent, its candidate
+eligibility, visibility, and currentness match this API; the response DTO,
+ordering, and numbered-page contract continue to follow RAD.
+
+When `nacos.ai.rad.search.mode=INDEX` and the Agent projection is not READY,
+the HTTP and gRPC bindings return equivalent explicit service-unavailable
+errors. `AUTO` uses the complete legacy scan before readiness and the index
+after readiness. A binding does not expose the selected physical path and does
+not downgrade or mix results within one request after an index-call failure.
+
 Discover maps `agentName`, `version`, and `label` directly. Repeated filter
 parameters are `protocol`, `transport`, and `endpointSource`.
 `protocolVersion` is singular. `metadataSelector` is one URL-encoded JSON

--- a/specs/en/ai/agent-management-spec.md
+++ b/specs/en/ai/agent-management-spec.md
@@ -261,6 +261,23 @@ Agent metadata, Agent Version definitions, and Runtime Endpoints do not own one
 another's lifecycle. Deleting or disabling an Agent definition changes its
 read projection but does not delete still-live runtime publisher state.
 
+An Agent catalog Search document is rebuildable derived state, not another
+fact source. The following successful commits schedule one coalesced
+`search_index` task by `(namespaceId, agent, agentName)`: Agent creation,
+directory metadata or governance updates, Version publish/online/offline/delete,
+common-latest or custom-label changes, canonical definition changes through the
+legacy A2A facade, and Agent deletion. The task re-reads current facts and
+projects common latest plus the complete online-Version catalog; consecutive
+changes advance only the task revision.
+
+Runtime Endpoint registration/deregistration, Publisher heartbeat, health
+state, and Runtime revision do not schedule this task and never enter the Agent
+catalog index. Scheduling failure does not roll back an already successful
+Agent lifecycle operation. Durable task retry and Reconciliation converge as
+defined by the [AI Resource Search Spec](ai-resource-search-spec.md). Deleting
+the derived document is the correct index result when the Agent is absent,
+disabled, or has no online Version.
+
 ## 5. Call Interfaces And Declared Endpoints
 
 ### 5.1 AgentCallInterface

--- a/specs/en/ai/agent-storage-spec.md
+++ b/specs/en/ai/agent-storage-spec.md
@@ -623,7 +623,8 @@ set uses the Version `contentDigest` as its opaque source revision.
 
 | Read | Facts read | AI Storage read |
 | --- | --- | :---: |
-| Management Agent list or RAD Search | `ai_resource` page. | No |
+| Management Agent list | `ai_resource` page. | No |
+| RAD or generic Agent Search | Current Agent Search document; RAD `AUTO/SCAN` uses the compatibility scan before readiness. | No |
 | Agent overview | Resource plus bounded Version-row page. | No |
 | Exact Version detail | One Version row. | One |
 | Runtime Endpoint snapshot | Complete internal `ServiceStorage` projection for one protocol; optional binding filter. | No |
@@ -635,6 +636,7 @@ set uses the Version `contentDigest` as its opaque source revision.
 | Create or update draft | AI Storage fixed key plus Version row. | Pointer, bytes, size, and digest agree. |
 | Publish, online, offline, delete, label/latest | Version row plus Resource summaries. | Rebuild derived catalog. |
 | Runtime register, Publisher heartbeat, deregister | Naming Client runtime state. | Does not write AI Resource or Storage. |
+| Agent directory or Version lifecycle commit | Coalesced `search_index` revision in `ai_resource_task`. | Asynchronously re-reads facts and rebuilds the derived index. |
 
 Cache validators follow facts:
 
@@ -669,6 +671,22 @@ observable incomplete operation that is retried or cleaned as orphan content.
 Digest mismatch must never return unverified content. `versionCatalog` and
 Resource version summaries are rebuildable derived data; their consistency is
 not delegated to Storage providers.
+
+The Agent Search projection is also rebuildable derived state. At most one
+current document exists per `(namespaceId, agentName)`. Its `resourceVersion`
+is the exact online Version referenced by common latest, and it contains the
+complete deterministically ordered online-Version catalog, `protocols` and
+`artifactKinds` facets, projection version, and source digest. The source
+digest covers canonical Agent metadata, the Version catalog, common latest,
+the latest Version `contentDigest`, artifact kinds, and projection version; a
+modification timestamp is not its sole input.
+
+The relational document, chunks, and embedded facets are replaced completely
+in one transaction. The index stores no Runtime Endpoint, health, Publisher,
+heartbeat, or Runtime revision. Backfill/Reconciliation scans through the
+resource-type handler in bounded resource-key batches and maintains cluster
+readiness by `(agent, projectionVersion)`. Task, lease, and read-mode semantics
+are defined by the [AI Resource Search Spec](ai-resource-search-spec.md).
 
 ## 9. Capacity And Security
 

--- a/specs/en/ai/agentspec-spec.md
+++ b/specs/en/ai/agentspec-spec.md
@@ -53,6 +53,17 @@ a provider uses `nacos_config`.
 Unlike Skill, AgentSpec does not maintain a separate manifest index. Version
 metadata and storage pointers are authoritative.
 
+AgentSpec participates in generic AI Resource Search and provides a
+resource-specific Search facade with `resourceType=agentspec` fixed. Both reuse
+the document/chunk/facet, currentness, visibility, and pagination semantics
+from the [AI Resource Search Spec](ai-resource-search-spec.md). The AgentSpec
+handler projects the latest online Version's name, description, business tags,
+public dependencies, and capability descriptions. Resource content containing
+credentials or private runtime values does not enter chunks. The existing
+keyword-paged Client Search migrates to this facade and must not filter again
+after shared-index pagination. Generic Search restricted to AgentSpec has the
+same candidate eligibility as resource-specific Search.
+
 ## 4. Lifecycle
 
 AgentSpec follows the shared [AI Resource Lifecycle Spec](ai-resource-lifecycle-spec.md):

--- a/specs/en/ai/ai-registry-adaptor-spec.md
+++ b/specs/en/ai/ai-registry-adaptor-spec.md
@@ -29,7 +29,7 @@ Nacos AI Registry resources into external registry response shapes, including:
 - MCP Server data exposed through MCP Registry v0-compatible read APIs;
 - Skill data exposed through skills CLI and well-known discovery-compatible
   endpoints;
-- Skill, Prompt, and MCP data exposed through Agentic Resource Discovery (ARD)
+- Agent, Skill, Prompt, and MCP data exposed through Agentic Resource Discovery (ARD)
   search, explore, catalog, and artifact endpoints;
 - protocol-specific pagination, search, response, and file-fetch behavior
   required by those ecosystems.
@@ -57,13 +57,20 @@ registry surface is explicitly enabled:
 | --- | --- | --- |
 | `nacos.ai.mcp.registry.enabled` | `false` | Enables MCP Registry-compatible endpoints. |
 | `nacos.ai.skill.registry.enabled` | `false` | Enables Skill registry-compatible endpoints. |
-| `nacos.ai.ard.enabled` | `false` | Enables ARD endpoints and their required AI resource search runtime. |
+| `nacos.ai.ard.enabled` | `false` | Enables only ARD endpoints; it does not own the base AI resource search runtime. |
+| `nacos.ai.resource.search.enabled` | `true` | Enables the base relational search shared by RAD, ARD, and resource APIs in the main AI module. |
 | `nacos.ai.registry.port` | `9080` | HTTP port used by the adaptor context. |
 | `nacos.ai.mcp.registry.port` | deprecated | Legacy fallback for the adaptor port. |
 
 Users must opt in because the adaptor consumes an additional port and exposes
 protocol shapes that are designed for community clients rather than Nacos
 Admin, Console, or Client API consumers.
+
+With `nacos.ai.ard.enabled=true` and
+`nacos.ai.resource.search.enabled=false`, server startup fails explicitly
+during configuration validation and does not create an ARD-specific index.
+Disabling ARD does not affect the index, tasks, or
+Reconciliation used by RAD or resource-specific Search.
 
 Disabling ARD must not require PostgreSQL pgvector. AI resource search document
 and chunk metadata use the main datasource, while the pgvector extension and
@@ -187,7 +194,7 @@ endpoints from the adaptor web context:
 
 | Method | Path | Behavior |
 | --- | --- | --- |
-| `POST` | `/v3/ai/ard/search` | Searches the latest online Skill, Prompt, and MCP resources. |
+| `POST` | `/v3/ai/ard/search` | Searches the latest online Agent, Skill, Prompt, and MCP resources. |
 | `POST` | `/v3/ai/ard/explore` | Returns facets for discoverable resources. |
 | `GET` | `/v3/ai/ard/agents` | Lists discoverable resources with filters and pagination. |
 | `GET` | `/v3/ai/ard/ai-catalog.json` | Returns a namespace-scoped catalog. |
@@ -233,17 +240,45 @@ implementation must not append the main Nacos server context path to it.
 For Skill resources, the artifact endpoint returns the complete Skill archive,
 including `SKILL.md` and its packaged resources, using
 `application/agent-skills+zip`. Prompt and MCP artifacts use their
-protocol-defined representations. A deployment with the default Nacos server
-on port 8848 and the adaptor on port 9080 must work without gateway path
-co-location.
+protocol-defined representations. Agent supports:
+
+```text
+application/a2a-agent-card+json
+application/vnd.nacos.ai-agent+json
+```
+
+The former is available only when the exact common-latest Version contains a
+complete valid A2A Agent Card and returns only that native card. The latter
+returns a versioned, protocol-neutral Nacos Agent definition without Runtime
+Endpoints, health, Publishers, heartbeats, owner, scope, or review state. An
+artifact URL includes the exact Version, its `contentDigest`, and the
+representation key. An offline Version, digest mismatch, or unavailable
+representation returns ARD not found. The Nacos representation validates
+against
+[`NacosAgentArtifact`](../../schemas/ai/agent/0.2.0/agent-artifact.schema.json#/$defs/NacosAgentArtifact).
+A deployment with the default Nacos server on port 8848 and the adaptor on port
+9080 must work without gateway path co-location.
+
+The shared Agent Search document remains singular per logical Agent. Its
+`artifactKinds` uses at least the stable keys `a2a-agent-card` and
+`nacos-agent`. An ARD media-type filter maps to
+`resourceType=agent + artifactKinds`, not merely to `protocols`. One ARD
+request returns at most one entry for one logical Agent. Without a type filter,
+a pure-A2A latest prefers the A2A representation, while a multi-protocol or
+custom-protocol latest prefers the Nacos representation. With a type filter,
+selection uses the same deterministic primary order among requested and
+actually available representations. Representation selection does not change
+the logical resource identifier; the representation-specific artifact URL
+distinguishes content. Filtering and representation selection occur before
+totals and page-token calculation.
 
 ### 6.3 Discovery Boundary
 
 The AI module owns the protocol-neutral capability defined by the
-[AI Resource Search Spec](ai-resource-search-spec.md). ARD is its only consumer
-in this version, so `nacos.ai.ard.enabled` activates the required search
-runtime without creating a separate operator-facing search switch or another
-public API.
+[AI Resource Search Spec](ai-resource-search-spec.md). RAD, ARD, generic AI
+Resource Search, and resource-specific Search share that runtime;
+`nacos.ai.ard.enabled` controls only the adaptor protocol surface and neither
+activates nor disables base Search Core.
 
 Visibility and current-version validation occur before the requested result
 limit is applied. List and aggregation scans use bounded database batches.
@@ -293,9 +328,9 @@ aggregation.
 ### 6.4 Index Consistency
 
 Canonical resource writes remain authoritative. Relational replacement of one
-resource's search document and chunks is atomic: deleting the previous index
-rows, inserting the new document, and inserting all chunks occur in one
-datasource transaction.
+resource's search document, chunks, and embedded facets is atomic: deleting
+the previous index rows, inserting the new document, and inserting all chunks
+occur in one datasource transaction.
 
 Relational and vector indexes do not require a distributed transaction.
 Instead, the AI module records an idempotent, durable resource-level indexing
@@ -331,6 +366,10 @@ it, against the actual adaptor web context.
 At minimum, integration coverage includes list `items`, integer search score,
 URI `source`, trust identity behavior, protocol error bodies, catalog schema,
 and Skill ZIP retrieval when the main server and adaptor use separate ports.
+Agent coverage also includes pure A2A, multi-protocol, A2A only on an older
+online Version, both media-type filters, stable logical identifiers,
+representation-specific URLs, offline/digest invalidation, and artifacts that
+exclude Runtime state.
 
 ## 7. Compatibility Rules
 

--- a/specs/en/ai/ai-resource-search-spec.md
+++ b/specs/en/ai/ai-resource-search-spec.md
@@ -23,44 +23,88 @@ deterministic listing, pagination, and aggregation.
 
 ## 1. Scope And Activation
 
-AI Resource Search is an internal reusable capability. It does not define a
-Nacos HTTP API, Java SDK API, Console API, or external protocol response.
+AI Resource Search is a reusable, protocol-neutral logical capability in the
+`ai` module. RAD, ARD, generic AI Resource Search, and resource-specific Search
+must share this capability rather than maintain separate indexes or search
+engines. Their HTTP, Java SDK, Console, and external-protocol responses are
+defined by the corresponding API or adaptor specifications.
 
-The ARD adaptor is the only consumer in this version. Consequently,
-`nacos.ai.ard.enabled` activates both the ARD surface and its required search
-runtime. There is no separate operator-facing search switch until another
-consumer exists. The search implementation must not otherwise depend on ARD
-request, response, identifier, federation, media-type, or artifact semantics.
+The base relational search runtime is activated independently by
+`nacos.ai.resource.search.enabled`, whose default is `true`.
+`nacos.ai.ard.enabled` controls only the ARD Web Context and protocol endpoints;
+it must not disable the search runtime required by RAD or other resource APIs.
+The combination `nacos.ai.ard.enabled=true` and
+`nacos.ai.resource.search.enabled=false` is invalid; server startup must fail
+explicitly during configuration validation. It must not create a hidden
+ARD-specific index. The search implementation must
+not depend on ARD request, response, identifier, federation, media-type, or
+artifact semantics.
 
 ## 2. Ownership Boundary
 
 The AI module owns:
 
-- canonical search documents and chunks;
+- canonical search document, chunk, and facet projections;
+- the resource-type handler registry, Query Planner, and multi-channel result
+  fusion;
 - durable index tasks and reconciliation;
 - keyword and optional vector recall;
 - ranking and deterministic tie-breaking;
 - visibility advice and per-resource visibility enforcement;
 - latest-label and current online-version validation;
-- canonical filters, opaque cursor pagination, and complete-set aggregation.
+- typed predicates, opaque cursors, numbered pages, and complete-set
+  aggregation;
+- readiness for each resource projection generation.
 
-Protocol adaptors own request parsing, protocol validation, protocol-specific
-filter translation, identifiers, media types, response DTOs, error bodies,
-artifact URLs, and federation behavior.
+Protocol adaptors or resource-specific API facades own request parsing,
+protocol validation, type-specific filter translation, response DTOs, and
+error mapping. Identifiers, media types, artifact URLs, and federation behavior
+belong only to the corresponding protocol adaptor.
 
 ## 3. Search Model
 
-The internal query model contains namespace, text, canonical resource types,
-canonical filters, time boundaries, sort order, page size, and opaque cursor.
-It must not contain protocol DTOs or protocol-specific field names.
+The internal query model contains namespace, text, one or more canonical
+resource types, typed predicates, time boundaries, sort order, and cursor or
+numbered-page information. It must not contain protocol DTOs or
+protocol-specific field names.
+
+Canonical predicates support at least:
+
+```text
+field
+operator = EXACT_ANY | EXACT_ALL | LITERAL_CONTAINS
+values[]
+caseSensitive
+```
+
+The operator defines ANY, ALL, or literal-contains behavior within one
+predicate, and multiple predicates are combined with AND.
+`metadata.<facetKey>` is a protocol-neutral facet path. Implementations treat
+`%`, `_`, and the escape character as literal input and must not let database
+LIKE wildcards change literal-contains semantics. A type-specific facade may
+fix the resource type, permitted fields, case rules, and field weights, but it
+must not change common visibility, enabled, or currentness rules. Existing
+protocol filters may retain compatibility entry points, but are converted to
+canonical predicates before entering Search Core.
 
 Search results are application DTOs rather than persistence entities. A result
 may expose the canonical resource key, current version, display and search
 metadata, timestamps, and relevance score. Database row identifiers, index
 status, and task state remain internal to the search implementation.
 
-Visibility and current-version validation occur before page limits are
-applied. Cursors use stable resource anchors rather than mutable list offsets.
+Visibility, enabled, and current-version validation occur before totals,
+offsets, and page limits are applied. Cursors use stable resource anchors
+rather than mutable list offsets. A numbered page returns `totalCount`,
+`pageNumber`, `pagesAvailable`, and current-page items. An implementation may
+stream past the offset, but must not truncate candidates before calculating the
+total.
+
+Generic Search provides unified recall and ranking across resource types.
+Resource-specific Search fixes one resource type in the Query Planner and may
+apply type-specific predicates and weights. When generic Search specifies only
+one resource type, its eligibility, visibility, and currentness results match
+the corresponding resource-specific Search. Cross-type Search must not be
+implemented by concatenating already-paginated resource-specific results.
 
 ## 4. Aggregation
 
@@ -93,6 +137,82 @@ must not create the pgvector extension or an embedding table.
 Canonical resource writes remain authoritative. Search documents and chunks
 are derived state and may be rebuilt.
 
+A logical `IndexProjection` consists of one document, zero or more chunks, and
+a facet set:
+
+- the document stores resource identity, display information, state, current
+  version, source digest, and stable ordering fields;
+- facets store exact-filter properties. The first generation may keep generic
+  key/value or array facets in document metadata without immediately adding a
+  physical table;
+- chunks contain only text used for keyword or vector recall. Facets do not
+  become standalone chunks and are not embedded;
+- structured document/facet and keyword indexes are mandatory for base Search,
+  while the vector index is an optional recall channel; and
+- a resource such as Agent populates only facets it owns and must not require
+  Skill, Prompt, MCP, or AgentSpec to add Agent-specific columns.
+
+One Query Planner/Fusion coordinates candidate generation, structured
+filtering, de-duplication, score fusion, visibility, currentness, and pagination
+across all recall channels. When a vector provider cannot push down facets,
+the planner uses a bounded candidate strategy whose completeness can be
+demonstrated. It must not apply one post-filter to a fixed top-K result and
+claim complete totals or pages.
+
+### 5.1 Resource-Type Handlers
+
+Every resource type declared searchable registers a protocol-neutral type
+handler with at least these semantics:
+
+```text
+resourceType()
+project(namespaceId, resourceName) -> Optional<IndexProjection>
+scan(namespaceId, cursor, batchSize) -> SourcePage
+isCurrent(document) -> boolean
+exists(namespaceId, resourceName) -> boolean
+```
+
+An empty `project` result means that the resource is absent, undiscoverable, or
+has no valid current version, and the index service deletes that logical
+resource's derived document. `scan` is used only by Backfill/Reconciliation
+and scans by stable resource key in bounded batches. `isCurrent` enforces the
+resource's enabled, visibility, current-version, and source-digest rules. A
+handler belongs to the `ai` module and must not reference ARD DTOs, URLs, or
+media types.
+
+The searchable types declared by this specification are Agent, AgentSpec,
+Skill, Prompt, and MCP. If a future AI Resource does not participate in generic
+Search, its resource specification states that exclusion explicitly; an
+unimplemented handler must not silently omit a declared type.
+
+### 5.2 Agent Projection
+
+At most one enabled document exists per `(namespaceId, agentName)`. Its
+`resourceVersion` is the exact online Version referenced by common `latest`.
+An Agent document projects at least:
+
+- directory fields such as display name, description, business tags, provider,
+  icon, and scope;
+- an ordered compact catalog of all online Versions;
+- `metadata.protocols`, the ordered de-duplicated union of protocols across all
+  online Versions;
+- `metadata.artifactKinds`, the set of complete representation keys exportable
+  from the exact common-latest Version; and
+- `metadata.projectionVersion` plus a `sourceDigest` over stable business facts.
+
+`protocols` describes invocation protocols, while `artifactKinds` describes
+complete version artifacts that can be returned; they are not interchangeable.
+Agent name, description, tags, capabilities, and examples may produce chunks.
+Scope, owner, status, protocols, and artifact kinds remain structured fields.
+Runtime Endpoints, health, Publishers, heartbeats, and Runtime revisions never
+enter the durable search index.
+
+The Agent source digest is canonical-JSON SHA-256 over Agent metadata that
+affects catalog or search projection, the complete version catalog, common
+latest, the latest Version `contentDigest`, artifact kinds, and projection
+version. A semantically irrelevant modification timestamp does not by itself
+change the digest.
+
 Canonical resource identity fields and task-control fields use exact,
 case-sensitive comparison consistent with canonical resource storage. Keyword
 matching remains case-insensitive through locale-stable query normalization;
@@ -100,13 +220,24 @@ it must not depend on a datasource-specific case-insensitive table collation.
 
 ## 6. Consistency
 
-Replacing one resource version's relational document and chunks is atomic.
+Replacing one logical resource's relational document, chunks, and embedded
+facets is atomic.
 Relational and vector indexes do not require a distributed transaction.
 Instead, an idempotent durable `search_index` task re-reads canonical state and
 converges both indexes. Its task key is SHA-256 over task type, namespace, and
 the logical subject composed of resource type and resource name. Including the
 task type permits other AI resource workflows to use the same table without
 colliding with search-index tasks.
+
+After a canonical resource lifecycle transaction commits successfully, one
+coalesced task is scheduled by `(namespaceId, resourceType, resourceName)`.
+Scheduling failure does not roll back the authoritative write; metrics, alerts,
+and reconciliation repair it. Agent creation, directory metadata or governance
+changes, Version publish/online/offline/delete, common-latest or custom-label
+changes, canonical definition changes made through the legacy A2A facade, and
+Agent deletion all schedule the task. Endpoint registration, deregistration,
+heartbeat, health changes, and Runtime revisions do not schedule a catalog
+index task.
 
 The same task row owns two durable stages:
 
@@ -189,27 +320,74 @@ historical full refresh. Reconciliation preserves the durable enhancement
 intent, revision, stage, retry delay, and lease of an active task for the same
 resource. Vector reconciliation compares the relational document identity as
 well as model and chunk count. Discovery reads only enabled documents whose
-configured indexes have converged.
+configured indexes have converged. Each type handler's reconciliation detects
+missing, partial, stale, and orphaned projections. Agent reconciliation also
+compares projection version, source digest, common latest, version catalog,
+and optional vector state. Deleting the derived document is the correct
+converged result for a resource with no online Version or one that is disabled
+or deleted; it is not a permanent retry condition.
 
 ## 7. Resource Bounds
 
 List, aggregation, reconciliation, and durable-task polling scan relational
-state in bounded database batches. List pagination retains only the requested
-page and one look-ahead result in memory after visibility and current-version
-validation. Reconciliation does not retain every canonical resource name in
-memory. Its cluster-wide scan lease records an owner and expiry, renews through
-CAS while scanning, and releases only while the same owner still holds it.
+state in bounded database batches. Source scans and numbered lists use a stable
+resource-key keyset, with an immutable row key breaking ordering ties. After
+predicate, visibility, and current-version validation, list pagination retains
+only the requested page and one look-ahead result in memory. A numbered page
+retains only an additional counter, not all matching items. Reconciliation
+does not retain every canonical resource name in memory. Its cluster-wide scan
+lease records an owner and expiry, renews through CAS while scanning, and
+releases only while the same owner still holds it.
 
 Keyword and vector recall have a configurable per-channel candidate bound.
 When a channel exceeds the bound, discovery fails explicitly instead of
 returning a silently truncated result set. Operators may tune the bound with
 `nacos.ai.resource.search.max-recall-candidates`.
 
-## 8. Upgrade And Initialization
+## 8. Readiness And Read Modes
+
+A resource type that moves from a legacy scan path to the index maintains
+durable, cluster-shared readiness by `(resourceType, projectionVersion)`. A
+Backfill scan lease identifies only the current scan owner and does not replace
+readiness.
+
+A projection generation is marked `READY` through CAS only after all of these
+conditions hold:
+
+1. every valid namespace was enumerated successfully, without using a `public`
+   fallback to hide enumeration failure;
+2. one bounded source scan for the resource type completed and every detected
+   difference was scheduled successfully;
+3. a subsequent verification pass found no unrepaired missing, stale, or
+   orphaned document;
+4. no pending, processing, or retry task from that pass remains; and
+5. the readiness record names the current projection version.
+
+`READY` is sticky for one generation. Ordinary lifecycle work that is briefly
+pending does not return that generation to unready; query currentness checks
+exclude stale documents until the task converges. A projection contract change
+increments the projection version and creates a new readiness generation.
+
+RAD Search selects its read path with
+`nacos.ai.rad.search.mode=AUTO|INDEX|SCAN`, defaulting to `AUTO`:
+
+| Mode | Not READY | READY | Index-call failure |
+|---|---|---|---|
+| `AUTO` | Use the complete legacy scan path | Switch stickily in-process to the index | Fail explicitly; no per-request fallback |
+| `INDEX` | Return service unavailable explicitly | Use the index | Fail explicitly |
+| `SCAN` | Use legacy scan | Always use legacy scan | Not applicable |
+
+One request never combines partial index and partial legacy-scan results. The
+switch must not change RAD name, tag, protocol, case, ordering, total,
+pagination, visibility, or version-catalog contracts. Another consumer that
+needs a compatibility read mode defines it in its protocol or API spec but
+still reuses this readiness.
+
+## 9. Upgrade And Initialization
 
 Deployments that created the ARD search schema before durable retry was added
 must initialize all three protocol-neutral relational tables before enabling
-`nacos.ai.ard.enabled`:
+`nacos.ai.resource.search.enabled`:
 
 - `ai_resource_search_document`;
 - `ai_resource_search_chunk`;
@@ -248,20 +426,31 @@ PostgreSQL deployments that do not enable the default vector plugin need no
 pgvector objects. Deployments that enable it must separately run the optional
 schema owned by `nacos-default-ai-vector-plugin`.
 
-## 9. Compatibility And Tests
+Before `AUTO` or `INDEX` uses a newly added resource type, that type completes
+Backfill and readiness for its projection generation. The index remains
+rebuildable derived state; it does not change the authoritative canonical
+resource or Runtime Endpoint stores and does not migrate Runtime state into the
+relational search tables.
+
+## 10. Compatibility And Tests
 
 Internal search names, persistence models, tables, configuration, and vector
-SPI packages remain protocol-neutral even while ARD is the only consumer.
+SPI packages remain protocol-neutral. Existing ARD Skill, Prompt, and MCP
+request, cursor, ordering, and artifact behavior remains compatible while the
+shared core is extended.
 
-Tests cover keyword and vector recall, ranking, visibility, current-version
-validation, cursor pagination, full-set aggregation beyond one page,
-transactional replacement, both durable task stages, lease recovery,
+Tests cover keyword and vector recall, structured facets, typed predicates,
+ranking, visibility, current-version validation, cursor and numbered pages,
+full-set aggregation beyond one page, equivalence between generic single-type
+and resource-specific Search, transactional replacement, both durable task
+stages, lease recovery,
 superseded revisions, versioned task payload and result, task-type isolation,
 timezone-independent Epoch scheduling, deterministic-clock lease and retry
 boundaries, consecutive lifecycle coalescing that preserves an active lease,
 stale-worker release fencing by lease token, idempotent enhancement retry,
 configuration-fingerprint recording without global rescheduling, lifecycle
-enhancement intent, and
-repair-triggered reconciliation enhancement without historical full refresh.
-Protocol adaptors separately test their request grammar and response
-conformance.
+enhancement intent, repair-triggered reconciliation enhancement without
+historical full refresh, Agent lifecycle scheduling versus Runtime Endpoint
+non-scheduling, readiness CAS/restart/new generations, and the
+`AUTO/INDEX/SCAN` matrix. Protocol adaptors and resource APIs separately test
+their request grammar, response conformance, and single-type cross-results.

--- a/specs/en/ai/mcp-server-spec.md
+++ b/specs/en/ai/mcp-server-spec.md
@@ -88,6 +88,18 @@ requires persistent endpoint visibility.
 - gRPC payloads include query, release, and endpoint registration requests as
   defined by the [gRPC API Spec](../grpc-api/api-spec.md).
 
+MCP participates in generic AI Resource Search and provides a
+resource-specific Search facade with `resourceType=mcp` fixed. Both reuse the
+same index and Query Planner from the
+[AI Resource Search Spec](ai-resource-search-spec.md); a Config-backed name
+list does not remain a separate full-text search engine. The MCP handler may
+project server name, description, tools, resources, and public tags. Endpoint
+credentials, runtime instances, and sensitive authentication metadata do not
+enter search chunks. Before migration to canonical AI Resource storage, the
+handler may read compatibility storage but produces the same canonical
+projection. Generic Search restricted to MCP has the same candidate
+eligibility as resource-specific Search.
+
 ## 5. Current Compatibility Storage
 
 Current MCP implementation stores MCP metadata through Config-shaped records

--- a/specs/en/ai/prompt-spec.md
+++ b/specs/en/ai/prompt-spec.md
@@ -65,6 +65,17 @@ server may return a not-modified error.
 Subscriptions should report Prompt changes without exposing broad management
 listing behavior to runtime clients.
 
+Prompt participates in generic AI Resource Search and provides a
+resource-specific Search facade with `resourceType=prompt` fixed. Both reuse
+the same index and Query Planner from the
+[AI Resource Search Spec](ai-resource-search-spec.md). The Prompt handler
+projects only caller-visible, enabled resources whose latest resolves to an
+online Version, including name, description, business tags, and template
+description suitable for search. Credentials, secret defaults, and runtime
+parameter values that may occur in a template do not enter chunks. Generic
+Search restricted to Prompt matches resource-specific Search eligibility,
+visibility, and currentness.
+
 ## 5. Storage
 
 Prompt persists the selected storage provider in each version descriptor.

--- a/specs/en/ai/rad-protocol-spec.md
+++ b/specs/en/ai/rad-protocol-spec.md
@@ -441,6 +441,28 @@ Search MUST:
 
 `pageNo` defaults to `1`; `pageSize` defaults to `20` and is at most `100`.
 
+Search reuses the shared Search Core defined by the
+[AI Resource Search Spec](ai-resource-search-spec.md) and fixes the request to
+`resourceType=agent`:
+
+- `agentNameContains` maps to case-sensitive `LITERAL_CONTAINS`, where `%`,
+  `_`, and the escape character are all literals;
+- `tagsAll` maps to case-sensitive `EXACT_ALL`;
+- `protocolsAny` maps to case-sensitive `EXACT_ANY`;
+- different filter categories combine with AND, and filtering, visibility,
+  and currentness checks all occur before totals and page truncation; and
+- the complete online-Version catalog comes from the current Search document,
+  while Runtime Endpoints, health, Publishers, and heartbeats enter neither the
+  Search index nor its response.
+
+`nacos.ai.rad.search.mode` selects `AUTO`, `INDEX`, or `SCAN`. Before the first
+Agent projection Backfill is READY, `AUTO` uses the complete legacy scan path
+and `INDEX` returns service unavailable explicitly. After readiness, `AUTO`
+switches stickily in-process to the index. An index-call failure does not cause
+per-request fallback, and one request never mixes the two paths. All three
+modes preserve this section's filtering, ordering, total, pagination,
+visibility, and version-catalog results.
+
 ## 5. Discover
 
 `AgentDiscoveryRequest` contains:

--- a/specs/en/ai/skill-spec.md
+++ b/specs/en/ai/skill-spec.md
@@ -178,6 +178,16 @@ Skill also maintains a lightweight manifest for client-side discovery. The
 manifest is an index derived from Skill metadata and must not become the source
 of truth for lifecycle state.
 
+Skill participates in generic AI Resource Search and provides a
+resource-specific Search facade with `resourceType=skill` fixed. Both reuse the
+document/chunk/facet, currentness, visibility, and pagination semantics from
+the [AI Resource Search Spec](ai-resource-search-spec.md); neither the manifest
+nor an existing management list becomes a second Search index. The Skill
+handler projects the latest online Version's name, description, tags, and
+searchable manifest content. Package scripts, credentials, and undeclared
+binary content do not enter search chunks. Generic Search restricted to Skill
+has the same candidate eligibility as resource-specific Search.
+
 Storage extension rules are defined by the
 [AI Storage Plugin Spec](../plugin/ai-storage-plugin-spec.md).
 

--- a/specs/en/plugin/ai-vector-plugin-spec.md
+++ b/specs/en/plugin/ai-vector-plugin-spec.md
@@ -31,9 +31,11 @@ Vector indexing is optional. An inactive AI resource search runtime or no
 available vector provider must not prevent Nacos startup, canonical AI
 resource writes, or keyword search. The selected provider is configured by
 `nacos.ai.resource.search.vector.provider`; provider-specific settings remain
-owned by the implementation. In the current release, disabling the only
-consumer through `nacos.ai.ard.enabled=false` also leaves this runtime
-inactive.
+owned by the implementation. The shared Search Core controlled by
+`nacos.ai.resource.search.enabled` consumes the vector provider for RAD, ARD,
+generic AI Resource Search, and resource-specific Search. The
+`nacos.ai.ard.enabled` setting controls only ARD protocol endpoints and must
+not independently decide vector-provider activation.
 
 ## 2. Provider Lifecycle
 
@@ -126,5 +128,6 @@ backward-compatible default or a coordinated compatibility change.
 SPI contract tests cover provider selection, no-op fallback, idempotent
 replace/delete, scoped search, and lifecycle cleanup. The default PostgreSQL
 implementation additionally tests schema isolation, operation without
-pgvector when disabled, transactional replacement inside the provider, and
-reconciliation after simulated vector failures.
+pgvector when disabled, availability to non-ARD consumers when the shared
+Search Core is enabled and ARD is disabled, transactional replacement inside
+the provider, and reconciliation after simulated vector failures.

--- a/specs/en/testing/api-integration-test-spec.md
+++ b/specs/en/testing/api-integration-test-spec.md
@@ -160,3 +160,31 @@ or the full surface selection.
 
 Minimum validation for documentation-only IT registry changes is license and
 format checks for the affected module.
+
+## 9. AI Resource Search And Agent Scenarios
+
+When shared Search Core, Agent projection, or ARD Agent representation changes,
+the OpenAPI IT scenario matrix covers at least:
+
+- RAD and resource-specific Search still use the base index when ARD is disabled
+  and `nacos.ai.resource.search.enabled=true`;
+- Agent-name literal contains, tag ALL, protocol ANY, combined AND, case rules,
+  literal `%`, `_`, and `\\`, first/middle/last/out-of-range pages, and correct
+  totals;
+- bounded convergence after create, metadata update, Version
+  publish/online/offline/delete, and latest/label changes;
+- Endpoint register/deregister/heartbeat changes Discover only and does not
+  change the catalog Search document;
+- equivalent results before and after `AUTO` readiness without mixing,
+  explicit failure for unready `INDEX`, and the compatibility path for `SCAN`;
+- generic Search restricted to Agent, AgentSpec, Skill, Prompt, or MCP matches
+  the corresponding resource-specific Search eligibility, visibility, and
+  currentness; and
+- ARD pure-A2A, multi-protocol, and A2A-only-on-an-older-online-Version type
+  filtering, primary representation, stable identifier,
+  representation-specific artifact URL, offline/digest invalidation, and
+  Runtime-state exclusion.
+
+Tests of asynchronous indexing use only bounded polling of public API results;
+they do not depend on a fixed sleep, internal database rows, or task execution
+order.

--- a/specs/en/testing/java-sdk-integration-test-spec.md
+++ b/specs/en/testing/java-sdk-integration-test-spec.md
@@ -152,3 +152,26 @@ Java SDK ITs intentionally use the dedicated `java-sdk-integration-test` Maven
 profile. The generic `integration-test` profile is reserved for HTTP API IT
 workflows and must not accidentally run SDK tests that depend on SDK gRPC
 connection readiness or optional server abilities.
+
+## 8. AI Resource Search And Agent Scenarios
+
+When public AI SDK Search or Agent behavior changes, Java SDK IT covers at
+least:
+
+- a real SDK client performing Agent single-condition, combined-predicate,
+  numbered-page, and default-namespace queries;
+- equivalent Agent catalog results over HTTP and gRPC for the same facts and
+  transport selection;
+- bounded convergence after Agent publish/online/offline/latest transitions,
+  while Endpoint operations change Discover only;
+- matching eligibility between generic single-type Search and
+  resource-specific Agent, AgentSpec, Skill, Prompt, and MCP Search;
+- the same Search contract for supported client transport
+  `AUTO/HTTP/GRPC`, with a controlled exception when ability negotiation rejects
+  a transport; and
+- SDK shutdown, reconnect, and redo neither duplicate catalog-index writes nor
+  expose Runtime Endpoints in Search results.
+
+Protocol conformance for ARD artifacts remains covered by OpenAPI/adaptor IT.
+Java SDK IT validates only observable catalog and Discover behavior through
+public SDK contracts.

--- a/specs/schemas/README.md
+++ b/specs/schemas/README.md
@@ -83,4 +83,5 @@ being accepted accidentally where another was expected.
 | --- | --- | --- | --- |
 | `ai/rad/0.1.0/rad-protocol.schema.json` | `0.1.0` | Experimental | RAD Search, Discover, Watch snapshot, and Runtime Endpoint publication objects. |
 | `ai/agent/0.1.0/agent-management.schema.json` | `0.1.0` | Experimental | Public Agent management resources and bounded read views. |
+| `ai/agent/0.2.0/agent-artifact.schema.json` | `0.2.0` | Experimental | Version-pinned protocol-neutral Agent artifact for ARD and other registry adaptors. |
 | `ai/agent/internal/v1/agent-storage.schema.json` | `1` | Internal experimental | Agent resource extension, version content and storage pointer, Naming projection, codecs, composers, and digest contracts. |

--- a/specs/schemas/ai/agent/0.2.0/agent-artifact.schema.json
+++ b/specs/schemas/ai/agent/0.2.0/agent-artifact.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nacos.io/schemas/ai/agent/0.2.0/agent-artifact.schema.json",
+  "$comment": "Copyright 1999-2026 Alibaba Group Holding Ltd. Licensed under the Apache License, Version 2.0.",
+  "title": "Nacos Agent Artifact 0.2.0",
+  "description": "Version-pinned, protocol-neutral Agent definition returned as application/vnd.nacos.ai-agent+json.",
+  "x-status": "experimental",
+  "x-schema-version": "0.2.0",
+  "x-entrypoints": {
+    "NacosAgentArtifact": "#/$defs/NacosAgentArtifact"
+  },
+  "$defs": {
+    "NacosAgentArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "agentName",
+        "version",
+        "contentDigest",
+        "callInterfaces"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "const": "1.0"
+        },
+        "agentName": {
+          "$ref": "../0.1.0/agent-management.schema.json#/$defs/AgentName"
+        },
+        "version": {
+          "$ref": "../0.1.0/agent-management.schema.json#/$defs/AgentVersion"
+        },
+        "contentDigest": {
+          "$ref": "../0.1.0/agent-management.schema.json#/$defs/ContentDigest"
+        },
+        "callInterfaces": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "items": {
+            "$ref": "../0.1.0/agent-management.schema.json#/$defs/AgentCallInterface"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specs/zh-cn/ai/a2a-agent-spec.md
+++ b/specs/zh-cn/ai/a2a-agent-spec.md
@@ -68,6 +68,11 @@ A2A Binding 是一个 `AgentCallInterface`：
 当前 descriptor 基线支持 A2A 1.0 字段和现有 0.x 兼容字段。Adapter 规范化时不得
 用拼装出的通用 Agent 对象替换保存的 native descriptor。
 
+common latest 精确 Version 中的 A2A CallInterface 只有通过该版本基线的完整 AgentCard 校验时，
+才声明 ARD 表示 `application/a2a-agent-card+json`。Artifact 直接返回保存的 native descriptor，
+不得把多协议 Nacos Agent 外层对象伪装成 AgentCard。旧 online Version 支持 A2A 只影响 RAD
+`protocolsAny=a2a`；如果 common latest 不含合法 AgentCard，则不产生当前 A2A ARD 表示。
+
 `registrationType=URL` 映射为 `[DECLARED,RUNTIME]`，
 `registrationType=SERVICE` 映射为 `[RUNTIME,DECLARED]`。Registration type 是旧投影
 字段，不参与 Agent 身份，也不进入新 API。
@@ -173,4 +178,6 @@ SDK shutdown 必须停止所有旧 AgentCard 轮询任务。
 ## 7. 演进
 
 上游 AgentCard 字段或 A2A 协议版本变化由 A2A Adapter 和版本化 Agent CallInterface 处理，
-不得重新定义标准 Agent 身份或协议无关的 RAD 结果。
+不得重新定义标准 Agent 身份或协议无关的 RAD 结果。ARD 使用的 AgentCard media type 与固定
+上游 Schema 基线由 [AI Registry 适配器规范](ai-registry-adaptor-spec.md)共同版本化；变化时必须
+同步更新 adapter fixture、校验器、规范和一致性测试。

--- a/specs/zh-cn/ai/agent-api-spec.md
+++ b/specs/zh-cn/ai/agent-api-spec.md
@@ -176,6 +176,16 @@ gRPC 写入不得盲目通过 HTTP 重试。
 Search query 名称与 RAD 字段相同。重复 `tagsAll` 取 AND，重复 `protocolsAny` 取 OR；
 `agentNameContains` 是大小写敏感的 literal substring。
 
+Agent Search 是共享 Search Core 上固定 `resourceType=agent` 的资源专用 Facade，不维护第二套
+索引或在索引分页后执行二次业务过滤。`agentNameContains`、`tagsAll` 和 `protocolsAny` 必须
+在 total 与分页截断前转换为 [AI 资源检索规范](ai-resource-search-spec.md)的类型化 predicate。
+通用 AI Resource Search 只查询 Agent 时，候选资格、可见性和当前性必须与本 API 一致；响应 DTO、
+排序和 numbered page 仍遵循 RAD。
+
+`nacos.ai.rad.search.mode=INDEX` 且 Agent projection 未 READY 时，HTTP 和 gRPC Binding 返回
+明确的 service unavailable 等价错误；`AUTO` 在 readiness 前使用完整旧扫描，READY 后使用索引。
+Binding 不暴露当前物理路径，也不得因索引调用失败在一次请求内降级或混合结果。
+
 Discover 直接映射 `agentName`、`version` 和 `label`。重复 Filter 参数为 `protocol`、
 `transport` 和 `endpointSource`，`protocolVersion` 为单值。`metadataSelector` 使用一个
 URL encoded JSON object，而不是动态 `metadata.<key>` 参数名。

--- a/specs/zh-cn/ai/agent-management-spec.md
+++ b/specs/zh-cn/ai/agent-management-spec.md
@@ -232,6 +232,17 @@ online Version，就必须存在且仅存在一个有效的 `latestVersion`，�
 Agent 元数据、Agent Version 定义和 Runtime Endpoint 之间不互相拥有生命周期。删除或
 disable Agent 定义会改变读取投影，但不会删除仍然活跃的运行时 publisher 状态。
 
+Agent 目录 Search document 是可重建派生状态，不是新的事实源。以下成功提交会按
+`(namespaceId, agent, agentName)` 调度一个合并的 `search_index` 任务：创建 Agent、目录
+metadata 或治理字段更新、Version publish/online/offline/delete、common latest 或自定义
+label 变化、legacy A2A facade 产生 canonical 定义变化，以及 Agent 删除。任务重新读取最新事实，
+投影 common latest 和全部 online Version 的目录；连续变化只推进任务 revision。
+
+Runtime Endpoint register/deregister、Publisher heartbeat、健康状态和 Runtime revision 不得调度
+该任务，也不得写入 Agent 目录索引。调度失败不回滚已经成功的 Agent 生命周期操作，持久任务重试和
+Reconciliation 按 [AI 资源检索规范](ai-resource-search-spec.md)最终收敛。Agent 不存在、disabled
+或没有 online Version 时，正确的索引结果是删除派生文档。
+
 ## 5. CallInterface 与 Declared Endpoint
 
 ### 5.1 AgentCallInterface

--- a/specs/zh-cn/ai/agent-storage-spec.md
+++ b/specs/zh-cn/ai/agent-storage-spec.md
@@ -524,7 +524,8 @@ Endpoint set 及其 revision，不维护第二份投影缓存。
 
 | 读取 | 读取事实 | AI Storage 读取 |
 | --- | --- | :---: |
-| 管控 Agent 列表或 RAD Search | `ai_resource` page。 | 否 |
+| 管控 Agent 列表 | `ai_resource` page。 | 否 |
+| RAD 或通用 Agent Search | 当前 Agent Search document；未 READY 的 RAD `AUTO/SCAN` 使用兼容扫描。 | 否 |
 | Agent overview | Resource 和有界 Version-row page。 | 否 |
 | 精确 Version detail | 一行 Version。 | 一次 |
 | Runtime Endpoint Snapshot | 一个 protocol 的完整内部 `ServiceStorage` 投影；可选 binding filter。 | 否 |
@@ -536,6 +537,7 @@ Endpoint set 及其 revision，不维护第二份投影缓存。
 | 创建或更新 draft | AI Storage 固定 key 和 Version row。 | Pointer、bytes、size 和 digest 一致。 |
 | Publish、online、offline、delete、label/latest | Version row 和 Resource 摘要。 | 重建派生目录。 |
 | Runtime register、Publisher heartbeat、deregister | Naming Client 运行时状态。 | 不写 AI Resource 或 Storage。 |
+| Agent 目录或 Version 生命周期提交 | `ai_resource_task` 中合并的 `search_index` revision。 | 异步重读事实并重建派生索引。 |
 
 缓存校验值跟随事实：
 
@@ -562,6 +564,17 @@ Agent、Prompt、Skill 和 AgentSpec 统一采用。
 Storage 写入成功但元数据写入失败时，形成可观测的不完整操作，并通过重试或孤儿内容清理处理。
 Digest 不一致时不得返回未校验内容。`versionCatalog` 和 Resource Version 摘要是可重建
 派生数据；其一致性不得下放给 Storage provider。
+
+Agent Search 投影同样是可重建派生状态。每个 `(namespaceId, agentName)` 最多存在一个当前
+document，其 `resourceVersion` 为 common latest 指向的精确 online Version，并包含完整、确定性
+排序的 online Version 目录、`protocols` 和 `artifactKinds` facets、projection version 与
+source digest。Source digest 由 canonical Agent metadata、Version 目录、common latest、latest
+Version `contentDigest`、artifactKinds 和 projection version 计算，不以修改时间作为唯一依据。
+
+关系 document、chunks 和内嵌 facets 在一个事务中完整替换。索引不保存 Runtime Endpoint、健康、
+Publisher、心跳或 Runtime revision。Backfill/Reconciliation 通过资源类型处理器按有界 resource-key
+批次扫描，并按 `(agent, projectionVersion)` 维护集群 readiness；具体任务、lease 和读模式语义由
+[AI 资源检索规范](ai-resource-search-spec.md)定义。
 
 ## 9. 容量与安全
 

--- a/specs/zh-cn/ai/agentspec-spec.md
+++ b/specs/zh-cn/ai/agentspec-spec.md
@@ -49,6 +49,13 @@ provider，有效 provider 配置只选择新版本。缺少 provider 的历史�
 
 不同于 Skill，AgentSpec 不维护独立 manifest index。版本元数据和存储指针是事实来源。
 
+AgentSpec 参与通用 AI Resource Search，并提供固定 `resourceType=agentspec` 的资源专用 Search
+Facade。两者复用 [AI 资源检索规范](ai-resource-search-spec.md)的 document/chunk/facet、
+当前性、可见性和分页。AgentSpec handler 投影 latest online Version 的名称、description、业务
+tags、公开依赖和能力说明；嵌入 credential 或私有运行时值的资源内容不得进入 chunk。现有按 keyword
+分页的 Client Search 必须逐步切换为该 Facade，不能在共享索引分页后再次过滤。通用 Search 只指定
+AgentSpec 时与专用 Search 候选资格一致。
+
 ## 4. 生命周期
 
 AgentSpec 遵循共享的 [AI 资源生命周期规范](ai-resource-lifecycle-spec.md)：

--- a/specs/zh-cn/ai/ai-registry-adaptor-spec.md
+++ b/specs/zh-cn/ai/ai-registry-adaptor-spec.md
@@ -28,7 +28,7 @@ AI Registry 适配器负责协议兼容面。它将 Nacos AI Registry 资源转�
 - 通过 MCP Registry v0 兼容只读 API 暴露 MCP Server 数据；
 - 通过 skills CLI 与 well-known discovery 兼容端点暴露 Skill 数据；
 - 通过 Agentic Resource Discovery（ARD）的搜索、探索、目录和 artifact 端点暴露
-  Skill、Prompt 和 MCP 数据；
+  Agent、Skill、Prompt 和 MCP 数据；
 - 这些生态需要的协议特定分页、搜索、响应和文件读取行为。
 
 适配器不负责标准 AI resource identity、生命周期、存储、可见性或发布规则。这些规则仍由
@@ -50,12 +50,17 @@ AI Registry 适配器负责协议兼容面。它将 Nacos AI Registry 资源转�
 | --- | --- | --- |
 | `nacos.ai.mcp.registry.enabled` | `false` | 开启 MCP Registry 兼容端点。 |
 | `nacos.ai.skill.registry.enabled` | `false` | 开启 Skill registry 兼容端点。 |
-| `nacos.ai.ard.enabled` | `false` | 开启 ARD 端点及其依赖的 AI 资源检索运行时。 |
+| `nacos.ai.ard.enabled` | `false` | 只开启 ARD 端点；不拥有基础 AI 资源检索运行时。 |
+| `nacos.ai.resource.search.enabled` | `true` | 在主 AI 模块中开启 RAD、ARD 和资源 API 共用的基础关系检索。 |
 | `nacos.ai.registry.port` | `9080` | 适配器 Context 使用的 HTTP 端口。 |
 | `nacos.ai.mcp.registry.port` | deprecated | 适配器端口的历史兼容配置。 |
 
 用户必须主动开启该能力，因为适配器会额外占用端口，并暴露面向社区客户端的协议形态，
 而不是面向 Nacos Admin、Console 或 Client API 消费者的标准接口。
+
+`nacos.ai.ard.enabled=true` 且 `nacos.ai.resource.search.enabled=false` 时，服务端必须在启动配置
+校验时明确失败，不能创建 ARD 专属索引。关闭 ARD 不影响 RAD 或资源专用
+Search 的索引、任务和 Reconciliation。
 
 关闭 ARD 时不能要求安装 PostgreSQL pgvector。AI 资源检索 document 和 chunk 元数据使用
 主数据源；pgvector 扩展及 `ai_resource_search_embedding_pg` 表只能通过
@@ -161,7 +166,7 @@ Nacos 以 ARD 上游 commit
 
 | 方法 | 路径 | 行为 |
 | --- | --- | --- |
-| `POST` | `/v3/ai/ard/search` | 搜索最新 online 的 Skill、Prompt 和 MCP 资源。 |
+| `POST` | `/v3/ai/ard/search` | 搜索最新 online 的 Agent、Skill、Prompt 和 MCP 资源。 |
 | `POST` | `/v3/ai/ard/explore` | 返回可发现资源的 facets。 |
 | `GET` | `/v3/ai/ard/agents` | 按过滤条件和分页参数列出可发现资源。 |
 | `GET` | `/v3/ai/ard/ai-catalog.json` | 返回 namespace 维度的 catalog。 |
@@ -200,14 +205,35 @@ Nacos 主服务 context path。
 
 对于 Skill 资源，artifact 端点以 `application/agent-skills+zip` 返回完整 Skill
 压缩包，其中包含 `SKILL.md` 及其打包资源。Prompt 和 MCP artifact 使用各自协议规定的
-表示形式。默认 Nacos 主服务运行在 8848、适配器运行在 9080 时，无需通过网关合并路径
+表示形式。Agent 支持：
+
+```text
+application/a2a-agent-card+json
+application/vnd.nacos.ai-agent+json
+```
+
+前者只在 common latest 精确 Version 中存在可完整导出的合法 A2A Agent Card 时可用，响应只
+包含该原生 Agent Card。后者返回版本化、协议无关的 Nacos Agent 定义，不包含 Runtime Endpoint、
+健康、Publisher、心跳、owner、scope 或审批状态。Artifact URL 必须包含精确 Version、该
+Version 的 `contentDigest` 和 representation key；Version offline、digest 不匹配或表示不可用时
+返回 ARD not found。Nacos 表示必须通过
+[`NacosAgentArtifact`](../../schemas/ai/agent/0.2.0/agent-artifact.schema.json#/$defs/NacosAgentArtifact)
+校验。默认 Nacos 主服务运行在 8848、适配器运行在 9080 时，无需通过网关合并路径
 也必须可以正常获取 artifact。
+
+共享 Agent Search document 仍然每个逻辑 Agent 只有一个。其 `artifactKinds` 至少使用稳定 key
+`a2a-agent-card` 和 `nacos-agent`。ARD media type filter 先映射为
+`resourceType=agent + artifactKinds`，不能只按 `protocols` 判断。一个 ARD 请求对同一逻辑 Agent
+最多返回一个 Entry：无 type filter 时，纯 A2A latest 优先 A2A 表示，多协议或自定义协议 latest
+优先 Nacos 表示；有 type filter 时从请求允许且实际存在的表示中选择同一确定性 primary 顺序。
+表示切换不改变逻辑 resource identifier，representation-specific Artifact URL 负责区分内容。
+过滤和表示选择必须在 total 与 page token 计算前完成。
 
 ### 6.3 Discovery 边界
 
-AI 模块负责 [AI 资源检索规范](ai-resource-search-spec.md)定义的协议无关能力。当前版本只有
-ARD 使用该能力，因此 `nacos.ai.ard.enabled` 会激活其依赖的检索运行时，但不会增加独立的
-运维检索开关或其他公开 API。
+AI 模块负责 [AI 资源检索规范](ai-resource-search-spec.md)定义的协议无关能力。RAD、ARD、
+通用 AI Resource Search 和资源专用 Search 共用该运行时；`nacos.ai.ard.enabled` 只控制
+适配器协议面，不激活或关闭基础 Search Core。
 
 可见性与当前版本校验必须在截取请求结果数量之前执行。列表和聚合按有界数据库批次扫描；
 关键词和向量召回使用 AI 资源检索规范定义的边界，任一通道超过配置上限时必须明确失败。
@@ -242,8 +268,8 @@ Explore facet 必须在可见性、当前版本和请求过滤后，对完整的
 
 ### 6.4 索引一致性
 
-标准资源写入是事实来源。单个资源对应的 search document 和 chunks 必须原子替换：删除旧
-索引行、插入新 document、插入全部 chunks 必须在同一个数据源事务中完成。
+标准资源写入是事实来源。单个资源对应的 search document、chunks 和内嵌 facets 必须原子
+替换：删除旧索引行、插入新 document、插入全部 chunks 必须在同一个数据源事务中完成。
 
 关系索引与向量索引之间不要求分布式事务。AI 模块改为记录资源级、幂等、持久化的索引任务，
 任务以 namespace、resource type 和 resource name 为键。Consumer 重新读取标准资源状态，
@@ -268,7 +294,9 @@ embedding model、向量文档数量与关系 chunks，并调度缺失、部分�
 Context 运行固定版本的官方 conformance runner，或运行从该 runner 等价转换出的测试矩阵。
 
 集成测试至少覆盖列表 `items`、整数搜索 score、URI `source`、trust identity 行为、
-协议错误体、catalog schema，以及主服务和适配器使用不同端口时的 Skill ZIP 获取。
+协议错误体、catalog schema，以及主服务和适配器使用不同端口时的 Skill ZIP 获取。Agent
+还必须覆盖纯 A2A、多协议、只有旧 online Version 支持 A2A、两种 media type filter、稳定逻辑
+identifier、representation-specific URL、offline/digest 失效，以及 Artifact 不包含 Runtime 状态。
 
 ## 7. 兼容规则
 

--- a/specs/zh-cn/ai/ai-resource-search-spec.md
+++ b/specs/zh-cn/ai/ai-resource-search-spec.md
@@ -21,38 +21,65 @@
 
 ## 1. 范围与激活
 
-AI Resource Search 是可复用的内部能力，不定义 Nacos HTTP API、Java SDK API、
-Console API 或外部协议响应。
+AI Resource Search 是 `ai` 模块内可复用、协议无关的逻辑能力。RAD、ARD、通用 AI Resource
+Search 和资源专用 Search 都必须复用该能力，不得分别维护索引或搜索引擎。HTTP、Java SDK、
+Console 和外部协议响应由各自的 API 或适配器规范定义。
 
-当前版本只有 ARD 适配器使用该能力，因此 `nacos.ai.ard.enabled` 同时激活 ARD 协议面
-及其依赖的检索运行时。在出现其他消费者之前，不增加独立的运维检索开关。除激活关系外，
-检索实现不得依赖 ARD 请求、响应、identifier、federation、media type 或 artifact 语义。
+基础关系检索运行时由 `nacos.ai.resource.search.enabled` 独立激活，默认值为 `true`。
+`nacos.ai.ard.enabled` 只控制 ARD Web Context 和协议端点，不得关闭 RAD 或其他资源 API
+依赖的检索运行时。`nacos.ai.ard.enabled=true` 且
+`nacos.ai.resource.search.enabled=false` 是非法组合，服务端必须在启动配置校验时明确失败，
+不能隐式创建一套 ARD 专属索引。检索实现不得依赖 ARD 请求、响应、identifier、federation、media type 或
+artifact 语义。
 
 ## 2. 所有权边界
 
 AI 模块负责：
 
-- 标准 search document 和 chunk；
+- 标准 search document、chunk 和 facet 投影；
+- 资源类型处理器注册、Query Planner 和多召回通道结果融合；
 - 持久化索引任务与 reconciliation；
 - 关键词召回和可选向量召回；
 - 排序及确定性 tie-breaking；
 - 可见性 query advice 和逐资源可见性校验；
 - latest label 和当前 online version 校验；
-- 标准 filter、不透明 cursor 分页和完整结果集聚合。
+- 类型化 predicate、不透明 cursor、numbered page 和完整结果集聚合；
+- 每种资源投影代际的 readiness。
 
-协议适配器负责请求解析、协议校验、协议 filter 转换、identifier、media type、响应 DTO、
-错误响应、artifact URL 和 federation 行为。
+协议适配器或资源专用 API Facade 负责请求解析、协议校验、类型专用 filter 转换、响应 DTO
+和错误映射。identifier、media type、artifact URL 和 federation 行为仅属于对应协议适配器。
 
 ## 3. 检索模型
 
-内部 query model 包含 namespace、text、标准 resource type、标准 filter、时间边界、
-排序、page size 和不透明 cursor，不得包含协议 DTO 或协议专属字段名。
+内部 query model 包含 namespace、text、一个或多个标准 resource type、类型化 predicate、
+时间边界、排序及 cursor 或 numbered page 信息，不得包含协议 DTO 或协议专属字段名。
+
+标准 predicate 至少支持：
+
+```text
+field
+operator = EXACT_ANY | EXACT_ALL | LITERAL_CONTAINS
+values[]
+caseSensitive
+```
+
+同一个 predicate 内由 operator 定义 ANY、ALL 或 literal contains；多个 predicate 使用 AND
+组合。`metadata.<facetKey>` 是协议无关 facet 路径。实现必须把 `%`、`_` 和 escape char 当作
+普通输入字符，不能让数据库 LIKE 通配符改变 literal contains 语义。类型专用 Facade 可以固定
+resource type、允许的字段、大小写和字段权重，但不得改变公共可见性、enabled 和 currentness
+规则。现有协议 filter 可保留兼容入口，但进入 Search Core 前必须转换为标准 predicate。
 
 检索结果使用 application DTO，而不是持久化实体。结果可以暴露标准资源键、当前版本、
 展示与检索元数据、时间戳和相关度分数。数据库行 ID、索引状态和任务状态保留在检索实现内部。
 
-可见性和当前版本校验必须在 page limit 之前完成。Cursor 使用稳定资源锚点，不能使用可变
-列表 offset。
+可见性、enabled 和当前版本校验必须在 total、offset 和 page limit 之前完成。Cursor 使用稳定
+资源锚点，不能使用可变列表 offset。Numbered page 返回 `totalCount`、`pageNumber`、
+`pagesAvailable` 和当前页 items；实现可以流式跳过 offset，但不得先截断候选再计算 total。
+
+通用 Search 支持跨资源类型统一召回和排名；资源专用 Search 在 Query Planner 中固定一个
+resource type，并可以使用类型专用 predicate 和权重。通用 Search 只指定一个 resource type
+时，其候选资格、可见性和当前性结果必须与对应资源专用 Search 一致。跨类型 Search 不得通过
+拼接多个已经分页的专用结果实现。
 
 ## 4. 聚合
 
@@ -79,17 +106,77 @@ embedding 表。
 
 标准资源写入始终是事实来源。Search document 和 chunk 属于可重建的派生状态。
 
+逻辑 `IndexProjection` 由一个 document、零到多个 chunk 和 facet 集合组成：
+
+- document 保存资源身份、展示信息、状态、当前版本、source digest 和稳定排序字段；
+- facet 保存精确过滤属性。第一代实现可以将通用 key/value 或 array facet 保存在 document
+  metadata 中，不要求立即增加物理表；
+- chunk 只保存关键词或向量召回所需的文本内容。Facet 不生成独立 chunk，也不进入 embedding；
+- 结构化 document/facet 和关键词索引是基础 Search 的必选组成，向量索引是可选召回通道；
+- Agent 等资源只能填充自己拥有的 facet，不能要求 Skill、Prompt、MCP 或 AgentSpec 增加
+  Agent 专属列。
+
+所有召回通道由同一个 Query Planner/Fusion 负责候选生成、结构化过滤、去重、分数融合、
+可见性、当前性和分页。向量 Provider 不能下推 facet 时，Planner 必须使用有界且可证明完整的
+候选策略；禁止对固定 top-K 结果只做一次后过滤后声称 total 或分页完整。
+
+### 5.1 资源类型处理器
+
+每个声明可检索的资源类型必须注册协议无关的类型处理器，至少提供以下语义：
+
+```text
+resourceType()
+project(namespaceId, resourceName) -> Optional<IndexProjection>
+scan(namespaceId, cursor, batchSize) -> SourcePage
+isCurrent(document) -> boolean
+exists(namespaceId, resourceName) -> boolean
+```
+
+`project` 返回空表示资源不存在、不可发现或没有合法当前版本，索引服务删除该逻辑资源的派生
+文档。`scan` 只用于 Backfill/Reconciliation，必须按稳定资源键有界扫描。`isCurrent` 必须执行
+该资源的 enabled、可见性、当前版本和 source digest 校验。处理器属于 `ai` 模块，不能引用
+ARD DTO、URL 或 media type。
+
+本规范声明的可检索类型为 Agent、AgentSpec、Skill、Prompt 和 MCP。若将来某个 AI Resource
+不参加通用 Search，必须在该资源规范中明确声明；不能仅因为尚未实现处理器而静默漏掉。
+
+### 5.2 Agent 投影
+
+每个 `(namespaceId, agentName)` 最多维护一个 enabled document。其 `resourceVersion` 是
+common `latest` 指向的精确 online Version。Agent document 至少投影：
+
+- display name、description、business tags、provider、icon 和 scope 等目录字段；
+- 全部 online Version 的有序紧凑 version catalog；
+- 全部 online Version 的 protocol 有序去重并集 `metadata.protocols`；
+- common latest 精确 Version 可完整导出的表示 key 集合 `metadata.artifactKinds`；
+- `metadata.projectionVersion` 和由稳定业务事实生成的 `sourceDigest`。
+
+`protocols` 表示调用协议，`artifactKinds` 表示可完整返回的版本制品，两者不得混用。Agent name、
+description、tags、能力和示例可以生成 chunk；scope、owner、status、protocols 和
+artifactKinds 仅作为结构化字段。Runtime Endpoint、健康状态、Publisher、心跳和 Runtime
+revision 永远不进入持久搜索索引。
+
+Agent source digest 使用 canonical JSON 的 SHA-256，覆盖影响目录或检索投影的 Agent metadata、
+完整 version catalog、common latest、latest Version `contentDigest`、artifactKinds 和
+projection version；无语义的修改时间不单独触发 digest 变化。
+
 标准资源标识字段和任务控制字段必须与标准资源存储保持一致，使用精确且大小写敏感的比较。
 关键词匹配继续通过与 Locale 无关的查询规范化实现大小写不敏感，不得依赖数据源专属的表级
 大小写不敏感排序规则。
 
 ## 6. 一致性
 
-单个资源版本的关系 document 和 chunks 必须原子替换。关系索引与向量索引之间不要求分布式
+单个逻辑资源的关系 document、chunks 和内嵌 facets 必须原子替换。关系索引与向量索引之间不要求分布式
 事务；系统使用幂等的 `search_index` 持久化任务重新读取标准资源状态并收敛两类索引。任务
 key 是 task type、namespace 以及由 resource type 和 resource name 组成的逻辑 subject
 的 SHA-256。Key 包含 task type，因此其他 AI 资源工作流复用同一张表时不会与检索索引任务
 冲突。
+
+标准资源生命周期事务成功提交后，按 `(namespaceId, resourceType, resourceName)` 调度合并任务。
+调度失败不得回滚已经成功的事实写入，由指标、告警和 reconciliation 修复。Agent 创建、目录
+metadata 或治理字段变化、Version publish/online/offline/delete、common latest 或自定义 label
+变化、legacy A2A facade 产生的 canonical 定义变化，以及 Agent 删除都必须调度。Endpoint
+register、deregister、heartbeat、健康变化和 Runtime revision 不得调度目录索引任务。
 
 同一任务行负责两个持久化阶段：
 
@@ -148,12 +235,17 @@ Enhancement 不得重新调度该已完成资源。开关已开启但配置不�
 因此开启 Enhancement 不会导致历史数据全量刷新。同一资源已有活动任务时，
 reconciliation 必须保留其 Payload 中持久化的 Enhancement 意图，以及 revision、阶段、
 重试延迟和 lease。向量 reconciliation 除模型和 chunk 数量外，还必须比较关系 document
-标识。检索只读取所配置索引已经收敛的 enabled document。
+标识。检索只读取所配置索引已经收敛的 enabled document。每个类型处理器的 reconciliation
+必须检测缺失、部分、过期和孤儿投影；Agent 还必须比较 projection version、source digest、
+common latest、version catalog 和可选向量状态。无 online Version、disabled 或 deleted
+资源的正确收敛结果是删除派生文档，而不是永久重试。
 
 ## 7. 资源边界
 
-列表、聚合、reconciliation 和持久化任务轮询必须按有界数据库批次扫描关系状态。完成
-可见性和当前版本校验后，列表分页在内存中只保留请求页及一条用于判断下一页的记录。
+列表、聚合、reconciliation 和持久化任务轮询必须按有界数据库批次扫描关系状态。资源源扫描和
+numbered list 使用稳定的 resource-key keyset；排序并列时使用不可变行键消除歧义。完成
+predicate、可见性和当前版本校验后，列表分页在内存中只保留请求页及一条用于判断下一页的记录，
+numbered page 只额外保留计数器，不能保留全部匹配项。
 Reconciliation 不得在内存中保留全部标准资源名称。集群扫描 lease 必须记录 owner 和
 过期时间，扫描期间通过 CAS 续租，并且只有相同 owner 仍持有 lease 时才能释放。
 
@@ -161,10 +253,39 @@ Reconciliation 不得在内存中保留全部标准资源名称。集群扫描 l
 返回静默截断的结果。运维可通过 `nacos.ai.resource.search.max-recall-candidates`
 调整该上限。
 
-## 8. 升级与初始化
+## 8. Readiness 与读模式
+
+需要从旧扫描路径切换到索引的资源类型，必须按 `(resourceType, projectionVersion)` 维护持久、
+集群共享的 readiness。Backfill 扫描 lease 只表示当前扫描 owner，不能替代 readiness。
+
+一个 projection generation 只有在以下条件全部满足时才能通过 CAS 标记为 `READY`：
+
+1. 成功枚举全部有效 namespace，且没有用 `public` fallback 掩盖枚举失败；
+2. 完成一轮该资源类型的有界 source scan，扫描差异均已成功调度；
+3. 后续验证轮没有未修复的缺失、过期或孤儿文档；
+4. 没有属于该轮的 pending、processing 或 retry 任务；
+5. readiness record 写入当前 projection version。
+
+`READY` 对同一 generation 是 sticky 的。普通生命周期任务短暂 pending 不把该 generation
+退回未就绪；查询的 currentness 校验先排除陈旧文档，任务随后收敛。投影契约变化必须递增
+projection version 并创建新的 readiness generation。
+
+RAD Search 使用 `nacos.ai.rad.search.mode=AUTO|INDEX|SCAN` 选择读路径，默认 `AUTO`：
+
+| 模式 | 未 READY | READY | 索引调用失败 |
+|---|---|---|---|
+| `AUTO` | 使用完整旧扫描路径 | 进程内 sticky 切换到索引 | 明确失败，不逐请求回退 |
+| `INDEX` | 明确 service unavailable | 使用索引 | 明确失败 |
+| `SCAN` | 使用旧扫描 | 始终使用旧扫描 | 不涉及索引 |
+
+一次请求不得合并部分索引和部分旧扫描结果。切换不得改变 RAD 名称、Tag、Protocol、大小写、
+排序、total、分页、可见性或 version catalog 契约。其他消费者若需要兼容读模式，必须在其协议
+或 API 规范中定义，但仍复用同一 readiness。
+
+## 9. 升级与初始化
 
 如果部署环境曾在引入持久化重试之前创建 ARD 检索表，则在开启
-`nacos.ai.ard.enabled` 前，必须使用当前数据库对应的 Schema 补齐以下三个协议无关关系表：
+`nacos.ai.resource.search.enabled` 前，必须使用当前数据库对应的 Schema 补齐以下三个协议无关关系表：
 
 - `ai_resource_search_document`；
 - `ai_resource_search_chunk`；
@@ -194,15 +315,21 @@ Result、阶段、重试、租约、revision 和完成检查点，不能替代�
 PostgreSQL 环境如果不开启默认向量插件，无需创建任何 pgvector 对象；如果开启，则必须另外
 执行 `nacos-default-ai-vector-plugin` 自己维护的可选 Schema。
 
-## 9. 兼容与测试
+新增资源类型必须先完成对应 projection generation 的 Backfill 和 readiness，再让 `AUTO` 或
+`INDEX` 使用该索引。索引是可重建派生状态，不改变标准资源或 Runtime Endpoint 的事实源，也
+不要求把 Runtime 状态迁移到关系检索表。
 
-即使当前只有 ARD 消费者，内部检索命名、持久化模型、表、配置和 Vector SPI package 仍须
-保持协议无关。
+## 10. 兼容与测试
 
-测试覆盖关键词和向量召回、排序、可见性、当前版本校验、cursor 分页、超过单页范围的全量
-聚合、事务替换、两个持久化任务阶段、lease 恢复、过期 revision、Enhancement 幂等重试、
+内部检索命名、持久化模型、表、配置和 Vector SPI package 必须保持协议无关。现有 ARD
+Skill、Prompt 和 MCP 的请求、cursor、排序与 artifact 行为在共享内核扩展时保持兼容。
+
+测试覆盖关键词和向量召回、结构化 facet、类型化 predicate、排序、可见性、当前版本校验、
+cursor 和 numbered page、超过单页范围的全量聚合、通用单类型与资源专用 Search 一致性、
+事务替换、两个持久化任务阶段、lease 恢复、过期 revision、Enhancement 幂等重试、
 版本化任务 Payload 和 Result、task type 隔离、时区无关的 Epoch 调度、确定性时钟下的
 lease 与重试边界、连续生命周期合并保留活动租约、基于 lease token 防止旧 worker 释放
 新租约、配置 fingerprint 记录但不全量重调度、生命周期 Enhancement 意图，
-以及仅对实际修复资源执行 Enhancement 且不全量刷新历史数据的 reconciliation。各协议
-适配器分别测试自己的请求语法和响应一致性。
+仅对实际修复资源执行 Enhancement 且不全量刷新历史数据的 reconciliation、Agent lifecycle
+调度与 Runtime Endpoint 非调度、readiness CAS/重启/新 generation，以及 `AUTO/INDEX/SCAN`
+交叉行为。各协议适配器和资源 API 分别测试自己的请求语法、响应一致性和单类型交叉结果。

--- a/specs/zh-cn/ai/mcp-server-spec.md
+++ b/specs/zh-cn/ai/mcp-server-spec.md
@@ -79,6 +79,13 @@ endpoint 可见性时，应使用非临时服务/实例行为。
 - gRPC payload 包含查询、发布和 endpoint 注册请求，详见
   [gRPC API 规范](../grpc-api/api-spec.md)。
 
+MCP 参与通用 AI Resource Search，并提供固定 `resourceType=mcp` 的资源专用 Search
+Facade。两者复用 [AI 资源检索规范](ai-resource-search-spec.md)的同一索引和 Query Planner，
+不能继续把 Config-backed 名称列表作为独立的全文搜索引擎。MCP handler 可以投影 server name、
+description、tools、resources 和公开 tags；endpoint credential、运行时 instance 和敏感 auth
+metadata 不进入检索 chunk。迁移到标准 AI Resource 前，handler 可以读取兼容存储，但必须生成相同
+的标准 projection。通用 Search 只指定 MCP 时与专用 Search 候选资格一致。
+
 ## 5. 当前兼容存储
 
 当前 MCP 实现通过 Config 形态记录保存 MCP 元数据，并通过 Naming service 表达

--- a/specs/zh-cn/ai/prompt-spec.md
+++ b/specs/zh-cn/ai/prompt-spec.md
@@ -61,6 +61,12 @@ Prompt。如果 md5 与当前版本内容 md5 一致，服务端可以返回 not
 
 订阅应报告 Prompt 变更，但不应向运行时客户端暴露宽范围管理列表能力。
 
+Prompt 参与通用 AI Resource Search，并提供固定 `resourceType=prompt` 的资源专用 Search
+Facade。两者复用 [AI 资源检索规范](ai-resource-search-spec.md)的同一索引和 Query Planner。
+Prompt handler 只投影调用方可见、enabled、latest 可解析到 online Version 的名称、description、
+业务 tags 和适合检索的模板说明；模板中可能出现的 credential、secret 默认值和运行时参数值不得进入
+chunk。通用 Search 只指定 Prompt 时与专用 Search 的候选资格、可见性和当前性一致。
+
 ## 5. 存储
 
 Prompt 在每个版本的存储描述中持久化选定的 provider。已有版本的操作使用已持久化的

--- a/specs/zh-cn/ai/rad-protocol-spec.md
+++ b/specs/zh-cn/ai/rad-protocol-spec.md
@@ -392,6 +392,22 @@ Search 必须：
 
 `pageNo` 缺省为 `1`，`pageSize` 缺省为 `20` 且最大为 `100`。
 
+Search 复用 [AI 资源检索规范](ai-resource-search-spec.md)定义的共享 Search Core，并将
+请求固定为 `resourceType=agent`：
+
+- `agentNameContains` 映射为大小写敏感的 `LITERAL_CONTAINS`，其中 `%`、`_` 和 escape
+  char 均为普通字符；
+- `tagsAll` 映射为大小写敏感的 `EXACT_ALL`；
+- `protocolsAny` 映射为大小写敏感的 `EXACT_ANY`；
+- 多类 filter 使用 AND 组合；过滤、可见性和当前性校验都必须在 total 和页截断前完成；
+- Agent 的完整 online Version 目录来自当前 Search document，Runtime Endpoint、健康状态、
+  Publisher 和心跳不进入 Search 索引或响应。
+
+`nacos.ai.rad.search.mode` 可以选择 `AUTO`、`INDEX` 或 `SCAN`。首次 Agent projection
+Backfill 未 READY 时，`AUTO` 使用完整旧扫描路径，`INDEX` 明确返回 service unavailable；
+READY 后 `AUTO` 以进程内 sticky 方式切换到索引。索引调用失败不得按请求回退，单次请求也
+不得混合两条路径。三种模式必须保持本节的过滤、排序、total、分页、可见性和版本目录结果等价。
+
 ## 5. Discover
 
 `AgentDiscoveryRequest` 包含：

--- a/specs/zh-cn/ai/skill-spec.md
+++ b/specs/zh-cn/ai/skill-spec.md
@@ -140,6 +140,13 @@ AI 存储保存。默认存储为 `nacos_config`，但它只是实现后端。
 Skill 还维护一个轻量 manifest 以支持客户端发现。Manifest 是从 Skill 元数据派生的
 索引，不应成为生命周期状态的事实来源。
 
+Skill 参与通用 AI Resource Search，并提供固定 `resourceType=skill` 的资源专用 Search
+Facade。两者复用 [AI 资源检索规范](ai-resource-search-spec.md)的 document/chunk/facet、
+当前性、可见性和分页，不得把 manifest 或既有管理列表当作第二套 Search 索引。Skill handler
+投影 latest online Version 的名称、description、tags 和可检索 manifest 内容；包内脚本、
+credential 和未声明的二进制内容不进入检索 chunk。通用 Search 只指定 Skill 时与专用 Search
+候选资格一致。
+
 存储扩展规则由 [AI 存储插件规范](../plugin/ai-storage-plugin-spec.md)定义。
 
 ## 5. 生命周期

--- a/specs/zh-cn/plugin/ai-vector-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-vector-plugin-spec.md
@@ -28,7 +28,9 @@ PostgreSQL 实现由 `nacos-default-ai-vector-plugin` 提供。
 向量索引是可选能力。AI 资源检索运行时未激活或者没有可用 Vector Provider 时，不能阻止
 Nacos 启动、标准 AI 资源写入或关键词检索。通过
 `nacos.ai.resource.search.vector.provider` 选择 Provider，Provider 专属配置由各实现负责。
-当前版本只有 ARD 一个消费者，因此 `nacos.ai.ard.enabled=false` 时该运行时也不激活。
+Vector Provider 由 `nacos.ai.resource.search.enabled` 控制的共享 Search Core 使用；RAD、ARD、
+通用 AI Resource Search 和资源专用 Search 都可以消费该能力。`nacos.ai.ard.enabled` 只控制
+ARD 协议端点，不得单独决定 Vector Provider 的激活状态。
 
 ## 2. Provider 生命周期
 
@@ -99,4 +101,5 @@ SPI 变更必须保持插件模块 Java 8 兼容，并遵循 Nacos 插件兼容�
 
 SPI 契约测试覆盖 Provider 选择、no-op fallback、幂等 replace/delete、限定范围的搜索和
 生命周期清理。默认 PostgreSQL 实现还需要测试 Schema 隔离、关闭向量能力时不依赖
-pgvector、Provider 内部事务替换，以及模拟向量失败后的 reconciliation。
+pgvector、共享 Search Core 开启而 ARD 关闭时仍可供其他消费者使用、Provider 内部事务替换，
+以及模拟向量失败后的 reconciliation。

--- a/specs/zh-cn/testing/api-integration-test-spec.md
+++ b/specs/zh-cn/testing/api-integration-test-spec.md
@@ -142,3 +142,20 @@ API IT 变更需要对 `test/openapi-test` 运行格式化和编译验证。在�
 服务可用时，应运行相关 Failsafe IT 选择或对应 API 面的全量选择。
 
 仅修改 IT 覆盖索引文档时，最低验证要求是受影响模块的 license 和格式检查。
+
+## 9. AI Resource Search 与 Agent 场景
+
+共享 Search Core、Agent projection 或 ARD Agent 表示变更时，OpenAPI IT 场景矩阵至少覆盖：
+
+- ARD 关闭但 `nacos.ai.resource.search.enabled=true` 时，RAD 和资源专用 Search 仍可使用基础索引；
+- Agent 名称 literal contains、Tag ALL、Protocol ANY、组合 AND、大小写及 `%`、`_`、`\\`
+  字面量，首/中/尾/越界页与正确 total；
+- 创建、metadata 更新、Version publish/online/offline/delete、latest/label 变化后的有界等待收敛；
+- Endpoint register/deregister/heartbeat 只改变 Discover，不改变目录 Search document；
+- `AUTO` readiness 前后结果等价且不混合，`INDEX` 未 READY 明确失败，`SCAN` 始终走兼容路径；
+- 通用 Search 指定单一 Agent、AgentSpec、Skill、Prompt 或 MCP 时，与对应资源专用 Search 的候选
+  资格、可见性和当前性结果一致；
+- ARD 纯 A2A、多协议和只有旧 online Version 支持 A2A 的 type filter、primary 表示、稳定
+  identifier、representation-specific Artifact URL、offline/digest 失效和 Runtime 状态排除。
+
+测试异步索引时只允许有界轮询公开 API 可见结果，不得依赖固定 sleep、数据库内部行或任务执行顺序。

--- a/specs/zh-cn/testing/java-sdk-integration-test-spec.md
+++ b/specs/zh-cn/testing/java-sdk-integration-test-spec.md
@@ -134,3 +134,17 @@ verify`。
 Java SDK IT 必须使用独立的 `java-sdk-integration-test` Maven profile。通用
 `integration-test` profile 保留给 HTTP API IT 工作流，不能意外运行依赖 SDK
 gRPC 连接就绪状态或可选服务端能力的 SDK 测试。
+
+## 8. AI Resource Search 与 Agent 场景
+
+公共 AI SDK Search 或 Agent 行为变更时，Java SDK IT 至少覆盖：
+
+- 真实 SDK Client 对 Agent 单条件、组合 predicate、numbered page 和默认 namespace 的结果；
+- HTTP 与 gRPC Agent Search 在相同事实和传输选择下返回等价目录；
+- Agent publish/online/offline/latest 切换后的有界收敛，且 Endpoint 操作只改变 Discover；
+- 通用单类型 Search 与 Agent、AgentSpec、Skill、Prompt、MCP 资源专用 Search 的候选资格一致；
+- Client transport `AUTO/HTTP/GRPC` 可用时保持同一 Search 契约，协商不支持时返回受控异常；
+- SDK shutdown、重连和 redo 不重复写目录索引，也不把 Runtime Endpoint 带入 Search 结果。
+
+涉及 ARD Artifact 的协议一致性继续由 OpenAPI/适配器 IT 覆盖；Java SDK IT 只通过公开 SDK
+合同验证其可观察目录与 Discover 行为。


### PR DESCRIPTION
For #14804

## What is the purpose of the change

Define the formal contract for the next RAD/ARD shared-search implementation stage after the
resource type-handler extraction in #15730.

The specifications previously described ARD-oriented search behavior but did not fully define
independent Search Core activation, typed predicates, Agent index readiness, deterministic Agent
artifact representation, or the relationship between generic and resource-specific Search APIs.
This change closes those contract gaps before the corresponding behavior is implemented.

## Brief changelog

* Define an independently activated Search Core shared by RAD, ARD, generic AI Resource Search,
  and resource-specific Search APIs.
* Specify the common Document/Chunk/Facet projection, typed predicate semantics, bounded keyset
  scanning, numbered pagination, ranking, and per-resource projection readiness.
* Define Agent search projection and lifecycle boundaries without indexing Runtime Endpoints.
* Define RAD `AUTO`, `INDEX`, and `SCAN` behavior before and after Agent index readiness.
* Define deterministic A2A Agent Card and Nacos Agent artifact selection for ARD, including stable
  logical identity and representation-specific artifact URLs.
* Add the experimental `application/vnd.nacos.ai-agent+json` artifact schema at version `0.2.0`.
* Align the AI vector plugin with the shared Search Core instead of ARD-only activation.
* Define generic/resource-specific Search parity and the corresponding OpenAPI and Java SDK
  integration-test scenario matrices in both English and Simplified Chinese specs.

## Verifying this change

* `mvn -q -DskipTests spotless:apply`
* `mvn -q -DskipTests spotless:check apache-rat:check`
* `git diff --check`
* Validated relative Markdown links in all changed specification files.
* Parsed the new JSON Schema and verified all referenced Agent definitions exist.

This PR changes only specifications and JSON Schema. It contains no production code, public API
implementation, SDK implementation, database migration, or runtime behavior, so no unit or
integration test suite is required for this change.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Update the formal English and Simplified Chinese specifications and test scenario matrices.
* [x] Run the relevant formatting, license, link, and schema validations for this specs-only PR.
