### PR TITLE
[ISSUE #14817] Backport deprecated AI API gate to 3.2.4

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/controller/PipelineAdminController.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/controller/PipelineAdminController.java
@@ -28,6 +28,7 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.auth.annotation.Secured;
+import com.alibaba.nacos.core.controller.compatibility.CompatibilityHelper;
 import com.alibaba.nacos.core.model.form.PageForm;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.constant.SignType;
@@ -92,6 +93,8 @@ public class PipelineAdminController {
     @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.ADMIN_API)
     public Result<PipelineExecution> getPipeline(@PathVariable String pipelineId)
         throws NacosException {
+        CompatibilityHelper.check(
+            "GET /v3/admin/ai/pipelines/detail?pipelineId={pipelineId}");
         return Result.success(pipelineQueryService.getPipeline(pipelineId));
     }
     
@@ -107,6 +110,7 @@ public class PipelineAdminController {
     public Result<Page<PipelineExecution>> listPipelinesLegacy(PipelineListForm form,
         PageForm pageForm)
         throws NacosException {
+        CompatibilityHelper.check("GET /v3/admin/ai/pipelines/list");
         form.validate();
         pageForm.validate();
         return Result.success(

--- a/ai/src/main/java/com/alibaba/nacos/ai/importer/config/AiResourceImportProperties.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/importer/config/AiResourceImportProperties.java
@@ -50,8 +50,6 @@ public class AiResourceImportProperties {
     
     private boolean enabled;
     
-    private boolean legacyMcpImportApiEnabled;
-    
     private boolean allowUserUrl;
     
     private int defaultConnectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT_MILLIS;
@@ -86,8 +84,6 @@ public class AiResourceImportProperties {
     public static AiResourceImportProperties load(Properties properties) {
         AiResourceImportProperties result = new AiResourceImportProperties();
         result.setEnabled(getBoolean(properties, PREFIX + "enabled", false));
-        result.setLegacyMcpImportApiEnabled(getBoolean(properties,
-            PREFIX + "legacy-mcp-api-enabled", false));
         result.setAllowUserUrl(getBoolean(properties, PREFIX + "allow-user-url", false));
         result.setDefaultConnectTimeoutMillis(getInt(properties,
             PREFIX + "default-connect-timeout-ms", DEFAULT_CONNECT_TIMEOUT_MILLIS));
@@ -203,14 +199,6 @@ public class AiResourceImportProperties {
     
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
-    }
-    
-    public boolean isLegacyMcpImportApiEnabled() {
-        return legacyMcpImportApiEnabled;
-    }
-    
-    public void setLegacyMcpImportApiEnabled(boolean legacyMcpImportApiEnabled) {
-        this.legacyMcpImportApiEnabled = legacyMcpImportApiEnabled;
     }
     
     public boolean isAllowUserUrl() {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/McpLegacyImportAdapter.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/McpLegacyImportAdapter.java
@@ -85,9 +85,6 @@ public class McpLegacyImportAdapter {
      */
     public McpServerImportValidationResult validateImport(String namespaceId,
         McpServerImportRequest request) throws NacosException {
-        if (!isLegacyApiEnabled()) {
-            return deprecatedValidation();
-        }
         if (!shouldRouteToUnifiedImport(request)) {
             return shouldRejectUserUrl(request) ? rejectedValidation()
                 : mcpServerImportService.validateImport(namespaceId, request);
@@ -111,9 +108,6 @@ public class McpLegacyImportAdapter {
      */
     public McpServerImportResponse executeImport(String namespaceId, McpServerImportRequest request)
         throws NacosException {
-        if (!isLegacyApiEnabled()) {
-            return deprecatedResponse();
-        }
         if (!shouldRouteToUnifiedImport(request)) {
             return shouldRejectUserUrl(request) ? rejectedResponse()
                 : mcpServerImportService.executeImport(namespaceId, request);
@@ -130,10 +124,6 @@ public class McpLegacyImportAdapter {
     private boolean shouldRouteToUnifiedImport(McpServerImportRequest request) {
         return request != null && ExternalDataTypeEnum.URL.getName().equals(request.getImportType())
             && !isUrl(request.getData());
-    }
-    
-    private boolean isLegacyApiEnabled() {
-        return propertiesSupplier.get().isLegacyMcpImportApiEnabled();
     }
     
     private boolean shouldRejectUserUrl(McpServerImportRequest request) {
@@ -299,18 +289,6 @@ public class McpLegacyImportAdapter {
     
     private McpServerImportResponse rejectedResponse() {
         return failedResponse("Legacy URL import is disabled. Please use a configured source id.");
-    }
-    
-    private McpServerImportValidationResult deprecatedValidation() {
-        return failedValidation("Legacy MCP import API is disabled. Please use the unified "
-            + "AI resource import API or enable nacos.ai.resource.import.legacy-mcp-api-enabled "
-            + "for a compatibility window.");
-    }
-    
-    private McpServerImportResponse deprecatedResponse() {
-        return failedResponse("Legacy MCP import API is disabled. Please use the unified "
-            + "AI resource import API or enable nacos.ai.resource.import.legacy-mcp-api-enabled "
-            + "for a compatibility window.");
     }
     
     private McpServerImportValidationResult failedValidation(String errorMessage) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/controller/PipelineAdminControllerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/controller/PipelineAdminControllerTest.java
@@ -23,6 +23,8 @@ import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.core.controller.compatibility.CompatibilityHelper;
+import com.alibaba.nacos.core.exception.NacosApiExceptionHandler;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.AfterEach;
@@ -31,7 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.env.StandardEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -39,9 +42,11 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -57,15 +62,20 @@ class PipelineAdminControllerTest {
     
     private MockMvc mockMvc;
     
+    private MockEnvironment environment;
+    
     @BeforeEach
     void setUp() {
-        EnvUtil.setEnvironment(new StandardEnvironment());
+        environment = new MockEnvironment();
+        EnvUtil.setEnvironment(environment);
         mockMvc = MockMvcBuilders.standaloneSetup(new PipelineAdminController(pipelineQueryService))
+            .setControllerAdvice(new NacosApiExceptionHandler())
             .build();
     }
     
     @AfterEach
     void tearDown() {
+        EnvUtil.setEnvironment(null);
     }
     
     @Test
@@ -101,7 +111,19 @@ class PipelineAdminControllerTest {
     }
     
     @Test
-    void listPipelinesLegacyBasePathStillWorks() throws Exception {
+    void listPipelinesLegacyBasePathDisabledByDefault() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.get(ADMIN_BASE).param("resourceType", "SKILL")
+                .param("pageNo", "1").param("pageSize", "10"))
+            .andReturn().getResponse();
+        
+        assertDeprecated(response, "GET /v3/admin/ai/pipelines/list");
+        verifyNoInteractions(pipelineQueryService);
+    }
+    
+    @Test
+    void listPipelinesLegacyBasePathWorksWhenCompatibilityEnabled() throws Exception {
+        environment.setProperty(CompatibilityHelper.API_COMPATIBILITY_ENABLED_KEY, "true");
         Page<PipelineExecution> page = new Page<>();
         when(pipelineQueryService.listPipelines(anyString(), isNull(), isNull(), isNull(), anyInt(),
             anyInt()))
@@ -117,7 +139,19 @@ class PipelineAdminControllerTest {
     }
     
     @Test
-    void getPipelineLegacyPathVariableStillWorks() throws Exception {
+    void getPipelineLegacyPathVariableDisabledByDefault() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.get(ADMIN_BASE + "/legacy-id"))
+            .andReturn().getResponse();
+        
+        assertDeprecated(response,
+            "GET /v3/admin/ai/pipelines/detail?pipelineId={pipelineId}");
+        verifyNoInteractions(pipelineQueryService);
+    }
+    
+    @Test
+    void getPipelineLegacyPathVariableWorksWhenCompatibilityEnabled() throws Exception {
+        environment.setProperty(CompatibilityHelper.API_COMPATIBILITY_ENABLED_KEY, "true");
         PipelineExecution execution = new PipelineExecution();
         execution.setExecutionId("legacy-id");
         when(pipelineQueryService.getPipeline("legacy-id")).thenReturn(execution);
@@ -129,5 +163,15 @@ class PipelineAdminControllerTest {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("legacy-id", result.getData().getExecutionId());
+    }
+    
+    private void assertDeprecated(MockHttpServletResponse response, String alternative)
+        throws Exception {
+        assertEquals(HttpStatus.GONE.value(), response.getStatus());
+        Result<String> result = JacksonUtils.toObj(response.getContentAsString(),
+            new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.API_DEPRECATED.getCode(), result.getCode());
+        assertTrue(result.getData().contains(alternative));
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/importer/config/AiResourceImportPropertiesTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/importer/config/AiResourceImportPropertiesTest.java
@@ -31,7 +31,6 @@ class AiResourceImportPropertiesTest {
     void testLoadSourcesFromProperties() {
         Properties raw = new Properties();
         raw.setProperty("nacos.ai.resource.import.enabled", "true");
-        raw.setProperty("nacos.ai.resource.import.legacy-mcp-api-enabled", "true");
         raw.setProperty("nacos.ai.resource.import.default-connect-timeout-ms", "2000");
         raw.setProperty("nacos.ai.resource.import.default-max-artifact-size", "2048");
         raw.setProperty("nacos.ai.resource.import.sources[0].source-id", "mcp-official");
@@ -46,7 +45,6 @@ class AiResourceImportPropertiesTest {
         AiResourceImportProperties properties = AiResourceImportProperties.load(raw);
         
         assertTrue(properties.isEnabled());
-        assertTrue(properties.isLegacyMcpImportApiEnabled());
         assertFalse(properties.isAllowUserUrl());
         assertEquals(2000, properties.getDefaultConnectTimeoutMillis());
         assertEquals(2048, properties.getDefaultMaxArtifactSize());

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/McpLegacyImportAdapterTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/McpLegacyImportAdapterTest.java
@@ -71,23 +71,8 @@ class McpLegacyImportAdapterTest {
     void setUp() {
         adapter = new McpLegacyImportAdapter(mcpServerImportService, importManager);
         AiResourceImportProperties properties = new AiResourceImportProperties();
-        properties.setLegacyMcpImportApiEnabled(true);
         ReflectionTestUtils.setField(adapter, "propertiesSupplier",
             (Supplier<AiResourceImportProperties>) () -> properties);
-    }
-    
-    @Test
-    void testLegacyApiDisabledByDefault() throws Exception {
-        AiResourceImportProperties properties = new AiResourceImportProperties();
-        ReflectionTestUtils.setField(adapter, "propertiesSupplier",
-            (Supplier<AiResourceImportProperties>) () -> properties);
-        McpServerImportRequest request = request("source-1");
-        
-        McpServerImportValidationResult result = adapter.validateImport("public", request);
-        
-        assertFalse(result.isValid());
-        assertTrue(result.getErrors().get(0).contains("Legacy MCP import API is disabled"));
-        verifyNoInteractions(mcpServerImportService, importManager);
     }
     
     @Test
@@ -137,7 +122,6 @@ class McpLegacyImportAdapterTest {
     @Test
     void testUserUrlFallbackWhenExplicitlyAllowed() throws Exception {
         AiResourceImportProperties properties = new AiResourceImportProperties();
-        properties.setLegacyMcpImportApiEnabled(true);
         properties.setAllowUserUrl(true);
         ReflectionTestUtils.setField(adapter, "propertiesSupplier",
             (Supplier<AiResourceImportProperties>) () -> properties);

--- a/bootstrap/src/main/resources/application.properties
+++ b/bootstrap/src/main/resources/application.properties
@@ -234,12 +234,10 @@ server.tomcat.basedir=file:.
 ### Include message field
 server.error.include-message=ALWAYS
 
-### Enabled for open API compatibility
+### Reopen deprecated v3 APIs pending removal during a migration window. Disabled by default.
+# nacos.core.api.compatibility.enabled=false
+### Enabled for legacy open API compatibility provided by nacos-api-legacy-adapter
 # nacos.core.api.compatibility.client.enabled=true
-### Enabled for admin API compatibility
-# nacos.core.api.compatibility.admin.enabled=false
-### Enabled for console API compatibility
-# nacos.core.api.compatibility.console.enabled=false
 
 #--------------- Nacos Console Configurations ---------------#
 

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleMcpController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleMcpController.java
@@ -42,6 +42,7 @@ import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.api.utils.StringUtils;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.console.proxy.ai.McpProxy;
+import com.alibaba.nacos.core.controller.compatibility.CompatibilityHelper;
 import com.alibaba.nacos.core.model.form.PageForm;
 import com.alibaba.nacos.core.paramcheck.ExtractorManager;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
@@ -244,6 +245,7 @@ public class ConsoleMcpController {
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
     public Result<McpServerImportValidationResult> validateImport(McpImportForm mcpImportForm)
         throws NacosException {
+        CompatibilityHelper.check("POST /v3/console/ai/import/validate");
         mcpImportForm.validate();
         McpServerImportRequest request = convertToImportRequest(mcpImportForm);
         McpServerImportValidationResult result =
@@ -263,6 +265,7 @@ public class ConsoleMcpController {
     @Secured(action = ActionTypes.WRITE, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
     public Result<McpServerImportResponse> executeImport(McpImportForm mcpImportForm)
         throws NacosException {
+        CompatibilityHelper.check("POST /v3/console/ai/import/execute");
         mcpImportForm.validate();
         McpServerImportRequest request = convertToImportRequest(mcpImportForm);
         McpServerImportResponse response =

--- a/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsolePipelineController.java
+++ b/console/src/main/java/com/alibaba/nacos/console/controller/v3/ai/ConsolePipelineController.java
@@ -28,6 +28,7 @@ import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.auth.annotation.Secured;
 import com.alibaba.nacos.console.proxy.ai.PipelineProxy;
+import com.alibaba.nacos.core.controller.compatibility.CompatibilityHelper;
 import com.alibaba.nacos.core.model.form.PageForm;
 import com.alibaba.nacos.plugin.auth.constant.ActionTypes;
 import com.alibaba.nacos.plugin.auth.constant.SignType;
@@ -92,6 +93,8 @@ public class ConsolePipelineController {
     @Secured(action = ActionTypes.READ, signType = SignType.AI, apiType = ApiType.CONSOLE_API)
     public Result<PipelineExecution> getPipeline(@PathVariable String pipelineId)
         throws NacosException {
+        CompatibilityHelper.check(
+            "GET /v3/console/ai/pipelines/detail?pipelineId={pipelineId}");
         return Result.success(pipelineProxy.getPipeline(pipelineId));
     }
     
@@ -107,6 +110,7 @@ public class ConsolePipelineController {
     public Result<Page<PipelineExecution>> listPipelinesLegacy(PipelineListForm form,
         PageForm pageForm)
         throws NacosException {
+        CompatibilityHelper.check("GET /v3/console/ai/pipelines/list");
         form.validate();
         pageForm.validate();
         return Result.success(

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleMcpControllerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsoleMcpControllerTest.java
@@ -25,14 +25,18 @@ import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.console.proxy.ai.McpProxy;
+import com.alibaba.nacos.core.controller.compatibility.CompatibilityHelper;
+import com.alibaba.nacos.core.exception.NacosApiExceptionHandler;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.env.StandardEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -43,8 +47,10 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,11 +61,20 @@ class ConsoleMcpControllerTest {
     
     private MockMvc mockMvc;
     
+    private MockEnvironment environment;
+    
     @BeforeEach
     void setUp() {
-        EnvUtil.setEnvironment(new StandardEnvironment());
+        environment = new MockEnvironment();
+        EnvUtil.setEnvironment(environment);
         mockMvc = MockMvcBuilders.standaloneSetup(
-            new ConsoleMcpController(mcpProxy)).build();
+            new ConsoleMcpController(mcpProxy))
+            .setControllerAdvice(new NacosApiExceptionHandler()).build();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(null);
     }
     
     @Test
@@ -144,7 +159,21 @@ class ConsoleMcpControllerTest {
     }
     
     @Test
-    void testValidateImport() throws Exception {
+    void testValidateImportDisabledByDefault() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.post("/v3/console/ai/mcp/import/validate")
+                .param("namespaceId", "nacos-default-mcp")
+                .param("importType", "json")
+                .param("data", "[{\"name\":\"test-server\"}]"))
+            .andReturn().getResponse();
+        
+        assertDeprecated(response, "POST /v3/console/ai/import/validate");
+        verifyNoInteractions(mcpProxy);
+    }
+    
+    @Test
+    void testValidateImportWhenCompatibilityEnabled() throws Exception {
+        environment.setProperty(CompatibilityHelper.API_COMPATIBILITY_ENABLED_KEY, "true");
         McpServerImportValidationResult validationResult =
             new McpServerImportValidationResult();
         when(mcpProxy.validateImport(anyString(), any())).thenReturn(validationResult);
@@ -166,7 +195,21 @@ class ConsoleMcpControllerTest {
     }
     
     @Test
-    void testExecuteImport() throws Exception {
+    void testExecuteImportDisabledByDefault() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.post("/v3/console/ai/mcp/import/execute")
+                .param("namespaceId", "nacos-default-mcp")
+                .param("importType", "json")
+                .param("data", "[{\"name\":\"test-server\"}]"))
+            .andReturn().getResponse();
+        
+        assertDeprecated(response, "POST /v3/console/ai/import/execute");
+        verifyNoInteractions(mcpProxy);
+    }
+    
+    @Test
+    void testExecuteImportWhenCompatibilityEnabled() throws Exception {
+        environment.setProperty(CompatibilityHelper.API_COMPATIBILITY_ENABLED_KEY, "true");
         McpServerImportResponse importResponse = new McpServerImportResponse();
         when(mcpProxy.executeImport(anyString(), any())).thenReturn(importResponse);
         
@@ -184,5 +227,15 @@ class ConsoleMcpControllerTest {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertNotNull(result.getData());
+    }
+    
+    private void assertDeprecated(MockHttpServletResponse response, String alternative)
+        throws Exception {
+        assertEquals(HttpStatus.GONE.value(), response.getStatus());
+        Result<String> result = JacksonUtils.toObj(response.getContentAsString(),
+            new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.API_DEPRECATED.getCode(), result.getCode());
+        assertTrue(result.getData().contains(alternative));
     }
 }

--- a/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsolePipelineControllerTest.java
+++ b/console/src/test/java/com/alibaba/nacos/console/controller/v3/ai/ConsolePipelineControllerTest.java
@@ -23,6 +23,8 @@ import com.alibaba.nacos.api.model.v2.ErrorCode;
 import com.alibaba.nacos.api.model.v2.Result;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.console.proxy.ai.PipelineProxy;
+import com.alibaba.nacos.core.controller.compatibility.CompatibilityHelper;
+import com.alibaba.nacos.core.exception.NacosApiExceptionHandler;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.AfterEach;
@@ -31,7 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.env.StandardEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -39,9 +42,11 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -57,15 +62,20 @@ class ConsolePipelineControllerTest {
     
     private MockMvc mockMvc;
     
+    private MockEnvironment environment;
+    
     @BeforeEach
     void setUp() {
-        EnvUtil.setEnvironment(new StandardEnvironment());
+        environment = new MockEnvironment();
+        EnvUtil.setEnvironment(environment);
         mockMvc =
-            MockMvcBuilders.standaloneSetup(new ConsolePipelineController(pipelineProxy)).build();
+            MockMvcBuilders.standaloneSetup(new ConsolePipelineController(pipelineProxy))
+                .setControllerAdvice(new NacosApiExceptionHandler()).build();
     }
     
     @AfterEach
     void tearDown() {
+        EnvUtil.setEnvironment(null);
     }
     
     @Test
@@ -101,7 +111,19 @@ class ConsolePipelineControllerTest {
     }
     
     @Test
-    void listPipelinesLegacyBasePathStillWorks() throws Exception {
+    void listPipelinesLegacyBasePathDisabledByDefault() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.get(CONSOLE_BASE).param("resourceType", "SKILL")
+                .param("pageNo", "1").param("pageSize", "10"))
+            .andReturn().getResponse();
+        
+        assertDeprecated(response, "GET /v3/console/ai/pipelines/list");
+        verifyNoInteractions(pipelineProxy);
+    }
+    
+    @Test
+    void listPipelinesLegacyBasePathWorksWhenCompatibilityEnabled() throws Exception {
+        environment.setProperty(CompatibilityHelper.API_COMPATIBILITY_ENABLED_KEY, "true");
         Page<PipelineExecution> page = new Page<>();
         when(pipelineProxy.listPipelines(anyString(), isNull(), isNull(), isNull(), anyInt(),
             anyInt()))
@@ -117,7 +139,19 @@ class ConsolePipelineControllerTest {
     }
     
     @Test
-    void getPipelineLegacyPathVariableStillWorks() throws Exception {
+    void getPipelineLegacyPathVariableDisabledByDefault() throws Exception {
+        MockHttpServletResponse response = mockMvc.perform(
+            MockMvcRequestBuilders.get(CONSOLE_BASE + "/legacy-id"))
+            .andReturn().getResponse();
+        
+        assertDeprecated(response,
+            "GET /v3/console/ai/pipelines/detail?pipelineId={pipelineId}");
+        verifyNoInteractions(pipelineProxy);
+    }
+    
+    @Test
+    void getPipelineLegacyPathVariableWorksWhenCompatibilityEnabled() throws Exception {
+        environment.setProperty(CompatibilityHelper.API_COMPATIBILITY_ENABLED_KEY, "true");
         PipelineExecution execution = new PipelineExecution();
         execution.setExecutionId("legacy-id");
         when(pipelineProxy.getPipeline("legacy-id")).thenReturn(execution);
@@ -129,5 +163,15 @@ class ConsolePipelineControllerTest {
             });
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("legacy-id", result.getData().getExecutionId());
+    }
+    
+    private void assertDeprecated(MockHttpServletResponse response, String alternative)
+        throws Exception {
+        assertEquals(HttpStatus.GONE.value(), response.getStatus());
+        Result<String> result = JacksonUtils.toObj(response.getContentAsString(),
+            new TypeReference<>() {
+            });
+        assertEquals(ErrorCode.API_DEPRECATED.getCode(), result.getCode());
+        assertTrue(result.getData().contains(alternative));
     }
 }

--- a/core/src/main/java/com/alibaba/nacos/core/controller/compatibility/CompatibilityHelper.java
+++ b/core/src/main/java/com/alibaba/nacos/core/controller/compatibility/CompatibilityHelper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.controller.compatibility;
+
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Compatibility gate for a small number of deprecated APIs pending removal.
+ *
+ * @author xiweng.yy
+ */
+public final class CompatibilityHelper {
+    
+    public static final String API_COMPATIBILITY_ENABLED_KEY =
+        "nacos.core.api.compatibility.enabled";
+    
+    private static final String DEPRECATED_API_MESSAGE =
+        "Current API is deprecated. Please use API(s) `%s` instead, or set `%s=true` "
+            + "in application.properties during migration.";
+    
+    private CompatibilityHelper() {
+    }
+    
+    /**
+     * Check whether deprecated API compatibility is enabled.
+     *
+     * @param alternatives replacement APIs
+     * @throws NacosApiException if deprecated APIs are disabled
+     */
+    public static void check(String alternatives) throws NacosApiException {
+        if (EnvUtil.getProperty(API_COMPATIBILITY_ENABLED_KEY, Boolean.class, false)) {
+            return;
+        }
+        throw new NacosApiException(HttpStatus.GONE.value(), ErrorCode.API_DEPRECATED,
+            String.format(DEPRECATED_API_MESSAGE, alternatives,
+                API_COMPATIBILITY_ENABLED_KEY));
+    }
+}

--- a/core/src/test/java/com/alibaba/nacos/core/controller/compatibility/CompatibilityHelperTest.java
+++ b/core/src/test/java/com/alibaba/nacos/core/controller/compatibility/CompatibilityHelperTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.core.controller.compatibility;
+
+import com.alibaba.nacos.api.exception.api.NacosApiException;
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.sys.env.EnvUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompatibilityHelperTest {
+    
+    private static final String ALTERNATIVE = "GET /v3/test/resources/detail";
+    
+    private MockEnvironment environment;
+    
+    @BeforeEach
+    void setUp() {
+        environment = new MockEnvironment();
+        EnvUtil.setEnvironment(environment);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        EnvUtil.setEnvironment(null);
+    }
+    
+    @Test
+    void shouldRejectDeprecatedApiByDefault() {
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> CompatibilityHelper.check(ALTERNATIVE));
+        
+        assertEquals(HttpStatus.GONE.value(), exception.getErrCode());
+        assertEquals(ErrorCode.API_DEPRECATED.getCode(), exception.getDetailErrCode());
+        assertTrue(exception.getErrMsg().contains(ALTERNATIVE));
+        assertTrue(exception.getErrMsg()
+            .contains(CompatibilityHelper.API_COMPATIBILITY_ENABLED_KEY));
+    }
+    
+    @Test
+    void shouldAllowDeprecatedApiWhenCompatibilityEnabled() {
+        environment.setProperty(CompatibilityHelper.API_COMPATIBILITY_ENABLED_KEY, "true");
+        
+        assertDoesNotThrow(() -> CompatibilityHelper.check(ALTERNATIVE));
+    }
+}

--- a/distribution/conf/application.properties
+++ b/distribution/conf/application.properties
@@ -221,12 +221,10 @@ server.tomcat.basedir=file:.
 ### Include message field
 server.error.include-message=ALWAYS
 
-### Enabled for open API compatibility
+### Reopen deprecated v3 APIs pending removal during a migration window. Disabled by default.
+# nacos.core.api.compatibility.enabled=false
+### Enabled for legacy open API compatibility provided by nacos-api-legacy-adapter
 # nacos.core.api.compatibility.client.enabled=true
-### Enabled for admin API compatibility
-# nacos.core.api.compatibility.admin.enabled=false
-### Enabled for console API compatibility
-# nacos.core.api.compatibility.console.enabled=false
 
 #--------------- Nacos Console Configurations ---------------#
 
@@ -386,8 +384,6 @@ nacos.istio.mcp.server.enabled=false
 #nacos.ai.skill.auto-publish-after-review.enabled=false
 
 #*************** AI Resource Importer Configurations ***************#
-# Optional: reopen deprecated legacy MCP import APIs during a compatibility window.
-#nacos.ai.resource.import.legacy-mcp-api-enabled=false
 # Optional: allow legacy MCP import APIs to fetch user-provided URLs when reopened.
 #nacos.ai.resource.import.allow-user-url=false
 # Optional: enable the built-in official MCP registry import source. Source id: mcp-official.

--- a/doc/ai-resource-import-operator-guide.md
+++ b/doc/ai-resource-import-operator-guide.md
@@ -239,14 +239,18 @@ POST /v3/console/ai/mcp/import/execute
 Operators may reopen them temporarily during a migration window:
 
 ```properties
-nacos.ai.resource.import.legacy-mcp-api-enabled=true
+nacos.core.api.compatibility.enabled=true
 ```
+
+The former `nacos.ai.resource.import.legacy-mcp-api-enabled` property is no
+longer recognized. The shared switch also reopens other explicitly gated
+deprecated v3 APIs; use it only during a controlled migration window.
 
 Legacy direct URL import remains disabled even when the legacy endpoints are
 enabled. It should only be reopened in controlled deployments:
 
 ```properties
-nacos.ai.resource.import.legacy-mcp-api-enabled=true
+nacos.core.api.compatibility.enabled=true
 nacos.ai.resource.import.allow-user-url=true
 ```
 

--- a/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImpl.java
+++ b/maintainer-client/src/main/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImpl.java
@@ -28,6 +28,7 @@ import com.alibaba.nacos.maintainer.client.model.HttpRequest;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,7 +52,14 @@ final class PipelineMaintainerServiceImpl extends AbstractAiDelegateMaintainerSe
             return parseResultFromHttp(executeSyncHttpRequest(httpRequest));
         } catch (NacosException e) {
             if (e.getErrCode() == NacosException.NOT_FOUND) {
-                return getPipelineDetailLegacy(pipelineId);
+                try {
+                    return getPipelineDetailLegacy(pipelineId);
+                } catch (NacosException legacyException) {
+                    if (legacyException.getErrCode() == HttpURLConnection.HTTP_GONE) {
+                        throw e;
+                    }
+                    throw legacyException;
+                }
             }
             throw e;
         }

--- a/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImplTest.java
+++ b/maintainer-client/src/test/java/com/alibaba/nacos/maintainer/client/ai/PipelineMaintainerServiceImplTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -163,6 +164,19 @@ class PipelineMaintainerServiceImplTest {
         
         assertEquals(ErrorCode.SUCCESS.getCode(), result.getCode());
         assertEquals("legacy", result.getData().get("executionId").asText());
+    }
+    
+    @Test
+    void getPipelineDetailPreservesCanonical404WhenLegacyApiIsGone() throws NacosException {
+        doThrow(new NacosException(NacosException.NOT_FOUND, "pipeline not found"))
+            .doThrow(new NacosException(HttpURLConnection.HTTP_GONE, "API deprecated"))
+            .when(clientHttpProxy).executeSyncHttpRequest(any(HttpRequest.class));
+        
+        NacosException exception = assertThrows(NacosException.class,
+            () -> pipelineMaintainerService.getPipelineDetail("missing"));
+        
+        assertEquals(NacosException.NOT_FOUND, exception.getErrCode());
+        assertEquals("pipeline not found", exception.getErrMsg());
     }
     
     // ========== Additional Tests for Coverage ==========

--- a/specs/en/design/compatibility-deprecation-spec.md
+++ b/specs/en/design/compatibility-deprecation-spec.md
@@ -139,7 +139,38 @@ The following items are current compatibility or deprecation examples:
 This list is not exhaustive. Each domain spec remains responsible for exact
 domain behavior and migration details.
 
-## 9. Legacy HTTP API Adapter
+## 9. Deprecated V3 API Gate
+
+A small set of deprecated v3 APIs pending removal is disabled by default:
+
+| Deprecated API | Canonical replacement |
+| --- | --- |
+| `GET /v3/admin/ai/pipelines` | `GET /v3/admin/ai/pipelines/list` |
+| `GET /v3/admin/ai/pipelines/{pipelineId}` | `GET /v3/admin/ai/pipelines/detail?pipelineId={pipelineId}` |
+| `GET /v3/console/ai/pipelines` | `GET /v3/console/ai/pipelines/list` |
+| `GET /v3/console/ai/pipelines/{pipelineId}` | `GET /v3/console/ai/pipelines/detail?pipelineId={pipelineId}` |
+| `POST /v3/console/ai/mcp/import/validate` | `POST /v3/console/ai/import/validate` |
+| `POST /v3/console/ai/mcp/import/execute` | `POST /v3/console/ai/import/execute` |
+
+Disabled endpoints return HTTP `410 Gone` with the `API_DEPRECATED` result code
+and identify their canonical replacement. Operators may temporarily reopen all
+of these endpoints during migration with:
+
+```properties
+nacos.core.api.compatibility.enabled=true
+```
+
+The switch is intentionally shared and applies only to APIs that explicitly use
+the v3 compatibility gate. It does not replace the audience-specific switches
+owned by `nacos-api-legacy-adapter`. Authentication and authorization still
+apply to reopened endpoints.
+
+The former `nacos.ai.resource.import.legacy-mcp-api-enabled` property is no
+longer recognized. Legacy MCP direct URL import additionally requires
+`nacos.ai.resource.import.allow-user-url=true`; operators should prefer managed
+source configuration instead.
+
+## 10. Legacy HTTP API Adapter
 
 Starting with the Nacos 3.2.0 line, legacy v1 and v2 HTTP APIs are no longer
 part of the default Nacos server distribution. They are a separate compatibility
@@ -160,7 +191,7 @@ Rules:
 Domain specs should mention legacy v1/v2 behavior only as migration context or
 when a current compatibility path depends on it.
 
-## 10. Related Specs
+## 11. Related Specs
 
 - [HTTP API Spec](../http-api/api-spec.md)
 - [V3 API Surface](../http-api/v3-api-surface.md)

--- a/specs/en/http-api/response-error-spec.md
+++ b/specs/en/http-api/response-error-spec.md
@@ -65,6 +65,9 @@ v3 errors:
 | data access, servlet, or IO failures | 500 | `DATA_ACCESS_ERROR` |
 | unhandled exceptions | 500 | generic failure |
 
+Deprecated v3 APIs that use the shared compatibility gate return HTTP `410 Gone`
+with `API_DEPRECATED` while `nacos.core.api.compatibility.enabled` is false.
+
 ## 4. Exception Handler Convergence
 
 Nacos-owned v3 HTTP APIs should converge on `@NacosApi` and

--- a/specs/en/http-api/v3-api-surface.md
+++ b/specs/en/http-api/v3-api-surface.md
@@ -212,3 +212,10 @@ user-facing documentation should describe the new APIs as the primary contract.
 Deprecated endpoints should be documented only in compatibility sections with
 migration guidance, following the
 [Compatibility And Deprecation Spec](../design/compatibility-deprecation-spec.md).
+
+The legacy Pipeline base-path list and path-variable detail endpoints, together
+with `POST /v3/console/ai/mcp/import/{validate|execute}`, are disabled by default.
+They return HTTP `410 Gone` with `API_DEPRECATED`. Operators may temporarily
+reopen all explicitly gated v3 compatibility endpoints with
+`nacos.core.api.compatibility.enabled=true`. The former
+`nacos.ai.resource.import.legacy-mcp-api-enabled` property is no longer read.

--- a/specs/en/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/en/plugin/ai-resource-import-plugin-spec.md
@@ -398,16 +398,21 @@ from a user-owned MCP runtime endpoint and remains outside the AI resource
 marketplace or registry import flow.
 
 The compatibility endpoints are disabled by default. Operators may reopen them
-temporarily with `nacos.ai.resource.import.legacy-mcp-api-enabled=true` while
-clients migrate to `/v3/{admin|console}/ai/import/*`.
+temporarily with `nacos.core.api.compatibility.enabled=true` while clients
+migrate to `/v3/{admin|console}/ai/import/*`.
+
+The former `nacos.ai.resource.import.legacy-mcp-api-enabled` property is no
+longer recognized. The shared compatibility switch also reopens other
+explicitly gated deprecated v3 APIs, as defined by the
+[Compatibility And Deprecation Spec](../design/compatibility-deprecation-spec.md).
 
 For legacy `importType=url`, the request must not use a user-provided URL as a
 network target by default. It may be interpreted as a `sourceId` when it matches
 an enabled source. Otherwise the request should fail with a migration message.
 Legacy direct URL import may only be enabled by explicit operator configuration
 for controlled deployments by setting
-`nacos.ai.resource.import.allow-user-url=true` together with the legacy API
-switch.
+`nacos.ai.resource.import.allow-user-url=true` together with
+`nacos.core.api.compatibility.enabled=true`.
 
 Legacy `importType=json` and `importType=file` may be mapped to built-in local
 importers because they do not require server-side network access.

--- a/specs/zh-cn/design/compatibility-deprecation-spec.md
+++ b/specs/zh-cn/design/compatibility-deprecation-spec.md
@@ -112,7 +112,33 @@ Schema 清理应平衡正确性和运维成本。冗余字段可以为了避免�
 
 此清单不穷尽所有项目。每个领域规范仍负责精确领域行为和迁移细节。
 
-## 9. Legacy HTTP API Adapter
+## 9. 废弃 V3 API 门禁
+
+以下少量待移除的废弃 v3 API 默认关闭：
+
+| 废弃 API | 标准替代 API |
+| --- | --- |
+| `GET /v3/admin/ai/pipelines` | `GET /v3/admin/ai/pipelines/list` |
+| `GET /v3/admin/ai/pipelines/{pipelineId}` | `GET /v3/admin/ai/pipelines/detail?pipelineId={pipelineId}` |
+| `GET /v3/console/ai/pipelines` | `GET /v3/console/ai/pipelines/list` |
+| `GET /v3/console/ai/pipelines/{pipelineId}` | `GET /v3/console/ai/pipelines/detail?pipelineId={pipelineId}` |
+| `POST /v3/console/ai/mcp/import/validate` | `POST /v3/console/ai/import/validate` |
+| `POST /v3/console/ai/mcp/import/execute` | `POST /v3/console/ai/import/execute` |
+
+关闭时，端点返回 HTTP `410 Gone` 和 `API_DEPRECATED` 结果码，并说明对应的标准替代 API。
+运维人员可以在迁移窗口内通过以下配置临时重新开启全部这些端点：
+
+```properties
+nacos.core.api.compatibility.enabled=true
+```
+
+该开关有意设计为共享开关，只作用于显式接入 v3 兼容门禁的 API，不替代
+`nacos-api-legacy-adapter` 按 API 受众维护的兼容开关。重新开启端点后，原有认证和鉴权仍然生效。
+
+旧的 `nacos.ai.resource.import.legacy-mcp-api-enabled` 参数不再识别。旧 MCP 直接 URL 导入还必须
+额外设置 `nacos.ai.resource.import.allow-user-url=true`；运维侧应优先使用受管 source 配置。
+
+## 10. Legacy HTTP API Adapter
 
 从 Nacos 3.2.0 版本线开始，legacy v1 和 v2 HTTP API 不再属于默认 Nacos server 发行包。它们是由
 [nacos-api-legacy-adapter](https://github.com/nacos-group/nacos-api-legacy-adapter)提供的独立兼容面。
@@ -128,7 +154,7 @@ Schema 清理应平衡正确性和运维成本。冗余字段可以为了避免�
 
 领域规范只应在迁移上下文中提及 legacy v1/v2 行为，或在当前兼容路径依赖它时进行说明。
 
-## 10. 相关规范
+## 11. 相关规范
 
 - [HTTP API 规范](../http-api/api-spec.md)
 - [V3 API 范围](../http-api/v3-api-surface.md)

--- a/specs/zh-cn/http-api/response-error-spec.md
+++ b/specs/zh-cn/http-api/response-error-spec.md
@@ -62,6 +62,9 @@ v3 错误：
 | 数据访问、Servlet 或 IO 失败 | 500 | `DATA_ACCESS_ERROR` |
 | 未处理异常 | 500 | 通用失败 |
 
+接入共享兼容门禁的废弃 v3 API 在 `nacos.core.api.compatibility.enabled=false` 时返回
+HTTP `410 Gone` 和 `API_DEPRECATED`。
+
 ## 4. ExceptionHandler 收敛
 
 Nacos 自有的 v3 HTTP API 应收敛到 `@NacosApi` 和

--- a/specs/zh-cn/http-api/v3-api-surface.md
+++ b/specs/zh-cn/http-api/v3-api-surface.md
@@ -196,3 +196,8 @@ REST 风格 API 替代。这些旧端点应视为废弃兼容 API：
 兼容端点可以在过渡期内继续保留，但面向用户的文档应以新 API 作为主要契约。
 废弃端点只应出现在兼容章节中，并按照
 [兼容与废弃策略规范](../design/compatibility-deprecation-spec.md)提供迁移说明。
+
+旧 Pipeline base-path list、path-variable detail 端点，以及
+`POST /v3/console/ai/mcp/import/{validate|execute}` 默认关闭，返回 HTTP `410 Gone` 和
+`API_DEPRECATED`。运维人员可以通过 `nacos.core.api.compatibility.enabled=true` 临时重新开启全部
+显式接入门禁的 v3 兼容 API。旧的 `nacos.ai.resource.import.legacy-mcp-api-enabled` 参数不再读取。

--- a/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
+++ b/specs/zh-cn/plugin/ai-resource-import-plugin-spec.md
@@ -342,15 +342,17 @@ validate 和 execute 端点应通过兼容 adapter 路由到统一导入管理�
 在构建 MCP Server schema 时，从用户自有 MCP runtime endpoint 拉取 tools 的辅助能力，不属于
 AI 资源市场或 registry 导入流程。
 
-兼容端点默认关闭。运维可以在迁移窗口期通过
-`nacos.ai.resource.import.legacy-mcp-api-enabled=true` 临时重新开启，客户端应迁移到
-`/v3/{admin|console}/ai/import/*`。
+兼容端点默认关闭。运维可以在迁移窗口期通过 `nacos.core.api.compatibility.enabled=true`
+临时重新开启，客户端应迁移到 `/v3/{admin|console}/ai/import/*`。
+
+旧的 `nacos.ai.resource.import.legacy-mcp-api-enabled` 参数不再识别。共享兼容开关还会重新开启其他
+显式接入门禁的废弃 v3 API，具体范围由[兼容与废弃策略规范](../design/compatibility-deprecation-spec.md)定义。
 
 对于旧的 `importType=url`，请求默认不得把用户传入 URL 作为网络目标。当 `data` 匹配已启用
 source 时，可以按 `sourceId` 解释；否则应失败并提示迁移到
 `nacos.ai.resource.import.sources` 配置。旧的直接 URL 导入只能由运维同时开启
-`nacos.ai.resource.import.legacy-mcp-api-enabled=true` 和
-`nacos.ai.resource.import.allow-user-url=true` 后用于受控部署。
+`nacos.core.api.compatibility.enabled=true` 和 `nacos.ai.resource.import.allow-user-url=true`
+后用于受控部署。
 
 旧的 `importType=json` 和 `importType=file` 可以映射为内置本地 importer，因为它们不需要服务端
 发起网络访问。

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/ai/DeprecatedAiApiCompatibilityOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/ai/DeprecatedAiApiCompatibilityOpenApiITCase.java
@@ -161,12 +161,17 @@ public class DeprecatedAiApiCompatibilityOpenApiITCase {
     
     private void assertGone(HttpRestResult<String> response, String replacement) {
         assertError(response, 410, ErrorCode.API_DEPRECATED);
-        assertTrue(response.getData().contains(replacement), response.getData());
+        assertTrue(responseBody(response).contains(replacement), responseBody(response));
     }
     
     private void assertError(HttpRestResult<String> response, int httpCode, ErrorCode errorCode) {
-        assertEquals(httpCode, response.getCode(), response.getData());
-        JsonNode root = JacksonUtils.toObj(response.getData());
-        assertEquals(errorCode.getCode().intValue(), root.get("code").asInt(), response.getData());
+        String responseBody = responseBody(response);
+        assertEquals(httpCode, response.getCode(), responseBody);
+        JsonNode root = JacksonUtils.toObj(responseBody);
+        assertEquals(errorCode.getCode().intValue(), root.get("code").asInt(), responseBody);
+    }
+    
+    private String responseBody(HttpRestResult<String> response) {
+        return response.getData() == null ? response.getMessage() : response.getData();
     }
 }

--- a/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/ai/DeprecatedAiApiCompatibilityOpenApiITCase.java
+++ b/test/openapi-test/src/test/java/com/alibaba/nacos/test/openapi/ai/DeprecatedAiApiCompatibilityOpenApiITCase.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.test.openapi.ai;
+
+import com.alibaba.nacos.api.model.v2.ErrorCode;
+import com.alibaba.nacos.common.http.HttpRestResult;
+import com.alibaba.nacos.common.http.client.NacosRestTemplate;
+import com.alibaba.nacos.common.http.client.request.DefaultHttpClientRequest;
+import com.alibaba.nacos.common.http.param.Header;
+import com.alibaba.nacos.common.http.param.Query;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for deprecated v3 AI APIs controlled by the shared compatibility gate.
+ *
+ * <p>The v3.2.4 maintenance branch uses self-contained OpenAPI integration tests, so this case
+ * covers the six gated endpoints and verifies that their canonical replacements remain active.
+ *
+ * @author xiweng.yy
+ */
+public class DeprecatedAiApiCompatibilityOpenApiITCase {
+    
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(DeprecatedAiApiCompatibilityOpenApiITCase.class);
+    
+    private static final String NACOS_HOST = System.getProperty("nacos.host", "127.0.0.1");
+    
+    private static final String NACOS_PORT = System.getProperty("nacos.port", "8848");
+    
+    private static final String CONSOLE_PORT = System.getProperty("nacos.console.port", "8080");
+    
+    private static final String SERVER_BASE_URL =
+        "http://" + NACOS_HOST + ":" + NACOS_PORT + "/nacos";
+    
+    private static final String CONSOLE_BASE_URL =
+        "http://" + NACOS_HOST + ":" + CONSOLE_PORT;
+    
+    private static final String ADMIN_PIPELINE_PATH = "/v3/admin/ai/pipelines";
+    
+    private static final String CONSOLE_PIPELINE_PATH = "/v3/console/ai/pipelines";
+    
+    private static final String CONSOLE_MCP_IMPORT_PATH = "/v3/console/ai/mcp/import";
+    
+    private static final String CONSOLE_IMPORT_PATH = "/v3/console/ai/import";
+    
+    private CloseableHttpClient httpClient;
+    
+    private NacosRestTemplate nacosRestTemplate;
+    
+    @BeforeEach
+    public void setUp() throws Exception {
+        httpClient = HttpClientBuilder.create().build();
+        nacosRestTemplate = new NacosRestTemplate(LOGGER,
+            new DefaultHttpClientRequest(httpClient, RequestConfig.DEFAULT));
+    }
+    
+    @AfterEach
+    public void tearDown() throws Exception {
+        nacosRestTemplate.close();
+    }
+    
+    @Test
+    public void testAdminPipelineCompatibilityGate() throws Exception {
+        Query listQuery = pipelineListQuery();
+        assertSuccessPage(get(SERVER_BASE_URL, ADMIN_PIPELINE_PATH + "/list", listQuery));
+        assertGone(get(SERVER_BASE_URL, ADMIN_PIPELINE_PATH, listQuery),
+            "GET /v3/admin/ai/pipelines/list");
+        
+        String absentPipelineId = "pipeline-" + UUID.randomUUID();
+        assertError(get(SERVER_BASE_URL, ADMIN_PIPELINE_PATH + "/detail",
+            Query.newInstance().addParam("pipelineId", absentPipelineId)), 404,
+            ErrorCode.RESOURCE_NOT_FOUND);
+        assertGone(get(SERVER_BASE_URL, ADMIN_PIPELINE_PATH + "/" + absentPipelineId,
+            Query.newInstance()),
+            "GET /v3/admin/ai/pipelines/detail?pipelineId={pipelineId}");
+    }
+    
+    @Test
+    public void testConsolePipelineCompatibilityGate() throws Exception {
+        Query listQuery = pipelineListQuery();
+        assertSuccessPage(get(CONSOLE_BASE_URL, CONSOLE_PIPELINE_PATH + "/list", listQuery));
+        assertGone(get(CONSOLE_BASE_URL, CONSOLE_PIPELINE_PATH, listQuery),
+            "GET /v3/console/ai/pipelines/list");
+        
+        String absentPipelineId = "pipeline-" + UUID.randomUUID();
+        assertError(get(CONSOLE_BASE_URL, CONSOLE_PIPELINE_PATH + "/detail",
+            Query.newInstance().addParam("pipelineId", absentPipelineId)), 404,
+            ErrorCode.RESOURCE_NOT_FOUND);
+        assertGone(get(CONSOLE_BASE_URL, CONSOLE_PIPELINE_PATH + "/" + absentPipelineId,
+            Query.newInstance()),
+            "GET /v3/console/ai/pipelines/detail?pipelineId={pipelineId}");
+    }
+    
+    @Test
+    public void testLegacyMcpImportCompatibilityGate() throws Exception {
+        assertGone(post(CONSOLE_BASE_URL, CONSOLE_MCP_IMPORT_PATH + "/validate"),
+            "POST /v3/console/ai/import/validate");
+        assertGone(post(CONSOLE_BASE_URL, CONSOLE_MCP_IMPORT_PATH + "/execute"),
+            "POST /v3/console/ai/import/execute");
+        
+        assertEquals(400, post(CONSOLE_BASE_URL, CONSOLE_IMPORT_PATH + "/validate").getCode());
+        assertEquals(400, post(CONSOLE_BASE_URL, CONSOLE_IMPORT_PATH + "/execute").getCode());
+    }
+    
+    private Query pipelineListQuery() {
+        return Query.newInstance().addParam("resourceType", "prompt")
+            .addParam("resourceName", "pipeline-" + UUID.randomUUID())
+            .addParam("namespaceId", "public").addParam("version", "1.0.0")
+            .addParam("pageNo", "1").addParam("pageSize", "10");
+    }
+    
+    private HttpRestResult<String> get(String baseUrl, String path, Query query)
+        throws Exception {
+        return nacosRestTemplate.get(baseUrl + path, Header.EMPTY, query, String.class);
+    }
+    
+    private HttpRestResult<String> post(String baseUrl, String path) throws Exception {
+        return nacosRestTemplate.postForm(baseUrl + path, Header.EMPTY, Collections.emptyMap(),
+            String.class);
+    }
+    
+    private void assertSuccessPage(HttpRestResult<String> response) {
+        assertEquals(200, response.getCode(), response.getData());
+        JsonNode root = JacksonUtils.toObj(response.getData());
+        assertEquals(ErrorCode.SUCCESS.getCode().intValue(), root.get("code").asInt(),
+            response.getData());
+        JsonNode data = root.get("data");
+        assertNotNull(data, response.getData());
+        assertTrue(data.has("pageItems"), response.getData());
+    }
+    
+    private void assertGone(HttpRestResult<String> response, String replacement) {
+        assertError(response, 410, ErrorCode.API_DEPRECATED);
+        assertTrue(response.getData().contains(replacement), response.getData());
+    }
+    
+    private void assertError(HttpRestResult<String> response, int httpCode, ErrorCode errorCode) {
+        assertEquals(httpCode, response.getCode(), response.getData());
+        JsonNode root = JacksonUtils.toObj(response.getData());
+        assertEquals(errorCode.getCode().intValue(), root.get("code").asInt(), response.getData());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Backport #15734 to `v3.2.4-develop` for #14817. The legacy MCP import portion is also related to #15183.

Several deprecated v3 AI APIs remain callable by default on the 3.2.4 maintenance branch even though canonical replacements already exist. This backport disables those explicitly selected endpoints by default while retaining one temporary migration switch.

The shared switch is `nacos.core.api.compatibility.enabled`, disabled by default. A gated request returns HTTP 410 with `API_DEPRECATED` and the canonical replacement. Setting the switch to `true` restores the existing controller flow, including authentication, validation, and business behavior.

The old `nacos.ai.resource.import.legacy-mcp-api-enabled` input is no longer recognized. The separate `nacos.ai.resource.import.allow-user-url` protection remains in effect for legacy direct URL import.

## Brief changelog

* Cherry-pick the implementation and follow-up fix from #15734 onto the latest `v3.2.4-develop`.
* Add `CompatibilityHelper` in core for explicitly gated deprecated v3 APIs.
* Gate the deprecated Admin and Console Pipeline base-path list and path-variable detail APIs.
* Gate the deprecated Console MCP import validate and execute APIs.
* Remove the temporary MCP-specific compatibility property and route all six APIs through the shared switch.
* Preserve the canonical Pipeline detail 404 when a Maintainer SDK compatibility fallback reaches a gated legacy API.
* Update unit tests, operator documentation, and English/Chinese compatibility and API specs.
* Add a self-contained OpenAPI IT compatible with this maintenance branch.
* Remove unused Admin and Console legacy-adapter switch examples while retaining the Client adapter example.

The maintenance branch does not contain the newer shared OpenAPI IT base/coverage registries or the Maintainer SDK IT module from `develop`. Therefore, this backport uses a target-compatible standalone OpenAPI IT and the existing Maintainer client unit tests.

## Verifying this change

* Started the built standalone distribution locally and verified:
  * all six deprecated APIs return HTTP 410 and `API_DEPRECATED` by default;
  * with `nacos.core.api.compatibility.enabled=true`, the old Pipeline list APIs return 200, missing details retain 404, and old MCP import APIs enter validation and return 400;
  * setting only `nacos.ai.resource.import.legacy-mcp-api-enabled=true` does not reopen either MCP API;
  * canonical Pipeline and unified import APIs remain available.
* Passed the target-compatible standalone OpenAPI IT:
  * `DeprecatedAiApiCompatibilityOpenApiITCase`: 3 tests, 0 failures, 0 errors.
* Passed 39 targeted unit tests across core, Maintainer client, AI, and Console modules.
* Passed the full 60-module release build:
  * `mvn -B '-Prelease-nacos,!dev' -Dmaven.test.skip=true clean install`
* Passed the full 60-module CI static gate:
  * `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e`

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [x] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass.
