### PR TITLE
[ISSUE #15476] Backport Prompt visibility checks to v3.2.4

### DIFF
--- a/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
+++ b/ai/src/main/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImpl.java
@@ -26,6 +26,7 @@ import com.alibaba.nacos.ai.pipeline.model.PipelineExecutionStatus;
 import com.alibaba.nacos.ai.pipeline.model.PipelineNodeResult;
 import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
 import com.alibaba.nacos.ai.service.VisibilityHelper;
+import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.ai.service.resource.ResourceVersionInfo;
 import com.alibaba.nacos.ai.service.trace.AiResourceTraceService;
@@ -55,6 +56,7 @@ import com.alibaba.nacos.plugin.ai.pipeline.model.PublishPipelineResourceType;
 import com.alibaba.nacos.plugin.ai.pipeline.model.ResourceFileContent;
 import com.alibaba.nacos.plugin.ai.pipeline.model.ResourceFilesPipelineContext;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
+import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -635,7 +637,7 @@ public class PromptOperationServiceImpl implements PromptOperationService {
     @Override
     public PromptMetaInfo getPromptDetail(String namespaceId, String promptKey)
         throws NacosException {
-        AiResource meta = requireMeta(namespaceId, promptKey);
+        AiResource meta = requireReadableMeta(namespaceId, promptKey);
         PromptVersionInfoPojo versionInfo = requireVersionInfo(meta);
         
         PromptMetaInfo detail = new PromptMetaInfo();
@@ -681,7 +683,7 @@ public class PromptOperationServiceImpl implements PromptOperationService {
     public PromptVersionInfo getPromptVersionDetail(String namespaceId, String promptKey,
         String version)
         throws NacosException {
-        requireMeta(namespaceId, promptKey);
+        requireReadableMeta(namespaceId, promptKey);
         if (StringUtils.isBlank(version)) {
             throw new NacosApiException(NacosException.INVALID_PARAM, ErrorCode.PARAMETER_MISSING,
                 "version is required");
@@ -726,9 +728,13 @@ public class PromptOperationServiceImpl implements PromptOperationService {
                 .generateLikeArgument(Constants.ALL_PATTERN + bizTags + Constants.ALL_PATTERN)
             : null;
         
-        Page<AiResource> metaPage =
-            resourceManager.listMetaByType(namespaceId, RESOURCE_TYPE_PROMPT, nameLike,
-                bizTagsLike, pageNo, pageSize);
+        QueryCondition queryCondition =
+            resourceManager.buildQueryCondition(namespaceId, RESOURCE_TYPE_PROMPT, nameLike,
+                bizTagsLike, VisibilityConstants.ACTION_READ);
+        if (queryCondition.isAlwaysEmpty()) {
+            return AiResourceManager.buildEmptyPage(pageNo);
+        }
+        Page<AiResource> metaPage = resourceManager.listMeta(queryCondition, pageNo, pageSize);
         
         List<PromptMetaSummary> items = new ArrayList<>();
         if (metaPage != null && metaPage.getPageItems() != null) {
@@ -768,7 +774,7 @@ public class PromptOperationServiceImpl implements PromptOperationService {
     public Page<PromptVersionSummary> listPromptVersions(String namespaceId, String promptKey,
         int pageNo,
         int pageSize) throws NacosException {
-        requireMeta(namespaceId, promptKey);
+        requireReadableMeta(namespaceId, promptKey);
         
         Page<AiResourceVersion> versionPage = resourceManager.listVersions(namespaceId, promptKey,
             RESOURCE_TYPE_PROMPT, null, pageNo, pageSize);
@@ -806,11 +812,7 @@ public class PromptOperationServiceImpl implements PromptOperationService {
     public PromptVersionInfo queryPrompt(String namespaceId, String promptKey, String version,
         String label)
         throws NacosException {
-        AiResource meta = resourceManager.findMeta(namespaceId, promptKey, RESOURCE_TYPE_PROMPT);
-        if (meta == null) {
-            throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
-                "Prompt not found: " + promptKey);
-        }
+        AiResource meta = requireReadableMeta(namespaceId, promptKey);
         
         PromptVersionInfoPojo info = requireVersionInfo(meta);
         String resolved = resolveClientVersion(info, version, label);
@@ -946,6 +948,13 @@ public class PromptOperationServiceImpl implements PromptOperationService {
             throw new NacosApiException(NacosException.NOT_FOUND, ErrorCode.RESOURCE_NOT_FOUND,
                 "Prompt not found: " + promptKey);
         }
+        return meta;
+    }
+    
+    private AiResource requireReadableMeta(String namespaceId, String promptKey)
+        throws NacosException {
+        AiResource meta = requireMeta(namespaceId, promptKey);
+        resourceManager.ensureReadableOrNotFound(meta, "Prompt not found: " + promptKey);
         return meta;
     }
     

--- a/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
+++ b/ai/src/test/java/com/alibaba/nacos/ai/service/prompt/PromptOperationServiceImplTest.java
@@ -27,6 +27,7 @@ import com.alibaba.nacos.ai.pipeline.model.PipelineConfig;
 import com.alibaba.nacos.ai.pipeline.repository.PipelineExecutionRepository;
 import com.alibaba.nacos.ai.service.repository.AiResourcePersistService;
 import com.alibaba.nacos.ai.service.repository.AiResourceVersionPersistService;
+import com.alibaba.nacos.ai.service.repository.QueryCondition;
 import com.alibaba.nacos.ai.service.resource.AiResourceManager;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaInfo;
 import com.alibaba.nacos.api.ai.model.prompt.PromptMetaSummary;
@@ -38,10 +39,16 @@ import com.alibaba.nacos.api.model.Page;
 import com.alibaba.nacos.common.notify.NotifyCenter;
 import com.alibaba.nacos.common.utils.JacksonUtils;
 import com.alibaba.nacos.config.server.service.ConfigOperationService;
+import com.alibaba.nacos.core.context.RequestContextHolder;
 import com.alibaba.nacos.plugin.ai.storage.AiResourceStorageRouter;
 import com.alibaba.nacos.plugin.ai.storage.model.StorageKey;
 import com.alibaba.nacos.plugin.ai.storage.spi.AiResourceStorage;
+import com.alibaba.nacos.plugin.visibility.constant.VisibilityConstants;
+import com.alibaba.nacos.plugin.visibility.model.BaseVisibilityPredicate;
+import com.alibaba.nacos.plugin.visibility.spi.QueryAdvisor;
+import com.alibaba.nacos.plugin.visibility.spi.ValidationResult;
 import com.alibaba.nacos.plugin.visibility.spi.VisibilityPluginManager;
+import com.alibaba.nacos.plugin.visibility.spi.VisibilityService;
 import com.alibaba.nacos.sys.env.EnvUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,7 +71,9 @@ import java.util.concurrent.Executors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -121,6 +130,7 @@ class PromptOperationServiceImplTest {
     
     @BeforeEach
     void setUp() {
+        RequestContextHolder.removeContext();
         EnvUtil.setEnvironment(new StandardEnvironment());
         AiResourceStorageRouter.reset();
         lenient().when(storage.type()).thenReturn("nacos_config");
@@ -148,6 +158,7 @@ class PromptOperationServiceImplTest {
     
     @AfterEach
     void tearDown() {
+        RequestContextHolder.removeContext();
         if (visibilityManagerStatic != null) {
             visibilityManagerStatic.close();
         }
@@ -699,6 +710,20 @@ class PromptOperationServiceImplTest {
     }
     
     @Test
+    void testGetPromptDetailDeniedByReadFilterShouldReturnNotFound() {
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE))
+            .thenReturn(createMeta(PROMPT_KEY, 1L, "{\"labels\":{}}"));
+        mockDeniedReadVisibility();
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.getPromptDetail(NS, PROMPT_KEY));
+        
+        assertEquals(NacosException.NOT_FOUND, exception.getErrCode());
+        verify(aiResourceVersionPersistService, never()).list(eq(NS), eq(PROMPT_KEY),
+            eq(PROMPT_TYPE), any(), anyInt(), anyInt());
+    }
+    
+    @Test
     void testGetPromptVersionDetailSuccessfully() throws NacosException {
         AiResource meta = createMeta(PROMPT_KEY, 1L, "{\"labels\":{}}");
         when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE)).thenReturn(meta);
@@ -716,6 +741,22 @@ class PromptOperationServiceImplTest {
         assertEquals("0.0.1", result.getVersion());
     }
     
+    @Test
+    void testGetPromptVersionDetailDeniedByReadFilterShouldReturnNotFound()
+        throws NacosException {
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE))
+            .thenReturn(createMeta(PROMPT_KEY, 1L, "{\"labels\":{}}"));
+        mockDeniedReadVisibility();
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.getPromptVersionDetail(NS, PROMPT_KEY, "0.0.1"));
+        
+        assertEquals(NacosException.NOT_FOUND, exception.getErrCode());
+        verify(aiResourceVersionPersistService, never())
+            .find(NS, PROMPT_KEY, PROMPT_TYPE, "0.0.1");
+        verify(storage, never()).get(any(StorageKey.class));
+    }
+    
     // ========== listPrompts / listPromptVersions ==========
     
     @Test
@@ -726,7 +767,7 @@ class PromptOperationServiceImplTest {
         AiResource r =
             createMeta(PROMPT_KEY, 1L, "{\"labels\":{\"latest\":\"0.0.1\"},\"onlineCnt\":1}");
         metaPage.setPageItems(Collections.singletonList(r));
-        when(aiResourcePersistService.list(eq(NS), eq(PROMPT_TYPE), any(), any(), eq(1), eq(10)))
+        when(aiResourcePersistService.list(any(QueryCondition.class), eq(1), eq(10)))
             .thenReturn(metaPage);
         
         Page<PromptMetaSummary> result = service.listPrompts(NS, null, null, null, 1, 10);
@@ -735,6 +776,53 @@ class PromptOperationServiceImplTest {
         assertEquals(1, result.getTotalCount());
         assertEquals(1, result.getPageItems().size());
         assertEquals(PROMPT_KEY, result.getPageItems().get(0).getPromptKey());
+    }
+    
+    @Test
+    void testListPromptsShouldApplyVisibilityQueryAdvice() throws NacosException {
+        QueryAdvisor advisor = new QueryAdvisor();
+        advisor.setBasePredicate(BaseVisibilityPredicate.PUBLIC);
+        VisibilityService visibilityService = mock(VisibilityService.class);
+        when(visibilityService.adviseQuery(anyString(), eq(VisibilityConstants.ACTION_READ),
+            anyString(), any())).thenReturn(advisor);
+        when(mockVisibilityManager.findVisibilityService(anyString()))
+            .thenReturn(Optional.of(visibilityService));
+        Page<AiResource> metaPage = new Page<>();
+        metaPage.setPageItems(Collections.emptyList());
+        when(aiResourcePersistService.list(any(QueryCondition.class), eq(2), eq(5)))
+            .thenReturn(metaPage);
+        
+        service.listPrompts(NS, null, null, null, 2, 5);
+        
+        ArgumentCaptor<QueryCondition> conditionCaptor =
+            ArgumentCaptor.forClass(QueryCondition.class);
+        verify(aiResourcePersistService).list(conditionCaptor.capture(), eq(2), eq(5));
+        assertEquals(NS, conditionCaptor.getValue().getNamespaceId());
+        assertEquals(PROMPT_TYPE, conditionCaptor.getValue().getType());
+        assertEquals(VisibilityConstants.SCOPE_PUBLIC, conditionCaptor.getValue().getScope());
+        verify(visibilityService).adviseQuery(anyString(), eq(VisibilityConstants.ACTION_READ),
+            anyString(), any());
+    }
+    
+    @Test
+    void testListPromptsShouldReturnEmptyPageWhenVisibilityQueryIsEmpty()
+        throws NacosException {
+        QueryAdvisor advisor = new QueryAdvisor();
+        advisor.setBasePredicate(BaseVisibilityPredicate.OWNER);
+        VisibilityService visibilityService = mock(VisibilityService.class);
+        when(visibilityService.adviseQuery(anyString(), eq(VisibilityConstants.ACTION_READ),
+            anyString(), any())).thenReturn(advisor);
+        when(mockVisibilityManager.findVisibilityService(anyString()))
+            .thenReturn(Optional.of(visibilityService));
+        
+        Page<PromptMetaSummary> result =
+            service.listPrompts(NS, null, null, null, 3, 10);
+        
+        assertEquals(3, result.getPageNumber());
+        assertEquals(0, result.getTotalCount());
+        assertTrue(result.getPageItems().isEmpty());
+        verify(aiResourcePersistService, never()).list(any(QueryCondition.class), anyInt(),
+            anyInt());
     }
     
     @Test
@@ -755,6 +843,20 @@ class PromptOperationServiceImplTest {
         assertNotNull(result);
         assertEquals(1, result.getTotalCount());
         assertEquals("0.0.1", result.getPageItems().get(0).getVersion());
+    }
+    
+    @Test
+    void testListPromptVersionsDeniedByReadFilterShouldReturnNotFound() {
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE))
+            .thenReturn(createMeta(PROMPT_KEY, 1L, "{\"labels\":{}}"));
+        mockDeniedReadVisibility();
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.listPromptVersions(NS, PROMPT_KEY, 1, 10));
+        
+        assertEquals(NacosException.NOT_FOUND, exception.getErrCode());
+        verify(aiResourceVersionPersistService, never()).list(eq(NS), eq(PROMPT_KEY),
+            eq(PROMPT_TYPE), any(), eq(1), eq(10));
     }
     
     // ========== queryPrompt (Client) ==========
@@ -793,6 +895,21 @@ class PromptOperationServiceImplTest {
         assertEquals("0.0.1", result.getVersion());
     }
     
+    @Test
+    void testQueryPromptDeniedByReadFilterShouldReturnNotFound() throws NacosException {
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE))
+            .thenReturn(createMeta(PROMPT_KEY, 1L, "{\"labels\":{\"latest\":\"0.0.1\"}}"));
+        mockDeniedReadVisibility();
+        
+        NacosApiException exception = assertThrows(NacosApiException.class,
+            () -> service.queryPrompt(NS, PROMPT_KEY, null, null));
+        
+        assertEquals(NacosException.NOT_FOUND, exception.getErrCode());
+        verify(aiResourceVersionPersistService, never())
+            .find(NS, PROMPT_KEY, PROMPT_TYPE, "0.0.1");
+        verify(storage, never()).get(any(StorageKey.class));
+    }
+    
     // ========== downloadPromptVersion ==========
     
     @Test
@@ -821,6 +938,21 @@ class PromptOperationServiceImplTest {
             assertEquals(NS, published.getNamespaceId());
             assertEquals(PROMPT_KEY, published.getName());
             assertEquals("0.0.1", published.getVersion());
+        }
+    }
+    
+    @Test
+    void testDownloadPromptVersionDeniedByReadFilterShouldNotPublishEvent() {
+        when(aiResourcePersistService.find(NS, PROMPT_KEY, PROMPT_TYPE))
+            .thenReturn(createMeta(PROMPT_KEY, 1L, "{\"labels\":{}}"));
+        mockDeniedReadVisibility();
+        
+        try (MockedStatic<NotifyCenter> notifyCenterStatic = mockStatic(NotifyCenter.class)) {
+            NacosApiException exception = assertThrows(NacosApiException.class,
+                () -> service.downloadPromptVersion(NS, PROMPT_KEY, "0.0.1"));
+            
+            assertEquals(NacosException.NOT_FOUND, exception.getErrCode());
+            notifyCenterStatic.verifyNoInteractions();
         }
     }
     
@@ -862,6 +994,15 @@ class PromptOperationServiceImplTest {
         row.setStatus(status);
         row.setAuthor("-");
         return row;
+    }
+    
+    private void mockDeniedReadVisibility() {
+        VisibilityService visibilityService = mock(VisibilityService.class);
+        when(visibilityService.validateVisibility(anyString(),
+            eq(VisibilityConstants.ACTION_READ), anyString(), any()))
+            .thenReturn(ValidationResult.deny("denied"));
+        when(mockVisibilityManager.findVisibilityService(anyString()))
+            .thenReturn(Optional.of(visibilityService));
     }
     
     private void mockStorageGet(byte[] content) throws NacosException {


### PR DESCRIPTION
For #15476

Backport #15737 to `v3.2.4-develop`.

## What is the purpose of the change

Prompt list and single-resource read paths on the 3.2.4 maintenance branch bypass the visibility plugin. An authenticated non-owner with API-level permission can therefore observe private Prompt metadata or content.

The original squash commit could not be cherry-picked cleanly because the maintenance branch has a different Prompt service baseline and does not contain the newer Prompt OpenAPI IT suites and coverage registries. This PR applies the equivalent service fix and focused unit coverage on top of `v3.2.4-develop`.

## Brief changelog

* Apply visibility `QueryAdvisor`/`QueryCondition` filtering before Prompt list count and pagination.
* Validate Prompt visibility for governance detail, version detail/list, downloads, and Client queries.
* Return not found for denied reads while retaining access denied for denied writes.
* Prevent denied downloads from emitting download-count events.
* Add focused Prompt service tests for visibility filtering and denied read paths.

The target branch does not yet contain the Prompt Admin/Client/Console OpenAPI IT classes or the API scenario/coverage registries changed by #15737, so those develop-only files are not introduced by this focused backport. The corresponding HTTP behavior was verified against a standalone target-branch build with authentication and visibility enabled.

## Verifying this change

* `mvn -pl ai spotless:apply`
* `mvn -pl ai spotless:check`
* `mvn -pl ai -Dtest=PromptOperationServiceImplTest test` (65 tests passed)
* `mvn -pl ai clean test` (1,346 tests passed, 2 skipped)
* `mvn '-Prelease-nacos,!dev' -Dmaven.test.skip=true clean package` (60 modules passed)
* `mvn -B clean compile apache-rat:check checkstyle:check spotbugs:check spotless:check -e -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn` (60 modules passed)
* Auth-enabled standalone `v3.2.4-develop` runtime verification:
  * owner list/detail and Client/Console/Admin reads return HTTP 200;
  * non-owner list is empty and single-resource reads/download/Client query return HTTP 404;
  * a denied download leaves the download count unchanged;
  * an explicit read grant restores single-resource visibility and revocation hides it again;
  * a non-owner write continues to return HTTP 403.

Follow this checklist to help us incorporate your contribution quickly and easily:

* [x] Make sure there is a Github issue filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
* [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
* [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
* [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/alibaba/nacos/tree/master/test).
* [ ] Run `mvn -B clean package apache-rat:check spotbugs:check -DskipTests` to make sure basic checks pass. Run `mvn clean install` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test` to make sure integration-test pass. The CI-equivalent full static check, affected-module unit tests, full package, and standalone runtime verification listed above passed locally.
