### PR TITLE
feat(ai): add canonical Agent search indexing

### DIFF
--- a/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/service/ard/ArdSearchServiceImplTest.java
+++ b/ai-registry-adaptor/src/test/java/com/alibaba/nacos/airegistry/service/ard/ArdSearchServiceImplTest.java
@@ -279,7 +279,8 @@ class ArdSearchServiceImplTest {
         
         ArdSearchResponse response = service.search(requestWithFilters("api",
             List.of(filter("metadata.resourceType", List.of("skill")),
-                filter("metadata.inputTypes", "json"))));
+                filter("metadata.inputTypes", "json"), filter("version", "1.0.0"),
+                filter("displayName", "api"))));
         
         assertEquals(1, response.getResults().size());
     }

--- a/ai/src/main/java/com/alibaba/nacos/ai/config/AiResourceIndexBackfillTask.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/config/AiResourceIndexBackfillTask.java
@@ -28,11 +28,13 @@ import com.alibaba.nacos.ai.service.search.AiResourceSearchTypeHandler;
 import com.alibaba.nacos.ai.service.search.AiResourceSearchTypeHandlerRegistry;
 import com.alibaba.nacos.ai.service.search.AiResourceSearchConstants;
 import com.alibaba.nacos.ai.service.search.AiResourceSearchRepository;
+import com.alibaba.nacos.ai.service.search.AiResourceSearchReadinessService;
 import com.alibaba.nacos.ai.service.search.McpAiResourceSearchTypeHandler;
 import com.alibaba.nacos.ai.service.search.StoredAiResourceSearchTypeHandler;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.api.model.response.Namespace;
 import com.alibaba.nacos.common.executor.ExecutorFactory;
+import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.common.utils.StringUtils;
 import com.alibaba.nacos.common.utils.ThreadFactoryBuilder;
 import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
@@ -54,7 +56,9 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
@@ -122,6 +126,8 @@ public class AiResourceIndexBackfillTask
     
     private final ConfigOperationService configOperationService;
     
+    private final AiResourceSearchReadinessService readinessService;
+    
     @Autowired
     public AiResourceIndexBackfillTask(AiResourceSearchTypeHandlerRegistry typeHandlerRegistry,
         AiResourceSearchRepository repository,
@@ -129,7 +135,8 @@ public class AiResourceIndexBackfillTask
         AiResourceEmbeddingService embeddingService, AiResourceVectorIndex vectorIndex,
         NamespaceOperationService namespaceOperationService,
         ConfigQueryChainService configQueryChainService,
-        ConfigOperationService configOperationService) {
+        ConfigOperationService configOperationService,
+        AiResourceSearchReadinessService readinessService) {
         this.typeHandlerRegistry = typeHandlerRegistry;
         this.repository = repository;
         this.indexMaintenanceService = indexMaintenanceService;
@@ -138,6 +145,7 @@ public class AiResourceIndexBackfillTask
         this.namespaceOperationService = namespaceOperationService;
         this.configQueryChainService = configQueryChainService;
         this.configOperationService = configOperationService;
+        this.readinessService = readinessService;
     }
     
     AiResourceIndexBackfillTask(AiResourceManager resourceManager,
@@ -152,7 +160,8 @@ public class AiResourceIndexBackfillTask
                 AiResourceIndexContentLoader.NOOP),
             new McpAiResourceSearchTypeHandler(mcpServerOperationService))), repository,
             indexMaintenanceService, embeddingService, vectorIndex, namespaceOperationService,
-            configQueryChainService, configOperationService);
+            configQueryChainService, configOperationService,
+            AiResourceSearchReadinessService.NOOP);
     }
     
     @Override
@@ -184,16 +193,27 @@ public class AiResourceIndexBackfillTask
                 return;
             }
             BackfillStats stats = new BackfillStats();
+            Map<String, ReadinessTarget> readinessTargets = readinessTargets();
             ReconciliationContext context = reconciliationContext();
-            for (Namespace namespace : getNamespaces()) {
+            NamespaceScan namespaceScan = getNamespaces();
+            for (Namespace namespace : namespaceScan.namespaces) {
                 marker.assertOwned();
                 String namespaceId = namespace.getNamespace();
                 for (AiResourceSearchTypeHandler handler : typeHandlerRegistry.handlers()) {
                     for (String resourceType : handler.resourceTypes()) {
-                        reconcileResources(namespaceId, resourceType, handler, context, marker,
-                            stats);
+                        BackfillStats typeStats = reconcileResources(namespaceId, resourceType,
+                            handler, context, marker);
+                        stats.add(typeStats);
+                        ReadinessTarget target = readinessTargets.get(resourceType);
+                        if (target != null) {
+                            target.stats.add(typeStats);
+                        }
                     }
                 }
+            }
+            marker.assertOwned();
+            if (namespaceScan.complete) {
+                recordReadiness(readinessTargets);
             }
             LOGGER.info(
                 "AI resource index backfill completed: scanned={}, rebuilt={}, skipped={}, failed={}",
@@ -207,22 +227,23 @@ public class AiResourceIndexBackfillTask
         }
     }
     
-    private List<Namespace> getNamespaces() {
+    private NamespaceScan getNamespaces() {
         try {
             List<Namespace> namespaces = namespaceOperationService.getNamespaceList();
             if (namespaces != null && !namespaces.isEmpty()) {
-                return namespaces;
+                return new NamespaceScan(namespaces, true);
             }
         } catch (Exception e) {
             LOGGER.warn("Failed to list namespaces for AI resource index backfill", e);
         }
-        return Collections.singletonList(new Namespace(
-            com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID, "public"));
+        return new NamespaceScan(Collections.singletonList(new Namespace(
+            com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID, "public")), false);
     }
     
-    private void reconcileResources(String namespaceId, String resourceType,
-        AiResourceSearchTypeHandler handler, ReconciliationContext context, MarkerLease marker,
-        BackfillStats stats) throws Exception {
+    private BackfillStats reconcileResources(String namespaceId, String resourceType,
+        AiResourceSearchTypeHandler handler, ReconciliationContext context, MarkerLease marker)
+        throws Exception {
+        BackfillStats stats = new BackfillStats();
         int pageNo = 1;
         while (true) {
             marker.assertOwned();
@@ -240,6 +261,28 @@ public class AiResourceIndexBackfillTask
             pageNo++;
         }
         scheduleOrphanDeletes(namespaceId, resourceType, handler, marker, stats);
+        return stats;
+    }
+    
+    private Map<String, ReadinessTarget> readinessTargets() {
+        Map<String, ReadinessTarget> result = new LinkedHashMap<>();
+        for (AiResourceSearchTypeHandler handler : typeHandlerRegistry.handlers()) {
+            if (handler.projectionVersion() <= 0) {
+                continue;
+            }
+            for (String resourceType : handler.resourceTypes()) {
+                result.put(resourceType,
+                    new ReadinessTarget(resourceType, handler.projectionVersion()));
+            }
+        }
+        return result;
+    }
+    
+    private void recordReadiness(Map<String, ReadinessTarget> targets) {
+        for (ReadinessTarget target : targets.values()) {
+            readinessService.recordCompletedScan(target.resourceType, target.projectionVersion,
+                target.stats.rebuilt == 0 && target.stats.failed == 0);
+        }
     }
     
     private void backfillResource(String namespaceId, String resourceType,
@@ -356,9 +399,10 @@ public class AiResourceIndexBackfillTask
     
     private MarkerLease tryAcquireBackfillMarker() {
         String owner = UUID.randomUUID().toString();
+        String content = markerContent(owner);
         try {
-            publishMarker(markerContent(owner), false, null);
-            return new MarkerLease(owner);
+            publishMarker(content, false, null);
+            return new MarkerLease(owner, markerMd5(content));
         } catch (ConfigAlreadyExistsException e) {
             MarkerRecord current = readMarker();
             if (current == null || !current.expired()) {
@@ -371,9 +415,9 @@ public class AiResourceIndexBackfillTask
                 return null;
             }
             try {
-                publishMarker(markerContent(owner), true, current.md5);
+                publishMarker(content, true, current.md5);
                 LOGGER.warn("Took over expired AI resource index reconciliation lease");
-                return new MarkerLease(owner);
+                return new MarkerLease(owner, markerMd5(content));
             } catch (Exception takeoverFailure) {
                 LOGGER.info("AI resource index reconciliation lease was taken by another node");
                 return null;
@@ -407,6 +451,11 @@ public class AiResourceIndexBackfillTask
         return owner + "|" + (System.currentTimeMillis() + BACKFILL_MARKER_STALE_MILLIS);
     }
     
+    private String markerMd5(String content) {
+        return MD5Utils.md5Hex(content,
+            com.alibaba.nacos.api.common.Constants.ENCODE);
+    }
+    
     private void publishMarker(String content, boolean updateForExist, String casMd5)
         throws Exception {
         ConfigForm form = new ConfigForm();
@@ -436,6 +485,39 @@ public class AiResourceIndexBackfillTask
         private int skipped;
         
         private int failed;
+        
+        private void add(BackfillStats source) {
+            scanned += source.scanned;
+            rebuilt += source.rebuilt;
+            skipped += source.skipped;
+            failed += source.failed;
+        }
+    }
+    
+    private static final class ReadinessTarget {
+        
+        private final String resourceType;
+        
+        private final int projectionVersion;
+        
+        private final BackfillStats stats = new BackfillStats();
+        
+        private ReadinessTarget(String resourceType, int projectionVersion) {
+            this.resourceType = resourceType;
+            this.projectionVersion = projectionVersion;
+        }
+    }
+    
+    private static final class NamespaceScan {
+        
+        private final List<Namespace> namespaces;
+        
+        private final boolean complete;
+        
+        private NamespaceScan(List<Namespace> namespaces, boolean complete) {
+            this.namespaces = namespaces;
+            this.complete = complete;
+        }
     }
     
     private static final class ReconciliationContext {
@@ -458,8 +540,11 @@ public class AiResourceIndexBackfillTask
         
         private final ScheduledFuture<?> renewal;
         
-        private MarkerLease(String owner) {
+        private String currentMd5;
+        
+        private MarkerLease(String owner, String markerMd5) {
             this.owner = owner;
+            this.currentMd5 = markerMd5;
             this.renewal = markerLeaseExecutor.scheduleWithFixedDelay(this::renewSafely,
                 BACKFILL_MARKER_RENEW_MILLIS, BACKFILL_MARKER_RENEW_MILLIS,
                 TimeUnit.MILLISECONDS);
@@ -472,15 +557,14 @@ public class AiResourceIndexBackfillTask
             }
         }
         
-        private void renewSafely() {
+        private synchronized void renewSafely() {
+            if (!owned.get()) {
+                return;
+            }
             try {
-                MarkerRecord current = readMarker();
-                if (current == null || !owner.equals(current.owner)
-                    || StringUtils.isBlank(current.md5)) {
-                    owned.set(false);
-                    return;
-                }
-                publishMarker(markerContent(owner), true, current.md5);
+                String content = markerContent(owner);
+                publishMarker(content, true, currentMd5);
+                currentMd5 = markerMd5(content);
             } catch (Exception e) {
                 owned.set(false);
                 LOGGER.warn("Failed to renew AI resource index reconciliation lease", e);
@@ -488,17 +572,13 @@ public class AiResourceIndexBackfillTask
         }
         
         @Override
-        public void close() {
+        public synchronized void close() {
             renewal.cancel(false);
-            if (!owned.get()) {
+            if (!owned.compareAndSet(true, false)) {
                 return;
             }
             try {
-                MarkerRecord current = readMarker();
-                if (current != null && owner.equals(current.owner)
-                    && StringUtils.isNotBlank(current.md5)) {
-                    publishMarker(owner + "|0", true, current.md5);
-                }
+                publishMarker(owner + "|0", true, currentMd5);
             } catch (Exception e) {
                 LOGGER.warn("Failed to release AI resource index reconciliation lease", e);
             }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/agent/AgentOperationService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/agent/AgentOperationService.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.service.resource.PublishPipelineInfo;
 import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
+import com.alibaba.nacos.ai.service.search.AiResourceIndexMaintenanceService;
 import com.alibaba.nacos.ai.service.agent.storage.AgentVersionContentSerializer;
 import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
@@ -51,6 +52,7 @@ import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
 import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -95,11 +97,22 @@ public class AgentOperationService {
     
     private final PublishPipelineExecutor publishPipelineExecutor;
     
+    private AiResourceIndexMaintenanceService resourceIndexMaintenanceService =
+        AiResourceIndexMaintenanceService.NOOP;
+    
     public AgentOperationService(AgentPersistenceService persistenceService,
         AiResourceManager resourceManager, PublishPipelineExecutor publishPipelineExecutor) {
         this.persistenceService = persistenceService;
         this.resourceManager = resourceManager;
         this.publishPipelineExecutor = publishPipelineExecutor;
+    }
+    
+    @Autowired(required = false)
+    public void setAiResourceIndexMaintenanceService(
+        AiResourceIndexMaintenanceService resourceIndexMaintenanceService) {
+        if (resourceIndexMaintenanceService != null) {
+            this.resourceIndexMaintenanceService = resourceIndexMaintenanceService;
+        }
     }
     
     /**
@@ -149,6 +162,8 @@ public class AgentOperationService {
                 requireWritableMeta(replacement.getNamespaceId(), replacement.getAgentName());
             Agent result = persistenceService.tryUpdateAgent(replacement, current);
             if (result != null) {
+                scheduleAgentIndexMaintenance(replacement.getNamespaceId(),
+                    replacement.getAgentName());
                 AiResourceTraceService.logSuccess(RESOURCE_TYPE, replacement.getAgentName(), null,
                     AiResourceTraceService.OP_UPDATE_RESOURCE,
                     VisibilityHelper.resolveCurrentIdentity(), VisibilityHelper.resolveClientIp());
@@ -246,6 +261,7 @@ public class AgentOperationService {
         String agentName = request.getAgentName();
         AgentVersionDetail draft = toDraft(request);
         AiResource meta = resourceManager.findMeta(namespaceId, agentName, RESOURCE_TYPE);
+        boolean directoryCreated = meta == null || hasInitialAgentMetadata(request);
         AgentVersionDetail result;
         if (meta == null) {
             requireInitialDraftContent(request);
@@ -270,6 +286,9 @@ public class AgentOperationService {
         AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, request.getVersion(),
             AiResourceTraceService.OP_CREATE_DRAFT, VisibilityHelper.resolveCurrentIdentity(),
             VisibilityHelper.resolveClientIp());
+        if (directoryCreated) {
+            scheduleAgentIndexMaintenance(namespaceId, agentName);
+        }
         return result;
     }
     
@@ -295,6 +314,7 @@ public class AgentOperationService {
             AgentVersionDetail result = persistenceService.createInitialOnlineVersion(
                 toInitialLegacyAgent(namespaceId, request), toOnlineVersion(request),
                 LEGACY_A2A_RESOURCE_SOURCE);
+            scheduleAgentIndexMaintenance(namespaceId, agentName);
             traceLegacySuccess(agentName, version, OP_LEGACY_A2A_RELEASE, "mode=register");
             return result;
         } catch (Exception e) {
@@ -328,6 +348,7 @@ public class AgentOperationService {
                     AgentVersionDetail result = persistenceService.createInitialOnlineVersion(
                         toInitialLegacyAgent(namespaceId, request), toOnlineVersion(request),
                         LEGACY_A2A_RESOURCE_SOURCE);
+                    scheduleAgentIndexMaintenance(namespaceId, agentName);
                     traceLegacySuccess(agentName, version, OP_LEGACY_A2A_RELEASE,
                         "mode=client-create");
                     return result;
@@ -344,6 +365,7 @@ public class AgentOperationService {
             VisibilityHelper.checkWritableResource(current);
             AgentVersionDetail result = directOnlineExistingAgent(namespaceId, request,
                 setAsLatest, true);
+            scheduleAgentIndexMaintenance(namespaceId, agentName);
             traceLegacySuccess(agentName, version, OP_LEGACY_A2A_RELEASE,
                 "mode=client-release");
             return result;
@@ -371,6 +393,7 @@ public class AgentOperationService {
             requireWritableMeta(namespaceId, agentName);
             AgentVersionDetail result = directOnlineExistingAgent(namespaceId, request,
                 setAsLatest, false);
+            scheduleAgentIndexMaintenance(namespaceId, agentName);
             traceLegacySuccess(agentName, version, OP_LEGACY_A2A_RELEASE,
                 "mode=management-update");
             return result;
@@ -406,6 +429,7 @@ public class AgentOperationService {
                 return false;
             }
             persistenceService.deleteVersion(namespaceId, agentName, version);
+            scheduleAgentIndexMaintenance(namespaceId, agentName);
             traceLegacySuccess(agentName, version, OP_LEGACY_A2A_DELETE, "mode=version");
             return true;
         } catch (Exception e) {
@@ -433,6 +457,7 @@ public class AgentOperationService {
             }
             VisibilityHelper.checkWritableResource(current);
             persistenceService.deleteAgent(namespaceId, agentName);
+            scheduleAgentIndexMaintenance(namespaceId, agentName);
             traceLegacySuccess(agentName, null, OP_LEGACY_A2A_DELETE, "mode=agent");
             return true;
         } catch (Exception e) {
@@ -493,6 +518,7 @@ public class AgentOperationService {
     public void deleteAgent(String namespaceId, String agentName) throws NacosException {
         requireWritableMeta(namespaceId, agentName);
         persistenceService.deleteAgent(namespaceId, agentName);
+        scheduleAgentIndexMaintenance(namespaceId, agentName);
         AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, null,
             AiResourceTraceService.OP_DELETE_RESOURCE, VisibilityHelper.resolveCurrentIdentity(),
             VisibilityHelper.resolveClientIp());
@@ -627,6 +653,7 @@ public class AgentOperationService {
                 + versionInfo.getEditingVersion());
         }
         resourceManager.doRedraft(namespaceId, agentName, RESOURCE_TYPE, version);
+        scheduleAgentIndexMaintenance(namespaceId, agentName);
         return persistenceService.getAgentVersionSummary(namespaceId, agentName, version);
     }
     
@@ -668,6 +695,7 @@ public class AgentOperationService {
         persistenceService.updateVersionStatus(namespaceId, agentName, version,
             AiConstants.Agent.VERSION_STATUS_OFFLINE);
         persistenceService.synchronizeDerivedState(namespaceId, agentName, null, null, null, null);
+        scheduleAgentIndexMaintenance(namespaceId, agentName);
         AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, version,
             AiResourceTraceService.OP_OFFLINE_VERSION, VisibilityHelper.resolveCurrentIdentity(),
             VisibilityHelper.resolveClientIp());
@@ -688,6 +716,7 @@ public class AgentOperationService {
         requireWritableMeta(namespaceId, agentName);
         Agent result = persistenceService.synchronizeDerivedState(namespaceId, agentName, null,
             labels, null, null);
+        scheduleAgentIndexMaintenance(namespaceId, agentName);
         AiResourceTraceService.logSuccess(RESOURCE_TYPE, agentName, null,
             AiResourceTraceService.OP_UPDATE_LABELS, VisibilityHelper.resolveCurrentIdentity(),
             VisibilityHelper.resolveClientIp());
@@ -870,6 +899,16 @@ public class AgentOperationService {
             AiConstants.Agent.VERSION_STATUS_ONLINE);
         persistenceService.synchronizeDerivedState(namespaceId, agentName, version, null,
             clearEditing ? version : null, clearReviewing ? version : null);
+        scheduleAgentIndexMaintenance(namespaceId, agentName);
+    }
+    
+    private void scheduleAgentIndexMaintenance(String namespaceId, String agentName) {
+        try {
+            resourceIndexMaintenanceService.schedule(namespaceId, RESOURCE_TYPE, agentName);
+        } catch (RuntimeException e) {
+            LOGGER.warn("Failed to schedule Agent search-index maintenance for {} in namespace {}",
+                agentName, namespaceId, e);
+        }
     }
     
     private AiResource requireMeta(String namespaceId, String agentName) throws NacosException {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/AgentAiResourceSearchTypeHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/AgentAiResourceSearchTypeHandler.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.search;
+
+import com.alibaba.nacos.ai.config.ConditionalOnAiResourceSearchEnabled;
+import com.alibaba.nacos.ai.constant.AiResourceConstants;
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.search.AiResourceSearchDocument;
+import com.alibaba.nacos.ai.service.agent.AgentPersistenceService;
+import com.alibaba.nacos.ai.service.resource.AiResourceManager;
+import com.alibaba.nacos.api.ai.constant.AiConstants;
+import com.alibaba.nacos.api.ai.model.agent.Agent;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionCatalog;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionDetail;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
+import com.alibaba.nacos.common.utils.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Search type handler for canonical Agent directory and common-latest Version facts.
+ *
+ * @author Nacos
+ */
+@Service
+@ConditionalOnAiResourceSearchEnabled
+public class AgentAiResourceSearchTypeHandler implements AiResourceSearchTypeHandler {
+    
+    private static final String RESOURCE_TYPE = Constants.Agent.RESOURCE_TYPE_AGENT;
+    
+    private final AiResourceManager resourceManager;
+    
+    private final AgentPersistenceService persistenceService;
+    
+    private final AgentSearchIndexProjector projector;
+    
+    @Autowired
+    public AgentAiResourceSearchTypeHandler(AiResourceManager resourceManager,
+        AgentPersistenceService persistenceService) {
+        this(resourceManager, persistenceService, new AgentSearchIndexProjector());
+    }
+    
+    AgentAiResourceSearchTypeHandler(AiResourceManager resourceManager,
+        AgentPersistenceService persistenceService, AgentSearchIndexProjector projector) {
+        this.resourceManager = resourceManager;
+        this.persistenceService = persistenceService;
+        this.projector = projector;
+    }
+    
+    @Override
+    public int projectionVersion() {
+        return AgentSearchIndexProjector.PROJECTION_VERSION;
+    }
+    
+    @Override
+    public Collection<String> resourceTypes() {
+        return Collections.singletonList(RESOURCE_TYPE);
+    }
+    
+    @Override
+    public AiResourceIndexProjection project(String namespaceId, String resourceType,
+        String resourceName, String version) throws NacosException {
+        if (!RESOURCE_TYPE.equals(resourceType)) {
+            return null;
+        }
+        AiResource meta = resourceManager.findMeta(namespaceId, resourceName, RESOURCE_TYPE);
+        return projectAgent(namespaceId, resourceName, meta, version);
+    }
+    
+    @Override
+    public AiResourceIndexSourcePage scan(String namespaceId, String resourceType, int pageNo,
+        int pageSize) {
+        if (!RESOURCE_TYPE.equals(resourceType)) {
+            return new AiResourceIndexSourcePage(Collections.emptyList(), false);
+        }
+        Page<AiResource> page = resourceManager.listMetaByType(namespaceId, RESOURCE_TYPE, null,
+            null, pageNo, pageSize);
+        List<AiResource> resources = page == null ? null : page.getPageItems();
+        if (resources == null || resources.isEmpty()) {
+            return new AiResourceIndexSourcePage(Collections.emptyList(), false);
+        }
+        List<AiResourceIndexSource> items = new ArrayList<>();
+        for (AiResource resource : resources) {
+            String resourceName = resource == null ? null : resource.getName();
+            try {
+                items.add(AiResourceIndexSource.success(resourceName,
+                    projectAgent(namespaceId, resourceName, resource, null)));
+            } catch (Exception e) {
+                items.add(AiResourceIndexSource.failed(resourceName, e));
+            }
+        }
+        return new AiResourceIndexSourcePage(items, resources.size() >= pageSize);
+    }
+    
+    @Override
+    public boolean isCurrent(AiResourceSearchDocument document) throws NacosException {
+        if (document == null || !RESOURCE_TYPE.equals(document.getResourceType())) {
+            return false;
+        }
+        AiResource meta = resourceManager.findMeta(document.getNamespaceId(),
+            document.getResourceName(), RESOURCE_TYPE);
+        if (!isEnabled(meta)) {
+            return false;
+        }
+        try {
+            resourceManager.ensureReadableOrNotFound(meta,
+                "Agent not found: " + document.getResourceName());
+            AiResourceIndexProjection expected = projectAgent(document.getNamespaceId(),
+                document.getResourceName(), meta, document.getResourceVersion());
+            return expected != null && Objects.equals(document.getResourceVersion(),
+                expected.getDocument().getResourceVersion())
+                && Objects.equals(document.getSourceDigest(),
+                    expected.getDocument().getSourceDigest());
+        } catch (NacosException e) {
+            return false;
+        }
+    }
+    
+    @Override
+    public boolean exists(String namespaceId, String resourceType, String resourceName) {
+        return RESOURCE_TYPE.equals(resourceType)
+            && resourceManager.findMeta(namespaceId, resourceName, RESOURCE_TYPE) != null;
+    }
+    
+    private AiResourceIndexProjection projectAgent(String namespaceId, String resourceName,
+        AiResource meta, String requestedVersion) throws NacosException {
+        if (!isEnabled(meta) || StringUtils.isBlank(resourceName)) {
+            return null;
+        }
+        Agent agent = persistenceService.getAgent(namespaceId, resourceName);
+        AgentVersionCatalog catalog = agent.getVersionCatalog();
+        String latestVersion = catalog == null ? null : catalog.getLatestVersion();
+        if (StringUtils.isBlank(latestVersion)
+            || StringUtils.isNotBlank(requestedVersion)
+                && !latestVersion.equals(requestedVersion)) {
+            return null;
+        }
+        AgentVersionDetail latest =
+            persistenceService.getAgentVersion(namespaceId, resourceName, latestVersion);
+        if (!AiConstants.Agent.VERSION_STATUS_ONLINE.equals(latest.getStatus())) {
+            return null;
+        }
+        return projector.project(agent, latest);
+    }
+    
+    private boolean isEnabled(AiResource resource) {
+        return resource != null && AiResourceConstants.META_STATUS_ENABLE.equalsIgnoreCase(
+            resource.getStatus());
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/AgentSearchIndexProjector.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/AgentSearchIndexProjector.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.search;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.model.search.AiResourceSearchDocument;
+import com.alibaba.nacos.ai.utils.AgentRequestUtil;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCapabilities;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCard;
+import com.alibaba.nacos.api.ai.model.a2a.AgentExtension;
+import com.alibaba.nacos.api.ai.model.a2a.AgentSkill;
+import com.alibaba.nacos.api.ai.model.agent.Agent;
+import com.alibaba.nacos.api.ai.model.agent.AgentCallInterface;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionCatalog;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionCatalogEntry;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionDetail;
+import com.alibaba.nacos.api.utils.json.JsonUtils;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Builds the deterministic shared-search projection for one canonical Agent.
+ *
+ * @author Nacos
+ */
+public class AgentSearchIndexProjector {
+    
+    public static final int PROJECTION_VERSION = 1;
+    
+    static final String ARTIFACT_KIND_A2A_AGENT_CARD = "a2a-agent-card";
+    
+    static final String ARTIFACT_KIND_NACOS_AGENT = "nacos-agent";
+    
+    private static final String A2A_PROTOCOL = "a2a";
+    
+    private static final int MAX_AGENT_CONTENT_CHARS = 12000;
+    
+    private final AiResourceIndexProjectionBuilder projectionBuilder =
+        new AiResourceIndexProjectionBuilder();
+    
+    /**
+     * Project the current common-latest Agent definition.
+     *
+     * @param agent canonical Agent directory
+     * @param latest exact common-latest online Version
+     * @return complete document, chunk, and facet projection
+     */
+    public AiResourceIndexProjection project(Agent agent, AgentVersionDetail latest) {
+        if (agent == null || latest == null) {
+            throw new IllegalArgumentException("Agent and latest Version must not be null");
+        }
+        AgentCard a2aCard = findValidA2aCard(agent.getAgentName(), latest);
+        List<String> protocols = collectProtocols(agent.getVersionCatalog());
+        List<String> artifactKinds = artifactKinds(a2aCard);
+        AiResourceSearchDocument document = buildDocument(agent, latest, protocols,
+            artifactKinds, a2aCard);
+        return projectionBuilder.build(document, buildContents(latest, a2aCard),
+            AiResourceSearchConstants.CHUNK_TYPE_AGENT_CONTENT);
+    }
+    
+    private AiResourceSearchDocument buildDocument(Agent agent, AgentVersionDetail latest,
+        List<String> protocols, List<String> artifactKinds, AgentCard a2aCard) {
+        AiResourceSearchDocument result = new AiResourceSearchDocument();
+        result.setNamespaceId(agent.getNamespaceId());
+        result.setResourceType(Constants.Agent.RESOURCE_TYPE_AGENT);
+        result.setResourceName(agent.getAgentName());
+        result.setResourceVersion(latest.getVersion());
+        result.setDisplayName(StringUtils.isBlank(agent.getDisplayName())
+            ? agent.getAgentName() : agent.getDisplayName());
+        result.setDescription(agent.getDescription());
+        result.setTags(JacksonUtils.toJson(nullToEmpty(agent.getTags())));
+        result.setCapabilities(JacksonUtils.toJson(capabilities(latest, a2aCard)));
+        result.setRepresentativeQueries(JacksonUtils.toJson(
+            representativeQueries(agent, a2aCard)));
+        result.setMetadata(JacksonUtils.toJson(metadata(agent, latest, protocols,
+            artifactKinds)));
+        result.setSourceDigest(sourceDigest(agent, latest, artifactKinds));
+        result.setStatus(AiResourceSearchConstants.STATUS_ENABLED);
+        result.setGenerateMode(AiResourceSearchConstants.GENERATE_MODE_AUTO);
+        Long modified = latest.getUpdateTime() == null ? agent.getUpdateTime()
+            : latest.getUpdateTime();
+        if (modified != null) {
+            result.setGmtModified(new Timestamp(modified));
+        }
+        return result;
+    }
+    
+    private Map<String, Object> metadata(Agent agent, AgentVersionDetail latest,
+        List<String> protocols, List<String> artifactKinds) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("namespaceId", agent.getNamespaceId());
+        result.put("resourceType", Constants.Agent.RESOURCE_TYPE_AGENT);
+        result.put("resourceName", agent.getAgentName());
+        result.put("resourceVersion", latest.getVersion());
+        putIfPresent(result, "iconUrl", agent.getIconUrl());
+        putIfPresent(result, "provider", agent.getProvider());
+        result.put("protocols", protocols);
+        result.put("artifactKinds", artifactKinds);
+        result.put("versionCatalog", agent.getVersionCatalog());
+        putIfPresent(result, "scope", agent.getScope());
+        putIfPresent(result, "owner", agent.getOwner());
+        result.put("projectionVersion", PROJECTION_VERSION);
+        return result;
+    }
+    
+    private List<String> collectProtocols(AgentVersionCatalog catalog) {
+        if (catalog == null || catalog.getOnlineVersions() == null) {
+            return Collections.emptyList();
+        }
+        Set<String> result = new LinkedHashSet<>();
+        for (AgentVersionCatalogEntry entry : catalog.getOnlineVersions()) {
+            if (entry == null || entry.getProtocols() == null) {
+                continue;
+            }
+            for (String protocol : entry.getProtocols()) {
+                addIfNotBlank(result, protocol);
+            }
+        }
+        return new ArrayList<>(result);
+    }
+    
+    private List<String> artifactKinds(AgentCard a2aCard) {
+        List<String> result = new ArrayList<>();
+        if (a2aCard != null) {
+            result.add(ARTIFACT_KIND_A2A_AGENT_CARD);
+        }
+        result.add(ARTIFACT_KIND_NACOS_AGENT);
+        return result;
+    }
+    
+    private List<String> capabilities(AgentVersionDetail latest, AgentCard card) {
+        Set<String> result = new LinkedHashSet<>();
+        if (latest.getCallInterfaces() != null) {
+            for (AgentCallInterface callInterface : latest.getCallInterfaces()) {
+                if (callInterface != null) {
+                    addIfNotBlank(result, callInterface.getProtocol());
+                }
+            }
+        }
+        if (card != null) {
+            addA2aCapabilities(result, card);
+        }
+        return new ArrayList<>(result);
+    }
+    
+    private void addA2aCapabilities(Set<String> target, AgentCard card) {
+        AgentCapabilities capabilities = card.getCapabilities();
+        if (capabilities != null) {
+            addFlag(target, "streaming", capabilities.getStreaming());
+            addFlag(target, "push-notifications", capabilities.getPushNotifications());
+            addFlag(target, "state-transition-history",
+                capabilities.getStateTransitionHistory());
+            addFlag(target, "extended-agent-card", capabilities.getExtendedAgentCard());
+            if (capabilities.getExtensions() != null) {
+                for (AgentExtension extension : capabilities.getExtensions()) {
+                    if (extension != null) {
+                        addIfNotBlank(target, extension.getUri());
+                    }
+                }
+            }
+        }
+        if (card.getSkills() != null) {
+            for (AgentSkill skill : card.getSkills()) {
+                if (skill == null) {
+                    continue;
+                }
+                addIfNotBlank(target, skill.getId());
+                addIfNotBlank(target, skill.getName());
+                addAll(target, skill.getTags());
+            }
+        }
+    }
+    
+    private List<String> representativeQueries(Agent agent, AgentCard card) {
+        Set<String> result = new LinkedHashSet<>();
+        addIfNotBlank(result, agent.getAgentName());
+        addIfNotBlank(result, agent.getDisplayName());
+        addIfNotBlank(result, agent.getDescription());
+        if (card != null) {
+            addIfNotBlank(result, card.getName());
+            addIfNotBlank(result, card.getDescription());
+            if (card.getSkills() != null) {
+                for (AgentSkill skill : card.getSkills()) {
+                    if (skill == null) {
+                        continue;
+                    }
+                    addIfNotBlank(result, skill.getName());
+                    addIfNotBlank(result, skill.getDescription());
+                    addAll(result, skill.getExamples());
+                }
+            }
+        }
+        return new ArrayList<>(result);
+    }
+    
+    private List<AiResourceIndexEnhancementContent> buildContents(AgentVersionDetail latest,
+        AgentCard a2aCard) {
+        List<AiResourceIndexEnhancementContent> result = new ArrayList<>();
+        if (a2aCard != null) {
+            addContent(result, "agent-a2a.json", a2aText(a2aCard));
+        }
+        if (latest.getCallInterfaces() == null) {
+            return result;
+        }
+        int index = 0;
+        for (AgentCallInterface callInterface : latest.getCallInterfaces()) {
+            if (callInterface != null && !A2A_PROTOCOL.equals(callInterface.getProtocol())) {
+                addContent(result, "agent-" + index + '-' + callInterface.getProtocol()
+                    + ".json", descriptorText(callInterface.getNativeDescriptor()));
+            }
+            index++;
+        }
+        return result;
+    }
+    
+    private void addContent(List<AiResourceIndexEnhancementContent> target, String path,
+        String content) {
+        if (StringUtils.isNotBlank(content)) {
+            target.add(new AiResourceIndexEnhancementContent(path, limit(content)));
+        }
+    }
+    
+    private String a2aText(AgentCard card) {
+        StringBuilder result = new StringBuilder();
+        appendLine(result, card.getName());
+        appendLine(result, card.getDescription());
+        if (card.getSkills() != null) {
+            for (AgentSkill skill : card.getSkills()) {
+                if (skill == null) {
+                    continue;
+                }
+                appendLine(result, skill.getId());
+                appendLine(result, skill.getName());
+                appendLine(result, skill.getDescription());
+                appendLines(result, skill.getTags());
+                appendLines(result, skill.getExamples());
+            }
+        }
+        return result.toString();
+    }
+    
+    private String descriptorText(Object descriptor) {
+        if (descriptor == null) {
+            return null;
+        }
+        try {
+            return JsonUtils.toCanonicalJson(descriptor);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+    
+    private AgentCard findValidA2aCard(String agentName, AgentVersionDetail latest) {
+        if (latest.getCallInterfaces() == null) {
+            return null;
+        }
+        for (AgentCallInterface callInterface : latest.getCallInterfaces()) {
+            if (callInterface == null || !A2A_PROTOCOL.equals(callInterface.getProtocol())) {
+                continue;
+            }
+            try {
+                AgentCard card = JacksonUtils.toObj(
+                    JacksonUtils.toJson(callInterface.getNativeDescriptor()), AgentCard.class);
+                AgentRequestUtil.validateAgentCard(card);
+                if (agentName.equals(card.getName()) && latest.getVersion().equals(
+                    card.getVersion())) {
+                    return card;
+                }
+            } catch (Exception ignored) {
+                // An invalid A2A descriptor is not a complete A2A representation.
+            }
+        }
+        return null;
+    }
+    
+    private String sourceDigest(Agent agent, AgentVersionDetail latest,
+        List<String> artifactKinds) {
+        Map<String, Object> source = new LinkedHashMap<>();
+        source.put("status", agent.getStatus());
+        source.put("displayName", agent.getDisplayName());
+        source.put("description", agent.getDescription());
+        source.put("iconUrl", agent.getIconUrl());
+        source.put("provider", agent.getProvider());
+        source.put("tags", agent.getTags());
+        source.put("scope", agent.getScope());
+        source.put("owner", agent.getOwner());
+        source.put("versionCatalog", agent.getVersionCatalog());
+        source.put("latestVersion", latest.getVersion());
+        source.put("contentDigest", latest.getContentDigest());
+        source.put("artifactKinds", artifactKinds);
+        source.put("projectionVersion", PROJECTION_VERSION);
+        return sha256(JsonUtils.toCanonicalJson(source));
+    }
+    
+    private String sha256(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder result = new StringBuilder(digest.length * 2);
+            for (byte each : digest) {
+                result.append(String.format("%02x", each & 0xff));
+            }
+            return result.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+    
+    private String limit(String value) {
+        return value.length() <= MAX_AGENT_CONTENT_CHARS ? value
+            : value.substring(0, MAX_AGENT_CONTENT_CHARS);
+    }
+    
+    private void appendLines(StringBuilder target, List<String> values) {
+        if (values != null) {
+            for (String value : values) {
+                appendLine(target, value);
+            }
+        }
+    }
+    
+    private void appendLine(StringBuilder target, String value) {
+        if (StringUtils.isNotBlank(value)) {
+            target.append(value).append('\n');
+        }
+    }
+    
+    private void putIfPresent(Map<String, Object> target, String key, Object value) {
+        if (value != null
+            && (!(value instanceof String) || StringUtils.isNotBlank((String) value))) {
+            target.put(key, value);
+        }
+    }
+    
+    private void addFlag(Set<String> target, String value, Boolean enabled) {
+        if (Boolean.TRUE.equals(enabled)) {
+            target.add(value);
+        }
+    }
+    
+    private void addAll(Set<String> target, List<String> values) {
+        if (values != null) {
+            for (String value : values) {
+                addIfNotBlank(target, value);
+            }
+        }
+    }
+    
+    private void addIfNotBlank(Set<String> target, String value) {
+        if (StringUtils.isNotBlank(value)) {
+            target.add(value);
+        }
+    }
+    
+    private <T> List<T> nullToEmpty(List<T> values) {
+        return values == null ? Collections.emptyList() : values;
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceIndexTaskRepository.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceIndexTaskRepository.java
@@ -45,6 +45,14 @@ public interface AiResourceIndexTaskRepository {
     List<AiResourceIndexTask> findDueTasks(int limit);
     
     /**
+     * Check whether one resource type still has pending, processing, or retry work.
+     *
+     * @param resourceType exact canonical resource type
+     * @return {@code true} when unfinished work or an undecodable unfinished task exists
+     */
+    boolean hasUnfinishedTasks(String resourceType);
+    
+    /**
      * Claim one task revision for exclusive processing with a new lease token for the given
      * duration in milliseconds.
      */

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchChunkBuilder.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchChunkBuilder.java
@@ -232,9 +232,6 @@ public class AiResourceSearchChunkBuilder {
     }
     
     private List<String> toStringList(Object value) {
-        if (value == null) {
-            return Collections.emptyList();
-        }
         if (value instanceof Collection) {
             List<String> result = new ArrayList<>();
             for (Object each : (Collection<?>) value) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchConstants.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchConstants.java
@@ -49,6 +49,8 @@ public final class AiResourceSearchConstants {
     
     public static final String CHUNK_TYPE_MCP_CONTENT = "mcp_content";
     
+    public static final String CHUNK_TYPE_AGENT_CONTENT = "agent_content";
+    
     public static final String CHUNK_TYPE_AI_SUMMARY = "ai_summary";
     
     public static final String CHUNK_TYPE_SEARCH_INTENT = "search_intent";

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchReadinessService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchReadinessService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.search;
+
+/**
+ * Maintains cluster-shared convergence readiness for one search projection generation.
+ *
+ * @author Nacos
+ */
+public interface AiResourceSearchReadinessService {
+    
+    AiResourceSearchReadinessService NOOP = new AiResourceSearchReadinessService() {
+        
+        @Override
+        public boolean isReady(String resourceType, int projectionVersion) {
+            return false;
+        }
+        
+        @Override
+        public void recordCompletedScan(String resourceType, int projectionVersion,
+            boolean clean) {
+        }
+    };
+    
+    /**
+     * Check whether the exact projection generation has converged.
+     */
+    boolean isReady(String resourceType, int projectionVersion);
+    
+    /**
+     * Record one complete all-namespace scan.
+     *
+     * <p>The first scan establishes verification state. A later clean scan may mark the
+     * generation ready after unfinished durable tasks have drained.</p>
+     */
+    void recordCompletedScan(String resourceType, int projectionVersion, boolean clean);
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchService.java
@@ -603,10 +603,10 @@ public class AiResourceSearchService {
     }
     
     private boolean matchesPredicate(Predicate predicate, List<String> actual) {
-        if (predicate == null || predicate.getValues().isEmpty()) {
+        if (predicate.getValues().isEmpty()) {
             return true;
         }
-        if (actual == null || actual.isEmpty()) {
+        if (actual.isEmpty()) {
             return false;
         }
         if (PredicateOperator.EXACT_ALL == predicate.getOperator()) {

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchTypeHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/AiResourceSearchTypeHandler.java
@@ -29,6 +29,17 @@ import java.util.Collection;
 public interface AiResourceSearchTypeHandler {
     
     /**
+     * Projection contract generation used for durable readiness.
+     *
+     * <p>Handlers that are not guarded by a compatibility read-path switch return {@code 0}.</p>
+     *
+     * @return projection generation, or {@code 0} when readiness is not required
+     */
+    default int projectionVersion() {
+        return 0;
+    }
+    
+    /**
      * Resource types owned by this handler.
      *
      * @return non-empty resource type collection

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/ConfigAiResourceSearchReadinessService.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/ConfigAiResourceSearchReadinessService.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.search;
+
+import com.alibaba.nacos.ai.config.ConditionalOnAiResourceSearchEnabled;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.StringUtils;
+import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
+import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
+import com.alibaba.nacos.config.server.model.form.ConfigForm;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+
+/**
+ * Config-CAS backed search projection readiness coordination.
+ *
+ * @author Nacos
+ */
+@Service
+@ConditionalOnAiResourceSearchEnabled
+public class ConfigAiResourceSearchReadinessService
+    implements AiResourceSearchReadinessService {
+    
+    static final String READINESS_DATA_ID_PREFIX = "nacos.ai.resource.search.readiness.";
+    
+    static final String READINESS_GROUP = "nacos_internal";
+    
+    static final String STATE_VERIFYING = "VERIFYING";
+    
+    static final String STATE_READY = "READY";
+    
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(ConfigAiResourceSearchReadinessService.class);
+    
+    private final ConfigQueryChainService configQueryChainService;
+    
+    private final ConfigOperationService configOperationService;
+    
+    private final AiResourceIndexTaskRepository taskRepository;
+    
+    private final Clock clock;
+    
+    @Autowired
+    public ConfigAiResourceSearchReadinessService(
+        ConfigQueryChainService configQueryChainService,
+        ConfigOperationService configOperationService,
+        AiResourceIndexTaskRepository taskRepository) {
+        this(configQueryChainService, configOperationService, taskRepository, Clock.systemUTC());
+    }
+    
+    ConfigAiResourceSearchReadinessService(ConfigQueryChainService configQueryChainService,
+        ConfigOperationService configOperationService,
+        AiResourceIndexTaskRepository taskRepository, Clock clock) {
+        this.configQueryChainService = configQueryChainService;
+        this.configOperationService = configOperationService;
+        this.taskRepository = taskRepository;
+        this.clock = clock;
+    }
+    
+    @Override
+    public boolean isReady(String resourceType, int projectionVersion) {
+        if (StringUtils.isBlank(resourceType) || projectionVersion <= 0) {
+            return false;
+        }
+        ReadResult current = read(resourceType, projectionVersion);
+        return current.record != null && current.record.matches(resourceType, projectionVersion)
+            && STATE_READY.equals(current.record.getState());
+    }
+    
+    @Override
+    public void recordCompletedScan(String resourceType, int projectionVersion, boolean clean) {
+        if (StringUtils.isBlank(resourceType) || projectionVersion <= 0) {
+            return;
+        }
+        try {
+            ReadResult current = read(resourceType, projectionVersion);
+            if (current.record != null && current.record.matches(resourceType, projectionVersion)
+                && STATE_READY.equals(current.record.getState())) {
+                return;
+            }
+            boolean verifiedBefore = current.record != null
+                && current.record.matches(resourceType, projectionVersion)
+                && STATE_VERIFYING.equals(current.record.getState());
+            boolean ready = clean && verifiedBefore
+                && !taskRepository.hasUnfinishedTasks(resourceType);
+            ReadinessRecord next = new ReadinessRecord();
+            next.setResourceType(resourceType);
+            next.setProjectionVersion(projectionVersion);
+            next.setState(ready ? STATE_READY : STATE_VERIFYING);
+            next.setCompletedAt(ready ? clock.millis() : 0L);
+            publish(resourceType, projectionVersion, JacksonUtils.toJson(next), current);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to advance AI resource search readiness for {} projection {}",
+                resourceType, projectionVersion, e);
+        }
+    }
+    
+    private ReadResult read(String resourceType, int projectionVersion) {
+        try {
+            ConfigQueryChainRequest request = ConfigQueryChainRequest.buildConfigQueryChainRequest(
+                dataId(resourceType, projectionVersion), READINESS_GROUP,
+                com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID);
+            ConfigQueryChainResponse response = configQueryChainService.handle(request);
+            if (response == null || response
+                .getStatus() == ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND) {
+                return ReadResult.absent();
+            }
+            if (StringUtils.isBlank(response.getContent())) {
+                return ReadResult.present(null, response.getMd5());
+            }
+            try {
+                return ReadResult.present(JacksonUtils.toObj(response.getContent(),
+                    ReadinessRecord.class), response.getMd5());
+            } catch (Exception e) {
+                LOGGER.warn("Invalid AI resource search readiness record for {} projection {}",
+                    resourceType, projectionVersion, e);
+                return ReadResult.present(null, response.getMd5());
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to read AI resource search readiness for {} projection {}",
+                resourceType, projectionVersion, e);
+            return ReadResult.unavailable();
+        }
+    }
+    
+    private void publish(String resourceType, int projectionVersion, String content,
+        ReadResult current) throws Exception {
+        if (!current.available) {
+            return;
+        }
+        if (current.exists && StringUtils.isBlank(current.md5)) {
+            LOGGER.warn("Cannot CAS AI resource search readiness for {} projection {}",
+                resourceType, projectionVersion);
+            return;
+        }
+        ConfigForm form = new ConfigForm();
+        form.setNamespaceId(com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID);
+        form.setGroup(READINESS_GROUP);
+        form.setDataId(dataId(resourceType, projectionVersion));
+        form.setContent(content);
+        form.setSrcUser("nacos");
+        ConfigRequestInfo requestInfo = new ConfigRequestInfo();
+        requestInfo.setUpdateForExist(current.exists);
+        requestInfo.setCasMd5(current.exists ? current.md5 : null);
+        try {
+            configOperationService.publishConfig(form, requestInfo, null);
+        } catch (ConfigAlreadyExistsException e) {
+            LOGGER.debug("AI resource search readiness was concurrently initialized for {}",
+                resourceType);
+        }
+    }
+    
+    private String dataId(String resourceType, int projectionVersion) {
+        return READINESS_DATA_ID_PREFIX + resourceType + ".v" + projectionVersion;
+    }
+    
+    public static class ReadinessRecord {
+        
+        private String resourceType;
+        
+        private int projectionVersion;
+        
+        private String state;
+        
+        private long completedAt;
+        
+        public String getResourceType() {
+            return resourceType;
+        }
+        
+        public void setResourceType(String resourceType) {
+            this.resourceType = resourceType;
+        }
+        
+        public int getProjectionVersion() {
+            return projectionVersion;
+        }
+        
+        public void setProjectionVersion(int projectionVersion) {
+            this.projectionVersion = projectionVersion;
+        }
+        
+        public String getState() {
+            return state;
+        }
+        
+        public void setState(String state) {
+            this.state = state;
+        }
+        
+        public long getCompletedAt() {
+            return completedAt;
+        }
+        
+        public void setCompletedAt(long completedAt) {
+            this.completedAt = completedAt;
+        }
+        
+        private boolean matches(String expectedType, int expectedProjectionVersion) {
+            return expectedProjectionVersion == projectionVersion
+                && expectedType.equals(resourceType);
+        }
+    }
+    
+    private static final class ReadResult {
+        
+        private final boolean available;
+        
+        private final boolean exists;
+        
+        private final ReadinessRecord record;
+        
+        private final String md5;
+        
+        private ReadResult(boolean available, boolean exists, ReadinessRecord record,
+            String md5) {
+            this.available = available;
+            this.exists = exists;
+            this.record = record;
+            this.md5 = md5;
+        }
+        
+        private static ReadResult absent() {
+            return new ReadResult(true, false, null, null);
+        }
+        
+        private static ReadResult present(ReadinessRecord record, String md5) {
+            return new ReadResult(true, true, record, md5);
+        }
+        
+        private static ReadResult unavailable() {
+            return new ReadResult(false, false, null, null);
+        }
+    }
+}

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/JdbcAiResourceIndexTaskRepository.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/JdbcAiResourceIndexTaskRepository.java
@@ -60,6 +60,8 @@ public class JdbcAiResourceIndexTaskRepository implements AiResourceIndexTaskRep
     
     private static final int MAX_ERROR_LENGTH = 2000;
     
+    private static final int UNFINISHED_SCAN_PAGE_SIZE = 100;
+    
     private static final RowMapper<AiResourceIndexTask> ROW_MAPPER =
         new AiResourceIndexTaskRowMapper();
     
@@ -156,6 +158,40 @@ public class JdbcAiResourceIndexTaskRepository implements AiResourceIndexTaskRep
             quarantineMalformedTask(malformedTask);
         }
         return rows.tasks;
+    }
+    
+    @Override
+    public boolean hasUnfinishedTasks(String resourceType) {
+        String afterTaskKey = "";
+        while (true) {
+            List<UnfinishedTaskRow> rows = scanUnfinishedTasks(afterTaskKey);
+            if (rows.isEmpty()) {
+                return false;
+            }
+            for (UnfinishedTaskRow row : rows) {
+                if (row.matches(resourceType)) {
+                    return true;
+                }
+            }
+            afterTaskKey = rows.get(rows.size() - 1).taskKey;
+            if (rows.size() < UNFINISHED_SCAN_PAGE_SIZE) {
+                return false;
+            }
+        }
+    }
+    
+    private List<UnfinishedTaskRow> scanUnfinishedTasks(String afterTaskKey) {
+        String sql = "SELECT task_key, task_payload FROM ai_resource_task WHERE task_type=? "
+            + "AND status<>? AND task_key>? ORDER BY task_key";
+        return getJdbcTemplate().query(connection -> {
+            PreparedStatement statement = connection.prepareStatement(sql);
+            statement.setString(1, AiResourceIndexTask.TASK_TYPE);
+            statement.setString(2, STATUS_COMPLETED);
+            statement.setString(3, afterTaskKey);
+            statement.setMaxRows(UNFINISHED_SCAN_PAGE_SIZE);
+            return statement;
+        }, (rs, rowNum) -> new UnfinishedTaskRow(rs.getString("task_key"),
+            rs.getString("task_payload")));
     }
     
     @Override
@@ -421,6 +457,34 @@ public class JdbcAiResourceIndexTaskRepository implements AiResourceIndexTaskRep
             this.revision = revision;
             this.taskStage = taskStage;
             this.error = error;
+        }
+    }
+    
+    private static final class UnfinishedTaskRow {
+        
+        private final String taskKey;
+        
+        private final String taskPayload;
+        
+        private UnfinishedTaskRow(String taskKey, String taskPayload) {
+            this.taskKey = taskKey;
+            this.taskPayload = taskPayload;
+        }
+        
+        private boolean matches(String resourceType) {
+            try {
+                AiResourceIndexTaskPayload payload = JacksonUtils.toObj(taskPayload,
+                    AiResourceIndexTaskPayload.class);
+                return payload == null || payload.getSubject() == null
+                    || payload.getOptions() == null
+                    || payload
+                        .getSchemaVersion() != AiResourceIndexTaskPayload.CURRENT_SCHEMA_VERSION
+                    || payload.getSubject().getResourceType() == null
+                    || payload.getSubject().getResourceName() == null
+                    || resourceType.equals(payload.getSubject().getResourceType());
+            } catch (Exception e) {
+                return true;
+            }
         }
     }
 }

--- a/ai/src/main/java/com/alibaba/nacos/ai/service/search/McpAiResourceSearchTypeHandler.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/search/McpAiResourceSearchTypeHandler.java
@@ -333,6 +333,6 @@ public class McpAiResourceSearchTypeHandler implements AiResourceSearchTypeHandl
     }
     
     private String limit(String text, int maxLength) {
-        return text == null || text.length() <= maxLength ? text : text.substring(0, maxLength);
+        return text.length() <= maxLength ? text : text.substring(0, maxLength);
     }
 }

--- a/ai/src/test/java/com/alibaba/nacos/ai/config/AiResourceIndexBackfillTaskTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/config/AiResourceIndexBackfillTaskTest.java
@@ -24,8 +24,14 @@ import com.alibaba.nacos.ai.model.search.AiResourceSearchDocument;
 import com.alibaba.nacos.ai.service.McpServerOperationService;
 import com.alibaba.nacos.ai.service.search.AiResourceEmbeddingService;
 import com.alibaba.nacos.ai.service.search.AiResourceIndexMaintenanceService;
+import com.alibaba.nacos.ai.service.search.AiResourceIndexProjection;
+import com.alibaba.nacos.ai.service.search.AiResourceIndexSource;
+import com.alibaba.nacos.ai.service.search.AiResourceIndexSourcePage;
 import com.alibaba.nacos.ai.service.search.AiResourceSearchDocumentBuilder;
+import com.alibaba.nacos.ai.service.search.AiResourceSearchReadinessService;
 import com.alibaba.nacos.ai.service.search.AiResourceSearchRepository;
+import com.alibaba.nacos.ai.service.search.AiResourceSearchTypeHandler;
+import com.alibaba.nacos.ai.service.search.AiResourceSearchTypeHandlerRegistry;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.storage.NacosConfigAiResourceStorage;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
@@ -34,8 +40,10 @@ import com.alibaba.nacos.api.exception.NacosException;
 import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.api.model.response.Namespace;
 import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.alibaba.nacos.common.utils.MD5Utils;
 import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
 import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
+import com.alibaba.nacos.config.server.model.form.ConfigForm;
 import com.alibaba.nacos.config.server.service.ConfigOperationService;
 import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
 import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
@@ -60,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -68,6 +77,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -113,6 +123,9 @@ class AiResourceIndexBackfillTaskTest {
     
     @Mock
     private ConfigOperationService configOperationService;
+    
+    @Mock
+    private AiResourceSearchReadinessService readinessService;
     
     private AiResourceIndexBackfillTask task;
     
@@ -403,6 +416,60 @@ class AiResourceIndexBackfillTaskTest {
     }
     
     @Test
+    void shouldRecordCleanAgentProjectionScanReadiness() throws Exception {
+        AiResourceSearchTypeHandler handler = agentHandler();
+        when(handler.scan(PUBLIC_NAMESPACE, Constants.Agent.RESOURCE_TYPE_AGENT, 1, 100))
+            .thenReturn(new AiResourceIndexSourcePage(Collections.emptyList(), false));
+        useHandlers(handler);
+        
+        task.onApplicationEvent(rootContextEvent());
+        
+        verify(readinessService, timeout(ASYNC_TIMEOUT)).recordCompletedScan(
+            Constants.Agent.RESOURCE_TYPE_AGENT, 1, true);
+    }
+    
+    @Test
+    void shouldRecordDirtyAgentProjectionScanBeforeTasksDrain() throws Exception {
+        AiResourceSearchTypeHandler handler = agentHandler();
+        AiResourceSearchDocument document = new AiResourceSearchDocument();
+        document.setNamespaceId(PUBLIC_NAMESPACE);
+        document.setResourceType(Constants.Agent.RESOURCE_TYPE_AGENT);
+        document.setResourceName("agent-a");
+        document.setResourceVersion("1.0.0");
+        document.setSourceDigest("digest");
+        AiResourceIndexProjection projection =
+            new AiResourceIndexProjection(document, null, null, null);
+        when(handler.scan(PUBLIC_NAMESPACE, Constants.Agent.RESOURCE_TYPE_AGENT, 1, 100))
+            .thenReturn(new AiResourceIndexSourcePage(
+                List.of(AiResourceIndexSource.success("agent-a", projection)), false));
+        useHandlers(handler);
+        
+        task.onApplicationEvent(rootContextEvent());
+        
+        verify(indexMaintenanceService, timeout(ASYNC_TIMEOUT)).scheduleReconciliation(
+            PUBLIC_NAMESPACE, Constants.Agent.RESOURCE_TYPE_AGENT, "agent-a");
+        verify(readinessService, timeout(ASYNC_TIMEOUT)).recordCompletedScan(
+            Constants.Agent.RESOURCE_TYPE_AGENT, 1, false);
+    }
+    
+    @Test
+    void shouldNotAdvanceReadinessWhenNamespaceEnumerationFallsBack() throws Exception {
+        AiResourceSearchTypeHandler handler = agentHandler();
+        when(namespaceOperationService.getNamespaceList())
+            .thenThrow(new IllegalStateException("namespace unavailable"));
+        when(handler.scan(PUBLIC_NAMESPACE, Constants.Agent.RESOURCE_TYPE_AGENT, 1, 100))
+            .thenReturn(new AiResourceIndexSourcePage(Collections.emptyList(), false));
+        useHandlers(handler);
+        
+        task.onApplicationEvent(rootContextEvent());
+        
+        verify(handler, timeout(ASYNC_TIMEOUT)).scan(PUBLIC_NAMESPACE,
+            Constants.Agent.RESOURCE_TYPE_AGENT, 1, 100);
+        verify(readinessService, after(ASYNC_TIMEOUT).never()).recordCompletedScan(
+            anyString(), anyInt(), org.mockito.ArgumentMatchers.anyBoolean());
+    }
+    
+    @Test
     void shouldSkipWhenAnotherNodeOwnsMarker() throws Exception {
         when(configOperationService.publishConfig(any(), any(), any()))
             .thenThrow(new ConfigAlreadyExistsException("marker exists"));
@@ -431,16 +498,46 @@ class AiResourceIndexBackfillTaskTest {
         
         task.onApplicationEvent(rootContextEvent());
         
+        ArgumentCaptor<ConfigForm> forms = ArgumentCaptor.forClass(ConfigForm.class);
         ArgumentCaptor<ConfigRequestInfo> requestInfo =
             ArgumentCaptor.forClass(ConfigRequestInfo.class);
-        verify(configOperationService, timeout(ASYNC_TIMEOUT).times(2))
-            .publishConfig(any(), requestInfo.capture(), isNull());
+        verify(configOperationService, timeout(ASYNC_TIMEOUT).times(3))
+            .publishConfig(forms.capture(), requestInfo.capture(), isNull());
         assertEquals("stale-marker-md5", requestInfo.getAllValues().get(1).getCasMd5());
+        assertTrue(forms.getAllValues().get(2).getContent().endsWith("|0"));
+        assertEquals(MD5Utils.md5Hex(forms.getAllValues().get(1).getContent(),
+            com.alibaba.nacos.api.common.Constants.ENCODE),
+            requestInfo.getAllValues().get(2).getCasMd5());
     }
     
     private void verifyMarkerReleased() throws Exception {
-        verify(configOperationService, timeout(ASYNC_TIMEOUT)).publishConfig(any(), any(),
-            isNull());
+        ArgumentCaptor<ConfigForm> forms = ArgumentCaptor.forClass(ConfigForm.class);
+        ArgumentCaptor<ConfigRequestInfo> requestInfo =
+            ArgumentCaptor.forClass(ConfigRequestInfo.class);
+        verify(configOperationService, timeout(ASYNC_TIMEOUT).times(2))
+            .publishConfig(forms.capture(), requestInfo.capture(), isNull());
+        ConfigForm acquired = forms.getAllValues().get(0);
+        ConfigForm released = forms.getAllValues().get(1);
+        assertTrue(released.getContent().endsWith("|0"));
+        assertEquals(MD5Utils.md5Hex(acquired.getContent(),
+            com.alibaba.nacos.api.common.Constants.ENCODE),
+            requestInfo.getAllValues().get(1).getCasMd5());
+    }
+    
+    private AiResourceSearchTypeHandler agentHandler() {
+        AiResourceSearchTypeHandler result = mock(AiResourceSearchTypeHandler.class);
+        when(result.resourceTypes())
+            .thenReturn(List.of(Constants.Agent.RESOURCE_TYPE_AGENT));
+        when(result.projectionVersion()).thenReturn(1);
+        return result;
+    }
+    
+    private void useHandlers(AiResourceSearchTypeHandler handler) {
+        task.destroy();
+        task = new AiResourceIndexBackfillTask(
+            new AiResourceSearchTypeHandlerRegistry(List.of(handler)), repository,
+            indexMaintenanceService, embeddingService, vectorIndex, namespaceOperationService,
+            configQueryChainService, configOperationService, readinessService);
     }
     
     private ApplicationReadyEvent rootContextEvent() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/agent/AgentOperationServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/agent/AgentOperationServiceTest.java
@@ -29,6 +29,7 @@ import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.service.resource.PublishPipelineInfo;
 import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
+import com.alibaba.nacos.ai.service.search.AiResourceIndexMaintenanceService;
 import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
 import com.alibaba.nacos.api.ai.constant.AiConstants;
 import com.alibaba.nacos.api.ai.model.agent.Agent;
@@ -99,6 +100,9 @@ class AgentOperationServiceTest {
     @Mock
     private PublishPipelineExecutor publishPipelineExecutor;
     
+    @Mock
+    private AiResourceIndexMaintenanceService indexMaintenanceService;
+    
     private AgentOperationService service;
     
     private MockedStatic<VisibilityHelper> visibilityHelper;
@@ -110,6 +114,7 @@ class AgentOperationServiceTest {
         service =
             new AgentOperationService(persistenceService, resourceManager,
                 publishPipelineExecutor);
+        service.setAiResourceIndexMaintenanceService(indexMaintenanceService);
         visibilityHelper = org.mockito.Mockito.mockStatic(VisibilityHelper.class);
         visibilityHelper.when(VisibilityHelper::resolveCurrentIdentity).thenReturn("alice");
         visibilityHelper.when(VisibilityHelper::resolveClientIp).thenReturn("127.0.0.1");
@@ -180,6 +185,8 @@ class AgentOperationServiceTest {
         assertEquals("alice", draftCaptor.getValue().getAuthor());
         verify(resourceManager).findMeta(NAMESPACE_ID, AGENT_NAME,
             Constants.Agent.RESOURCE_TYPE_AGENT);
+        verify(indexMaintenanceService).schedule(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME);
     }
     
     @Test
@@ -224,6 +231,8 @@ class AgentOperationServiceTest {
         assertSame(expected, service.createDraft(NAMESPACE_ID, request));
         
         visibilityHelper.verify(() -> VisibilityHelper.checkWritableResource(meta));
+        verify(indexMaintenanceService).schedule(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME);
         verify(persistenceService).createInitialDraft(any(Agent.class),
             any(AgentVersionDetail.class));
         verify(persistenceService, never()).createDraft(eq(NAMESPACE_ID), eq(AGENT_NAME),
@@ -266,6 +275,26 @@ class AgentOperationServiceTest {
         verify(resourceManager).ensureReadableOrNotFound(meta,
             "Agent not found: " + AGENT_NAME);
         visibilityHelper.verify(() -> VisibilityHelper.checkWritableResource(meta));
+        verify(indexMaintenanceService).schedule(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME);
+    }
+    
+    @Test
+    void testIndexSchedulingFailureDoesNotRollbackCommittedAgentUpdate() throws NacosException {
+        AiResource meta = meta(null, null);
+        Agent replacement = new Agent();
+        replacement.setNamespaceId(NAMESPACE_ID);
+        replacement.setAgentName(AGENT_NAME);
+        Agent updated = new Agent();
+        when(resourceManager.requireMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(meta);
+        when(persistenceService.tryUpdateAgent(replacement, meta)).thenReturn(updated);
+        doThrow(new IllegalStateException("task store unavailable"))
+            .when(indexMaintenanceService).schedule(NAMESPACE_ID,
+                Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME);
+        service.setAiResourceIndexMaintenanceService(null);
+        
+        assertSame(updated, service.updateAgent(replacement));
     }
     
     @Test
@@ -446,6 +475,8 @@ class AgentOperationServiceTest {
             org.mockito.Mockito.times(4));
         verify(persistenceService).deleteDraft(NAMESPACE_ID, AGENT_NAME, VERSION);
         verify(persistenceService).deleteAgent(NAMESPACE_ID, AGENT_NAME);
+        verify(indexMaintenanceService).schedule(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME);
     }
     
     @Test
@@ -865,6 +896,8 @@ class AgentOperationServiceTest {
             null, null);
         verify(persistenceService).synchronizeDerivedState(NAMESPACE_ID, AGENT_NAME, null, null,
             null, null);
+        verify(indexMaintenanceService, org.mockito.Mockito.times(2)).schedule(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME);
     }
     
     @Test
@@ -877,6 +910,8 @@ class AgentOperationServiceTest {
             null, null)).thenReturn(updated);
         
         assertSame(updated, service.updateLabels(NAMESPACE_ID, AGENT_NAME, labels));
+        verify(indexMaintenanceService).schedule(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME);
     }
     
     @Test
@@ -898,6 +933,8 @@ class AgentOperationServiceTest {
             agentCaptor.getValue().getStatus());
         assertEquals(AiConstants.Agent.VERSION_STATUS_ONLINE,
             versionCaptor.getValue().getStatus());
+        verify(indexMaintenanceService).schedule(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME);
         assertSame(request.getCallInterfaces(), versionCaptor.getValue().getCallInterfaces());
         assertEquals(request.getAuthor(), versionCaptor.getValue().getAuthor());
         assertEquals(request.getChangeDescription(),

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/AgentAiResourceSearchTypeHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/AgentAiResourceSearchTypeHandlerTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.search;
+
+import com.alibaba.nacos.ai.constant.Constants;
+import com.alibaba.nacos.ai.model.AiResource;
+import com.alibaba.nacos.ai.model.search.AiResourceSearchDocument;
+import com.alibaba.nacos.ai.service.agent.AgentPersistenceService;
+import com.alibaba.nacos.ai.service.resource.AiResourceManager;
+import com.alibaba.nacos.api.ai.model.agent.Agent;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionCatalog;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionDetail;
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.model.Page;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentAiResourceSearchTypeHandlerTest {
+    
+    private static final String NAMESPACE_ID = "public";
+    
+    private static final String AGENT_NAME = "agent-a";
+    
+    private static final String VERSION = "1.0.0";
+    
+    @Mock
+    private AiResourceManager resourceManager;
+    
+    @Mock
+    private AgentPersistenceService persistenceService;
+    
+    @Mock
+    private AgentSearchIndexProjector projector;
+    
+    private AgentAiResourceSearchTypeHandler handler;
+    
+    @BeforeEach
+    void setUp() {
+        handler = new AgentAiResourceSearchTypeHandler(resourceManager, persistenceService,
+            projector);
+    }
+    
+    @Test
+    void shouldDeclareAgentProjectionGeneration() {
+        assertEquals(1, handler.projectionVersion());
+        assertEquals(Collections.singletonList(Constants.Agent.RESOURCE_TYPE_AGENT),
+            handler.resourceTypes());
+        assertEquals(Collections.singletonList(Constants.Agent.RESOURCE_TYPE_AGENT),
+            new AgentAiResourceSearchTypeHandler(resourceManager, persistenceService)
+                .resourceTypes());
+        assertEquals(0, new NoopHandler().projectionVersion());
+    }
+    
+    @Test
+    void shouldDeclareProductionInjectionConstructor() throws NoSuchMethodException {
+        assertNotNull(AgentAiResourceSearchTypeHandler.class.getConstructor(
+            AiResourceManager.class, AgentPersistenceService.class).getAnnotation(
+                Autowired.class));
+    }
+    
+    @Test
+    void shouldProjectOnlyEnabledCommonLatestOnlineVersion() throws Exception {
+        AiResource meta = meta("enable", AGENT_NAME);
+        Agent agent = agent(VERSION);
+        AgentVersionDetail latest = version("online");
+        AiResourceIndexProjection expected = projection("digest");
+        when(resourceManager.findMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(meta);
+        when(persistenceService.getAgent(NAMESPACE_ID, AGENT_NAME)).thenReturn(agent);
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(latest);
+        when(projector.project(agent, latest)).thenReturn(expected);
+        
+        assertNull(handler.project(NAMESPACE_ID, "skill", AGENT_NAME, null));
+        assertNull(handler.project(NAMESPACE_ID, Constants.Agent.RESOURCE_TYPE_AGENT,
+            AGENT_NAME, "2.0.0"));
+        assertSame(expected, handler.project(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME, VERSION));
+    }
+    
+    @Test
+    void shouldSkipMissingDisabledLatestOrOfflineAgent() throws Exception {
+        assertNull(handler.project(NAMESPACE_ID, Constants.Agent.RESOURCE_TYPE_AGENT,
+            AGENT_NAME, null));
+        AiResource disabled = meta("disable", AGENT_NAME);
+        when(resourceManager.findMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(disabled);
+        assertNull(handler.project(NAMESPACE_ID, Constants.Agent.RESOURCE_TYPE_AGENT,
+            AGENT_NAME, null));
+        
+        AiResource enabled = meta("enable", AGENT_NAME);
+        Agent noCatalog = agent(null);
+        when(resourceManager.findMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(enabled);
+        when(persistenceService.getAgent(NAMESPACE_ID, AGENT_NAME)).thenReturn(noCatalog);
+        assertNull(handler.project(NAMESPACE_ID, Constants.Agent.RESOURCE_TYPE_AGENT,
+            AGENT_NAME, null));
+        noCatalog.setVersionCatalog(null);
+        assertNull(handler.project(NAMESPACE_ID, Constants.Agent.RESOURCE_TYPE_AGENT,
+            AGENT_NAME, null));
+        
+        Agent agent = agent(VERSION);
+        when(persistenceService.getAgent(NAMESPACE_ID, AGENT_NAME)).thenReturn(agent);
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(version("offline"));
+        assertNull(handler.project(NAMESPACE_ID, Constants.Agent.RESOURCE_TYPE_AGENT,
+            AGENT_NAME, null));
+    }
+    
+    @Test
+    void shouldScanBoundedPageAndIsolateProjectionFailures() throws Exception {
+        AiResource good = meta("enable", "good");
+        AiResource failed = meta("enable", "failed");
+        Page<AiResource> page = new Page<>();
+        page.setPageItems(Arrays.asList(null, good, failed));
+        when(resourceManager.listMetaByType(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, null, 1, 3)).thenReturn(page);
+        Agent goodAgent = agent(VERSION);
+        AgentVersionDetail goodVersion = version("online");
+        when(persistenceService.getAgent(NAMESPACE_ID, "good")).thenReturn(goodAgent);
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, "good", VERSION))
+            .thenReturn(goodVersion);
+        when(projector.project(goodAgent, goodVersion)).thenReturn(projection("good"));
+        when(persistenceService.getAgent(NAMESPACE_ID, "failed"))
+            .thenThrow(new NacosException(NacosException.SERVER_ERROR, "broken"));
+        
+        AiResourceIndexSourcePage result = handler.scan(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, 1, 3);
+        
+        assertTrue(result.hasMore());
+        assertEquals(3, result.getItems().size());
+        assertNull(result.getItems().get(0).getProjection());
+        assertEquals("good", result.getItems().get(1).getResourceName());
+        assertEquals("failed", result.getItems().get(2).getResourceName());
+        assertTrue(result.getItems().get(2).getFailure() instanceof NacosException);
+        assertFalse(handler.scan(NAMESPACE_ID, "skill", 1, 3).hasMore());
+        when(resourceManager.listMetaByType(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, null, 2, 3)).thenReturn(null);
+        assertTrue(handler.scan(NAMESPACE_ID, Constants.Agent.RESOURCE_TYPE_AGENT, 2, 3)
+            .getItems().isEmpty());
+        Page<AiResource> shortPage = new Page<>();
+        shortPage.setPageItems(Collections.singletonList(null));
+        when(resourceManager.listMetaByType(NAMESPACE_ID,
+            Constants.Agent.RESOURCE_TYPE_AGENT, null, null, 3, 4)).thenReturn(shortPage);
+        assertFalse(handler.scan(NAMESPACE_ID, Constants.Agent.RESOURCE_TYPE_AGENT, 3, 4)
+            .hasMore());
+    }
+    
+    @Test
+    void shouldValidateCurrentReadableDigest() throws Exception {
+        AiResource meta = meta("enable", AGENT_NAME);
+        Agent agent = agent(VERSION);
+        AgentVersionDetail latest = version("online");
+        AiResourceSearchDocument document = projection("digest").getDocument();
+        when(resourceManager.findMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(meta);
+        when(persistenceService.getAgent(NAMESPACE_ID, AGENT_NAME)).thenReturn(agent);
+        when(persistenceService.getAgentVersion(NAMESPACE_ID, AGENT_NAME, VERSION))
+            .thenReturn(latest);
+        when(projector.project(agent, latest)).thenReturn(projection("digest"));
+        
+        assertTrue(handler.isCurrent(document));
+        document.setSourceDigest("stale");
+        assertFalse(handler.isCurrent(document));
+        verify(resourceManager, times(2)).ensureReadableOrNotFound(meta,
+            "Agent not found: " + AGENT_NAME);
+    }
+    
+    @Test
+    void shouldRejectUnreadableOrInvalidCurrentDocument() throws Exception {
+        assertFalse(handler.isCurrent(null));
+        AiResourceSearchDocument wrongType = new AiResourceSearchDocument();
+        wrongType.setResourceType("skill");
+        assertFalse(handler.isCurrent(wrongType));
+        AiResourceSearchDocument document = projection("digest").getDocument();
+        AiResource disabled = meta("disable", AGENT_NAME);
+        when(resourceManager.findMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(disabled);
+        assertFalse(handler.isCurrent(document));
+        
+        AiResource enabled = meta("enable", AGENT_NAME);
+        when(resourceManager.findMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(enabled);
+        doThrow(new NacosException(NacosException.NOT_FOUND, "hidden"))
+            .when(resourceManager).ensureReadableOrNotFound(enabled,
+                "Agent not found: " + AGENT_NAME);
+        assertFalse(handler.isCurrent(document));
+        verify(persistenceService, never()).getAgent(NAMESPACE_ID, AGENT_NAME);
+    }
+    
+    @Test
+    void shouldCheckCanonicalExistenceByType() {
+        when(resourceManager.findMeta(NAMESPACE_ID, AGENT_NAME,
+            Constants.Agent.RESOURCE_TYPE_AGENT)).thenReturn(meta("enable", AGENT_NAME));
+        
+        assertTrue(handler.exists(NAMESPACE_ID, Constants.Agent.RESOURCE_TYPE_AGENT, AGENT_NAME));
+        assertFalse(handler.exists(NAMESPACE_ID, "skill", AGENT_NAME));
+    }
+    
+    private AiResource meta(String status, String name) {
+        AiResource result = new AiResource();
+        result.setNamespaceId(NAMESPACE_ID);
+        result.setName(name);
+        result.setType(Constants.Agent.RESOURCE_TYPE_AGENT);
+        result.setStatus(status);
+        return result;
+    }
+    
+    private Agent agent(String latestVersion) {
+        Agent result = new Agent();
+        result.setNamespaceId(NAMESPACE_ID);
+        result.setAgentName(AGENT_NAME);
+        if (latestVersion != null) {
+            AgentVersionCatalog catalog = new AgentVersionCatalog();
+            catalog.setLatestVersion(latestVersion);
+            result.setVersionCatalog(catalog);
+        } else {
+            result.setVersionCatalog(new AgentVersionCatalog());
+        }
+        return result;
+    }
+    
+    private AgentVersionDetail version(String status) {
+        AgentVersionDetail result = new AgentVersionDetail();
+        result.setVersion(VERSION);
+        result.setStatus(status);
+        return result;
+    }
+    
+    private AiResourceIndexProjection projection(String digest) {
+        AiResourceSearchDocument document = new AiResourceSearchDocument();
+        document.setNamespaceId(NAMESPACE_ID);
+        document.setResourceType(Constants.Agent.RESOURCE_TYPE_AGENT);
+        document.setResourceName(AGENT_NAME);
+        document.setResourceVersion(VERSION);
+        document.setSourceDigest(digest);
+        return new AiResourceIndexProjection(document, null, null, null);
+    }
+    
+    private static final class NoopHandler implements AiResourceSearchTypeHandler {
+        
+        @Override
+        public List<String> resourceTypes() {
+            return Collections.emptyList();
+        }
+        
+        @Override
+        public AiResourceIndexProjection project(String namespaceId, String resourceType,
+            String resourceName, String version) {
+            return null;
+        }
+        
+        @Override
+        public AiResourceIndexSourcePage scan(String namespaceId, String resourceType, int pageNo,
+            int pageSize) {
+            return null;
+        }
+        
+        @Override
+        public boolean isCurrent(AiResourceSearchDocument document) {
+            return false;
+        }
+        
+        @Override
+        public boolean exists(String namespaceId, String resourceType, String resourceName) {
+            return false;
+        }
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/AgentSearchIndexProjectorTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/AgentSearchIndexProjectorTest.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.search;
+
+import com.alibaba.nacos.ai.model.search.AiResourceSearchDocument;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCapabilities;
+import com.alibaba.nacos.api.ai.model.a2a.AgentCard;
+import com.alibaba.nacos.api.ai.model.a2a.AgentExtension;
+import com.alibaba.nacos.api.ai.model.a2a.AgentSkill;
+import com.alibaba.nacos.api.ai.model.agent.Agent;
+import com.alibaba.nacos.api.ai.model.agent.AgentCallInterface;
+import com.alibaba.nacos.api.ai.model.agent.AgentProvider;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionCatalog;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionCatalogEntry;
+import com.alibaba.nacos.api.ai.model.agent.AgentVersionDetail;
+import com.alibaba.nacos.common.utils.JacksonUtils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+class AgentSearchIndexProjectorTest {
+    
+    private static final TypeReference<Map<String, Object>> MAP_TYPE =
+        new TypeReference<Map<String, Object>>() {
+        };
+    
+    private static final TypeReference<List<String>> LIST_TYPE =
+        new TypeReference<List<String>>() {
+        };
+    
+    private final AgentSearchIndexProjector projector = new AgentSearchIndexProjector();
+    
+    @Test
+    void shouldProjectMultiVersionA2aAndCustomDefinition() {
+        Agent agent = agent();
+        AgentVersionDetail latest = latest();
+        AgentCard card = a2aCard();
+        AgentCallInterface a2a = callInterface("a2a", card);
+        Map<String, Object> customDescriptor = new LinkedHashMap<>();
+        customDescriptor.put("z", "tail");
+        customDescriptor.put("a", "head");
+        AgentCallInterface custom = callInterface("acme-rpc", customDescriptor);
+        latest.setCallInterfaces(Arrays.asList(a2a, null, custom));
+        
+        AiResourceIndexProjection projection = projector.project(agent, latest);
+        AiResourceSearchDocument document = projection.getDocument();
+        Map<String, Object> metadata = JacksonUtils.toObj(document.getMetadata(), MAP_TYPE);
+        final List<String> capabilities =
+            JacksonUtils.toObj(document.getCapabilities(), LIST_TYPE);
+        final List<String> queries =
+            JacksonUtils.toObj(document.getRepresentativeQueries(), LIST_TYPE);
+        
+        assertEquals("public", document.getNamespaceId());
+        assertEquals("agent", document.getResourceType());
+        assertEquals("research-agent", document.getResourceName());
+        assertEquals("2.0.0", document.getResourceVersion());
+        assertEquals("Research Agent", document.getDisplayName());
+        assertEquals("Find research", document.getDescription());
+        assertEquals(2000L, document.getGmtModified().getTime());
+        assertEquals(64, document.getSourceDigest().length());
+        assertEquals(List.of("a2a", "acme-rpc"), metadata.get("protocols"));
+        assertEquals(List.of("a2a-agent-card", "nacos-agent"),
+            metadata.get("artifactKinds"));
+        assertEquals(1, metadata.get("projectionVersion"));
+        assertTrue(metadata.containsKey("provider"));
+        assertTrue(capabilities.containsAll(List.of("a2a", "acme-rpc", "streaming",
+            "push-notifications", "state-transition-history", "extended-agent-card",
+            "urn:extension", "research", "Research Skill", "academic")));
+        assertTrue(queries.containsAll(List.of("research-agent", "Research Agent",
+            "Find research", "Research Skill", "Search journals")));
+        assertEquals(2, projection.getEnhancementContents().size());
+        assertTrue(projection.getEnhancementContents().get(0).getText()
+            .contains("Search journals"));
+        assertEquals("{\"a\":\"head\",\"z\":\"tail\"}",
+            projection.getEnhancementContents().get(1).getText());
+        assertTrue(projection.getChunks().stream()
+            .anyMatch(chunk -> AiResourceSearchConstants.CHUNK_TYPE_AGENT_CONTENT
+                .equals(chunk.getChunkType())));
+    }
+    
+    @Test
+    void shouldKeepNacosArtifactWhenA2aIsInvalidOrOnlyOldVersionSupportsIt() {
+        Agent agent = agent();
+        agent.setDisplayName(" ");
+        agent.setTags(null);
+        agent.setIconUrl(null);
+        agent.setProvider(null);
+        agent.setOwner(null);
+        agent.setScope(null);
+        AgentVersionDetail latest = latest();
+        latest.setUpdateTime(null);
+        latest.setCallInterfaces(List.of(callInterface("a2a", a2aCard("other", "2.0.0"))));
+        
+        AiResourceIndexProjection projection = projector.project(agent, latest);
+        Map<String, Object> metadata = JacksonUtils.toObj(
+            projection.getDocument().getMetadata(), MAP_TYPE);
+        
+        assertEquals("research-agent", projection.getDocument().getDisplayName());
+        assertEquals(1000L, projection.getDocument().getGmtModified().getTime());
+        assertEquals(List.of("nacos-agent"), metadata.get("artifactKinds"));
+        assertEquals(Collections.emptyList(), projection.getEnhancementContents());
+        assertFalse(metadata.containsKey("provider"));
+        assertFalse(metadata.containsKey("owner"));
+    }
+    
+    @Test
+    void shouldProjectPureA2aAgentWithoutInventingOtherProtocols() {
+        Agent agent = agent();
+        AgentVersionCatalogEntry latestEntry = new AgentVersionCatalogEntry();
+        latestEntry.setVersion("2.0.0");
+        latestEntry.setLabels(Arrays.asList("latest", "stable"));
+        latestEntry.setProtocols(List.of("a2a"));
+        agent.getVersionCatalog().setOnlineVersions(List.of(latestEntry));
+        AgentVersionDetail latest = latest();
+        latest.setCallInterfaces(List.of(callInterface("a2a", a2aCard())));
+        
+        AiResourceIndexProjection projection = projector.project(agent, latest);
+        Map<String, Object> metadata = JacksonUtils.toObj(
+            projection.getDocument().getMetadata(), MAP_TYPE);
+        
+        assertEquals(List.of("a2a"), metadata.get("protocols"));
+        assertEquals(List.of("a2a-agent-card", "nacos-agent"),
+            metadata.get("artifactKinds"));
+        assertEquals(1, projection.getEnhancementContents().size());
+    }
+    
+    @Test
+    void shouldSkipBrokenA2aAndDescriptorButContinueToValidContent() {
+        Agent agent = agent();
+        AgentVersionDetail latest = latest();
+        AgentCallInterface brokenA2a = callInterface("a2a", null);
+        AgentCallInterface validA2a = callInterface("a2a", a2aCard());
+        AgentCallInterface brokenCustom = callInterface("custom", new FailingDescriptor());
+        AgentCallInterface emptyCustom = callInterface("empty", null);
+        latest.setCallInterfaces(Arrays.asList(brokenA2a, validA2a, brokenCustom, emptyCustom));
+        
+        AiResourceIndexProjection projection = projector.project(agent, latest);
+        Map<String, Object> metadata = JacksonUtils.toObj(
+            projection.getDocument().getMetadata(), MAP_TYPE);
+        
+        assertEquals(List.of("a2a-agent-card", "nacos-agent"),
+            metadata.get("artifactKinds"));
+        assertEquals(1, projection.getEnhancementContents().size());
+    }
+    
+    @Test
+    void shouldBoundCustomDescriptorContent() {
+        Agent agent = agent();
+        AgentVersionDetail latest = latest();
+        latest.setCallInterfaces(List.of(callInterface("custom",
+            Collections.singletonMap("content", "x".repeat(1024 * 1024)))));
+        
+        AiResourceIndexProjection projection = projector.project(agent, latest);
+        
+        assertEquals(12000, projection.getEnhancementContents().get(0).getText().length());
+    }
+    
+    @Test
+    void shouldHandleMissingCatalogEntriesAndCallInterfaces() {
+        Agent agent = agent();
+        agent.setVersionCatalog(null);
+        AgentVersionDetail latest = latest();
+        latest.setCallInterfaces(null);
+        AiResourceIndexProjection withoutCatalog = projector.project(agent, latest);
+        Map<String, Object> metadata = JacksonUtils.toObj(
+            withoutCatalog.getDocument().getMetadata(), MAP_TYPE);
+        assertEquals(Collections.emptyList(), metadata.get("protocols"));
+        assertEquals(List.of("nacos-agent"), metadata.get("artifactKinds"));
+        assertTrue(withoutCatalog.getEnhancementContents().isEmpty());
+        
+        AgentVersionCatalog catalog = catalog();
+        AgentVersionCatalogEntry withoutProtocols = new AgentVersionCatalogEntry();
+        withoutProtocols.setVersion("2.0.0");
+        catalog.setOnlineVersions(Arrays.asList(null, withoutProtocols));
+        agent.setVersionCatalog(catalog);
+        AiResourceIndexProjection withoutProtocolsProjection = projector.project(agent, latest);
+        Map<String, Object> withoutProtocolsMetadata = JacksonUtils.toObj(
+            withoutProtocolsProjection.getDocument().getMetadata(), MAP_TYPE);
+        assertEquals(Collections.emptyList(), withoutProtocolsMetadata.get("protocols"));
+    }
+    
+    @Test
+    void shouldUseStableFactsInsteadOfTimestampsForDigest() {
+        Agent firstAgent = agent();
+        AgentVersionDetail firstLatest = latest();
+        String first = projector.project(firstAgent, firstLatest).getDocument().getSourceDigest();
+        firstAgent.setUpdateTime(9999L);
+        firstLatest.setUpdateTime(8888L);
+        String timestampOnly = projector.project(firstAgent, firstLatest).getDocument()
+            .getSourceDigest();
+        firstLatest.setContentDigest("changed");
+        String changedContent = projector.project(firstAgent, firstLatest).getDocument()
+            .getSourceDigest();
+        firstLatest.setCallInterfaces(List.of(callInterface("a2a", a2aCard())));
+        String changedArtifact = projector.project(firstAgent, firstLatest).getDocument()
+            .getSourceDigest();
+        firstAgent.setDescription("changed description");
+        String changedMetadata = projector.project(firstAgent, firstLatest).getDocument()
+            .getSourceDigest();
+        firstAgent.getVersionCatalog().getOnlineVersions().get(0).setLabels(List.of("stable"));
+        String changedCatalog = projector.project(firstAgent, firstLatest).getDocument()
+            .getSourceDigest();
+        
+        assertEquals(first, timestampOnly);
+        assertNotEquals(timestampOnly, changedContent);
+        assertNotEquals(changedContent, changedArtifact);
+        assertNotEquals(changedArtifact, changedMetadata);
+        assertNotEquals(changedMetadata, changedCatalog);
+    }
+    
+    @Test
+    void shouldRejectMissingProjectionFactsAndWrapMissingSha256() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> projector.project(null, latest()));
+        assertThrows(IllegalArgumentException.class, () -> projector.project(agent(), null));
+        try (MockedStatic<MessageDigest> digest = mockStatic(MessageDigest.class)) {
+            digest.when(() -> MessageDigest.getInstance(eq("SHA-256")))
+                .thenThrow(new NoSuchAlgorithmException("missing"));
+            assertThrows(IllegalStateException.class,
+                () -> projector.project(agent(), latest()));
+        }
+    }
+    
+    private Agent agent() {
+        Agent result = new Agent();
+        result.setNamespaceId("public");
+        result.setAgentName("research-agent");
+        result.setDisplayName("Research Agent");
+        result.setDescription("Find research");
+        result.setIconUrl("https://example.com/icon.png");
+        AgentProvider provider = new AgentProvider();
+        provider.setName("Nacos");
+        provider.setUrl("https://nacos.io");
+        result.setProvider(provider);
+        result.setTags(List.of("research", "assistant"));
+        result.setStatus("enable");
+        result.setOwner("alice");
+        result.setScope("PUBLIC");
+        result.setVersionCatalog(catalog());
+        result.setUpdateTime(1000L);
+        return result;
+    }
+    
+    private AgentVersionCatalog catalog() {
+        AgentVersionCatalog result = new AgentVersionCatalog();
+        result.setLatestVersion("2.0.0");
+        AgentVersionCatalogEntry latest = new AgentVersionCatalogEntry();
+        latest.setVersion("2.0.0");
+        latest.setLabels(List.of("latest"));
+        latest.setProtocols(Arrays.asList("a2a", "acme-rpc", "a2a", null, ""));
+        AgentVersionCatalogEntry old = new AgentVersionCatalogEntry();
+        old.setVersion("1.0.0");
+        old.setLabels(Collections.emptyList());
+        old.setProtocols(List.of("a2a"));
+        result.setOnlineVersions(Arrays.asList(latest, null, old));
+        return result;
+    }
+    
+    private AgentVersionDetail latest() {
+        AgentVersionDetail result = new AgentVersionDetail();
+        result.setNamespaceId("public");
+        result.setAgentName("research-agent");
+        result.setVersion("2.0.0");
+        result.setStatus("online");
+        result.setCallInterfaces(Collections.emptyList());
+        result.setContentDigest("sha256:content");
+        result.setUpdateTime(2000L);
+        return result;
+    }
+    
+    private AgentCard a2aCard() {
+        return a2aCard("research-agent", "2.0.0");
+    }
+    
+    private AgentCard a2aCard(String name, String version) {
+        AgentCard result = new AgentCard();
+        result.setName(name);
+        result.setVersion(version);
+        result.setDescription("Research card");
+        result.setUrl("https://example.com/a2a");
+        result.setPreferredTransport("HTTP+JSON");
+        result.setProtocolVersion("0.3.0");
+        AgentCapabilities capabilities = new AgentCapabilities();
+        capabilities.setStreaming(true);
+        capabilities.setPushNotifications(true);
+        capabilities.setStateTransitionHistory(true);
+        capabilities.setExtendedAgentCard(true);
+        AgentExtension extension = new AgentExtension();
+        extension.setUri("urn:extension");
+        capabilities.setExtensions(Arrays.asList(extension, null));
+        result.setCapabilities(capabilities);
+        AgentSkill skill = new AgentSkill();
+        skill.setId("research");
+        skill.setName("Research Skill");
+        skill.setDescription("Search publications");
+        skill.setTags(Arrays.asList("academic", null));
+        skill.setExamples(List.of("Search journals"));
+        result.setSkills(Arrays.asList(skill, null));
+        return result;
+    }
+    
+    private AgentCallInterface callInterface(String protocol, Object descriptor) {
+        AgentCallInterface result = new AgentCallInterface();
+        result.setProtocol(protocol);
+        result.setNativeDescriptor(descriptor);
+        return result;
+    }
+    
+    public static class FailingDescriptor {
+        
+        public String getValue() {
+            throw new IllegalStateException("cannot serialize");
+        }
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceIndexProjectionBuilderTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceIndexProjectionBuilderTest.java
@@ -80,6 +80,9 @@ class AiResourceIndexProjectionBuilderTest {
         assertTrue(invalidMetadata.getFacets().isEmpty());
         assertTrue(invalidMetadata.getChunks().stream()
             .anyMatch(chunk -> "content".equals(chunk.getChunkType())));
+        document.setMetadata("null");
+        assertTrue(new AiResourceIndexProjectionBuilder().build(document, null, null)
+            .getFacets().isEmpty());
         assertThrows(NullPointerException.class,
             () -> new AiResourceIndexProjection(null, null, null, null));
     }

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceIndexServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceIndexServiceImplTest.java
@@ -40,9 +40,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -292,9 +294,13 @@ class AiResourceIndexServiceImplTest {
         when(repository.listChunks(10L)).thenReturn(List.of(baseChunk));
         when(enhancementService.enhanceWithResult(any(AiResourceSearchDocument.class), anyList(),
             anyList())).thenReturn(new AiResourceIndexEnhancementResult(
-                List.of(new AiResourceIndexEnhancementChunk(
-                    AiResourceSearchConstants.CHUNK_TYPE_SEARCH_INTENT,
-                    "参数表格 parameter table", "{\"source\":\"llm\"}")),
+                List.of(
+                    new AiResourceIndexEnhancementChunk(
+                        AiResourceSearchConstants.CHUNK_TYPE_DESCRIPTION,
+                        "must not persist as an enhancement", null),
+                    new AiResourceIndexEnhancementChunk(
+                        AiResourceSearchConstants.CHUNK_TYPE_SEARCH_INTENT,
+                        "参数表格 parameter table", "{\"source\":\"llm\"}")),
                 "fingerprint-v1"));
         when(repository.replaceEnhancementChunks(any(AiResourceSearchDocument.class), anyList()))
             .thenAnswer(invocation -> {
@@ -341,6 +347,9 @@ class AiResourceIndexServiceImplTest {
             .thenReturn(entry);
         when(resourceManager.findMeta("public", "api-helper", Constants.Skills.RESOURCE_TYPE_SKILL))
             .thenReturn(meta());
+        when(resourceManager.findVersion("public", "api-helper",
+            Constants.Skills.RESOURCE_TYPE_SKILL, "1.0.0"))
+            .thenReturn(version(AiResourceConstants.VERSION_STATUS_ONLINE));
         
         assertFalse(service.enhanceLatestAiResource("public",
             Constants.Skills.RESOURCE_TYPE_SKILL, "api-helper"));
@@ -385,6 +394,112 @@ class AiResourceIndexServiceImplTest {
         assertNull(result);
         verify(repository, never()).replaceEnhancementChunks(any(), anyList());
         verify(vectorIndex, never()).replaceResourceVersion(any(), any(), any(), any(), anyList());
+    }
+    
+    @Test
+    void enhancementShouldStopAtEachLaterOwnershipBoundary() throws Exception {
+        AiResourceIndexServiceImpl service = service(enhancementService, contentLoader);
+        AiResourceSearchDocument entry = enhancementEntry();
+        prepareEnhancement(entry);
+        when(vectorIndex.available()).thenReturn(true);
+        AtomicInteger beforePersistenceChecks = new AtomicInteger();
+        String beforePersistence = service.enhanceLatestAiResource("public",
+            Constants.Skills.RESOURCE_TYPE_SKILL, "api-helper",
+            () -> beforePersistenceChecks.incrementAndGet() == 1);
+        assertNull(beforePersistence);
+        verify(repository, never()).replaceEnhancementChunks(any(), anyList());
+        
+        org.mockito.Mockito.reset(repository, resourceManager, enhancementService, contentLoader,
+            vectorIndex);
+        entry = enhancementEntry();
+        prepareEnhancement(entry);
+        when(vectorIndex.available()).thenReturn(true);
+        when(repository.replaceEnhancementChunks(entry, Collections.emptyList()))
+            .thenReturn(Collections.emptyList());
+        AtomicInteger beforeVectorChecks = new AtomicInteger();
+        String beforeVector = service.enhanceLatestAiResource("public",
+            Constants.Skills.RESOURCE_TYPE_SKILL, "api-helper",
+            () -> beforeVectorChecks.incrementAndGet() <= 2);
+        assertNull(beforeVector);
+        verify(repository).replaceEnhancementChunks(entry, Collections.emptyList());
+        verify(vectorIndex, never()).replaceResourceVersion(any(), any(), any(), any(), anyList());
+    }
+    
+    @Test
+    void enhancementShouldRejectUnavailableService() {
+        AiResourceIndexServiceImpl service = service(enhancementService, contentLoader);
+        AiResourceSearchDocument entry = enhancementEntry();
+        when(repository.findEntry("public", Constants.Skills.RESOURCE_TYPE_SKILL, "api-helper"))
+            .thenReturn(entry);
+        when(resourceManager.findMeta("public", "api-helper", Constants.Skills.RESOURCE_TYPE_SKILL))
+            .thenReturn(meta());
+        when(resourceManager.findVersion("public", "api-helper",
+            Constants.Skills.RESOURCE_TYPE_SKILL, "1.0.0"))
+            .thenReturn(version(AiResourceConstants.VERSION_STATUS_ONLINE));
+        when(enhancementService.ready()).thenReturn(false);
+        
+        assertThrows(IllegalStateException.class, () -> service.enhanceLatestAiResource("public",
+            Constants.Skills.RESOURCE_TYPE_SKILL, "api-helper"));
+    }
+    
+    @Test
+    void missingHandlerAndNoopEnhancementShouldUseSafeFallbacks() throws Exception {
+        AiResourceSearchTypeHandlerRegistry emptyRegistry =
+            new AiResourceSearchTypeHandlerRegistry(Collections.emptyList());
+        AiResourceIndexServiceImpl service = new AiResourceIndexServiceImpl(repository,
+            embeddingService, vectorIndex, null, emptyRegistry);
+        
+        assertFalse(service.isEnhancementRequested());
+        assertEquals(AiResourceIndexEnhancementService.NOOP.fingerprint(),
+            service.enhancementFingerprint());
+        service.rebuildAiResource("public", "unknown", "missing", "1.0.0");
+        assertFalse(service.rebuildLatestAiResource("public", "unknown", "missing"));
+        AiResourceSearchDocument entry = enhancementEntry();
+        when(repository.findEntry("public", "unknown", "indexed")).thenReturn(entry);
+        assertFalse(service.enhanceLatestAiResource("public", "unknown", "indexed"));
+        verify(repository).deleteByResourceVersion("public", "unknown", "missing", "1.0.0");
+        verify(repository).deleteByResource("public", "unknown", "missing");
+    }
+    
+    @Test
+    void deletionShouldValidateKeysAndRemoveRelationalAndVectorState() {
+        AiResourceIndexServiceImpl service = service();
+        service.deleteResource("public", "skill", null);
+        service.deleteResourceVersion("public", "skill", "name", null);
+        verify(repository, never()).deleteByResource(any(), any(), any());
+        verify(repository, never()).deleteByResourceVersion(any(), any(), any(), any());
+        when(vectorIndex.available()).thenReturn(true);
+        
+        service.deleteResource("public", "skill", "name");
+        service.deleteResourceVersion("public", "skill", "name", "1.0.0");
+        
+        verify(vectorIndex).deleteByResource("public", "skill", "name");
+        verify(repository).deleteByResource("public", "skill", "name");
+        verify(vectorIndex).deleteByResourceVersion("public", "skill", "name", "1.0.0");
+        verify(repository).deleteByResourceVersion("public", "skill", "name", "1.0.0");
+    }
+    
+    @Test
+    void rebuildShouldAllowVectorIndexWithNoPersistedChunks() throws Exception {
+        AiResourceIndexServiceImpl service = service();
+        when(resourceManager.findMeta("public", "api-helper", Constants.Skills.RESOURCE_TYPE_SKILL))
+            .thenReturn(meta());
+        when(resourceManager.findVersion("public", "api-helper",
+            Constants.Skills.RESOURCE_TYPE_SKILL, "1.0.0"))
+            .thenReturn(version(AiResourceConstants.VERSION_STATUS_ONLINE));
+        when(vectorIndex.available()).thenReturn(true);
+        when(repository.replaceEntry(any(), anyList())).thenAnswer(invocation -> {
+            AiResourceSearchDocument entry = invocation.getArgument(0);
+            entry.setId(1L);
+            return Collections.emptyList();
+        });
+        
+        service.rebuildAiResource("public", Constants.Skills.RESOURCE_TYPE_SKILL, "api-helper",
+            "1.0.0");
+        
+        verify(vectorIndex).replaceResourceVersion("public",
+            Constants.Skills.RESOURCE_TYPE_SKILL, "api-helper", "1.0.0",
+            Collections.emptyList());
     }
     
     @Test
@@ -448,6 +563,31 @@ class AiResourceIndexServiceImplTest {
                 new McpAiResourceSearchTypeHandler(mcpServerOperationService)));
         return new AiResourceIndexServiceImpl(repository, embeddingService, vectorIndex,
             indexEnhancementService, registry);
+    }
+    
+    private AiResourceSearchDocument enhancementEntry() {
+        AiResourceSearchDocument result = new AiResourceSearchDocument();
+        result.setId(10L);
+        result.setNamespaceId("public");
+        result.setResourceType(Constants.Skills.RESOURCE_TYPE_SKILL);
+        result.setResourceName("api-helper");
+        result.setResourceVersion("1.0.0");
+        return result;
+    }
+    
+    private void prepareEnhancement(AiResourceSearchDocument entry) throws Exception {
+        when(repository.findEntry("public", Constants.Skills.RESOURCE_TYPE_SKILL, "api-helper"))
+            .thenReturn(entry);
+        when(resourceManager.findMeta("public", "api-helper", Constants.Skills.RESOURCE_TYPE_SKILL))
+            .thenReturn(meta());
+        when(resourceManager.findVersion("public", "api-helper",
+            Constants.Skills.RESOURCE_TYPE_SKILL, "1.0.0"))
+            .thenReturn(version(AiResourceConstants.VERSION_STATUS_ONLINE));
+        when(enhancementService.ready()).thenReturn(true);
+        when(repository.listChunks(10L)).thenReturn(Collections.emptyList());
+        when(enhancementService.enhanceWithResult(any(), anyList(), anyList()))
+            .thenReturn(new AiResourceIndexEnhancementResult(Collections.emptyList(),
+                "fingerprint-v1"));
     }
     
     private AiResource meta() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceSearchChunkBuilderTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceSearchChunkBuilderTest.java
@@ -23,9 +23,13 @@ import com.alibaba.nacos.api.ai.model.prompt.PromptUtils;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -143,6 +147,51 @@ class AiResourceSearchChunkBuilderTest {
                 .equals(chunk.getChunkType())));
         assertTrue(chunks.stream().anyMatch(
             chunk -> chunk.getChunkText().contains("avatar_video")));
+    }
+    
+    @Test
+    void buildersShouldHandleEmptyMalformedAndDuplicateInputs() {
+        AiResourceSearchChunkBuilder builder = new AiResourceSearchChunkBuilder();
+        AiResourceSearchDocument entry = entry();
+        assertTrue(builder.buildSourceContentChunks(entry, null).isEmpty());
+        assertTrue(builder.buildSourceContentChunks(entry, Collections.emptyList()).isEmpty());
+        assertTrue(builder.buildSourceContentChunks(entry, List.of(
+            new AiResourceIndexEnhancementContent("unknown", "ignored"))).isEmpty());
+        assertTrue(builder.buildSourceContentChunks(entry, Arrays.asList(null,
+            new AiResourceIndexEnhancementContent("unknown", "ignored"))).isEmpty());
+        assertTrue(builder.buildSourceContentChunks(null, List.of(
+            new AiResourceIndexEnhancementContent("SKILL.md", "ignored"))).isEmpty());
+        assertTrue(builder.buildSourceContentChunks(entry, List.of(
+            new AiResourceIndexEnhancementContent("SKILL.md", "text")), "").isEmpty());
+        List<AiResourceSearchChunk> customSource = builder.buildSourceContentChunks(entry,
+            Arrays.asList(null,
+                new AiResourceIndexEnhancementContent("custom.txt", "custom content")),
+            "custom");
+        assertEquals(1, customSource.size());
+        assertTrue(customSource.get(0).getMetadata().contains("content"));
+        
+        assertTrue(builder.buildEnhancementChunks(entry, null).isEmpty());
+        assertTrue(builder.buildEnhancementChunks(entry, Collections.emptyList()).isEmpty());
+        List<AiResourceSearchChunk> enhancements = builder.buildEnhancementChunks(entry,
+            Arrays.asList(null, new AiResourceIndexEnhancementChunk("", "ignored", null),
+                new AiResourceIndexEnhancementChunk("custom", " ", null),
+                new AiResourceIndexEnhancementChunk("custom", "same", null),
+                new AiResourceIndexEnhancementChunk("custom", "same", null)));
+        assertEquals(1, enhancements.size());
+        
+        entry.setTags("null");
+        entry.setCapabilities("not-json");
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("inputTypes", null);
+        metadata.put("riskLevel", 7);
+        entry.setMetadata(JacksonUtils.toJson(metadata));
+        assertFalse(builder.buildChunks(entry).isEmpty());
+        entry.setMetadata("null");
+        assertFalse(builder.buildChunks(entry).isEmpty());
+        entry.setMetadata("");
+        assertFalse(builder.buildChunks(entry).isEmpty());
+        entry.setMetadata("not-json");
+        assertFalse(builder.buildChunks(entry).isEmpty());
     }
     
     private AiResourceSearchDocument entry() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceSearchServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceSearchServiceTest.java
@@ -40,12 +40,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -221,7 +224,7 @@ class AiResourceSearchServiceTest {
             .thenReturn(List.of(matching, wildcardLookalike));
         mockCurrentResources();
         Query query = listQuery();
-        query.setPredicates(List.of(
+        query.setPredicates(Arrays.asList(null,
             new Predicate("tags", PredicateOperator.EXACT_ALL,
                 List.of("research", "citations"), false),
             new Predicate("displayName", PredicateOperator.LITERAL_CONTAINS,
@@ -256,6 +259,29 @@ class AiResourceSearchServiceTest {
         predicate.setCaseSensitive(false);
         query.setFilters(Map.of("displayName", List.of("assistant")));
         assertEquals(1, service.list(query).getItems().size());
+    }
+    
+    @Test
+    void predicatesShouldRejectMissingFieldsMissingValuesAndNullTokens() throws Exception {
+        AiResourceSearchService service = new AiResourceSearchService(resourceManager,
+            mcpServerOperationService, repository, embeddingService, vectorIndex);
+        AiResourceSearchDocument document = entry(1L, "AgentOne");
+        document.setTags(JacksonUtils.toJson(Arrays.asList("value", null)));
+        when(repository.scanEnabledEntries("public", List.of("skill"), 0L, 500))
+            .thenReturn(List.of(document));
+        Query query = listQuery();
+        query.setPredicates(List.of(new Predicate("tags", PredicateOperator.EXACT_ALL,
+            List.of("value", "missing"), false)));
+        assertEquals(0, service.list(query).getItems().size());
+        query.setPredicates(List.of(new Predicate("unknown", PredicateOperator.EXACT_ANY,
+            List.of("value"), false)));
+        assertEquals(0, service.list(query).getItems().size());
+        query.setPredicates(List.of(new Predicate("tags", PredicateOperator.EXACT_ANY,
+            Collections.singletonList(null), false)));
+        assertEquals(0, service.list(query).getItems().size());
+        query.setPredicates(List.of(new Predicate(null, PredicateOperator.EXACT_ANY,
+            List.of("value"), false)));
+        assertEquals(0, service.list(query).getItems().size());
     }
     
     @Test
@@ -296,6 +322,25 @@ class AiResourceSearchServiceTest {
     }
     
     @Test
+    void numberedListShouldContinueCountingAfterRequestedPageIsFull() throws Exception {
+        AiResourceSearchService service = new AiResourceSearchService(resourceManager,
+            mcpServerOperationService, repository, embeddingService, vectorIndex);
+        when(repository.scanEnabledEntriesByResourceKey("public", List.of("skill"), null, null,
+            0L, 500)).thenReturn(List.of(entry(1L, "alpha"), entry(2L, "bravo"),
+                entry(3L, "charlie")));
+        mockCurrentResources();
+        Query query = listQuery();
+        query.setPageSize(1);
+        
+        NumberedPage page = service.numberedList(query);
+        
+        assertEquals(3L, page.getTotalCount());
+        assertEquals(3, page.getPagesAvailable());
+        assertEquals(List.of("alpha"),
+            List.of(page.getItems().get(0).getResourceName()));
+    }
+    
+    @Test
     void numberedListShouldAdvanceAcrossBoundedResourceKeyBatches() throws Exception {
         AiResourceSearchService service = new AiResourceSearchService(resourceManager,
             mcpServerOperationService, repository, embeddingService, vectorIndex);
@@ -319,6 +364,119 @@ class AiResourceSearchServiceTest {
         assertEquals(251, page.getPagesAvailable());
         assertEquals(1, page.getItems().size());
         assertEquals("skill-500", page.getItems().get(0).getResourceName());
+    }
+    
+    @Test
+    void numberedListShouldHandleNullBatchAndRejectIncompleteAnchor() throws Exception {
+        AiResourceSearchService service = new AiResourceSearchService(resourceManager,
+            mcpServerOperationService, repository, embeddingService, vectorIndex);
+        Query query = listQuery();
+        when(repository.scanEnabledEntriesByResourceKey("public", List.of("skill"), null, null,
+            0L, 500)).thenReturn(null, Collections.emptyList());
+        NumberedPage empty = service.numberedList(query);
+        assertEquals(0L, empty.getTotalCount());
+        assertEquals(0, empty.getPagesAvailable());
+        assertEquals(0L, service.numberedList(query).getTotalCount());
+        
+        AiResourceSearchDocument incomplete = entry(1L, "incomplete");
+        incomplete.setId(null);
+        incomplete.setStatus("disabled");
+        AiResourceSearchDocument missingType = entry(1L, "missing-type");
+        missingType.setResourceType(null);
+        missingType.setStatus("disabled");
+        AiResourceSearchDocument missingName = entry(1L, "missing-name");
+        missingName.setResourceName(null);
+        missingName.setStatus("disabled");
+        when(repository.scanEnabledEntriesByResourceKey("public", List.of("skill"), null, null,
+            0L, 500)).thenReturn(List.of(incomplete), List.of(missingType), List.of(missingName));
+        assertThrows(IllegalStateException.class, () -> service.numberedList(query));
+        assertThrows(IllegalStateException.class, () -> service.numberedList(query));
+        assertThrows(IllegalStateException.class, () -> service.numberedList(query));
+    }
+    
+    @Test
+    void numberedListShouldRejectEveryNonAdvancingResourceKeyDimension() {
+        AiResourceSearchService service = new AiResourceSearchService(resourceManager,
+            mcpServerOperationService, repository, embeddingService, vectorIndex);
+        Query query = listQuery();
+        List<AiResourceSearchDocument> firstBatch = new ArrayList<>();
+        for (long id = 1L; id <= 500L; id++) {
+            AiResourceSearchDocument document = entry(id, String.format("skill-%03d", id - 1L));
+            document.setStatus("disabled");
+            firstBatch.add(document);
+        }
+        AiResourceSearchDocument typeBackwards = entry(501L, "z");
+        typeBackwards.setResourceType("prompt");
+        typeBackwards.setStatus("disabled");
+        AiResourceSearchDocument nameBackwards = entry(501L, "skill-400");
+        nameBackwards.setStatus("disabled");
+        AiResourceSearchDocument idBackwards = entry(500L, "skill-499");
+        idBackwards.setStatus("disabled");
+        when(repository.scanEnabledEntriesByResourceKey("public", List.of("skill"), null, null,
+            0L, 500)).thenReturn(firstBatch);
+        when(repository.scanEnabledEntriesByResourceKey("public", List.of("skill"), "skill",
+            "skill-499", 500L, 500)).thenReturn(List.of(typeBackwards),
+                List.of(nameBackwards), List.of(idBackwards));
+        
+        assertThrows(IllegalStateException.class, () -> service.numberedList(query));
+        assertThrows(IllegalStateException.class, () -> service.numberedList(query));
+        assertThrows(IllegalStateException.class, () -> service.numberedList(query));
+    }
+    
+    @Test
+    void numberedListShouldAcceptEveryAdvancingResourceKeyDimension() throws Exception {
+        AiResourceSearchService service = new AiResourceSearchService(resourceManager,
+            mcpServerOperationService, repository, embeddingService, vectorIndex);
+        Query query = listQuery();
+        List<AiResourceSearchDocument> firstBatch = new ArrayList<>();
+        for (long id = 1L; id <= 500L; id++) {
+            AiResourceSearchDocument document = entry(id, String.format("skill-%03d", id - 1L));
+            document.setStatus("disabled");
+            firstBatch.add(document);
+        }
+        AiResourceSearchDocument typeAdvance = entry(501L, "alpha");
+        typeAdvance.setResourceType("tool");
+        typeAdvance.setStatus("disabled");
+        AiResourceSearchDocument nameAdvance = entry(501L, "skill-500");
+        nameAdvance.setStatus("disabled");
+        AiResourceSearchDocument idAdvance = entry(501L, "skill-499");
+        idAdvance.setStatus("disabled");
+        when(repository.scanEnabledEntriesByResourceKey("public", List.of("skill"), null, null,
+            0L, 500)).thenReturn(firstBatch, firstBatch, firstBatch);
+        when(repository.scanEnabledEntriesByResourceKey("public", List.of("skill"), "skill",
+            "skill-499", 500L, 500)).thenReturn(List.of(typeAdvance),
+                List.of(nameAdvance), List.of(idAdvance));
+        
+        assertEquals(0L, service.numberedList(query).getTotalCount());
+        assertEquals(0L, service.numberedList(query).getTotalCount());
+        assertEquals(0L, service.numberedList(query).getTotalCount());
+    }
+    
+    @Test
+    void queryPredicateAndNumberedPageShouldNormalizeAndExposeValues() {
+        Query query = new Query();
+        query.setPageNumber(0);
+        query.setPageSize(0);
+        query.setPredicates(null);
+        assertEquals(1, query.getPageNumber());
+        assertEquals(1, query.getPageSize());
+        assertTrue(query.getPredicates().isEmpty());
+        
+        Predicate predicate = new Predicate();
+        predicate.setField("resourceName");
+        predicate.setOperator(null);
+        predicate.setValues(null);
+        predicate.setCaseSensitive(true);
+        assertEquals("resourceName", predicate.getField());
+        assertEquals(PredicateOperator.EXACT_ANY, predicate.getOperator());
+        assertTrue(predicate.getValues().isEmpty());
+        assertTrue(predicate.isCaseSensitive());
+        
+        NumberedPage page = new NumberedPage(Collections.emptyList(), 3L, 2, 4);
+        assertTrue(page.getItems().isEmpty());
+        assertEquals(3L, page.getTotalCount());
+        assertEquals(2, page.getPageNumber());
+        assertEquals(4, page.getPagesAvailable());
     }
     
     private Query listQuery() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceSearchTypeHandlerRegistryTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/AiResourceSearchTypeHandlerRegistryTest.java
@@ -70,7 +70,13 @@ class AiResourceSearchTypeHandlerRegistryTest {
                 List.of(new TestHandler(Collections.emptyList(), true))));
         assertThrows(IllegalStateException.class,
             () -> new AiResourceSearchTypeHandlerRegistry(
+                List.of(new TestHandler(null, true))));
+        assertThrows(IllegalStateException.class,
+            () -> new AiResourceSearchTypeHandlerRegistry(
                 List.of(new TestHandler(List.of(" "), true))));
+        TestHandler repeated = new TestHandler(Arrays.asList("skill", "skill"), true);
+        assertSame(repeated,
+            new AiResourceSearchTypeHandlerRegistry(List.of(repeated)).get("skill"));
     }
     
     private static class TestHandler implements AiResourceSearchTypeHandler {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/ConfigAiResourceSearchReadinessServiceTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/ConfigAiResourceSearchReadinessServiceTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 1999-2026 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.ai.service.search;
+
+import com.alibaba.nacos.config.server.exception.ConfigAlreadyExistsException;
+import com.alibaba.nacos.config.server.model.ConfigRequestInfo;
+import com.alibaba.nacos.config.server.model.form.ConfigForm;
+import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.config.server.service.query.ConfigQueryChainService;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainRequest;
+import com.alibaba.nacos.config.server.service.query.model.ConfigQueryChainResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.lang.reflect.Constructor;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigAiResourceSearchReadinessServiceTest {
+    
+    private static final String RESOURCE_TYPE = "agent";
+    
+    private static final int PROJECTION_VERSION = 1;
+    
+    @Mock
+    private ConfigQueryChainService configQueryChainService;
+    
+    @Mock
+    private ConfigOperationService configOperationService;
+    
+    @Mock
+    private AiResourceIndexTaskRepository taskRepository;
+    
+    private ConfigAiResourceSearchReadinessService service;
+    
+    @BeforeEach
+    void setUp() {
+        Clock clock = Clock.fixed(Instant.ofEpochMilli(12345L), ZoneOffset.UTC);
+        service = new ConfigAiResourceSearchReadinessService(configQueryChainService,
+            configOperationService, taskRepository, clock);
+    }
+    
+    @Test
+    void shouldRequireExactReadyGeneration() {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response(record("agent", 1, "READY", 12L), "md5"),
+                response(record("agent", 1, "VERIFYING", 0L), "md5"),
+                response(record("agent", 2, "READY", 12L), "md5"));
+        
+        assertTrue(service.isReady(RESOURCE_TYPE, PROJECTION_VERSION));
+        assertFalse(service.isReady(RESOURCE_TYPE, PROJECTION_VERSION));
+        assertFalse(service.isReady(RESOURCE_TYPE, PROJECTION_VERSION));
+        assertFalse(service.isReady("", PROJECTION_VERSION));
+        assertFalse(service.isReady(RESOURCE_TYPE, 0));
+    }
+    
+    @Test
+    void shouldExposeSafeDefaultAndNoopImplementations() {
+        ConfigAiResourceSearchReadinessService defaultClockService =
+            new ConfigAiResourceSearchReadinessService(configQueryChainService,
+                configOperationService, taskRepository);
+        assertFalse(defaultClockService.isReady("", PROJECTION_VERSION));
+        assertFalse(AiResourceSearchReadinessService.NOOP.isReady(RESOURCE_TYPE,
+            PROJECTION_VERSION));
+        assertDoesNotThrow(() -> AiResourceSearchReadinessService.NOOP.recordCompletedScan(
+            RESOURCE_TYPE, PROJECTION_VERSION, true));
+    }
+    
+    @Test
+    void shouldDeclareProductionInjectionConstructor() throws Exception {
+        Constructor<ConfigAiResourceSearchReadinessService> constructor =
+            ConfigAiResourceSearchReadinessService.class.getConstructor(
+                ConfigQueryChainService.class, ConfigOperationService.class,
+                AiResourceIndexTaskRepository.class);
+        
+        assertTrue(constructor.isAnnotationPresent(Autowired.class));
+    }
+    
+    @Test
+    void shouldReturnFalseForAbsentInvalidOrUnavailableRecord() {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(notFound(), null, response("", "md5"), response("not-json", "md5"))
+            .thenThrow(new IllegalStateException("query failed"));
+        
+        assertFalse(service.isReady(RESOURCE_TYPE, PROJECTION_VERSION));
+        assertFalse(service.isReady(RESOURCE_TYPE, PROJECTION_VERSION));
+        assertFalse(service.isReady(RESOURCE_TYPE, PROJECTION_VERSION));
+        assertFalse(service.isReady(RESOURCE_TYPE, PROJECTION_VERSION));
+        assertFalse(service.isReady(RESOURCE_TYPE, PROJECTION_VERSION));
+    }
+    
+    @Test
+    void shouldEstablishVerifyingOnFirstCompleteScan() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(notFound());
+        
+        service.recordCompletedScan(RESOURCE_TYPE, PROJECTION_VERSION, true);
+        
+        ArgumentCaptor<ConfigForm> form = ArgumentCaptor.forClass(ConfigForm.class);
+        ArgumentCaptor<ConfigRequestInfo> request =
+            ArgumentCaptor.forClass(ConfigRequestInfo.class);
+        verify(configOperationService).publishConfig(form.capture(), request.capture(), isNull());
+        assertTrue(form.getValue().getDataId().endsWith("agent.v1"));
+        assertTrue(form.getValue().getContent().contains("\"state\":\"VERIFYING\""));
+        assertFalse(request.getValue().getUpdateForExist());
+        verifyNoInteractions(taskRepository);
+    }
+    
+    @Test
+    void shouldBecomeReadyOnlyAfterCleanVerificationAndTaskDrain() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response(record("agent", 1, "VERIFYING", 0L), "cas-md5"));
+        when(taskRepository.hasUnfinishedTasks(RESOURCE_TYPE)).thenReturn(false);
+        
+        service.recordCompletedScan(RESOURCE_TYPE, PROJECTION_VERSION, true);
+        
+        ArgumentCaptor<ConfigForm> form = ArgumentCaptor.forClass(ConfigForm.class);
+        ArgumentCaptor<ConfigRequestInfo> request =
+            ArgumentCaptor.forClass(ConfigRequestInfo.class);
+        verify(configOperationService).publishConfig(form.capture(), request.capture(), isNull());
+        assertTrue(form.getValue().getContent().contains("\"state\":\"READY\""));
+        assertTrue(form.getValue().getContent().contains("\"completedAt\":12345"));
+        assertTrue(request.getValue().getUpdateForExist());
+        assertEquals("cas-md5", request.getValue().getCasMd5());
+    }
+    
+    @Test
+    void shouldRemainVerifyingForDirtyScanOrUnfinishedTask() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response(record("agent", 1, "VERIFYING", 0L), "one"),
+                response(record("agent", 1, "VERIFYING", 0L), "two"));
+        when(taskRepository.hasUnfinishedTasks(RESOURCE_TYPE)).thenReturn(true);
+        
+        service.recordCompletedScan(RESOURCE_TYPE, PROJECTION_VERSION, false);
+        service.recordCompletedScan(RESOURCE_TYPE, PROJECTION_VERSION, true);
+        
+        ArgumentCaptor<ConfigForm> forms = ArgumentCaptor.forClass(ConfigForm.class);
+        verify(configOperationService, org.mockito.Mockito.times(2))
+            .publishConfig(forms.capture(), any(ConfigRequestInfo.class), isNull());
+        assertTrue(forms.getAllValues().stream()
+            .allMatch(form -> form.getContent().contains("\"state\":\"VERIFYING\"")));
+        verify(taskRepository).hasUnfinishedTasks(RESOURCE_TYPE);
+    }
+    
+    @Test
+    void shouldKeepReadyStickyAndIgnoreInvalidInputs() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response(record("agent", 1, "READY", 12L), "md5"));
+        
+        service.recordCompletedScan(RESOURCE_TYPE, PROJECTION_VERSION, false);
+        service.recordCompletedScan("", PROJECTION_VERSION, true);
+        service.recordCompletedScan(RESOURCE_TYPE, 0, true);
+        
+        verify(configOperationService, never()).publishConfig(any(), any(), any());
+        verifyNoInteractions(taskRepository);
+    }
+    
+    @Test
+    void shouldRepairMalformedRecordThroughCasButRefuseMissingCasMetadata() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(response("invalid", "repair-md5"), response("invalid", null));
+        
+        service.recordCompletedScan(RESOURCE_TYPE, PROJECTION_VERSION, true);
+        service.recordCompletedScan(RESOURCE_TYPE, PROJECTION_VERSION, true);
+        
+        ArgumentCaptor<ConfigRequestInfo> request =
+            ArgumentCaptor.forClass(ConfigRequestInfo.class);
+        verify(configOperationService).publishConfig(any(ConfigForm.class), request.capture(),
+            isNull());
+        assertEquals("repair-md5", request.getValue().getCasMd5());
+    }
+    
+    @Test
+    void shouldNotAdvanceWhenReadOrTaskInspectionFails() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenThrow(new IllegalStateException("query"))
+            .thenReturn(response(record("agent", 1, "VERIFYING", 0L), "md5"));
+        when(taskRepository.hasUnfinishedTasks(RESOURCE_TYPE))
+            .thenThrow(new IllegalStateException("tasks"));
+        
+        assertDoesNotThrow(() -> service.recordCompletedScan(RESOURCE_TYPE,
+            PROJECTION_VERSION, true));
+        assertDoesNotThrow(() -> service.recordCompletedScan(RESOURCE_TYPE,
+            PROJECTION_VERSION, true));
+        
+        verify(configOperationService, never()).publishConfig(any(), any(), any());
+    }
+    
+    @Test
+    void shouldIgnoreConcurrentInitialization() throws Exception {
+        when(configQueryChainService.handle(any(ConfigQueryChainRequest.class)))
+            .thenReturn(notFound());
+        doThrow(new ConfigAlreadyExistsException("exists"))
+            .when(configOperationService).publishConfig(any(), any(), isNull());
+        
+        assertDoesNotThrow(() -> service.recordCompletedScan(RESOURCE_TYPE,
+            PROJECTION_VERSION, false));
+    }
+    
+    private ConfigQueryChainResponse notFound() {
+        ConfigQueryChainResponse result = new ConfigQueryChainResponse();
+        result.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_NOT_FOUND);
+        return result;
+    }
+    
+    private ConfigQueryChainResponse response(String content, String md5) {
+        ConfigQueryChainResponse result = new ConfigQueryChainResponse();
+        result.setStatus(ConfigQueryChainResponse.ConfigQueryStatus.CONFIG_FOUND_FORMAL);
+        result.setContent(content);
+        result.setMd5(md5);
+        return result;
+    }
+    
+    private String record(String resourceType, int version, String state, long completedAt) {
+        return "{\"resourceType\":\"" + resourceType + "\",\"projectionVersion\":"
+            + version + ",\"state\":\"" + state + "\",\"completedAt\":"
+            + completedAt + '}';
+    }
+}

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/JdbcAiResourceIndexTaskRepositoryTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/JdbcAiResourceIndexTaskRepositoryTest.java
@@ -367,12 +367,71 @@ class JdbcAiResourceIndexTaskRepositoryTest {
             .contains("Failed to decode AI resource task"));
     }
     
+    @Test
+    void shouldDetectUnfinishedTasksForExactResourceTypeAcrossPages() {
+        for (int i = 0; i < 100; i++) {
+            insertTask(String.format("%03d", i), "skill", "skill-" + i,
+                JdbcAiResourceIndexTaskRepository.STATUS_PENDING);
+        }
+        insertTask("zzz-agent", "agent", "agent-a",
+            JdbcAiResourceIndexTaskRepository.STATUS_PROCESSING);
+        
+        assertTrue(repository.hasUnfinishedTasks("agent"));
+        assertTrue(repository.hasUnfinishedTasks("skill"));
+        assertFalse(repository.hasUnfinishedTasks("prompt"));
+    }
+    
+    @Test
+    void shouldIgnoreCompletedAndOtherTaskTypesForReadiness() {
+        insertTask("completed-agent", "agent", "agent-a",
+            JdbcAiResourceIndexTaskRepository.STATUS_COMPLETED);
+        jdbcTemplate.update("INSERT INTO ai_resource_task "
+            + "(task_key, namespace_id, task_type, task_stage, status, task_payload, "
+            + "task_result, retry_count, revision, next_execute_at, lease_token, "
+            + "lease_expire_at, last_error, gmt_create, gmt_modified) "
+            + "VALUES (?, ?, ?, ?, ?, ?, NULL, 0, 1, ?, 0, NULL, NULL, "
+            + "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", "other-agent", "public",
+            "other-task", "stage", JdbcAiResourceIndexTaskRepository.STATUS_PENDING,
+            JacksonUtils.toJson(new AiResourceIndexTaskPayload("agent", "agent-a", false)),
+            currentEpochMillis);
+        
+        assertFalse(repository.hasUnfinishedTasks("agent"));
+    }
+    
+    @Test
+    void shouldTreatMalformedUnfinishedTaskAsNotReady() {
+        jdbcTemplate.update("INSERT INTO ai_resource_task "
+            + "(task_key, namespace_id, task_type, task_stage, status, task_payload, "
+            + "task_result, retry_count, revision, next_execute_at, lease_token, "
+            + "lease_expire_at, last_error, gmt_create, gmt_modified) "
+            + "VALUES (?, ?, ?, ?, ?, ?, NULL, 0, 1, ?, 0, NULL, NULL, "
+            + "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", "malformed", "public",
+            AiResourceIndexTask.TASK_TYPE, AiResourceIndexTask.STAGE_BASE_INDEX,
+            JdbcAiResourceIndexTaskRepository.STATUS_PENDING, "not-json",
+            currentEpochMillis);
+        
+        assertTrue(repository.hasUnfinishedTasks("agent"));
+    }
+    
     private AiResourceIndexTask scheduleEnhancementTask() {
         repository.schedule("public", "skill", "avatar", true);
         AiResourceIndexTask baseTask = repository.findDueTasks(10).get(0);
         assertTrue(repository.claim(baseTask, 60_000L));
         assertTrue(repository.advanceToEnhancement(baseTask));
         return repository.findDueTasks(10).get(0);
+    }
+    
+    private void insertTask(String taskKey, String resourceType, String resourceName,
+        String status) {
+        jdbcTemplate.update("INSERT INTO ai_resource_task "
+            + "(task_key, namespace_id, task_type, task_stage, status, task_payload, "
+            + "task_result, retry_count, revision, next_execute_at, lease_token, "
+            + "lease_expire_at, last_error, gmt_create, gmt_modified) "
+            + "VALUES (?, ?, ?, ?, ?, ?, NULL, 0, 1, ?, 0, NULL, NULL, "
+            + "CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", taskKey, "public",
+            AiResourceIndexTask.TASK_TYPE, AiResourceIndexTask.STAGE_BASE_INDEX, status,
+            JacksonUtils.toJson(new AiResourceIndexTaskPayload(resourceType, resourceName, false)),
+            currentEpochMillis);
     }
     
     private void advanceTime(long millis) {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/McpAiResourceSearchTypeHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/McpAiResourceSearchTypeHandlerTest.java
@@ -38,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -146,6 +147,66 @@ class McpAiResourceSearchTypeHandlerTest {
     }
     
     @Test
+    void projectShouldHandleEveryOptionalCollectionAndVersionFallback() throws Exception {
+        McpServerDetailInfo optional = detail(true);
+        optional.setCapabilities(Collections.emptyList());
+        ServerVersionDetail blankVersion = new ServerVersionDetail();
+        blankVersion.setVersion(" ");
+        blankVersion.setIs_latest(true);
+        optional.setVersionDetail(blankVersion);
+        optional.setVersion("fallback-version");
+        McpTool blankTool = new McpTool();
+        blankTool.setInputSchema(Collections.emptyMap());
+        blankTool.setOutputSchema(Collections.emptyMap());
+        McpToolSpecification optionalTools = new McpToolSpecification();
+        optionalTools.setTools(List.of(blankTool));
+        optional.setToolSpec(optionalTools);
+        Map<String, Object> blankResource = new LinkedHashMap<>();
+        blankResource.put("name", " ");
+        blankResource.put("description", null);
+        McpResourceSpecification optionalResources = new McpResourceSpecification();
+        optionalResources.setResources(List.of(blankResource));
+        optional.setResourceSpec(optionalResources);
+        when(mcpServerOperationService.getMcpServerDetail("public", "optional", null, null))
+            .thenReturn(optional);
+        
+        AiResourceIndexProjection projection = handler().project("public",
+            AiResourceConstants.RESOURCE_TYPE_MCP, "optional", null);
+        
+        assertEquals("fallback-version", projection.getDocument().getResourceVersion());
+        assertEquals(3, projection.getEnhancementContents().size());
+        
+        McpServerDetailInfo nullLists = detail(true);
+        McpToolSpecification nullTools = new McpToolSpecification();
+        nullTools.setTools(null);
+        nullLists.setToolSpec(nullTools);
+        McpResourceSpecification nullResources = new McpResourceSpecification();
+        nullResources.setResources(null);
+        nullResources.setResourceTemplates(null);
+        nullLists.setResourceSpec(nullResources);
+        when(mcpServerOperationService.getMcpServerDetail("public", "null-lists", null, null))
+            .thenReturn(nullLists);
+        assertEquals(1, handler().project("public", AiResourceConstants.RESOURCE_TYPE_MCP,
+            "null-lists", null).getEnhancementContents().size());
+        
+        McpServerDetailInfo emptyTools = detail(true);
+        McpToolSpecification emptyToolSpec = new McpToolSpecification();
+        emptyToolSpec.setTools(Collections.emptyList());
+        emptyTools.setToolSpec(emptyToolSpec);
+        when(mcpServerOperationService.getMcpServerDetail("public", "empty-tools", null, null))
+            .thenReturn(emptyTools);
+        assertEquals(1, handler().project("public", AiResourceConstants.RESOURCE_TYPE_MCP,
+            "empty-tools", null).getEnhancementContents().size());
+        
+        McpServerDetailInfo inactive = detail(true);
+        inactive.setStatus(AiConstants.Mcp.MCP_STATUS_DEPRECATED);
+        when(mcpServerOperationService.getMcpServerDetail("public", "inactive", null, null))
+            .thenReturn(inactive);
+        assertNull(handler().project("public", AiResourceConstants.RESOURCE_TYPE_MCP,
+            "inactive", null));
+    }
+    
+    @Test
     void scanShouldReturnBoundedMcpSources() {
         McpServerBasicInfo valid = basic("mcp", "MCP", "1.0.0");
         when(mcpServerOperationService.listMcpServerWithPage("public", null,
@@ -234,6 +295,23 @@ class McpAiResourceSearchTypeHandlerTest {
     }
     
     @Test
+    void isCurrentShouldRejectDisabledInactiveAndVersionlessMcp() throws Exception {
+        AiResourceSearchDocument document = document();
+        McpServerDetailInfo disabled = detail(true);
+        disabled.setEnabled(false);
+        McpServerDetailInfo inactive = detail(true);
+        inactive.setStatus(AiConstants.Mcp.MCP_STATUS_DEPRECATED);
+        McpServerDetailInfo versionless = detail(true);
+        versionless.setVersionDetail(null);
+        when(mcpServerOperationService.getMcpServerDetail("public", "mcp-research",
+            "Research MCP", "1.0.0")).thenReturn(disabled, inactive, versionless);
+        
+        assertFalse(handler().isCurrent(document));
+        assertFalse(handler().isCurrent(document));
+        assertFalse(handler().isCurrent(document));
+    }
+    
+    @Test
     void existsShouldMapNotFoundAndPropagateUnexpectedFailure() throws Exception {
         when(mcpServerOperationService.getMcpServerDetail("public", "mcp", null, null))
             .thenReturn(detail(true));
@@ -243,12 +321,37 @@ class McpAiResourceSearchTypeHandlerTest {
         when(mcpServerOperationService.getMcpServerDetail("public", "missing", null, null))
             .thenThrow(new NacosException(NacosException.NOT_FOUND, "missing"));
         assertFalse(handler().exists("public", AiResourceConstants.RESOURCE_TYPE_MCP, "missing"));
+        when(mcpServerOperationService.getMcpServerDetail("public", "empty", null, null))
+            .thenReturn(null);
+        assertFalse(handler().exists("public", AiResourceConstants.RESOURCE_TYPE_MCP, "empty"));
         when(mcpServerOperationService.getMcpServerDetail("public", "failed", null, null))
             .thenThrow(new NacosException(NacosException.SERVER_ERROR, "failed"));
         assertThrows(NacosException.class, () -> handler().exists("public",
             AiResourceConstants.RESOURCE_TYPE_MCP, "failed"));
         assertEquals(List.of(AiResourceConstants.RESOURCE_TYPE_MCP),
             List.copyOf(handler().resourceTypes()));
+    }
+    
+    @Test
+    void isCurrentShouldHandleNullDetailAndJsonNullMetadata() throws Exception {
+        AiResourceSearchDocument document = document();
+        document.setMetadata("null");
+        when(mcpServerOperationService.getMcpServerDetail("public", "mcp-research", null,
+            "1.0.0")).thenReturn(null);
+        assertFalse(handler().isCurrent(document));
+    }
+    
+    @Test
+    void projectShouldBoundLargeMcpContent() throws Exception {
+        McpServerDetailInfo detail = detail(true);
+        detail.setDescription(String.join("", Collections.nCopies(13000, "x")));
+        when(mcpServerOperationService.getMcpServerDetail("public", "large", null, null))
+            .thenReturn(detail);
+        
+        AiResourceIndexProjection projection = handler().project("public",
+            AiResourceConstants.RESOURCE_TYPE_MCP, "large", null);
+        
+        assertEquals(12000, projection.getEnhancementContents().get(0).getText().length());
     }
     
     private McpAiResourceSearchTypeHandler handler() {

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/search/StoredAiResourceSearchTypeHandlerTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/search/StoredAiResourceSearchTypeHandlerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -85,6 +86,22 @@ class StoredAiResourceSearchTypeHandlerTest {
     }
     
     @Test
+    void projectShouldUseNoopContentLoaderWhenDependencyIsAbsent() {
+        AiResource resource = resource(AiResourceConstants.RESOURCE_TYPE_SKILL, "skill", "1.0.0");
+        when(resourceManager.findMeta("public", "skill", AiResourceConstants.RESOURCE_TYPE_SKILL))
+            .thenReturn(resource);
+        when(resourceManager.findVersion("public", "skill",
+            AiResourceConstants.RESOURCE_TYPE_SKILL, "1.0.0")).thenReturn(version("skill",
+                AiResourceConstants.RESOURCE_TYPE_SKILL, "1.0.0",
+                AiResourceConstants.VERSION_STATUS_ONLINE));
+        StoredAiResourceSearchTypeHandler handler =
+            new StoredAiResourceSearchTypeHandler(resourceManager, null);
+        
+        assertTrue(handler.project("public", AiResourceConstants.RESOURCE_TYPE_SKILL,
+            "skill", null).getEnhancementContents().isEmpty());
+    }
+    
+    @Test
     void projectShouldBuildExactPromptAndTolerateContentFailure() throws Exception {
         String resourceType = NacosConfigAiResourceStorage.RESOURCE_TYPE_PROMPT;
         AiResource resource = resource(resourceType, "prompt", "2.0.0");
@@ -128,6 +145,25 @@ class StoredAiResourceSearchTypeHandlerTest {
                 AiResourceConstants.VERSION_STATUS_DRAFT));
         assertNull(handler.project("public", AiResourceConstants.RESOURCE_TYPE_SKILL,
             "offline", null));
+        
+        AiResource missingVersion = resource(AiResourceConstants.RESOURCE_TYPE_SKILL,
+            "missing-version", "1.0.0");
+        when(resourceManager.findMeta("public", "missing-version",
+            AiResourceConstants.RESOURCE_TYPE_SKILL)).thenReturn(missingVersion);
+        assertNull(handler.project("public", AiResourceConstants.RESOURCE_TYPE_SKILL,
+            "missing-version", null));
+        
+        AiResource disabled = resource(AiResourceConstants.RESOURCE_TYPE_SKILL,
+            "disabled", "1.0.0");
+        disabled.setStatus(AiResourceConstants.META_STATUS_DISABLE);
+        when(resourceManager.findMeta("public", "disabled",
+            AiResourceConstants.RESOURCE_TYPE_SKILL)).thenReturn(disabled);
+        when(resourceManager.findVersion("public", "disabled",
+            AiResourceConstants.RESOURCE_TYPE_SKILL, "1.0.0"))
+            .thenReturn(version("disabled", AiResourceConstants.RESOURCE_TYPE_SKILL, "1.0.0",
+                AiResourceConstants.VERSION_STATUS_ONLINE));
+        assertNull(handler.project("public", AiResourceConstants.RESOURCE_TYPE_SKILL,
+            "disabled", null));
     }
     
     @Test
@@ -135,7 +171,7 @@ class StoredAiResourceSearchTypeHandlerTest {
         AiResource valid = resource(AiResourceConstants.RESOURCE_TYPE_SKILL, "valid", "1.0.0");
         AiResource broken = resource(AiResourceConstants.RESOURCE_TYPE_SKILL, "broken", "1.0.0");
         when(resourceManager.listMetaByType("public", AiResourceConstants.RESOURCE_TYPE_SKILL,
-            null, null, 1, 2)).thenReturn(page(List.of(valid, broken)));
+            null, null, 1, 3)).thenReturn(page(Arrays.asList(null, valid, broken)));
         when(resourceManager.findVersion("public", "valid",
             AiResourceConstants.RESOURCE_TYPE_SKILL, "1.0.0"))
             .thenReturn(version("valid", AiResourceConstants.RESOURCE_TYPE_SKILL, "1.0.0",
@@ -145,12 +181,13 @@ class StoredAiResourceSearchTypeHandlerTest {
             .thenThrow(new IllegalStateException("broken source"));
         
         AiResourceIndexSourcePage result = handler().scan("public",
-            AiResourceConstants.RESOURCE_TYPE_SKILL, 1, 2);
+            AiResourceConstants.RESOURCE_TYPE_SKILL, 1, 3);
         
         assertTrue(result.hasMore());
-        assertEquals(2, result.getItems().size());
-        assertTrue(result.getItems().get(0).getProjection() != null);
-        assertEquals("broken source", result.getItems().get(1).getFailure().getMessage());
+        assertEquals(3, result.getItems().size());
+        assertNull(result.getItems().get(0).getProjection());
+        assertTrue(result.getItems().get(1).getProjection() != null);
+        assertEquals("broken source", result.getItems().get(2).getFailure().getMessage());
         assertTrue(handler().scan("public", "agent", 1, 2).getItems().isEmpty());
         assertTrue(handler().scan("public", NacosConfigAiResourceStorage.RESOURCE_TYPE_PROMPT,
             1, 2).getItems().isEmpty());
@@ -205,6 +242,13 @@ class StoredAiResourceSearchTypeHandlerTest {
             .thenReturn(version("offline", AiResourceConstants.RESOURCE_TYPE_SKILL, "1.0.0",
                 AiResourceConstants.VERSION_STATUS_DRAFT));
         assertFalse(handler().isCurrent(document("offline",
+            AiResourceConstants.RESOURCE_TYPE_SKILL, "1.0.0")));
+        
+        AiResource missingVersion = resource(AiResourceConstants.RESOURCE_TYPE_SKILL,
+            "missing-version", "1.0.0");
+        when(resourceManager.findMeta("public", "missing-version",
+            AiResourceConstants.RESOURCE_TYPE_SKILL)).thenReturn(missingVersion);
+        assertFalse(handler().isCurrent(document("missing-version",
             AiResourceConstants.RESOURCE_TYPE_SKILL, "1.0.0")));
     }
     


### PR DESCRIPTION
## What is the purpose of the change

Integrate canonical RAD Agents with the shared AI Resource Search index without switching the public Agent Search API yet. This establishes deterministic latest-version projections, durable lifecycle scheduling, cluster-shared readiness, and reconciliation/backfill convergence for the next search cutover phase.

## Brief changelog

- Add an Agent search type handler and deterministic Document/Chunk/Facet projector.
- Enqueue durable index tasks for Agent lifecycle changes and reconcile missing, stale, and orphan Agent documents.
- Add Config-CAS readiness coordination for Agent projection v1.
- Harden reconciliation lease renewal and release against asynchronous Config cache visibility.
- Preserve existing public Agent Search behavior until a later cutover phase.
- Add focused unit coverage, including prior PR #15730 and #15733 Codecov gaps.

## Verifying this change

- `mvn -pl ai,ai-registry-adaptor spotless:apply spotless:check`
- `mvn -pl ai test`: 2201 tests, 0 failures, 0 errors, 2 skipped.
- `mvn -pl ai-registry-adaptor -Dtest=ArdSearchServiceImplTest test`: 26 tests passed.
- Full CI-equivalent static check across all 62 modules passed.
- A real standalone Nacos instance published `rad-index-live-20260818-final@1.2.3`; Derby contained one enabled Agent document, eight enabled chunks, a completed durable task with no retry/error, and `agent.v1` readiness in `READY` state.

## Checklist

- [x] The change is scoped to Agent shared-index projection and lifecycle convergence.
- [x] Unit tests and real standalone verification cover the new behavior.
- [x] Public Agent Search API behavior is not switched by this PR.

